### PR TITLE
Create with_id_shared_for_testing helper

### DIFF
--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -193,8 +193,8 @@ async fn transaction_manager_object_dependency() {
             Object::with_id_owner_for_testing(gas_object_id, owner)
         })
         .collect();
-    let shared_object = Object::shared_for_testing();
-    let shared_object_2 = Object::shared_for_testing();
+    let shared_object = Object::with_id_shared_for_testing(ObjectID::random());
+    let shared_object_2 = Object::with_id_shared_for_testing(ObjectID::random());
 
     let state = init_state_with_objects(
         [
@@ -260,7 +260,7 @@ async fn transaction_manager_object_dependency() {
         .unwrap();
 
     // Enqueue one transaction with two readonly shared object inputs, `shared_object` and `shared_object_2`.
-    let shared_version_2 = 2000.into();
+    let shared_version_2 = 1000.into();
     let shared_object_arg_read_2 = ObjectArg::SharedObject {
         id: shared_object_2.id(),
         initial_shared_version: 0.into(),

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -922,14 +922,18 @@ impl Object {
         Self::immutable_with_id_for_testing(IMMUTABLE_OBJECT_ID.with(|id| *id))
     }
 
-    /// make a test shared object.
+    /// Make a test shared object. Note that this function returns the same object called from the same thread.
     pub fn shared_for_testing() -> Object {
         thread_local! {
             static SHARED_OBJECT_ID: ObjectID = ObjectID::random();
         }
 
-        let obj =
-            MoveObject::new_gas_coin(OBJECT_START_VERSION, SHARED_OBJECT_ID.with(|id| *id), 10);
+        Object::with_id_shared_for_testing(SHARED_OBJECT_ID.with(|id| *id))
+    }
+
+    /// Make a new test sahred object.
+    pub fn with_id_shared_for_testing(id: ObjectID) -> Object {
+        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, id, 10);
         let owner = Owner::Shared {
             initial_shared_version: obj.version(),
         };


### PR DESCRIPTION
## Description 

Trying to pull some independent changes from #17200 .

Noticed that `shared_for_testing` always return the same shared object if called from the same thread. Added a new `with_id_shared_for_testing` instead of changing `shared_for_testing`'s behavior since I guess it was purposely created in that way.

## Test plan 

Unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
