### PR TITLE
Ensure that reconfiguration cannot happen while we are in enqueue_impl (or other methods)

### DIFF
--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -54,7 +54,10 @@ pub struct TransactionManager {
     cache_read: Arc<dyn ExecutionCacheRead>,
     tx_ready_certificates: UnboundedSender<PendingCertificate>,
     metrics: Arc<AuthorityMetrics>,
-    inner: RwLock<Inner>,
+    // inner is a doubly nested lock so that we can enforce that an outer lock (for read) is held
+    // before the inner lock (for read or write) can be acquired. During reconfiguration, we acquire
+    // the outer lock for write, to ensure that no other threads can be running while we reconfigure.
+    inner: RwLock<RwLock<Inner>>,
 }
 
 #[derive(Clone, Debug)]
@@ -343,7 +346,7 @@ impl TransactionManager {
         let transaction_manager = TransactionManager {
             cache_read,
             metrics: metrics.clone(),
-            inner: RwLock::new(Inner::new(epoch_store.epoch(), metrics)),
+            inner: RwLock::new(RwLock::new(Inner::new(epoch_store.epoch(), metrics))),
             tx_ready_certificates,
         };
         transaction_manager.enqueue(epoch_store.all_pending_execution().unwrap(), epoch_store);
@@ -399,6 +402,8 @@ impl TransactionManager {
         )>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
+        let reconfig_lock = self.inner.read();
+
         // filter out already executed certs
         let certs: Vec<_> = certs
             .into_iter()
@@ -467,7 +472,7 @@ impl TransactionManager {
             .collect();
 
         {
-            let mut inner = self.inner.write();
+            let mut inner = reconfig_lock.write();
             for (key, value) in object_availability.iter_mut() {
                 if let Some(available) = inner.available_objects_cache.is_object_available(key) {
                     *value = Some(available);
@@ -501,7 +506,7 @@ impl TransactionManager {
         // executed.
 
         // Internal lock is held only for updating the internal state.
-        let mut inner = self.inner.write();
+        let mut inner = reconfig_lock.write();
 
         let _scope = monitored_scope("TransactionManager::enqueue::wlock");
 
@@ -665,7 +670,8 @@ impl TransactionManager {
         input_keys: Vec<InputKey>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
-        let mut inner = self.inner.write();
+        let reconfig_lock = self.inner.read();
+        let mut inner = reconfig_lock.write();
         let _scope = monitored_scope("TransactionManager::objects_available::wlock");
         self.objects_available_locked(&mut inner, epoch_store, input_keys, true, Instant::now());
         inner.maybe_shrink_capacity();
@@ -720,9 +726,10 @@ impl TransactionManager {
         output_object_keys: Vec<InputKey>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
+        let reconfig_lock = self.inner.read();
         {
             let commit_time = Instant::now();
-            let mut inner = self.inner.write();
+            let mut inner = reconfig_lock.write();
             let _scope = monitored_scope("TransactionManager::notify_commit::wlock");
 
             if inner.epoch != epoch_store.epoch() {
@@ -769,7 +776,8 @@ impl TransactionManager {
 
     /// Gets the missing input object keys for the given transaction.
     pub(crate) fn get_missing_input(&self, digest: &TransactionDigest) -> Option<Vec<InputKey>> {
-        let inner = self.inner.read();
+        let reconfig_lock = self.inner.read();
+        let inner = reconfig_lock.read();
         inner
             .pending_certificates
             .get(digest)
@@ -781,7 +789,8 @@ impl TransactionManager {
         &self,
         keys: Vec<ObjectID>,
     ) -> Vec<(ObjectID, usize, Option<Duration>)> {
-        let inner = self.inner.read();
+        let reconfig_lock = self.inner.read();
+        let inner = reconfig_lock.read();
         keys.into_iter()
             .map(|key| {
                 let default_map = IndexMap::new();
@@ -797,14 +806,16 @@ impl TransactionManager {
 
     // Returns the number of transactions pending or being executed right now.
     pub(crate) fn inflight_queue_len(&self) -> usize {
-        let inner = self.inner.read();
+        let reconfig_lock = self.inner.read();
+        let inner = reconfig_lock.read();
         inner.pending_certificates.len() + inner.executing_certificates.len()
     }
 
     // Reconfigures the TransactionManager for a new epoch. Existing transactions will be dropped
     // because they are no longer relevant and may be incorrect in the new epoch.
     pub(crate) fn reconfigure(&self, new_epoch: EpochId) {
-        let mut inner = self.inner.write();
+        let reconfig_lock = self.inner.write();
+        let mut inner = reconfig_lock.write();
         *inner = Inner::new(new_epoch, self.metrics.clone());
     }
 
@@ -862,7 +873,8 @@ impl TransactionManager {
     // Verify TM has no pending item for tests.
     #[cfg(test)]
     fn check_empty_for_testing(&self) {
-        let inner = self.inner.read();
+        let reconfig_lock = self.inner.read();
+        let inner = reconfig_lock.read();
         assert!(
             inner.missing_inputs.is_empty(),
             "Missing inputs: {:?}",


### PR DESCRIPTION
 In enqueue_impl, we acquire inner.write() twice - in between these two critical sections we need to ensure that the cache is in unbounded mode so that we do not miss object writes that happen in between.

However, since we do not hold the lock the entire time, reconfiguration could previously happen. This would reset the inner state, and then we could crash at https://github.com/MystenLabs/sui/blob/d181e3f6ec8c3e185c239543f2613103db806eee/crates/sui-core/src/transaction_manager.rs#L201 when attempting to disable unbounded mode.

This PR ensures that reconfig cannot happen at any point during `enqueue_impl` or any other method that holds the lock. (Note that other methods were not affected since `enqueue_impl` is the only one that has two separate critsecs)