### PR TITLE
[gql][cherry-pick] Update h2 to 0.3.26 (#17032)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5061,9 +5061,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/sdk/build-scripts/src/build-dapp-kit.ts
+++ b/sdk/build-scripts/src/build-dapp-kit.ts
@@ -6,7 +6,7 @@ import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 import prefixSelector from 'postcss-prefix-selector';
 
-import { buildPackage } from './utils/buildPackage';
+import { buildPackage } from './utils/buildPackage.js';
 
 buildPackage({
 	plugins: [

--- a/sdk/build-scripts/src/build-package.ts
+++ b/sdk/build-scripts/src/build-package.ts
@@ -1,7 +1,7 @@
 #! /usr/bin/env tsx
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import { buildPackage } from './utils/buildPackage';
+import { buildPackage } from './utils/buildPackage.js';
 
 buildPackage().catch((error) => {
 	console.error(error);

--- a/sdk/build-scripts/src/utils/buildPackage.ts
+++ b/sdk/build-scripts/src/utils/buildPackage.ts
@@ -4,7 +4,8 @@
 import { execSync } from 'child_process';
 import { existsSync, promises as fs } from 'fs';
 import * as path from 'path';
-import { build, BuildOptions } from 'esbuild';
+import type { BuildOptions } from 'esbuild';
+import { build } from 'esbuild';
 
 interface PackageJSON {
 	name?: string;


### PR DESCRIPTION
## Description 

Fix to:
```
error[vulnerability] Degradation of service in h2 servers with CONTINUATION Flood
```

## Test Plan 

`cargo deny check advisories` must pass

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
