### PR TITLE
[data ingestion] reader: support FN based REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12386,6 +12386,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "sui-rest-api",
  "sui-storage",
  "sui-types",
  "tap",

--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -25,6 +25,7 @@ sui-types.workspace = true
 url.workspace = true
 tempfile.workspace = true
 tap.workspace = true
+sui-rest-api.workspace = true
 
 [dev-dependencies]
 rand.workspace = true


### PR DESCRIPTION
temporary functionality. 
Intended for use in environments like devnet/staging when remote bucket is not available.
In future should be covered by colocation functionality.
It has a side benefit that even for testnet/mainnet we will have an option to fallback to querying FN 