### PR TITLE
[bridge 73] add `eth_contracts_start_block_fallback`

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -552,7 +552,8 @@ pub(crate) async fn start_bridge_cluster(
                 eth_rpc_url: eth_environment.rpc_url.clone(),
                 eth_bridge_proxy_address: eth_bridge_contract_address.clone(),
                 eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
-                eth_contracts_start_block_override: Some(0),
+                eth_contracts_start_block_fallback: Some(0),
+                eth_contracts_start_block_override: None,
             },
             sui: SuiConfig {
                 sui_rpc_url: test_cluster.fullnode_handle.rpc_url.clone(),

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -100,6 +100,7 @@ pub fn generate_bridge_node_config_and_write_to_file(
             eth_rpc_url: "your_eth_rpc_url".to_string(),
             eth_bridge_proxy_address: "0x0000000000000000000000000000000000000000".to_string(),
             eth_bridge_chain_id: BridgeChainId::EthSepolia as u8,
+            eth_contracts_start_block_fallback: Some(0),
             eth_contracts_start_block_override: None,
         },
         approved_governance_actions: vec![],


### PR DESCRIPTION
## Description 

This PR adds `eth_contracts_start_block_fallback` in `BridgeNodeConfig`. The comment describes it enough:
```
    /// The starting block for EthSyncer to monitor eth contracts.
    /// It is required when `run_client` is true. Usually this is
    /// the block number when the bridge contracts are deployed.
    /// When BridgeNode starts, it reads the contract watermark from storage.
    /// If the watermark is not found, it will start from this fallback block number.
    /// If the watermark is found, it will start from the watermark.
    /// this v.s.`eth_contracts_start_block_override`:
    pub eth_contracts_start_block_fallback: Option<u64>,
    /// The starting block for EthSyncer to monitor eth contracts. It overrides
    /// the watermark in storage. This is useful when we want to reprocess the events
    /// from a specific block number.
    /// Note: this field has to be reset after starting the BridgeNode, otherwise it will
    /// reprocess the events from this block number every time it starts.
    #[serde(skip_serializing_if = "Option::is_none")]
    pub eth_contracts_start_block_override: Option<u64>,
```

Overall, this field provides the ability to give a fallback block to start when no cursor found in DB.  While `eth_contracts_start_block_override` is more intrusive because of its highest precedence and stickiness (you need to remove it from config before restarting the node to void it)  .

To better test the behavior, i spin out `get_sui_modules_to_watch` and `get_eth_contracts_to_watch`.

## Test plan 

existing and new unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
