### PR TITLE
[Consensus] improve logs and panic messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,6 +2622,7 @@ dependencies = [
  "enum_dispatch",
  "fastcrypto",
  "futures",
+ "itertools 0.10.5",
  "mockall",
  "mysten-metrics",
  "mysten-network",

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -21,6 +21,7 @@ dashmap.workspace = true
 enum_dispatch.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
+itertools.workspace = true
 quinn-proto.workspace = true
 mockall.workspace = true
 mysten-metrics.workspace = true

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -83,7 +83,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[peer_hostname, "send_block"])
+                .with_label_values(&[peer_hostname, "handle_send_block"])
                 .inc();
             let e = ConsensusError::UnexpectedAuthority(signed_block.author(), peer);
             info!("Block with wrong authority from {}: {}", peer, e);
@@ -97,7 +97,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[peer_hostname])
+                .with_label_values(&[peer_hostname, "handle_send_block"])
                 .inc();
             info!("Invalid block from {}: {}", peer, e);
             return Err(e);

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -10,7 +10,7 @@ use futures::{ready, stream, task, Stream, StreamExt};
 use parking_lot::RwLock;
 use tokio::{sync::broadcast, time::sleep};
 use tokio_util::sync::ReusableBoxFuture;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     block::{timestamp_utc_ms, BlockAPI as _, BlockRef, SignedBlock, VerifiedBlock, GENESIS_ROUND},
@@ -105,11 +105,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
 
         // Reject block with timestamp too far in the future.
-        let forward_time_drift = Duration::from_millis(
-            verified_block
-                .timestamp_ms()
-                .saturating_sub(timestamp_utc_ms()),
-        );
+        let now = timestamp_utc_ms();
+        let forward_time_drift =
+            Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
         if forward_time_drift > self.context.parameters.max_forward_time_drift {
             self.context
                 .metrics
@@ -117,9 +115,19 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .rejected_future_blocks
                 .with_label_values(&[&peer_hostname])
                 .inc();
-            return Err(ConsensusError::BlockTooFarInFuture {
-                block_timestamp: verified_block.timestamp_ms(),
-                forward_time_drift,
+            debug!(
+                "Block {:?} timestamp ({} > {}) is too far in the future, rejected.",
+                verified_block.reference(),
+                verified_block.timestamp_ms(),
+                now,
+            );
+            return Err(ConsensusError::BlockRejected {
+                block_ref: verified_block.reference(),
+                reason: format!(
+                    "Block timestamp is too far in the future: {} > {}",
+                    verified_block.timestamp_ms(),
+                    now
+                ),
             });
         }
 
@@ -131,6 +139,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .block_timestamp_drift_wait_ms
                 .with_label_values(&[peer_hostname, &"handle_send_block"])
                 .inc_by(forward_time_drift.as_millis() as u64);
+            debug!(
+                "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
+                verified_block.reference(),
+                verified_block.timestamp_ms(),
+                now,
+                forward_time_drift.as_millis(),
+            );
             sleep(forward_time_drift).await;
         }
 
@@ -160,9 +175,16 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .rejected_blocks
                 .with_label_values(&[&"commit_lagging"])
                 .inc();
+            debug!(
+                "Block {:?} is rejected because last commit index is lagging quorum commit index too much ({} < {})",
+                verified_block.reference(),
+                last_commit_index,
+                quorum_commit_index,
+            );
             return Err(ConsensusError::BlockRejected {
+                block_ref: verified_block.reference(),
                 reason: format!(
-                    "Local commit index {} is too far behind the quorum commit index {}",
+                    "Last commit index is lagging quorum commit index too much ({} < {})",
                     last_commit_index, quorum_commit_index,
                 ),
             });

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -195,13 +195,13 @@ impl BlockRef {
 // TODO: re-evaluate formats for production debugging.
 impl fmt::Display for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}{}({})", self.author, self.round, self.digest)
+        write!(f, "B{}({},{})", self.round, self.author, self.digest)
     }
 }
 
 impl fmt::Debug for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}{}({:?})", self.author, self.round, self.digest)
