### PR TITLE
Update shared object overload config

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -741,8 +741,16 @@ pub struct AuthorityOverloadConfig {
     // is overloaded.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub check_system_overload_at_execution: bool,
-    // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
-    // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
+
+    // Reject a transaction if transaction manager queue length is above this threshold.
+    // 100_000 = 10k TPS * 5s resident time in transaction manager (pending + executing) * 2.
+    #[serde(default = "default_max_transaction_manager_queue_length")]
+    pub max_transaction_manager_queue_length: usize,
+
+    // Reject a transaction if the number of pending transactions depending on the object
+    // is above the threshold.
+    #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
+    pub max_transaction_manager_per_object_queue_length: usize,
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
@@ -777,6 +785,14 @@ fn default_check_system_overload_at_signing() -> bool {
     true
 }
 
+fn default_max_transaction_manager_queue_length() -> usize {
+    100_000
+}
+
+fn default_max_transaction_manager_per_object_queue_length() -> usize {
+    200
+}
+
 impl Default for AuthorityOverloadConfig {
     fn default() -> Self {
         Self {
@@ -790,6 +806,9 @@ impl Default for AuthorityOverloadConfig {
             safe_transaction_ready_rate: default_safe_transaction_ready_rate(),
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
+            max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
+            max_transaction_manager_per_object_queue_length:
+                default_max_transaction_manager_per_object_queue_length(),
         }
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -993,7 +993,7 @@ impl AuthorityState {
             self.check_authority_overload(tx_data)?;
         }
         self.transaction_manager
-            .check_execution_overload(&self.overload_config(), tx_data)?;
+            .check_execution_overload(self.overload_config(), tx_data)?;
         consensus_adapter.check_consensus_overload()?;
         Ok(())
     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -826,8 +826,8 @@ impl AuthorityState {
         self.committee_store.clone()
     }
 
-    pub fn max_txn_age_in_queue(&self) -> Duration {
-        self.authority_overload_config.max_txn_age_in_queue
+    pub fn overload_config(&self) -> &AuthorityOverloadConfig {
+        &self.authority_overload_config
     }
 
     pub fn get_epoch_state_commitments(
@@ -993,7 +993,7 @@ impl AuthorityState {
             self.check_authority_overload(tx_data)?;
         }
         self.transaction_manager
-            .check_execution_overload(self.max_txn_age_in_queue(), tx_data)?;
+            .check_execution_overload(&self.overload_config(), tx_data)?;
         consensus_adapter.check_consensus_overload()?;
         Ok(())
     }

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -579,7 +579,7 @@ async fn test_per_object_overload() {
         .build_and_sign(&key);
     let res = authorities[3]
         .transaction_manager()
-        .check_execution_overload(authorities[3].max_txn_age_in_queue(), shared_txn.data());
+        .check_execution_overload(&authorities[3].overload_config(), shared_txn.data());
     let message = format!("{res:?}");
     assert!(
         message.contains("TooManyTransactionsPendingOnObject"),
@@ -707,7 +707,7 @@ async fn test_txn_age_overload() {
         .build_and_sign(&key);
     let res = authorities[3]
         .transaction_manager()
-        .check_execution_overload(authorities[3].max_txn_age_in_queue(), shared_txn.data());
+        .check_execution_overload(authorities[3].overload_config(), shared_txn.data());
     let message = format!("{res:?}");
     assert!(
         message.contains("TooOldTransactionPendingOnObject"),

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -21,7 +21,6 @@ use crate::test_utils::{
     init_local_authorities, init_local_authorities_with_overload_thresholds,
     make_transfer_object_move_transaction,
 };
-use crate::transaction_manager::MAX_PER_OBJECT_QUEUE_LENGTH;
 use sui_types::error::SuiError;
 
 use std::collections::BTreeSet;
@@ -545,7 +544,10 @@ async fn test_per_object_overload() {
     // Sign and try execute 1000 txns on the first three authorities. And enqueue them on the last authority.
     // First shared counter txn has input object available on authority 3. So to overload authority 3, 1 more
     // txn is needed.
-    let num_txns = MAX_PER_OBJECT_QUEUE_LENGTH + 1;
+    let num_txns = authorities[3]
+        .overload_config()
+        .max_transaction_manager_per_object_queue_length
+        + 1;
     for gas_object in gas_objects.iter().take(num_txns) {
         let gas_ref = get_latest_ref(authority_clients[0].clone(), gas_object.id()).await;
         let shared_txn = TestTransactionBuilder::new(addr, gas_ref, rgp)
@@ -579,7 +581,7 @@ async fn test_per_object_overload() {
         .build_and_sign(&key);
     let res = authorities[3]
         .transaction_manager()
-        .check_execution_overload(&authorities[3].overload_config(), shared_txn.data());
+        .check_execution_overload(authorities[3].overload_config(), shared_txn.data());
     let message = format!("{res:?}");
     assert!(
         message.contains("TooManyTransactionsPendingOnObject"),

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -130,6 +130,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -257,6 +259,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -384,6 +388,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -511,6 +517,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -638,6 +646,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -765,6 +775,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -892,6 +904,8 @@ validator_configs:
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
+      max-transaction-manager-queue-length: 100000
+      max-transaction-manager-per-object-queue-length: 200
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=
@@ -899,4 +913,3 @@ account_keys:
   - mfPjCoE6SX0Sl84MnmNS/LS+tfPpkn7I8tziuk2g0WM=
   - 5RWlYF22jS9i76zLl8jP2D3D8GC5ht+IP1dWUBGZxi8=
 genesis: "[fake genesis]"
-


### PR DESCRIPTION
## Description 

Move `MAX_TM_QUEUE_LENGTH` and `MAX_PER_OBJECT_QUEUE_LENGTH` to AuthorityOverloadConfig, so that changing them doesn't require a new release.

This PR just move the config, and should be a no-op

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
