### PR TITLE
[GraphQL/Package] Evict system packages on epoch boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12778,6 +12778,7 @@ dependencies = [
  "test-cluster",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "url",
 ]
@@ -12847,6 +12848,7 @@ dependencies = [
  "telemetry-subscribers",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower",
  "tower-http",
  "tracing",

--- a/crates/sui-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/df_handler.rs
@@ -6,6 +6,7 @@ use fastcrypto::encoding::{Base64, Encoding};
 use std::collections::HashMap;
 use std::path::Path;
 use sui_indexer::errors::IndexerError;
+use sui_types::SYSTEM_PACKAGE_ADDRESSES;
 use tap::tap::TapFallible;
 use tracing::warn;
 
@@ -51,6 +52,11 @@ impl Handler for DynamicFieldHandler {
                 checkpoint_transaction,
             )
             .await?;
+            if checkpoint_summary.end_of_epoch_data.is_some() {
+                self.resolver
+                    .package_store()
+                    .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
+            }
         }
         Ok(())
     }

--- a/crates/sui-analytics-indexer/src/handlers/event_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/event_handler.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
+use sui_types::SYSTEM_PACKAGE_ADDRESSES;
 
 use std::path::Path;
 
@@ -48,6 +49,11 @@ impl Handler for EventHandler {
                     events,
                 )
                 .await?;
+            }
+            if checkpoint_summary.end_of_epoch_data.is_some() {
+                self.resolver
+                    .package_store()
+                    .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
             }
         }
         Ok(())

--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
 use std::path::Path;
+use sui_types::SYSTEM_PACKAGE_ADDRESSES;
 
 use sui_indexer::framework::Handler;
 use sui_json_rpc_types::SuiMoveStruct;
@@ -50,6 +51,11 @@ impl Handler for ObjectHandler {
                 &checkpoint_transaction.effects,
             )
             .await?;
+            if checkpoint_summary.end_of_epoch_data.is_some() {
+                self.resolver
+                    .package_store()
+                    .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
+            }
         }
         Ok(())
     }

--- a/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use std::collections::BTreeMap;
 use std::path::Path;
+use sui_types::SYSTEM_PACKAGE_ADDRESSES;
 
 use sui_indexer::framework::Handler;
 use sui_package_resolver::Resolver;
@@ -44,6 +45,11 @@ impl Handler for WrappedObjectHandler {
                 checkpoint_transaction,
             )
             .await?;
+            if checkpoint_summary.end_of_epoch_data.is_some() {
+                self.resolver
+                    .package_store()
+                    .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
+            }
         }
         Ok(())
     }

--- a/crates/sui-analytics-indexer/src/package_store.rs
+++ b/crates/sui-analytics-indexer/src/package_store.rs
@@ -10,7 +10,7 @@ use sui_package_resolver::{
     error::Error as PackageResolverError, Package, PackageStore, PackageStoreWithLruCache, Result,
 };
 use sui_rest_api::Client;
-use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::base_types::ObjectID;
 use sui_types::object::Object;
 use thiserror::Error;
 use typed_store::rocks::{DBMap, MetricConf};
