### PR TITLE
indexer breaking change: merge back tx_ tables

### DIFF
--- a/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
@@ -4,8 +4,7 @@ CREATE TABLE tx_senders (
     -- SuiAddress in bytes.
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(sender, tx_sequence_number, cp_sequence_number)
-) PARTITION BY RANGE (cp_sequence_number);
-CREATE TABLE tx_senders_partition_0 PARTITION OF tx_senders FOR VALUES FROM (0) TO (MAXVALUE);
+);
 CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_recipients (
@@ -14,8 +13,7 @@ CREATE TABLE tx_recipients (
     -- SuiAddress in bytes.
     recipient                   BYTEA        NOT NULL,
     PRIMARY KEY(recipient, tx_sequence_number, cp_sequence_number)
-) PARTITION BY RANGE (cp_sequence_number);
-CREATE TABLE tx_recipients_partition_0 PARTITION OF tx_recipients FOR VALUES FROM (0) TO (MAXVALUE);
+);
 CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_input_objects (
@@ -24,8 +22,7 @@ CREATE TABLE tx_input_objects (
     -- Object ID in bytes. 
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
-) PARTITION BY RANGE (cp_sequence_number);
-CREATE TABLE tx_input_objects_partition_0 PARTITION OF tx_input_objects FOR VALUES FROM (0) TO (MAXVALUE);
+);
 
 CREATE TABLE tx_changed_objects (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -33,8 +30,7 @@ CREATE TABLE tx_changed_objects (
     -- Object Id in bytes.
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
-) PARTITION BY RANGE (cp_sequence_number);
-CREATE TABLE tx_changed_objects_partition_0 PARTITION OF tx_changed_objects FOR VALUES FROM (0) TO (MAXVALUE);
+);
 
 CREATE TABLE tx_calls (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -45,8 +41,7 @@ CREATE TABLE tx_calls (
     -- 1. Using Primary Key as a unique index.
     -- 2. Diesel does not like tables with no primary key.
     PRIMARY KEY(package, tx_sequence_number, cp_sequence_number)
-) PARTITION BY RANGE (cp_sequence_number);
-CREATE TABLE tx_calls_partition_0 PARTITION OF tx_calls FOR VALUES FROM (0) TO (MAXVALUE);
+);
 CREATE INDEX tx_calls_module ON tx_calls (package, module, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_func ON tx_calls (package, module, func, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number, cp_sequence_number);

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -233,25 +233,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    tx_calls_partition_0 (package, tx_sequence_number, cp_sequence_number) {
-        cp_sequence_number -> Int8,
-        tx_sequence_number -> Int8,
-        package -> Bytea,
-        module -> Text,
-        func -> Text,
-    }
-}
-
-diesel::table! {
     tx_changed_objects (object_id, tx_sequence_number, cp_sequence_number) {
-        cp_sequence_number -> Int8,
-        tx_sequence_number -> Int8,
-        object_id -> Bytea,
-    }
-}
-
-diesel::table! {
-    tx_changed_objects_partition_0 (object_id, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         object_id -> Bytea,
@@ -267,14 +249,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    tx_input_objects_partition_0 (object_id, tx_sequence_number, cp_sequence_number) {
-        cp_sequence_number -> Int8,
-        tx_sequence_number -> Int8,
-        object_id -> Bytea,
-    }
-}
-
-diesel::table! {
     tx_recipients (recipient, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
@@ -283,23 +257,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    tx_recipients_partition_0 (recipient, tx_sequence_number, cp_sequence_number) {
-        cp_sequence_number -> Int8,
-        tx_sequence_number -> Int8,
-        recipient -> Bytea,
-    }
-}
-
-diesel::table! {
     tx_senders (sender, tx_sequence_number, cp_sequence_number) {
-        cp_sequence_number -> Int8,
-        tx_sequence_number -> Int8,
-        sender -> Bytea,
-    }
-}
-
-diesel::table! {
-    tx_senders_partition_0 (sender, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         sender -> Bytea,
@@ -320,13 +278,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     transactions,
     transactions_partition_0,
     tx_calls,
-    tx_calls_partition_0,
     tx_changed_objects,
-    tx_changed_objects_partition_0,
     tx_input_objects,
-    tx_input_objects_partition_0,
     tx_recipients,
-    tx_recipients_partition_0,
     tx_senders,
-    tx_senders_partition_0,
 );


### PR DESCRIPTION
## Description 

the original intention was to partition tx_ tables such that they can be easily pruned by dropping old partitions, however that indicates that for each query with a "lookup key" like sender, we will have to scan all partitions, which can be costly.

also after pulling the numbers from DB, the sizes of these tables are relatively small and thus we can take the extra storage for now in favor of reading side perf.

## Test plan 

benchmark and experiment 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
