### PR TITLE
Fix batch replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13468,6 +13468,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -34,6 +34,7 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tabled.workspace = true
 
 shared-crypto.workspace = true

--- a/crates/sui-replay/src/batch_replay.rs
+++ b/crates/sui-replay/src/batch_replay.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::replay::{ExecutionSandboxState, LocalExec};
+use crate::types::ReplayEngineError;
+use futures::future::join_all;
+use futures::FutureExt;
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+use sui_config::node::ExpensiveSafetyCheckConfig;
+use sui_types::base_types::TransactionDigest;
+use tokio::time::Instant;
+use tracing::{error, info};
+
+/// Given a list of transaction digests, replay them in parallel using `num_tasks` tasks.
+/// If `terminate_early` is true, the replay will terminate early if any transaction fails;
+/// otherwise it will try to finish all transactions.
+pub async fn batch_replay(
+    tx_digests: impl Iterator<Item = TransactionDigest>,
+    num_tasks: u64,
+    rpc_url: String,
+    expensive_safety_check_config: ExpensiveSafetyCheckConfig,
+    use_authority: bool,
+    terminate_early: bool,
+) {
+    let provider = Arc::new(TransactionDigestProvider::new(tx_digests));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut tasks = vec![];
+    let cur_time = Instant::now();
+    for _ in 0..num_tasks {
+        let provider = provider.clone();
+        let expensive_safety_check_config = expensive_safety_check_config.clone();
+        let rpc_url_ref = rpc_url.as_ref();
+        let cancel = cancel.clone();
+        tasks.push(run_task(
+            provider,
+            rpc_url_ref,
+            expensive_safety_check_config,
+            use_authority,
+            terminate_early,
+            cancel,
+        ));
+    }
+    let all_failed_transactions: Vec<_> = join_all(tasks).await.into_iter().flatten().collect();
+    info!(
+        "Finished replaying {} transactions, took {:?}",
+        provider.get_executed_count(),
+        cur_time.elapsed()
+    );
+    if all_failed_transactions.is_empty() {
+        info!("All transactions passed");
+    } else {
+        error!("Some transactions failed: {:?}", all_failed_transactions);
+    }
+}
+
+struct TransactionDigestProvider {
+    digests: Mutex<VecDeque<TransactionDigest>>,
+    total_count: usize,
+    executed_count: AtomicUsize,
+}
+
+impl TransactionDigestProvider {
+    pub fn new(digests: impl Iterator<Item = TransactionDigest>) -> Self {
+        let digests: VecDeque<_> = digests.collect();
+        let total_count = digests.len();
+        Self {
+            digests: Mutex::new(digests),
+            total_count,
+            executed_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn get_total_count(&self) -> usize {
+        self.total_count
+    }
+
+    pub fn get_executed_count(&self) -> usize {
+        self.executed_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns the index and digest of the next transaction, if any.
+    pub fn next_digest(&self) -> Option<(usize, TransactionDigest)> {
+        let next_digest = self.digests.lock().pop_front();
+        next_digest.map(|digest| {
+            let executed_count = self
+                .executed_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            (executed_count + 1, digest)
+        })
+    }
+}
+
+async fn run_task(
+    tx_digest_provider: Arc<TransactionDigestProvider>,
+    http_url: &str,
+    expensive_safety_check_config: ExpensiveSafetyCheckConfig,
+    use_authority: bool,
+    terminate_early: bool,
+    cancel: tokio_util::sync::CancellationToken,
+) -> Vec<ReplayEngineError> {
+    let total_count = tx_digest_provider.get_total_count();
+    let mut failed_transactions = vec![];
+    let mut executor = LocalExec::new_from_fn_url(http_url).await.unwrap();
+    while let Some((index, digest)) = tx_digest_provider.next_digest() {
+        if cancel.is_cancelled() {
+            break;
+        }
+        info!(
+            "[{}/{}] Replaying transaction {:?}...",
+            index, total_count, digest
+        );
+        let async_func = execute_transaction(
+            &mut executor,
+            &digest,
+            expensive_safety_check_config.clone(),
+            use_authority,
+        )
+        .fuse();
+        let result = tokio::select! {
+            result = async_func => result,
+            _ = cancel.cancelled() => {
+                break;
+            }
+        };
+        if let Err(err) = result {
+            error!("Replaying transaction {:?} forked: {:?}", digest, err);
+            if terminate_early {
+                cancel.cancel();
+                failed_transactions.push(err);
+                break;
+            }
+        } else {
+            info!("Replaying transaction {:?} succeeded", digest);
+        }
+    }
+    failed_transactions
+}
+
+async fn execute_transaction(
+    executor: &mut LocalExec,
+    digest: &TransactionDigest,
+    expensive_safety_check_config: ExpensiveSafetyCheckConfig,
+    use_authority: bool,
+) -> Result<ExecutionSandboxState, ReplayEngineError> {
+    *executor = loop {
+        match executor.clone().reset_for_new_execution_with_client().await {
+            Ok(executor) => break executor,
+            Err(err) => {
+                error!("Failed to reset executor: {:?}. Retrying in 3s", err);
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            }
+        }
+    };
+    let sandbox_state = loop {
+        let result = executor
+            .execute_transaction(
+                digest,
+                expensive_safety_check_config.clone(),
+                use_authority,
+                None,
+                None,
+                None,
+            )
+            .await;
+        match result {
+            Ok(sandbox_state) => break sandbox_state,
+            Err(err) => {
+                error!("Failed to execute transaction: {:?}. Retrying in 3s", err);
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            }
+        }
+    };
+    sandbox_state.check_effects()?;
+    Ok(sandbox_state)
+}

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -844,7 +844,7 @@ impl SuiClientCommands {
                 let cmd = ReplayToolCommand::ReplayBatch {
                     path,
                     terminate_early,
-                    batch_size: 16,
+                    num_tasks: 16,
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =


### PR DESCRIPTION
## Description 

This PR fixes an issue where the batch replay would get stuck.
The core fix is to remove the `tokio::spawn` from the task creation, and instead it pushes an async function directly.
This allows the runtime to schedule tasks together during `join_all`.

It also does some optimizations: instead of scheduling batches one by one, this PR creates N tasks, each pulling transaction digests from a dequeue. This speeds up execution.
This PR also makes each task to reuse the executor, which allows for package cache reuse, another speedup.

## Test plan 

Run locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