+        write!(f, "B{}({},{:?})", self.round, self.author, self.digest)
     }
 }
 
@@ -513,11 +513,12 @@ impl fmt::Debug for VerifiedBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{:?}({}ms;{:?};{};v)",
+            "{:?}({}ms;{:?};{}t;{}c)",
             self.reference(),
             self.timestamp_ms(),
             self.ancestors(),
-            self.transactions().len()
+            self.transactions().len(),
+            self.commit_votes().len(),
         )
     }
 }

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use itertools::Itertools as _;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use tracing::{debug, warn};
@@ -82,8 +83,8 @@ impl BlockManager {
 
         blocks.sort_by_key(|b| b.round());
         debug!(
-            "Trying to accept blocks: {:?}",
-            blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
+            "Trying to accept blocks: {}",
+            blocks.iter().map(|b| b.reference().to_string()).join(",")
         );
 
         let mut accepted_blocks = vec![];

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -9,7 +9,7 @@ use std::{
 
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{
     block::{BlockAPI, BlockRef, VerifiedBlock},
@@ -81,6 +81,10 @@ impl BlockManager {
         let _s = monitored_scope("BlockManager::try_accept_blocks");
 
         blocks.sort_by_key(|b| b.round());
+        debug!(
+            "Trying to accept blocks: {:?}",
+            blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
+        );
 
         let mut accepted_blocks = vec![];
         let missing_blocks_before = self.missing_blocks.clone();

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -250,6 +250,18 @@ impl CommitRef {
     }
 }
 
+impl fmt::Display for CommitRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "C{}({})", self.index, self.digest)
+    }
+}
+
+impl fmt::Debug for CommitRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "C{}({:?})", self.index, self.digest)
+    }
+}
+
 // Represents a vote on a Commit.
 pub type CommitVote = CommitRef;
 

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -32,7 +32,8 @@ use std::{
 
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
-use futures::{stream::FuturesOrdered, StreamExt};
+use futures::{stream::FuturesOrdered, StreamExt as _};
+use itertools::Itertools as _;
 use mysten_metrics::spawn_logged_monitored_task;
 use parking_lot::{Mutex, RwLock};
 use rand::prelude::SliceRandom as _;
@@ -197,11 +198,11 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             continue 'fetched;
                         }
                         debug!(
-                            "Fetched certified blocks {:?}",
+                            "Fetched certified blocks: {}",
                             blocks
                                 .iter()
-                                .map(|b| b.reference())
-                                .collect::<Vec<_>>()
+                                .map(|b| b.reference().to_string())
+                                .join(","),
                         );
                         // If core thread cannot handle the incoming blocks, it is ok to block here.
                         // Also it is possible to have missing ancestors because an equivocating validator

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -127,13 +127,13 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     // Update synced_commit_index periodically to make sure it is not smaller than
                     // local commit index.
                     synced_commit_index = synced_commit_index.max(local_commit_index);
-                    // TODO: pause commit sync when execution of commits is lagging behind.
+                    info!(
+                        "Checking to schedule fetches: synced_commit_index={}, highest_scheduled_index={}, quorum_commit_index={}",
+                        synced_commit_index, highest_scheduled_index.unwrap_or(0), quorum_commit_index,
+                    );
+                    // TODO: pause commit sync when execution of commits is lagging behind, maybe through Core.
                     // TODO: cleanup inflight fetches that are no longer needed.
                     let fetch_after_index = synced_commit_index.max(highest_scheduled_index.unwrap_or(0));
