### PR TITLE
[gql] thread cancellation token through indexer to address flaky graphql e2e tests

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -23,6 +23,7 @@ use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_types::storage::ReadStore;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
+use tokio::join;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -111,6 +112,8 @@ pub async fn serve_executor(
     data_ingestion_path: PathBuf,
 ) -> ExecutorCluster {
     let db_url = graphql_connection_config.db_url.clone();
+    // Creates a cancellation token and adds this to the ExecutorCluster, so that we can send a
+    // cancellation token on cleanup
     let cancellation_token = CancellationToken::new();
 
     let executor_server_url: SocketAddr = format!("127.0.0.1:{}", internal_data_source_rpc_port)
@@ -136,6 +139,7 @@ pub async fn serve_executor(
         ReaderWriterConfig::writer_mode(snapshot_config.clone()),
         Some(graphql_connection_config.db_name()),
         Some(data_ingestion_path),
+        cancellation_token.clone(),
     )
     .await;
 
@@ -323,11 +327,11 @@ impl ExecutorCluster {
         latest_cp, latest_snapshot_cp));
     }
 
-    /// Deletes the database created for the test and sends a cancellation signal to the graphql
-    /// service. When this function is awaited on, the callsite will wait for the graphql service to
-    /// terminate its background task and then itself.
+    /// Sends a cancellation signal to the graphql and indexer services, waits for them to complete,
+    /// and then deletes the database created for the test.
     pub async fn cleanup_resources(self) {
         self.cancellation_token.cancel();
+        let _ = join!(self.graphql_server_join_handle, self.indexer_join_handle);
         let db_url = self.graphql_connection_config.db_url.clone();
         force_delete_database(db_url).await;
     }

--- a/crates/sui-indexer/src/framework/builder.rs
+++ b/crates/sui-indexer/src/framework/builder.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio_util::sync::CancellationToken;
 
 use crate::metrics::IndexerMetrics;
 
@@ -54,6 +55,7 @@ impl IndexerBuilder {
     }
 
     pub async fn run(self) {
+        let cancel = CancellationToken::new();
         let (downloaded_checkpoint_data_sender, downloaded_checkpoint_data_receiver) =
             mysten_metrics::metered_channel::channel(
                 self.checkpoint_buffer_size,
@@ -71,6 +73,7 @@ impl IndexerBuilder {
             self.last_downloaded_checkpoint,
             downloaded_checkpoint_data_sender,
             self.metrics.clone(),
+            cancel.clone(),
         );
         mysten_metrics::spawn_monitored_task!(fetcher.run());
 
@@ -82,6 +85,7 @@ impl IndexerBuilder {
             ),
             self.handlers,
             self.metrics.clone(),
+            cancel,
         )
         .await;
     }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -21,6 +21,7 @@ use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
 };
 use sui_types::object::Object;
+use tokio_util::sync::CancellationToken;
 
 use tokio::sync::watch;
 
@@ -64,6 +65,7 @@ pub async fn new_handlers<S>(
     client: Client,
     metrics: IndexerMetrics,
     next_checkpoint_sequence_number: CheckpointSequenceNumber,
+    cancel: CancellationToken,
 ) -> Result<CheckpointHandler<S>, IndexerError>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
@@ -92,6 +94,7 @@ where
         indexed_checkpoint_receiver,
         tx,
         next_checkpoint_sequence_number,
