### PR TITLE
[move-ide] Reset pre-compiled libs on manifest change

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -11,7 +11,7 @@ use lsp_types::{
     HoverProviderCapability, OneOf, SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
 };
-use move_compiler::{command_line::compiler::FullyCompiledProgram, linters::LintLevel};
+use move_compiler::linters::LintLevel;
 use std::{
     collections::BTreeMap,
     path::PathBuf,
@@ -53,7 +53,7 @@ fn main() {
     let (connection, io_threads) = Connection::stdio();
     let symbols = Arc::new(Mutex::new(symbols::empty_symbols()));
     let pkg_deps = Arc::new(Mutex::new(
-        BTreeMap::<PathBuf, Arc<FullyCompiledProgram>>::new(),
+        BTreeMap::<PathBuf, symbols::PrecompiledPkgDeps>::new(),
     ));
     let ide_files_root: VfsPath = MemoryFS::new().into();
     let context = Context {
@@ -260,7 +260,7 @@ fn on_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, Arc<FullyCompiledProgram>>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, symbols::PrecompiledPkgDeps>>>,
     shutdown_request_received: bool,
 ) -> bool {
     if shutdown_request_received {

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     context::Context,
-    symbols::{self, DefInfo, DefLoc, SymbolicatorRunner, Symbols},
+    symbols::{self, DefInfo, DefLoc, PrecompiledPkgDeps, SymbolicatorRunner, Symbols},
 };
 use lsp_server::Request;
 use lsp_types::{
@@ -12,7 +12,6 @@ use lsp_types::{
 };
 use move_command_line_common::files::FileHash;
 use move_compiler::{
-    command_line::compiler::FullyCompiledProgram,
     editions::Edition,
     expansion::ast::Visibility,
     linters::LintLevel,
@@ -363,7 +362,7 @@ pub fn on_completion_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, Arc<FullyCompiledProgram>>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecompiledPkgDeps>>>,
 ) {
     eprintln!("handling completion request");
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())


### PR DESCRIPTION
## Description 

This PR adds clearing of pre-compiled dependencies for a given package if the manifest file of this package changes.

## Test plan 

Tested manually to verify that pre-compiled dependencies are re-computed on manifest file change
