### PR TITLE
[gql][cherry-pick] epoch boundary task notifier and listener example (#16806)

### DIFF
--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -43,11 +43,6 @@ pub(crate) struct ConsistentNamedCursor {
     pub c: u64,
 }
 
-/// The high checkpoint watermark stamped on each GraphQL request. This is used to ensure
-/// cross-query consistency.
-#[derive(Clone, Copy)]
-pub(crate) struct CheckpointViewedAt(pub u64);
-
 /// Trait for cursors that have a checkpoint sequence number associated with them.
 pub(crate) trait Checkpointed: CursorType {
     fn checkpoint_viewed_at(&self) -> u64;

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -1,16 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::watermark_task::{Watermark, WatermarkLock, WatermarkTask};
 use crate::config::{
     ConnectionConfig, ServiceConfig, Version, MAX_CONCURRENT_REQUESTS,
     RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD,
 };
-use crate::consistency::CheckpointViewedAt;
 use crate::context_data::package_cache::DbPackageStore;
 use crate::data::Db;
 use crate::metrics::Metrics;
 use crate::mutation::Mutation;
-use crate::types::checkpoint::Checkpoint;
 use crate::types::move_object::IMoveObject;
 use crate::types::object::IObject;
 use crate::types::owner::IOwner;
@@ -30,8 +29,8 @@ use crate::{
 use async_graphql::dataloader::DataLoader;
 use async_graphql::extensions::ApolloTracing;
 use async_graphql::extensions::Tracing;
+use async_graphql::EmptySubscription;
 use async_graphql::{extensions::ExtensionFactory, Schema, SchemaBuilder};
-use async_graphql::{EmptySubscription, ServerError};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::extract::FromRef;
 use axum::extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo, State};
@@ -48,8 +47,6 @@ use mysten_metrics::spawn_monitored_task;
 use mysten_network::callback::{CallbackLayer, MakeCallbackHandler, ResponseHandler};
 use std::convert::Infallible;
 use std::net::TcpStream;
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
-use std::sync::Arc;
 use std::{any::Any, net::SocketAddr, time::Instant};
 use sui_graphql_rpc_headers::{LIMITS_HEADER, VERSION_HEADER};
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
@@ -59,15 +56,13 @@ use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
 use tower::{Layer, Service};
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use uuid::Uuid;
 
 pub(crate) struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
-    /// The following fields are internally used for background tasks
-    checkpoint_watermark: CheckpointWatermark,
+    watermark_task: WatermarkTask,
     state: AppState,
-    db_reader: Db,
 }
 
 impl Server {
@@ -76,23 +71,12 @@ impl Server {
     pub async fn run(self) -> Result<(), Error> {
         get_or_init_server_start_time().await;
 
-        // A handle that spawns a background task to periodically update the `CheckpointViewedAt`,
-        // which is the u64 high watermark of checkpoints that the service is guaranteed to produce
-        // a consistent result for.
+        // A handle that spawns a background task to periodically update the `Watermark`, which
+        // consists of the checkpoint upper bound and current epoch.
         let watermark_task = {
-            let metrics = self.state.metrics.clone();
-            let sleep_ms = self.state.service.background_tasks.watermark_update_ms;
-            let cancellation_token = self.state.cancellation_token.clone();
             info!("Starting watermark update task");
             spawn_monitored_task!(async move {
-                update_watermark(
-                    &self.db_reader,
-                    self.checkpoint_watermark,
-                    metrics,
-                    tokio::time::Duration::from_millis(sleep_ms),
-                    cancellation_token,
-                )
-                .await;
+                self.watermark_task.run().await;
             })
         };
 
@@ -110,8 +94,8 @@ impl Server {
             })
         };
 
-        // Wait for both tasks to complete. This ensures that the service doesn't fully shut down
-        // until both the background task and the server have completed their shutdown processes.
+        // Wait for all tasks to complete. This ensures that the service doesn't fully shut down
+        // until all tasks and the server have completed their shutdown processes.
         let _ = join!(watermark_task, server_task);
 
         Ok(())
@@ -133,11 +117,6 @@ pub(crate) struct AppState {
     cancellation_token: CancellationToken,
     pub version: Version,
 }
-
-/// The high checkpoint watermark stamped on each GraphQL request. This is used to ensure
-/// cross-query consistency.
-#[derive(Clone)]
-pub(crate) struct CheckpointWatermark(pub Arc<AtomicU64>);
 
 impl AppState {
     pub(crate) fn new(
@@ -302,12 +281,17 @@ impl ServerBuilder {
         let state = self.state.clone();
         let (address, schema, db_reader, router) = self.build_components();
 
-        // Initialize the checkpoint watermark for the background task to update.
-        let checkpoint_watermark = CheckpointWatermark(Arc::new(AtomicU64::new(0)));
+        // Initialize the watermark background task struct.
+        let watermark_task = WatermarkTask::new(
+            db_reader.clone(),
+            state.metrics.clone(),
+            std::time::Duration::from_millis(state.service.background_tasks.watermark_update_ms),
+            state.cancellation_token.clone(),
+        );
 
         let app = router
             .layer(axum::extract::Extension(schema))
-            .layer(axum::extract::Extension(checkpoint_watermark.clone()))
+            .layer(axum::extract::Extension(watermark_task.lock()))
             .layer(Self::cors()?);
 
         Ok(Server {
@@ -317,9 +301,8 @@ impl ServerBuilder {
                     .map_err(|_| Error::Internal(format!("Failed to parse address {}", address)))?,
             )
             .serve(app.into_make_service_with_connect_info::<SocketAddr>()),
-            checkpoint_watermark,
+            watermark_task,
             state,
-            db_reader,
         })
     }
 
@@ -454,11 +437,11 @@ pub fn export_schema() -> String {
 }
 
 /// Entry point for graphql requests. Each request is stamped with a unique ID, a `ShowUsage` flag
-/// if set in the request headers, and the high checkpoint watermark as set by the background task.
+/// if set in the request headers, and the watermark as set by the background task.
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: axum::Extension<SuiGraphQLSchema>,
-    watermark: axum::Extension<CheckpointWatermark>,
+    axum::Extension(watermark_lock): axum::Extension<WatermarkLock>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> (axum::http::Extensions, GraphQLResponse) {
@@ -471,10 +454,7 @@ async fn graphql_handler(
     // Note: if a load balancer is used it must be configured to forward the client IP address
     req.data.insert(addr);
 
-    let checkpoint_viewed_at = watermark.0 .0.load(Relaxed);
-
-    // This wrapping is done to delineate the watermark from potentially other u64 types.
-    req.data.insert(CheckpointViewedAt(checkpoint_viewed_at));
+    req.data.insert(Watermark::new(watermark_lock).await);
 
     let result = schema.execute(req).await;
 
@@ -565,39 +545,6 @@ async fn get_or_init_server_start_time() -> &'static Instant {
     ONCE.get_or_init(|| async move { Instant::now() }).await
 }
 
-/// Starts an infinite loop that periodically updates the `checkpoint_viewed_at` high watermark.
-pub(crate) async fn update_watermark(
-    db: &Db,
-    checkpoint_viewed_at: CheckpointWatermark,
-    metrics: Metrics,
-    sleep_ms: tokio::time::Duration,
-    cancellation_token: CancellationToken,
-) {
-    loop {
-        tokio::select! {
-                    _ = cancellation_token.cancelled() => {
-                        info!("Shutdown signal received, terminating watermark update task");
-                        return;
-                    },
-                    _ = tokio::time::sleep(sleep_ms) => {
-                        let new_checkpoint_viewed_at =
-                    match Checkpoint::query_latest_checkpoint_sequence_number(db).await {
-                        Ok(checkpoint) => Some(checkpoint),
-                        Err(e) => {
-                            error!("{}", e);
-                            metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
-                            None
-                        }
-                    };
-
-                if let Some(checkpoint) = new_checkpoint_viewed_at {
-                    checkpoint_viewed_at.0.store(checkpoint, Relaxed);
-                }
-            }
-        }
-    }
-}
-
 pub mod tests {
     use super::*;
     use crate::{
@@ -631,7 +578,10 @@ pub mod tests {
         let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader);
         let cancellation_token = CancellationToken::new();
-        let watermark = CheckpointViewedAt(1);
+        let watermark = Watermark {
+            checkpoint: 1,
+            epoch: 0,
+        };
         let state = AppState::new(
             connection_config.clone(),
             service_config.clone(),

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -5,3 +5,4 @@ pub mod graphiql_server;
 
 pub mod builder;
 pub mod version;
+pub(crate) mod watermark_task;

--- a/crates/sui-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/sui-graphql-rpc/src/server/watermark_task.rs
@@ -1,0 +1,135 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::error::Error;
+use crate::metrics::Metrics;
+use async_graphql::ServerError;
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
+use std::mem;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_indexer::schema::checkpoints;
+use tokio::sync::{watch, RwLock};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+/// Watermark task that periodically updates the current checkpoint and epoch values.
+pub(crate) struct WatermarkTask {
+    /// Thread-safe watermark that avoids writer starvation
+    watermark: WatermarkLock,
+    db: Db,
+    metrics: Metrics,
+    sleep: Duration,
+    cancel: CancellationToken,
+    sender: watch::Sender<u64>,
+    _receiver: watch::Receiver<u64>,
+}
+
+pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
+
+/// Watermark used by GraphQL queries to ensure cross-query consistency and flag epoch-boundary
+/// changes.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Watermark {
+    /// The checkpoint upper-bound for the query.
+    pub checkpoint: u64,
+    /// The current epoch.
+    pub epoch: u64,
+}
+
+/// Starts an infinite loop that periodically updates the `checkpoint_viewed_at` high watermark.
+impl WatermarkTask {
+    pub(crate) fn new(
+        db: Db,
+        metrics: Metrics,
+        sleep: Duration,
+        cancel: CancellationToken,
+    ) -> Self {
+        let (sender, _receiver) = watch::channel(0);
+
+        Self {
+            watermark: Default::default(),
+            db,
+            metrics,
+            sleep,
+            cancel,
+            sender,
+            _receiver,
+        }
+    }
+
+    pub(crate) async fn run(&self) {
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    info!("Shutdown signal received, terminating watermark update task");
+                    return;
+                },
+                _ = tokio::time::sleep(self.sleep) => {
+                    let Watermark { checkpoint, epoch } = match Watermark::query(&self.db).await {
+                        Ok(Some(watermark)) => watermark,
+                        Ok(None) => continue,
+                        Err(e) => {
+                            error!("{}", e);
+                            self.metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
+                            continue;
+                        }
+                    };
+
+                    // Write the watermark as follows to limit how long we hold the lock
+                    let prev_epoch = {
+                        let mut w = self.watermark.write().await;
+                        w.checkpoint = checkpoint;
+                        mem::replace(&mut w.epoch, epoch)
+                    };
+
+                    if epoch > prev_epoch {
+                        self.sender.send(epoch).unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn lock(&self) -> WatermarkLock {
+        self.watermark.clone()
+    }
+
+    pub(crate) fn _receiver(&self) -> watch::Receiver<u64> {
+        self._receiver.clone()
+    }
+}
+
+impl Watermark {
+    pub(crate) async fn new(lock: WatermarkLock) -> Self {
+        let w = lock.read().await;
+        Self {
+            checkpoint: w.checkpoint,
+            epoch: w.epoch,
+        }
+    }
+
+    pub(crate) async fn query(db: &Db) -> Result<Option<Watermark>, Error> {
+        use checkpoints::dsl;
+        let Some((checkpoint, epoch)): Option<(i64, i64)> = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .select((dsl::sequence_number, dsl::epoch))
+                        .order_by(dsl::sequence_number.desc())
+                })
+                .optional()
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch checkpoint: {e}")))?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Watermark {
+            checkpoint: checkpoint as u64,
+            epoch: epoch as u64,
+        }))
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -34,8 +34,9 @@ use super::{
     transaction_metadata::TransactionMetadata,
     type_filter::ExactTypeFilter,
 };
-use crate::consistency::{consistent_range, CheckpointViewedAt};
+use crate::consistency::consistent_range;
 use crate::data::QueryExecutor;
+use crate::server::watermark_task::Watermark;
 use crate::types::base64::Base64 as GraphQLBase64;
 use crate::types::zklogin_verify_signature::verify_zklogin_signature;
 use crate::types::zklogin_verify_signature::ZkLoginIntentScope;
@@ -59,10 +60,10 @@ impl Query {
     /// Range of checkpoints that the RPC has data available for (for data
     /// that can be tied to a particular checkpoint).
     async fn available_range(&self, ctx: &Context<'_>) -> Result<AvailableRange> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
         let result = ctx
             .data_unchecked::<Db>()
-            .execute(move |conn| consistent_range(conn, Some(checkpoint_viewed_at)))
+            .execute(move |conn| consistent_range(conn, Some(checkpoint)))
             .await
             .extend()?;
 
@@ -186,11 +187,11 @@ impl Query {
     }
 
     async fn owner(&self, ctx: &Context<'_>, address: SuiAddress) -> Result<Option<Owner>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         Ok(Some(Owner {
             address,
-            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            checkpoint_viewed_at: Some(checkpoint),
         }))
     }
 
@@ -202,7 +203,7 @@ impl Query {
         address: SuiAddress,
         version: Option<u64>,
     ) -> Result<Option<Object>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         match version {
             Some(version) => Object::query(
@@ -210,7 +211,7 @@ impl Query {
                 address,
                 ObjectLookupKey::VersionAt {
                     version,
-                    checkpoint_viewed_at: Some(checkpoint_viewed_at),
+                    checkpoint_viewed_at: Some(checkpoint),
                 },
             )
             .await
@@ -218,7 +219,7 @@ impl Query {
             None => Object::query(
                 ctx.data_unchecked(),
                 address,
-                ObjectLookupKey::LatestAt(checkpoint_viewed_at),
+                ObjectLookupKey::LatestAt(checkpoint),
             )
             .await
             .extend(),
@@ -227,11 +228,11 @@ impl Query {
 
     /// Look-up an Account by its SuiAddress.
     async fn address(&self, ctx: &Context<'_>, address: SuiAddress) -> Result<Option<Address>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         Ok(Some(Address {
             address,
-            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            checkpoint_viewed_at: Some(checkpoint),
         }))
     }
 
@@ -247,11 +248,9 @@ impl Query {
 
     /// Fetch epoch information by ID (defaults to the latest epoch).
     async fn epoch(&self, ctx: &Context<'_>, id: Option<u64>) -> Result<Option<Epoch>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
-        Epoch::query(ctx, id, Some(checkpoint_viewed_at))
-            .await
-            .extend()
+        Epoch::query(ctx, id, Some(checkpoint)).await.extend()
     }
 
     /// Fetch checkpoint information by sequence number or digest (defaults to the latest available
@@ -261,9 +260,9 @@ impl Query {
         ctx: &Context<'_>,
         id: Option<CheckpointId>,
     ) -> Result<Option<Checkpoint>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
-        Checkpoint::query(ctx, id.unwrap_or_default(), Some(checkpoint_viewed_at))
+        Checkpoint::query(ctx, id.unwrap_or_default(), Some(checkpoint))
             .await
             .extend()
     }
@@ -274,9 +273,9 @@ impl Query {
         ctx: &Context<'_>,
         digest: Digest,
     ) -> Result<Option<TransactionBlock>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
-        TransactionBlock::query(ctx.data_unchecked(), digest, Some(checkpoint_viewed_at))
+        TransactionBlock::query(ctx.data_unchecked(), digest, Some(checkpoint))
             .await
             .extend()
     }
@@ -294,7 +293,7 @@ impl Query {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
@@ -303,7 +302,7 @@ impl Query {
             page,
             coin,
             /* owner */ None,
-            Some(checkpoint_viewed_at),
+            Some(checkpoint),
         )
         .await
         .extend()
@@ -318,14 +317,14 @@ impl Query {
         last: Option<u64>,
         before: Option<checkpoint::Cursor>,
     ) -> Result<Connection<String, Checkpoint>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         Checkpoint::paginate(
             ctx.data_unchecked(),
             page,
             /* epoch */ None,
-            Some(checkpoint_viewed_at),
+            Some(checkpoint),
         )
         .await
         .extend()
@@ -341,14 +340,14 @@ impl Query {
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
     ) -> Result<Connection<String, TransactionBlock>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         TransactionBlock::paginate(
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            Some(checkpoint_viewed_at),
+            Some(checkpoint),
         )
         .await
         .extend()
@@ -364,14 +363,14 @@ impl Query {
         before: Option<event::Cursor>,
         filter: Option<EventFilter>,
     ) -> Result<Connection<String, Event>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         Event::paginate(
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            Some(checkpoint_viewed_at),
+            Some(checkpoint),
         )
         .await
         .extend()
@@ -387,14 +386,14 @@ impl Query {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
 
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         Object::paginate(
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            Some(checkpoint_viewed_at),
+            Some(checkpoint),
         )
         .await
         .extend()
@@ -418,15 +417,15 @@ impl Query {
         ctx: &Context<'_>,
         domain: Domain,
     ) -> Result<Option<Address>> {
-        let CheckpointViewedAt(checkpoint_viewed_at) = *ctx.data()?;
+        let Watermark { checkpoint, .. } = *ctx.data()?;
         Ok(
-            SuinsRegistration::resolve_to_record(ctx, &domain, Some(checkpoint_viewed_at))
+            SuinsRegistration::resolve_to_record(ctx, &domain, Some(checkpoint))
                 .await
                 .extend()?
                 .and_then(|r| r.target_address)
                 .map(|a| Address {
                     address: a.into(),
-                    checkpoint_viewed_at: Some(checkpoint_viewed_at),
+                    checkpoint_viewed_at: Some(checkpoint),
                 }),
         )
     }


### PR DESCRIPTION
Cherrypick change to extend the existing checkpoint watermark task to also report the current epoch. Additionally set up a watch channel to notify listeners on epoch change.


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
