### PR TITLE
[nodefw/drainer] add a drain flag and file

### DIFF
--- a/nre/bpf/nodefw/nodefw/src/drainer.rs
+++ b/nre/bpf/nodefw/nodefw/src/drainer.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use tokio_util::sync::CancellationToken;
 use tracing::info;

--- a/nre/bpf/nodefw/nodefw/src/drainer.rs
+++ b/nre/bpf/nodefw/nodefw/src/drainer.rs
@@ -1,0 +1,23 @@
+use std::fs;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+pub async fn watch(ctx: CancellationToken, path: &str) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                if let Ok(_) = fs::metadata(path) {
+                    // drain file exists, unload program and close things down
+                    info!("drain file found, terminating firewall");
+                    return;
+                }
+            }
+            _ = ctx.cancelled() => {
+                return;
+            }
+        }
+    }
+}

--- a/nre/bpf/nodefw/nodefw/src/lib.rs
+++ b/nre/bpf/nodefw/nodefw/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod drainer;
 pub mod fwmap;
 pub mod server;
 pub mod time;

--- a/nre/bpf/nodefw/nodefw/src/main.rs
+++ b/nre/bpf/nodefw/nodefw/src/main.rs
@@ -8,8 +8,8 @@ use aya::BpfLoader;
 use aya_log::BpfLogger;
 use clap::{Parser, ValueEnum};
 use nodefw::fwmap::{ttl_watcher, Firewall};
-use nodefw::server;
 use nodefw::time::get_ktime_get_ns;
+use nodefw::{drainer, server};
 use nodefw_common::Meta;
 use std::sync::{Arc, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -21,6 +21,8 @@ struct Opt {
     iface: String,
     #[clap(short, long, value_enum, default_value_t=Mode::Default)]
     mode: Mode,
+    #[clap(short, long)]
+    drain_file: String,
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -93,17 +95,28 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let listener = std::net::TcpListener::bind(nodefw::var!(
         "NODEFW_LISTEN_ON",
-        "127.0.0.1:8080".into(),
+        "127.0.0.1:8081".into(),
         String
     ))
     .unwrap();
     info!("Listening for signal to terminate...");
     let sc = server::ServerConfig {
-        ctx,
+        ctx: ctx.clone(),
         listener,
         router,
     };
-    let _ = server::serve(sc).await;
+    loop {
+        tokio::select! {
+            _ = server::serve(sc) => {
+                ctx.cancel();
+                break;
+            },
+            _ = drainer::watch(ctx.clone(), &opt.drain_file) => {
+                ctx.cancel();
+                break;
+            },
+        }
+    }
     info!("firewall has stopped, exiting.");
     Ok(())
 }

--- a/nre/bpf/nodefw/nodefw/src/main.rs
+++ b/nre/bpf/nodefw/nodefw/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let listener = std::net::TcpListener::bind(nodefw::var!(
         "NODEFW_LISTEN_ON",
-        "127.0.0.1:8081".into(),
+        "127.0.0.1:8080".into(),
         String
     ))
     .unwrap();


### PR DESCRIPTION
## Description
Add a drain file to control the firewall if needed.

## Test Plan
`RUST_LOG=info cargo bpf run -- --drain-file /tmp/drain`

then rm or touch the file at /tmp/drain.  the firewall will unload or be prevented from loading if present.


https://github.com/MystenLabs/sui/assets/123987499/0a21b9f0-b9ca-47c4-a5b2-6217c350a75d



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
