### PR TITLE
[EASY][Release Notes] Fix regex raw string

### DIFF
--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -14,7 +14,7 @@ from typing import NamedTuple
 RE_NUM = re.compile("[0-9_]+")
 
 RE_PR = re.compile(
-    "^.*\(#(\d+)\)$",
+    r"^.*\(#(\d+)\)$",
     re.MULTILINE,
 )
 


### PR DESCRIPTION
## Description

I forgot to make one of the regex strings a raw string, and now Python is complaining about invalid escapes.

## Test plan

```
sui$ ./scripts/release_notes.py --help
```

No longer produces a syntax warning.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
