### PR TITLE
[Types] Abstraction for defining built-in IDs and Packages

### DIFF
--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -86,92 +86,51 @@ pub mod zk_login_util;
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 
-/// 0x1-- account address where Move stdlib modules are stored
-/// Same as the ObjectID
-pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::ONE;
-pub const MOVE_STDLIB_PACKAGE_ID: ObjectID = ObjectID::from_address(MOVE_STDLIB_ADDRESS);
+macro_rules! built_in_ids {
+    ($($addr:ident / $id:ident = $init:expr);* $(;)?) => {
+        $(
+            pub const $addr: AccountAddress = builtin_address($init);
+            pub const $id: ObjectID = ObjectID::from_address($addr);
+        )*
+    }
+}
 
-/// 0x2-- account address where sui framework modules are stored
-/// Same as the ObjectID
-pub const SUI_FRAMEWORK_ADDRESS: AccountAddress = address_from_single_byte(2);
-pub const SUI_FRAMEWORK_PACKAGE_ID: ObjectID = ObjectID::from_address(SUI_FRAMEWORK_ADDRESS);
+macro_rules! built_in_pkgs {
+    ($($addr:ident / $id:ident = $init:expr);* $(;)?) => {
+        built_in_ids! { $($addr / $id = $init;)* }
+        pub const SYSTEM_PACKAGE_ADDRESSES: &[AccountAddress] = &[$($addr),*];
+        pub fn is_system_package(addr: impl Into<AccountAddress>) -> bool {
+            matches!(addr.into(), $($addr)|*)
+        }
+    }
+}
 
-/// 0x3-- account address where sui system modules are stored
-/// Same as the ObjectID
-pub const SUI_SYSTEM_ADDRESS: AccountAddress = address_from_single_byte(3);
-pub const SUI_SYSTEM_PACKAGE_ID: ObjectID = ObjectID::from_address(SUI_SYSTEM_ADDRESS);
+built_in_pkgs! {
+    MOVE_STDLIB_ADDRESS / MOVE_STDLIB_PACKAGE_ID = 0x1;
+    SUI_FRAMEWORK_ADDRESS / SUI_FRAMEWORK_PACKAGE_ID = 0x2;
+    SUI_SYSTEM_ADDRESS / SUI_SYSTEM_PACKAGE_ID = 0x3;
+    BRIDGE_ADDRESS / BRIDGE_PACKAGE_ID = 0xb;
+    DEEPBOOK_ADDRESS / DEEPBOOK_PACKAGE_ID = 0xdee9;
+}
 
-/// 0xdee9-- account address where DeepBook modules are stored
-/// Same as the ObjectID
-pub const DEEPBOOK_ADDRESS: AccountAddress = deepbook_addr();
-pub const DEEPBOOK_PACKAGE_ID: ObjectID = ObjectID::from_address(DEEPBOOK_ADDRESS);
+built_in_ids! {
+    SUI_SYSTEM_STATE_ADDRESS / SUI_SYSTEM_STATE_OBJECT_ID = 0x5;
+    SUI_CLOCK_ADDRESS / SUI_CLOCK_OBJECT_ID = 0x6;
+    SUI_AUTHENTICATOR_STATE_ADDRESS / SUI_AUTHENTICATOR_STATE_OBJECT_ID = 0x7;
+    SUI_RANDOMNESS_STATE_ADDRESS / SUI_RANDOMNESS_STATE_OBJECT_ID = 0x8;
+    SUI_BRIDGE_ADDRESS / SUI_BRIDGE_OBJECT_ID = 0x9;
+    SUI_DENY_LIST_ADDRESS / SUI_DENY_LIST_OBJECT_ID = 0x403;
+}
 
-/// 0xb-- account address where Bridge modules are stored
-/// Same as the ObjectID
-pub const BRIDGE_ADDRESS: AccountAddress = address_from_single_byte(11);
-pub const BRIDGE_PACKAGE_ID: ObjectID = ObjectID::from_address(BRIDGE_ADDRESS);
-
-/// 0x5: hardcoded object ID for the singleton sui system state object.
-pub const SUI_SYSTEM_STATE_ADDRESS: AccountAddress = address_from_single_byte(5);
-pub const SUI_SYSTEM_STATE_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_SYSTEM_STATE_ADDRESS);
 pub const SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
