### PR TITLE
[replay] Fix for receiving object transactions

### DIFF
--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -668,10 +668,6 @@ impl LocalExec {
             &input_objects.filter_shared_objects().len(),
             &tx_info.shared_object_refs.len()
         );
-        assert_eq!(
-            input_objects.transaction_dependencies(),
-            tx_info.dependencies.clone().into_iter().collect(),
-        );
         // At this point we have all the objects needed for replay
 
         // This assumes we already initialized the protocol version table `protocol_version_epoch_table`


### PR DESCRIPTION
## Description 

For receiving object transactions, the dependency assert is no longer valid.
This PR removes the assert.

## Test plan 

Replay on a receiving object transaction.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
