### PR TITLE
[Consensus] backpressure from consensus handler into core

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -346,7 +346,7 @@ mod tests {
     use sui_protocol_config::ProtocolConfig;
     use tempfile::TempDir;
     use tokio::{
-        sync::{broadcast, mpsc::unbounded_channel},
+        sync::{broadcast, mpsc},
         time::sleep,
     };
 
@@ -463,7 +463,7 @@ mod tests {
         let protocol_keypair = keypairs[own_index].1.clone();
         let network_keypair = keypairs[own_index].0.clone();
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = mpsc::channel(100);
         let commit_consumer = CommitConsumer::new(sender, 0, 0);
 
         let authority = ConsensusAuthority::start(
@@ -570,7 +570,7 @@ mod tests {
             let protocol_keypair = keypairs[index].1.clone();
             let network_keypair = keypairs[index].0.clone();
 
-            let (sender, receiver) = unbounded_channel();
+            let (sender, receiver) = mpsc::channel(100);
             let commit_consumer = CommitConsumer::new(sender, 0, 0);
 
             async move {

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -14,7 +14,7 @@ use consensus_config::{AuthorityIndex, DefaultHashFunction, DIGEST_LENGTH};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction as _};
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 
 use crate::{
     block::{BlockAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock},
@@ -352,7 +352,7 @@ pub fn load_committed_subdag_from_store(
 
 pub struct CommitConsumer {
     // A channel to send the committed sub dags through
-    pub sender: UnboundedSender<CommittedSubDag>,
+    pub sender: Sender<CommittedSubDag>,
     // Leader round of the last commit that the consumer has processed.
     pub last_processed_commit_round: Round,
     // Index of the last commit that the consumer has processed. This is useful for
@@ -364,7 +364,7 @@ pub struct CommitConsumer {
 
 impl CommitConsumer {
     pub fn new(
-        sender: UnboundedSender<CommittedSubDag>,
+        sender: Sender<CommittedSubDag>,
         last_processed_commit_round: Round,
         last_processed_commit_index: CommitIndex,
     ) -> Self {

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -582,10 +582,7 @@ mod test {
 
     use consensus_config::{local_committee_and_keys, AuthorityIndex, Parameters, Stake};
     use sui_protocol_config::ProtocolConfig;
-    use tokio::{
-        sync::mpsc::{unbounded_channel, UnboundedReceiver},
-        time::sleep,
-    };
+    use tokio::{sync::mpsc, time::sleep};
 
     use super::*;
     use crate::{
@@ -642,7 +639,7 @@ mod test {
             LeaderSwapTable::default(),
         ));
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = mpsc::channel(100);
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -757,7 +754,7 @@ mod test {
             LeaderSwapTable::default(),
         ));
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = mpsc::channel(100);
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -851,7 +848,7 @@ mod test {
             LeaderSwapTable::default(),
         ));
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = mpsc::channel(100);
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -958,7 +955,7 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = mpsc::channel(100);
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -1237,7 +1234,7 @@ mod test {
         Core,
         CoreSignalsReceivers,
         broadcast::Receiver<VerifiedBlock>,
-        UnboundedReceiver<CommittedSubDag>,
+        mpsc::Receiver<CommittedSubDag>,
         Arc<impl Store>,
     )> {
         let mut cores = Vec::new();
@@ -1269,7 +1266,7 @@ mod test {
             // Need at least one subscriber to the block broadcast channel.
             let block_receiver = signal_receivers.block_broadcast_receiver();
 
-            let (commit_sender, commit_receiver) = unbounded_channel();
+            let (commit_sender, commit_receiver) = mpsc::channel(100);
             let commit_observer = CommitObserver::new(
                 context.clone(),
                 CommitConsumer::new(commit_sender.clone(), 0, 0),

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -176,7 +176,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 #[cfg(test)]
 mod test {
     use parking_lot::RwLock;
-    use tokio::sync::mpsc::unbounded_channel;
+    use tokio::sync::mpsc;
 
     use super::*;
     use crate::{
@@ -208,7 +208,7 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let _block_receiver = signal_receivers.block_broadcast_receiver();
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = mpsc::channel(100);
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -26,6 +26,7 @@ use sui_types::{
     sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
     transaction::{SenderSignedData, VerifiedTransaction},
 };
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, instrument, trace_span};
 
 use crate::{
@@ -517,7 +518,7 @@ pub struct MysticetiConsensusHandler {
 impl MysticetiConsensusHandler {
     pub fn new(
         mut consensus_handler: ConsensusHandler<CheckpointService>,
-        mut receiver: tokio::sync::mpsc::UnboundedReceiver<consensus_core::CommittedSubDag>,
+        mut receiver: mpsc::Receiver<consensus_core::CommittedSubDag>,
     ) -> Self {
         let handle = spawn_monitored_task!(async move {
             while let Some(committed_subdag) = receiver.recv().await {


### PR DESCRIPTION
## Description 

During commit sync, commit output rate significantly outpaces what consensus handler can process. This leads to significant memory usage growth. Using a large enough buffer for the channel into consensus handler, the memory usage should be limited while not blocking normal Core operations.

## Test plan 

TODO

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
