### PR TITLE
[TrafficController] Delegate error weighting to the server

### DIFF
--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -11,7 +11,7 @@ use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::time::Duration;
 use std::time::{Instant, SystemTime};
-use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType, ServiceResponse};
+use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType, Weight};
 use tracing::info;
 
 pub struct TrafficSketch {
@@ -121,7 +121,7 @@ impl TrafficSketch {
 pub struct TrafficTally {
     pub connection_ip: Option<IpAddr>,
     pub proxy_ip: Option<IpAddr>,
-    pub result: ServiceResponse,
+    pub weight: Weight,
     pub timestamp: SystemTime,
 }
 
@@ -392,13 +392,13 @@ mod tests {
         let alice = TrafficTally {
             connection_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
             proxy_ip: None,
-            result: ServiceResponse::Validator(Ok(())),
+            weight: Weight::zero(),
             timestamp: SystemTime::now(),
         };
         let bob = TrafficTally {
             connection_ip: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
             proxy_ip: None,
-            result: ServiceResponse::Validator(Ok(())),
+            weight: Weight::zero(),
             timestamp: SystemTime::now(),
         };
 

--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -4,7 +4,6 @@
 use std::time::SystemTime;
 use std::{net::SocketAddr, sync::Arc};
 use sui_types::traffic_control::RemoteFirewallConfig;
-use sui_types::traffic_control::ServiceResponse;
 
 use axum::extract::{ConnectInfo, Json, State};
 use futures::StreamExt;
@@ -23,7 +22,7 @@ use sui_core::traffic_controller::{
     metrics::TrafficControllerMetrics, policies::TrafficTally, TrafficController,
 };
 use sui_types::error::{SuiError, SuiResult};
-use sui_types::traffic_control::PolicyConfig;
+use sui_types::traffic_control::{PolicyConfig, Weight};
 
 use crate::routing_layer::RpcRouter;
 use sui_json_rpc_api::CLIENT_TARGET_API_VERSION_HEADER;
@@ -188,12 +187,21 @@ fn handle_traffic_resp(
     client_ip: SocketAddr,
     response: &MethodResponse,
 ) {
+    let error = response.error_code.map(ErrorCode::from);
     traffic_controller.tally(TrafficTally {
         connection_ip: Some(client_ip.ip()),
         proxy_ip: None,
-        result: ServiceResponse::Fullnode(response.clone()),
+        weight: error.map(normalize).unwrap_or(Weight::zero()),
         timestamp: SystemTime::now(),
     });
+}
+
+// TODO: refine error matching here
+fn normalize(err: ErrorCode) -> Weight {
+    match err {
+        ErrorCode::InvalidRequest | ErrorCode::InvalidParams => Weight::one(),
+        _ => Weight::zero(),
+    }
 }
 
 async fn process_request<L: Logger>(


### PR DESCRIPTION
## Description 

The list of servers that need to run traffic controller is 2 and will be 3 with graphql, perhaps more later.

Instead of requiring that traffic controller understand different error types for each server, allow the server to define the importance of an error type by replacing `ServiceResponse` in `TrafficTally` with a `Weight`, which is a float between 0 and 1, generated by each server. For errors that the server does not care about, weight is set to 0, and ignored by traffic controller during error tallying. For spam tallying, we disregard weight and consider all tallies.

## Test plan 

This logic currently only serves to simplify some error case statements. In later PR's, we will test this logic against error-aware policies (there are currently none). So for now, just ensure all existing tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
