### PR TITLE
[move compiler]Make otw error prompts more user-friendly

### DIFF
--- a/docs/content/standards/display.mdx
+++ b/docs/content/standards/display.mdx
@@ -100,7 +100,7 @@ module examples::my_hero {
         let publisher = package::claim(otw, ctx);
 
         // Get a new `Display` object for the `Hero` type.
-        let display = display::new_with_fields<Hero>(
+        let mut display = display::new_with_fields<Hero>(
             &publisher, keys, values, ctx
         );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -404,7 +404,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
             let msg = format!(
                 "Invalid parameter '{}' of type {}. \
                 Expected a one-time witness type, {}::{otw_name}, \
-                like this: ({}: {otw_name}, other parameter...)",
+                like this: ({}: {otw_name}, ...other parameters)",
                 first_var.value.name,
                 error_format(first_ty, &Subst::empty()),
                 context.current_module(),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -403,10 +403,12 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
         if !is_otw {
             let msg = format!(
                 "Invalid parameter '{}' of type {}. \
-                Expected a one-time witness type, '{}::{otw_name}",
+                Expected a one-time witness type, {}::{otw_name}, \
+                like this: ({}: {otw_name}, other parameter...)",
                 first_var.value.name,
                 error_format(first_ty, &Subst::empty()),
                 context.current_module(),
+                first_var.value.name,
             );
             let mut diag = diag!(
                 INIT_FUN_DIAG,


### PR DESCRIPTION
## Description 

Make otw error prompts more user-friendly

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
