### PR TITLE
[move-ide] Removed test dependency on Sui framework

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -6629,27 +6629,13 @@ fn implicit_uses_test() {
         &symbols,
         1,
         3,
-        12,
+        13,
         "implicit_uses.move",
-        64,
-        18,
-        "object.move",
-        "public struct sui::object::UID has store {\n\tid: sui::object::ID\n}",
-        Some((64, 18, "object.move")),
-    );
-    // implicit struct as parameter type
-    assert_use_def(
-        mod_symbols,
-        &symbols,
-        2,
         6,
-        29,
-        "implicit_uses.move",
-        20,
-        18,
-        "tx_context.move",
-        "public struct sui::tx_context::TxContext has drop {\n\tepoch: u64,\n\tepoch_timestamp_ms: u64,\n\tids_created: u64,\n\tsender: address,\n\ttx_hash: vector<u8>\n}",
-        Some((20, 18, "tx_context.move")),
+        11,
+        "option.move",
+        "public struct std::option::Option<Element> has copy, drop, store {\n\tvec: vector<Element>\n}",
+        Some((6, 11, "option.move")),
     );
     // implicit module name in function call
     assert_use_def(
@@ -6657,12 +6643,12 @@ fn implicit_uses_test() {
         &symbols,
         2,
         7,
-        18,
+        26,
         "implicit_uses.move",
-        4,
+        1,
         12,
-        "object.move",
-        "module sui::object",
+        "option.move",
+        "module std::option",
         None,
     );
 }

--- a/external-crates/move/crates/move-analyzer/tests/move-2024/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/move-2024/Move.toml
@@ -3,9 +3,8 @@ name = "Move2024"
 version = "0.0.1"
 edition = "2024.beta"
 
-#include Sui as dependency to test that importing it does not crash the symbolicator
 [dependencies]
-Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework/" }
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
 
 [addresses]
 Move2024 = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/move-2024/sources/implicit_uses.move
+++ b/external-crates/move/crates/move-analyzer/tests/move-2024/sources/implicit_uses.move
@@ -1,10 +1,10 @@
 module Move2024::implicit_uses {
 
-    public struct Obj {
-        id: UID
+    public struct SomeStruct {
+        opt: Option<u8>,
     }
 
-    public fun foo(ctx: &mut TxContext): Obj {
-        Obj { id: object::new(ctx) }
+    public fun foo(): SomeStruct {
+        SomeStruct { opt: option::some(42) }
     }
 }


### PR DESCRIPTION
## Description 

This PR removed a dependency of move-analyzer's tests on Sui framework code.

## Test plan 

Testing for implicit imports has been made dependent on Move stdlib instead.
