### PR TITLE
[bridge/70] cache the result of get_mutable_bridge_object_arg

### DIFF
--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -19,7 +19,6 @@ use sui_types::{
     transaction::Transaction,
 };
 
-use crate::error::BridgeResult;
 use crate::{
     client::bridge_authority_aggregator::BridgeAuthorityAggregator,
     error::BridgeError,
@@ -94,9 +93,11 @@ where
         key: SuiKeyPair,
         sui_address: SuiAddress,
         gas_object_id: ObjectID,
-    ) -> BridgeResult<Self> {
-        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await?;
-        Ok(Self {
+    ) -> Self {
+        let bridge_object_arg = sui_client
+            .get_mutable_bridge_object_arg_must_succeed()
+            .await;
+        Self {
             sui_client,
             bridge_auth_agg,
             store,
@@ -104,7 +105,7 @@ where
             gas_object_id,
             sui_address,
             bridge_object_arg,
-        })
+        }
     }
 
     fn run_inner(
@@ -1088,8 +1089,7 @@ mod tests {
             sui_address,
             gas_object_ref.0,
         )
-        .await
-        .unwrap();
+        .await;
 
         let (executor_handle, signing_tx, execution_tx) = executor.run_inner();
         handles.extend(executor_handle);

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -179,9 +179,8 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
     // Now let the recipient send the coin back to ETH
     let eth_address_1 = EthAddress::random();
     let bridge_obj_arg = sui_bridge_client
-        .get_mutable_bridge_object_arg()
-        .await
-        .unwrap();
+        .get_mutable_bridge_object_arg_must_succeed()
+        .await;
     let nonce = 0;
 
     let sui_token_type_tags = sui_bridge_client.get_token_id_map().await.unwrap();

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -147,8 +147,7 @@ async fn start_client_components(
         client_config.sui_address,
         client_config.gas_object_ref.0,
     )
-    .await
-    .expect("Failed to create bridge action executor");
+    .await;
 
     let orchestrator =
         BridgeOrchestrator::new(sui_client, sui_events_rx, eth_events_rx, store.clone());

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -624,7 +624,9 @@ mod tests {
         let context = &mut test_cluster.wallet;
         let sender = context.active_address().unwrap();
         let usdc_amount = 5000000;
-        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+        let bridge_object_arg = sui_client
+            .get_mutable_bridge_object_arg_must_succeed()
+            .await;
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // 1. Test Eth -> Sui Transfer approval
@@ -692,7 +694,9 @@ mod tests {
         assert!(!summary.is_frozen);
 
         let context = &mut test_cluster.wallet;
-        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+        let bridge_object_arg = sui_client
+            .get_mutable_bridge_object_arg_must_succeed()
+            .await;
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // 1. Pause
@@ -757,7 +761,9 @@ mod tests {
         }
 
         let context = &mut test_cluster.wallet;
-        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+        let bridge_object_arg = sui_client
+            .get_mutable_bridge_object_arg_must_succeed()
+            .await;
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // 1. blocklist The victim
@@ -842,7 +848,9 @@ mod tests {
             .collect::<HashMap<_, _>>();
 
         let context = &mut test_cluster.wallet;
-        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+        let bridge_object_arg = sui_client
+            .get_mutable_bridge_object_arg_must_succeed()
+            .await;
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // update limit
@@ -898,7 +906,9 @@ mod tests {
         assert_ne!(notional_values[&TOKEN_ID_USDC], 69_000 * USD_MULTIPLIER);
 
         let context = &mut test_cluster.wallet;
-        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+        let bridge_object_arg = sui_client
+            .get_mutable_bridge_object_arg_must_succeed()
+            .await;
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // update price

--- a/crates/sui-bridge/src/tools/cli.rs
+++ b/crates/sui-bridge/src/tools/cli.rs
@@ -90,9 +90,8 @@ async fn main() -> anyhow::Result<()> {
                     .await
                     .expect("Failed to request committee signatures");
                 let bridge_arg = sui_client
-                    .get_mutable_bridge_object_arg()
-                    .await
-                    .expect("Failed to get mutable bridge object arg");
+                    .get_mutable_bridge_object_arg_must_succeed()
+                    .await;
                 let id_token_map = sui_client.get_token_id_map().await.unwrap();
                 let tx = build_sui_transaction(
                     sui_address,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -367,9 +367,8 @@ impl SuiCommand {
                 println!("rpc_url: {}", rpc_url);
                 let sui_bridge_client = SuiBridgeClient::new(rpc_url).await?;
                 let bridge_arg = sui_bridge_client
-                    .get_mutable_bridge_object_arg()
-                    .await
-                    .unwrap();
+                    .get_mutable_bridge_object_arg_must_succeed()
+                    .await;
                 assert_eq!(
                     network_config.validator_configs().len(),
                     bridge_committee_config


### PR DESCRIPTION
## Description 

instead of querying the bridge arg on chain every time, we do this in the beginning of the program and cache it. If the fetch (with retry) fails, it panics.

## Test plan 

existing tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