-                    info!(
-                        "Checking to schedule fetches: synced_commit_index={}, fetch_after_index={}, quorum_commit_index={}",
-                        synced_commit_index, fetch_after_index, quorum_commit_index
-                    );
                     // When the node is falling behind, schedule pending fetches which will be executed on later.
                     'pending: for prev_end in (fetch_after_index..=quorum_commit_index).step_by(inner.context.parameters.commit_sync_batch_size as usize) {
                         // Create range with inclusive start and end.

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -41,7 +41,7 @@ use tokio::{
     task::{JoinHandle, JoinSet},
     time::{sleep, Instant, MissedTickBehavior},
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     block::{timestamp_utc_ms, BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
@@ -196,6 +196,13 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         if fetched_end <= synced_commit_index {
                             continue 'fetched;
                         }
+                        debug!(
+                            "Fetched certified blocks {:?}",
+                            blocks
+                                .iter()
+                                .map(|b| b.reference())
+                                .collect::<Vec<_>>()
+                        );
                         // If core thread cannot handle the incoming blocks, it is ok to block here.
                         // Also it is possible to have missing ancestors because an equivocating validator
                         // may produce blocks that are not included in commits but are ancestors to other blocks.

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -4,6 +4,7 @@
 use std::{collections::BTreeSet, iter, sync::Arc, time::Duration};
 
 use consensus_config::ProtocolKeyPair;
+use itertools::Itertools as _;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use tokio::sync::{broadcast, watch};
@@ -176,11 +177,11 @@ impl Core {
 
         if !accepted_blocks.is_empty() {
             debug!(
-                "Accepted blocks: {:?}",
+                "Accepted blocks: {}",
                 accepted_blocks
                     .iter()
-                    .map(|b| b.reference())
-                    .collect::<Vec<_>>()
+                    .map(|b| b.reference().to_string())
+                    .join(",")
             );
 
             // Now add accepted blocks to the threshold clock and pending ancestors list.
@@ -396,7 +397,15 @@ impl Core {
             .into_iter()
             .filter_map(|leader| leader.into_committed_block())
             .collect::<Vec<_>>();
-        debug!("Committing leaders: {:?}", committed_leaders);
+        if !committed_leaders.is_empty() {
+            debug!(
+                "Committing leaders: {}",
+                committed_leaders
+                    .iter()
+                    .map(|b| b.reference().to_string())
+                    .join(",")
+            );
+        }
 
         self.commit_observer.handle_commit(committed_leaders)
     }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -175,6 +175,14 @@ impl Core {
         let (accepted_blocks, missing_blocks) = self.block_manager.try_accept_blocks(blocks);
 
         if !accepted_blocks.is_empty() {
+            debug!(
+                "Accepted blocks: {:?}",
+                accepted_blocks
+                    .iter()
+                    .map(|b| b.reference())
+                    .collect::<Vec<_>>()
+            );
+
             // Now add accepted blocks to the threshold clock and pending ancestors list.
             self.add_accepted_blocks(accepted_blocks);
 
@@ -182,6 +190,10 @@ impl Core {
 
             // Try to propose now since there are new blocks accepted.
             self.try_propose(false)?;
+        }
+
+        if !missing_blocks.is_empty() {
+            debug!("Missing blocks: {:?}", missing_blocks);
         }
 
         Ok(missing_blocks)
@@ -384,6 +396,7 @@ impl Core {
             .into_iter()
             .filter_map(|leader| leader.into_committed_block())
             .collect::<Vec<_>>();
+        debug!("Committing leaders: {:?}", committed_leaders);
 
         self.commit_observer.handle_commit(committed_leaders)
     }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -274,8 +274,8 @@ impl Core {
         self.context
             .metrics
             .node_metrics
-            .block_ancestors_count
-            .inc_by(ancestors.len() as u64);
+            .block_ancestors
+            .observe(ancestors.len() as f64);
 
         // Ensure ancestor timestamps are not more advanced than the current time.
         // Also catch the issue if system's clock go backwards.

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::{
     block::{
@@ -171,6 +171,10 @@ impl DagState {
 
     /// Accepts a blocks into DagState and keeps it in memory.
     pub(crate) fn accept_blocks(&mut self, blocks: Vec<VerifiedBlock>) {
+        debug!(
+            "Accepting blocks: {:?}",
+            blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
+        );
         for block in blocks {
             self.accept_block(block);
         }
@@ -599,6 +603,13 @@ impl DagState {
         if blocks.is_empty() && commits.is_empty() {
             return;
         }
+        debug!(
+            "Flushing {} blocks ({:?}) and {} commits ({:?}) to storage.",
+            blocks.len(),
+            blocks.iter().map(|b| b.reference()).collect::<Vec<_>>(),
+            commits.len(),
+            commits.iter().map(|c| c.reference()).collect::<Vec<_>>(),
+        );
         self.store
             .write(WriteBatch::new(
                 blocks,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
+use itertools::Itertools as _;
 use tracing::{debug, error};
 
 use crate::{
@@ -172,8 +173,8 @@ impl DagState {
     /// Accepts a blocks into DagState and keeps it in memory.
     pub(crate) fn accept_blocks(&mut self, blocks: Vec<VerifiedBlock>) {
         debug!(
-            "Accepting blocks: {:?}",
-            blocks.iter().map(|b| b.reference()).collect::<Vec<_>>()
+            "Accepting blocks: {}",
+            blocks.iter().map(|b| b.reference().to_string()).join(",")
         );
         for block in blocks {
             self.accept_block(block);
@@ -604,11 +605,11 @@ impl DagState {
             return;
         }
         debug!(
-            "Flushing {} blocks ({:?}) and {} commits ({:?}) to storage.",
+            "Flushing {} blocks ({}) and {} commits ({}) to storage.",
             blocks.len(),
-            blocks.iter().map(|b| b.reference()).collect::<Vec<_>>(),
+            blocks.iter().map(|b| b.reference().to_string()).join(","),
             commits.len(),
-            commits.iter().map(|c| c.reference()).collect::<Vec<_>>(),
+            commits.iter().map(|c| c.reference().to_string()).join(","),
         );
         self.store
             .write(WriteBatch::new(

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -1,15 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use consensus_config::{AuthorityIndex, Epoch, Stake};
 use fastcrypto::error::FastCryptoError;
 use thiserror::Error;
 use typed_store::TypedStoreError;
 
 use crate::{
-    block::{BlockRef, BlockTimestampMs, Round},
+    block::{BlockRef, Round},
     commit::Commit,
     CommitIndex,
 };
@@ -71,8 +69,8 @@ pub enum ConsensusError {
     #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
     SynchronizerSaturated(AuthorityIndex),
 
-    #[error("Block rejected: {reason}")]
-    BlockRejected { reason: String },
+    #[error("Block {block_ref:?} rejected: {reason}")]
+    BlockRejected { block_ref: BlockRef, reason: String },
 
     #[error("Ancestor is in wrong position: block {block_authority}, ancestor {ancestor_authority}, position {position}")]
     InvalidAncestorPosition {
@@ -103,12 +101,6 @@ pub enum ConsensusError {
     InvalidBlockTimestamp {
         max_timestamp_ms: u64,
         block_timestamp_ms: u64,
-    },
-
-    #[error("Block at {block_timestamp}ms is too far in the future: {forward_time_drift:?}")]
-    BlockTooFarInFuture {
-        block_timestamp: BlockTimestampMs,
-        forward_time_drift: Duration,
     },
 
     #[error("No available authority to fetch commits")]

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -77,6 +77,7 @@ pub(crate) struct NodeMetrics {
     pub block_commit_latency: Histogram,
     pub block_proposed: IntCounterVec,
     pub block_size: Histogram,
+    pub block_ancestors_count: IntCounter,
     pub block_timestamp_drift_wait_ms: IntCounterVec,
     pub blocks_per_commit_count: Histogram,
     pub broadcaster_rtt_estimate_ms: IntGaugeVec,
@@ -141,6 +142,11 @@ impl NodeMetrics {
                 "block_size",
                 "The size (in bytes) of proposed blocks",
                 SIZE_BUCKETS.to_vec(),
+                registry
+            ).unwrap(),
+            block_ancestors_count: register_int_counter_with_registry!(
+                "block_ancestors_count",
+                "Total number of ancestors in proposed blocks",
                 registry
             ).unwrap(),
             block_timestamp_drift_wait_ms: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use prometheus::{
-    register_histogram_vec_with_registry, register_histogram_with_registry,
+    exponential_buckets, register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Histogram,
     HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
@@ -77,7 +77,7 @@ pub(crate) struct NodeMetrics {
     pub block_commit_latency: Histogram,
     pub block_proposed: IntCounterVec,
     pub block_size: Histogram,
-    pub block_ancestors_count: IntCounter,
+    pub block_ancestors: Histogram,
     pub block_timestamp_drift_wait_ms: IntCounterVec,
     pub blocks_per_commit_count: Histogram,
     pub broadcaster_rtt_estimate_ms: IntGaugeVec,
@@ -144,10 +144,11 @@ impl NodeMetrics {
                 SIZE_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
-            block_ancestors_count: register_int_counter_with_registry!(
-                "block_ancestors_count",
-                "Total number of ancestors in proposed blocks",
-                registry
+            block_ancestors: register_histogram_with_registry!(
+                "block_ancestors",
+                "Number of ancestors in proposed blocks",
+                exponential_buckets(1.0, 1.4, 20).unwrap(),
+                registry,
             ).unwrap(),
             block_timestamp_drift_wait_ms: register_int_counter_vec_with_registry!(
                 "block_timestamp_drift_wait_ms",

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -100,7 +100,7 @@ impl AnemoClient {
                         if let Some(peer) = network.peer(peer_id) {
                             return Ok(ConsensusRpcClient::new(peer));
                         }
-                        error!("Peer {} should be connected.", peer_id)
+                        warn!("Peer {} should be connected.", peer_id)
                     }
                     Err(RecvError::Closed) => return Err(ConsensusError::Shutdown),
                     Err(RecvError::Lagged(_)) => {

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -3,7 +3,8 @@
 
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
-use futures::StreamExt;
+use futures::StreamExt as _;
+use itertools::Itertools as _;
 use mysten_metrics::{monitored_future, monitored_scope};
 use parking_lot::Mutex;
 #[cfg(not(test))]
@@ -304,11 +305,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             verified_blocks.push(verified_block);
         }
         debug!(
-            "Synced missing ancestor blocks {:?} from peer {peer_index}",
+            "Synced missing ancestor blocks {} from peer {peer_index}",
             verified_blocks
                 .iter()
-                .map(|b| b.reference())
-                .collect::<Vec<_>>()
+                .map(|b| b.reference().to_string())
+                .join(","),
         );
 
         // Now send them to core for processing. Ignore the returned missing blocks as we don't want

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -303,6 +303,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
             verified_blocks.push(verified_block);
         }
+        debug!(
+            "Synced missing ancestor blocks {:?} from peer {peer_index}",
+            verified_blocks
+                .iter()
+                .map(|b| b.reference())
+                .collect::<Vec<_>>()
+        );
 
         // Now send them to core for processing. Ignore the returned missing blocks as we don't want
         // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -9,7 +9,7 @@ use sui_protocol_config::ProtocolConfig;
 use tap::tap::TapFallible;
 use thiserror::Error;
 use tokio::sync::oneshot;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::block::Transaction;
 use crate::context::Context;
@@ -134,7 +134,7 @@ impl TransactionClient {
         let included_in_block = self.submit_no_wait(transaction).await?;
         included_in_block
             .await
-            .tap_err(|e| error!("Transaction acknowledge failed with {:?}", e))
+            .tap_err(|e| warn!("Transaction acknowledge failed with {:?}", e))
             .map_err(|e| ClientError::ConsensusShuttingDown(e.to_string()))
     }
 


### PR DESCRIPTION
## Description 

Improve panic message when local timestamp < accepted block timestamp.

Add more details to logs for block creation and processing.

Remove logic no longer necessary after using DagState for proposing and keeping track of last proposed ancestors.

Ensure timestamp_utc_ms() returns monotonic values. Ensure after Core recover, local time > max ancestor timestamp.

## Test plan 

CI
Simulation

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
