### PR TITLE
Move all ETH wrapping and unwrapping to vault

### DIFF
--- a/bridge/evm/contracts/BridgeVault.sol
+++ b/bridge/evm/contracts/BridgeVault.sol
@@ -59,7 +59,11 @@ contract BridgeVault is Ownable, IBridgeVault {
         recipientAddress.transfer(amount);
     }
 
-    /// @notice Enables the contract to receive ETH.
-    /// @dev This function is required to receive ETH when unwrapping WETH.
-    receive() external payable {}
+    /// @notice Wraps ass eth sent to this contract.
+    /// @dev skip if sender is wETH contract to avoid infinite loop.
+    receive() external payable {
+        if (msg.sender != address(wETH)) {
+            wETH.deposit{value: msg.value}();
+        }
+    }
 }

--- a/bridge/evm/contracts/BridgeVault.sol
+++ b/bridge/evm/contracts/BridgeVault.sol
@@ -59,7 +59,7 @@ contract BridgeVault is Ownable, IBridgeVault {
         recipientAddress.transfer(amount);
     }
 
-    /// @notice Wraps ass eth sent to this contract.
+    /// @notice Wraps as eth sent to this contract.
     /// @dev skip if sender is wETH contract to avoid infinite loop.
     receive() external payable {
         if (msg.sender != address(wETH)) {

--- a/bridge/evm/script/deploy_bridge.s.sol
+++ b/bridge/evm/script/deploy_bridge.s.sol
@@ -143,9 +143,7 @@ contract DeployBridge is Script {
 
         address suiBridge = Upgrades.deployUUPSProxy(
             "SuiBridge.sol",
-            abi.encodeCall(
-                SuiBridge.initialize, (bridgeCommittee, address(vault), limiter, deployConfig.WETH)
-            )
+            abi.encodeCall(SuiBridge.initialize, (bridgeCommittee, address(vault), limiter))
         );
 
         // transfer vault ownership to bridge

--- a/bridge/evm/test/BridgeBaseTest.t.sol
+++ b/bridge/evm/test/BridgeBaseTest.t.sol
@@ -134,7 +134,7 @@ contract BridgeBaseTest is Test {
         // deploy bridge =====================================================================
 
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
     }

--- a/bridge/evm/test/BridgeConfigTest.t.sol
+++ b/bridge/evm/test/BridgeConfigTest.t.sol
@@ -306,7 +306,7 @@ contract BridgeConfigTest is BridgeBaseTest {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
 
@@ -364,7 +364,7 @@ contract BridgeConfigTest is BridgeBaseTest {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
 
@@ -429,7 +429,7 @@ contract BridgeConfigTest is BridgeBaseTest {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
 

--- a/bridge/evm/test/BridgeLimiterTest.t.sol
+++ b/bridge/evm/test/BridgeLimiterTest.t.sol
@@ -256,7 +256,7 @@ contract BridgeLimiterTest is BridgeBaseTest {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
 
@@ -323,7 +323,7 @@ contract BridgeLimiterTest is BridgeBaseTest {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
 
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));

--- a/bridge/evm/test/CommitteeUpgradeableTest.t.sol
+++ b/bridge/evm/test/CommitteeUpgradeableTest.t.sol
@@ -56,7 +56,7 @@ contract CommitteeUpgradeableTest is BridgeBaseTest {
         // deploy sui bridge
         address _bridge = Upgrades.deployUUPSProxy(
             "SuiBridge.sol",
-            abi.encodeCall(SuiBridge.initialize, (_committee, address(0), address(0), address(0)))
+            abi.encodeCall(SuiBridge.initialize, (_committee, address(0), address(0)))
         );
 
         bridge = SuiBridge(_bridge);

--- a/bridge/evm/test/SuiBridgeTest.t.sol
+++ b/bridge/evm/test/SuiBridgeTest.t.sol
@@ -15,7 +15,6 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
     function testSuiBridgeInitialization() public {
         assertEq(address(bridge.committee()), address(committee));
         assertEq(address(bridge.vault()), address(vault));
-        assertEq(address(bridge.wETH()), wETH);
     }
 
     function testTransferBridgedTokensWithSignaturesTokenDailyLimitExceeded() public {
@@ -583,7 +582,7 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
 
@@ -666,7 +665,7 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
 
         bytes memory payload = hex"00";
         // Create emergency op message
@@ -718,7 +717,7 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), supportedChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
 
         assertFalse(bridge.paused());
 
@@ -835,7 +834,7 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
         limiter = new BridgeLimiter();
         limiter.initialize(address(committee), _supportedDestinationChains, totalLimits);
         bridge = new SuiBridge();
-        bridge.initialize(address(committee), address(vault), address(limiter), wETH);
+        bridge.initialize(address(committee), address(vault), address(limiter));
         vault.transferOwnership(address(bridge));
         limiter.transferOwnership(address(bridge));
 


### PR DESCRIPTION
## Description 

Thanks to @dariorussi for pointing out this very obvious design flaw. The SuiBridge contract no longer needs reference the WETH contract at all, and the vault takes care of all wrapping and unwrapping of ETH. 

## Test plan 

Updated necessary tests 
