### PR TITLE
[bridge 72/n] rework node config a little bit

### DIFF
--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -1,18 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::abi::{EthBridgeCommittee, EthBridgeConfig, EthSuiBridge};
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::error::BridgeError;
 use crate::eth_client::EthClient;
 use crate::sui_client::SuiClient;
-use crate::types::BridgeAction;
+use crate::types::{is_route_valid, BridgeAction};
 use anyhow::anyhow;
+use ethers::providers::Middleware;
 use ethers::types::Address as EthAddress;
-use fastcrypto::traits::EncodeDecodeBase64;
+use fastcrypto::traits::{EncodeDecodeBase64, KeyPair};
 use futures::{future, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -22,10 +24,59 @@ use sui_sdk::apis::CoinReadApi;
 use sui_sdk::{SuiClient as SuiSdkClient, SuiClientBuilder};
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::bridge::BridgeChainId;
 use sui_types::crypto::SuiKeyPair;
+use sui_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
 use sui_types::event::EventID;
 use sui_types::object::Owner;
 use tracing::info;
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct EthConfig {
+    /// Rpc url for Eth fullnode, used for query stuff.
+    pub eth_rpc_url: String,
+    /// The proxy address of SuiBridge
+    pub eth_bridge_proxy_address: String,
+    /// The expected BridgeChainId on Eth side.
+    pub eth_bridge_chain_id: u8,
+    // TODO: we need to hardcode the starting blocks for eth networks for cold start.
+    /// Override the start block number for each eth address. Key must be in `eth_addresses`.
+    /// When set, EthSyncer will start from this block number (inclusively) instead of the one in storage.
+    /// Note: This field should be rarely used. Only use it when you understand how to follow up.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eth_contracts_start_block_override: Option<u64>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SuiConfig {
+    /// Rpc url for Sui fullnode, used for query stuff and submit transactions.
+    pub sui_rpc_url: String,
+    /// The expected BridgeChainId on Sui side.
+    pub sui_bridge_chain_id: u8,
+    /// Path of the file where bridge client key (any SuiKeyPair) is stored as Base64 encoded `flag || privkey`.
+    /// If `run_client` is true, and this is None, then use `bridge_authority_key_path_base64_raw` as client key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_client_key_path_base64_sui_key: Option<PathBuf>,
+    /// The gas object to use for paying for gas fees for the client. It needs to
+    /// be owned by the address associated with bridge client key. If not set
+    /// and `run_client` is true, it will query and use the gas object with highest
+    /// amount for the account.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_client_gas_object: Option<ObjectID>,
+    /// Override the last processed EventID for bridge module `bridge`.
+    /// When set, SuiSyncer will start from this cursor (exclusively) instead of the one in storage.
+    /// If the cursor is not found in storage or override, the query will start from genesis.
+    /// Key: sui module, Value: last processed EventID (tx_digest, event_seq).
+    /// Note 1: This field should be rarely used. Only use it when you understand how to follow up.
+    /// Note 2: the EventID needs to be valid, namely it must exist and matches the filter.
+    /// Otherwise, it will miss one event because of fullnode Event query semantics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sui_bridge_module_last_processed_event_id_override: Option<EventID>,
+}
 
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -37,48 +88,18 @@ pub struct BridgeNodeConfig {
     pub metrics_port: u16,
     /// Path of the file where bridge authority key (Secp256k1) is stored as Base64 encoded `privkey`.
     pub bridge_authority_key_path_base64_raw: PathBuf,
-    /// Rpc url for Sui fullnode, used for query stuff and submit transactions.
-    pub sui_rpc_url: String,
-    /// Rpc url for Eth fullnode, used for query stuff.
-    pub eth_rpc_url: String,
-    /// The eth contract addresses (hex). It must not be empty. It serves two purpose:
-    /// 1. validator only signs bridge actions that are generated from these contracts.
-    /// 2. for EthSyncer to watch for when `run_client` is true.
-    pub eth_addresses: Vec<String>,
-    /// Path of the file where bridge client key (any SuiKeyPair) is stored as Base64 encoded `flag || privkey`.
-    /// If `run_client` is true, and this is None, then use `bridge_authority_key_path_base64_raw` as client key.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bridge_client_key_path_base64_sui_key: Option<PathBuf>,
     /// Whether to run client. If true, `bridge_client_key_path_base64_sui_key`,
     /// and `db_path` needs to be provided.
     pub run_client: bool,
-    /// The gas object to use for paying for gas fees for the client. It needs to
-    /// be owned by the address associated with bridge client key. If not set
-    /// and `run_client` is true, it will query and use the gas object with highest
-    /// amount for the account.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bridge_client_gas_object: Option<ObjectID>,
     /// Path of the client storage. Required when `run_client` is true.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_path: Option<PathBuf>,
-    // TODO: we need to hardcode the starting blocks for eth networks for cold start.
-    /// Override the start block number for each eth address. Key must be in `eth_addresses`.
-    /// When set, EthSyncer will start from this block number (inclusively) instead of the one in storage.
-    /// Key: eth address, Value:  block number to start from
-    /// Note: This field should be rarely used. Only use it when you understand how to follow up.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub eth_bridge_contracts_start_block_override: Option<BTreeMap<String, u64>>,
-    /// Override the last processed EventID for bridge module `bridge`.
-    /// When set, SuiSyncer will start from this cursor (exclusively) instead of the one in storage.
-    /// If the cursor is not found in storage or override, the query will start from genesis.
-    /// Key: sui module, Value: last processed EventID (tx_digest, event_seq).
-    /// Note 1: This field should be rarely used. Only use it when you understand how to follow up.
-    /// Note 2: the EventID needs to be valid, namely it must exist and matches the filter.
-    /// Otherwise, it will miss one event because of fullnode Event query semantics.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sui_bridge_module_last_processed_event_id_override: Option<EventID>,
     /// A list of approved governance actions. Action in this list will be signed when requested by client.
     pub approved_governance_actions: Vec<BridgeAction>,
+    /// Sui configuration
+    pub sui: SuiConfig,
+    /// Eth configuration
+    pub eth: EthConfig,
 }
 
 impl Config for BridgeNodeConfig {}
@@ -87,38 +108,53 @@ impl BridgeNodeConfig {
     pub async fn validate(
         &self,
     ) -> anyhow::Result<(BridgeServerConfig, Option<BridgeClientConfig>)> {
+        if !is_route_valid(
+            BridgeChainId::try_from(self.sui.sui_bridge_chain_id)?,
+            BridgeChainId::try_from(self.eth.eth_bridge_chain_id)?,
+        ) {
+            return Err(anyhow!(
+                "Route between Sui chain id {} and Eth chain id {} is not valid",
+                self.sui.sui_bridge_chain_id,
+                self.eth.eth_bridge_chain_id,
+            ));
+        };
+
         let bridge_authority_key =
             read_bridge_authority_key(&self.bridge_authority_key_path_base64_raw)?;
 
-        // TODO: verify it's part of bridge committee
-        let sui_client = Arc::new(SuiClient::<SuiSdkClient>::new(&self.sui_rpc_url).await?);
-
-        // TODO(audit-blocking): verify Sui Chain ID matches bridge Chain ID
-
-        if self.eth_addresses.is_empty() {
-            return Err(anyhow!("`eth_addresses` must contain at least one address"));
+        // we do this check here instead of `prepare_for_sui` below because
+        // that is only called when `run_client` is true.
+        let sui_client = Arc::new(SuiClient::<SuiSdkClient>::new(&self.sui.sui_rpc_url).await?);
+        let bridge_committee = sui_client
+            .get_bridge_committee()
+            .await
+            .map_err(|e| anyhow!("Error getting bridge committee: {:?}", e))?;
+        if !bridge_committee.is_active_member(&bridge_authority_key.public().into()) {
+            return Err(anyhow!(
+                "Bridge authority key is not part of bridge committee"
+            ));
         }
-        let eth_bridge_contracts = self
-            .eth_addresses
-            .iter()
-            .map(|addr| EthAddress::from_str(addr))
-            .collect::<Result<Vec<_>, _>>()?;
-        let eth_client = Arc::new(
-            EthClient::<ethers::providers::Http>::new(
-                &self.eth_rpc_url,
-                HashSet::from_iter(eth_bridge_contracts.iter().cloned()),
-            )
-            .await?,
-        );
-        // TODO(audit-blocking): verify Ethereum Chain ID matches bridge Chain ID
+
+        let (eth_client, eth_contracts) = self.prepare_for_eth().await?;
+        let bridge_summary = sui_client
+            .get_bridge_summary()
+            .await
+            .map_err(|e| anyhow!("Error getting bridge summary: {:?}", e))?;
+        if bridge_summary.chain_id != self.sui.sui_bridge_chain_id {
+            anyhow::bail!(
+                "Bridge chain id mismatch: expected {}, but connected to {}",
+                self.sui.sui_bridge_chain_id,
+                bridge_summary.chain_id
+            );
+        }
 
         // Validate approved actions that must be governace actions
         for action in &self.approved_governance_actions {
             if !action.is_governace_action() {
-                return Err(anyhow::anyhow!(format!(
+                anyhow::bail!(format!(
                     "{:?}",
                     BridgeError::ActionIsNotGovernanceAction(action.clone())
-                )));
+                ));
             }
         }
         let approved_governance_actions = self.approved_governance_actions.clone();
@@ -131,67 +167,19 @@ impl BridgeNodeConfig {
             eth_client: eth_client.clone(),
             approved_governance_actions,
         };
-
         if !self.run_client {
             return Ok((bridge_server_config, None));
         }
+
         // If client is enabled, prepare client config
-        let bridge_client_key = if self.bridge_client_key_path_base64_sui_key.is_none() {
-            let bridge_client_key =
-                read_bridge_authority_key(&self.bridge_authority_key_path_base64_raw)?;
-            Ok(SuiKeyPair::from(bridge_client_key))
-        } else {
-            read_bridge_client_key(self.bridge_client_key_path_base64_sui_key.as_ref().unwrap())
-        }?;
+        let (bridge_client_key, client_sui_address, gas_object_ref) =
+            self.prepare_for_sui(sui_client.clone()).await?;
 
-        let client_sui_address = SuiAddress::from(&bridge_client_key.public());
-        info!("Bridge client sui address: {:?}", client_sui_address);
-
-        // TODO: decide a minimal amount here and return if no coin has enough balance
-        let gas_object_id = match self.bridge_client_gas_object {
-            Some(id) => id,
-            None => {
-                let sui_client = SuiClientBuilder::default().build(&self.sui_rpc_url).await?;
-                let coin =
-                    pick_highest_balance_coin(sui_client.coin_read_api(), client_sui_address, 0)
-                        .await?;
-                coin.coin_object_id
-            }
-        };
         let db_path = self
             .db_path
             .clone()
             .ok_or(anyhow!("`db_path` is required when `run_client` is true"))?;
 
-        let mut eth_bridge_contracts_start_block_override = BTreeMap::new();
-        match &self.eth_bridge_contracts_start_block_override {
-            Some(overrides) => {
-                for (addr, block_number) in overrides {
-                    let address = EthAddress::from_str(addr)?;
-                    if eth_bridge_contracts.contains(&address) {
-                        eth_bridge_contracts_start_block_override.insert(address, *block_number);
-                    } else {
-                        return Err(anyhow!(
-                            "Override start block number for address {:?} is not in `eth_addresses`",
-                            addr
-                        ));
-                    }
-                }
-            }
-            None => {}
-        }
-
-        let (gas_coin, gas_object_ref, owner) = sui_client
-            .get_gas_data_panic_if_not_gas(gas_object_id)
-            .await;
-        if owner != Owner::AddressOwner(client_sui_address) {
-            return Err(anyhow!("Gas object {:?} is not owned by bridge client key's associated sui address {:?}, but {:?}", gas_object_id, client_sui_address, owner));
-        }
-        info!(
-            "Starting bridge client with gas object {:?}, balance: {}",
-            gas_object_ref.0,
-            gas_coin.value()
-        );
         let bridge_client_config = BridgeClientConfig {
             sui_address: client_sui_address,
             key: bridge_client_key,
@@ -200,13 +188,156 @@ impl BridgeNodeConfig {
             sui_client: sui_client.clone(),
             eth_client: eth_client.clone(),
             db_path,
-            eth_bridge_contracts,
-            eth_bridge_contracts_start_block_override,
+            eth_contracts,
+            eth_contracts_start_block_override: self.eth.eth_contracts_start_block_override,
             sui_bridge_module_last_processed_event_id_override: self
+                .sui
                 .sui_bridge_module_last_processed_event_id_override,
         };
 
         Ok((bridge_server_config, Some(bridge_client_config)))
+    }
+
+    async fn prepare_for_eth(
+        &self,
+    ) -> anyhow::Result<(Arc<EthClient<ethers::providers::Http>>, Vec<EthAddress>)> {
+        let bridge_proxy_address = EthAddress::from_str(&self.eth.eth_bridge_proxy_address)?;
+        let provider = Arc::new(
+            ethers::prelude::Provider::<ethers::providers::Http>::try_from(&self.eth.eth_rpc_url)
+                .unwrap()
+                .interval(std::time::Duration::from_millis(2000)),
+        );
+        let chain_id = provider.get_chainid().await?;
+        let sui_bridge = EthSuiBridge::new(bridge_proxy_address, provider.clone());
+        let committee_address: EthAddress = sui_bridge.committee().call().await?;
+        let limiter_address: EthAddress = sui_bridge.limiter().call().await?;
+        let vault_address: EthAddress = sui_bridge.vault().call().await?;
+        let committee = EthBridgeCommittee::new(committee_address, provider.clone());
+        let config_address: EthAddress = committee.config().call().await?;
+        let config = EthBridgeConfig::new(config_address, provider.clone());
+
+        // If bridge chain id is Eth Mainent or Sepolia, we expect to see chain
+        // identifier to match accordingly.
+        let bridge_chain_id: u8 = config.chain_id().call().await?;
+        if self.eth.eth_bridge_chain_id != bridge_chain_id {
+            return Err(anyhow!(
+                "Bridge chain id mismatch: expected {}, but connected to {}",
+                self.eth.eth_bridge_chain_id,
+                bridge_chain_id
+            ));
+        }
+        if bridge_chain_id == BridgeChainId::EthMainnet as u8 && chain_id.as_u64() != 1 {
+            anyhow::bail!(
+                "Expected Eth chain id 1, but connected to {}",
+                chain_id.as_u64()
+            );
+        }
+        if bridge_chain_id == BridgeChainId::EthSepolia as u8 && chain_id.as_u64() != 11155111 {
+            anyhow::bail!(
+                "Expected Eth chain id 11155111, but connected to {}",
+                chain_id.as_u64()
+            );
+        }
+        info!(
+            "Connected to Eth chain: {}, Bridge chain id: {}",
+            chain_id.as_u64(),
+            bridge_chain_id,
+        );
+
+        let eth_client = Arc::new(
+            EthClient::<ethers::providers::Http>::new(
+                &self.eth.eth_rpc_url,
+                HashSet::from_iter(vec![
+                    bridge_proxy_address,
+                    committee_address,
+                    config_address,
+                    limiter_address,
+                    vault_address,
+                ]),
+            )
+            .await?,
+        );
+        let contract_addresses = vec![
+            bridge_proxy_address,
+            committee_address,
+            config_address,
+            limiter_address,
+            vault_address,
+        ];
+        Ok((eth_client, contract_addresses))
+    }
+
+    async fn prepare_for_sui(
+        &self,
+        sui_client: Arc<SuiClient<SuiSdkClient>>,
+    ) -> anyhow::Result<(SuiKeyPair, SuiAddress, ObjectRef)> {
+        let bridge_client_key = match &self.sui.bridge_client_key_path_base64_sui_key {
+            None => {
+                let bridge_client_key =
+                    read_bridge_authority_key(&self.bridge_authority_key_path_base64_raw)?;
+                Ok(SuiKeyPair::from(bridge_client_key))
+            }
+            Some(path) => read_bridge_client_key(path),
+        }?;
+
+        // If bridge chain id is Sui Mainent or Testnet, we expect to see chain
+        // identifier to match accordingly.
+        let sui_identifier = sui_client
+            .get_chain_identifier()
+            .await
+            .map_err(|e| anyhow!("Error getting chain identifier from Sui: {:?}", e))?;
+        if self.sui.sui_bridge_chain_id == BridgeChainId::SuiMainnet as u8
+            && sui_identifier != get_mainnet_chain_identifier().to_string()
+        {
+            anyhow::bail!(
+                "Expected sui chain identifier {}, but connected to {}",
+                self.sui.sui_bridge_chain_id,
+                sui_identifier
+            );
+        }
+        if self.sui.sui_bridge_chain_id == BridgeChainId::SuiTestnet as u8
+            && sui_identifier != get_testnet_chain_identifier().to_string()
+        {
+            anyhow::bail!(
+                "Expected sui chain identifier {}, but connected to {}",
+                self.sui.sui_bridge_chain_id,
+                sui_identifier
+            );
+        }
+        info!(
+            "Connected to Sui chain: {}, Bridge chain id: {}",
+            sui_identifier, self.sui.sui_bridge_chain_id,
+        );
+
+        let client_sui_address = SuiAddress::from(&bridge_client_key.public());
+
+        // TODO: decide a minimal amount here
+        let gas_object_id = match self.sui.bridge_client_gas_object {
+            Some(id) => id,
+            None => {
+                let sui_client = SuiClientBuilder::default()
+                    .build(&self.sui.sui_rpc_url)
+                    .await?;
+                let coin =
+                    pick_highest_balance_coin(sui_client.coin_read_api(), client_sui_address, 0)
+                        .await?;
+                coin.coin_object_id
+            }
+        };
+        let (gas_coin, gas_object_ref, owner) = sui_client
+            .get_gas_data_panic_if_not_gas(gas_object_id)
+            .await;
+        if owner != Owner::AddressOwner(client_sui_address) {
+            return Err(anyhow!("Gas object {:?} is not owned by bridge client key's associated sui address {:?}, but {:?}", gas_object_id, client_sui_address, owner));
+        }
+        info!(
+            "Starting bridge client with address: {:?}, gas object {:?}, balance: {}",
+            client_sui_address,
+            gas_object_ref.0,
+            gas_coin.value()
+        );
+
+        Ok((bridge_client_key, client_sui_address, gas_object_ref))
     }
 }
 
@@ -229,8 +360,8 @@ pub struct BridgeClientConfig {
     pub sui_client: Arc<SuiClient<SuiSdkClient>>,
     pub eth_client: Arc<EthClient<ethers::providers::Http>>,
     pub db_path: PathBuf,
-    pub eth_bridge_contracts: Vec<EthAddress>,
-    pub eth_bridge_contracts_start_block_override: BTreeMap<EthAddress, u64>,
+    pub eth_contracts: Vec<EthAddress>,
+    pub eth_contracts_start_block_override: Option<u64>,
     pub sui_bridge_module_last_processed_event_id_override: Option<EventID>,
 }
 
@@ -301,4 +432,13 @@ pub async fn pick_highest_balance_coin(
         ));
     }
     Ok(highest_balance_coin.unwrap())
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct EthContractAddresses {
+    pub sui_bridge: EthAddress,
+    pub bridge_committee: EthAddress,
+    pub bridge_config: EthAddress,
+    pub bridge_limiter: EthAddress,
+    pub bridge_vault: EthAddress,
 }

--- a/crates/sui-bridge/src/e2e_test_utils.rs
+++ b/crates/sui-bridge/src/e2e_test_utils.rs
@@ -1,16 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::abi::EthBridgeCommittee;
+use crate::crypto::BridgeAuthorityKeyPair;
+use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::server::APPLICATION_JSON;
 use crate::types::{AddTokensOnSuiAction, BridgeAction};
+use crate::utils::get_eth_signer_client;
+use crate::utils::EthSigner;
+use ethers::types::Address as EthAddress;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::process::Command;
+use std::str::FromStr;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::bridge::{
     BridgeChainId, BRIDGE_MODULE_NAME, BRIDGE_REGISTER_FOREIGN_TOKEN_FUNCTION_NAME,
 };
+use sui_types::committee::TOTAL_VOTING_POWER;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{ObjectArg, TransactionData};
 use sui_types::BRIDGE_PACKAGE_ID;
+
+use tracing::error;
+use tracing::info;
+
+const BRIDGE_COMMITTEE_NAME: &str = "BridgeCommittee";
+const SUI_BRIDGE_NAME: &str = "SuiBridge";
+const BRIDGE_CONFIG_NAME: &str = "BridgeConfig";
+const BRIDGE_LIMITER_NAME: &str = "BridgeLimiter";
+const BRIDGE_VAULT_NAME: &str = "BridgeVault";
+const BTC_NAME: &str = "BTC";
+const ETH_NAME: &str = "ETH";
+const USDC_NAME: &str = "USDC";
+const USDT_NAME: &str = "USDT";
 
 pub async fn publish_coins_return_add_coins_on_sui_action(
     wallet_context: &mut WalletContext,
@@ -112,4 +138,206 @@ pub async fn wait_for_server_to_be_up(server_url: String, timeout_sec: u64) -> a
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
     Ok(())
+}
+
+pub async fn get_eth_signer_client_e2e_test_only(
+    eth_rpc_url: &str,
+) -> anyhow::Result<(EthSigner, String)> {
+    // This private key is derived from the default anvil setting.
+    // Mnemonic:          test test test test test test test test test test test junk
+    // Derivation path:   m/44'/60'/0'/0/
+    // DO NOT USE IT ANYWHERE ELSE EXCEPT FOR RUNNING AUTOMATIC INTEGRATION TESTING
+    let url = eth_rpc_url.to_string();
+    let private_key_0 = "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
+    let signer_0 = get_eth_signer_client(&url, private_key_0).await?;
+    Ok((signer_0, private_key_0.to_string()))
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DeployedSolContracts {
+    pub sui_bridge: EthAddress,
+    pub bridge_committee: EthAddress,
+    pub bridge_limiter: EthAddress,
+    pub bridge_vault: EthAddress,
+    pub bridge_config: EthAddress,
+    pub btc: EthAddress,
+    pub eth: EthAddress,
+    pub usdc: EthAddress,
+    pub usdt: EthAddress,
+}
+
+impl DeployedSolContracts {
+    pub fn eth_adress_to_hex(addr: EthAddress) -> String {
+        format!("{:x}", addr)
+    }
+
+    pub fn sui_bridge_addrress_hex(&self) -> String {
+        Self::eth_adress_to_hex(self.sui_bridge)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SolDeployConfig {
+    committee_member_stake: Vec<u64>,
+    committee_members: Vec<String>,
+    min_committee_stake_required: u64,
+    source_chain_id: u64,
+    supported_chain_ids: Vec<u64>,
+    supported_chain_limits_in_dollars: Vec<u64>,
+    supported_tokens: Vec<String>,
+    token_prices: Vec<u64>,
+}
+
+pub async fn deploy_sol_contract(
+    anvil_url: &str,
+    eth_signer: EthSigner,
+    bridge_authority_keys: Vec<BridgeAuthorityKeyPair>,
+    tx: tokio::sync::oneshot::Sender<DeployedSolContracts>,
+    eth_private_key_hex: String,
+) {
+    let sol_path = format!("{}/../../bridge/evm", env!("CARGO_MANIFEST_DIR"));
+
+    // Write the deploy config to a temp file then provide it to the forge late
+    let deploy_config_path = tempfile::tempdir()
+        .unwrap()
+        .into_path()
+        .join("sol_deploy_config.json");
+    let node_len = bridge_authority_keys.len();
+    let stake = TOTAL_VOTING_POWER / (node_len as u64);
+    let committee_members = bridge_authority_keys
+        .iter()
+        .map(|k| {
+            format!(
+                "0x{:x}",
+                BridgeAuthorityPublicKeyBytes::from(&k.public).to_eth_address()
+            )
+        })
+        .collect::<Vec<_>>();
+    let committee_member_stake = vec![stake; node_len];
+    let deploy_config = SolDeployConfig {
+        committee_member_stake: committee_member_stake.clone(),
+        committee_members: committee_members.clone(),
+        min_committee_stake_required: 10000,
+        source_chain_id: BridgeChainId::EthCustom as u64,
+        supported_chain_ids: vec![1, 2, 3],
+        supported_chain_limits_in_dollars: vec![
+            1000000000000000,
+            1000000000000000,
+            1000000000000000,
+        ],
+        supported_tokens: vec![], // this is set up in the deploy script
+        token_prices: vec![12800, 432518900, 25969600, 10000, 10000],
+    };
+
+    let serialized_config = serde_json::to_string_pretty(&deploy_config).unwrap();
+    tracing::debug!(
+        "Serialized config written to {:?}: {:?}",
+        deploy_config_path,
+        serialized_config
+    );
+    let mut file = File::create(deploy_config_path.clone()).unwrap();
+    file.write_all(serialized_config.as_bytes()).unwrap();
+
+    // override for the deploy script
+    std::env::set_var("OVERRIDE_CONFIG_PATH", deploy_config_path.to_str().unwrap());
+    std::env::set_var("PRIVATE_KEY", eth_private_key_hex);
+    std::env::set_var("ETHERSCAN_API_KEY", "n/a");
+
+    info!("Deploying solidity contracts");
+    Command::new("forge")
+        .current_dir(sol_path.clone())
+        .arg("clean")
+        .status()
+        .expect("Failed to execute `forge clean`");
+
+    let mut child = Command::new("forge")
+        .current_dir(sol_path)
+        .arg("script")
+        .arg("script/deploy_bridge.s.sol")
+        .arg("--fork-url")
+        .arg(anvil_url)
+        .arg("--broadcast")
+        .arg("--ffi")
+        .arg("--chain")
+        .arg("31337")
+        .stdout(std::process::Stdio::piped()) // Capture stdout
+        .stderr(std::process::Stdio::piped()) // Capture stderr
+        .spawn()
+        .unwrap();
+
+    let mut stdout = child.stdout.take().expect("Failed to open stdout");
+    let mut stderr = child.stderr.take().expect("Failed to open stderr");
+
+    // Read stdout/stderr to String
+    let mut s = String::new();
+    stdout.read_to_string(&mut s).unwrap();
+    let mut e = String::new();
+    stderr.read_to_string(&mut e).unwrap();
+
+    // Wait for the child process to finish and collect its status
+    let status = child.wait().unwrap();
+    if status.success() {
+        info!("Solidity contract deployment finished successfully");
+    } else {
+        error!(
+            "Solidity contract deployment exited with code: {:?}",
+            status.code()
+        );
+    }
+    println!("Stdout: {}", s);
+    println!("Stdout: {}", e);
+
+    let mut deployed_contracts = BTreeMap::new();
+    // Process the stdout to parse contract addresses
+    for line in s.lines() {
+        if line.contains("[Deployed]") {
+            let replaced_line = line.replace("[Deployed]", "");
+            let trimmed_line = replaced_line.trim();
+            let parts: Vec<&str> = trimmed_line.split(':').collect();
+            if parts.len() == 2 {
+                let contract_name = parts[0].to_string().trim().to_string();
+                let contract_address = EthAddress::from_str(parts[1].to_string().trim()).unwrap();
+                deployed_contracts.insert(contract_name, contract_address);
+            }
+        }
+    }
+
+    let contracts = DeployedSolContracts {
+        sui_bridge: *deployed_contracts.get(SUI_BRIDGE_NAME).unwrap(),
+        bridge_committee: *deployed_contracts.get(BRIDGE_COMMITTEE_NAME).unwrap(),
+        bridge_config: *deployed_contracts.get(BRIDGE_CONFIG_NAME).unwrap(),
+        bridge_limiter: *deployed_contracts.get(BRIDGE_LIMITER_NAME).unwrap(),
+        bridge_vault: *deployed_contracts.get(BRIDGE_VAULT_NAME).unwrap(),
+        btc: *deployed_contracts.get(BTC_NAME).unwrap(),
+        eth: *deployed_contracts.get(ETH_NAME).unwrap(),
+        usdc: *deployed_contracts.get(USDC_NAME).unwrap(),
+        usdt: *deployed_contracts.get(USDT_NAME).unwrap(),
+    };
+    let eth_bridge_committee =
+        EthBridgeCommittee::new(contracts.bridge_committee, eth_signer.clone().into());
+    for (i, (m, s)) in committee_members
+        .iter()
+        .zip(committee_member_stake.iter())
+        .enumerate()
+    {
+        let eth_address = EthAddress::from_str(m).unwrap();
+        assert_eq!(
+            eth_bridge_committee
+                .committee_index(eth_address)
+                .await
+                .unwrap(),
+            i as u8
+        );
+        assert_eq!(
+            eth_bridge_committee
+                .committee_stake(eth_address)
+                .await
+                .unwrap(),
+            *s as u16
+        );
+        assert!(!eth_bridge_committee.blocklist(eth_address).await.unwrap());
+    }
+    tx.send(contracts).unwrap();
 }

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::abi::{eth_sui_bridge, EthBridgeCommittee, EthBridgeEvent, EthSuiBridge};
+use crate::abi::{eth_sui_bridge, EthBridgeEvent, EthSuiBridge};
 use crate::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
-use crate::config::BridgeNodeConfig;
-use crate::crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKeyBytes};
+use crate::config::{BridgeNodeConfig, EthConfig, SuiConfig};
 use crate::e2e_test_utils::publish_coins_return_add_coins_on_sui_action;
 use crate::events::SuiBridgeEvent;
 use crate::node::run_bridge_node;
 use crate::sui_client::SuiBridgeClient;
 use crate::sui_transaction_builder::build_add_tokens_on_sui_transaction;
+use crate::test_utils::deploy_sol_contract;
+use crate::test_utils::get_eth_signer_client_e2e_test_only;
 use crate::types::{BridgeAction, BridgeActionStatus, SuiToEthBridgeAction};
 use crate::utils::EthSigner;
 use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
@@ -17,14 +18,10 @@ use eth_sui_bridge::EthSuiBridgeEvents;
 use ethers::prelude::*;
 use ethers::types::Address as EthAddress;
 use move_core_types::ident_str;
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
-use std::fs::File;
-use std::io::Read;
-use std::io::Write;
+use std::collections::HashMap;
+
 use std::path::Path;
-use std::process::Command;
-use std::str::FromStr;
+
 use std::sync::Arc;
 use sui_config::local_ip_utils::get_available_port;
 use sui_json_rpc_types::{
@@ -34,7 +31,6 @@ use sui_sdk::wallet_context::WalletContext;
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::bridge::{BridgeChainId, BridgeTokenMetadata, BRIDGE_MODULE_NAME, TOKEN_ID_ETH};
-use sui_types::committee::TOTAL_VOTING_POWER;
 use sui_types::crypto::EncodeDecodeBase64;
 use sui_types::crypto::KeypairTraits;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -43,19 +39,7 @@ use sui_types::{TypeTag, BRIDGE_PACKAGE_ID};
 use tempfile::tempdir;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
-use tracing::{error, info};
-
-use crate::utils::get_eth_signer_client;
-
-pub const BRIDGE_COMMITTEE_NAME: &str = "BridgeCommittee";
-pub const SUI_BRIDGE_NAME: &str = "SuiBridge";
-pub const BRIDGE_CONFIG_NAME: &str = "BridgeConfig";
-pub const BRIDGE_LIMITER_NAME: &str = "BridgeLimiter";
-pub const BRIDGE_VAULT_NAME: &str = "BridgeVault";
-pub const BTC_NAME: &str = "BTC";
-pub const ETH_NAME: &str = "ETH";
-pub const USDC_NAME: &str = "USDC";
-pub const USDT_NAME: &str = "USDT";
+use tracing::info;
 
 #[tokio::test]
 async fn test_bridge_from_eth_to_sui_to_eth() {
@@ -286,6 +270,30 @@ async fn test_add_new_coins_on_sui() {
         1, // seq num
     )
     .await;
+    let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
+    let bridge_authority_keys = test_cluster
+        .bridge_authority_keys
+        .as_ref()
+        .unwrap()
+        .iter()
+        .map(|k| k.copy())
+        .collect::<Vec<_>>();
+    let anvil_url = format!("http://127.0.0.1:{}", anvil_port);
+    let (eth_signer_0, eth_private_key_hex_0) = get_eth_signer_client_e2e_test_only(&anvil_url)
+        .await
+        .unwrap();
+    tokio::task::spawn(async move {
+        deploy_sol_contract(
+            &anvil_url,
+            eth_signer_0,
+            bridge_authority_keys,
+            tx_ack,
+            eth_private_key_hex_0,
+        )
+        .await
+    });
+    let deployed_contracts = rx_ack.await.unwrap();
+    info!("Deployed contracts: {:?}", deployed_contracts);
 
     // TODO: do not block on `build_with_bridge`, return with bridge keys immediately
     // to parallize the setup.
@@ -296,7 +304,7 @@ async fn test_add_new_coins_on_sui() {
     start_bridge_cluster(
         &test_cluster,
         anvil_port,
-        "0x0000000000000000000000000000000000000000".into(),
+        deployed_contracts.sui_bridge_addrress_hex(),
         vec![
             vec![action.clone()],
             vec![action.clone()],
@@ -305,7 +313,7 @@ async fn test_add_new_coins_on_sui() {
         ],
     )
     .await;
-    test_cluster.wait_for_bridge_cluster_to_be_up(5).await;
+    test_cluster.wait_for_bridge_cluster_to_be_up(10).await;
     info!("Bridge cluster is up");
     let bridge_committee = Arc::new(
         sui_bridge_client
@@ -366,172 +374,7 @@ async fn test_add_new_coins_on_sui() {
     eth_node_process.kill().unwrap();
 }
 
-async fn deploy_sol_contract(
-    anvil_url: &str,
-    eth_signer: EthSigner,
-    bridge_authority_keys: Vec<BridgeAuthorityKeyPair>,
-    tx: tokio::sync::oneshot::Sender<DeployedSolContracts>,
-    eth_private_key_hex: String,
-) {
-    let sol_path = format!("{}/../../bridge/evm", env!("CARGO_MANIFEST_DIR"));
-
-    // Write the deploy config to a temp file then provide it to the forge late
-    let deploy_config_path = tempfile::tempdir()
-        .unwrap()
-        .into_path()
-        .join("sol_deploy_config.json");
-    let node_len = bridge_authority_keys.len();
-    let stake = TOTAL_VOTING_POWER / (node_len as u64);
-    let committee_members = bridge_authority_keys
-        .iter()
-        .map(|k| {
-            format!(
-                "0x{:x}",
-                BridgeAuthorityPublicKeyBytes::from(&k.public).to_eth_address()
-            )
-        })
-        .collect::<Vec<_>>();
-    let committee_member_stake = vec![stake; node_len];
-    let deploy_config = SolDeployConfig {
-        committee_member_stake: committee_member_stake.clone(),
-        committee_members: committee_members.clone(),
-        min_committee_stake_required: 10000,
-        source_chain_id: 12,
-        supported_chain_ids: vec![1, 2, 3],
-        supported_chain_limits_in_dollars: vec![
-            1000000000000000,
-            1000000000000000,
-            1000000000000000,
-        ],
-        supported_tokens: vec![], // this is set up in the deploy script
-        token_prices: vec![12800, 432518900, 25969600, 10000, 10000],
-    };
-
-    let serialized_config = serde_json::to_string_pretty(&deploy_config).unwrap();
-    tracing::debug!(
-        "Serialized config written to {:?}: {:?}",
-        deploy_config_path,
-        serialized_config
-    );
-    let mut file = File::create(deploy_config_path.clone()).unwrap();
-    file.write_all(serialized_config.as_bytes()).unwrap();
-
-    // override for the deploy script
-    std::env::set_var("OVERRIDE_CONFIG_PATH", deploy_config_path.to_str().unwrap());
-    std::env::set_var("PRIVATE_KEY", eth_private_key_hex);
-    std::env::set_var("ETHERSCAN_API_KEY", "n/a");
-
-    info!("Deploying solidity contracts");
-    Command::new("forge")
-        .current_dir(sol_path.clone())
-        .arg("clean")
-        .status()
-        .expect("Failed to execute `forge clean`");
-
-    let mut child = Command::new("forge")
-        .current_dir(sol_path)
-        .arg("script")
-        .arg("script/deploy_bridge.s.sol")
-        .arg("--fork-url")
-        .arg(anvil_url)
-        .arg("--broadcast")
-        .arg("--ffi")
-        .arg("--chain")
-        .arg("31337")
-        .stdout(std::process::Stdio::piped()) // Capture stdout
-        .stderr(std::process::Stdio::piped()) // Capture stderr
-        .spawn()
-        .unwrap();
-
-    let mut stdout = child.stdout.take().expect("Failed to open stdout");
-    let mut stderr = child.stderr.take().expect("Failed to open stderr");
-
-    // Read stdout/stderr to String
-    let mut s = String::new();
-    stdout.read_to_string(&mut s).unwrap();
-    let mut e = String::new();
-    stderr.read_to_string(&mut e).unwrap();
-
-    // Wait for the child process to finish and collect its status
-    let status = child.wait().unwrap();
-    if status.success() {
-        info!("Solidity contract deployment finished successfully");
-    } else {
-        error!(
-            "Solidity contract deployment exited with code: {:?}",
-            status.code()
-        );
-    }
-    println!("Stdout: {}", s);
-    println!("Stdout: {}", e);
-
-    let mut deployed_contracts = BTreeMap::new();
-    // Process the stdout to parse contract addresses
-    for line in s.lines() {
-        if line.contains("[Deployed]") {
-            let replaced_line = line.replace("[Deployed]", "");
-            let trimmed_line = replaced_line.trim();
-            let parts: Vec<&str> = trimmed_line.split(':').collect();
-            if parts.len() == 2 {
-                let contract_name = parts[0].to_string().trim().to_string();
-                let contract_address = EthAddress::from_str(parts[1].to_string().trim()).unwrap();
-                deployed_contracts.insert(contract_name, contract_address);
-            }
-        }
-    }
-
-    let contracts = DeployedSolContracts {
-        sui_bridge: *deployed_contracts.get(SUI_BRIDGE_NAME).unwrap(),
-        bridge_committee: *deployed_contracts.get(BRIDGE_COMMITTEE_NAME).unwrap(),
-        bridge_config: *deployed_contracts.get(BRIDGE_CONFIG_NAME).unwrap(),
-        bridge_limiter: *deployed_contracts.get(BRIDGE_LIMITER_NAME).unwrap(),
-        bridge_vault: *deployed_contracts.get(BRIDGE_VAULT_NAME).unwrap(),
-        btc: *deployed_contracts.get(BTC_NAME).unwrap(),
-        eth: *deployed_contracts.get(ETH_NAME).unwrap(),
-        usdc: *deployed_contracts.get(USDC_NAME).unwrap(),
-        usdt: *deployed_contracts.get(USDT_NAME).unwrap(),
-    };
-    let eth_bridge_committee =
-        EthBridgeCommittee::new(contracts.bridge_committee, eth_signer.clone().into());
-    for (i, (m, s)) in committee_members
-        .iter()
-        .zip(committee_member_stake.iter())
-        .enumerate()
-    {
-        let eth_address = EthAddress::from_str(m).unwrap();
-        assert_eq!(
-            eth_bridge_committee
-                .committee_index(eth_address)
-                .await
-                .unwrap(),
-            i as u8
-        );
-        assert_eq!(
-            eth_bridge_committee
-                .committee_stake(eth_address)
-                .await
-                .unwrap(),
-            *s as u16
-        );
-        assert!(!eth_bridge_committee.blocklist(eth_address).await.unwrap());
-    }
-    tx.send(contracts).unwrap();
-}
-
-pub async fn get_eth_signer_client_e2e_test_only(
-    eth_rpc_url: &str,
-) -> anyhow::Result<(EthSigner, String)> {
-    // This private key is derived from the default anvil setting.
-    // Mnemonic:          test test test test test test test test test test test junk
-    // Derivation path:   m/44'/60'/0'/0/
-    // DO NOT USE IT ANYWHERE ELSE EXCEPT FOR RUNNING AUTOMATIC INTEGRATION TESTING
-    let url = eth_rpc_url.to_string();
-    let private_key_0 = "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
-    let signer_0 = get_eth_signer_client(&url, private_key_0).await?;
-    Ok((signer_0, private_key_0.to_string()))
-}
-
-async fn deposit_native_eth_to_sol_contract(
+pub async fn deposit_native_eth_to_sol_contract(
     signer: &EthSigner,
     contract_address: EthAddress,
     sui_recipient_address: SuiAddress,
@@ -593,19 +436,22 @@ async fn start_bridge_cluster(
             server_listen_port: *server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: authority_key_path,
-            sui_rpc_url: test_cluster.fullnode_handle.rpc_url.clone(),
-            eth_rpc_url: eth_rpc_url.clone(),
-            eth_addresses: vec![eth_bridge_contract_address.clone()],
             approved_governance_actions,
             run_client: true,
-            bridge_client_key_path_base64_sui_key: None,
-            bridge_client_gas_object: None,
             db_path: Some(db_path),
-            eth_bridge_contracts_start_block_override: Some(BTreeMap::from_iter(vec![(
-                eth_bridge_contract_address.clone(),
-                0,
-            )])),
-            sui_bridge_module_last_processed_event_id_override: None,
+            eth: EthConfig {
+                eth_rpc_url: eth_rpc_url.clone(),
+                eth_bridge_proxy_address: eth_bridge_contract_address.clone(),
+                eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
+                eth_contracts_start_block_override: Some(0),
+            },
+            sui: SuiConfig {
+                sui_rpc_url: test_cluster.fullnode_handle.rpc_url.clone(),
+                sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
+                bridge_client_key_path_base64_sui_key: None,
+                bridge_client_gas_object: None,
+                sui_bridge_module_last_processed_event_id_override: None,
+            },
         };
         // Spawn bridge node in memory
         let config_clone = config.clone();
@@ -614,19 +460,6 @@ async fn start_bridge_cluster(
             run_bridge_node(config_clone).await.unwrap();
         });
     }
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SolDeployConfig {
-    committee_member_stake: Vec<u64>,
-    committee_members: Vec<String>,
-    min_committee_stake_required: u64,
-    source_chain_id: u64,
-    supported_chain_ids: Vec<u64>,
-    supported_chain_limits_in_dollars: Vec<u64>,
-    supported_tokens: Vec<String>,
-    token_prices: Vec<u64>,
 }
 
 async fn deposit_eth_to_sui_package(
@@ -672,30 +505,6 @@ async fn deposit_eth_to_sui_package(
     );
     let tx = wallet_context.sign_transaction(&tx_data);
     wallet_context.execute_transaction_must_succeed(tx).await
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-struct DeployedSolContracts {
-    pub sui_bridge: EthAddress,
-    pub bridge_committee: EthAddress,
-    pub bridge_limiter: EthAddress,
-    pub bridge_vault: EthAddress,
-    pub bridge_config: EthAddress,
-    pub btc: EthAddress,
-    pub eth: EthAddress,
-    pub usdc: EthAddress,
-    pub usdt: EthAddress,
-}
-
-impl DeployedSolContracts {
-    fn eth_adress_to_hex(addr: EthAddress) -> String {
-        format!("{:x}", addr)
-    }
-
-    pub fn sui_bridge_addrress_hex(&self) -> String {
-        Self::eth_adress_to_hex(self.sui_bridge)
-    }
 }
 
 async fn init_eth_to_sui_bridge(

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -4,13 +4,13 @@
 use crate::abi::{eth_sui_bridge, EthBridgeEvent, EthSuiBridge};
 use crate::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
 use crate::config::{BridgeNodeConfig, EthConfig, SuiConfig};
+use crate::e2e_test_utils::deploy_sol_contract;
+use crate::e2e_test_utils::get_eth_signer_client_e2e_test_only;
 use crate::e2e_test_utils::publish_coins_return_add_coins_on_sui_action;
 use crate::events::SuiBridgeEvent;
 use crate::node::run_bridge_node;
 use crate::sui_client::SuiBridgeClient;
 use crate::sui_transaction_builder::build_add_tokens_on_sui_transaction;
-use crate::test_utils::deploy_sol_contract;
-use crate::test_utils::get_eth_signer_client_e2e_test_only;
 use crate::types::{BridgeAction, BridgeActionStatus, SuiToEthBridgeAction};
 use crate::utils::EthSigner;
 use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -82,25 +82,20 @@ async fn start_client_components(
     };
 
     let stored_eth_cursors = store
-        .get_eth_event_cursors(&client_config.eth_bridge_contracts)
+        .get_eth_event_cursors(&client_config.eth_contracts)
         .map_err(|e| anyhow::anyhow!("Unable to get eth event cursors from storage: {e:?}"))?;
     let mut eth_contracts_to_watch = HashMap::new();
-    for (contract, cursor) in client_config
-        .eth_bridge_contracts
-        .iter()
-        .zip(stored_eth_cursors)
-    {
-        if client_config
-            .eth_bridge_contracts_start_block_override
-            .contains_key(contract)
-        {
+    for (contract, cursor) in client_config.eth_contracts.iter().zip(stored_eth_cursors) {
+        if client_config.eth_contracts_start_block_override.is_some() {
             eth_contracts_to_watch.insert(
                 *contract,
-                client_config.eth_bridge_contracts_start_block_override[contract],
+                client_config.eth_contracts_start_block_override.unwrap(),
             );
             info!(
                 "Overriding cursor for eth bridge contract {} to {}. Stored cursor: {:?}",
-                contract, client_config.eth_bridge_contracts_start_block_override[contract], cursor
+                contract,
+                client_config.eth_contracts_start_block_override.unwrap(),
+                cursor
             );
         } else if let Some(cursor) = cursor {
             // +1: The stored value is the last block that was processed, so we start from the next block.
@@ -158,16 +153,21 @@ async fn start_client_components(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use ethers::types::Address as EthAddress;
     use std::process::Child;
 
     use super::*;
     use crate::config::BridgeNodeConfig;
+    use crate::config::EthConfig;
+    use crate::config::SuiConfig;
     use crate::e2e_test_utils::wait_for_server_to_be_up;
+    use crate::test_utils::deploy_sol_contract;
+    use crate::test_utils::get_eth_signer_client_e2e_test_only;
     use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use sui_config::local_ip_utils::get_available_port;
     use sui_types::base_types::SuiAddress;
+    use sui_types::bridge::BridgeChainId;
     use sui_types::crypto::get_key_pair;
     use sui_types::crypto::EncodeDecodeBase64;
     use sui_types::crypto::KeypairTraits;
@@ -177,12 +177,10 @@ mod tests {
     use tempfile::tempdir;
     use test_cluster::TestClusterBuilder;
 
-    const DUMMY_ETH_ADDRESS: &str = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984";
-
     #[tokio::test]
     async fn test_starting_bridge_node() {
         telemetry_subscribers::init_for_testing();
-        let (test_cluster, anvil_port, mut child) = setup().await;
+        let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
 
         // prepare node config (server only)
         let tmp_dir = tempdir().unwrap().into_path();
@@ -196,16 +194,22 @@ mod tests {
             server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
-            sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
-            eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
-            eth_addresses: vec![DUMMY_ETH_ADDRESS.into()],
+            sui: SuiConfig {
+                sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+                sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
+                bridge_client_key_path_base64_sui_key: None,
+                bridge_client_gas_object: None,
+                sui_bridge_module_last_processed_event_id_override: None,
+            },
+            eth: EthConfig {
+                eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
+                eth_bridge_proxy_address: format!("{:#x}", bridge_contract_address),
+                eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
+                eth_contracts_start_block_override: None,
+            },
             approved_governance_actions: vec![],
             run_client: false,
-            bridge_client_key_path_base64_sui_key: None,
-            bridge_client_gas_object: None,
             db_path: None,
-            eth_bridge_contracts_start_block_override: None,
-            sui_bridge_module_last_processed_event_id_override: None,
         };
         // Spawn bridge node in memory
         tokio::spawn(async move {
@@ -222,7 +226,7 @@ mod tests {
     #[tokio::test]
     async fn test_starting_bridge_node_with_client() {
         telemetry_subscribers::init_for_testing();
-        let (test_cluster, anvil_port, mut child) = setup().await;
+        let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
 
         // prepare node config (server + client)
         let tmp_dir = tempdir().unwrap().into_path();
@@ -244,22 +248,25 @@ mod tests {
             server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
-            sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
-            eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
-            eth_addresses: vec![DUMMY_ETH_ADDRESS.into()],
+            sui: SuiConfig {
+                sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+                sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
+                bridge_client_key_path_base64_sui_key: None,
+                bridge_client_gas_object: None,
+                sui_bridge_module_last_processed_event_id_override: Some(EventID {
+                    tx_digest: TransactionDigest::random(),
+                    event_seq: 0,
+                }),
+            },
+            eth: EthConfig {
+                eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
+                eth_bridge_proxy_address: format!("{:#x}", bridge_contract_address),
+                eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
+                eth_contracts_start_block_override: Some(0),
+            },
             approved_governance_actions: vec![],
             run_client: true,
-            bridge_client_key_path_base64_sui_key: None,
-            bridge_client_gas_object: None,
             db_path: Some(db_path),
-            eth_bridge_contracts_start_block_override: Some(BTreeMap::from_iter(vec![(
-                DUMMY_ETH_ADDRESS.into(),
-                0,
-            )])),
-            sui_bridge_module_last_processed_event_id_override: Some(EventID {
-                tx_digest: TransactionDigest::random(),
-                event_seq: 0,
-            }),
         };
         // Spawn bridge node in memory
         let config_clone = config.clone();
@@ -279,7 +286,7 @@ mod tests {
     #[tokio::test]
     async fn test_starting_bridge_node_with_client_and_separate_client_key() {
         telemetry_subscribers::init_for_testing();
-        let (test_cluster, anvil_port, mut child) = setup().await;
+        let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
 
         // prepare node config (server + client)
         let tmp_dir = tempdir().unwrap().into_path();
@@ -311,22 +318,25 @@ mod tests {
             server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
-            sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
-            eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
-            eth_addresses: vec![DUMMY_ETH_ADDRESS.into()],
+            sui: SuiConfig {
+                sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+                sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
+                bridge_client_key_path_base64_sui_key: Some(tmp_dir.join(client_key_path)),
+                bridge_client_gas_object: Some(gas_obj),
+                sui_bridge_module_last_processed_event_id_override: Some(EventID {
+                    tx_digest: TransactionDigest::random(),
+                    event_seq: 0,
+                }),
+            },
+            eth: EthConfig {
+                eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
+                eth_bridge_proxy_address: format!("{:#x}", bridge_contract_address),
+                eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
+                eth_contracts_start_block_override: Some(0),
+            },
             approved_governance_actions: vec![],
             run_client: true,
-            bridge_client_key_path_base64_sui_key: Some(tmp_dir.join(client_key_path)),
-            bridge_client_gas_object: Some(gas_obj),
             db_path: Some(db_path),
-            eth_bridge_contracts_start_block_override: Some(BTreeMap::from_iter(vec![(
-                DUMMY_ETH_ADDRESS.into(),
-                0,
-            )])),
-            sui_bridge_module_last_processed_event_id_override: Some(EventID {
-                tx_digest: TransactionDigest::random(),
-                event_seq: 0,
-            }),
         };
         // Spawn bridge node in memory
         let config_clone = config.clone();
@@ -343,7 +353,15 @@ mod tests {
         res.unwrap();
     }
 
-    async fn setup() -> (test_cluster::TestCluster, u16, Child) {
+    async fn setup() -> (test_cluster::TestCluster, u16, Child, EthAddress) {
+        // Start eth node with anvil
+        let anvil_port = get_available_port("127.0.0.1");
+        let eth_node_process = std::process::Command::new("anvil")
+            .arg("--port")
+            .arg(anvil_port.to_string())
+            .spawn()
+            .expect("Failed to start anvil");
+
         let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
             .build_with_bridge(true)
@@ -353,14 +371,34 @@ mod tests {
             .trigger_reconfiguration_if_not_yet_and_assert_bridge_committee_initialized()
             .await;
 
-        // Start eth node with anvil
-        let anvil_port = get_available_port("127.0.0.1");
-        let eth_node_process = std::process::Command::new("anvil")
-            .arg("--port")
-            .arg(anvil_port.to_string())
-            .spawn()
-            .expect("Failed to start anvil");
-
-        (test_cluster, anvil_port, eth_node_process)
+        let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
+        let bridge_authority_keys = test_cluster
+            .bridge_authority_keys
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|k| k.copy())
+            .collect::<Vec<_>>();
+        let anvil_url = format!("http://127.0.0.1:{}", anvil_port);
+        let (eth_signer_0, eth_private_key_hex_0) = get_eth_signer_client_e2e_test_only(&anvil_url)
+            .await
+            .unwrap();
+        tokio::task::spawn(async move {
+            deploy_sol_contract(
+                &anvil_url,
+                eth_signer_0,
+                bridge_authority_keys,
+                tx_ack,
+                eth_private_key_hex_0,
+            )
+            .await
+        });
+        let address = rx_ack.await.unwrap();
+        (
+            test_cluster,
+            anvil_port,
+            eth_node_process,
+            address.sui_bridge,
+        )
     }
 }

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -160,9 +160,9 @@ mod tests {
     use crate::config::BridgeNodeConfig;
     use crate::config::EthConfig;
     use crate::config::SuiConfig;
+    use crate::e2e_test_utils::deploy_sol_contract;
+    use crate::e2e_test_utils::get_eth_signer_client_e2e_test_only;
     use crate::e2e_test_utils::wait_for_server_to_be_up;
-    use crate::test_utils::deploy_sol_contract;
-    use crate::test_utils::get_eth_signer_client_e2e_test_only;
     use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use sui_config::local_ip_utils::get_available_port;

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -272,6 +272,10 @@ where
         BridgeCommittee::new(authorities)
     }
 
+    pub async fn get_chain_identifier(&self) -> BridgeResult<String> {
+        Ok(self.inner.get_chain_identifier().await?)
+    }
+
     pub async fn execute_transaction_block_with_effects(
         &self,
         tx: sui_types::transaction::Transaction,

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::abi::EthBridgeCommittee;
 use crate::abi::EthToSuiTokenBridgeV1;
-use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::eth_mock_provider::EthMockProvider;
 use crate::events::SuiBridgeEvent;
 use crate::server::mock_handler::run_mock_server;
@@ -11,8 +9,6 @@ use crate::sui_transaction_builder::build_sui_transaction;
 use crate::types::{
     BridgeCommitteeValiditySignInfo, CertifiedBridgeAction, VerifiedCertifiedBridgeAction,
 };
-use crate::utils::get_eth_signer_client;
-use crate::utils::EthSigner;
 use crate::{
     crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKey, BridgeAuthoritySignInfo},
     events::EmittedSuiToEthTokenBridgeV1,
@@ -32,15 +28,10 @@ use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::KeyPair;
 use hex_literal::hex;
 use move_core_types::language_storage::TypeTag;
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
-use std::fs::File;
-use std::io::{Read, Write};
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
-use std::process::Command;
-use std::str::FromStr;
 use sui_config::local_ip_utils;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_sdk::wallet_context::WalletContext;
@@ -48,24 +39,11 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::bridge::{BridgeChainId, TOKEN_ID_USDC};
-use sui_types::committee::TOTAL_VOTING_POWER;
 use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::{base_types::SuiAddress, crypto::get_key_pair, digests::TransactionDigest};
 use sui_types::{BRIDGE_PACKAGE_ID, SUI_BRIDGE_OBJECT_ID};
 use tokio::task::JoinHandle;
-use tracing::error;
-use tracing::info;
-
-pub const BRIDGE_COMMITTEE_NAME: &str = "BridgeCommittee";
-pub const SUI_BRIDGE_NAME: &str = "SuiBridge";
-pub const BRIDGE_CONFIG_NAME: &str = "BridgeConfig";
-pub const BRIDGE_LIMITER_NAME: &str = "BridgeLimiter";
-pub const BRIDGE_VAULT_NAME: &str = "BridgeVault";
-pub const BTC_NAME: &str = "BTC";
-pub const ETH_NAME: &str = "ETH";
-pub const USDC_NAME: &str = "USDC";
-pub const USDT_NAME: &str = "USDT";
 
 pub const DUMMY_MUTALBE_BRIDGE_OBJECT_ARG: ObjectArg = ObjectArg::SharedObject {
     id: SUI_BRIDGE_OBJECT_ID,
@@ -408,206 +386,4 @@ pub async fn approve_action_with_validator_secrets(
         "Didn't find the creted object owned by {}",
         expected_token_receiver
     );
-}
-
-pub async fn get_eth_signer_client_e2e_test_only(
-    eth_rpc_url: &str,
-) -> anyhow::Result<(EthSigner, String)> {
-    // This private key is derived from the default anvil setting.
-    // Mnemonic:          test test test test test test test test test test test junk
-    // Derivation path:   m/44'/60'/0'/0/
-    // DO NOT USE IT ANYWHERE ELSE EXCEPT FOR RUNNING AUTOMATIC INTEGRATION TESTING
-    let url = eth_rpc_url.to_string();
-    let private_key_0 = "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
-    let signer_0 = get_eth_signer_client(&url, private_key_0).await?;
-    Ok((signer_0, private_key_0.to_string()))
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub struct DeployedSolContracts {
-    pub sui_bridge: EthAddress,
-    pub bridge_committee: EthAddress,
-    pub bridge_limiter: EthAddress,
-    pub bridge_vault: EthAddress,
-    pub bridge_config: EthAddress,
-    pub btc: EthAddress,
-    pub eth: EthAddress,
-    pub usdc: EthAddress,
-    pub usdt: EthAddress,
-}
-
-impl DeployedSolContracts {
-    pub fn eth_adress_to_hex(addr: EthAddress) -> String {
-        format!("{:x}", addr)
-    }
-
-    pub fn sui_bridge_addrress_hex(&self) -> String {
-        Self::eth_adress_to_hex(self.sui_bridge)
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SolDeployConfig {
-    committee_member_stake: Vec<u64>,
-    committee_members: Vec<String>,
-    min_committee_stake_required: u64,
-    source_chain_id: u64,
-    supported_chain_ids: Vec<u64>,
-    supported_chain_limits_in_dollars: Vec<u64>,
-    supported_tokens: Vec<String>,
-    token_prices: Vec<u64>,
-}
-
-pub async fn deploy_sol_contract(
-    anvil_url: &str,
-    eth_signer: EthSigner,
-    bridge_authority_keys: Vec<BridgeAuthorityKeyPair>,
-    tx: tokio::sync::oneshot::Sender<DeployedSolContracts>,
-    eth_private_key_hex: String,
-) {
-    let sol_path = format!("{}/../../bridge/evm", env!("CARGO_MANIFEST_DIR"));
-
-    // Write the deploy config to a temp file then provide it to the forge late
-    let deploy_config_path = tempfile::tempdir()
-        .unwrap()
-        .into_path()
-        .join("sol_deploy_config.json");
-    let node_len = bridge_authority_keys.len();
-    let stake = TOTAL_VOTING_POWER / (node_len as u64);
-    let committee_members = bridge_authority_keys
-        .iter()
-        .map(|k| {
-            format!(
-                "0x{:x}",
-                BridgeAuthorityPublicKeyBytes::from(&k.public).to_eth_address()
-            )
-        })
-        .collect::<Vec<_>>();
-    let committee_member_stake = vec![stake; node_len];
-    let deploy_config = SolDeployConfig {
-        committee_member_stake: committee_member_stake.clone(),
-        committee_members: committee_members.clone(),
-        min_committee_stake_required: 10000,
-        source_chain_id: BridgeChainId::EthCustom as u64,
-        supported_chain_ids: vec![1, 2, 3],
-        supported_chain_limits_in_dollars: vec![
-            1000000000000000,
-            1000000000000000,
-            1000000000000000,
-        ],
-        supported_tokens: vec![], // this is set up in the deploy script
-        token_prices: vec![12800, 432518900, 25969600, 10000, 10000],
-    };
-
-    let serialized_config = serde_json::to_string_pretty(&deploy_config).unwrap();
-    tracing::debug!(
-        "Serialized config written to {:?}: {:?}",
-        deploy_config_path,
-        serialized_config
-    );
-    let mut file = File::create(deploy_config_path.clone()).unwrap();
-    file.write_all(serialized_config.as_bytes()).unwrap();
-
-    // override for the deploy script
-    std::env::set_var("OVERRIDE_CONFIG_PATH", deploy_config_path.to_str().unwrap());
-    std::env::set_var("PRIVATE_KEY", eth_private_key_hex);
-    std::env::set_var("ETHERSCAN_API_KEY", "n/a");
-
-    info!("Deploying solidity contracts");
-    Command::new("forge")
-        .current_dir(sol_path.clone())
-        .arg("clean")
-        .status()
-        .expect("Failed to execute `forge clean`");
-
-    let mut child = Command::new("forge")
-        .current_dir(sol_path)
-        .arg("script")
-        .arg("script/deploy_bridge.s.sol")
-        .arg("--fork-url")
-        .arg(anvil_url)
-        .arg("--broadcast")
-        .arg("--ffi")
-        .arg("--chain")
-        .arg("31337")
-        .stdout(std::process::Stdio::piped()) // Capture stdout
-        .stderr(std::process::Stdio::piped()) // Capture stderr
-        .spawn()
-        .unwrap();
-
-    let mut stdout = child.stdout.take().expect("Failed to open stdout");
-    let mut stderr = child.stderr.take().expect("Failed to open stderr");
-
-    // Read stdout/stderr to String
-    let mut s = String::new();
-    stdout.read_to_string(&mut s).unwrap();
-    let mut e = String::new();
-    stderr.read_to_string(&mut e).unwrap();
-
-    // Wait for the child process to finish and collect its status
-    let status = child.wait().unwrap();
-    if status.success() {
-        info!("Solidity contract deployment finished successfully");
-    } else {
-        error!(
-            "Solidity contract deployment exited with code: {:?}",
-            status.code()
-        );
-    }
-    println!("Stdout: {}", s);
-    println!("Stdout: {}", e);
-
-    let mut deployed_contracts = BTreeMap::new();
-    // Process the stdout to parse contract addresses
-    for line in s.lines() {
-        if line.contains("[Deployed]") {
-            let replaced_line = line.replace("[Deployed]", "");
-            let trimmed_line = replaced_line.trim();
-            let parts: Vec<&str> = trimmed_line.split(':').collect();
-            if parts.len() == 2 {
-                let contract_name = parts[0].to_string().trim().to_string();
-                let contract_address = EthAddress::from_str(parts[1].to_string().trim()).unwrap();
-                deployed_contracts.insert(contract_name, contract_address);
-            }
-        }
-    }
-
-    let contracts = DeployedSolContracts {
-        sui_bridge: *deployed_contracts.get(SUI_BRIDGE_NAME).unwrap(),
-        bridge_committee: *deployed_contracts.get(BRIDGE_COMMITTEE_NAME).unwrap(),
-        bridge_config: *deployed_contracts.get(BRIDGE_CONFIG_NAME).unwrap(),
-        bridge_limiter: *deployed_contracts.get(BRIDGE_LIMITER_NAME).unwrap(),
-        bridge_vault: *deployed_contracts.get(BRIDGE_VAULT_NAME).unwrap(),
-        btc: *deployed_contracts.get(BTC_NAME).unwrap(),
-        eth: *deployed_contracts.get(ETH_NAME).unwrap(),
-        usdc: *deployed_contracts.get(USDC_NAME).unwrap(),
-        usdt: *deployed_contracts.get(USDT_NAME).unwrap(),
-    };
-    let eth_bridge_committee =
-        EthBridgeCommittee::new(contracts.bridge_committee, eth_signer.clone().into());
-    for (i, (m, s)) in committee_members
-        .iter()
-        .zip(committee_member_stake.iter())
-        .enumerate()
-    {
-        let eth_address = EthAddress::from_str(m).unwrap();
-        assert_eq!(
-            eth_bridge_committee
-                .committee_index(eth_address)
-                .await
-                .unwrap(),
-            i as u8
-        );
-        assert_eq!(
-            eth_bridge_committee
-                .committee_stake(eth_address)
-                .await
-                .unwrap(),
-            *s as u16
-        );
-        assert!(!eth_bridge_committee.blocklist(eth_address).await.unwrap());
-    }
-    tx.send(contracts).unwrap();
 }

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::abi::EthBridgeCommittee;
 use crate::abi::EthToSuiTokenBridgeV1;
+use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::eth_mock_provider::EthMockProvider;
 use crate::events::SuiBridgeEvent;
 use crate::server::mock_handler::run_mock_server;
@@ -9,6 +11,8 @@ use crate::sui_transaction_builder::build_sui_transaction;
 use crate::types::{
     BridgeCommitteeValiditySignInfo, CertifiedBridgeAction, VerifiedCertifiedBridgeAction,
 };
+use crate::utils::get_eth_signer_client;
+use crate::utils::EthSigner;
 use crate::{
     crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKey, BridgeAuthoritySignInfo},
     events::EmittedSuiToEthTokenBridgeV1,
@@ -28,10 +32,15 @@ use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::KeyPair;
 use hex_literal::hex;
 use move_core_types::language_storage::TypeTag;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
+use std::io::{Read, Write};
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
+use std::process::Command;
+use std::str::FromStr;
 use sui_config::local_ip_utils;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_sdk::wallet_context::WalletContext;
@@ -39,11 +48,24 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::bridge::{BridgeChainId, TOKEN_ID_USDC};
+use sui_types::committee::TOTAL_VOTING_POWER;
 use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::{base_types::SuiAddress, crypto::get_key_pair, digests::TransactionDigest};
 use sui_types::{BRIDGE_PACKAGE_ID, SUI_BRIDGE_OBJECT_ID};
 use tokio::task::JoinHandle;
+use tracing::error;
+use tracing::info;
+
+pub const BRIDGE_COMMITTEE_NAME: &str = "BridgeCommittee";
+pub const SUI_BRIDGE_NAME: &str = "SuiBridge";
+pub const BRIDGE_CONFIG_NAME: &str = "BridgeConfig";
+pub const BRIDGE_LIMITER_NAME: &str = "BridgeLimiter";
+pub const BRIDGE_VAULT_NAME: &str = "BridgeVault";
+pub const BTC_NAME: &str = "BTC";
+pub const ETH_NAME: &str = "ETH";
+pub const USDC_NAME: &str = "USDC";
+pub const USDT_NAME: &str = "USDT";
 
 pub const DUMMY_MUTALBE_BRIDGE_OBJECT_ARG: ObjectArg = ObjectArg::SharedObject {
     id: SUI_BRIDGE_OBJECT_ID,
@@ -386,4 +408,206 @@ pub async fn approve_action_with_validator_secrets(
         "Didn't find the creted object owned by {}",
         expected_token_receiver
     );
+}
+
+pub async fn get_eth_signer_client_e2e_test_only(
+    eth_rpc_url: &str,
+) -> anyhow::Result<(EthSigner, String)> {
+    // This private key is derived from the default anvil setting.
+    // Mnemonic:          test test test test test test test test test test test junk
+    // Derivation path:   m/44'/60'/0'/0/
+    // DO NOT USE IT ANYWHERE ELSE EXCEPT FOR RUNNING AUTOMATIC INTEGRATION TESTING
+    let url = eth_rpc_url.to_string();
+    let private_key_0 = "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
+    let signer_0 = get_eth_signer_client(&url, private_key_0).await?;
+    Ok((signer_0, private_key_0.to_string()))
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DeployedSolContracts {
+    pub sui_bridge: EthAddress,
+    pub bridge_committee: EthAddress,
+    pub bridge_limiter: EthAddress,
+    pub bridge_vault: EthAddress,
+    pub bridge_config: EthAddress,
+    pub btc: EthAddress,
+    pub eth: EthAddress,
+    pub usdc: EthAddress,
+    pub usdt: EthAddress,
+}
+
+impl DeployedSolContracts {
+    pub fn eth_adress_to_hex(addr: EthAddress) -> String {
+        format!("{:x}", addr)
+    }
+
+    pub fn sui_bridge_addrress_hex(&self) -> String {
+        Self::eth_adress_to_hex(self.sui_bridge)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SolDeployConfig {
+    committee_member_stake: Vec<u64>,
+    committee_members: Vec<String>,
+    min_committee_stake_required: u64,
+    source_chain_id: u64,
+    supported_chain_ids: Vec<u64>,
+    supported_chain_limits_in_dollars: Vec<u64>,
+    supported_tokens: Vec<String>,
+    token_prices: Vec<u64>,
+}
+
+pub async fn deploy_sol_contract(
+    anvil_url: &str,
+    eth_signer: EthSigner,
+    bridge_authority_keys: Vec<BridgeAuthorityKeyPair>,
+    tx: tokio::sync::oneshot::Sender<DeployedSolContracts>,
+    eth_private_key_hex: String,
+) {
+    let sol_path = format!("{}/../../bridge/evm", env!("CARGO_MANIFEST_DIR"));
+
+    // Write the deploy config to a temp file then provide it to the forge late
+    let deploy_config_path = tempfile::tempdir()
+        .unwrap()
+        .into_path()
+        .join("sol_deploy_config.json");
+    let node_len = bridge_authority_keys.len();
+    let stake = TOTAL_VOTING_POWER / (node_len as u64);
+    let committee_members = bridge_authority_keys
+        .iter()
+        .map(|k| {
+            format!(
+                "0x{:x}",
+                BridgeAuthorityPublicKeyBytes::from(&k.public).to_eth_address()
+            )
+        })
+        .collect::<Vec<_>>();
+    let committee_member_stake = vec![stake; node_len];
+    let deploy_config = SolDeployConfig {
+        committee_member_stake: committee_member_stake.clone(),
+        committee_members: committee_members.clone(),
+        min_committee_stake_required: 10000,
+        source_chain_id: BridgeChainId::EthCustom as u64,
+        supported_chain_ids: vec![1, 2, 3],
+        supported_chain_limits_in_dollars: vec![
+            1000000000000000,
+            1000000000000000,
+            1000000000000000,
+        ],
+        supported_tokens: vec![], // this is set up in the deploy script
+        token_prices: vec![12800, 432518900, 25969600, 10000, 10000],
+    };
+
+    let serialized_config = serde_json::to_string_pretty(&deploy_config).unwrap();
+    tracing::debug!(
+        "Serialized config written to {:?}: {:?}",
+        deploy_config_path,
+        serialized_config
+    );
+    let mut file = File::create(deploy_config_path.clone()).unwrap();
+    file.write_all(serialized_config.as_bytes()).unwrap();
+
+    // override for the deploy script
+    std::env::set_var("OVERRIDE_CONFIG_PATH", deploy_config_path.to_str().unwrap());
+    std::env::set_var("PRIVATE_KEY", eth_private_key_hex);
+    std::env::set_var("ETHERSCAN_API_KEY", "n/a");
+
+    info!("Deploying solidity contracts");
+    Command::new("forge")
+        .current_dir(sol_path.clone())
+        .arg("clean")
+        .status()
+        .expect("Failed to execute `forge clean`");
+
+    let mut child = Command::new("forge")
+        .current_dir(sol_path)
+        .arg("script")
+        .arg("script/deploy_bridge.s.sol")
+        .arg("--fork-url")
+        .arg(anvil_url)
+        .arg("--broadcast")
+        .arg("--ffi")
+        .arg("--chain")
+        .arg("31337")
+        .stdout(std::process::Stdio::piped()) // Capture stdout
+        .stderr(std::process::Stdio::piped()) // Capture stderr
+        .spawn()
+        .unwrap();
+
+    let mut stdout = child.stdout.take().expect("Failed to open stdout");
+    let mut stderr = child.stderr.take().expect("Failed to open stderr");
+
+    // Read stdout/stderr to String
+    let mut s = String::new();
+    stdout.read_to_string(&mut s).unwrap();
+    let mut e = String::new();
+    stderr.read_to_string(&mut e).unwrap();
+
+    // Wait for the child process to finish and collect its status
+    let status = child.wait().unwrap();
+    if status.success() {
+        info!("Solidity contract deployment finished successfully");
+    } else {
+        error!(
+            "Solidity contract deployment exited with code: {:?}",
+            status.code()
+        );
+    }
+    println!("Stdout: {}", s);
+    println!("Stdout: {}", e);
+
+    let mut deployed_contracts = BTreeMap::new();
+    // Process the stdout to parse contract addresses
+    for line in s.lines() {
+        if line.contains("[Deployed]") {
+            let replaced_line = line.replace("[Deployed]", "");
+            let trimmed_line = replaced_line.trim();
+            let parts: Vec<&str> = trimmed_line.split(':').collect();
+            if parts.len() == 2 {
+                let contract_name = parts[0].to_string().trim().to_string();
+                let contract_address = EthAddress::from_str(parts[1].to_string().trim()).unwrap();
+                deployed_contracts.insert(contract_name, contract_address);
+            }
+        }
+    }
+
+    let contracts = DeployedSolContracts {
+        sui_bridge: *deployed_contracts.get(SUI_BRIDGE_NAME).unwrap(),
+        bridge_committee: *deployed_contracts.get(BRIDGE_COMMITTEE_NAME).unwrap(),
+        bridge_config: *deployed_contracts.get(BRIDGE_CONFIG_NAME).unwrap(),
+        bridge_limiter: *deployed_contracts.get(BRIDGE_LIMITER_NAME).unwrap(),
+        bridge_vault: *deployed_contracts.get(BRIDGE_VAULT_NAME).unwrap(),
+        btc: *deployed_contracts.get(BTC_NAME).unwrap(),
+        eth: *deployed_contracts.get(ETH_NAME).unwrap(),
+        usdc: *deployed_contracts.get(USDC_NAME).unwrap(),
+        usdt: *deployed_contracts.get(USDT_NAME).unwrap(),
+    };
+    let eth_bridge_committee =
+        EthBridgeCommittee::new(contracts.bridge_committee, eth_signer.clone().into());
+    for (i, (m, s)) in committee_members
+        .iter()
+        .zip(committee_member_stake.iter())
+        .enumerate()
+    {
+        let eth_address = EthAddress::from_str(m).unwrap();
+        assert_eq!(
+            eth_bridge_committee
+                .committee_index(eth_address)
+                .await
+                .unwrap(),
+            i as u8
+        );
+        assert_eq!(
+            eth_bridge_committee
+                .committee_stake(eth_address)
+                .await
+                .unwrap(),
+            *s as u16
+        );
+        assert!(!eth_bridge_committee.blocklist(eth_address).await.unwrap());
+    }
+    tx.send(contracts).unwrap();
 }

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -467,6 +467,30 @@ pub struct EthLog {
     pub log: Log,
 }
 
+/// Check if the bridge route is valid
+/// Only mainnet can bridge to mainnet, other than that we do not care.
+pub fn is_route_valid(one: BridgeChainId, other: BridgeChainId) -> bool {
+    if one.is_sui_chain() && other.is_sui_chain() {
+        return false;
+    }
+    if !one.is_sui_chain() && !other.is_sui_chain() {
+        return false;
+    }
+    if one == BridgeChainId::EthMainnet {
+        return other == BridgeChainId::SuiMainnet;
+    }
+    if one == BridgeChainId::SuiMainnet {
+        return other == BridgeChainId::EthMainnet;
+    }
+    if other == BridgeChainId::EthMainnet {
+        return one == BridgeChainId::SuiMainnet;
+    }
+    if other == BridgeChainId::SuiMainnet {
+        return one == BridgeChainId::EthMainnet;
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_utils::get_test_authority_and_key;

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::BridgeNodeConfig;
+use crate::config::EthConfig;
+use crate::config::SuiConfig;
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use anyhow::anyhow;
@@ -17,6 +19,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use sui_config::Config;
 use sui_types::base_types::SuiAddress;
+use sui_types::bridge::BridgeChainId;
 use sui_types::crypto::get_key_pair;
 use sui_types::crypto::SuiKeyPair;
 
@@ -76,19 +79,25 @@ pub fn generate_bridge_node_config_and_write_to_file(
         server_listen_port: 9191,
         metrics_port: 9184,
         bridge_authority_key_path_base64_raw: PathBuf::from("/path/to/your/bridge_authority_key"),
-        sui_rpc_url: "your_sui_rpc_url".to_string(),
-        eth_rpc_url: "your_eth_rpc_url".to_string(),
-        eth_addresses: vec!["bridge_eth_proxy_address".into()],
+        sui: SuiConfig {
+            sui_rpc_url: "your_sui_rpc_url".to_string(),
+            sui_bridge_chain_id: BridgeChainId::SuiTestnet as u8,
+            bridge_client_key_path_base64_sui_key: None,
+            bridge_client_gas_object: None,
+            sui_bridge_module_last_processed_event_id_override: None,
+        },
+        eth: EthConfig {
+            eth_rpc_url: "your_eth_rpc_url".to_string(),
+            eth_bridge_proxy_address: "0x0000000000000000000000000000000000000000".to_string(),
+            eth_bridge_chain_id: BridgeChainId::EthSepolia as u8,
+            eth_contracts_start_block_override: None,
+        },
         approved_governance_actions: vec![],
         run_client,
-        bridge_client_key_path_base64_sui_key: None,
-        bridge_client_gas_object: None,
         db_path: None,
-        eth_bridge_contracts_start_block_override: None,
-        sui_bridge_module_last_processed_event_id_override: None,
     };
     if run_client {
-        config.bridge_client_key_path_base64_sui_key =
+        config.sui.bridge_client_key_path_base64_sui_key =
             Some(PathBuf::from("/path/to/your/bridge_client_key"));
         config.db_path = Some(PathBuf::from("/path/to/your/client_db"));
     }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -527,7 +527,11 @@ impl TestCluster {
             let server_url = format!("http://127.0.0.1:{}", port);
             tasks.push(wait_for_server_to_be_up(server_url, timeout_sec));
         }
-        join_all(tasks).await;
+        join_all(tasks)
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<Vec<_>>>()
+            .unwrap();
     }
 
     pub async fn get_mut_bridge_arg(&self) -> Option<ObjectArg> {


### PR DESCRIPTION
## Description 

(the meat is in `config.rs`)

This PR reworks `BridgeNodeConfig` to make it easier to reason about. The main changes:
1. add `sui_bridge_chain_id` and `eth_bridge_chain_id`
2. sui related fields are moved to `SuiConfig`
3. eth related fields are moved to `EthConfig`
4. `eth_addresses` is now `eth_bridge_proxy_address`, and when the node starts, it fetches all contracts's addresses starting from `EthSuiBridge` 

Other than that, i also moved some common test utils around from `basic.rs` to `test_utils.rs`.

## Test plan 

unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
