### PR TITLE
wallet: disable hex import for private key

### DIFF
--- a/apps/wallet/src/ui/app/components/accounts/ImportPrivateKeyForm.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/ImportPrivateKeyForm.tsx
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import { privateKeyValidation } from '../../helpers/validation/privateKeyValidation';
 import { Form } from '../../shared/forms/Form';
 import { TextAreaField } from '../../shared/forms/TextAreaField';
-import Alert from '../alert';
 
 const formSchema = z.object({
 	privateKey: privateKeyValidation,
@@ -30,20 +29,11 @@ export function ImportPrivateKeyForm({ onSubmit }: ImportPrivateKeyFormProps) {
 	const {
 		register,
 		formState: { isSubmitting, isValid },
-		watch,
 	} = form;
 	const navigate = useNavigate();
-	const privateKey = watch('privateKey');
-	const isHexadecimal = isValid && !privateKey.startsWith('suiprivkey');
 	return (
 		<Form className="flex flex-col h-full gap-2" form={form} onSubmit={onSubmit}>
 			<TextAreaField label="Enter Private Key" rows={4} {...register('privateKey')} />
-			{isHexadecimal ? (
-				<Alert mode="warning">
-					Importing Hex encoded Private Key will soon be deprecated, please use Bech32 encoded
-					private key that starts with "suiprivkey" instead
-				</Alert>
-			) : null}
 			<div className="flex gap-2.5 mt-auto">
 				<Button variant="outline" size="tall" text="Cancel" onClick={() => navigate(-1)} />
 				<Button

--- a/apps/wallet/src/ui/app/helpers/validation/privateKeyValidation.ts
+++ b/apps/wallet/src/ui/app/helpers/validation/privateKeyValidation.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { decodeSuiPrivateKey, encodeSuiPrivateKey } from '@mysten/sui.js/cryptography/keypair';
-import { hexToBytes } from '@noble/hashes/utils';
+import { decodeSuiPrivateKey } from '@mysten/sui.js/cryptography/keypair';
 import { z } from 'zod';
 
 export const privateKeyValidation = z
@@ -10,36 +9,13 @@ export const privateKeyValidation = z
 	.trim()
 	.nonempty('Private Key is required.')
 	.transform((privateKey, context) => {
-		if (!privateKey.startsWith('suiprivkey')) {
-			const hexValue = privateKey.startsWith('0x') ? privateKey.slice(2) : privateKey;
-			let privateKeyBytes: Uint8Array | undefined;
-
-			try {
-				privateKeyBytes = hexToBytes(hexValue);
-			} catch (error) {
-				context.addIssue({
-					code: 'custom',
-					message: 'Invalid Private Key, please use a Bech32 encoded 33-byte string.',
-				});
-				return z.NEVER;
-			}
-
-			if (![32, 64].includes(privateKeyBytes.length)) {
-				context.addIssue({
-					code: 'custom',
-					message: 'Hex encoded Private Key must be either 32 or 64 bytes.',
-				});
-				return z.NEVER;
-			}
-
-			return encodeSuiPrivateKey(privateKeyBytes.slice(0, 32), 'ED25519');
-		}
 		try {
 			decodeSuiPrivateKey(privateKey);
 		} catch (error) {
 			context.addIssue({
 				code: 'custom',
-				message: 'Invalid Private Key, please use a Bech32 encoded 33-byte string',
+				message:
+					'Invalid Private Key, please use a Bech32 encoded 33-byte string. Learn more: https://github.com/sui-foundation/sips/blob/main/sips/sip-15.md',
 			});
 			return z.NEVER;
 		}


### PR DESCRIPTION
## Description 

as notified in https://github.com/sui-foundation/sips/blob/main/sips/sip-15.md we are deprecating hex private key importing. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