@@ -112,11 +112,6 @@ impl LocalDBPackageStore {
 
 #[async_trait]
 impl PackageStore for LocalDBPackageStore {
-    async fn version(&self, id: AccountAddress) -> Result<SequenceNumber> {
-        let object = self.get(id).await?;
-        Ok(object.version())
-    }
-
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
         let object = self.get(id).await?;
         Ok(Arc::new(Package::read(&object)?))

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::system_package_task::SystemPackageTask;
 use super::watermark_task::{Watermark, WatermarkLock, WatermarkTask};
 use crate::config::{
     ConnectionConfig, ServiceConfig, Version, MAX_CONCURRENT_REQUESTS,
     RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD,
 };
-use crate::data::package_resolver::DbPackageStore;
+use crate::data::package_resolver::{DbPackageStore, PackageResolver};
 use crate::data::Db;
 use crate::metrics::Metrics;
 use crate::mutation::Mutation;
@@ -47,6 +48,7 @@ use mysten_metrics::spawn_monitored_task;
 use mysten_network::callback::{CallbackLayer, MakeCallbackHandler, ResponseHandler};
 use std::convert::Infallible;
 use std::net::TcpStream;
+use std::sync::Arc;
 use std::{any::Any, net::SocketAddr, time::Instant};
 use sui_graphql_rpc_headers::{LIMITS_HEADER, VERSION_HEADER};
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
@@ -62,13 +64,14 @@ use uuid::Uuid;
 pub(crate) struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
     watermark_task: WatermarkTask,
+    system_package_task: SystemPackageTask,
     state: AppState,
 }
 
 impl Server {
     /// Start the GraphQL service and any background tasks it is dependent on. When a cancellation
     /// signal is received, the method waits for all tasks to complete before returning.
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(mut self) -> Result<(), Error> {
         get_or_init_server_start_time().await;
 
         // A handle that spawns a background task to periodically update the `Watermark`, which
@@ -77,6 +80,14 @@ impl Server {
             info!("Starting watermark update task");
             spawn_monitored_task!(async move {
                 self.watermark_task.run().await;
+            })
+        };
+
+        // A handle that spawns a background task to evict system packages on epoch changes.
+        let system_package_task = {
+            info!("Starting system package task");
+            spawn_monitored_task!(async move {
+                self.system_package_task.run().await;
             })
         };
 
@@ -96,7 +107,7 @@ impl Server {
 
         // Wait for all tasks to complete. This ensures that the service doesn't fully shut down
         // until all tasks and the server have completed their shutdown processes.
-        let _ = join!(watermark_task, server_task);
+        let _ = join!(watermark_task, system_package_task, server_task);
 
         Ok(())
     }
@@ -107,6 +118,7 @@ pub(crate) struct ServerBuilder {
     schema: SchemaBuilder<Query, Mutation, EmptySubscription>,
     router: Option<Router>,
     db_reader: Option<Db>,
+    resolver: Option<PackageResolver>,
 }
 
 #[derive(Clone)]
@@ -155,6 +167,7 @@ impl ServerBuilder {
             schema: schema_builder(),
             router: None,
             db_reader: None,
+            resolver: None,
         }
     }
 
@@ -187,19 +200,22 @@ impl ServerBuilder {
         String,
         Schema<Query, Mutation, EmptySubscription>,
         Db,
+        PackageResolver,
         Router,
     ) {
         let address = self.address();
         let ServerBuilder {
+            state: _,
             schema,
             db_reader,
+            resolver,
             router,
-            ..
         } = self;
         (
             address,
             schema.finish(),
             db_reader.expect("DB reader not initialized"),
+            resolver.expect("Package resolver not initialized"),
             router.expect("Router not initialized"),
         )
     }
@@ -279,13 +295,19 @@ impl ServerBuilder {
     /// Consumes the `ServerBuilder` to create a `Server` that can be run.
     pub fn build(self) -> Result<Server, Error> {
         let state = self.state.clone();
-        let (address, schema, db_reader, router) = self.build_components();
+        let (address, schema, db_reader, resolver, router) = self.build_components();
 
         // Initialize the watermark background task struct.
         let watermark_task = WatermarkTask::new(
             db_reader.clone(),
             state.metrics.clone(),
             std::time::Duration::from_millis(state.service.background_tasks.watermark_update_ms),
+            state.cancellation_token.clone(),
+        );
+
+        let system_package_task = SystemPackageTask::new(
+            resolver,
+            watermark_task.epoch_receiver(),
             state.cancellation_token.clone(),
         );
 
@@ -302,6 +324,7 @@ impl ServerBuilder {
             )
             .serve(app.into_make_service_with_connect_info::<SocketAddr>()),
             watermark_task,
+            system_package_task,
             state,
         })
     }
@@ -364,8 +387,13 @@ impl ServerBuilder {
         let db = Db::new(reader.clone(), config.service.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader.clone());
         let package_store = DbPackageStore::new(db.clone());
-        let package_cache = PackageStoreWithLruCache::new(package_store);
+        let resolver = Arc::new(Resolver::new_with_limits(
+            PackageStoreWithLruCache::new(package_store),
+            config.service.limits.package_resolver_limits(),
+        ));
+
         builder.db_reader = Some(db.clone());
+        builder.resolver = Some(resolver.clone());
 
         // SDK for talking to fullnode. Used for executing transactions only
         // TODO: fail fast if no url, once we enable mutations fully
@@ -388,10 +416,7 @@ impl ServerBuilder {
             .context_data(DataLoader::new(db.clone(), tokio::spawn))
             .context_data(db)
             .context_data(pg_conn_pool)
-            .context_data(Resolver::new_with_limits(
-                package_cache,
-                config.service.limits.package_resolver_limits(),
-            ))
+            .context_data(resolver)
             .context_data(sui_sdk_client)
             .context_data(name_service_config)
             .context_data(zklogin_config)

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -4,5 +4,6 @@
 pub mod graphiql_server;
 
 pub mod builder;
+pub(crate) mod system_package_task;
 pub mod version;
 pub(crate) mod watermark_task;

--- a/crates/sui-graphql-rpc/src/server/system_package_task.rs
+++ b/crates/sui-graphql-rpc/src/server/system_package_task.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_types::SYSTEM_PACKAGE_ADDRESSES;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::data::package_resolver::PackageResolver;
+
+/// Background task responsible for evicting system packages from the package resolver's cache on
+/// epoch boundaries.
+pub(crate) struct SystemPackageTask {
+    resolver: PackageResolver,
+    epoch_rx: watch::Receiver<u64>,
+    cancel: CancellationToken,
+}
+
+impl SystemPackageTask {
+    pub(crate) fn new(
+        resolver: PackageResolver,
+        epoch_rx: watch::Receiver<u64>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            resolver,
+            epoch_rx,
+            cancel,
+        }
+    }
+
+    pub(crate) async fn run(&mut self) {
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    info!("Shutdown signal received, terminating system package eviction task");
+                    return;
+                }
+
+                _ = self.epoch_rx.changed() => {
+                    self.resolver
+                        .package_store()
+                        .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/src/server/system_package_task.rs
+++ b/crates/sui-graphql-rpc/src/server/system_package_task.rs
@@ -38,6 +38,7 @@ impl SystemPackageTask {
                 }
 
                 _ = self.epoch_rx.changed() => {
+                    info!("Detected epoch boundary, evicting system packages from cache");
                     self.resolver
                         .package_store()
                         .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());

--- a/crates/sui-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/sui-graphql-rpc/src/server/watermark_task.rs
@@ -23,7 +23,7 @@ pub(crate) struct WatermarkTask {
     sleep: Duration,
     cancel: CancellationToken,
     sender: watch::Sender<u64>,
-    _receiver: watch::Receiver<u64>,
+    receiver: watch::Receiver<u64>,
 }
 
 pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
@@ -46,7 +46,7 @@ impl WatermarkTask {
         sleep: Duration,
         cancel: CancellationToken,
     ) -> Self {
-        let (sender, _receiver) = watch::channel(0);
+        let (sender, receiver) = watch::channel(0);
 
         Self {
             watermark: Default::default(),
@@ -55,7 +55,7 @@ impl WatermarkTask {
             sleep,
             cancel,
             sender,
-            _receiver,
+            receiver,
         }
     }
 
@@ -96,8 +96,9 @@ impl WatermarkTask {
         self.watermark.clone()
     }
 
-    pub(crate) fn _receiver(&self) -> watch::Receiver<u64> {
-        self._receiver.clone()
+    /// Receiver for subscribing to epoch changes.
+    pub(crate) fn epoch_receiver(&self) -> watch::Receiver<u64> {
+        self.receiver.clone()
     }
 }
 

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -29,6 +29,7 @@ regex.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true, features = ["rt"] }
 url.workspace = true
 
 fastcrypto = { workspace = true, features = ["copy_key"] }

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -66,8 +66,10 @@ pub const EVENT_SEQUENCE_NUMBER_STR: &str = "event_sequence_number";
 #[derive(Clone)]
 pub struct IndexerReader {
     pool: PgConnectionPool,
-    package_resolver: Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>,
+    package_resolver: PackageResolver,
 }
+
+pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>;
 
 // Impl for common initialization and utilities
 impl IndexerReader {
@@ -1616,7 +1618,7 @@ impl IndexerReader {
         ))
     }
 
-    pub fn package_resolver(&self) -> Arc<Resolver<impl PackageStore>> {
+    pub fn package_resolver(&self) -> PackageResolver {
         self.package_resolver.clone()
     }
 }

--- a/crates/sui-indexer/src/store/package_resolver.rs
+++ b/crates/sui-indexer/src/store/package_resolver.rs
@@ -10,7 +10,7 @@ use diesel::{QueryDsl, RunQueryDsl};
 
 use move_core_types::account_address::AccountAddress;
 use sui_package_resolver::{error::Error as PackageResolverError, Package, PackageStore};
-use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::base_types::ObjectID;
 use sui_types::object::Object;
 
 use crate::db::PgConnectionPool;
@@ -35,16 +35,6 @@ impl IndexerStorePackageResolver {
 
 #[async_trait]
 impl PackageStore for IndexerStorePackageResolver {
-    async fn version(&self, id: AccountAddress) -> Result<SequenceNumber, PackageResolverError> {
-        let version =
-            self.get_package_version_from_db(id)
-                .map_err(|e| PackageResolverError::Store {
-                    store: "PostgresDB",
-                    source: Box::new(e),
-                })?;
-        Ok(version)
-    }
-
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>, PackageResolverError> {
         let pkg = self
             .get_package_from_db_in_blocking_task(id)
@@ -58,26 +48,6 @@ impl PackageStore for IndexerStorePackageResolver {
 }
 
 impl IndexerStorePackageResolver {
-    fn get_package_version_from_db(
-        &self,
-        id: AccountAddress,
-    ) -> Result<SequenceNumber, IndexerError> {
-        let Some(version) = read_only_blocking!(&self.cp, |conn| {
-            let query = objects::dsl::objects
-                .select(objects::dsl::object_version)
-                .filter(objects::dsl::object_id.eq(id.to_vec()));
-            query.get_result::<i64>(conn).optional()
-        })?
-        else {
-            return Err(IndexerError::PostgresReadError(format!(
-                "Package version not found in DB: {:?}",
-                id
-            )));
-        };
-
-        Ok(SequenceNumber::from_u64(version as u64))
-    }
-
     fn get_package_from_db(&self, id: AccountAddress) -> Result<Package, IndexerError> {
         let Some(bcs) = read_only_blocking!(&self.cp, |conn| {
             let query = objects::dsl::objects
@@ -133,20 +103,6 @@ impl InterimPackageResolver {
 
 #[async_trait]
 impl PackageStore for InterimPackageResolver {
-    async fn version(&self, addr: AccountAddress) -> Result<SequenceNumber, PackageResolverError> {
-        let package_id = ObjectID::from(addr);
-        let maybe_version = {
-            let buffer_guard = self.package_buffer.lock().unwrap();
-            buffer_guard.get_version(&package_id)
-        };
-        if let Some(version) = maybe_version {
-            self.metrics.indexing_package_resolver_in_mem_hit.inc();
-            Ok(SequenceNumber::from_u64(version))
-        } else {
-            self.package_db_resolver.version(addr).await
-        }
-    }
-
     async fn fetch(&self, addr: AccountAddress) -> Result<Arc<Package>, PackageResolverError> {
         let package_id = ObjectID::from(addr);
         let maybe_obj = {

--- a/crates/sui-indexer/src/system_package_task.rs
+++ b/crates/sui-indexer/src/system_package_task.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use sui_types::SYSTEM_PACKAGE_ADDRESSES;
+use tokio_util::sync::CancellationToken;
+
+use crate::{indexer_reader::IndexerReader, schema::epochs};
+
+/// Background task responsible for evicting system packages from the package resolver's cache after
+/// detecting an epoch boundary.
+pub(crate) struct SystemPackageTask {
+    /// Holds the DB connection and also the package resolver to evict packages from.
+    reader: IndexerReader,
+    /// Signal to cancel the task.
+    cancel: CancellationToken,
+    /// Interval to sleep for between checks.
+    interval: Duration,
+}
+
+impl SystemPackageTask {
+    pub(crate) fn new(
+        reader: IndexerReader,
+        cancel: CancellationToken,
+        interval: Duration,
+    ) -> Self {
+        Self {
+            reader,
+            cancel,
+            interval,
+        }
+    }
+
+    pub(crate) async fn run(&self) {
+        let mut last_epoch: i64 = 0;
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    tracing::info!(
+                        "Shutdown signal received, terminating system package eviction task"
+                    );
+                    return;
+                }
+                _ = tokio::time::sleep(self.interval) => {
+                    let next_epoch: i64 = match self.reader.spawn_blocking(move |this| {
+                        this.run_query(|conn| {
+                            epochs::dsl::epochs
+                                .select(epochs::dsl::epoch)
+                                .order_by(epochs::epoch.desc())
+                                .first(conn)
+                        })
+                    }).await {
+                        Ok(epoch) => epoch,
+                        Err(e) => {
+                            tracing::error!("Failed to fetch latest epoch: {:?}", e);
+                            continue;
+                        }
+                    };
+
+                    if next_epoch > last_epoch {
+                        last_epoch = next_epoch;
+                        self.reader
+                            .package_resolver()
+                            .package_store()
+                            .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-indexer/src/system_package_task.rs
+++ b/crates/sui-indexer/src/system_package_task.rs
@@ -61,6 +61,9 @@ impl SystemPackageTask {
 
                     if next_epoch > last_epoch {
                         last_epoch = next_epoch;
+                        tracing::info!(
+                            "Detected epoch boundary, evicting system packages from cache"
+                        );
                         self.reader
                             .package_resolver()
                             .package_store()

--- a/crates/sui-json-rpc-tests/tests/routing_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/routing_tests.rs
@@ -24,7 +24,7 @@ async fn test_rpc_backward_compatibility() {
     builder.register_module(TestApiModule).unwrap();
 
     let address = local_ip_utils::new_local_tcp_socket_for_testing();
-    let _handle = builder.start(address, None, None).await.unwrap();
+    let _handle = builder.start(address, None, None, None).await.unwrap();
     let url = format!("http://0.0.0.0:{}", address.port());
 
     // Test with un-versioned client
@@ -103,7 +103,7 @@ async fn test_disable_routing() {
     builder.register_module(TestApiModule).unwrap();
 
     let address = local_ip_utils::new_local_tcp_socket_for_testing();
-    let _handle = builder.start(address, None, None).await.unwrap();
+    let _handle = builder.start(address, None, None, None).await.unwrap();
     let url = format!("http://0.0.0.0:{}", address.port());
 
     // try to access old method directly should fail

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -28,6 +28,7 @@ async-trait.workspace = true
 serde.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true, features = ["rt"] }
 signature.workspace = true
 thiserror.workspace = true
 bcs.workspace = true

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -16,6 +16,7 @@ use sui_core::traffic_controller::metrics::TrafficControllerMetrics;
 use sui_types::traffic_control::PolicyConfig;
 use sui_types::traffic_control::RemoteFirewallConfig;
 use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::info;
@@ -257,6 +258,7 @@ impl JsonRpcServerBuilder {
         listen_address: SocketAddr,
         _custom_runtime: Option<Handle>,
         server_type: Option<ServerType>,
+        cancel: Option<CancellationToken>,
     ) -> Result<ServerHandle, Error> {
         let app = self.to_router(server_type).await?;
 
@@ -264,6 +266,12 @@ impl JsonRpcServerBuilder {
             .serve(app.into_make_service_with_connect_info::<SocketAddr>());
 
         let addr = server.local_addr();
+        let server = server.with_graceful_shutdown(async {
+            if let Some(cancel) = cancel {
+                cancel.cancel();
+            }
+        });
+
         let handle = tokio::spawn(async move { server.await.unwrap() });
 
         let handle = ServerHandle {

--- a/crates/sui-light-client/src/main.rs
+++ b/crates/sui-light-client/src/main.rs
@@ -8,7 +8,7 @@ use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 
 use sui_rest_api::{CheckpointData, Client};
 use sui_types::{
-    base_types::{ObjectID, SequenceNumber},
+    base_types::ObjectID,
     committee::Committee,
     crypto::AuthorityQuorumSignInfo,
     digests::TransactionDigest,
@@ -42,22 +42,17 @@ struct Args {
 }
 
 struct RemotePackageStore {
-    client: Client,
     config: Config,
 }
 
 impl RemotePackageStore {
-    pub fn new(client: Client, config: Config) -> Self {
-        Self { client, config }
+    pub fn new(config: Config) -> Self {
+        Self { config }
     }
 }
 
 #[async_trait]
 impl PackageStore for RemotePackageStore {
-    /// Latest version of the object at `id`.
-    async fn version(&self, id: AccountAddress) -> ResolverResult<SequenceNumber> {
-        Ok(self.client.get_object(id.into()).await.unwrap().version())
-    }
     /// Read package contents. Fails if `id` is not an object, not a package, or is malformed in
     /// some way.
     async fn fetch(&self, id: AccountAddress) -> ResolverResult<Arc<Package>> {
@@ -466,8 +461,7 @@ pub async fn main() {
         config.checkpoint_summary_dir.display()
     );
 
-    let client: Client = Client::new(config.rest_url());
-    let remote_package_store = RemotePackageStore::new(client, config.clone());
+    let remote_package_store = RemotePackageStore::new(config.clone());
     let resolver = Resolver::new(remote_package_store);
 
     match args.command {

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -31,7 +31,7 @@ use move_core_types::{
 };
 use sui_types::move_package::TypeOrigin;
 use sui_types::object::Object;
-use sui_types::{base_types::SequenceNumber, is_system_package, Identifier};
+use sui_types::{base_types::SequenceNumber, Identifier};
 
 pub mod error;
 
@@ -84,8 +84,8 @@ pub struct Package {
     /// is referred to by in other packages) to its storage ID (the ID it is loaded from on chain).
     linkage: Linkage,
 
-    /// The version this package was loaded at -- necessary for cache invalidation of system
-    /// packages.
+    /// The version this package was loaded at -- necessary for handling race conditions when
+    /// loading system packages.
     version: SequenceNumber,
 
     modules: BTreeMap<String, Module>,
@@ -205,8 +205,6 @@ struct ResolutionContext<'l> {
 /// store during testing.
 #[async_trait]
 pub trait PackageStore: Send + Sync + 'static {
-    /// Latest version of the object at `id`.
-    async fn version(&self, id: AccountAddress) -> Result<SequenceNumber>;
     /// Read package contents. Fails if `id` is not an object, not a package, or is malformed in
     /// some way.
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>>;
@@ -216,9 +214,6 @@ macro_rules! as_ref_impl {
     ($type:ty) => {
         #[async_trait]
         impl PackageStore for $type {
-            async fn version(&self, id: AccountAddress) -> Result<SequenceNumber> {
-                self.as_ref().version(id).await
-            }
             async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
                 self.as_ref().fetch(id).await
             }
@@ -455,29 +450,30 @@ impl<T> PackageStoreWithLruCache<T> {
         let packages = Mutex::new(LruCache::new(PACKAGE_CACHE_SIZE));
         Self { packages, inner }
     }
+
+    /// Removes all packages with ids in `ids` from the cache, if they exist. Does nothing for ids
+    /// that are not in the cache. Accepts `self` immutably as it operates under the lock.
+    pub fn evict(&self, ids: impl IntoIterator<Item = AccountAddress>) {
+        let mut packages = self.packages.lock().unwrap();
+        for id in ids {
+            packages.pop(&id);
+        }
+    }
 }
 
 #[async_trait]
 impl<T: PackageStore> PackageStore for PackageStoreWithLruCache<T> {
-    async fn version(&self, id: AccountAddress) -> Result<SequenceNumber> {
-        self.inner.version(id).await
-    }
-
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
-        let candidate = {
+        if let Some(package) = {
             // Release the lock after getting the package
             let mut packages = self.packages.lock().unwrap();
             packages.get(&id).map(Arc::clone)
+        } {
+            return Ok(package);
         };
 
-        // System packages can be invalidated in the cache if a newer version exists.
-        match candidate {
-            Some(package) if !is_system_package(id) => return Ok(package),
-            Some(package) if self.version(id).await? <= package.version => return Ok(package),
-            Some(_) | None => { /* nop */ }
-        }
-
         let package = self.inner.fetch(id).await?;
+
         // Try and insert the package into the cache, accounting for races.  In most cases the
         // racing fetches will produce the same package, but for system packages, they may not, so
         // favour the package that has the newer version, or if they are the same, the package that
@@ -1610,6 +1606,9 @@ mod tests {
             cached_package(2, BTreeMap::new(), &build_package("s1"), &s1_types()),
         );
 
+        // Evict the package from the cache
+        resolver.package_store().evict([addr("0x1")]);
+
         let layout = resolver.type_layout(type_("0x1::m::T1")).await.unwrap();
         insta::assert_snapshot!(format!("{layout:#}"));
     }
@@ -1622,37 +1621,30 @@ mod tests {
         ]);
         let resolver = Resolver::new(cache);
 
-        let stats = |inner: &Arc<RwLock<InnerStore>>| {
-            let i = inner.read().unwrap();
-            (i.fetches, i.version_checks)
-        };
-
-        assert_eq!(stats(&inner), (0, 0));
+        assert_eq!(inner.read().unwrap().fetches, 0);
         let l0 = resolver.type_layout(type_("0xa0::m::T0")).await.unwrap();
 
         // Load A0.
-        assert_eq!(stats(&inner), (1, 0));
+        assert_eq!(inner.read().unwrap().fetches, 1);
 
-        // Layouts are the same, no need to reload the package.  Not a system package, so no version
-        // check needed.
+        // Layouts are the same, no need to reload the package.
         let l1 = resolver.type_layout(type_("0xa0::m::T0")).await.unwrap();
         assert_eq!(format!("{l0}"), format!("{l1}"));
-        assert_eq!(stats(&inner), (1, 0));
+        assert_eq!(inner.read().unwrap().fetches, 1);
 
         // Different type, but same package, so no extra fetch.
         let l2 = resolver.type_layout(type_("0xa0::m::T2")).await.unwrap();
         assert_ne!(format!("{l0}"), format!("{l2}"));
-        assert_eq!(stats(&inner), (1, 0));
+        assert_eq!(inner.read().unwrap().fetches, 1);
 
-        // New package to load.  It's a system package, which would need a version check if it
-        // already existed in the cache, but it doesn't yet, so we only see a fetch.
+        // New package to load.
         let l3 = resolver.type_layout(type_("0x1::m::T0")).await.unwrap();
-        assert_eq!(stats(&inner), (2, 0));
+        assert_eq!(inner.read().unwrap().fetches, 2);
 
-        // Reload the same system package type, which will cause a version check.
+        // Reload the same system package type, it gets fetched from cache
         let l4 = resolver.type_layout(type_("0x1::m::T0")).await.unwrap();
         assert_eq!(format!("{l3}"), format!("{l4}"));
-        assert_eq!(stats(&inner), (2, 1));
+        assert_eq!(inner.read().unwrap().fetches, 2);
 
         // Upgrade the system package
         inner.write().unwrap().replace(
@@ -1660,12 +1652,15 @@ mod tests {
             cached_package(2, BTreeMap::new(), &build_package("s1"), &s1_types()),
         );
 
-        // Reload the same system type again.  The version check fails and the system package is
-        // refetched (even though the type is the same as before).  This usage pattern (layouts for
-        // system types) is why a layout cache would be particularly helpful (future optimisation).
+        // Evict the package from the cache
+        resolver.package_store().evict([addr("0x1")]);
+
+        // Reload the system system type again. It will be refetched (even though the type is the
+        // same as before). This usage pattern (layouts for system types) is why a layout cache
+        // would be particularly helpful (future optimisation).
         let l5 = resolver.type_layout(type_("0x1::m::T0")).await.unwrap();
         assert_eq!(format!("{l4}"), format!("{l5}"));
-        assert_eq!(stats(&inner), (3, 2));
+        assert_eq!(inner.read().unwrap().fetches, 3);
     }
 
     #[tokio::test]
@@ -2323,7 +2318,10 @@ mod tests {
     /// have a 'published-at' address), and their transitive dependencies are also in `packages`.
     fn package_cache(
         packages: impl IntoIterator<Item = (u64, CompiledPackage, TypeOriginTable)>,
-    ) -> (Arc<RwLock<InnerStore>>, Box<dyn PackageStore>) {
+    ) -> (
+        Arc<RwLock<InnerStore>>,
+        PackageStoreWithLruCache<InMemoryPackageStore>,
+    ) {
         let packages_by_storage_id: BTreeMap<AccountAddress, _> = packages
             .into_iter()
             .map(|(version, package, origins)| {
@@ -2359,16 +2357,13 @@ mod tests {
         let inner = Arc::new(RwLock::new(InnerStore {
             packages,
             fetches: 0,
-            version_checks: 0,
         }));
 
         let store = InMemoryPackageStore {
             inner: inner.clone(),
         };
 
-        let store_with_cache = PackageStoreWithLruCache::new(store);
-
-        (inner, Box::new(store_with_cache))
+        (inner, PackageStoreWithLruCache::new(store))
     }
 
     fn cached_package(
@@ -2462,21 +2457,10 @@ mod tests {
     struct InnerStore {
         packages: BTreeMap<AccountAddress, Package>,
         fetches: usize,
-        version_checks: usize,
     }
 
     #[async_trait]
     impl PackageStore for InMemoryPackageStore {
-        async fn version(&self, id: AccountAddress) -> Result<SequenceNumber> {
-            let mut inner = self.inner.as_ref().write().unwrap();
-            inner.version_checks += 1;
-            inner
-                .packages
-                .get(&id)
-                .ok_or_else(|| Error::PackageNotFound(id))
-                .map(|p| p.version)
-        }
-
         async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
             let mut inner = self.inner.as_ref().write().unwrap();
             inner.fetches += 1;


### PR DESCRIPTION
## Description

Replace `version` based API with one where the LruCache-based store includes an API for evicting packages, and this gets called by a background task that detects epoch changes.

## Test plan

This change was tested manually, by running a local cluster and simulating a protocol upgrade:

Start by creating a genesis config with a fast epoch duration, and run the network for some time:

```
sui$ cargo run --bin sui -- genesis -f --with-faucet --epoch-duration-ms 10000
sui$ RUST_LOG='off,sui_graphql_rpc=INFO' cargo run --bin sui-test-validator -- \
  --graphql-port 9001 \
  --with-indexer      \
  --c ~/.sui/sui_config
```

After some time, apply a pretend system package upgrade, and restart the `sui-test-validator` invocation:

```diff
diff --git a/crates/sui-framework/packages/sui-framework/sources/sui.move b/crates/sui-framework/packages/sui-framework/sources/sui.move
index 90c7daab59c..883b5ffa9b3 100644
--- a/crates/sui-framework/packages/sui-framework/sources/sui.move
+++ b/crates/sui-framework/packages/sui-framework/sources/sui.move
@@ -26,6 +26,11 @@ module sui::sui {
     /// Name of the coin
     public struct SUI has drop {}
 
+    #[allow(unused_field)]
+    public struct Test {
+        x: u64,
+    }
+
     #[allow(unused_function)]
     /// Register the `SUI` Coin to acquire its `Supply`.
     /// This should be called only once during genesis creation.
diff --git a/crates/sui-protocol-config/src/lib.rs b/crates/sui-protocol-config/src/lib.rs
index 1ec86479379..ae96a57ef4a 100644
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 43;
+const MAX_PROTOCOL_VERSION: u64 = 44;
 
 // Record history of protocol version allocations here:
 //
@@ -2090,6 +2090,7 @@ impl ProtocolConfig {
                     cfg.feature_flags.zklogin_max_epoch_upper_bound_delta = Some(30);
                     cfg.max_meter_ticks_per_package = Some(16_000_000);
                 }
+                44 => {}
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.
```

Meanwhile, repeatedly perform the following GraphQL query:

```
query {
  type(type: "0x2::sui::Test") {
    abilities
  }
}
```

This will initially error (because the type does not exist), until the epoch boundary where the package was upgraded, at which point it will start to succeed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
