### PR TITLE
Congestion control triggered transaction cancellation

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5125,7 +5125,7 @@ impl NodeStateDump {
                 }
                 InputSharedObject::ReadDeleted(..)
                 | InputSharedObject::MutateDeleted(..)
-                | InputSharedObject::Cancelled(..) => (),
+                | InputSharedObject::Cancelled(..) => (), // TODO: consider record congested objects.
             }
         }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -199,6 +199,7 @@ pub mod epoch_start_configuration;
 pub mod shared_object_congestion_tracker;
 pub mod shared_object_version_manager;
 pub mod test_authority_builder;
+pub mod transaction_deferral;
 
 pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;
@@ -5122,7 +5123,9 @@ impl NodeStateDump {
                         shared_objects.push(ObjDumpFormat::new(w))
                     }
                 }
-                InputSharedObject::ReadDeleted(..) | InputSharedObject::MutateDeleted(..) => (),
+                InputSharedObject::ReadDeleted(..)
+                | InputSharedObject::MutateDeleted(..)
+                | InputSharedObject::Cancelled(..) => (),
             }
         }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -21,6 +21,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sui_config::node::ExpensiveSafetyCheckConfig;
+use sui_macros::fail_point_arg;
 use sui_types::accumulator::Accumulator;
 use sui_types::authenticator_state::{get_authenticator_state, ActiveJwk};
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest};
@@ -2764,6 +2765,14 @@ impl AuthorityPerEpochStore {
             Default::default();
         let mut shared_object_using_randomness_congestion_tracker: SharedObjectCongestionTracker =
             Default::default();
+
+        fail_point_arg!(
+            "initial_congestion_tracker",
+            |tracker: SharedObjectCongestionTracker| {
+                info!("Initialize shared_object_congestion_tracker {:?}", tracker);
+                shared_object_congestion_tracker = tracker;
+            }
+        );
 
         let mut randomness_state_updated = false;
         for tx in transactions {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1455,6 +1455,7 @@ impl AuthorityPerEpochStore {
             cache_reader,
             certificates,
             None,
+            &BTreeMap::new(),
         )
         .await?
         .assigned_versions;

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_per_epoch_store::DeferralKey;
+use crate::authority::transaction_deferral::DeferralKey;
 use narwhal_types::Round;
 use std::collections::HashMap;
 use sui_types::base_types::{ObjectID, TransactionDigest};

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use sui_types::base_types::{ObjectID, TransactionDigest};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::transaction::SharedInputObject;
-use tracing::info;
 
 // SharedObjectCongestionTracker stores the accumulated cost of executing transactions on an object, for
 // all transactions in a consensus commit.
@@ -57,12 +56,6 @@ impl SharedObjectCongestionTracker {
     ) -> Option<(DeferralKey, Vec<ObjectID>)> {
         let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
         let start_cost = self.compute_tx_start_at_cost(&shared_input_objects);
-        info!(
-            "Check txn deferral, start_cost: {}, budget: {}, bar: {}",
-            start_cost,
-            cert.gas_budget(),
-            max_accumulated_txn_cost_per_object_in_checkpoint
-        );
         if start_cost + cert.gas_budget() <= max_accumulated_txn_cost_per_object_in_checkpoint {
             return None;
         }

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use sui_types::base_types::{ObjectID, TransactionDigest};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::transaction::SharedInputObject;
+use tracing::info;
 
 // SharedObjectCongestionTracker stores the accumulated cost of executing transactions on an object, for
 // all transactions in a consensus commit.
@@ -56,8 +57,8 @@ impl SharedObjectCongestionTracker {
     ) -> Option<(DeferralKey, Vec<ObjectID>)> {
         let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
         let start_cost = self.compute_tx_start_at_cost(&shared_input_objects);
-        println!(
-            "ZZZZZZ start_cost: {}, budget: {}, bar: {}",
+        info!(
+            "Check txn deferral, start_cost: {}, budget: {}, bar: {}",
             start_cost,
             cert.gas_budget(),
             max_accumulated_txn_cost_per_object_in_checkpoint

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -56,6 +56,12 @@ impl SharedObjectCongestionTracker {
     ) -> Option<(DeferralKey, Vec<ObjectID>)> {
         let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
         let start_cost = self.compute_tx_start_at_cost(&shared_input_objects);
+        println!(
+            "ZZZZZZ start_cost: {}, budget: {}, bar: {}",
+            start_cost,
+            cert.gas_budget(),
+            max_accumulated_txn_cost_per_object_in_checkpoint
+        );
         if start_cost + cert.gas_budget() <= max_accumulated_txn_cost_per_object_in_checkpoint {
             return None;
         }

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -13,7 +13,7 @@ use sui_types::crypto::RandomnessRound;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::storage::{
-    transaction_input_object_keys, transaction_receiving_object_keys, ObjectKey,
+    transaction_non_shared_input_object_keys, transaction_receiving_object_keys, ObjectKey,
 };
 use sui_types::transaction::{
     SenderSignedData, SharedInputObject, TransactionDataAPI, TransactionKey,
@@ -177,8 +177,8 @@ fn assign_versions_for_certificate(
     // Make an iterator to update the locks of the transaction's shared objects.
     let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
 
-    let mut input_object_keys =
-        transaction_input_object_keys(cert).expect("Transaction input should have been verified");
+    let mut input_object_keys = transaction_non_shared_input_object_keys(cert)
+        .expect("Transaction input should have been verified");
     let mut assigned_versions = Vec::with_capacity(shared_input_objects.len());
     let mut is_mutable_input = Vec::with_capacity(shared_input_objects.len());
     // Record receiving object versions towards the shared version computation.
@@ -193,7 +193,6 @@ fn assign_versions_for_certificate(
                 SequenceNumber::CANCELLED_READ
             };
             assigned_versions.push((*id, assigned_version));
-            input_object_keys.push(ObjectKey(*id, SequenceNumber::MIN));
             is_mutable_input.push(false);
         }
     } else {

--- a/crates/sui-core/src/authority/transaction_deferral.rs
+++ b/crates/sui-core/src/authority/transaction_deferral.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use narwhal_types::Round;
+use serde::{Deserialize, Serialize};
+use sui_types::base_types::ObjectID;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum DeferralKey {
+    // For transactions deferred until new randomness is available (whether delayd due to
+    // DKG, or skipped commits).
+    Randomness {
+        deferred_from_round: Round, // commit round, not randomness round
+    },
+    // ConsensusRound deferral key requires both the round to which the tx should be deferred (so that
+    // we can efficiently load all txns that are now ready), and the round from which it has been
+    // deferred (so that multiple rounds can efficiently defer to the same future round).
+    ConsensusRound {
+        future_round: Round,
+        deferred_from_round: Round,
+    },
+}
+
+impl DeferralKey {
+    fn new_for_randomness(deferred_from_round: Round) -> Self {
+        Self::Randomness {
+            deferred_from_round,
+        }
+    }
+
+    pub fn new_for_consensus_round(future_round: Round, deferred_from_round: Round) -> Self {
+        Self::ConsensusRound {
+            future_round,
+            deferred_from_round,
+        }
+    }
+
+    fn full_range_for_randomness() -> (Self, Self) {
+        (
+            Self::Randomness {
+                deferred_from_round: 0,
+            },
+            Self::Randomness {
+                deferred_from_round: u64::MAX,
+            },
+        )
+    }
+
+    // Returns a range of deferral keys that are deferred up to the given consensus round.
+    fn range_for_up_to_consensus_round(consensus_round: Round) -> (Self, Self) {
+        (
+            Self::ConsensusRound {
+                future_round: 0,
+                deferred_from_round: 0,
+            },
+            Self::ConsensusRound {
+                future_round: consensus_round.checked_add(1).unwrap(),
+                deferred_from_round: 0,
+            },
+        )
+    }
+
+    pub fn deferred_from_round(&self) -> Round {
+        match self {
+            Self::Randomness {
+                deferred_from_round,
+            } => *deferred_from_round,
+            Self::ConsensusRound {
+                deferred_from_round,
+                ..
+            } => *deferred_from_round,
+        }
+    }
+}
+
+pub enum DeferralReason {
+    RandomnessNotReady,
+
+    // The list of objects are congested objects.
+    SharedObjectCongestion(Vec<ObjectID>),
+}
+
+pub fn transaction_deferral_within_limit(
+    deferral_key: &DeferralKey,
+    max_deferral_rounds_for_congestion_control: u64,
+) -> bool {
+    if let DeferralKey::ConsensusRound {
+        future_round,
+        deferred_from_round,
+    } = deferral_key
+    {
+        return (future_round - deferred_from_round) < max_deferral_rounds_for_congestion_control;
+    }
+    true
+}
+
+#[cfg(test)]
+mod object_cost_tests {
+    use super::*;
+    use typed_store::Map;
+    use typed_store::{
+        rocks::{DBMap, MetricConf},
+        traits::{TableSummary, TypedStoreDebug},
+    };
+    use typed_store_derive::DBMapUtils;
+
+    #[tokio::test]
+    async fn test_deferral_key_sort_order() {
+        use rand::prelude::*;
+
+        #[derive(DBMapUtils)]
+        struct TestDB {
+            deferred_certs: DBMap<DeferralKey, ()>,
+        }
+
+        // get a tempdir
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let db = TestDB::open_tables_read_write(
+            tempdir.path().to_owned(),
+            MetricConf::new("test_db"),
+            None,
+            None,
+        );
+
+        for _ in 0..10000 {
+            let future_round = rand::thread_rng().gen_range(0..u64::MAX);
+            let current_round = rand::thread_rng().gen_range(0..u64::MAX);
+
+            let key = DeferralKey::new_for_consensus_round(future_round, current_round);
+            db.deferred_certs.insert(&key, &()).unwrap();
+        }
+
+        let mut previous_future_round = 0;
+        for (key, _) in db.deferred_certs.unbounded_iter() {
+            match key {
+                DeferralKey::Randomness { .. } => (),
+                DeferralKey::ConsensusRound { future_round, .. } => {
+                    assert!(previous_future_round <= future_round);
+                    previous_future_round = future_round;
+                }
+            }
+        }
+    }
+
+    // Tests that fetching deferred transactions up to a given consensus rounds works as expected.
+    #[tokio::test]
+    async fn test_fetching_deferred_txs() {
+        use rand::prelude::*;
+
+        #[derive(DBMapUtils)]
+        struct TestDB {
+            deferred_certs: DBMap<DeferralKey, ()>,
+        }
+
+        // get a tempdir
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let db = TestDB::open_tables_read_write(
+            tempdir.path().to_owned(),
+            MetricConf::new("test_db"),
+            None,
+            None,
+        );
+
+        // All future rounds are between 100 and 300.
+        let min_future_round = 100;
+        let max_future_round = 300;
+        for _ in 0..10000 {
+            let future_round = rand::thread_rng().gen_range(min_future_round..=max_future_round);
+            let current_round = rand::thread_rng().gen_range(0..u64::MAX);
+
+            db.deferred_certs
+                .insert(
+                    &DeferralKey::new_for_consensus_round(future_round, current_round),
+                    &(),
+                )
+                .unwrap();
+            // Add a randomness deferral txn to make sure that it won't show up when fetching deferred consensus round txs.
+            db.deferred_certs
+                .insert(&DeferralKey::new_for_randomness(current_round), &())
+                .unwrap();
+        }
+
+        // Fetch all deferred transactions up to consensus round 200.
+        let (min, max) = DeferralKey::range_for_up_to_consensus_round(200);
+        let mut previous_future_round = 0;
+        let mut result_count = 0;
+        for result in db
+            .deferred_certs
+            .safe_iter_with_bounds(Some(min), Some(max))
+        {
+            let (key, _) = result.unwrap();
+            match key {
+                DeferralKey::Randomness { .. } => {
+                    panic!("Should not receive randomness deferral txn.")
+                }
+                DeferralKey::ConsensusRound { future_round, .. } => {
+                    assert!(previous_future_round <= future_round);
+                    previous_future_round = future_round;
+                    assert!(future_round <= 200);
+                    result_count += 1;
+                }
+            }
+        }
+        assert!(result_count > 0);
+    }
+}

--- a/crates/sui-core/src/authority/transaction_deferral.rs
+++ b/crates/sui-core/src/authority/transaction_deferral.rs
@@ -22,7 +22,7 @@ pub enum DeferralKey {
 }
 
 impl DeferralKey {
-    fn new_for_randomness(deferred_from_round: Round) -> Self {
+    pub fn new_for_randomness(deferred_from_round: Round) -> Self {
         Self::Randomness {
             deferred_from_round,
         }
@@ -35,7 +35,7 @@ impl DeferralKey {
         }
     }
 
-    fn full_range_for_randomness() -> (Self, Self) {
+    pub fn full_range_for_randomness() -> (Self, Self) {
         (
             Self::Randomness {
                 deferred_from_round: 0,
@@ -47,7 +47,7 @@ impl DeferralKey {
     }
 
     // Returns a range of deferral keys that are deferred up to the given consensus round.
-    fn range_for_up_to_consensus_round(consensus_round: Round) -> (Self, Self) {
+    pub fn range_for_up_to_consensus_round(consensus_round: Round) -> (Self, Self) {
         (
             Self::ConsensusRound {
                 future_round: 0,

--- a/crates/sui-core/src/authority/transaction_deferral.rs
+++ b/crates/sui-core/src/authority/transaction_deferral.rs
@@ -73,6 +73,7 @@ impl DeferralKey {
     }
 }
 
+#[derive(Debug)]
 pub enum DeferralReason {
     RandomnessNotReady,
 
@@ -91,6 +92,9 @@ pub fn transaction_deferral_within_limit(
     {
         return (future_round - deferred_from_round) <= max_deferral_rounds_for_congestion_control;
     }
+
+    // TODO: drop transactions at the end of the queue if the queue is too long.
+
     true
 }
 

--- a/crates/sui-core/src/authority/transaction_deferral.rs
+++ b/crates/sui-core/src/authority/transaction_deferral.rs
@@ -89,7 +89,7 @@ pub fn transaction_deferral_within_limit(
         deferred_from_round,
     } = deferral_key
     {
-        return (future_round - deferred_from_round) < max_deferral_rounds_for_congestion_control;
+        return (future_round - deferred_from_round) <= max_deferral_rounds_for_congestion_control;
     }
     true
 }

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -146,7 +146,7 @@ impl RWLockDependencyBuilder {
                         .entry(*effect.transaction_digest())
                         .or_default()
                         .push(ObjectKey(oid, version)),
-                    InputSharedObject::Cancelled(..) => (),
+                    InputSharedObject::Cancelled(..) => (), // TODO: confirm that consensus_commit_prologue is always at the beginning of the checkpoint, so that cancelled txn don't need to worry about dependency.
                 }
             }
         }

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -146,6 +146,7 @@ impl RWLockDependencyBuilder {
                         .entry(*effect.transaction_digest())
                         .or_default()
                         .push(ObjectKey(oid, version)),
+                    InputSharedObject::Cancelled(..) => (),
                 }
             }
         }

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -196,7 +196,10 @@ pub trait ExecutionCacheRead: Send + Sync {
             .into_iter(),
         ) {
             assert!(
-                input_key.version().is_none() || input_key.version().unwrap() < SequenceNumber::MAX
+                input_key.version().is_none() || input_key.version().unwrap() < SequenceNumber::MAX,
+                "Shared objects in cancelled transaction should always be available immediately, 
+                 but it appears that transaction manager is waiting for {:?} to become available",
+                input_key
             );
             // If the key exists at the specified version, then the object is available.
             if has_key {

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -196,7 +196,7 @@ pub trait ExecutionCacheRead: Send + Sync {
             .into_iter(),
         ) {
             assert!(
-                input_key.version().is_none() || input_key.version().unwrap() < SequenceNumber::MAX,
+                input_key.version().is_none() || input_key.version().unwrap().is_valid(),
                 "Shared objects in cancelled transaction should always be available immediately, 
                  but it appears that transaction manager is waiting for {:?} to become available",
                 input_key

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -195,6 +195,9 @@ pub trait ExecutionCacheRead: Send + Sync {
             )?
             .into_iter(),
         ) {
+            assert!(
+                input_key.version().is_none() || input_key.version().unwrap() < SequenceNumber::MAX
+            );
             // If the key exists at the specified version, then the object is available.
             if has_key {
                 versioned_results.push((*idx, true))

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -42,6 +42,9 @@ mod transaction_outputs;
 pub mod verify_indexes;
 
 #[cfg(test)]
+#[path = "unit_tests/congestion_control_tests.rs"]
+mod congestion_control_tests;
+#[cfg(test)]
 #[path = "unit_tests/move_package_publish_tests.rs"]
 mod move_package_publish_tests;
 #[cfg(test)]

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -167,7 +167,7 @@ impl TransactionInputLoader {
                     let version = shared_locks.get(id).unwrap_or_else(|| {
                         panic!("Shared object locks should have been set. key: {tx_key:?}, obj id: {id:?}")
                     });
-                    if version > &SequenceNumber::MAX {
+                    if version.is_cancelled() {
                         // Do not need to fetch shared object for cancelled transaction.
                         results[i] = Some(ObjectReadResult {
                             input_object_kind: *input,
@@ -198,7 +198,7 @@ impl TransactionInputLoader {
                     object: obj.into(),
                 },
                 (None, InputObjectKind::SharedMoveObject { id, .. }) => {
-                    assert!(key.1 < SequenceNumber::MAX);
+                    assert!(key.1.is_valid());
                     // Check if the object was deleted by a concurrently certified tx
                     let version = key.1;
                     if let Some(dependency) = self.cache.get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)? {

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -167,8 +167,17 @@ impl TransactionInputLoader {
                     let version = shared_locks.get(id).unwrap_or_else(|| {
                         panic!("Shared object locks should have been set. key: {tx_key:?}, obj id: {id:?}")
                     });
-                    object_keys.push(ObjectKey(*id, *version));
-                    fetches.push((i, input));
+                    if version > &SequenceNumber::MAX {
+                        results[i] = Some(ObjectReadResult {
+                            input_object_kind: *input,
+                            object: ObjectReadResultKind::CancelledTransactionSharedObject(
+                                *version,
+                            ),
+                        })
+                    } else {
+                        object_keys.push(ObjectKey(*id, *version));
+                        fetches.push((i, input));
+                    }
                 }
             }
         }
@@ -188,6 +197,7 @@ impl TransactionInputLoader {
                     object: obj.into(),
                 },
                 (None, InputObjectKind::SharedMoveObject { id, .. }) => {
+                    assert!(key.1 <= SequenceNumber::MAX);
                     // Check if the object was deleted by a concurrently certified tx
                     let version = key.1;
                     if let Some(dependency) = self.cache.get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)? {

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -168,6 +168,7 @@ impl TransactionInputLoader {
                         panic!("Shared object locks should have been set. key: {tx_key:?}, obj id: {id:?}")
                     });
                     if version > &SequenceNumber::MAX {
+                        // Do not need to fetch shared object for cancelled transaction.
                         results[i] = Some(ObjectReadResult {
                             input_object_kind: *input,
                             object: ObjectReadResultKind::CancelledTransactionSharedObject(
@@ -197,7 +198,7 @@ impl TransactionInputLoader {
                     object: obj.into(),
                 },
                 (None, InputObjectKind::SharedMoveObject { id, .. }) => {
-                    assert!(key.1 <= SequenceNumber::MAX);
+                    assert!(key.1 < SequenceNumber::MAX);
                     // Check if the object was deleted by a concurrently certified tx
                     let version = key.1;
                     if let Some(dependency) = self.cache.get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)? {

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -462,7 +462,8 @@ impl TransactionManager {
                         .version()
                         .is_some_and(|version| version > SequenceNumber::MAX)
                     {
-                        // Cancenlled txn objects should always be available.
+                        // Cancenlled txn objects should always be available immediately.
+                        // Don't need to wait on these objects for execution.
                         object_availability.insert(*key, Some(true));
                     } else {
                         object_availability.insert(*key, None);

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -458,7 +458,15 @@ impl TransactionManager {
                 }
 
                 for key in input_object_keys.iter() {
-                    object_availability.insert(*key, None);
+                    if key
+                        .version()
+                        .is_some_and(|version| version > SequenceNumber::MAX)
+                    {
+                        // Cancenlled txn objects should always be available.
+                        object_availability.insert(*key, Some(true));
+                    } else {
+                        object_availability.insert(*key, None);
+                    }
                 }
 
                 (cert, fx_digest, input_object_keys)
@@ -468,6 +476,9 @@ impl TransactionManager {
         {
             let mut inner = reconfig_lock.write();
             for (key, value) in object_availability.iter_mut() {
+                if value.is_some_and(|available| available) {
+                    continue;
+                }
                 if let Some(available) = inner.available_objects_cache.is_object_available(key) {
                     *value = Some(available);
                 }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -458,11 +458,8 @@ impl TransactionManager {
                 }
 
                 for key in input_object_keys.iter() {
-                    if key
-                        .version()
-                        .is_some_and(|version| version > SequenceNumber::MAX)
-                    {
-                        // Cancenlled txn objects should always be available immediately.
+                    if key.is_cancelled() {
+                        // Cancelled txn objects should always be available immediately.
                         // Don't need to wait on these objects for execution.
                         object_availability.insert(*key, Some(true));
                     } else {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5661,6 +5661,7 @@ async fn test_per_object_congestion_control() {
     protocol_config
         .set_per_object_congestion_control_mode(PerObjectCongestionControlMode::TotalGasBudget);
     protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint(200_000_000);
+    protocol_config.set_max_deferral_rounds_for_congestion_control(10);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -57,10 +57,10 @@ use sui_types::{
     SUI_FRAMEWORK_PACKAGE_ID, SUI_RANDOMNESS_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
-use crate::authority::authority_per_epoch_store::DeferralKey;
 use crate::authority::authority_store_tables::AuthorityPerpetualTables;
 use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::authority::transaction_deferral::DeferralKey;
 use crate::{
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     authority_server::AuthorityServer,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4359,7 +4359,6 @@ async fn execute_programmable_transaction_(
     gas_unit: u64,
 ) -> SuiResult<TransactionEffects> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    println!("ZZZZZ rgp: {:?}", rgp);
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let data =

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4359,6 +4359,7 @@ async fn execute_programmable_transaction_(
     gas_unit: u64,
 ) -> SuiResult<TransactionEffects> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
+    println!("ZZZZZ rgp: {:?}", rgp);
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let data =

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_types::{
+    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress},
+    crypto::{get_key_pair, AccountKeyPair},
+    effects::TransactionEffects,
+    execution_status::{CommandArgumentError, ExecutionFailureStatus},
+    object::Object,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{ProgrammableTransaction, Transaction},
+};
+
+use crate::authority::authority_test_utils::execute_sequenced_certificate_to_effects;
+use crate::{
+    authority::{
+        authority_tests::{
+            build_programmable_transaction, certify_shared_obj_transaction_no_execution,
+            enqueue_all_and_execute_all, execute_programmable_transaction,
+            execute_programmable_transaction_with_shared,
+        },
+        move_integration_tests::build_and_publish_test_package,
+        test_authority_builder::TestAuthorityBuilder,
+        AuthorityState,
+    },
+    move_call,
+};
+use move_core_types::ident_str;
+use sui_protocol_config::{Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion};
+use sui_types::base_types::TransactionDigest;
+use sui_types::committee::EpochId;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::error::{ExecutionError, SuiError};
+use sui_types::execution_status::ExecutionFailureStatus::{
+    InputObjectDeleted, SharedObjectOperationNotAllowed,
+};
+use sui_types::transaction::{ObjectArg, VerifiedCertificate};
+
+pub const TEST_ONLY_GAS_PRICE: u64 = 1000;
+pub const TEST_ONLY_GAS_UNIT_FOR_SUCCESSFUL_TX: u64 = 10_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_CONGESTED_TX: u64 = 90_000;
+
+async fn create_shared_object(
+    authority_state: &AuthorityState,
+    package: &ObjectRef,
+    sender: &SuiAddress,
+    sender_key: &AccountKeyPair,
+    gas_object_id: &ObjectID,
+) -> ObjectRef {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    move_call! {
+        builder,
+        (package.0)::congestion_control::create_shared()
+    };
+    let pt = builder.finish();
+
+    let create_shared_object_effects = execute_programmable_transaction(
+        authority_state,
+        gas_object_id,
+        sender,
+        sender_key,
+        pt,
+        TEST_ONLY_GAS_UNIT_FOR_SUCCESSFUL_TX,
+    )
+    .await
+    .unwrap();
+    assert_eq!(create_shared_object_effects.created().len(), 1);
+    create_shared_object_effects.created()[0].0
+}
+
+async fn create_owned_object(
+    authority_state: &AuthorityState,
+    package: &ObjectRef,
+    sender: &SuiAddress,
+    sender_key: &AccountKeyPair,
+    gas_object_id: &ObjectID,
+) -> ObjectRef {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    move_call! {
+        builder,
+        (package.0)::congestion_control::create_owned()
+    };
+    let pt = builder.finish();
+
+    let create_owned_object_effects = execute_programmable_transaction(
+        authority_state,
+        gas_object_id,
+        sender,
+        sender_key,
+        pt,
+        TEST_ONLY_GAS_UNIT_FOR_SUCCESSFUL_TX,
+    )
+    .await
+    .unwrap();
+    assert!(
+        create_owned_object_effects.status().is_ok(),
+        "Execution error {:?}",
+        create_owned_object_effects.status()
+    );
+    assert_eq!(create_owned_object_effects.created().len(), 1);
+    create_owned_object_effects.created()[0].0
+}
+
+async fn update_objects(
+    authority_state: &AuthorityState,
+    package: &ObjectRef,
+    sender: &SuiAddress,
+    sender_key: &AccountKeyPair,
+    gas_object_id: &ObjectID,
+    shared_object_1: &ObjectRef,
+    shared_object_2: &ObjectRef,
+    owned_object: &ObjectRef,
+) -> TransactionEffects {
+    let mut txn_builder = ProgrammableTransactionBuilder::new();
+    let arg1 = txn_builder
+        .obj(ObjectArg::SharedObject {
+            id: shared_object_1.0,
+            initial_shared_version: shared_object_1.1,
+            mutable: true,
+        })
+        .unwrap();
+    let arg2 = txn_builder
+        .obj(ObjectArg::SharedObject {
+            id: shared_object_2.0,
+            initial_shared_version: shared_object_2.1,
+            mutable: true,
+        })
+        .unwrap();
+    let arg3 = txn_builder
+        .obj(ObjectArg::ImmOrOwnedObject(*owned_object))
+        .unwrap();
+    move_call! {
+        txn_builder,
+        (package.0)::congestion_control::increment(arg1, arg2, arg3)
+    };
+    let pt = txn_builder.finish();
+    execute_programmable_transaction_with_shared(
+        authority_state,
+        gas_object_id,
+        &sender,
+        &sender_key,
+        pt,
+        TEST_ONLY_GAS_UNIT_FOR_CONGESTED_TX,
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_congestion_control_execution_cancellation() {
+    telemetry_subscribers::init_for_testing();
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    protocol_config
+        .set_per_object_congestion_control_mode(PerObjectCongestionControlMode::TotalGasBudget);
+    protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint(
+        TEST_ONLY_GAS_PRICE * TEST_ONLY_GAS_UNIT_FOR_CONGESTED_TX - 1,
+    );
+    protocol_config.set_max_deferral_rounds_for_congestion_control(0);
+    let authority_state = TestAuthorityBuilder::new()
+        .with_reference_gas_price(TEST_ONLY_GAS_PRICE)
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
+
+    let mut gas_object_ids = vec![];
+    for _ in 0..20 {
+        let gas_object_id = ObjectID::random();
+        let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
+        authority_state.insert_genesis_object(gas_object).await;
+        gas_object_ids.push(gas_object_id);
+    }
+
+    let package = build_and_publish_test_package(
+        &authority_state,
+        &sender,
+        &sender_key,
+        &gas_object_ids[0],
+        "congestion_control",
+        false,
+    )
+    .await;
+
+    let shared_object_1_initial_ref = create_shared_object(
+        &authority_state,
+        &package,
+        &sender,
+        &sender_key,
+        &gas_object_ids[0],
+    )
+    .await;
+
+    let shared_object_2_initial_ref = create_shared_object(
+        &authority_state,
+        &package,
+        &sender,
+        &sender_key,
+        &gas_object_ids[0],
+    )
+    .await;
+
+    let owned_object = create_owned_object(
+        &authority_state,
+        &package,
+        &sender,
+        &sender_key,
+        &gas_object_ids[0],
+    )
+    .await;
+
+    println!(
+        "Created objects {:?}\n {:?}\n {:?}\n",
+        shared_object_1_initial_ref, shared_object_2_initial_ref, owned_object
+    );
+
+    let effects = update_objects(
+        &authority_state,
+        &package,
+        &sender,
+        &sender_key,
+        &gas_object_ids[0],
+        &shared_object_1_initial_ref,
+        &shared_object_2_initial_ref,
+        &owned_object,
+    )
+    .await;
+
+    println!("ZZZZZZ {:?}", effects);
+}

--- a/crates/sui-core/src/unit_tests/data/congestion_control/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/congestion_control/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "congestion_control"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+congestion_control = "0x0"

--- a/crates/sui-core/src/unit_tests/data/congestion_control/sources/congestion_control.move
+++ b/crates/sui-core/src/unit_tests/data/congestion_control/sources/congestion_control.move
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module congestion_control::congestion_control {
-    // use sui::object::{Self, UID};
-    // use sui::transfer;
-    // use sui::tx_context::{Self, TxContext};
-
     public struct Object has key, store {
         id: UID,
         value: u64,

--- a/crates/sui-core/src/unit_tests/data/congestion_control/sources/congestion_control.move
+++ b/crates/sui-core/src/unit_tests/data/congestion_control/sources/congestion_control.move
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module congestion_control::congestion_control {
-    use sui::object::{Self, UID};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
+    // use sui::object::{Self, UID};
+    // use sui::transfer;
+    // use sui::tx_context::{Self, TxContext};
 
     public struct Object has key, store {
         id: UID,

--- a/crates/sui-core/src/unit_tests/data/congestion_control/sources/congestion_control.move
+++ b/crates/sui-core/src/unit_tests/data/congestion_control/sources/congestion_control.move
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module congestion_control::congestion_control {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create_owned(ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value: 0 },
+            tx_context::sender(ctx)
+        )
+    }
+
+    public entry fun create_shared(ctx: &mut TxContext) {
+        transfer::public_share_object(Object { id: object::new(ctx), value: 0 })
+    }
+
+    public entry fun increment(o1:  &mut Object, o2:  &mut Object, o3:  &mut Object) {
+        let m = o1.value + 1;
+        o1.value = m;
+        let m = o2.value + 1;
+        o2.value = m;
+        let m = o3.value + 1;
+        o3.value = m;
+    }
+}

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -193,8 +193,8 @@ async fn transaction_manager_object_dependency() {
             Object::with_id_owner_for_testing(gas_object_id, owner)
         })
         .collect();
-    let shared_object = Object::with_id_shared_for_testing(ObjectID::random());
-    let shared_object_2 = Object::with_id_shared_for_testing(ObjectID::random());
+    let shared_object = Object::shared_for_testing();
+    let shared_object_2 = Object::shared_for_testing();
 
     let state = init_state_with_objects(
         [
@@ -272,6 +272,13 @@ async fn transaction_manager_object_dependency() {
             CallArg::Object(shared_object_arg_default),
             CallArg::Object(shared_object_arg_read_2),
         ],
+    );
+    println!(
+        "Assign version {:?} {:?} {:?} {:?}",
+        shared_object.id(),
+        shared_version,
+        shared_object_2.id(),
+        shared_version_2
     );
     state
         .epoch_store_for_testing()

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -193,8 +193,8 @@ async fn transaction_manager_object_dependency() {
             Object::with_id_owner_for_testing(gas_object_id, owner)
         })
         .collect();
-    let shared_object = Object::shared_for_testing();
-    let shared_object_2 = Object::shared_for_testing();
+    let shared_object = Object::with_id_shared_for_testing(ObjectID::random());
+    let shared_object_2 = Object::with_id_shared_for_testing(ObjectID::random());
 
     let state = init_state_with_objects(
         [

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -222,6 +222,10 @@ CompressedSignature:
       ZkLogin:
         NEWTYPE:
           TYPENAME: ZkLoginAuthenticatorAsBytes
+CongestedObjects:
+  NEWTYPESTRUCT:
+    SEQ:
+      TYPENAME: ObjectID
 ConsensusCommitDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -424,6 +428,11 @@ ExecutionFailureStatus:
       SharedObjectOperationNotAllowed: UNIT
     32:
       InputObjectDeleted: UNIT
+    33:
+      ExecutionCancelledDueToSharedObjectCongestion:
+        STRUCT:
+          - congested_objects:
+              TYPENAME: CongestedObjects
 ExecutionStatus:
   ENUM:
     0:
@@ -1044,6 +1053,10 @@ UnchangedSharedKind:
           TYPENAME: SequenceNumber
     2:
       ReadDeleted:
+        NEWTYPE:
+          TYPENAME: SequenceNumber
+    3:
+      Cancelled:
         NEWTYPE:
           TYPENAME: SequenceNumber
 UpgradeInfo:

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3106,7 +3106,7 @@ type SharedInput {
 }
 
 """
-The transaction accpeted a shared object as input, but it's execution was cancelled.
+The transaction accpeted a shared object as input, but its execution was cancelled.
 """
 type SharedObjectCancelled {
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3105,8 +3105,17 @@ type SharedInput {
 	mutable: Boolean!
 }
 
+"""
+The transaction accpeted a shared object as input, but it's execution was cancelled.
+"""
 type SharedObjectCancelled {
+	"""
+	ID of the shared object.
+	"""
 	address: SuiAddress!
+	"""
+	The assigned shared object version. It is a special version indicating transaction cancellation reason.
+	"""
 	version: Int!
 }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3105,6 +3105,11 @@ type SharedInput {
 	mutable: Boolean!
 }
 
+type SharedObjectCancelled {
+	address: SuiAddress!
+	version: Int!
+}
+
 """
 The transaction accepted a shared object as input, but it was deleted before the transaction
 executed.
@@ -3873,7 +3878,7 @@ This information is considered part of the effects, because although the transac
 the shared object as input, consensus must schedule it and pick the version that is actually
 used.
 """
-union UnchangedSharedObject = SharedObjectRead | SharedObjectDelete
+union UnchangedSharedObject = SharedObjectRead | SharedObjectDelete | SharedObjectCancelled
 
 type UnchangedSharedObjectConnection {
 	"""

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -40,9 +40,13 @@ pub(crate) struct SharedObjectDelete {
     mutable: bool,
 }
 
+/// The transaction accpeted a shared object as input, but it's execution was cancelled.
 #[derive(SimpleObject)]
 pub(crate) struct SharedObjectCancelled {
+    /// ID of the shared object.
     address: SuiAddress,
+
+    /// The assigned shared object version. It is a special version indicating transaction cancellation reason.
     version: u64,
 }
 

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -40,7 +40,7 @@ pub(crate) struct SharedObjectDelete {
     mutable: bool,
 }
 
-/// The transaction accpeted a shared object as input, but it's execution was cancelled.
+/// The transaction accpeted a shared object as input, but its execution was cancelled.
 #[derive(SimpleObject)]
 pub(crate) struct SharedObjectCancelled {
     /// ID of the shared object.

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -14,6 +14,7 @@ use super::{object_read::ObjectRead, sui_address::SuiAddress};
 pub(crate) enum UnchangedSharedObject {
     Read(SharedObjectRead),
     Delete(SharedObjectDelete),
+    Cancelled(SharedObjectCancelled),
 }
 
 /// The transaction accepted a shared object as input, but only to read it.
@@ -37,6 +38,12 @@ pub(crate) struct SharedObjectDelete {
     /// Whether this transaction intended to use this shared object mutably or not. See
     /// `SharedInput.mutable` for further details.
     mutable: bool,
+}
+
+#[derive(SimpleObject)]
+pub(crate) struct SharedObjectCancelled {
+    address: SuiAddress,
+    version: u64,
 }
 
 /// Error for converting from an `InputSharedObject`.
@@ -70,6 +77,11 @@ impl UnchangedSharedObject {
                 address: id.into(),
                 version: v.value(),
                 mutable: true,
+            })),
+
+            I::Cancelled(id, v) => Ok(U::Cancelled(SharedObjectCancelled {
+                address: id.into(),
+                version: v.value(),
             })),
         }
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3110,7 +3110,7 @@ type SharedInput {
 }
 
 """
-The transaction accpeted a shared object as input, but it's execution was cancelled.
+The transaction accpeted a shared object as input, but its execution was cancelled.
 """
 type SharedObjectCancelled {
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3109,8 +3109,17 @@ type SharedInput {
 	mutable: Boolean!
 }
 
+"""
+The transaction accpeted a shared object as input, but it's execution was cancelled.
+"""
 type SharedObjectCancelled {
+	"""
+	ID of the shared object.
+	"""
 	address: SuiAddress!
+	"""
+	The assigned shared object version. It is a special version indicating transaction cancellation reason.
+	"""
 	version: Int!
 }
 
@@ -4182,4 +4191,3 @@ schema {
 	query: Query
 	mutation: Mutation
 }
-

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3109,6 +3109,11 @@ type SharedInput {
 	mutable: Boolean!
 }
 
+type SharedObjectCancelled {
+	address: SuiAddress!
+	version: Int!
+}
+
 """
 The transaction accepted a shared object as input, but it was deleted before the transaction
 executed.
@@ -3877,7 +3882,7 @@ This information is considered part of the effects, because although the transac
 the shared object as input, consensus must schedule it and pick the version that is actually
 used.
 """
-union UnchangedSharedObject = SharedObjectRead | SharedObjectDelete
+union UnchangedSharedObject = SharedObjectRead | SharedObjectDelete | SharedObjectCancelled
 
 type UnchangedSharedObjectConnection {
 	"""

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1723,6 +1723,7 @@
                 "max_checkpoint_size_bytes": {
                   "u64": "31457280"
                 },
+                "max_deferral_rounds_for_congestion_control": null,
                 "max_dependency_depth": {
                   "u64": "100"
                 },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1042,6 +1042,8 @@ pub struct ProtocolConfig {
     // The max accumulated txn execution cost per object in a checkpoint. Transactions
     // in a checkpoint will be deferred once their touch shared objects hit this limit.
     max_accumulated_txn_cost_per_object_in_checkpoint: Option<u64>,
+
+    max_deferral_rounds_for_congestion_control: Option<u64>,
 }
 
 // feature flags
@@ -1720,6 +1722,8 @@ impl ProtocolConfig {
             consensus_max_transactions_in_block_bytes: None,
 
             max_accumulated_txn_cost_per_object_in_checkpoint: None,
+
+            max_deferral_rounds_for_congestion_control: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2294,6 +2294,10 @@ impl ProtocolConfig {
         self.max_accumulated_txn_cost_per_object_in_checkpoint = Some(val);
     }
 
+    pub fn set_max_deferral_rounds_for_congestion_control(&mut self, val: u64) {
+        self.max_deferral_rounds_for_congestion_control = Some(val);
+    }
+
     pub fn set_zklogin_max_epoch_upper_bound_delta(&mut self, val: Option<u64>) {
         self.feature_flags.zklogin_max_epoch_upper_bound_delta = val
     }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1039,10 +1039,12 @@ pub struct ProtocolConfig {
     /// The maximum size of transactions included in a consensus proposed block
     consensus_max_transactions_in_block_bytes: Option<u64>,
 
-    // The max accumulated txn execution cost per object in a checkpoint. Transactions
-    // in a checkpoint will be deferred once their touch shared objects hit this limit.
+    /// The max accumulated txn execution cost per object in a checkpoint. Transactions
+    /// in a checkpoint will be deferred once their touch shared objects hit this limit.
     max_accumulated_txn_cost_per_object_in_checkpoint: Option<u64>,
 
+    /// The max number of consensus rounds a transaction can be deferred due to shared object congestion.
+    /// Transactions will be cancelled after this many rounds.
     max_deferral_rounds_for_congestion_control: Option<u64>,
 }
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1579,6 +1579,7 @@ impl LocalExec {
         // Add shared objects
         in_objs.extend(shared_inputs);
 
+        // TODO(Zhe): Account for cancelled transaction assigned version here, and tests.
         let resolved_input_objs = tx_info
             .input_objects
             .iter()

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -397,6 +397,8 @@ mod checked {
                 }
                 // We skip checking a deleted shared object because it no longer exists
                 ObjectReadResultKind::DeletedSharedObject(_, _) => (),
+                // We skip checking shared objects from cancelled transactions since we are not reading it.
+                ObjectReadResultKind::CancelledTransactionSharedObject(_) => (),
             }
         }
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1052,6 +1052,14 @@ impl SequenceNumber {
 
         SequenceNumber(max_input.0 + 1)
     }
+
+    pub fn is_cancelled(&self) -> bool {
+        self == &SequenceNumber::CANCELLED_READ || self == &SequenceNumber::CONGESTED
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self < &SequenceNumber::MAX
+    }
 }
 
 impl From<SequenceNumber> for u64 {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1003,6 +1003,8 @@ impl TxContext {
 impl SequenceNumber {
     pub const MIN: SequenceNumber = SequenceNumber(u64::MIN);
     pub const MAX: SequenceNumber = SequenceNumber(0x7fff_ffff_ffff_ffff);
+    pub const CANCELLED_READ: SequenceNumber = SequenceNumber(SequenceNumber::MAX.value() + 1);
+    pub const CONGESTED: SequenceNumber = SequenceNumber(SequenceNumber::MAX.value() + 2);
 
     pub const fn new() -> Self {
         SequenceNumber(0)

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -820,6 +820,7 @@ impl ObjectDigest {
     pub const MAX: ObjectDigest = Self::new([u8::MAX; 32]);
     pub const OBJECT_DIGEST_DELETED_BYTE_VAL: u8 = 99;
     pub const OBJECT_DIGEST_WRAPPED_BYTE_VAL: u8 = 88;
+    pub const OBJECT_DIGEST_CANCELLED_BYTE_VAL: u8 = 77;
 
     /// A marker that signifies the object is deleted.
     pub const OBJECT_DIGEST_DELETED: ObjectDigest =
@@ -828,6 +829,9 @@ impl ObjectDigest {
     /// A marker that signifies the object is wrapped into another object.
     pub const OBJECT_DIGEST_WRAPPED: ObjectDigest =
         Self::new([Self::OBJECT_DIGEST_WRAPPED_BYTE_VAL; 32]);
+
+    pub const OBJECT_DIGEST_CANCELLED: ObjectDigest =
+        Self::new([Self::OBJECT_DIGEST_CANCELLED_BYTE_VAL; 32]);
 
     pub const fn new(digest: [u8; 32]) -> Self {
         Self(Digest::new(digest))

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -276,6 +276,9 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
                 self.shared_objects
                     .push((id, version, ObjectDigest::OBJECT_DIGEST_DELETED));
             }
+            InputSharedObject::Cancelled(..) => {
+                panic!("Transaction cancellation is not supported in efect v1");
+            }
         }
     }
 

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -277,7 +277,7 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
                     .push((id, version, ObjectDigest::OBJECT_DIGEST_DELETED));
             }
             InputSharedObject::Cancelled(..) => {
-                panic!("Transaction cancellation is not supported in efect v1");
+                panic!("Transaction cancellation is not supported in effect v1");
             }
         }
     }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -585,5 +585,6 @@ pub enum UnchangedSharedKind {
     MutateDeleted(SequenceNumber),
     /// Deleted shared objects that appear as read-only in the input.
     ReadDeleted(SequenceNumber),
+    /// Shared objects in cancelled transaction. The sequence number embed cancellation reason.
     Cancelled(SequenceNumber),
 }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -118,6 +118,9 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
                     UnchangedSharedKind::ReadDeleted(seqno) => {
                         InputSharedObject::ReadDeleted(*id, *seqno)
                     }
+                    UnchangedSharedKind::Cancelled(seqno) => {
+                        InputSharedObject::Cancelled(*id, *seqno)
+                    }
                 },
             ))
             .collect()
@@ -354,6 +357,9 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
             InputSharedObject::MutateDeleted(obj_id, seqno) => self
                 .unchanged_shared_objects
                 .push((obj_id, UnchangedSharedKind::MutateDeleted(seqno))),
+            InputSharedObject::Cancelled(obj_id, seqno) => self
+                .unchanged_shared_objects
+                .push((obj_id, UnchangedSharedKind::Cancelled(seqno))),
         }
     }
 
@@ -419,6 +425,10 @@ impl TransactionEffectsV2 {
                     } else {
                         Some((id, UnchangedSharedKind::ReadDeleted(version)))
                     }
+                }
+                SharedInput::Cancelled((id, version)) => {
+                    debug_assert!(!changed_objects.contains_key(&id));
+                    Some((id, UnchangedSharedKind::Cancelled(version)))
                 }
             })
             .collect();
@@ -575,4 +585,5 @@ pub enum UnchangedSharedKind {
     MutateDeleted(SequenceNumber),
     /// Deleted shared objects that appear as read-only in the input.
     ReadDeleted(SequenceNumber),
+    Cancelled(SequenceNumber),
 }

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -304,6 +304,7 @@ pub enum InputSharedObject {
     ReadOnly(ObjectRef),
     ReadDeleted(ObjectID, SequenceNumber),
     MutateDeleted(ObjectID, SequenceNumber),
+    Cancelled(ObjectID, SequenceNumber),
 }
 
 impl InputSharedObject {
@@ -318,6 +319,9 @@ impl InputSharedObject {
             InputSharedObject::ReadDeleted(id, version)
             | InputSharedObject::MutateDeleted(id, version) => {
                 (*id, *version, ObjectDigest::OBJECT_DIGEST_DELETED)
+            }
+            InputSharedObject::Cancelled(id, version) => {
+                (*id, *version, ObjectDigest::OBJECT_DIGEST_CANCELLED)
             }
         }
     }
@@ -372,7 +376,8 @@ pub trait TransactionEffectsAPI {
                 InputSharedObject::MutateDeleted(id, _) => Some(id),
                 InputSharedObject::Mutate(..)
                 | InputSharedObject::ReadOnly(..)
-                | InputSharedObject::ReadDeleted(..) => None,
+                | InputSharedObject::ReadDeleted(..)
+                | InputSharedObject::Cancelled(..) => None,
             })
             .collect()
     }

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -40,6 +40,7 @@ pub type DeletedSharedObjects = Vec<DeletedSharedObjectInfo>;
 pub enum SharedInput {
     Existing(ObjectRef),
     Deleted(DeletedSharedObjectInfo),
+    Cancelled((ObjectID, SequenceNumber)),
 }
 
 impl<T> SuiResolver for T

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -470,7 +470,9 @@ impl From<Object> for ObjectOrTombstone {
 
 /// Fetch the `ObjectKey`s (IDs and versions) for non-shared input objects.  Includes owned,
 /// and immutable objects as well as the gas objects, but not move packages or shared objects.
-pub fn transaction_input_object_keys(tx: &SenderSignedData) -> SuiResult<Vec<ObjectKey>> {
+pub fn transaction_non_shared_input_object_keys(
+    tx: &SenderSignedData,
+) -> SuiResult<Vec<ObjectKey>> {
     use crate::transaction::InputObjectKind as I;
     Ok(tx
         .intent_message()

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -58,6 +58,13 @@ impl InputKey {
             InputKey::Package { .. } => None,
         }
     }
+
+    pub fn is_cancelled(&self) -> bool {
+        match self {
+            InputKey::VersionedObject { version, .. } => version.is_cancelled(),
+            InputKey::Package { .. } => false,
+        }
+    }
 }
 
 impl From<&Object> for InputKey {

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2810,6 +2810,7 @@ pub enum ObjectReadResultKind {
     // The version of the object that the transaction intended to read, and the digest of the tx
     // that deleted it.
     DeletedSharedObject(SequenceNumber, TransactionDigest),
+    // A shared object in a cancelled transaction. The sequence number embeds cancellation reason.
     CancelledTransactionSharedObject(SequenceNumber),
 }
 
@@ -3028,6 +3029,7 @@ impl InputObjects {
                 }
             }
         }
+
         if !congested_objects.is_empty() {
             Some(congested_objects)
         } else {

--- a/crates/sui-types/tests/staged/exec_failure_status.yaml
+++ b/crates/sui-types/tests/staged/exec_failure_status.yaml
@@ -32,3 +32,4 @@
 30: SuiMoveVerificationTimedout
 31: SharedObjectOperationNotAllowed
 32: InputObjectDeleted
+33: ExecutionCancelledDueToSharedObjectCongestion

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -265,6 +265,9 @@ impl<'backing> TemporaryStore<'backing> {
                 SharedInput::Deleted(_) => {
                     unreachable!("Shared object deletion not supported in effects v1")
                 }
+                SharedInput::Cancelled(_) => {
+                    unreachable!("Per object congestion control not supported in effects v1.")
+                }
             })
             .collect();
 

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -35,7 +35,7 @@ mod checked {
     use sui_types::error::{ExecutionError, ExecutionErrorKind};
     use sui_types::execution::is_certificate_denied;
     use sui_types::execution_config_utils::to_binary_config;
-    use sui_types::execution_status::ExecutionStatus;
+    use sui_types::execution_status::{CongestedObjects, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
@@ -50,7 +50,7 @@ mod checked {
         TransactionKind,
     };
     use sui_types::{
-        base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
+        base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, TxContext},
         object::{Object, ObjectInner},
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
         SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID,
@@ -84,6 +84,7 @@ mod checked {
         let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
         let contains_deleted_input = input_objects.contains_deleted_objects();
+        let congested_objects = input_objects.get_congested_objects();
 
         let mut temporary_store = TemporaryStore::new(
             store,
@@ -117,6 +118,7 @@ mod checked {
             enable_expensive_checks,
             deny_cert,
             contains_deleted_input,
+            congested_objects,
         );
 
         let status = if let Err(error) = &execution_result {
@@ -241,6 +243,7 @@ mod checked {
         enable_expensive_checks: bool,
         deny_cert: bool,
         contains_deleted_input: bool,
+        congested_objects: Option<Vec<ObjectID>>,
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, ExecutionError>,
@@ -268,6 +271,13 @@ mod checked {
             } else if contains_deleted_input {
                 Err(ExecutionError::new(
                     ExecutionErrorKind::InputObjectDeleted,
+                    None,
+                ))
+            } else if let Some(congested_objects) = congested_objects {
+                Err(ExecutionError::new(
+                    ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects: CongestedObjects(congested_objects),
+                    },
                     None,
                 ))
             } else {

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -213,6 +213,9 @@ impl<'backing> TemporaryStore<'backing> {
                     SharedInput::Deleted(_) => {
                         unreachable!("Shared object deletion not supported in effects v1")
                     }
+                    SharedInput::Cancelled(_) => {
+                        unreachable!("Per object congestion control not supported in effects v1.")
+                    }
                 })
                 .collect();
             self.into_effects_v1(

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -231,6 +231,9 @@ impl<'backing> TemporaryStore<'backing> {
                     SharedInput::Deleted(_) => {
                         unreachable!("Shared object deletion not supported in effects v1")
                     }
+                    SharedInput::Cancelled(_) => {
+                        unreachable!("Per object congestion control not supported in effects v1.")
+                    }
                 })
                 .collect();
             self.into_effects_v1(


### PR DESCRIPTION
## Description 

This PR implements congestion control triggered transaction cancellation. The motivation for the
cancellation is that we don't want a transaction to be deferred for too long, which impacts user
perceived latency. When a transaction is deferred for `max_deferral_rounds_for_congestion_control`
rounds, we will cancel the transaction.

To cancel a transaction, we cannot simply drop it on the floor and return an error, since if there is any
owned object used in the transaction, those owned objects are still locked. So we need to actually
send the transaction to the execution engine, unlock the owned object, and return error immediately
without running the transaction. User will also be charged for gas for cancelled transaction as well.

The cancellation logic works as follows. During shared object assignment in consensus handler,
we assign special object versions to shared objects in a cancelled transaction (SequenceNumber::CONGESTED,
and SequenceNumber::CANCELLED_READ, both are larger than SequenceNumber::MAX).
The version not only indicates transaction cancellation, in our case, it also informs which objects
are congested. The special version is how consensus handler communicates with transaction
manager and execution engine regarding whether a transaction should be cancelled.

Follow up PRs:
- We need to record cancelled transaction shared object version assignment in a new consensus
   commit prologue transaction.
- Replay cancelled transaction is currently not handled in this PR.
- If an object queue is already long enough, we may want to cancel transactions at the end of the queue
   if there is no hope to execute them in the future.

## Test plan 

Added unit test to tests:

- Shared object version assignment
- Consensus handler cancellation logic
- Transaction manager cancellation logic
- Execution engine cancellation logic

Added a integration test fo a controlled e2e test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
