### PR TITLE
[Consensus] improve resilience for commit and block sync

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -33,7 +33,7 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_max_forward_time_drift")]
     pub max_forward_time_drift: Duration,
 
-    // Number of blocks to fetch per request.
+    /// Number of blocks to fetch per request.
     #[serde(default = "Parameters::default_max_blocks_per_fetch")]
     pub max_blocks_per_fetch: usize,
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -15,7 +15,7 @@ use crate::{
     block_verifier::SignedBlockVerifier,
     broadcaster::Broadcaster,
     commit_observer::CommitObserver,
-    commit_syncer::{CommitSyncer, HighestCommitMonitor},
+    commit_syncer::{CommitSyncer, CommitVoteMonitor},
     context::Context,
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
@@ -236,11 +236,11 @@ where
             block_verifier.clone(),
         );
 
-        let highest_commit_monitor = Arc::new(HighestCommitMonitor::new(&context));
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_syncer = CommitSyncer::new(
             context.clone(),
             core_dispatcher.clone(),
-            highest_commit_monitor.clone(),
+            commit_vote_monitor.clone(),
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
@@ -249,7 +249,7 @@ where
         let network_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
-            highest_commit_monitor,
+            commit_vote_monitor,
             synchronizer.clone(),
             core_dispatcher,
             signals_receivers.block_broadcast_receiver(),
@@ -499,7 +499,7 @@ mod tests {
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
-            Arc::new(HighestCommitMonitor::new(&context)),
+            Arc::new(CommitVoteMonitor::new(context.clone())),
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -97,7 +97,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[peer_hostname, "send_block"])
+                .with_label_values(&[peer_hostname])
                 .inc();
             info!("Invalid block from {}: {}", peer, e);
             return Err(e);
@@ -129,7 +129,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .block_timestamp_drift_wait_ms
-                .with_label_values(&[peer_hostname])
+                .with_label_values(&[peer_hostname, &"handle_send_block"])
                 .inc_by(forward_time_drift.as_millis() as u64);
             sleep(forward_time_drift).await;
         }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -16,7 +16,7 @@ use crate::{
     block::{timestamp_utc_ms, BlockAPI as _, BlockRef, SignedBlock, VerifiedBlock, GENESIS_ROUND},
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, TrustedCommit},
-    commit_syncer::HighestCommitMonitor,
+    commit_syncer::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
@@ -31,7 +31,7 @@ use crate::{
 /// Authority's network service implementation, agnostic to the actual networking stack used.
 pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     context: Arc<Context>,
-    highest_commit_monitor: Arc<HighestCommitMonitor>,
+    commit_vote_monitor: Arc<CommitVoteMonitor>,
     block_verifier: Arc<dyn BlockVerifier>,
     synchronizer: Arc<SynchronizerHandle>,
     core_dispatcher: Arc<C>,
@@ -44,7 +44,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
     pub(crate) fn new(
         context: Arc<Context>,
         block_verifier: Arc<dyn BlockVerifier>,
-        highest_commit_monitor: Arc<HighestCommitMonitor>,
+        commit_vote_monitor: Arc<CommitVoteMonitor>,
         synchronizer: Arc<SynchronizerHandle>,
         core_dispatcher: Arc<C>,
         rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
@@ -54,7 +54,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         Self {
             context,
             block_verifier,
-            highest_commit_monitor,
+            commit_vote_monitor,
             synchronizer,
             core_dispatcher,
             rx_block_broadcaster,
@@ -134,9 +134,35 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             sleep(forward_time_drift).await;
         }
 
-        // Observe the block for the highest commit. When local commit is lagging too much,
+        // Observe the block for the commit votes. When local commit is lagging too much,
         // commit sync will be triggered.
-        self.highest_commit_monitor.observe(&verified_block);
+        self.commit_vote_monitor.observe(&verified_block);
+
+        // Reject blocks when local commit index is lagging too far from quorum commit index.
+        // Since the main issue of too many suspended blocks is memory usage not CPU,
+        // it is ok to reject after block verifications instead of before.
+        let last_commit_index = self.dag_state.read().last_commit_index();
+        let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
+        // The threshold to ignore block should be larger than commit_sync_batch_size,
+        // to avoid excessive block rejections and synchronizations.
+        const COMMIT_LAG_MULTIPLIER: u32 = 5;
+        if last_commit_index
+            + self.context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER
+            < quorum_commit_index
+        {
+            self.context
+                .metrics
+                .node_metrics
+                .rejected_blocks
+                .with_label_values(&[&"commit_lagging"])
+                .inc();
+            return Err(ConsensusError::BlockRejected {
+                reason: format!(
+                    "Local commit index {} is too far behind the quorum commit index {}",
+                    last_commit_index, quorum_commit_index,
+                ),
+            });
+        }
 
         self.context
             .metrics

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -591,6 +591,11 @@ impl TestBlock {
         self
     }
 
+    pub(crate) fn set_commit_votes(mut self, commit_votes: Vec<CommitVote>) -> Self {
+        self.block.commit_votes = commit_votes;
+        self
+    }
+
     pub(crate) fn build(self) -> Block {
         Block::V1(self.block)
     }

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -62,6 +62,9 @@ pub enum ConsensusError {
     #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
     SynchronizerSaturated(AuthorityIndex),
 
+    #[error("Block rejected: {reason}")]
+    BlockRejected { reason: String },
+
     #[error("Ancestor is in wrong position: block {block_authority}, ancestor {ancestor_authority}, position {position}")]
     InvalidAncestorPosition {
         block_authority: AuthorityIndex,

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -38,6 +38,15 @@ pub enum ConsensusError {
     #[error("Genesis blocks should not be queried!")]
     UnexpectedGenesisBlockRequested,
 
+    #[error(
+        "Expected {requested} but received {received} blocks returned from authority {authority}"
+    )]
+    UnexpectedNumberOfBlocksFetched {
+        authority: AuthorityIndex,
+        requested: usize,
+        received: usize,
+    },
+
     #[error("Unexpected block returned while fetching missing blocks")]
     UnexpectedFetchedBlock {
         index: AuthorityIndex,

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -90,6 +90,7 @@ pub(crate) struct NodeMetrics {
     pub fetch_blocks_scheduler_inflight: IntGauge,
     pub fetched_blocks: IntCounterVec,
     pub invalid_blocks: IntCounterVec,
+    pub rejected_blocks: IntCounterVec,
     pub rejected_future_blocks: IntCounterVec,
     pub verified_blocks: IntCounterVec,
     pub committed_leaders_total: IntCounterVec,
@@ -214,6 +215,12 @@ impl NodeMetrics {
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
                 &["authority", "source"],
+                registry,
+            ).unwrap(),
+            rejected_blocks: register_int_counter_vec_with_registry!(
+                "rejected_blocks",
+                "Number of blocks rejected before verifications",
+                &["reason"],
                 registry,
             ).unwrap(),
             rejected_future_blocks: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -144,7 +144,7 @@ impl NodeMetrics {
             block_timestamp_drift_wait_ms: register_int_counter_vec_with_registry!(
                 "block_timestamp_drift_wait_ms",
                 "Total time in ms spent waiting, when a received block has timestamp in future.",
-                &["authority"],
+                &["authority", "source"],
                 registry,
             ).unwrap(),
             blocks_per_commit_count: register_histogram_with_registry!(


### PR DESCRIPTION
## Description 

During catchup, a large number of suspended and "missing" blocks can be accumulated inside `BlockManager`. The memory usage can be significant. A mitigation is added here to stop accepting incoming blocks once local commit is lagging quorum commit progress significantly.

Also, fix commit and block syncer to verify the timestamps of blocks fetched. The local time can be behind the fetched block timestamps. For commit syncer fetching, potentially the fetch task needs to wait to enforce the invariant that local time > accepted block timestamp. For block syncer, since processing is done in a single thread, it has to drop the blocks with advanced timestamp for now.

## Test plan 

CI
private testnet

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
