### PR TITLE
indexer easy: add metrics for object snapshot backfill

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -291,7 +291,7 @@ impl ExecutorCluster {
 
         let latest_cp = self
             .indexer_store
-            .get_latest_tx_checkpoint_sequence_number()
+            .get_latest_checkpoint_sequence_number()
             .await
             .unwrap()
             .unwrap();
@@ -323,7 +323,7 @@ impl ExecutorCluster {
 
     pub async fn force_objects_snapshot_catchup(&self, start_cp: u64, end_cp: u64) {
         self.indexer_store
-            .persist_object_snapshot(start_cp, end_cp)
+            .update_objects_snapshot(start_cp, end_cp)
             .await
             .unwrap();
 

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -217,11 +217,15 @@ async fn commit_checkpoints<S>(
     metrics
         .latest_tx_checkpoint_sequence_number
         .set(last_checkpoint_seq as i64);
-
     metrics
         .total_tx_checkpoint_committed
         .inc_by(checkpoint_num as u64);
     metrics.total_transaction_committed.inc_by(tx_count as u64);
+    if object_snapshot_backfill_mode {
+        metrics
+            .latest_object_snapshot_sequence_number
+            .set(last_checkpoint_seq as i64);
+    }
     info!(
         elapsed,
         "Checkpoint {}-{} committed with {} transactions.",

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -3,12 +3,12 @@
 
 use std::collections::BTreeMap;
 
+use tap::tap::TapFallible;
 use tokio::sync::watch;
 use tracing::instrument;
-
-use tap::tap::TapFallible;
 use tracing::{error, info};
 
+use sui_rest_api::Client;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::metrics::IndexerMetrics;
@@ -18,9 +18,11 @@ use crate::types::IndexerResult;
 use super::{CheckpointDataToCommit, EpochToCommit};
 
 const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
+const OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG: u64 = 900;
 
 pub async fn start_tx_checkpoint_commit_task<S>(
     state: S,
+    client: Client,
     metrics: IndexerMetrics,
     tx_indexing_receiver: mysten_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
     commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
@@ -38,11 +40,29 @@ pub async fn start_tx_checkpoint_commit_task<S>(
 
     let mut stream = mysten_metrics::metered_channel::ReceiverStream::new(tx_indexing_receiver)
         .ready_chunks(checkpoint_commit_batch_size);
+    let mut object_snapshot_backfill_mode = true;
 
     while let Some(indexed_checkpoint_batch) = stream.next().await {
         if indexed_checkpoint_batch.is_empty() {
             continue;
         }
+
+        let mut latest_fn_cp_res = client.get_latest_checkpoint().await;
+        while let Err(_) = latest_fn_cp_res {
+            error!("Failed to get latest checkpoint from the network");
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            latest_fn_cp_res = client.get_latest_checkpoint().await;
+        }
+        // unwrap is safe here because we checked that latest_fn_cp_res is Ok above
+        let latest_fn_cp = latest_fn_cp_res.unwrap().sequence_number;
+        // unwrap is safe b/c we checked for empty batch above
+        let latest_committed_cp = indexed_checkpoint_batch
+            .last()
+            .clone()
+            .unwrap()
+            .checkpoint
+            .sequence_number;
+
         // split the batch into smaller batches per epoch to handle partitioning
         let mut indexed_checkpoint_batch_per_epoch = vec![];
         for indexed_checkpoint in indexed_checkpoint_batch {
@@ -55,6 +75,7 @@ pub async fn start_tx_checkpoint_commit_task<S>(
                     epoch,
                     &metrics,
                     &commit_notifier,
+                    object_snapshot_backfill_mode,
                 )
                 .await;
                 indexed_checkpoint_batch_per_epoch = vec![];
@@ -67,8 +88,12 @@ pub async fn start_tx_checkpoint_commit_task<S>(
                 None,
                 &metrics,
                 &commit_notifier,
+                object_snapshot_backfill_mode,
             )
             .await;
+        }
+        if latest_committed_cp + OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG > latest_fn_cp {
+            object_snapshot_backfill_mode = false;
         }
     }
 }
@@ -84,6 +109,7 @@ async fn commit_checkpoints<S>(
     epoch: Option<EpochToCommit>,
     metrics: &IndexerMetrics,
     commit_notifier: &watch::Sender<Option<CheckpointSequenceNumber>>,
+    object_snapshot_backfill_mode: bool,
 ) where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
@@ -140,6 +166,9 @@ async fn commit_checkpoints<S>(
             state.persist_objects(object_changes_batch.clone()),
             state.persist_object_history(object_history_changes_batch.clone()),
         ];
+        if object_snapshot_backfill_mode {
+            persist_tasks.push(state.persist_objects_snapshot(object_changes_batch));
+        }
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));
         }

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -120,8 +120,10 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_transactions_chunks: Histogram,
     pub checkpoint_db_commit_latency_transactions_chunks_transformation: Histogram,
     pub checkpoint_db_commit_latency_objects: Histogram,
+    pub checkpoint_db_commit_latency_objects_snapshot: Histogram,
     pub checkpoint_db_commit_latency_objects_history: Histogram,
     pub checkpoint_db_commit_latency_objects_chunks: Histogram,
+    pub checkpoint_db_commit_latency_objects_snapshot_chunks: Histogram,
     pub checkpoint_db_commit_latency_objects_history_chunks: Histogram,
     pub checkpoint_db_commit_latency_events: Histogram,
     pub checkpoint_db_commit_latency_events_chunks: Histogram,
@@ -403,6 +405,13 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            checkpoint_db_commit_latency_objects_snapshot: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_objects_snapshots",
+                "Time spent commiting objects snapshots",
+                DB_COMMIT_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
             checkpoint_db_commit_latency_objects_history: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_objects_history",
                 "Time spent commiting objects history",
@@ -412,6 +421,13 @@ impl IndexerMetrics {
             checkpoint_db_commit_latency_objects_chunks: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_objects_chunks",
                 "Time spent commiting objects chunks",
+                DB_COMMIT_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            checkpoint_db_commit_latency_objects_snapshot_chunks: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_objects_snapshot_chunks",
+                "Time spent commiting objects snapshot chunks",
                 DB_COMMIT_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -179,9 +179,9 @@ impl From<StoredDeletedObject> for StoredDeletedObjectSnapshot {
     fn from(o: StoredDeletedObject) -> Self {
         Self {
             object_id: o.object_id.to_vec(),
-            object_version: o.object_version as i64,
+            object_version: o.object_version,
             object_status: ObjectStatus::WrappedOrDeleted as i16,
-            checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
+            checkpoint_sequence_number: o.checkpoint_sequence_number,
         }
     }
 }

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -18,7 +18,7 @@ use sui_types::object::Object;
 use sui_types::object::ObjectRead;
 
 use crate::errors::IndexerError;
-use crate::schema::{objects, objects_history};
+use crate::schema::{objects, objects_history, objects_snapshot};
 use crate::types::{IndexedDeletedObject, IndexedObject, ObjectStatus};
 
 #[derive(Queryable)]
@@ -61,6 +61,48 @@ pub struct StoredObject {
     pub df_name: Option<Vec<u8>>,
     pub df_object_type: Option<String>,
     pub df_object_id: Option<Vec<u8>>,
+}
+
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = objects_snapshot, primary_key(object_id))]
+pub struct StoredObjectSnapshot {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub object_status: i16,
+    pub object_digest: Option<Vec<u8>>,
+    pub checkpoint_sequence_number: i64,
+    pub owner_type: Option<i16>,
+    pub owner_id: Option<Vec<u8>>,
+    pub object_type: Option<String>,
+    pub serialized_object: Option<Vec<u8>>,
+    pub coin_type: Option<String>,
+    pub coin_balance: Option<i64>,
+    pub df_kind: Option<i16>,
+    pub df_name: Option<Vec<u8>>,
+    pub df_object_type: Option<String>,
+    pub df_object_id: Option<Vec<u8>>,
+}
+
+impl From<StoredObject> for StoredObjectSnapshot {
+    fn from(o: StoredObject) -> Self {
+        Self {
+            object_id: o.object_id,
+            object_version: o.object_version,
+            object_status: ObjectStatus::Active as i16,
+            object_digest: Some(o.object_digest),
+            checkpoint_sequence_number: o.checkpoint_sequence_number,
+            owner_type: Some(o.owner_type),
+            owner_id: o.owner_id,
+            object_type: o.object_type,
+            serialized_object: Some(o.serialized_object),
+            coin_type: o.coin_type,
+            coin_balance: o.coin_balance,
+            df_kind: o.df_kind,
+            df_name: o.df_name,
+            df_object_type: o.df_object_type,
+            df_object_id: o.df_object_id,
+        }
+    }
 }
 
 #[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
@@ -118,6 +160,27 @@ impl From<IndexedDeletedObject> for StoredDeletedObject {
         Self {
             object_id: o.object_id.to_vec(),
             object_version: o.object_version as i64,
+            checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
+        }
+    }
+}
+
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = objects_snapshot, primary_key(object_id))]
+
+pub struct StoredDeletedObjectSnapshot {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub object_status: i16,
+    pub checkpoint_sequence_number: i64,
+}
+
+impl From<StoredDeletedObject> for StoredDeletedObjectSnapshot {
+    fn from(o: StoredDeletedObject) -> Self {
+        Self {
+            object_id: o.object_id.to_vec(),
+            object_version: o.object_version as i64,
+            object_status: ObjectStatus::WrappedOrDeleted as i16,
             checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
         }
     }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -20,7 +20,7 @@ pub enum ObjectChangeToCommit {
 
 #[async_trait]
 pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
-    async fn get_latest_tx_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError>;
+    async fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError>;
 
     async fn get_latest_object_snapshot_checkpoint_sequence_number(
         &self,
@@ -36,7 +36,14 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_object_snapshot(&self, start_cp: u64, end_cp: u64)
+    // persist objects snapshot with object changes during backfill
+    async fn persist_objects_snapshot(
+        &self,
+        object_changes: Vec<TransactionObjectChangesToCommit>,
+    ) -> Result<(), IndexerError>;
+
+    // update objects snapshot after backfill is done
+    async fn update_objects_snapshot(&self, start_cp: u64, end_cp: u64)
         -> Result<(), IndexerError>;
 
     async fn persist_checkpoints(

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -37,7 +37,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     ) -> Result<(), IndexerError>;
 
     // persist objects snapshot with object changes during backfill
-    async fn persist_objects_snapshot(
+    async fn backfill_objects_snapshot(
         &self,
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -31,7 +31,8 @@ use crate::models::display::StoredDisplay;
 use crate::models::epoch::StoredEpochInfo;
 use crate::models::events::StoredEvent;
 use crate::models::objects::{
-    StoredDeletedHistoryObject, StoredDeletedObject, StoredHistoryObject, StoredObject,
+    StoredDeletedHistoryObject, StoredDeletedObject, StoredDeletedObjectSnapshot,
+    StoredHistoryObject, StoredObject, StoredObjectSnapshot,
 };
 use crate::models::packages::StoredPackage;
 use crate::models::transactions::StoredTransaction;
@@ -68,7 +69,7 @@ const PG_COMMIT_PARALLEL_CHUNK_SIZE: usize = 100;
 // The amount of rows to update in one DB transcation, for objects particularly
 // Having this number too high may cause many db deadlocks because of
 // optimistic locking.
-const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE: usize = 500;
+const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE: usize = 1000;
 
 // with rn = 1, we only select the latest version of each object,
 // so that we don't have to update the same object multiple times.
@@ -134,7 +135,7 @@ impl PgIndexerStore {
         self.blocking_cp.clone()
     }
 
-    fn get_latest_tx_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError> {
+    fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError> {
         read_only_blocking!(&self.blocking_cp, |conn| {
             checkpoints::dsl::checkpoints
                 .select(max(checkpoints::sequence_number))
@@ -271,6 +272,103 @@ impl PgIndexerStore {
         })
     }
 
+    fn persist_objects_snapshot_chunk(
+        &self,
+        objects: Vec<ObjectChangeToCommit>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_objects_snapshot_chunks
+            .start_timer();
+        let mut mutated_objects: Vec<StoredObjectSnapshot> = vec![];
+        let mut deleted_object_ids: Vec<StoredDeletedObjectSnapshot> = vec![];
+
+        for object in objects {
+            match object {
+                ObjectChangeToCommit::MutatedObject(stored_object) => {
+                    mutated_objects.push(stored_object.into());
+                }
+                ObjectChangeToCommit::DeletedObject(stored_deleted_object) => {
+                    deleted_object_ids.push(stored_deleted_object.into());
+                }
+            }
+        }
+
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                for mutated_object_change_chunk in
+                    mutated_objects.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX)
+                {
+                    diesel::insert_into(objects_snapshot::table)
+                        .values(mutated_object_change_chunk)
+                        .on_conflict(objects_snapshot::object_id)
+                        .do_update()
+                        .set((
+                            objects_snapshot::object_version
+                                .eq(excluded(objects_snapshot::object_version)),
+                            objects_snapshot::object_status
+                                .eq(excluded(objects_snapshot::object_status)),
+                            objects_snapshot::object_digest
+                                .eq(excluded(objects_snapshot::object_digest)),
+                            objects_snapshot::checkpoint_sequence_number
+                                .eq(excluded(objects_snapshot::checkpoint_sequence_number)),
+                            objects_snapshot::owner_type.eq(excluded(objects_snapshot::owner_type)),
+                            objects_snapshot::owner_id.eq(excluded(objects_snapshot::owner_id)),
+                            objects_snapshot::object_type
+                                .eq(excluded(objects_snapshot::object_type)),
+                            objects_snapshot::serialized_object
+                                .eq(excluded(objects_snapshot::serialized_object)),
+                            objects_snapshot::coin_type.eq(excluded(objects_snapshot::coin_type)),
+                            objects_snapshot::coin_balance
+                                .eq(excluded(objects_snapshot::coin_balance)),
+                            objects_snapshot::df_kind.eq(excluded(objects_snapshot::df_kind)),
+                            objects_snapshot::df_name.eq(excluded(objects_snapshot::df_name)),
+                            objects_snapshot::df_object_type
+                                .eq(excluded(objects_snapshot::df_object_type)),
+                            objects_snapshot::df_object_id
+                                .eq(excluded(objects_snapshot::df_object_id)),
+                        ))
+                        .execute(conn)
+                        .map_err(IndexerError::from)
+                        .context("Failed to write object mutations to objects_snapshot in DB.")?;
+                }
+
+                for deleted_objects_chunk in
+                    deleted_object_ids.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX)
+                {
+                    diesel::insert_into(objects_snapshot::table)
+                        .values(deleted_objects_chunk)
+                        .on_conflict(objects_snapshot::object_id)
+                        .do_update()
+                        .set((
+                            objects_snapshot::object_id.eq(excluded(objects_snapshot::object_id)),
+                            objects_snapshot::object_version
+                                .eq(excluded(objects_snapshot::object_version)),
+                            objects_snapshot::object_status
+                                .eq(excluded(objects_snapshot::object_status)),
+                            objects_snapshot::checkpoint_sequence_number
+                                .eq(excluded(objects_snapshot::checkpoint_sequence_number)),
+                        ))
+                        .execute(conn)
+                        .map_err(IndexerError::from)
+                        .context("Failed to write object deletions to objects_snapshot in DB.")?;
+                }
+
+                Ok::<(), IndexerError>(())
+            },
+            Duration::from_secs(60)
+        )
+        .tap(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(
+                elapsed,
+                "Persisted {} chunked objects snapshot",
+                mutated_objects.len() + deleted_object_ids.len(),
+            )
+        })
+    }
+
     fn persist_objects_history_chunk(
         &self,
         objects: Vec<ObjectChangeToCommit>,
@@ -331,7 +429,7 @@ impl PgIndexerStore {
         })
     }
 
-    fn persist_object_snapshot(&self, start_cp: u64, end_cp: u64) -> Result<(), IndexerError> {
+    fn update_objects_snapshot(&self, start_cp: u64, end_cp: u64) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
@@ -826,8 +924,8 @@ impl PgIndexerStore {
 
 #[async_trait]
 impl IndexerStore for PgIndexerStore {
-    async fn get_latest_tx_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError> {
-        self.execute_in_blocking_worker(|this| this.get_latest_tx_checkpoint_sequence_number())
+    async fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError> {
+        self.execute_in_blocking_worker(|this| this.get_latest_checkpoint_sequence_number())
             .await
     }
 
@@ -874,6 +972,40 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
+    async fn persist_objects_snapshot(
+        &self,
+        object_changes: Vec<TransactionObjectChangesToCommit>,
+    ) -> Result<(), IndexerError> {
+        if object_changes.is_empty() {
+            return Ok(());
+        }
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_objects_snapshot
+            .start_timer();
+        let objects = make_final_list_of_objects_to_commit(object_changes);
+        let len = objects.len();
+        let chunks = chunk!(objects, self.parallel_objects_chunk_size);
+        let futures = chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_objects_snapshot_chunk(c)))
+            .collect::<Vec<_>>();
+
+        futures::future::join_all(futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWriteError(format!(
+                    "Failed to persist all objects snapshot chunks: {:?}",
+                    e
+                ))
+            })?;
+        let elapsed = guard.stop_and_record();
+        info!(elapsed, "Persisted {} objects snapshot", len);
+        Ok(())
+    }
+
     async fn persist_object_history(
         &self,
         object_changes: Vec<TransactionObjectChangesToCommit>,
@@ -917,7 +1049,7 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_object_snapshot(
+    async fn update_objects_snapshot(
         &self,
         start_cp: u64,
         end_cp: u64,
@@ -932,7 +1064,7 @@ impl IndexerStore for PgIndexerStore {
 
         let guard = self.metrics.update_object_snapshot_latency.start_timer();
 
-        self.spawn_blocking_task(move |this| this.persist_object_snapshot(start_cp, end_cp))
+        self.spawn_blocking_task(move |this| this.update_objects_snapshot(start_cp, end_cp))
             .await
             .map_err(|e| {
                 IndexerError::PostgresWriteError(format!(

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -272,7 +272,7 @@ impl PgIndexerStore {
         })
     }
 
-    fn persist_objects_snapshot_chunk(
+    fn backfill_objects_snapshot_chunk(
         &self,
         objects: Vec<ObjectChangeToCommit>,
     ) -> Result<(), IndexerError> {
@@ -972,7 +972,7 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_objects_snapshot(
+    async fn backfill_objects_snapshot(
         &self,
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError> {
@@ -988,7 +988,7 @@ impl IndexerStore for PgIndexerStore {
         let chunks = chunk!(objects, self.parallel_objects_chunk_size);
         let futures = chunks
             .into_iter()
-            .map(|c| self.spawn_blocking_task(move |this| this.persist_objects_snapshot_chunk(c)))
+            .map(|c| self.spawn_blocking_task(move |this| this.backfill_objects_snapshot_chunk(c)))
             .collect::<Vec<_>>();
 
         futures::future::join_all(futures)

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -77,7 +77,7 @@ mod ingestion_tests {
         tokio::time::timeout(Duration::from_secs(10), async {
             while {
                 let cp_opt = pg_store
-                    .get_latest_tx_checkpoint_sequence_number()
+                    .get_latest_checkpoint_sequence_number()
                     .await
                     .unwrap();
                 cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)


### PR DESCRIPTION
## Description 

to monitor the object snapshot rate while backfilling


## Test plan 

CI and monitor via deploying to benchmark 
https://github.com/MystenLabs/sui-operations/actions/workflows/sui-rpc.yaml

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