-
-/// 0x6: hardcoded object ID for the singleton clock object.
-pub const SUI_CLOCK_ADDRESS: AccountAddress = address_from_single_byte(6);
-pub const SUI_CLOCK_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_CLOCK_ADDRESS);
 pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
-
-/// 0x7: hardcode object ID for the singleton authenticator state object.
-pub const SUI_AUTHENTICATOR_STATE_ADDRESS: AccountAddress = address_from_single_byte(7);
-pub const SUI_AUTHENTICATOR_STATE_OBJECT_ID: ObjectID =
-    ObjectID::from_address(SUI_AUTHENTICATOR_STATE_ADDRESS);
 pub const SUI_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 
-/// 0x8: hardcode object ID for the singleton randomness state object.
-pub const SUI_RANDOMNESS_STATE_ADDRESS: AccountAddress = address_from_single_byte(8);
-pub const SUI_RANDOMNESS_STATE_OBJECT_ID: ObjectID =
-    ObjectID::from_address(SUI_RANDOMNESS_STATE_ADDRESS);
-
-/// 0x403: hardcode object ID for the singleton DenyList object.
-pub const SUI_DENY_LIST_ADDRESS: AccountAddress = deny_list_addr();
-pub const SUI_DENY_LIST_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_DENY_LIST_ADDRESS);
-
-/// 0x9: hardcode object ID for the singleton bridge object.
-pub const SUI_BRIDGE_ADDRESS: AccountAddress = address_from_single_byte(9);
-pub const SUI_BRIDGE_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_BRIDGE_ADDRESS);
-
-/// Return `true` if `addr` is a special system package that can be upgraded at epoch boundaries.
-/// All new system package ID's must be added here.
-pub fn is_system_package(addr: impl Into<AccountAddress>) -> bool {
-    matches!(
-        addr.into(),
-        MOVE_STDLIB_ADDRESS
-            | SUI_FRAMEWORK_ADDRESS
-            | SUI_SYSTEM_ADDRESS
-            | DEEPBOOK_ADDRESS
-            | BRIDGE_ADDRESS
-    )
-}
-
-const fn address_from_single_byte(b: u8) -> AccountAddress {
+const fn builtin_address(suffix: u16) -> AccountAddress {
     let mut addr = [0u8; AccountAddress::LENGTH];
-    addr[AccountAddress::LENGTH - 1] = b;
-    AccountAddress::new(addr)
-}
-
-/// return 0x0...dee9
-const fn deepbook_addr() -> AccountAddress {
-    let mut addr = [0u8; AccountAddress::LENGTH];
-    addr[AccountAddress::LENGTH - 2] = 0xde;
-    addr[AccountAddress::LENGTH - 1] = 0xe9;
-    AccountAddress::new(addr)
-}
-
-/// return 0x0...403
-const fn deny_list_addr() -> AccountAddress {
-    let mut addr = [0u8; AccountAddress::LENGTH];
-    addr[AccountAddress::LENGTH - 2] = 4;
-    addr[AccountAddress::LENGTH - 1] = 3;
+    let [hi, lo] = suffix.to_be_bytes();
+    addr[AccountAddress::LENGTH - 2] = hi;
+    addr[AccountAddress::LENGTH - 1] = lo;
     AccountAddress::new(addr)
 }
 


### PR DESCRIPTION
## Description

Main motivation for this change is to have a single source of truth to drive the `is_system_package` predicate and a list of system packages. This will be used by the GraphQL service to enumerate packages to evict from its package resolution cache on epoch boundaries.

In the process, I ended up creating a macro to avoid some of the duplication in this module (abstracts away defining all built-in IDs as `AccountAddress` and `ObjectID`, and provides a unified way to create the associated vanity IDs from a single `u16`).

## Test Plan

Existing simtests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
