### PR TITLE
Add --chain option to sui-tool replay commands

### DIFF
--- a/crates/sui-replay/src/config.rs
+++ b/crates/sui-replay/src/config.rs
@@ -7,7 +7,7 @@ use crate::types::ReplayEngineError;
 use http::Uri;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use tracing::log::warn;
+use tracing::info;
 
 pub const DEFAULT_CONFIG_PATH: &str = "~/.sui-replay/network-config.yaml";
 
@@ -25,7 +25,6 @@ pub struct ReplayableNetworkConfigSet {
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct ReplayableNetworkBaseConfig {
-    #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub epoch_zero_start_timestamp: u64,
@@ -36,14 +35,7 @@ pub struct ReplayableNetworkBaseConfig {
 }
 
 impl ReplayableNetworkConfigSet {
-    pub fn load_config(override_path: Option<String>) -> Result<Self, ReplayEngineError> {
-        let path = override_path.unwrap_or_else(|| {
-            warn!(
-                "No network config path specified, using default path: {}",
-                DEFAULT_CONFIG_PATH
-            );
-            DEFAULT_CONFIG_PATH.to_string()
-        });
+    pub fn load_config(path: String) -> Result<Self, ReplayEngineError> {
         let path = shellexpand::tilde(&path).to_string();
         let path = PathBuf::from_str(&path).unwrap();
         ReplayableNetworkConfigSet::from_file(path.clone()).map_err(|err| {
@@ -100,6 +92,10 @@ impl ReplayableNetworkConfigSet {
         })?;
         Ok(())
     }
+
+    pub fn get_base_config(&self, chain: &str) -> Option<&ReplayableNetworkBaseConfig> {
+        self.base_network_configs.iter().find(|c| c.name == chain)
+    }
 }
 
 impl Default for ReplayableNetworkConfigSet {
@@ -148,6 +144,36 @@ pub fn url_from_str(s: &str) -> Result<Uri, ReplayEngineError> {
     })
 }
 
+/// If rpc_url is provided, use it. Otherwise, load the network config from the config file.
+pub fn get_rpc_url(
+    rpc_url: Option<String>,
+    config_path: Option<PathBuf>,
+    chain: Option<String>,
+) -> anyhow::Result<String> {
+    if let Some(url) = rpc_url {
+        return Ok(url);
+    }
+
+    let config_path = config_path
+        .map(|p| p.to_str().unwrap().to_string())
+        .unwrap_or_else(|| DEFAULT_CONFIG_PATH.to_string());
+    let chain = chain.unwrap_or_else(|| "mainnet".to_string());
+    info!(
+        "RPC URL not provided. Loading network config for {:?} from config file {:?}. \
+                    If a different chain is desired, please provide the chain name.",
+        chain, config_path
+    );
+    let url = ReplayableNetworkConfigSet::load_config(config_path)?
+        .get_base_config(&chain)
+        .ok_or(anyhow::anyhow!(format!(
+            "Unable to find network config for {:?}",
+            chain
+        )))?
+        .public_full_node
+        .clone();
+    Ok(url)
+}
+
 #[test]
 fn test_yaml() {
     let mut set = ReplayableNetworkConfigSet::default();
@@ -158,7 +184,7 @@ fn test_yaml() {
     let final_path = set.save_config(Some(path_str.clone())).unwrap();
 
     // Read from file
-    let data = ReplayableNetworkConfigSet::load_config(Some(path_str)).unwrap();
+    let data = ReplayableNetworkConfigSet::load_config(path_str).unwrap();
     set.path = Some(final_path);
     assert!(set == data);
 }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -3,7 +3,6 @@
 
 use crate::chain_from_chain_id;
 use crate::{
-    config::ReplayableNetworkConfigSet,
     data_fetcher::{
         extract_epoch_and_version, DataFetcher, Fetchers, NodeStateDumpFetcher, RemoteFetcher,
     },
@@ -321,8 +320,7 @@ impl LocalExec {
     }
 
     pub async fn replay_with_network_config(
-        rpc_url: Option<String>,
-        path: Option<String>,
+        rpc_url: String,
         tx_digest: TransactionDigest,
         expensive_safety_check_config: ExpensiveSafetyCheckConfig,
         use_authority: bool,
@@ -330,79 +328,20 @@ impl LocalExec {
         protocol_version: Option<i64>,
         enable_profiler: Option<PathBuf>,
     ) -> Result<ExecutionSandboxState, ReplayEngineError> {
-        async fn inner_exec(
-            rpc_url: String,
-            tx_digest: TransactionDigest,
-            expensive_safety_check_config: ExpensiveSafetyCheckConfig,
-            use_authority: bool,
-            executor_version: Option<i64>,
-            protocol_version: Option<i64>,
-            enable_profiler: Option<PathBuf>,
-        ) -> Result<ExecutionSandboxState, ReplayEngineError> {
-            LocalExec::new_from_fn_url(&rpc_url)
-                .await?
-                .init_for_execution()
-                .await?
-                .execute_transaction(
-                    &tx_digest,
-                    expensive_safety_check_config,
-                    use_authority,
-                    executor_version,
-                    protocol_version,
-                    enable_profiler,
-                )
-                .await
-        }
-
-        if let Some(url) = rpc_url.clone() {
-            info!("Using RPC URL: {}", url);
-            return match inner_exec(
-                url,
-                tx_digest,
-                expensive_safety_check_config.clone(),
+        info!("Using RPC URL: {}", rpc_url);
+        LocalExec::new_from_fn_url(&rpc_url)
+            .await?
+            .init_for_execution()
+            .await?
+            .execute_transaction(
+                &tx_digest,
+                expensive_safety_check_config,
                 use_authority,
                 executor_version,
                 protocol_version,
                 enable_profiler,
             )
             .await
-            {
-                Ok(exec_state) => Ok(exec_state),
-                Err(e) => Err(ReplayEngineError::SuiRpcError {
-                    err: format!(
-                        "Failed to execute transaction with provided RPC URL: Error {}",
-                        e
-                    ),
-                }),
-            };
-        }
-
-        let cfg = ReplayableNetworkConfigSet::load_config(path)?;
-        for cfg in &cfg.base_network_configs {
-            info!(
-                "Attempting to replay with network rpc: {}",
-                cfg.public_full_node.clone()
-            );
-            match inner_exec(
-                cfg.public_full_node.clone(),
-                tx_digest,
-                expensive_safety_check_config.clone(),
-                use_authority,
-                executor_version,
-                protocol_version,
-                enable_profiler.clone(),
-            )
-            .await
-            {
-                Ok(exec_state) => return Ok(exec_state),
-                Err(e) => {
-                    warn!("Failed to execute transaction with network config: {}. Attempting next network config...", e);
-                    continue;
-                }
-            };
-        }
-        error!("No more configs to attempt. Try specifying Full Node RPC URL directly or provide a config file with a valid URL");
-        Err(ReplayEngineError::UnableToExecuteWithNetworkConfigs { cfgs: cfg })
     }
 
     /// This captures the state of the network at a given point in time and populates

--- a/crates/sui-replay/tests/regression_replay.rs
+++ b/crates/sui-replay/tests/regression_replay.rs
@@ -17,7 +17,7 @@ async fn replay_sandboxes() {
         assert!(path.is_file());
         let cmd = ReplayToolCommand::ReplaySandbox { path };
 
-        execute_replay_command(None, true, true, None, cmd)
+        execute_replay_command(None, true, true, None, None, cmd)
             .await
             .unwrap();
     }

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -396,8 +396,20 @@ pub enum ToolCommand {
         safety_checks: bool,
         #[arg(long = "authority")]
         use_authority: bool,
-        #[arg(long = "cfg-path", short)]
+        #[arg(
+            long = "cfg-path",
+            short,
+            help = "Path to the network config file. This should be specified when rpc_url is not present. \
+            If not specified we will use the default network config file at ~/.sui-replay/network-config.yaml"
+        )]
         cfg_path: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "The name of the chain to replay from, could be one of: mainnet, testnet, devnet.\
+            When rpc_url is not specified, this is used to load the corresponding config from the network config file.\
+            If not specified, mainnet will be used by default"
+        )]
+        chain: Option<String>,
         #[command(subcommand)]
         cmd: ReplayToolCommand,
     },
@@ -942,8 +954,9 @@ impl ToolCommand {
                 cmd,
                 use_authority,
                 cfg_path,
+                chain,
             } => {
-                execute_replay_command(rpc_url, safety_checks, use_authority, cfg_path, cmd)
+                execute_replay_command(rpc_url, safety_checks, use_authority, cfg_path, chain, cmd)
                     .await?;
             }
             ToolCommand::VerifyArchive {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -193,7 +193,7 @@ pub enum SuiClientCommands {
         #[clap(long)]
         gas_budget: u64,
 
-        /// Optional gas price for this call. Currently use only for testing and not in production enviroments.
+        /// Optional gas price for this call. Currently use only for testing and not in production environments.
         #[clap(hide = true)]
         gas_price: Option<u64>,
 
@@ -810,7 +810,8 @@ impl SuiClientCommands {
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
-                    sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
+                    sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
+                        .await?;
                 // this will be displayed via trace info, so no output is needed here
                 SuiClientCommandResult::NoOutput
             }
@@ -831,7 +832,8 @@ impl SuiClientCommands {
 
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
-                    sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
+                    sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
+                        .await?;
                 // this will be displayed via trace info, so no output is needed here
                 SuiClientCommandResult::NoOutput
             }
@@ -846,7 +848,8 @@ impl SuiClientCommands {
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
-                    sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
+                    sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
+                        .await?;
                 // this will be displayed via trace info, so no output is needed here
                 SuiClientCommandResult::NoOutput
             }
@@ -863,7 +866,8 @@ impl SuiClientCommands {
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
-                    sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
+                    sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
+                        .await?;
                 // this will be displayed via trace info, so no output is needed here
                 SuiClientCommandResult::NoOutput
             }

--- a/crates/sui/src/unit_tests/profiler_tests.rs
+++ b/crates/sui/src/unit_tests/profiler_tests.rs
@@ -53,7 +53,7 @@ async fn test_profiler() {
     };
 
     let command_result =
-        sui_replay::execute_replay_command(Some(testnet_url), false, false, None, cmd).await;
+        sui_replay::execute_replay_command(Some(testnet_url), false, false, None, None, cmd).await;
 
     assert!(command_result.is_ok());
 


### PR DESCRIPTION
## Description 

When rpc_url is not specified, previously the sui-tool would iterate through the network config and try each config one by one. This is rather unnecessary and inefficient.
This PR adds an explicit --chain option so that when rpc_url is not specified, it will use the config named `chain` in the config file. This simplifies some of the implementation and makes it faster to replay a transaction when the desired config is not the first one in the config file.

## Test plan 

CI
Run locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
