### PR TITLE
Fix sui move build with --path argument when using relative path.

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -37,8 +37,8 @@ impl Build {
         path: Option<PathBuf>,
         build_config: MoveBuildConfig,
     ) -> anyhow::Result<()> {
-        let rerooted_path = base::reroot_path(path.clone())?;
-        let build_config = resolve_lock_file_path(build_config, path)?;
+        let rerooted_path = base::reroot_path(path)?;
+        let build_config = resolve_lock_file_path(build_config, rerooted_path.clone())?;
         Self::execute_internal(
             rerooted_path,
             build_config,

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -38,7 +38,7 @@ impl Build {
         build_config: MoveBuildConfig,
     ) -> anyhow::Result<()> {
         let rerooted_path = base::reroot_path(path)?;
-        let build_config = resolve_lock_file_path(build_config, rerooted_path.clone())?;
+        let build_config = resolve_lock_file_path(build_config, Some(rerooted_path.clone()))?;
         Self::execute_internal(
             rerooted_path,
             build_config,


### PR DESCRIPTION
## Description 

Fix a bug which reproduces with:
```
sui move new test_rel_path
sui move build --path ./test_rel_path
```

`base::reroot_path()` modifies cwd which results in a second call during `resolve_lock_file_path()` to abort.

## Test plan 

Run above commands with the committed changes.

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui move build --path <relative_path>` does not abort with os error 2
- [ ] Rust SDK: 
