### PR TITLE
Adjust test to be more reliable

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -403,7 +403,7 @@ mod test {
 
         let init_framework =
             sui_framework_snapshot::load_bytecode_snapshot(starting_version).unwrap();
-        let mut test_cluster = init_test_cluster_builder(7, 5000)
+        let mut test_cluster = init_test_cluster_builder(4, 15000)
             .with_protocol_version(ProtocolVersion::new(starting_version))
             .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
                 starting_version,


### PR DESCRIPTION
Short epochs (<10 seconds) can result in failure to submit capabilities, which prevents upgrade from going through. Also the 7 validators are totally unnecessary for this test, using 4 will speed it up.