### PR TITLE
[Consensus] check timestamp invariant when accepting blocks

### DIFF
--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -15,7 +15,8 @@ use tracing::{debug, error};
 
 use crate::{
     block::{
-        genesis_blocks, BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock, GENESIS_ROUND,
+        genesis_blocks, timestamp_utc_ms, BlockAPI, BlockDigest, BlockRef, Round, Slot,
+        VerifiedBlock, GENESIS_ROUND,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitVote, TrustedCommit},
     context::Context,
@@ -140,6 +141,14 @@ impl DagState {
         let block_ref = block.reference();
         if self.contains_block(&block_ref) {
             return;
+        }
+
+        let now = timestamp_utc_ms();
+        if block.timestamp_ms() > now {
+            panic!(
+                "Block {:?} cannot be accepted! Block timestamp {} is greater than local timestamp {}.",
+                block, block.timestamp_ms(), now,
+            );
         }
 
         // TODO: Move this check to core


### PR DESCRIPTION
## Description 

There are multiple sources of blocks when accepting them into Core & DagState, so adding another invariant check inside DagState.

## Test plan 

CI
Simulation

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
