### PR TITLE
add route for version wildcards

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -225,6 +225,7 @@ impl ServerBuilder {
             let router: Router = Router::new()
                 .route("/", post(graphql_handler))
                 .route("/graphql", post(graphql_handler))
+                .route("/graphql/:version", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
                 .with_state(self.state.clone())
                 .route_layer(middleware::from_fn_with_state(


### PR DESCRIPTION
## Description 

Adding wildcard route to support additional graphql routes.

## Test plan 

`/health`

```
% curl http://127.0.0.1:8001/health -w "%{http_code}"
200%
```

`/`

```
% curl -X POST -H "Content-Type: application/json" --data '{ "query": "query { chainIdentifier }", "variables": { "userId": "123" } }' http://127.0.0.1:8001/ -w "%{http_code}"
{"data":{"chainIdentifier":"4c78adac"}}200%
```

`/graphql`

```
% curl -X POST -H "Content-Type: application/json" --data '{ "query": "query { chainIdentifier }", "variables": { "userId": "123" } }' http://127.0.0.1:8001/graphql -w "%{http_code}"
{"data":{"chainIdentifier":"4c78adac"}}200%
```

`graphql/hola`

```
% curl -X POST -H "Content-Type: application/json" --data '{ "query": "query { chainIdentifier }", "variables": { "userId": "123" } }' http://127.0.0.1:8001/graphql/hola -w "%{http_code}"
{"data":{"chainIdentifier":"4c78adac"}}200%
```