+        cancel.clone()
     ));
     Ok(CheckpointHandler::new(
         state,

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use tap::tap::TapFallible;
 use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use tracing::{error, info};
 
@@ -27,6 +28,7 @@ pub async fn start_tx_checkpoint_commit_task<S>(
     tx_indexing_receiver: mysten_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
     commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
+    cancel: CancellationToken,
 ) where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
@@ -46,6 +48,13 @@ pub async fn start_tx_checkpoint_commit_task<S>(
     let mut batch = vec![];
 
     while let Some(indexed_checkpoint_batch) = stream.next().await {
+        if cancel.is_cancelled() {
+            break;
+        }
+        if indexed_checkpoint_batch.is_empty() {
+            continue;
+        }
+
         let mut latest_fn_cp_res = client.get_latest_checkpoint().await;
         while latest_fn_cp_res.is_err() {
             error!("Failed to get latest checkpoint from the network");

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -51,9 +51,6 @@ pub async fn start_tx_checkpoint_commit_task<S>(
         if cancel.is_cancelled() {
             break;
         }
-        if indexed_checkpoint_batch.is_empty() {
-            continue;
-        }
 
         let mut latest_fn_cp_res = client.get_latest_checkpoint().await;
         while latest_fn_cp_res.is_err() {

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -6,6 +6,7 @@ use std::env;
 use anyhow::Result;
 use prometheus::Registry;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use mysten_metrics::spawn_monitored_task;
@@ -38,7 +39,14 @@ impl Indexer {
         metrics: IndexerMetrics,
     ) -> Result<(), IndexerError> {
         let snapshot_config = SnapshotLagConfig::default();
-        Indexer::start_writer_with_config(config, store, metrics, snapshot_config).await
+        Indexer::start_writer_with_config(
+            config,
+            store,
+            metrics,
+            snapshot_config,
+            CancellationToken::new(),
+        )
+        .await
     }
 
     pub async fn start_writer_with_config<S: IndexerStore + Sync + Send + Clone + 'static>(
@@ -46,6 +54,7 @@ impl Indexer {
         store: S,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
+        cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
         info!(
             "Sui Indexer Writer (version {:?}) started...",
@@ -78,6 +87,7 @@ impl Indexer {
             store.clone(),
             metrics.clone(),
             snapshot_config,
+            cancel.clone(),
         );
         spawn_monitored_task!(objects_snapshot_processor.start());
 
@@ -88,7 +98,7 @@ impl Indexer {
             1,
             DataIngestionMetrics::new(&Registry::new()),
         );
-        let worker = new_handlers(store, rest_client, metrics, watermark).await?;
+        let worker = new_handlers(store, rest_client, metrics, watermark, cancel.clone()).await?;
         let worker_pool = WorkerPool::new(worker, "workflow".to_string(), download_queue_size);
         let extra_reader_options = ReaderOptions {
             batch_size: download_queue_size,

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -91,8 +91,14 @@ impl Indexer {
         );
         spawn_monitored_task!(objects_snapshot_processor.start());
 
-        #[allow(unused_variables)]
+        let cancel_clone = cancel.clone();
         let (exit_sender, exit_receiver) = oneshot::channel();
+        // Spawn a task that links the cancellation token to the exit sender
+        spawn_monitored_task!(async move {
+            cancel_clone.cancelled().await;
+            let _ = exit_sender.send(());
+        });
+
         let mut executor = IndexerExecutor::new(
             ShimProgressStore(watermark),
             1,

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -5,6 +5,7 @@ use diesel::connection::SimpleConnection;
 use mysten_metrics::init_metrics;
 use secrecy::ExposeSecret;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use std::env;
 use std::net::SocketAddr;
@@ -51,6 +52,7 @@ pub async fn start_test_indexer(
         reader_writer_config,
         None,
         Some(data_ingestion_path),
+        CancellationToken::new(),
     )
     .await
 }
@@ -61,6 +63,7 @@ pub async fn start_test_indexer_impl(
     reader_writer_config: ReaderWriterConfig,
     new_database: Option<String>,
     data_ingestion_path: Option<PathBuf>,
+    cancel: CancellationToken,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
@@ -74,30 +77,15 @@ pub async fn start_test_indexer_impl(
         format!("postgres://postgres:{pw}@{pg_host}:{pg_port}")
     });
 
-    // dynamically set ports instead of all to 9000
-    let base_port = rpc_url
-        .chars()
-        .rev()
-        .take(4)
-        .collect::<String>()
-        .chars()
-        .rev()
-        .collect::<String>()
-        .parse::<u16>()
-        .unwrap();
+    let pool_config = PgConnectionPoolConfig::default();
 
-    // Set connection timeout for tests to 1 second
-    let mut pool_config = PgConnectionPoolConfig::default();
-    pool_config.set_connection_timeout(Duration::from_secs(1));
-
-    // Default writer mode
+    // Default to writer mode
     let mut config = IndexerConfig {
         db_url: Some(db_url.clone().into()),
         rpc_client_url: rpc_url,
         reset_db: true,
         fullnode_sync_worker: true,
         rpc_server_worker: false,
-        rpc_server_port: base_port + 1,
         remote_store_url: None,
         data_ingestion_path,
         ..Default::default()
@@ -164,6 +152,7 @@ pub async fn start_test_indexer_impl(
                     store_clone,
                     indexer_metrics,
                     snapshot_config,
+                    cancel,
                 )
                 .await
             })
@@ -188,9 +177,7 @@ pub async fn force_delete_database(db_url: String) {
     // This is necessary because you can't drop a database while being connected to it.
     // Hence switch to the default `postgres` database to drop the active database.
     let (default_db_url, db_name) = replace_db_name(&db_url, "postgres");
-    // Set connection timeout for tests to 1 second
-    let mut pool_config = PgConnectionPoolConfig::default();
-    pool_config.set_connection_timeout(Duration::from_secs(1));
+    let pool_config = PgConnectionPoolConfig::default();
 
     let blocking_pool =
         new_pg_connection_pool_with_config(&default_db_url, Some(5), pool_config).unwrap();

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -10,7 +10,6 @@ use tokio_util::sync::CancellationToken;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::time::Duration;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 use tracing::info;
 


### PR DESCRIPTION
## Description 

In the codebase today, when each e2e test is completed, we send a cancellation token to the graphql service and then delete the database created for the test. The issue is that the indexer and its supporting tasks continue to run, and now that they're trying to establish a connection to a db that does not exist, every connection will wait for `CONNECTION_TIMEOUT` duration. This means every test hangs for much longer than needed. To resolve, we thread a cancellation token through the indexer's test instantiation, so that on cleanup we can send a cancellation signal to both services, and finally spin down the db.

## Test plan 

Manually check that test duration is shorter.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
