### PR TITLE
Provide randomness in Move UTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13091,6 +13091,7 @@ dependencies = [
  "move-stdlib-natives",
  "move-vm-runtime",
  "move-vm-types",
+ "rand 0.8.5",
  "smallvec",
  "sui-protocol-config",
  "sui-types",

--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -307,9 +307,9 @@ module sui::random {
         &r.buffer
     }
 
-    // Random generator from a non-deterministic seed.
-    // To be used when non-deterministic randomness is needed in tests (e.g., fuzzing).
     #[test_only]
+    /// Random generator from a non-deterministic seed.
+    /// To be used when non-deterministic randomness is needed in tests (e.g., fuzzing).
     public fun new_generator_for_testing(): RandomGenerator {
         let seed = generate_rand_seed();
         RandomGenerator { seed, counter: 0, buffer: vector[] }

--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -311,10 +311,10 @@ module sui::random {
     // To be used when non-deterministic randomness is needed in tests (e.g., fuzzing).
     #[test_only]
     public fun new_generator_for_testing(): RandomGenerator {
-        let seed = get_rand_seed();
+        let seed = generate_rand_seed();
         RandomGenerator { seed, counter: 0, buffer: vector[] }
     }
 
     #[test_only]
-    native fun get_rand_seed(): vector<u8>;
+    native fun generate_rand_seed(): vector<u8>;
 }

--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -306,4 +306,15 @@ module sui::random {
     public fun generator_buffer(r: &RandomGenerator): &vector<u8> {
         &r.buffer
     }
+
+    // Random generator from a non-deterministic seed.
+    // To be used when non-deterministic randomness is needed in tests (e.g., fuzzing).
+    #[test_only]
+    public fun new_generator_for_testing(): RandomGenerator {
+        let seed = get_rand_seed();
+        RandomGenerator { seed, counter: 0, buffer: vector[] }
+    }
+
+    #[test_only]
+    native fun get_rand_seed(): vector<u8>;
 }

--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -312,6 +312,12 @@ module sui::random {
     /// To be used when non-deterministic randomness is needed in tests (e.g., fuzzing).
     public fun new_generator_for_testing(): RandomGenerator {
         let seed = generate_rand_seed();
+        new_generator_from_seed(seed)
+    }
+
+    #[test_only]
+    /// Random generator from a given seed.
+    public fun new_generator_from_seed(seed: vector<u8>): RandomGenerator {
         RandomGenerator { seed, counter: 0, buffer: vector[] }
     }
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
@@ -6,8 +6,9 @@
 module sui::bls12381_tests {
     use sui::bls12381;
     use sui::group_ops;
-    use std::hash::sha2_256;
+    use sui::random;
     use sui::test_utils::assert_eq;
+    use std::hash::sha2_256;
 
     const ORDER_BYTES: vector<u8> = x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001";
     const ORDER_MINUS_ONE_BYTES: vector<u8> = x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000";
@@ -160,6 +161,22 @@ module sui::bls12381_tests {
         let order_minus_one = bls12381::scalar_from_bytes(&ORDER_MINUS_ONE_BYTES);
         let _ = bls12381::scalar_add(&order_minus_one, &order_minus_one);
         let _ = bls12381::scalar_mul(&order_minus_one, &order_minus_one);
+    }
+
+
+    // TODO: This is a very basic test, extend it to cover more cases.
+    #[test]
+    fun test_scalar_random_add() {
+        let mut gen = random::new_generator_for_testing();
+        let x = gen.generate_u32() as u64;
+        let y = gen.generate_u32() as u64;
+        let sum = x + y;
+
+        let x_scalar = bls12381::scalar_from_u64(x);
+        let y_scalar = bls12381::scalar_from_u64(y);
+        let sum_scalar = bls12381::scalar_add(&x_scalar, &y_scalar);
+
+        assert!(group_ops::equal(&sum_scalar, &bls12381::scalar_from_u64(sum)), 0);
     }
 
     #[test]

--- a/sui-execution/latest/sui-move-natives/Cargo.toml
+++ b/sui-execution/latest/sui-move-natives/Cargo.toml
@@ -12,6 +12,7 @@ better_any.workspace = true
 bcs.workspace = true
 indexmap.workspace = true
 smallvec.workspace = true
+rand = { workspace = true, features = ["small_rng"] }
 
 fastcrypto-zkp.workspace = true
 fastcrypto.workspace = true

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -67,6 +67,7 @@ mod dynamic_field;
 mod event;
 mod object;
 pub mod object_runtime;
+mod random;
 pub mod test_scenario;
 mod test_utils;
 mod transfer;
@@ -855,6 +856,11 @@ pub fn all_natives(silent: bool) -> NativeFunctionTable {
             "test_utils",
             "create_one_time_witness",
             make_native!(test_utils::create_one_time_witness),
+        ),
+        (
+            "random",
+            "get_rand_seed",
+            make_native!(random::get_rand_seed),
         ),
         (
             "zklogin_verified_id",

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -859,8 +859,8 @@ pub fn all_natives(silent: bool) -> NativeFunctionTable {
         ),
         (
             "random",
-            "get_rand_seed",
-            make_native!(random::get_rand_seed),
+            "generate_rand_seed",
+            make_native!(random::generate_rand_seed),
         ),
         (
             "zklogin_verified_id",

--- a/sui-execution/latest/sui-move-natives/src/random.rs
+++ b/sui-execution/latest/sui-move-natives/src/random.rs
@@ -11,13 +11,15 @@ use rand::Rng;
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
-pub fn get_rand_seed(
+pub fn generate_rand_seed(
     _context: &mut NativeContext,
     _ty_args: Vec<Type>,
     _args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let mut seed = [0u8; 32];
-    rand::thread_rng().try_fill(&mut seed).expect("should never fail");
+    rand::thread_rng()
+        .try_fill(&mut seed)
+        .expect("should never fail");
     Ok(NativeResult::ok(
         legacy_test_cost(),
         smallvec![Value::vector_u8(seed)],

--- a/sui-execution/latest/sui-move-natives/src/random.rs
+++ b/sui-execution/latest/sui-move-natives/src/random.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::legacy_test_cost;
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+};
+use rand::Rng;
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn get_rand_seed(
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    _args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let mut seed = [0u8; 32];
+    rand::thread_rng().try_fill(&mut seed).expect("should never fail");
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![Value::vector_u8(seed)],
+    ))
+}


### PR DESCRIPTION
## Description 

Provide randomness in Move UTs: instantiate `RandomGenerator` from a given seed or a random one.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
