### PR TITLE
[cli] Switch to testnet as a default network environment 

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -587,12 +587,12 @@ async fn prompt_if_no_config(
                         String::new()
                     } else {
                         print!(
-                            "Sui Full node server URL (Defaults to Sui Devnet if not specified) : "
+                            "Sui Full node server URL (Defaults to Sui Tevnet if not specified) : "
                         );
                         read_line()?
                     };
                     Some(if url.trim().is_empty() {
-                        SuiEnv::devnet()
+                        SuiEnv::testnet()
                     } else {
                         print!("Environment alias for [{url}] : ");
                         let alias = read_line()?;


### PR DESCRIPTION
## Description 

If the CLI is ran for the first time and there is no client configuration (e.g., client.yaml file), the user will be prompted a menu to either enter a network or accept the defaults. This PR changes the default network from devnet to testnet.

## Test plan 

No tests needed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: The CLI will now create the testnet network instead of devnet when default configuration is accepted during initial configuration.
- [ ] Rust SDK: 
