### PR TITLE
[bridge] use different foundry-out for each test run

### DIFF
--- a/bridge/evm/.gitignore
+++ b/bridge/evm/.gitignore
@@ -4,10 +4,11 @@ cache*
 network_config.json
 .vscode
 cache/
-out/
+out*/
 *.txt
 !remappings.txt
 lcov.info
 broadcast/**/31337
 
 lib/*
+


### PR DESCRIPTION
## Description 

When we run multiple bridge tests in the same time, forge may complain about the conflicts. This PR fixes this problem by using a different FOUNDRY_OUT folder for each test run.


## Test plan 

CI tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
