### PR TITLE
[docs] add more sdks to reference page

### DIFF
--- a/docs/content/references/rust-sdk.mdx
+++ b/docs/content/references/rust-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sui Rust SDK
+title: Rust SDK
 description: The Sui Rust SDK provides Rust wrappers around the Sui API. Using the SDK, you can interact with Sui networks using the Rust programming language.
 ---
 

--- a/docs/content/references/sui-sdks.mdx
+++ b/docs/content/references/sui-sdks.mdx
@@ -4,23 +4,35 @@ title: Sui SDKs
 
 Sui provides developer kits that act as wrappers for the Sui API.
 
-## Sui dApp Kit
+## dApp Kit
 
 [Sui dApp Kit](https://sdk.mystenlabs.com/dapp-kit) is a web frontend SDK that interacts with the Sui API. It is available as an NPM package.
 
-## Sui Go SDK
+## Dart SDK
+
+[Sui Dark SDK](https://github.com/mofalabs/sui) is a cross-platform Sui SDK for Mobile, Web, and Desktop.
+
+## Go SDK
 
 For those that like gophers, see [Go SDK](https://github.com/block-vision/sui-go-sdk).
 
-## Sui Python SDK
+## Kotlin SDK
+
+[Ksui](https://github.com/mcxross/ksui) is a collection of Kotlin Multiplatform JSON-RPC wrapper and crypto utilities for interacting with a Sui Full node.
+
+## Python SDK
 
 For snake lovers, see [Python SDK](https://github.com/FrankC01/pysui).
 
-## Sui Rust SDK
+## Rust SDK
 
 See [Rust SDK](./rust-sdk.mdx) for SDK configuration and examples of using the Sui API with Rust.
 
-## Sui TypeScript SDK
+## Swift SDK
+
+[SuiKit](https://github.com/opendive/suikit) is a Swift SDK natively designed to make developing for the Sui Blockchain easy.
+
+## TypeScript SDK
 
 The Sui TypeScript SDK documentation is available in its own microsite: [Sui Typescript SDK](https://sdk.mystenlabs.com/typescript).
 

--- a/docs/content/sidebars/references.js
+++ b/docs/content/sidebars/references.js
@@ -71,18 +71,33 @@ const references = [
 			},
 			{
 				type: 'link',
-				label: 'Sui Go SDK',
+				label: 'Dart SDK',
+				href: 'https://github.com/mofalabs/sui',
+			},
+			{
+				type: 'link',
+				label: 'Go SDK',
 				href: 'https://github.com/block-vision/sui-go-sdk',
 			},
 			{
 				type: 'link',
-				label: 'Sui Python SDK',
+				label: 'Kotlin SDK',
+				href: 'https://github.com/mcxross/ksui',
+			},
+			{
+				type: 'link',
+				label: 'Python SDK',
 				href: 'https://github.com/FrankC01/pysui',
 			},
 			'references/rust-sdk',
 			{
 				type: 'link',
-				label: 'Sui TypeScript SDK',
+				label: 'Swift SDK',
+				href: 'https://github.com/opendive/suikit',
+			},
+			{
+				type: 'link',
+				label: 'TypeScript SDK',
 				href: 'https://sdk.mystenlabs.com/typescript',
 			},
 		],


### PR DESCRIPTION
## Description 

Adding more community SDKs to the SDK reference page

## Test plan 

Visual inspection

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
