### PR TITLE
indexer: fix partial commit failure bug

### DIFF
--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -38,7 +38,7 @@ pub(crate) mod diesel_macro {
                     .read_write()
                     .run($query)
                     .map_err(|e| {
-                        tracing::error!("Error with persisting data into DB: {:?}", e);
+                        tracing::error!("Error with persisting data into DB: {:?}, retrying...", e);
                         backoff::Error::Transient {
                             err: IndexerError::PostgresWriteError(e.to_string()),
                             retry_after: None,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -70,6 +70,7 @@ const PG_COMMIT_PARALLEL_CHUNK_SIZE: usize = 100;
 // Having this number too high may cause many db deadlocks because of
 // optimistic locking.
 const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE: usize = 500;
+const PG_DB_COMMIT_SLEEP_DURATION: Duration = Duration::from_secs(3600);
 
 // with rn = 1, we only select the latest version of each object,
 // so that we don't have to update the same object multiple times.
@@ -178,7 +179,7 @@ impl PgIndexerStore {
                     .context("Failed to write display updates to PostgresDB")?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )?;
 
         Ok(())
@@ -222,7 +223,7 @@ impl PgIndexerStore {
                     .context("Failed to write object mutation to PostgresDB")?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -258,7 +259,7 @@ impl PgIndexerStore {
 
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -327,7 +328,7 @@ impl PgIndexerStore {
                 }
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -387,7 +388,7 @@ impl PgIndexerStore {
 
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -410,7 +411,7 @@ impl PgIndexerStore {
                     conn,
                 )
             },
-            Duration::from_secs(10)
+            PG_DB_COMMIT_SLEEP_DURATION
         )?;
         Ok(())
     }
@@ -449,7 +450,7 @@ impl PgIndexerStore {
                 }
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -492,7 +493,7 @@ impl PgIndexerStore {
                 }
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -528,7 +529,7 @@ impl PgIndexerStore {
                 }
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -566,7 +567,7 @@ impl PgIndexerStore {
                 }
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();
@@ -633,7 +634,7 @@ impl PgIndexerStore {
                     }
                     Ok::<(), IndexerError>(())
                 },
-                Duration::from_secs(60)
+                PG_DB_COMMIT_SLEEP_DURATION
             )
             .tap(|_| {
                 let elapsed = now.elapsed().as_secs_f64();
@@ -662,7 +663,7 @@ impl PgIndexerStore {
                     }
                     Ok::<(), IndexerError>(())
                 },
-                Duration::from_secs(60)
+                PG_DB_COMMIT_SLEEP_DURATION
             )
             .tap(|_| {
                 let elapsed = now.elapsed().as_secs_f64();
@@ -689,7 +690,7 @@ impl PgIndexerStore {
                     }
                     Ok::<(), IndexerError>(())
                 },
-                Duration::from_secs(60)
+                PG_DB_COMMIT_SLEEP_DURATION
             )
             .tap(|_| {
                 let elapsed = now.elapsed().as_secs_f64();
@@ -715,7 +716,7 @@ impl PgIndexerStore {
                     }
                     Ok::<(), IndexerError>(())
                 },
-                Duration::from_secs(60)
+                PG_DB_COMMIT_SLEEP_DURATION
             )
             .tap(|_| {
                 let elapsed = now.elapsed().as_secs_f64();
@@ -792,7 +793,7 @@ impl PgIndexerStore {
                     .execute(conn)?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap(|_| {
             let elapsed = guard.stop_and_record();


### PR DESCRIPTION
## Description 

We had a couple of reports that although certain checkpoints have been committed, tx_senders and objects of the same checkpoint missed some data.

after investigation, the bug was on joinAll of 
```
Vec<JoinHandle<Result<(), IndexerError>>>
```
where it has a nested result, the outer one is Result<_, JoinError>, and the inner one is Result<(), IndexerError>, before this fix, when the DB commit retries run out, indexer will skip and move on b/c the outer Result is okay, this PR is to fix that.

Also increased the retry timeout to 3600 seconds, b/c when retry fails indexer will panic and restart the whole binary, which is relatively expansive and so we want to try more here.

## Test plan 

CI
will want to test and make sure that indexer does panic and restart, will look into it separately.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
