### PR TITLE
[crypto] Remove verify_user_input from message envelope trait

### DIFF
--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -50,7 +50,7 @@ use crate::retry_with_max_elapsed_time;
 use crate::sui_transaction_builder::get_bridge_package_id;
 use crate::types::BridgeActionStatus;
 use crate::types::BridgeInnerDynamicField;
-use crate::types::BridgeRecordDyanmicField;
+use crate::types::BridgeRecordDynamicField;
 use crate::types::MoveTypeBridgeMessageKey;
 use crate::types::MoveTypeBridgeRecord;
 use crate::types::{
@@ -350,12 +350,12 @@ impl SuiClientInner for SuiSdkClient {
             }
         };
 
-        // get_dynamic_field_object does not return bcs, so we have to issue anothe query
+        // get_dynamic_field_object does not return bcs, so we have to issue another query
         let bcs_bytes = self
             .read_api()
             .get_move_object_bcs(status_object_id)
             .await?;
-        let status_object: BridgeRecordDyanmicField = bcs::from_bytes(&bcs_bytes)?;
+        let status_object: BridgeRecordDynamicField = bcs::from_bytes(&bcs_bytes)?;
 
         if status_object.value.value.claimed {
             return Ok(BridgeActionStatus::Claimed);

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -34,7 +34,7 @@ pub const BRIDGE_AUTHORITY_TOTAL_VOTING_POWER: u64 = 10000;
 pub const USD_MULTIPLIER: u64 = 10000; // decimal places = 4
 
 pub type BridgeInnerDynamicField = Field<u64, MoveTypeBridgeInner>;
-pub type BridgeRecordDyanmicField = Field<
+pub type BridgeRecordDynamicField = Field<
     MoveTypeBridgeMessageKey,
     LinkedTableNode<MoveTypeBridgeMessageKey, MoveTypeBridgeRecord>,
 >;
@@ -334,7 +334,7 @@ impl BlocklistCommitteeAction {
         bytes.push(u8::try_from(self.blocklisted_members.len()).unwrap());
 
         // Add list of updated members
-        // Members are represented as pubkey dervied evm addresses (20 bytes)
+        // Members are represented as pubkey derived evm addresses (20 bytes)
         let members_bytes = self
             .blocklisted_members
             .iter()
@@ -619,10 +619,6 @@ impl Message for BridgeAction {
         unreachable!("BridgeEventDigest is not used today")
     }
 
-    fn verify_user_input(&self) -> SuiResult {
-        Ok(())
-    }
-
     fn verify_epoch(&self, _epoch: EpochId) -> SuiResult {
         Ok(())
     }
@@ -880,7 +876,7 @@ mod tests {
                 .unwrap(),
         )
         .unwrap();
-        // its evem address: 0xacaef39832cb995c4e049437a3e2ec6a7bad1ab5
+        // its evm address: 0xacaef39832cb995c4e049437a3e2ec6a7bad1ab5
         let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
             nonce: 68,
             chain_id: BridgeChainId::SuiDevnet,
@@ -1281,7 +1277,7 @@ mod tests {
 
     #[test]
     fn test_bridge_committee_filter_blocklisted_authorities() -> anyhow::Result<()> {
-        // Note: today BridgeCommitte does not shuffle authorities
+        // Note: today BridgeCommittee does not shuffle authorities
         let (authority1, _, _) = get_test_authority_and_key(5000, 9999);
         let (mut authority2, _, _) = get_test_authority_and_key(3000, 9999);
         authority2.is_blocklisted = true;

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -97,10 +97,6 @@ impl Message for TransactionEffects {
         TransactionEffectsDigest::new(default_hash(self))
     }
 
-    fn verify_user_input(&self) -> SuiResult {
-        Ok(())
-    }
-
     fn verify_epoch(&self, _: EpochId) -> SuiResult {
         // Authorities are allowed to re-sign effects from prior epochs, so we do not verify the
         // epoch here.

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -101,9 +101,6 @@ pub trait Message {
 
     fn digest(&self) -> Self::DigestType;
 
-    /// Perform cheap validity checks before any expensive crypto verification.
-    fn verify_user_input(&self) -> SuiResult;
-
     /// Verify that the message is from the correct epoch (e.g. for CertifiedCheckpointSummary
     /// we verify that the checkpoint is from the same epoch as the committee signatures).
     fn verify_epoch(&self, epoch: EpochId) -> SuiResult;

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -198,10 +198,6 @@ impl Message for CheckpointSummary {
         CheckpointDigest::new(default_hash(self))
     }
 
-    fn verify_user_input(&self) -> SuiResult {
-        Ok(())
-    }
-
     fn verify_epoch(&self, epoch: EpochId) -> SuiResult {
         fp_ensure!(
             self.epoch == epoch,


### PR DESCRIPTION
## Description 

`verify_user_input` is only applicable to SenderSignedData. There is no need to make it a trait function of Message.
It also contains a bunch of checks that are already done in either validity_check, or verify_message_signature. Remove those redundant checks.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
