### PR TITLE
[1/n][dialect_support]Generalize indexer code to support different sql dialects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,9 +3471,12 @@ dependencies = [
  "chrono",
  "diesel_derives",
  "itoa",
+ "mysqlclient-sys",
+ "percent-encoding",
  "pq-sys",
  "r2d2",
  "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -7445,6 +7448,16 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "mysqlclient-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61b381528ba293005c42a409dd73d034508e273bf90481f17ec2e964a6e969b"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "mysten-common"
@@ -12125,6 +12138,7 @@ dependencies = [
  "async-trait",
  "clap",
  "derivative",
+ "diesel",
  "fastcrypto",
  "futures",
  "jsonrpsee",
@@ -12636,6 +12650,7 @@ dependencies = [
  "clap",
  "const-str",
  "diesel",
+ "downcast",
  "either",
  "expect-test",
  "fastcrypto",
@@ -12732,6 +12747,7 @@ dependencies = [
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
+ "downcast",
  "fastcrypto",
  "futures",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,14 +310,12 @@ derive_builder = "0.12.0"
 derive_more = "0.99.17"
 diesel = { version = "2.1.0", features = [
   "chrono",
-  "postgres",
   "r2d2",
   "serde_json",
   "64-column-tables",
   "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-  "postgres_backend",
 ] }
-diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
+diesel-derive-enum = { version = "2.0.1" }
 diesel_migrations = { version = "2.0.0" }
 dirs = "4.0.0"
 duration-str = "0.5.0"

--- a/crates/data-transform/src/main.rs
+++ b/crates/data-transform/src/main.rs
@@ -16,7 +16,7 @@ use sui_types::object::MoveObject;
 
 use self::models::*;
 use std::env;
-use sui_indexer::db::new_pg_connection_pool;
+use sui_indexer::db::new_connection_pool;
 use sui_indexer::errors::IndexerError;
 use sui_indexer::store::package_resolver::IndexerStorePackageResolver;
 
@@ -35,7 +35,7 @@ use move_core_types::account_address::AccountAddress;
 struct GrootModuleResolver {
     module_map: HashMap<String, Vec<u8>>,
     #[allow(dead_code)]
-    original: IndexerStorePackageResolver,
+    original: IndexerStorePackageResolver<PgConnection>,
 }
 
 impl GrootModuleResolver {
@@ -157,7 +157,7 @@ fn main() {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let connection = &mut establish_connection();
 
-    let blocking_cp = new_pg_connection_pool(&database_url, None)
+    let blocking_cp = new_connection_pool(&database_url, None)
         .map_err(|e| anyhow!("Unable to connect to Postgres, is it running? {e}"));
     //let module_cache = Arc::new(SyncModuleCache::new(IndexerModuleResolver::new(blocking_cp.expect("REASON").clone())));
     //

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { workspace = true, features = ["full"] }
 jsonrpsee.workspace = true
 tracing.workspace = true
 clap.workspace = true
+diesel.workspace = true
 reqwest.workspace = true
 async-trait.workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
@@ -44,4 +45,6 @@ test-cluster.workspace = true
 move-core-types.workspace = true
 
 [features]
+default = ["postgres-feature"]
+postgres-feature = ["diesel/postgres", "diesel/postgres_backend"]
 pg_integration = []

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -227,7 +227,7 @@ impl Cluster for LocalNewCluster {
             (options.pg_address.clone(), indexer_address)
         {
             // Start in writer mode
-            start_test_indexer(
+            start_test_indexer::<diesel::PgConnection>(
                 Some(pg_address.clone()),
                 fullnode_url.clone(),
                 ReaderWriterConfig::writer_mode(None),
@@ -236,7 +236,7 @@ impl Cluster for LocalNewCluster {
             .await;
 
             // Start in reader mode
-            start_test_indexer(
+            start_test_indexer::<diesel::PgConnection>(
                 Some(pg_address),
                 fullnode_url.clone(),
                 ReaderWriterConfig::reader_mode(indexer_address.to_string()),

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -60,6 +60,7 @@ tower-http.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 im.workspace = true
+downcast = "0.11.0"
 
 sui-graphql-rpc-headers.workspace = true
 sui-graphql-rpc-client.workspace = true
@@ -71,7 +72,7 @@ bcs.workspace = true
 simulacrum.workspace = true  # todo: cleanup test only deps
 sui-json-rpc.workspace = true
 sui-json-rpc-types.workspace = true
-sui-indexer.workspace = true
+sui-indexer = { workspace = true, default-features = true }
 sui-rest-api.workspace = true
 sui-swarm-config.workspace = true
 test-cluster.workspace = true
@@ -88,7 +89,9 @@ sui-framework.workspace = true
 tower.workspace = true
 sui-test-transaction-builder.workspace = true
 
+
 [features]
-default = ["pg_backend"]
+default = ["pg_backend", "postgres-feature"]
+postgres-feature = ["diesel/postgres", "diesel/postgres_backend"]
 pg_integration = []
 pg_backend = []

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -6,8 +6,9 @@ use crate::{
     error::Error,
     types::{address::Address, sui_address::SuiAddress, validator::Validator},
 };
+use diesel::PgConnection;
 use std::{collections::BTreeMap, time::Duration};
-use sui_indexer::db::PgConnectionPoolConfig;
+use sui_indexer::db::ConnectionPoolConfig;
 use sui_indexer::{apis::GovernanceReadApi, indexer_reader::IndexerReader};
 use sui_json_rpc_types::Stake as RpcStakedSui;
 use sui_types::{
@@ -19,16 +20,16 @@ use sui_types::{
 };
 
 pub(crate) struct PgManager {
-    pub inner: IndexerReader,
+    pub inner: IndexerReader<PgConnection>,
 }
 
 impl PgManager {
-    pub(crate) fn new(inner: IndexerReader) -> Self {
+    pub(crate) fn new(inner: IndexerReader<PgConnection>) -> Self {
         Self { inner }
     }
 
     /// Create a new underlying reader, which is used by this type as well as other data providers.
-    pub(crate) fn reader(db_url: impl Into<String>) -> Result<IndexerReader, Error> {
+    pub(crate) fn reader(db_url: impl Into<String>) -> Result<IndexerReader<PgConnection>, Error> {
         Self::reader_with_config(
             db_url,
             DEFAULT_SERVER_DB_POOL_SIZE,
@@ -40,11 +41,11 @@ impl PgManager {
         db_url: impl Into<String>,
         pool_size: u32,
         timeout_ms: u64,
-    ) -> Result<IndexerReader, Error> {
-        let mut config = PgConnectionPoolConfig::default();
+    ) -> Result<IndexerReader<PgConnection>, Error> {
+        let mut config = ConnectionPoolConfig::default();
         config.set_pool_size(pool_size);
         config.set_statement_timeout(Duration::from_millis(timeout_ms));
-        IndexerReader::new_with_config(db_url, config)
+        IndexerReader::<PgConnection>::new_with_config(db_url, config)
             .map_err(|e| Error::Internal(format!("Failed to create reader: {e}")))
     }
 }

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -14,11 +14,12 @@ use diesel::{
 };
 use sui_indexer::indexer_reader::IndexerReader;
 
+use sui_indexer::{run_query_async, run_query_repeatable_async, spawn_read_only_blocking};
 use tracing::error;
 
 #[derive(Clone)]
 pub(crate) struct PgExecutor {
-    pub inner: IndexerReader,
+    pub inner: IndexerReader<diesel::PgConnection>,
     pub limits: Limits,
     pub metrics: Metrics,
 }
@@ -29,7 +30,11 @@ pub(crate) struct PgConnection<'c> {
 }
 
 impl PgExecutor {
-    pub(crate) fn new(inner: IndexerReader, limits: Limits, metrics: Metrics) -> Self {
+    pub(crate) fn new(
+        inner: IndexerReader<diesel::PgConnection>,
+        limits: Limits,
+        metrics: Metrics,
+    ) -> Self {
         Self {
             inner,
             limits,
@@ -54,10 +59,8 @@ impl QueryExecutor for PgExecutor {
     {
         let max_cost = self.limits.max_db_query_cost;
         let instant = Instant::now();
-        let result = self
-            .inner
-            .run_query_async(move |conn| txn(&mut PgConnection { max_cost, conn }))
-            .await;
+        let pool = self.inner.get_pool();
+        let result = run_query_async!(&pool, move |conn| txn(&mut PgConnection { max_cost, conn }));
         self.metrics
             .observe_db_data(instant.elapsed(), result.is_ok());
         if let Err(e) = &result {
@@ -76,10 +79,11 @@ impl QueryExecutor for PgExecutor {
     {
         let max_cost = self.limits.max_db_query_cost;
         let instant = Instant::now();
-        let result = self
-            .inner
-            .run_query_repeatable_async(move |conn| txn(&mut PgConnection { max_cost, conn }))
-            .await;
+        let pool = self.inner.get_pool();
+        let result = run_query_repeatable_async!(&pool, move |conn| txn(&mut PgConnection {
+            max_cost,
+            conn
+        }));
         self.metrics
             .observe_db_data(instant.elapsed(), result.is_ok());
         if let Err(e) = &result {
@@ -187,7 +191,7 @@ mod tests {
     use diesel::QueryDsl;
     use sui_framework::BuiltInFramework;
     use sui_indexer::{
-        db::{get_pg_pool_connection, new_pg_connection_pool, reset_database},
+        db::{get_pool_connection, new_connection_pool, reset_database},
         models::objects::StoredObject,
         schema::objects,
         types::IndexedObject,
@@ -195,8 +199,9 @@ mod tests {
 
     #[test]
     fn test_query_cost() {
-        let pool = new_pg_connection_pool(DEFAULT_SERVER_DB_URL, Some(5)).unwrap();
-        let mut conn = get_pg_pool_connection(&pool).unwrap();
+        let pool =
+            new_connection_pool::<diesel::PgConnection>(DEFAULT_SERVER_DB_URL, Some(5)).unwrap();
+        let mut conn = get_pool_connection(&pool).unwrap();
         reset_database(&mut conn, /* drop_all */ true).unwrap();
 
         let objects: Vec<StoredObject> = BuiltInFramework::iter_system_packages()

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -37,7 +37,7 @@ pub const DEFAULT_INTERNAL_DATA_SOURCE_PORT: u16 = 3000;
 
 pub struct ExecutorCluster {
     pub executor_server_handle: JoinHandle<()>,
-    pub indexer_store: PgIndexerStore,
+    pub indexer_store: PgIndexerStore<diesel::PgConnection>,
     pub indexer_join_handle: JoinHandle<Result<(), IndexerError>>,
     pub graphql_server_join_handle: JoinHandle<()>,
     pub graphql_client: SimpleClient,
@@ -48,7 +48,7 @@ pub struct ExecutorCluster {
 
 pub struct Cluster {
     pub validator_fullnode_handle: TestCluster,
-    pub indexer_store: PgIndexerStore,
+    pub indexer_store: PgIndexerStore<diesel::PgConnection>,
     pub indexer_join_handle: JoinHandle<Result<(), IndexerError>>,
     pub graphql_server_join_handle: JoinHandle<()>,
     pub graphql_client: SimpleClient,
@@ -333,7 +333,7 @@ impl ExecutorCluster {
         self.cancellation_token.cancel();
         let _ = join!(self.graphql_server_join_handle, self.indexer_join_handle);
         let db_url = self.graphql_connection_config.db_url.clone();
-        force_delete_database(db_url).await;
+        force_delete_database::<diesel::PgConnection>(db_url).await;
     }
 
     pub async fn force_objects_snapshot_catchup(&self, start_cp: u64, end_cp: u64) {

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -16,8 +16,8 @@ chrono.workspace = true
 serde_with.workspace = true
 clap.workspace = true
 tap.workspace = true
-diesel.workspace = true
-diesel-derive-enum.workspace = true
+diesel = { workspace = true, optional = true }
+diesel-derive-enum = { workspace = true, optional = true }
 futures.workspace = true
 itertools.workspace = true
 jsonrpsee.workspace = true
@@ -56,9 +56,13 @@ move-binary-format.workspace = true
 diesel_migrations.workspace = true
 cached.workspace = true
 secrecy = "0.8.0"
+downcast = "0.11.0"
 
 [features]
 pg_integration = []
+default = ["postgres-feature"]
+postgres-feature = ["diesel/postgres", "diesel/postgres_backend", "diesel-derive-enum/postgres"]
+mysql-feature = ["diesel/mysql", "diesel/mysql_backend", "diesel-derive-enum/mysql"]
 
 [dev-dependencies]
 sui-keys.workspace = true

--- a/crates/sui-indexer/src/apis/coin_api.rs
+++ b/crates/sui-indexer/src/apis/coin_api.rs
@@ -3,6 +3,7 @@
 
 use crate::indexer_reader::IndexerReader;
 use async_trait::async_trait;
+use diesel::r2d2::R2D2Connection;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use sui_json_rpc::coin_api::{parse_to_struct_tag, parse_to_type_tag};
@@ -14,18 +15,18 @@ use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::gas_coin::{GAS, TOTAL_SUPPLY_MIST};
 
-pub(crate) struct CoinReadApi {
-    inner: IndexerReader,
+pub(crate) struct CoinReadApi<T: R2D2Connection + 'static> {
+    inner: IndexerReader<T>,
 }
 
-impl CoinReadApi {
-    pub fn new(inner: IndexerReader) -> Self {
+impl<T: R2D2Connection> CoinReadApi<T> {
+    pub fn new(inner: IndexerReader<T>) -> Self {
         Self { inner }
     }
 }
 
 #[async_trait]
-impl CoinReadApiServer for CoinReadApi {
+impl<T: R2D2Connection + 'static> CoinReadApiServer for CoinReadApi<T> {
     async fn get_coins(
         &self,
         owner: SuiAddress,
@@ -142,7 +143,7 @@ impl CoinReadApiServer for CoinReadApi {
     }
 }
 
-impl SuiRpcModule for CoinReadApi {
+impl<T: R2D2Connection> SuiRpcModule for CoinReadApi<T> {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
     }

--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::indexer_reader::IndexerReader;
+use diesel::r2d2::R2D2Connection;
 use jsonrpsee::{core::RpcResult, RpcModule};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_api::{validate_limit, ExtendedApiServer, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS};
@@ -11,18 +12,18 @@ use sui_json_rpc_types::{
 use sui_open_rpc::Module;
 use sui_types::sui_serde::BigInt;
 
-pub(crate) struct ExtendedApi {
-    inner: IndexerReader,
+pub(crate) struct ExtendedApi<T: R2D2Connection + 'static> {
+    inner: IndexerReader<T>,
 }
 
-impl ExtendedApi {
-    pub fn new(inner: IndexerReader) -> Self {
+impl<T: R2D2Connection> ExtendedApi<T> {
+    pub fn new(inner: IndexerReader<T>) -> Self {
         Self { inner }
     }
 }
 
 #[async_trait::async_trait]
-impl ExtendedApiServer for ExtendedApi {
+impl<T: R2D2Connection + 'static> ExtendedApiServer for ExtendedApi<T> {
     async fn get_epochs(
         &self,
         cursor: Option<BigInt<u64>>,
@@ -80,7 +81,7 @@ impl ExtendedApiServer for ExtendedApi {
     }
 }
 
-impl SuiRpcModule for ExtendedApi {
+impl<T: R2D2Connection> SuiRpcModule for ExtendedApi<T> {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
     }

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use crate::{errors::IndexerError, indexer_reader::IndexerReader};
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, RpcModule};
 
-use cached::{proc_macro::cached, SizedCache};
+use cached::{proc_macro::cached, CachedAsync, SizedCache};
+use diesel::r2d2::R2D2Connection;
 use sui_json_rpc::{governance_api::ValidatorExchangeRates, SuiRpcModule};
 use sui_json_rpc_api::GovernanceReadApiServer;
 use sui_json_rpc_types::{
@@ -21,15 +23,20 @@ use sui_types::{
     sui_serde::BigInt,
     sui_system_state::{sui_system_state_summary::SuiSystemStateSummary, PoolTokenExchangeRate},
 };
+use tokio::sync::Mutex;
 
 #[derive(Clone)]
-pub struct GovernanceReadApi {
-    inner: IndexerReader,
+pub struct GovernanceReadApi<T: R2D2Connection + 'static> {
+    inner: IndexerReader<T>,
+    exchange_rate_cache: Arc<Mutex<SizedCache<EpochId, Vec<ValidatorExchangeRates>>>>,
 }
 
-impl GovernanceReadApi {
-    pub fn new(inner: IndexerReader) -> Self {
-        Self { inner }
+impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
+    pub fn new(inner: IndexerReader<T>) -> Self {
+        Self {
+            inner,
+            exchange_rate_cache: Arc::new(Mutex::new(SizedCache::with_size(1))),
+        }
     }
 
     /// Get a validator's APY by its address
@@ -47,7 +54,15 @@ impl GovernanceReadApi {
         let epoch = system_state_summary.epoch;
         let stake_subsidy_start_epoch = system_state_summary.stake_subsidy_start_epoch;
 
-        let exchange_rate_table = exchange_rates(self, system_state_summary).await?;
+        let exchange_rate_table = self
+            .exchange_rate_cache
+            .lock()
+            .await
+            .get_or_set_with(epoch, || async {
+                self.exchange_rates(system_state_summary).await.unwrap()
+            })
+            .await
+            .clone();
 
         let apys = sui_json_rpc::governance_api::calculate_apys(
             stake_subsidy_start_epoch,
@@ -131,7 +146,8 @@ impl GovernanceReadApi {
         let system_state_summary = self.get_latest_sui_system_state().await?;
         let epoch = system_state_summary.epoch;
 
-        let rates = exchange_rates(self, system_state_summary)
+        let rates = self
+            .exchange_rates(system_state_summary)
             .await?
             .into_iter()
             .map(|rates| (rates.pool_id, rates))
@@ -189,100 +205,94 @@ impl GovernanceReadApi {
         }
         Ok(delegated_stakes)
     }
-}
 
-/// Cached exchange rates for validators for the given epoch, the cache size is 1, it will be cleared when the epoch changes.
-/// rates are in descending order by epoch.
-#[cached(
-    type = "SizedCache<EpochId, Vec<ValidatorExchangeRates>>",
-    create = "{ SizedCache::with_size(1) }",
-    convert = "{ system_state_summary.epoch }",
-    result = true
-)]
-async fn exchange_rates(
-    state: &GovernanceReadApi,
-    system_state_summary: SuiSystemStateSummary,
-) -> Result<Vec<ValidatorExchangeRates>, IndexerError> {
-    // Get validator rate tables
-    let mut tables = vec![];
+    /// Cached exchange rates for validators for the given epoch, the cache size is 1, it will be cleared when the epoch changes.
+    /// rates are in descending order by epoch.
+    async fn exchange_rates(
+        &self,
+        system_state_summary: SuiSystemStateSummary,
+    ) -> Result<Vec<ValidatorExchangeRates>, IndexerError> {
+        // Get validator rate tables
+        let mut tables = vec![];
 
-    for validator in system_state_summary.active_validators {
-        tables.push((
-            validator.sui_address,
-            validator.staking_pool_id,
-            validator.exchange_rates_id,
-            validator.exchange_rates_size,
-            true,
-        ));
-    }
+        for validator in system_state_summary.active_validators {
+            tables.push((
+                validator.sui_address,
+                validator.staking_pool_id,
+                validator.exchange_rates_id,
+                validator.exchange_rates_size,
+                true,
+            ));
+        }
 
-    // Get inactive validator rate tables
-    for df in state
-        .inner
-        .get_dynamic_fields_in_blocking_task(
-            system_state_summary.inactive_pools_id,
-            None,
-            system_state_summary.inactive_pools_size as usize,
-        )
-        .await?
-    {
-        let pool_id: sui_types::id::ID = bcs::from_bytes(&df.bcs_name).map_err(|e| {
-            sui_types::error::SuiError::ObjectDeserializationError {
-                error: e.to_string(),
-            }
-        })?;
-        let inactive_pools_id = system_state_summary.inactive_pools_id;
-        let validator = state
+        // Get inactive validator rate tables
+        for df in self
             .inner
-            .spawn_blocking(move |this| {
-                sui_types::sui_system_state::get_validator_from_table(
-                    &this,
-                    inactive_pools_id,
-                    &pool_id,
-                )
-            })
-            .await?;
-        tables.push((
-            validator.sui_address,
-            validator.staking_pool_id,
-            validator.exchange_rates_id,
-            validator.exchange_rates_size,
-            false,
-        ));
-    }
-
-    let mut exchange_rates = vec![];
-    // Get exchange rates for each validator
-    for (address, pool_id, exchange_rates_id, exchange_rates_size, active) in tables {
-        let mut rates = vec![];
-        for df in state
-            .inner
-            .get_dynamic_fields_raw_in_blocking_task(
-                exchange_rates_id,
+            .get_dynamic_fields_in_blocking_task(
+                system_state_summary.inactive_pools_id,
                 None,
-                exchange_rates_size as usize,
+                system_state_summary.inactive_pools_size as usize,
             )
             .await?
         {
-            let dynamic_field = df
-                .to_dynamic_field::<EpochId, PoolTokenExchangeRate>()
-                .ok_or_else(|| sui_types::error::SuiError::ObjectDeserializationError {
-                    error: "dynamic field malformed".to_owned(),
-                })?;
-
-            rates.push((dynamic_field.name, dynamic_field.value));
+            let pool_id: sui_types::id::ID = bcs::from_bytes(&df.bcs_name).map_err(|e| {
+                sui_types::error::SuiError::ObjectDeserializationError {
+                    error: e.to_string(),
+                }
+            })?;
+            let inactive_pools_id = system_state_summary.inactive_pools_id;
+            let validator = self
+                .inner
+                .spawn_blocking(move |this| {
+                    sui_types::sui_system_state::get_validator_from_table(
+                        &this,
+                        inactive_pools_id,
+                        &pool_id,
+                    )
+                })
+                .await?;
+            tables.push((
+                validator.sui_address,
+                validator.staking_pool_id,
+                validator.exchange_rates_id,
+                validator.exchange_rates_size,
+                false,
+            ));
         }
 
-        rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
+        let mut exchange_rates = vec![];
+        // Get exchange rates for each validator
+        for (address, pool_id, exchange_rates_id, exchange_rates_size, active) in tables {
+            let mut rates = vec![];
+            for df in self
+                .inner
+                .get_dynamic_fields_raw_in_blocking_task(
+                    exchange_rates_id,
+                    None,
+                    exchange_rates_size as usize,
+                )
+                .await?
+            {
+                let dynamic_field = df
+                    .to_dynamic_field::<EpochId, PoolTokenExchangeRate>()
+                    .ok_or_else(|| sui_types::error::SuiError::ObjectDeserializationError {
+                        error: "dynamic field malformed".to_owned(),
+                    })?;
 
-        exchange_rates.push(ValidatorExchangeRates {
-            address,
-            pool_id,
-            active,
-            rates,
-        });
+                rates.push((dynamic_field.name, dynamic_field.value));
+            }
+
+            rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
+
+            exchange_rates.push(ValidatorExchangeRates {
+                address,
+                pool_id,
+                active,
+                rates,
+            });
+        }
+        Ok(exchange_rates)
     }
-    Ok(exchange_rates)
 }
 
 /// Cache a map representing the validators' APYs for this epoch
@@ -296,7 +306,7 @@ fn validators_apys_map(apys: ValidatorApys) -> BTreeMap<SuiAddress, f64> {
 }
 
 #[async_trait]
-impl GovernanceReadApiServer for GovernanceReadApi {
+impl<T: R2D2Connection + 'static> GovernanceReadApiServer for GovernanceReadApi<T> {
     async fn get_stakes_by_ids(
         &self,
         staked_sui_ids: Vec<ObjectID>,
@@ -335,7 +345,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 }
 
-impl SuiRpcModule for GovernanceReadApi {
+impl<T: R2D2Connection> SuiRpcModule for GovernanceReadApi<T> {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
     }

--- a/crates/sui-indexer/src/apis/move_utils.rs
+++ b/crates/sui-indexer/src/apis/move_utils.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
+use diesel::r2d2::R2D2Connection;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use move_binary_format::normalized::Module as NormalizedModule;
@@ -22,18 +23,18 @@ use sui_types::base_types::ObjectID;
 
 use crate::indexer_reader::IndexerReader;
 
-pub struct MoveUtilsApi {
-    inner: IndexerReader,
+pub struct MoveUtilsApi<T: R2D2Connection + 'static> {
+    inner: IndexerReader<T>,
 }
 
-impl MoveUtilsApi {
-    pub fn new(inner: IndexerReader) -> Self {
+impl<T: R2D2Connection> MoveUtilsApi<T> {
+    pub fn new(inner: IndexerReader<T>) -> Self {
         Self { inner }
     }
 }
 
 #[async_trait]
-impl MoveUtilsServer for MoveUtilsApi {
+impl<T: R2D2Connection + 'static> MoveUtilsServer for MoveUtilsApi<T> {
     async fn get_normalized_move_modules_by_package(
         &self,
         package_id: ObjectID,
@@ -132,7 +133,7 @@ impl MoveUtilsServer for MoveUtilsApi {
     }
 }
 
-impl SuiRpcModule for MoveUtilsApi {
+impl<T: R2D2Connection> SuiRpcModule for MoveUtilsApi<T> {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
     }

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use diesel::r2d2::R2D2Connection;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use sui_json_rpc::error::SuiRpcInputError;
@@ -26,12 +27,12 @@ use sui_types::sui_serde::BigInt;
 use sui_json_rpc_types::SuiLoadedChildObjectsResponse;
 
 #[derive(Clone)]
-pub(crate) struct ReadApi {
-    inner: IndexerReader,
+pub(crate) struct ReadApi<T: R2D2Connection + 'static> {
+    inner: IndexerReader<T>,
 }
 
-impl ReadApi {
-    pub fn new(inner: IndexerReader) -> Self {
+impl<T: R2D2Connection + 'static> ReadApi<T> {
+    pub fn new(inner: IndexerReader<T>) -> Self {
         Self { inner }
     }
 
@@ -62,7 +63,7 @@ impl ReadApi {
 }
 
 #[async_trait]
-impl ReadApiServer for ReadApi {
+impl<T: R2D2Connection + 'static> ReadApiServer for ReadApi<T> {
     async fn get_object(
         &self,
         object_id: ObjectID,
@@ -296,7 +297,7 @@ impl ReadApiServer for ReadApi {
     }
 }
 
-impl SuiRpcModule for ReadApi {
+impl<T: R2D2Connection> SuiRpcModule for ReadApi<T> {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
     }

--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -4,6 +4,7 @@
 use super::governance_api::GovernanceReadApi;
 use crate::indexer_reader::IndexerReader;
 use async_trait::async_trait;
+use diesel::r2d2::R2D2Connection;
 use move_core_types::language_storage::StructTag;
 use sui_json_rpc::transaction_builder_api::TransactionBuilderApi as SuiTransactionBuilderApi;
 use sui_json_rpc_types::{SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse};
@@ -11,19 +12,19 @@ use sui_transaction_builder::DataReader;
 use sui_types::base_types::{ObjectID, ObjectInfo, SuiAddress};
 use sui_types::object::Object;
 
-pub(crate) struct TransactionBuilderApi {
-    inner: IndexerReader,
+pub(crate) struct TransactionBuilderApi<T: R2D2Connection + 'static> {
+    inner: IndexerReader<T>,
 }
 
-impl TransactionBuilderApi {
+impl<T: R2D2Connection> TransactionBuilderApi<T> {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(inner: IndexerReader) -> SuiTransactionBuilderApi {
+    pub fn new(inner: IndexerReader<T>) -> SuiTransactionBuilderApi {
         SuiTransactionBuilderApi::new_with_data_reader(std::sync::Arc::new(Self { inner }))
     }
 }
 
 #[async_trait]
-impl DataReader for TransactionBuilderApi {
+impl<T: R2D2Connection> DataReader for TransactionBuilderApi<T> {
     async fn get_owned_objects(
         &self,
         address: SuiAddress,

--- a/crates/sui-indexer/src/db.rs
+++ b/crates/sui-indexer/src/db.rs
@@ -1,33 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::anyhow;
 use std::time::Duration;
 
-use anyhow::anyhow;
-use diesel::migration::MigrationSource;
-use diesel::{r2d2::ConnectionManager, PgConnection, RunQueryDsl};
-use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
-use tracing::info;
+use diesel::connection::BoxableConnection;
+use diesel::r2d2::{Pool, PooledConnection, R2D2Connection};
+use diesel::{r2d2::ConnectionManager, sql_query, RunQueryDsl};
 
 use crate::errors::IndexerError;
 
-pub type PgConnectionPool = diesel::r2d2::Pool<ConnectionManager<PgConnection>>;
-pub type PgPoolConnection = diesel::r2d2::PooledConnection<ConnectionManager<PgConnection>>;
+pub type ConnectionPool<T> = Pool<ConnectionManager<T>>;
+pub type PoolConnection<T> = PooledConnection<ConnectionManager<T>>;
 
 #[derive(Debug, Clone, Copy)]
-pub struct PgConnectionPoolConfig {
+pub struct ConnectionPoolConfig {
     pub pool_size: u32,
     pub connection_timeout: Duration,
     pub statement_timeout: Duration,
 }
 
-impl PgConnectionPoolConfig {
+impl ConnectionPoolConfig {
     const DEFAULT_POOL_SIZE: u32 = 100;
     const DEFAULT_CONNECTION_TIMEOUT: u64 = 3600;
     const DEFAULT_STATEMENT_TIMEOUT: u64 = 3600;
 
-    fn connection_config(&self) -> PgConnectionConfig {
-        PgConnectionConfig {
+    fn connection_config(&self) -> ConnectionConfig {
+        ConnectionConfig {
             statement_timeout: self.statement_timeout,
             read_only: false,
         }
@@ -46,7 +45,7 @@ impl PgConnectionPoolConfig {
     }
 }
 
-impl Default for PgConnectionPoolConfig {
+impl Default for ConnectionPoolConfig {
     fn default() -> Self {
         let db_pool_size = std::env::var("DB_POOL_SIZE")
             .ok()
@@ -70,49 +69,71 @@ impl Default for PgConnectionPoolConfig {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct PgConnectionConfig {
+pub struct ConnectionConfig {
     pub statement_timeout: Duration,
     pub read_only: bool,
 }
 
-impl diesel::r2d2::CustomizeConnection<PgConnection, diesel::r2d2::Error> for PgConnectionConfig {
-    fn on_acquire(&self, conn: &mut PgConnection) -> std::result::Result<(), diesel::r2d2::Error> {
-        use diesel::sql_query;
+impl<T: R2D2Connection + 'static> diesel::r2d2::CustomizeConnection<T, diesel::r2d2::Error>
+    for ConnectionConfig
+{
+    fn on_acquire(&self, conn: &mut T) -> std::result::Result<(), diesel::r2d2::Error> {
+        #[cfg(feature = "postgres-feature")]
+        {
+            conn.as_any_mut()
+                .downcast_mut::<diesel::PgConnection>()
+                .map_or_else(
+                    || {
+                        Err(diesel::r2d2::Error::QueryError(
+                            diesel::result::Error::DeserializationError(
+                                "Failed to downcast connection to PgConnection"
+                                    .to_string()
+                                    .into(),
+                            ),
+                        ))
+                    },
+                    |pg_conn| {
+                        sql_query(format!(
+                            "SET statement_timeout = {}",
+                            self.statement_timeout.as_millis(),
+                        ))
+                        .execute(pg_conn)
+                        .map_err(diesel::r2d2::Error::QueryError)?;
 
-        sql_query(format!(
-            "SET statement_timeout = {}",
-            self.statement_timeout.as_millis(),
-        ))
-        .execute(conn)
-        .map_err(diesel::r2d2::Error::QueryError)?;
-
-        if self.read_only {
-            sql_query("SET default_transaction_read_only = 't'")
-                .execute(conn)
-                .map_err(diesel::r2d2::Error::QueryError)?;
+                        if self.read_only {
+                            sql_query("SET default_transaction_read_only = 't'")
+                                .execute(pg_conn)
+                                .map_err(diesel::r2d2::Error::QueryError)?;
+                        }
+                        Ok(())
+                    },
+                )?;
+            Ok(())
         }
-
-        Ok(())
+        #[cfg(not(feature = "postgres-feature"))]
+        {
+            Ok(())
+        }
     }
 }
 
-pub fn new_pg_connection_pool(
+pub fn new_connection_pool<T: R2D2Connection + 'static>(
     db_url: &str,
     pool_size: Option<u32>,
-) -> Result<PgConnectionPool, IndexerError> {
-    let pool_config = PgConnectionPoolConfig::default();
-    new_pg_connection_pool_with_config(db_url, pool_size, pool_config)
+) -> Result<ConnectionPool<T>, IndexerError> {
+    let pool_config = ConnectionPoolConfig::default();
+    new_connection_pool_with_config(db_url, pool_size, pool_config)
 }
 
-pub fn new_pg_connection_pool_with_config(
+pub fn new_connection_pool_with_config<T: R2D2Connection + 'static>(
     db_url: &str,
     pool_size: Option<u32>,
-    pool_config: PgConnectionPoolConfig,
-) -> Result<PgConnectionPool, IndexerError> {
-    let manager = ConnectionManager::<PgConnection>::new(db_url);
+    pool_config: ConnectionPoolConfig,
+) -> Result<ConnectionPool<T>, IndexerError> {
+    let manager = ConnectionManager::<T>::new(db_url);
 
     let pool_size = pool_size.unwrap_or(pool_config.pool_size);
-    diesel::r2d2::Pool::builder()
+    Pool::builder()
         .max_size(pool_size)
         .connection_timeout(pool_config.connection_timeout)
         .connection_customizer(Box::new(pool_config.connection_config()))
@@ -125,7 +146,9 @@ pub fn new_pg_connection_pool_with_config(
         })
 }
 
-pub fn get_pg_pool_connection(pool: &PgConnectionPool) -> Result<PgPoolConnection, IndexerError> {
+pub fn get_pool_connection<T: R2D2Connection + Send + 'static>(
+    pool: &ConnectionPool<T>,
+) -> Result<PoolConnection<T>, IndexerError> {
     pool.get().map_err(|e| {
         IndexerError::PgPoolConnectionError(format!(
             "Failed to get connection from PG connection pool with error: {:?}",
@@ -134,52 +157,198 @@ pub fn get_pg_pool_connection(pool: &PgConnectionPool) -> Result<PgPoolConnectio
     })
 }
 
-const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
-
-/// Resets the database by reverting all migrations and reapplying them.
-///
-/// If `drop_all` is set to `true`, the function will drop all tables in the database before
-/// resetting the migrations. This option is destructive and will result in the loss of all
-/// data in the tables. Use with caution, especially in production environments.
-pub fn reset_database(conn: &mut PgPoolConnection, drop_all: bool) -> Result<(), anyhow::Error> {
-    info!("Resetting database ...");
-    if drop_all {
-        drop_all_tables(conn)
-            .map_err(|e| anyhow!("Encountering error when dropping all tables {e}"))?;
-    } else {
-        conn.revert_all_migrations(MIGRATIONS)
-            .map_err(|e| anyhow!("Error reverting all migrations {e}"))?;
+pub fn reset_database<T: R2D2Connection + Send + 'static>(
+    conn: &mut PoolConnection<T>,
+    drop_all: bool,
+) -> Result<(), anyhow::Error> {
+    #[cfg(feature = "postgres-feature")]
+    {
+        conn.as_any_mut()
+            .downcast_mut::<PoolConnection<diesel::PgConnection>>()
+            .map_or_else(
+                || Err(anyhow!("Failed to downcast connection to PgConnection")),
+                |pg_conn| {
+                    setup_postgres::reset_database(pg_conn, drop_all)?;
+                    Ok(())
+                },
+            )?;
     }
-    conn.run_migrations(&MIGRATIONS.migrations().unwrap())
-        .map_err(|e| anyhow!("Failed to run migrations {e}"))?;
-    info!("Reset database complete.");
+    #[cfg(feature = "mysql-feature")]
+    #[cfg(not(feature = "postgres-feature"))]
+    {
+        conn.as_any_mut()
+            .downcast_mut::<PoolConnection<diesel::MysqlConnection>>()
+            .map_or_else(
+                || Err(anyhow!("Failed to downcast connection to PgConnection")),
+                |mysql_conn| {
+                    setup_mysql::reset_database(mysql_conn, drop_all)
+                        .map_err(diesel::r2d2::Error::QueryError)?;
+                    Ok(())
+                },
+            )?;
+    }
     Ok(())
 }
 
-fn drop_all_tables(conn: &mut PgConnection) -> Result<(), diesel::result::Error> {
-    info!("Dropping all tables in the database");
-    let table_names: Vec<String> = diesel::dsl::sql::<diesel::sql_types::Text>(
-        "
-        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
-    ",
-    )
-    .load(conn)?;
+#[cfg(feature = "postgres-feature")]
+pub mod setup_postgres {
+    use crate::db::{get_pool_connection, new_connection_pool, PoolConnection};
+    use crate::errors::IndexerError;
+    use crate::indexer::Indexer;
+    use crate::metrics::IndexerMetrics;
+    use crate::store::PgIndexerStore;
+    use crate::IndexerConfig;
+    use anyhow::anyhow;
+    use diesel::migration::MigrationSource;
+    use diesel::{PgConnection, RunQueryDsl};
+    use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+    use prometheus::Registry;
+    use secrecy::ExposeSecret;
+    use tracing::{error, info};
 
-    for table_name in table_names {
-        let drop_table_query = format!("DROP TABLE IF EXISTS {} CASCADE", table_name);
-        diesel::sql_query(drop_table_query).execute(conn)?;
+    const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+    pub fn reset_database(
+        conn: &mut PoolConnection<PgConnection>,
+        drop_all: bool,
+    ) -> Result<(), anyhow::Error> {
+        info!("Resetting database ...");
+        if drop_all {
+            drop_all_tables(conn)
+                .map_err(|e| anyhow!("Encountering error when dropping all tables {e}"))?;
+        } else {
+            conn.revert_all_migrations(MIGRATIONS)
+                .map_err(|e| anyhow!("Error reverting all migrations {e}"))?;
+        }
+        conn.run_migrations(&MIGRATIONS.migrations().unwrap())
+            .map_err(|e| anyhow!("Failed to run migrations {e}"))?;
+        info!("Reset database complete.");
+        Ok(())
     }
 
-    // Recreate the __diesel_schema_migrations table
-    diesel::sql_query(
-        "
+    fn drop_all_tables(conn: &mut PgConnection) -> Result<(), diesel::result::Error> {
+        info!("Dropping all tables in the database");
+        let table_names: Vec<String> = diesel::dsl::sql::<diesel::sql_types::Text>(
+            "
+        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+    ",
+        )
+        .load(conn)?;
+
+        for table_name in table_names {
+            let drop_table_query = format!("DROP TABLE IF EXISTS {} CASCADE", table_name);
+            diesel::sql_query(drop_table_query).execute(conn)?;
+        }
+
+        // Recreate the __diesel_schema_migrations table
+        diesel::sql_query(
+            "
         CREATE TABLE __diesel_schema_migrations (
             version VARCHAR(50) PRIMARY KEY,
             run_on TIMESTAMP NOT NULL DEFAULT NOW()
         )
     ",
-    )
-    .execute(conn)?;
-    info!("Dropped all tables in the database");
-    Ok(())
+        )
+        .execute(conn)?;
+        info!("Dropped all tables in the database");
+        Ok(())
+    }
+
+    pub async fn setup(
+        indexer_config: IndexerConfig,
+        registry: Registry,
+    ) -> Result<(), IndexerError> {
+        let db_url_secret = indexer_config.get_db_url().map_err(|e| {
+            IndexerError::PgPoolConnectionError(format!(
+                "Failed parsing database url with error {:?}",
+                e
+            ))
+        })?;
+        let db_url = db_url_secret.expose_secret();
+        let blocking_cp = new_connection_pool::<PgConnection>(db_url, None).map_err(|e| {
+            error!(
+                "Failed creating Postgres connection pool with error {:?}",
+                e
+            );
+            e
+        })?;
+        if indexer_config.reset_db {
+            let mut conn = get_pool_connection(&blocking_cp).map_err(|e| {
+                error!(
+                    "Failed getting Postgres connection from connection pool with error {:?}",
+                    e
+                );
+                e
+            })?;
+            reset_database(&mut conn, /* drop_all */ true).map_err(|e| {
+                let db_err_msg = format!(
+                    "Failed resetting database with url: {:?} and error: {:?}",
+                    db_url, e
+                );
+                error!("{}", db_err_msg);
+                IndexerError::PostgresResetError(db_err_msg)
+            })?;
+        }
+        let indexer_metrics = IndexerMetrics::new(&registry);
+        mysten_metrics::init_metrics(&registry);
+
+        let report_cp = blocking_cp.clone();
+        let report_metrics = indexer_metrics.clone();
+        tokio::spawn(async move {
+            loop {
+                let cp_state = report_cp.state();
+                info!(
+                    "DB connection pool size: {}, with idle conn: {}.",
+                    cp_state.connections, cp_state.idle_connections
+                );
+                report_metrics
+                    .db_conn_pool_size
+                    .set(cp_state.connections as i64);
+                report_metrics
+                    .idle_db_conn
+                    .set(cp_state.idle_connections as i64);
+                tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+            }
+        });
+        if indexer_config.fullnode_sync_worker {
+            let store = PgIndexerStore::<PgConnection>::new(blocking_cp, indexer_metrics.clone());
+            return Indexer::start_writer::<PgIndexerStore<PgConnection>, PgConnection>(
+                &indexer_config,
+                store,
+                indexer_metrics,
+            )
+            .await;
+        } else if indexer_config.rpc_server_worker {
+            return Indexer::start_reader::<PgConnection>(
+                &indexer_config,
+                &registry,
+                db_url.to_string(),
+            )
+            .await;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "mysql-feature")]
+#[cfg(not(feature = "postgres-feature"))]
+pub mod setup_mysql {
+    use crate::db::PoolConnection;
+    use crate::errors::IndexerError;
+    use crate::IndexerConfig;
+    use diesel::MysqlConnection;
+    use prometheus::Registry;
+
+    pub fn reset_database(
+        _conn: &mut PoolConnection<MysqlConnection>,
+        _drop_all: bool,
+    ) -> Result<(), anyhow::Error> {
+        todo!()
+    }
+    pub async fn setup(
+        _indexer_config: IndexerConfig,
+        registry: Registry,
+    ) -> Result<(), IndexerError> {
+        todo!()
+    }
 }

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1,14 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Mutex;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Result};
-use cached::proc_macro::cached;
-use cached::SizedCache;
+use cached::{Cached, SizedCache};
+use diesel::r2d2::R2D2Connection;
 use diesel::{
     dsl::sql, r2d2::ConnectionManager, sql_types::Bool, ExpressionMethods, OptionalExtension,
-    PgConnection, QueryDsl, RunQueryDsl, TextExpressionMethods,
+    QueryDsl, RunQueryDsl, TextExpressionMethods,
 };
 use itertools::{any, Itertools};
 use tap::TapFallible;
@@ -42,8 +43,9 @@ use sui_types::{
 };
 use sui_types::{coin::CoinMetadata, event::EventID};
 
+use crate::db::{ConnectionConfig, ConnectionPool, ConnectionPoolConfig};
+use crate::store::diesel_macro::*;
 use crate::{
-    db::{PgConnectionConfig, PgConnectionPool, PgConnectionPoolConfig, PgPoolConnection},
     errors::IndexerError,
     models::{
         checkpoints::StoredCheckpoint,
@@ -63,28 +65,45 @@ pub const TX_SEQUENCE_NUMBER_STR: &str = "tx_sequence_number";
 pub const TRANSACTION_DIGEST_STR: &str = "transaction_digest";
 pub const EVENT_SEQUENCE_NUMBER_STR: &str = "event_sequence_number";
 
-#[derive(Clone)]
-pub struct IndexerReader {
-    pool: PgConnectionPool,
-    package_resolver: PackageResolver,
+pub struct IndexerReader<T>
+where
+    T: R2D2Connection + 'static,
+{
+    pool: ConnectionPool<T>,
+    package_resolver: PackageResolver<T>,
+    package_obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
 }
 
-pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>;
+impl<T> Clone for IndexerReader<T>
+where
+    T: R2D2Connection,
+{
+    fn clone(&self) -> IndexerReader<T> {
+        IndexerReader {
+            pool: self.pool.clone(),
+            package_resolver: self.package_resolver.clone(),
+            package_obj_type_cache: self.package_obj_type_cache.clone(),
+        }
+    }
+}
+
+pub type PackageResolver<T> =
+    Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver<T>>>>;
 
 // Impl for common initialization and utilities
-impl IndexerReader {
+impl<U: R2D2Connection + 'static> IndexerReader<U> {
     pub fn new<T: Into<String>>(db_url: T) -> Result<Self> {
-        let config = PgConnectionPoolConfig::default();
+        let config = ConnectionPoolConfig::default();
         Self::new_with_config(db_url, config)
     }
 
     pub fn new_with_config<T: Into<String>>(
         db_url: T,
-        config: PgConnectionPoolConfig,
+        config: ConnectionPoolConfig,
     ) -> Result<Self> {
-        let manager = ConnectionManager::<PgConnection>::new(db_url);
+        let manager = ConnectionManager::<U>::new(db_url);
 
-        let connection_config = PgConnectionConfig {
+        let connection_config = ConnectionConfig {
             statement_timeout: config.statement_timeout,
             read_only: true,
         };
@@ -99,51 +118,12 @@ impl IndexerReader {
         let indexer_store_pkg_resolver = IndexerStorePackageResolver::new(pool.clone());
         let package_cache = PackageStoreWithLruCache::new(indexer_store_pkg_resolver);
         let package_resolver = Arc::new(Resolver::new(package_cache));
-
+        let package_obj_type_cache = Arc::new(Mutex::new(SizedCache::with_size(10000)));
         Ok(Self {
             pool,
             package_resolver,
+            package_obj_type_cache,
         })
-    }
-
-    fn get_connection(&self) -> Result<PgPoolConnection, IndexerError> {
-        self.pool.get().map_err(|e| {
-            IndexerError::PgPoolConnectionError(format!(
-                "Failed to get connection from PG connection pool with error: {:?}",
-                e
-            ))
-        })
-    }
-
-    pub fn run_query<T, E, F>(&self, query: F) -> Result<T, IndexerError>
-    where
-        F: FnOnce(&mut PgConnection) -> Result<T, E>,
-        E: From<diesel::result::Error> + std::error::Error,
-    {
-        blocking_call_is_ok_or_panic();
-
-        let mut connection = self.get_connection()?;
-        connection
-            .build_transaction()
-            .read_only()
-            .run(query)
-            .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
-    }
-
-    pub fn run_query_repeatable<T, E, F>(&self, query: F) -> Result<T, IndexerError>
-    where
-        F: FnOnce(&mut PgConnection) -> Result<T, E>,
-        E: From<diesel::result::Error> + std::error::Error,
-    {
-        blocking_call_is_ok_or_panic();
-
-        let mut connection = self.get_connection()?;
-        connection
-            .build_transaction()
-            .read_only()
-            .repeatable_read()
-            .run(query)
-            .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
     }
 
     pub async fn spawn_blocking<F, R, E>(&self, f: F) -> Result<R, E>
@@ -164,51 +144,13 @@ impl IndexerReader {
         .expect("propagate any panics")
     }
 
-    pub async fn run_query_async<T, E, F>(&self, query: F) -> Result<T, IndexerError>
-    where
-        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
-        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
-        T: Send + 'static,
-    {
-        self.spawn_blocking(move |this| this.run_query(query)).await
-    }
-
-    pub async fn run_query_repeatable_async<T, E, F>(&self, query: F) -> Result<T, IndexerError>
-    where
-        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
-        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
-        T: Send + 'static,
-    {
-        self.spawn_blocking(move |this| this.run_query_repeatable(query))
-            .await
-    }
-}
-
-thread_local! {
-    static CALLED_FROM_BLOCKING_POOL: std::cell::RefCell<bool> = std::cell::RefCell::new(false);
-}
-
-/// Check that we are in a context conducive to making blocking calls.
-/// This is done by either:
-/// - Checking that we are not inside a tokio runtime context
-/// Or:
-/// - If we are inside a tokio runtime context, ensure that the call went through
-/// `IndexerReader::spawn_blocking` which properly moves the blocking call to a blocking thread
-/// pool.
-fn blocking_call_is_ok_or_panic() {
-    if tokio::runtime::Handle::try_current().is_ok()
-        && !CALLED_FROM_BLOCKING_POOL.with(|in_blocking_pool| *in_blocking_pool.borrow())
-    {
-        panic!(
-            "You are calling a blocking DB operation directly on an async thread. \
-                Please use IndexerReader::spawn_blocking instead to move the \
-                operation to a blocking thread"
-        );
+    pub fn get_pool(&self) -> ConnectionPool<U> {
+        self.pool.clone()
     }
 }
 
 // Impl for reading data from the DB
-impl IndexerReader {
+impl<U: R2D2Connection> IndexerReader<U> {
     fn get_object_from_db(
         &self,
         object_id: &ObjectID,
@@ -216,7 +158,7 @@ impl IndexerReader {
     ) -> Result<Option<StoredObject>, IndexerError> {
         let object_id = object_id.to_vec();
 
-        let stored_object = self.run_query(|conn| {
+        let stored_object = run_query!(&self.pool, |conn| {
             if let Some(version) = version {
                 objects::dsl::objects
                     .filter(objects::dsl::object_id.eq(object_id))
@@ -230,7 +172,6 @@ impl IndexerReader {
                     .optional()
             }
         })?;
-
         Ok(stored_object)
     }
 
@@ -274,7 +215,7 @@ impl IndexerReader {
 
     fn get_object_raw(&self, object_id: ObjectID) -> Result<Option<StoredObject>, IndexerError> {
         let id = object_id.to_vec();
-        let stored_object = self.run_query(|conn| {
+        let stored_object = run_query!(&self.pool, |conn| {
             objects::dsl::objects
                 .filter(objects::dsl::object_id.eq(id))
                 .first::<StoredObject>(conn)
@@ -303,7 +244,7 @@ impl IndexerReader {
         &self,
         epoch: Option<EpochId>,
     ) -> Result<Option<StoredEpochInfo>, IndexerError> {
-        let stored_epoch = self.run_query(|conn| {
+        let stored_epoch = run_query!(&self.pool, |conn| {
             if let Some(epoch) = epoch {
                 epochs::dsl::epochs
                     .filter(epochs::epoch.eq(epoch as i64))
@@ -321,7 +262,7 @@ impl IndexerReader {
     }
 
     pub fn get_latest_epoch_info_from_db(&self) -> Result<StoredEpochInfo, IndexerError> {
-        let stored_epoch = self.run_query(|conn| {
+        let stored_epoch = run_query!(&self.pool, |conn| {
             epochs::dsl::epochs
                 .order_by(epochs::epoch.desc())
                 .first::<StoredEpochInfo>(conn)
@@ -351,7 +292,7 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<StoredEpochInfo>, IndexerError> {
-        self.run_query(|conn| {
+        run_query!(&self.pool, |conn| {
             let mut boxed_query = epochs::table.into_boxed();
             if let Some(cursor) = cursor {
                 if descending_order {
@@ -419,22 +360,24 @@ impl IndexerReader {
         &self,
         checkpoint_id: CheckpointId,
     ) -> Result<Option<StoredCheckpoint>, IndexerError> {
-        let stored_checkpoint = self.run_query(|conn| match checkpoint_id {
-            CheckpointId::SequenceNumber(seq) => checkpoints::dsl::checkpoints
-                .filter(checkpoints::sequence_number.eq(seq as i64))
-                .first::<StoredCheckpoint>(conn)
-                .optional(),
-            CheckpointId::Digest(digest) => checkpoints::dsl::checkpoints
-                .filter(checkpoints::checkpoint_digest.eq(digest.into_inner().to_vec()))
-                .first::<StoredCheckpoint>(conn)
-                .optional(),
+        let stored_checkpoint = run_query!(&self.pool, |conn| {
+            match checkpoint_id {
+                CheckpointId::SequenceNumber(seq) => checkpoints::dsl::checkpoints
+                    .filter(checkpoints::sequence_number.eq(seq as i64))
+                    .first::<StoredCheckpoint>(conn)
+                    .optional(),
+                CheckpointId::Digest(digest) => checkpoints::dsl::checkpoints
+                    .filter(checkpoints::checkpoint_digest.eq(digest.into_inner().to_vec()))
+                    .first::<StoredCheckpoint>(conn)
+                    .optional(),
+            }
         })?;
 
         Ok(stored_checkpoint)
     }
 
     pub fn get_latest_checkpoint_from_db(&self) -> Result<StoredCheckpoint, IndexerError> {
-        let stored_checkpoint = self.run_query(|conn| {
+        let stored_checkpoint = run_query!(&self.pool, |conn| {
             checkpoints::dsl::checkpoints
                 .order_by(checkpoints::sequence_number.desc())
                 .first::<StoredCheckpoint>(conn)
@@ -468,7 +411,7 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<StoredCheckpoint>, IndexerError> {
-        self.run_query(|conn| {
+        run_query!(&self.pool, |conn| {
             let mut boxed_query = checkpoints::table.into_boxed();
             if let Some(cursor) = cursor {
                 if descending_order {
@@ -507,9 +450,9 @@ impl IndexerReader {
         &self,
         digest: TransactionDigest,
     ) -> Result<SuiTransactionBlockEffects, IndexerError> {
-        let stored_txn: StoredTransaction = self.run_query(|conn| {
+        let stored_txn: StoredTransaction = run_query!(&self.pool, |conn| {
             transactions::table
-                .filter(transactions::transaction_digest.eq(digest.inner().to_vec()))
+                .filter(transactions::transaction_digest.eq(digest.into_inner().to_vec()))
                 .first::<StoredTransaction>(conn)
         })?;
 
@@ -520,7 +463,7 @@ impl IndexerReader {
         &self,
         sequence_number: i64,
     ) -> Result<SuiTransactionBlockEffects, IndexerError> {
-        let stored_txn: StoredTransaction = self.run_query(|conn| {
+        let stored_txn: StoredTransaction = run_query!(&self.pool, |conn| {
             transactions::table
                 .filter(transactions::tx_sequence_number.eq(sequence_number))
                 .first::<StoredTransaction>(conn)
@@ -537,7 +480,7 @@ impl IndexerReader {
             .iter()
             .map(|digest| digest.inner().to_vec())
             .collect::<Vec<_>>();
-        self.run_query(|conn| {
+        run_query!(&self.pool, |conn| {
             transactions::table
                 .filter(transactions::transaction_digest.eq_any(digests))
                 .load::<StoredTransaction>(conn)
@@ -596,7 +539,7 @@ impl IndexerReader {
             }
             None => (),
         }
-        self.run_query(|conn| query.load::<StoredTransaction>(conn))
+        run_query!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
     }
 
     pub async fn get_owned_objects_in_blocking_task(
@@ -617,7 +560,7 @@ impl IndexerReader {
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
-        self.run_query(|conn| {
+        run_query!(&self.pool, |conn| {
             let mut query = objects::dsl::objects
                 .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
                 .filter(objects::dsl::owner_id.eq(address.to_vec()))
@@ -626,19 +569,26 @@ impl IndexerReader {
                 .into_boxed();
             if let Some(filter) = filter {
                 match filter {
-                    SuiObjectDataFilter::StructType (struct_tag ) => {
-                        let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
-                        query = query.filter(objects::dsl::object_type.like(format!("{}%",object_type)));
-                    },
+                    SuiObjectDataFilter::StructType(struct_tag) => {
+                        let object_type =
+                            struct_tag.to_canonical_string(/* with_prefix */ true);
+                        query =
+                            query.filter(objects::object_type.like(format!("{}%", object_type)));
+                    }
                     SuiObjectDataFilter::MatchAny(filters) => {
                         let mut condition = "(".to_string();
                         for (i, filter) in filters.iter().enumerate() {
-                            if let SuiObjectDataFilter::StructType (struct_tag) = filter {
-                                let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
+                            if let SuiObjectDataFilter::StructType(struct_tag) = filter {
+                                let object_type =
+                                    struct_tag.to_canonical_string(/* with_prefix */ true);
                                 if i == 0 {
-                                    condition += format!("objects.object_type LIKE '{}%'",object_type).as_str();
+                                    condition +=
+                                        format!("objects.object_type LIKE '{}%'", object_type)
+                                            .as_str();
                                 } else {
-                                    condition += format!(" OR objects.object_type LIKE '{}%'",object_type).as_str();
+                                    condition +=
+                                        format!(" OR objects.object_type LIKE '{}%'", object_type)
+                                            .as_str();
                                 }
                             } else {
                                 return Err(IndexerError::InvalidArgumentError(
@@ -648,12 +598,15 @@ impl IndexerReader {
                         }
                         condition += ")";
                         query = query.filter(sql::<Bool>(&condition));
-                    },
+                    }
                     SuiObjectDataFilter::MatchNone(filters) => {
                         for filter in filters {
-                            if let SuiObjectDataFilter::StructType (struct_tag) = filter {
-                                let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
-                                query = query.filter(objects::dsl::object_type.not_like(format!("{}%", object_type)));
+                            if let SuiObjectDataFilter::StructType(struct_tag) = filter {
+                                let object_type =
+                                    struct_tag.to_canonical_string(/* with_prefix */ true);
+                                query = query.filter(
+                                    objects::object_type.not_like(format!("{}%", object_type)),
+                                );
                             } else {
                                 return Err(IndexerError::InvalidArgumentError(
                                     "Invalid filter type. Only struct, MatchAny and MatchNone of struct filters are supported.".into(),
@@ -673,7 +626,9 @@ impl IndexerReader {
                 query = query.filter(objects::dsl::object_id.gt(object_cursor.to_vec()));
             }
 
-            query.load::<StoredObject>(conn).map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+            query
+                .load::<StoredObject>(conn)
+                .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
         })
     }
 
@@ -683,13 +638,14 @@ impl IndexerReader {
         object_type: String,
     ) -> Result<Vec<ObjectID>, IndexerError> {
         let object_ids = object_ids.into_iter().map(|id| id.to_vec()).collect_vec();
-        let filtered_ids = self.run_query(|conn| {
+        let filtered_ids = run_query!(&self.pool, |conn| {
             objects::dsl::objects
                 .filter(objects::object_id.eq_any(object_ids))
                 .filter(objects::object_type.eq(object_type))
                 .select(objects::object_id)
                 .load::<Vec<u8>>(conn)
         })?;
+
         filtered_ids
             .into_iter()
             .map(|id| {
@@ -716,8 +672,7 @@ impl IndexerReader {
         object_ids: Vec<ObjectID>,
     ) -> Result<Vec<StoredObject>, IndexerError> {
         let object_ids = object_ids.into_iter().map(|id| id.to_vec()).collect_vec();
-
-        self.run_query(|conn| {
+        run_query!(&self.pool, |conn| {
             objects::dsl::objects
                 .filter(objects::object_id.eq_any(object_ids))
                 .load::<StoredObject>(conn)
@@ -749,10 +704,10 @@ impl IndexerReader {
         } else {
             query = query.order(transactions::dsl::tx_sequence_number.asc());
         }
-
-        let stored_txes = self
-            .run_query_async(move |conn| query.limit(limit as i64).load::<StoredTransaction>(conn))
-            .await?;
+        let pool = self.get_pool();
+        let stored_txes = run_query_async!(&pool, move |conn| query
+            .limit(limit as i64)
+            .load::<StoredTransaction>(conn))?;
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
     }
@@ -778,16 +733,13 @@ impl IndexerReader {
         is_descending: bool,
     ) -> IndexerResult<Vec<SuiTransactionBlockResponse>> {
         let cursor_tx_seq = if let Some(cursor) = cursor {
-            let tx_seq = self
-                .run_query_async(move |conn| {
-                    transactions::dsl::transactions
-                        .select(transactions::tx_sequence_number)
-                        .filter(
-                            transactions::dsl::transaction_digest.eq(cursor.into_inner().to_vec()),
-                        )
-                        .first::<i64>(conn)
-                })
-                .await?;
+            let pool = self.get_pool();
+            let tx_seq = run_query_async!(&pool, move |conn| {
+                transactions::dsl::transactions
+                    .select(transactions::tx_sequence_number)
+                    .filter(transactions::dsl::transaction_digest.eq(cursor.into_inner().to_vec()))
+                    .first::<i64>(conn)
+            })?;
             Some(tx_seq)
         } else {
             None
@@ -966,14 +918,13 @@ impl IndexerReader {
         );
 
         tracing::debug!("query transaction blocks: {}", query);
-        let tx_sequence_numbers = self
-            .run_query_async(move |conn| {
-                diesel::sql_query(query.clone()).load::<TxSequenceNumber>(conn)
-            })
-            .await?
-            .into_iter()
-            .map(|tsn| tsn.tx_sequence_number)
-            .collect::<Vec<i64>>();
+        let pool = self.get_pool();
+        let tx_sequence_numbers = run_query_async!(&pool, move |conn| {
+            diesel::sql_query(query.clone()).load::<TxSequenceNumber>(conn)
+        })?
+        .into_iter()
+        .map(|tsn| tsn.tx_sequence_number)
+        .collect::<Vec<i64>>();
         self.multi_get_transaction_block_response_by_sequence_numbers_in_blocking_task(
             tx_sequence_numbers,
             options,
@@ -1026,14 +977,13 @@ impl IndexerReader {
         &self,
         digest: TransactionDigest,
     ) -> Result<Vec<sui_json_rpc_types::SuiEvent>, IndexerError> {
-        let (timestamp_ms, serialized_events) = self
-            .run_query_async(move |conn| {
-                transactions::table
-                    .filter(transactions::transaction_digest.eq(digest.into_inner().to_vec()))
-                    .select((transactions::timestamp_ms, transactions::events))
-                    .first::<(i64, Vec<Option<Vec<u8>>>)>(conn)
-            })
-            .await?;
+        let pool = self.get_pool();
+        let (timestamp_ms, serialized_events) = run_query_async!(&pool, move |conn| {
+            transactions::table
+                .filter(transactions::transaction_digest.eq(digest.into_inner().to_vec()))
+                .select((transactions::timestamp_ms, transactions::events))
+                .first::<(i64, Vec<Option<Vec<u8>>>)>(conn)
+        })?;
 
         let events = serialized_events
             .into_iter()
@@ -1098,33 +1048,28 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<SuiEvent>> {
+        let pool = self.get_pool();
         let (tx_seq, event_seq) = if let Some(cursor) = cursor {
             let EventID {
                 tx_digest,
                 event_seq,
             } = cursor;
-
-            let tx_seq = self
-                .run_query_async(move |conn| {
-                    transactions::dsl::transactions
-                        .select(transactions::tx_sequence_number)
-                        .filter(
-                            transactions::dsl::transaction_digest
-                                .eq(tx_digest.into_inner().to_vec()),
-                        )
-                        .first::<i64>(conn)
-                })
-                .await?;
+            let tx_seq = run_query_async!(&pool, move |conn| {
+                transactions::dsl::transactions
+                    .select(transactions::tx_sequence_number)
+                    .filter(
+                        transactions::dsl::transaction_digest.eq(tx_digest.into_inner().to_vec()),
+                    )
+                    .first::<i64>(conn)
+            })?;
             (tx_seq, event_seq)
         } else if descending_order {
-            let max_tx_seq: i64 = self
-                .run_query_async(move |conn| {
-                    events::dsl::events
-                        .select(events::tx_sequence_number)
-                        .order(events::dsl::tx_sequence_number.desc())
-                        .first::<i64>(conn)
-                })
-                .await?;
+            let max_tx_seq: i64 = run_query_async!(&pool, move |conn| {
+                events::dsl::events
+                    .select(events::tx_sequence_number)
+                    .order(events::dsl::tx_sequence_number.desc())
+                    .first::<i64>(conn)
+            })?;
             (max_tx_seq + 1, 0)
         } else {
             (-1, 0)
@@ -1221,9 +1166,9 @@ impl IndexerReader {
             )
         };
         tracing::debug!("query events: {}", query);
-        let stored_events = self
-            .run_query_async(move |conn| diesel::sql_query(query).load::<StoredEvent>(conn))
-            .await?;
+        let pool = self.get_pool();
+        let stored_events = run_query_async!(&pool, move |conn| diesel::sql_query(query)
+            .load::<StoredEvent>(conn))?;
 
         let mut sui_event_futures = vec![];
         for stored_event in stored_events {
@@ -1324,7 +1269,7 @@ impl IndexerReader {
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
-        let objects: Vec<StoredObject> = self.run_query(|conn| {
+        let objects: Vec<StoredObject> = run_query!(&self.pool, |conn| {
             let mut query = objects::dsl::objects
                 .filter(objects::dsl::owner_type.eq(OwnerType::Object as i16))
                 .filter(objects::dsl::owner_id.eq(parent_object_id.to_vec()))
@@ -1363,7 +1308,7 @@ impl IndexerReader {
         &self,
         object_ids: Vec<Vec<u8>>,
     ) -> IndexerResult<HashMap<ObjectID, ObjectRef>> {
-        self.run_query(|conn| {
+        run_query!(&self.pool, |conn| {
             let query = objects::dsl::objects
                 .select((
                     objects::dsl::object_id,
@@ -1408,7 +1353,7 @@ impl IndexerReader {
         &self,
         object_type: String,
     ) -> Result<Option<sui_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
-        let stored_display = self.run_query(|conn| {
+        let stored_display = run_query!(&self.pool, |conn| {
             display::table
                 .filter(display::object_type.eq(object_type))
                 .first::<StoredDisplay>(conn)
@@ -1458,7 +1403,7 @@ impl IndexerReader {
             .order((objects::dsl::coin_type.asc(), objects::dsl::object_id.asc()))
             .limit(limit as i64);
 
-        let stored_objects = self.run_query(|conn| query.load::<StoredObject>(conn))?;
+        let stored_objects = run_query!(&self.pool, |conn| query.load::<StoredObject>(conn))?;
 
         stored_objects
             .into_iter()
@@ -1506,8 +1451,8 @@ impl IndexerReader {
         );
 
         tracing::debug!("get coin balances query: {query}");
-        let coin_balances =
-            self.run_query(|conn| diesel::sql_query(query).load::<CoinBalance>(conn))?;
+        let coin_balances = run_query!(&self.pool, |conn| diesel::sql_query(query)
+            .load::<CoinBalance>(conn))?;
         coin_balances
             .into_iter()
             .map(|cb| cb.try_into())
@@ -1556,8 +1501,21 @@ impl IndexerReader {
         let package_id = coin_struct.address.into();
         let coin_metadata_type =
             CoinMetadata::type_(coin_struct).to_canonical_string(/* with_prefix */ true);
-        let coin_metadata_obj_id =
-            get_single_obj_id_from_package_publish(self, package_id, coin_metadata_type)?;
+        let coin_metadata_obj_id = *self
+            .package_obj_type_cache
+            .lock()
+            .unwrap()
+            .cache_get_or_set_with(
+                r#"{ format!("{}{}", package_id, obj_type) }"#.to_string(),
+                || {
+                    get_single_obj_id_from_package_publish(
+                        self,
+                        package_id,
+                        coin_metadata_type.clone(),
+                    )
+                    .unwrap()
+                },
+            );
         if let Some(id) = coin_metadata_obj_id {
             let metadata_object = self.get_object(&id, None)?;
             Ok(metadata_object.and_then(|v| SuiCoinMetadata::try_from(v).ok()))
@@ -1578,12 +1536,25 @@ impl IndexerReader {
         let package_id = coin_struct.address.into();
         let treasury_cap_type =
             TreasuryCap::type_(coin_struct).to_canonical_string(/* with_prefix */ true);
-        let treasury_cap_obj_id =
-            get_single_obj_id_from_package_publish(self, package_id, treasury_cap_type.clone())?
-                .ok_or(IndexerError::GenericError(format!(
-                    "Cannot find treasury cap for type {}",
-                    treasury_cap_type
-                )))?;
+        let treasury_cap_obj_id = self
+            .package_obj_type_cache
+            .lock()
+            .unwrap()
+            .cache_get_or_set_with(
+                r#"{ format!("{}{}", package_id, treasury_cap_type) }"#.to_string(),
+                || {
+                    get_single_obj_id_from_package_publish(
+                        self,
+                        package_id,
+                        treasury_cap_type.clone(),
+                    )
+                    .unwrap()
+                },
+            )
+            .ok_or(IndexerError::GenericError(format!(
+                "Cannot find treasury cap for type {}",
+                treasury_cap_type
+            )))?;
         let treasury_cap_obj_object =
             self.get_object(&treasury_cap_obj_id, None)?
                 .ok_or(IndexerError::GenericError(format!(
@@ -1594,36 +1565,34 @@ impl IndexerReader {
     }
 
     pub fn get_consistent_read_range(&self) -> Result<(i64, i64), IndexerError> {
-        let latest_checkpoint_sequence = self
-            .run_query(|conn| {
-                checkpoints::table
-                    .select(checkpoints::sequence_number)
-                    .order(checkpoints::sequence_number.desc())
-                    .first::<i64>(conn)
-                    .optional()
-            })?
-            .unwrap_or_default();
-        let latest_object_snapshot_checkpoint_sequence = self
-            .run_query(|conn| {
-                objects_snapshot::table
-                    .select(objects_snapshot::checkpoint_sequence_number)
-                    .order(objects_snapshot::checkpoint_sequence_number.desc())
-                    .first::<i64>(conn)
-                    .optional()
-            })?
-            .unwrap_or_default();
+        let latest_checkpoint_sequence = run_query!(&self.pool, |conn| {
+            checkpoints::table
+                .select(checkpoints::sequence_number)
+                .order(checkpoints::sequence_number.desc())
+                .first::<i64>(conn)
+                .optional()
+        })?
+        .unwrap_or_default();
+        let latest_object_snapshot_checkpoint_sequence = run_query!(&self.pool, |conn| {
+            objects_snapshot::table
+                .select(objects_snapshot::checkpoint_sequence_number)
+                .order(objects_snapshot::checkpoint_sequence_number.desc())
+                .first::<i64>(conn)
+                .optional()
+        })?
+        .unwrap_or_default();
         Ok((
             latest_object_snapshot_checkpoint_sequence,
             latest_checkpoint_sequence,
         ))
     }
 
-    pub fn package_resolver(&self) -> PackageResolver {
+    pub fn package_resolver(&self) -> PackageResolver<U> {
         self.package_resolver.clone()
     }
 }
 
-impl sui_types::storage::ObjectStore for IndexerReader {
+impl<U: R2D2Connection> sui_types::storage::ObjectStore for IndexerReader<U> {
     fn get_object(
         &self,
         object_id: &ObjectID,
@@ -1642,14 +1611,8 @@ impl sui_types::storage::ObjectStore for IndexerReader {
     }
 }
 
-#[cached(
-    type = "SizedCache<String, Option<ObjectID>>",
-    create = "{ SizedCache::with_size(10000) }",
-    convert = r#"{ format!("{}{}", package_id, obj_type) }"#,
-    result = true
-)]
-fn get_single_obj_id_from_package_publish(
-    reader: &IndexerReader,
+fn get_single_obj_id_from_package_publish<U: R2D2Connection>(
+    reader: &IndexerReader<U>,
     package_id: ObjectID,
     obj_type: String,
 ) -> Result<Option<ObjectID>, IndexerError> {

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use diesel::r2d2::R2D2Connection;
 use jsonrpsee::http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder};
 use metrics::IndexerMetrics;
 use mysten_metrics::spawn_monitored_task;
@@ -141,9 +142,9 @@ impl Default for IndexerConfig {
     }
 }
 
-pub async fn build_json_rpc_server(
+pub async fn build_json_rpc_server<T: R2D2Connection>(
     prometheus_registry: &Registry,
-    reader: IndexerReader,
+    reader: IndexerReader<T>,
     config: &IndexerConfig,
     custom_runtime: Option<Handle>,
 ) -> Result<ServerHandle, IndexerError> {

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -2,15 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use secrecy::ExposeSecret;
-use tracing::{error, info};
+use tracing::info;
 
-use sui_indexer::db::{get_pg_pool_connection, new_pg_connection_pool, reset_database};
 use sui_indexer::errors::IndexerError;
-use sui_indexer::indexer::Indexer;
 use sui_indexer::metrics::start_prometheus_server;
-use sui_indexer::metrics::IndexerMetrics;
-use sui_indexer::store::PgIndexerStore;
 use sui_indexer::IndexerConfig;
 
 #[tokio::main]
@@ -28,40 +23,6 @@ async fn main() -> Result<(), IndexerError> {
         indexer_config.remote_store_url = Some("https://checkpoints.mainnet.sui.io".to_string());
     }
     info!("Parsed indexer config: {:#?}", indexer_config);
-
-    let db_url_secret = indexer_config.get_db_url().map_err(|e| {
-        IndexerError::PgPoolConnectionError(format!(
-            "Failed parsing database url with error {:?}",
-            e
-        ))
-    })?;
-
-    let db_url = db_url_secret.expose_secret();
-    let blocking_cp = new_pg_connection_pool(db_url, None).map_err(|e| {
-        error!(
-            "Failed creating Postgres connection pool with error {:?}",
-            e
-        );
-        e
-    })?;
-    if indexer_config.reset_db {
-        let mut conn = get_pg_pool_connection(&blocking_cp).map_err(|e| {
-            error!(
-                "Failed getting Postgres connection from connection pool with error {:?}",
-                e
-            );
-            e
-        })?;
-        reset_database(&mut conn, /* drop_all */ true).map_err(|e| {
-            let db_err_msg = format!(
-                "Failed resetting database with url: {:?} and error: {:?}",
-                db_url, e
-            );
-            error!("{}", db_err_msg);
-            IndexerError::PostgresResetError(db_err_msg)
-        })?;
-    }
-
     let (_registry_service, registry) = start_prometheus_server(
         // NOTE: this parses the input host addr and port number for socket addr,
         // so unwrap() is safe here.
@@ -73,33 +34,11 @@ async fn main() -> Result<(), IndexerError> {
         .unwrap(),
         indexer_config.rpc_client_url.as_str(),
     )?;
-    let indexer_metrics = IndexerMetrics::new(&registry);
-    mysten_metrics::init_metrics(&registry);
+    #[cfg(feature = "postgres-feature")]
+    sui_indexer::db::setup_postgres::setup(indexer_config.clone(), registry.clone()).await?;
 
-    let report_cp = blocking_cp.clone();
-    let report_metrics = indexer_metrics.clone();
-    tokio::spawn(async move {
-        loop {
-            let cp_state = report_cp.state();
-            info!(
-                "DB connection pool size: {}, with idle conn: {}.",
-                cp_state.connections, cp_state.idle_connections
-            );
-            report_metrics
-                .db_conn_pool_size
-                .set(cp_state.connections as i64);
-            report_metrics
-                .idle_db_conn
-                .set(cp_state.idle_connections as i64);
-            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
-        }
-    });
-
-    if indexer_config.fullnode_sync_worker {
-        let store = PgIndexerStore::new(blocking_cp, indexer_metrics.clone());
-        return Indexer::start_writer(&indexer_config, store, indexer_metrics).await;
-    } else if indexer_config.rpc_server_worker {
-        return Indexer::start_reader(&indexer_config, &registry, db_url.to_string()).await;
-    }
+    #[cfg(feature = "mysql-feature")]
+    #[cfg(not(feature = "postgres-feature"))]
+    sui_indexer::db::setup_mysql::setup(indexer_config, registry).await?;
     Ok(())
 }

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -9,51 +9,257 @@ pub mod package_resolver;
 mod pg_indexer_store;
 mod pg_partition_manager;
 
-pub(crate) mod diesel_macro {
-    macro_rules! read_only_blocking {
+pub mod diesel_macro {
+    thread_local! {
+        pub static CALLED_FROM_BLOCKING_POOL: std::cell::RefCell<bool> = std::cell::RefCell::new(false);
+    }
+
+    #[macro_export]
+    macro_rules! read_only_repeatable_blocking {
         ($pool:expr, $query:expr) => {{
-            let mut pg_pool_conn = crate::db::get_pg_pool_connection($pool)?;
-            pg_pool_conn
-                .build_transaction()
-                .read_only()
-                .run($query)
-                .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+            use downcast::Any;
+            use $crate::db::get_pool_connection;
+            use $crate::db::PoolConnection;
+            #[cfg(feature = "postgres-feature")]
+            {
+                let mut pool_conn = get_pool_connection($pool)?;
+                pool_conn
+                    .as_any_mut()
+                    .downcast_mut::<PoolConnection<diesel::PgConnection>>()
+                    .unwrap()
+                    .build_transaction()
+                    .read_only()
+                    .repeatable_read()
+                    .run($query)
+                    .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+            }
+            #[cfg(feature = "mysql-feature")]
+            #[cfg(not(feature = "postgres-feature"))]
+            {
+                let mut pool_conn = get_pool_connection($pool)?;
+                pool_conn
+                    .as_any_mut()
+                    .downcast_mut::<PoolConnection<diesel::MysqlConnection>>()
+                    .unwrap()
+                    .transaction($query)
+                    .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+            }
         }};
     }
 
+    #[macro_export]
+    macro_rules! read_only_blocking {
+        ($pool:expr, $query:expr) => {{
+            use downcast::Any;
+            use $crate::db::get_pool_connection;
+            use $crate::db::PoolConnection;
+            #[cfg(feature = "postgres-feature")]
+            {
+                let mut pool_conn = get_pool_connection($pool)?;
+                pool_conn
+                    .as_any_mut()
+                    .downcast_mut::<PoolConnection<diesel::PgConnection>>()
+                    .unwrap()
+                    .build_transaction()
+                    .read_only()
+                    .run($query)
+                    .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+            }
+            #[cfg(feature = "mysql-feature")]
+            #[cfg(not(feature = "postgres-feature"))]
+            {
+                let mut pool_conn = get_pool_connection($pool)?;
+                pool_conn
+                    .as_any_mut()
+                    .downcast_mut::<PoolConnection<diesel::MysqlConnection>>()
+                    .unwrap()
+                    .transaction($query)
+                    .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+            }
+        }};
+    }
+
+    #[macro_export]
     macro_rules! transactional_blocking_with_retry {
         ($pool:expr, $query:expr, $max_elapsed:expr) => {{
+            use $crate::db::get_pool_connection;
+            use $crate::db::PoolConnection;
+            use $crate::errors::IndexerError;
             let mut backoff = backoff::ExponentialBackoff::default();
             backoff.max_elapsed_time = Some($max_elapsed);
-
             let result = match backoff::retry(backoff, || {
-                let mut pg_pool_conn = crate::db::get_pg_pool_connection($pool).map_err(|e| {
-                    backoff::Error::Transient {
-                        err: IndexerError::PostgresWriteError(e.to_string()),
-                        retry_after: None,
-                    }
-                })?;
-                pg_pool_conn
-                    .build_transaction()
-                    .read_write()
-                    .run($query)
-                    .map_err(|e| {
-                        tracing::error!("Error with persisting data into DB: {:?}, retrying...", e);
-                        backoff::Error::Transient {
+                #[cfg(feature = "postgres-feature")]
+                {
+                    let mut pool_conn =
+                        get_pool_connection($pool).map_err(|e| backoff::Error::Transient {
                             err: IndexerError::PostgresWriteError(e.to_string()),
                             retry_after: None,
-                        }
-                    })
+                        })?;
+                    pool_conn
+                        .as_any_mut()
+                        .downcast_mut::<PoolConnection<diesel::PgConnection>>()
+                        .unwrap()
+                        .build_transaction()
+                        .read_write()
+                        .run($query)
+                        .map_err(|e| {
+                            tracing::error!(
+                                "Error with persisting data into DB: {:?}, retrying...",
+                                e
+                            );
+                            backoff::Error::Transient {
+                                err: IndexerError::PostgresWriteError(e.to_string()),
+                                retry_after: None,
+                            }
+                        })
+                }
+                #[cfg(feature = "mysql-feature")]
+                #[cfg(not(feature = "postgres-feature"))]
+                {
+                    let mut pool_conn =
+                        get_pool_connection($pool).map_err(|e| backoff::Error::Transient {
+                            err: IndexerError::PostgresWriteError(e.to_string()),
+                            retry_after: None,
+                        })?;
+                    pool_conn
+                        .as_any_mut()
+                        .downcast_mut::<PoolConnection<diesel::MysqlConnection>>()
+                        .unwrap()
+                        .transaction($query)
+                        .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+                        .map_err(|e| {
+                            tracing::error!(
+                                "Error with persisting data into DB: {:?}, retrying...",
+                                e
+                            );
+                            backoff::Error::Transient {
+                                err: IndexerError::PostgresWriteError(e.to_string()),
+                                retry_after: None,
+                            }
+                        })
+                }
             }) {
                 Ok(v) => Ok(v),
                 Err(backoff::Error::Transient { err, .. }) => Err(err),
                 Err(backoff::Error::Permanent(err)) => Err(err),
             };
-
             result
         }};
     }
 
-    pub(crate) use read_only_blocking;
-    pub(crate) use transactional_blocking_with_retry;
+    #[macro_export]
+    macro_rules! spawn_read_only_blocking {
+        ($pool:expr, $query:expr, $repeatable_read:expr) => {{
+            use downcast::Any;
+            use $crate::db::get_pool_connection;
+            use $crate::db::PoolConnection;
+            use $crate::errors::IndexerError;
+            use $crate::store::diesel_macro::CALLED_FROM_BLOCKING_POOL;
+            let current_span = tracing::Span::current();
+            tokio::task::spawn_blocking(move || {
+                CALLED_FROM_BLOCKING_POOL
+                    .with(|in_blocking_pool| *in_blocking_pool.borrow_mut() = true);
+                let _guard = current_span.enter();
+                let mut pool_conn = get_pool_connection($pool).unwrap();
+                #[cfg(feature = "postgres-feature")]
+                {
+                    if $repeatable_read {
+                        pool_conn
+                            .as_any_mut()
+                            .downcast_mut::<PoolConnection<diesel::PgConnection>>()
+                            .unwrap()
+                            .build_transaction()
+                            .read_only()
+                            .repeatable_read()
+                            .run($query)
+                            .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+                    } else {
+                        pool_conn
+                            .as_any_mut()
+                            .downcast_mut::<PoolConnection<diesel::PgConnection>>()
+                            .unwrap()
+                            .build_transaction()
+                            .read_only()
+                            .run($query)
+                            .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+                    }
+                }
+                #[cfg(feature = "mysql-feature")]
+                #[cfg(not(feature = "postgres-feature"))]
+                {
+                    pool_conn
+                        .as_any_mut()
+                        .downcast_mut::<PoolConnection<diesel::MysqlConnection>>()
+                        .unwrap()
+                        .transaction($query)
+                        .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+                }
+            })
+            .await
+            .expect("Blocking call failed")
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! run_query {
+        ($pool:expr, $query:expr) => {{
+            blocking_call_is_ok_or_panic!();
+            read_only_blocking!($pool, $query)
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! run_query_repeatable {
+        ($pool:expr, $query:expr) => {{
+            blocking_call_is_ok_or_panic!();
+            read_only_repeatable_blocking!($pool, $query)
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! run_query_async {
+        ($pool:expr, $query:expr) => {{
+            spawn_read_only_blocking!($pool, $query, false)
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! run_query_repeatable_async {
+        ($pool:expr, $query:expr) => {{
+            spawn_read_only_blocking!($pool, $query, true)
+        }};
+    }
+
+    /// Check that we are in a context conducive to making blocking calls.
+    /// This is done by either:
+    /// - Checking that we are not inside a tokio runtime context
+    /// Or:
+    /// - If we are inside a tokio runtime context, ensure that the call went through
+    /// `IndexerReader::spawn_blocking` which properly moves the blocking call to a blocking thread
+    /// pool.
+    #[macro_export]
+    macro_rules! blocking_call_is_ok_or_panic {
+        () => {{
+            use $crate::store::diesel_macro::CALLED_FROM_BLOCKING_POOL;
+            if tokio::runtime::Handle::try_current().is_ok()
+                && !CALLED_FROM_BLOCKING_POOL.with(|in_blocking_pool| *in_blocking_pool.borrow())
+            {
+                panic!(
+                    "You are calling a blocking DB operation directly on an async thread. \
+                        Please use IndexerReader::spawn_blocking instead to move the \
+                        operation to a blocking thread"
+                );
+            }
+        }};
+    }
+
+    pub use blocking_call_is_ok_or_panic;
+    pub use read_only_blocking;
+    pub use read_only_repeatable_blocking;
+    pub use run_query;
+    pub use run_query_async;
+    pub use run_query_repeatable;
+    pub use run_query_repeatable_async;
+    pub use spawn_read_only_blocking;
+    pub use transactional_blocking_with_retry;
 }


### PR DESCRIPTION
## Description 

This PR generalizes the code in `sui-indexer` crate such that different diesel backends can be enabled through feature flags when compiling. The default backend is still postgres which means nothing changes in terms of how we build our binaries today. 

1. The most important thing is that we do all kinds of db operation through macros which are feature gated such that we only pull in relevant db specific dependencies. 
2.  In Cargo.toml by default we do not add any db specific dependencies but only pull them through features:
3. In `sui-indexer`, all instances of `diesel::PgConnection` are pulled with `postgres-feature` and similary all instances of `diesel::MySqlConnection` are pulled with `mysql-feature`
4. `run_query` and `run_query_async` are replaced with their corresponding macro invocations
5. We do not try to make other dependencies of `sui-indexer` generic in this PR. This includes `sui-graphql-rpc` which just works with `IndexerReader<PgConnection>` for now (in the future we will refactor read for other db backends but for now the focus is to get writes to be compatible first) 
6. Usages of `#[Cached(..)]` had to be replaced with an explicit usage of `SizedCache` as this macro doesn't seem to work for functions which take type parameters.
7. Next: we are going to introduce migrations for mysql and build `sui-indexer` for mysql


## Test plan 

Running this locally works: `cargo run  --bin sui-indexer -- --db-url "postgres://sadhansood:sadhansood@localhost/test"  --rpc-client-url "<>" --fullnode-sync-worker --reset-db`
