### PR TITLE
[GraphQL/Package] Query using Db, not IndexerReader

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -363,7 +363,7 @@ impl ServerBuilder {
         // DB
         let db = Db::new(reader.clone(), config.service.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader.clone());
-        let package_store = DbPackageStore(reader.clone());
+        let package_store = DbPackageStore::new(db.clone());
         let package_cache = PackageStoreWithLruCache::new(package_store);
         builder.db_reader = Some(db.clone());
 


### PR DESCRIPTION
## Description

Change GraphQL's package store implementation to depend on GraphQL's `Db` type, instead of `IndexerReader`. This means package loads are subject to our limits and metrics, and makes it easier to switch them to using data loaders in future.

## Test plan

Existing tests

## Stack

- #17177 
- #17178 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
