### PR TITLE
validator-api: support validators returning input/output objects when executing a certificate

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3473,6 +3473,62 @@ impl AuthorityState {
             .ok_or(SuiError::TransactionEventsNotFound { digest: *digest })
     }
 
+    pub fn get_transaction_input_objects(
+        &self,
+        effects: &TransactionEffects,
+    ) -> anyhow::Result<Vec<Object>> {
+        let input_object_keys = effects
+            .modified_at_versions()
+            .into_iter()
+            .map(|(object_id, version)| ObjectKey(object_id, version))
+            .collect::<Vec<_>>();
+
+        let input_objects = self
+            .get_object_store()
+            .multi_get_objects_by_key(&input_object_keys)?
+            .into_iter()
+            .enumerate()
+            .map(|(idx, maybe_object)| {
+                maybe_object.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "missing input object key {:?} from tx {}",
+                        input_object_keys[idx],
+                        effects.transaction_digest()
+                    )
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(input_objects)
+    }
+
+    pub fn get_transaction_output_objects(
+        &self,
+        effects: &TransactionEffects,
+    ) -> anyhow::Result<Vec<Object>> {
+        let output_object_keys = effects
+            .all_changed_objects()
+            .into_iter()
+            .map(|(object_ref, _owner, _kind)| ObjectKey::from(object_ref))
+            .collect::<Vec<_>>();
+
+        let output_objects = self
+            .get_object_store()
+            .multi_get_objects_by_key(&output_object_keys)?
+            .into_iter()
+            .enumerate()
+            .map(|(idx, maybe_object)| {
+                maybe_object.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "missing output object key {:?} from tx {}",
+                        output_object_keys[idx],
+                        effects.transaction_digest()
+                    )
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(output_objects)
+    }
+
     fn get_indexes(&self) -> SuiResult<Arc<IndexStore>> {
         match &self.indexes {
             Some(i) => Ok(i.clone()),

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -42,7 +42,7 @@ use prometheus::{
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, IntCounter, IntCounterVec, IntGauge, Registry,
 };
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::string::ToString;
 use std::sync::Arc;
 use std::time::Duration;
@@ -407,6 +407,14 @@ struct ProcessCertificateState {
     // 1) >= 2f+1 signatures
     // 2) >= f+1 non-retryable errors
     retryable: bool,
+
+    // collection of extended data returned from the validators.
+    // Not all validators will be asked to return this data so we need to hold onto it when one
+    // validator has provided it
+    events: Option<TransactionEvents>,
+    input_objects: Option<Vec<Object>>,
+    output_objects: Option<Vec<Object>>,
+    auxiliary_data: Option<Vec<u8>>,
 }
 
 #[derive(Debug)]
@@ -1485,7 +1493,25 @@ where
             non_retryable_errors: vec![],
             retryable_errors: vec![],
             retryable: true,
+            events: None,
+            input_objects: None,
+            output_objects: None,
+            auxiliary_data: None,
         };
+
+        // create a set of validators that we should sample to request input/output objects from
+        let validators_to_sample =
+            if request.include_input_objects || request.include_output_objects {
+                // Always at least ask 1 validator
+                let number_to_sample = std::cmp::max(1, self.committee.num_members() / 2);
+
+                self.committee
+                    .choose_multiple_weighted_iter(number_to_sample)
+                    .cloned()
+                    .collect()
+            } else {
+                HashSet::new()
+            };
 
         let tx_digest = *request.certificate.digest();
         let timeout_after_quorum = self.timeouts.post_quorum_timeout;
@@ -1514,8 +1540,22 @@ where
                 Box::pin(async move {
                     let _guard = GaugeGuard::acquire(&metrics_clone.inflight_certificate_requests);
                     if request_ref.include_input_objects || request_ref.include_output_objects {
+
+                        // adjust the request to validators we aren't planning on sampling
+                        let req = if validators_to_sample.contains(&name) {
+                            request_ref
+                        } else {
+                            HandleCertificateRequestV3 {
+                                include_events: false,
+                                include_input_objects: false,
+                                include_output_objects: false,
+                                include_auxiliary_data: false,
+                                ..request_ref
+                            }
+                        };
+
                         client
-                            .handle_certificate_v3(request_ref, client_addr)
+                            .handle_certificate_v3(req, client_addr)
                             .instrument(
                                 tracing::trace_span!("handle_certificate", authority =? name.concise()),
                             )
@@ -1676,6 +1716,23 @@ where
                     name = ?name.concise(),
                     "Validator handled certificate successfully",
                 );
+
+                if events.is_some() && state.events.is_none() {
+                    state.events = events;
+                }
+
+                if input_objects.is_some() && state.input_objects.is_none() {
+                    state.input_objects = input_objects;
+                }
+
+                if output_objects.is_some() && state.output_objects.is_none() {
+                    state.output_objects = output_objects;
+                }
+
+                if auxiliary_data.is_some() && state.auxiliary_data.is_none() {
+                    state.auxiliary_data = auxiliary_data;
+                }
+
                 let effects_digest = *signed_effects.digest();
                 // Note: here we aggregate votes by the hash of the effects structure
                 match state.effects_map.insert(
@@ -1708,10 +1765,10 @@ where
                             debug!(?tx_digest, "Got quorum for validators handle_certificate.");
                             Some(QuorumDriverResponse {
                                 effects_cert: ct,
-                                events,
-                                input_objects,
-                                output_objects,
-                                auxiliary_data,
+                                events: state.events.take(),
+                                input_objects: state.input_objects.take(),
+                                output_objects: state.output_objects.take(),
+                                auxiliary_data: state.auxiliary_data.take(),
                             })
                         })
                     }

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -14,8 +14,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_types::base_types::{AuthorityName, ObjectRef, TransactionDigest};
 use sui_types::committee::{Committee, EpochId, StakeUnit};
+use sui_types::messages_grpc::HandleCertificateRequestV3;
 use sui_types::quorum_driver_types::{
-    QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
+    ExecuteTransactionRequestV3, QuorumDriverEffectsQueueResult, QuorumDriverError,
+    QuorumDriverResponse, QuorumDriverResult,
 };
 use tap::TapFallible;
 use tokio::sync::Semaphore;
@@ -51,7 +53,7 @@ const TX_MAX_RETRY_TIMES: u32 = 10;
 
 #[derive(Clone)]
 pub struct QuorumDriverTask {
-    pub transaction: Transaction,
+    pub request: ExecuteTransactionRequestV3,
     pub tx_cert: Option<CertifiedTransaction>,
     pub retry_times: u32,
     pub next_retry_after: Instant,
@@ -61,7 +63,7 @@ pub struct QuorumDriverTask {
 impl Debug for QuorumDriverTask {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
-        write!(writer, "tx_digest={:?} ", self.transaction.digest())?;
+        write!(writer, "tx_digest={:?} ", self.request.transaction.digest())?;
         write!(writer, "has_tx_cert={} ", self.tx_cert.is_some())?;
         write!(writer, "retry_times={} ", self.retry_times)?;
         write!(writer, "next_retry_after={:?} ", self.next_retry_after)?;
@@ -136,16 +138,16 @@ impl<A: Clone> QuorumDriver<A> {
     /// If it has, notify failure.
     async fn enqueue_again_maybe(
         &self,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
         tx_cert: Option<CertifiedTransaction>,
         old_retry_times: u32,
         client_addr: Option<SocketAddr>,
     ) -> SuiResult<()> {
         if old_retry_times >= self.max_retry_times {
             // max out the retry times, notify failure
-            info!(tx_digest=?transaction.digest(), "Failed to reach finality after attempting for {} times", old_retry_times+1);
+            info!(tx_digest=?request.transaction.digest(), "Failed to reach finality after attempting for {} times", old_retry_times+1);
             self.notify(
-                &transaction,
+                &request.transaction,
                 &Err(
                     QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts {
                         total_attempts: old_retry_times + 1,
@@ -155,14 +157,14 @@ impl<A: Clone> QuorumDriver<A> {
             );
             return Ok(());
         }
-        self.backoff_and_enqueue(transaction, tx_cert, old_retry_times, client_addr)
+        self.backoff_and_enqueue(request, tx_cert, old_retry_times, client_addr)
             .await
     }
 
     /// Performs exponential backoff and enqueue the `transaction` to the execution queue.
     async fn backoff_and_enqueue(
         &self,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
         tx_cert: Option<CertifiedTransaction>,
         old_retry_times: u32,
         client_addr: Option<SocketAddr>,
@@ -180,7 +182,7 @@ impl<A: Clone> QuorumDriver<A> {
         };
 
         self.enqueue_task(QuorumDriverTask {
-            transaction,
+            request,
             tx_cert,
             retry_times: old_retry_times + 1,
             next_retry_after,
@@ -231,15 +233,15 @@ where
 {
     pub async fn submit_transaction(
         &self,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
     ) -> SuiResult<Registration<TransactionDigest, QuorumDriverResult>> {
-        let tx_digest = transaction.digest();
+        let tx_digest = request.transaction.digest();
         debug!(?tx_digest, "Received transaction execution request.");
         self.metrics.total_requests.inc();
 
         let ticket = self.notifier.register_one(tx_digest);
         self.enqueue_task(QuorumDriverTask {
-            transaction,
+            request,
             tx_cert: None,
             retry_times: 0,
             next_retry_after: Instant::now(),
@@ -253,10 +255,10 @@ where
     // already obtained prior to calling this function, for instance, TransactionOrchestrator
     pub async fn submit_transaction_no_ticket(
         &self,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
         client_addr: Option<SocketAddr>,
     ) -> SuiResult<()> {
-        let tx_digest = transaction.digest();
+        let tx_digest = request.transaction.digest();
         debug!(
             ?tx_digest,
             "Received transaction execution request, no ticket."
@@ -264,7 +266,7 @@ where
         self.metrics.total_requests.inc();
 
         self.enqueue_task(QuorumDriverTask {
-            transaction,
+            request,
             tx_cert: None,
             retry_times: 0,
             next_retry_after: Instant::now(),
@@ -460,14 +462,14 @@ where
 
     pub(crate) async fn process_certificate(
         &self,
-        certificate: CertifiedTransaction,
+        request: HandleCertificateRequestV3,
         client_addr: Option<SocketAddr>,
     ) -> Result<QuorumDriverResponse, Option<QuorumDriverError>> {
         let auth_agg = self.validators.load();
         let _cert_guard = GaugeGuard::acquire(&auth_agg.metrics.inflight_certificates);
-        let tx_digest = *certificate.digest();
-        let (effects, events) = auth_agg
-            .process_certificate(certificate.clone(), client_addr)
+        let tx_digest = *request.certificate.digest();
+        let response = auth_agg
+            .process_certificate(request.clone(), client_addr)
             .instrument(tracing::debug_span!("aggregator_process_cert", ?tx_digest))
             .await
             .map_err(|agg_err| match agg_err {
@@ -491,10 +493,6 @@ where
                     None
                 }
             })?;
-        let response = QuorumDriverResponse {
-            effects_cert: effects,
-            events,
-        };
 
         Ok(response)
     }
@@ -538,7 +536,16 @@ where
                 let result = self
                     .validators
                     .load()
-                    .process_certificate(cert, client_addr)
+                    .process_certificate(
+                        HandleCertificateRequestV3 {
+                            certificate: cert,
+                            include_events: true,
+                            include_input_objects: false,
+                            include_output_objects: false,
+                            include_auxiliary_data: false,
+                        },
+                        client_addr,
+                    )
                     .await
                     .tap_ok(|_resp| {
                         debug!(
@@ -652,19 +659,19 @@ where
     // already obtained prior to calling this function, for instance, TransactionOrchestrator
     pub async fn submit_transaction_no_ticket(
         &self,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
         client_addr: Option<SocketAddr>,
     ) -> SuiResult<()> {
         self.quorum_driver
-            .submit_transaction_no_ticket(transaction, client_addr)
+            .submit_transaction_no_ticket(request, client_addr)
             .await
     }
 
     pub async fn submit_transaction(
         &self,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
     ) -> SuiResult<Registration<TransactionDigest, QuorumDriverResult>> {
-        self.quorum_driver.submit_transaction(transaction).await
+        self.quorum_driver.submit_transaction(request).await
     }
 
     /// Create a new `QuorumDriverHandler` based on the same AuthorityAggregator.
@@ -737,12 +744,13 @@ where
     async fn process_task(quorum_driver: Arc<QuorumDriver<A>>, task: QuorumDriverTask) {
         debug!(?task, "Quorum Driver processing task");
         let QuorumDriverTask {
-            transaction,
+            request,
             tx_cert,
             retry_times: old_retry_times,
             client_addr,
             ..
         } = task;
+        let transaction = &request.transaction;
         let tx_digest = *transaction.digest();
         let is_single_writer_tx = !transaction.contains_shared_object();
 
@@ -766,15 +774,18 @@ where
                     );
                     let response = QuorumDriverResponse {
                         effects_cert,
-                        events,
+                        events: Some(events),
+                        input_objects: None,
+                        output_objects: None,
+                        auxiliary_data: None,
                     };
-                    quorum_driver.notify(&transaction, &Ok(response), old_retry_times + 1);
+                    quorum_driver.notify(transaction, &Ok(response), old_retry_times + 1);
                     return;
                 }
                 Err(err) => {
                     Self::handle_error(
                         quorum_driver,
-                        transaction,
+                        request,
                         err,
                         None,
                         old_retry_times,
@@ -788,7 +799,16 @@ where
         };
 
         let response = match quorum_driver
-            .process_certificate(tx_cert.clone(), client_addr)
+            .process_certificate(
+                HandleCertificateRequestV3 {
+                    certificate: tx_cert.clone(),
+                    include_events: request.include_events,
+                    include_input_objects: request.include_input_objects,
+                    include_output_objects: request.include_output_objects,
+                    include_auxiliary_data: request.include_auxiliary_data,
+                },
+                client_addr,
+            )
             .await
         {
             Ok(response) => {
@@ -800,7 +820,7 @@ where
             Err(err) => {
                 Self::handle_error(
                     quorum_driver,
-                    transaction,
+                    request,
                     err,
                     Some(tx_cert),
                     old_retry_times,
@@ -832,24 +852,24 @@ where
             );
         }
 
-        quorum_driver.notify(&transaction, &Ok(response), old_retry_times + 1);
+        quorum_driver.notify(transaction, &Ok(response), old_retry_times + 1);
     }
 
     fn handle_error(
         quorum_driver: Arc<QuorumDriver<A>>,
-        transaction: Transaction,
+        request: ExecuteTransactionRequestV3,
         err: Option<QuorumDriverError>,
         tx_cert: Option<CertifiedTransaction>,
         old_retry_times: u32,
         action: &'static str,
         client_addr: Option<SocketAddr>,
     ) {
-        let tx_digest = *transaction.digest();
+        let tx_digest = *request.transaction.digest();
         match err {
             None => {
                 debug!(?tx_digest, "Failed to {action} - Retrying");
                 spawn_monitored_task!(quorum_driver.enqueue_again_maybe(
-                    transaction.clone(),
+                    request.clone(),
                     tx_cert,
                     old_retry_times,
                     client_addr,
@@ -863,7 +883,7 @@ where
                 // reject any new transaction requests.
                 debug!(?tx_digest, "Failed to {action} - Retrying");
                 spawn_monitored_task!(quorum_driver.backoff_and_enqueue(
-                    transaction.clone(),
+                    request.clone(),
                     tx_cert,
                     old_retry_times,
                     client_addr,
@@ -872,7 +892,7 @@ where
             Some(qd_error) => {
                 debug!(?tx_digest, "Failed to {action}: {}", qd_error);
                 // non-retryable failure, this task reaches terminal state for now, notify waiter.
-                quorum_driver.notify(&transaction, &Err(qd_error), old_retry_times + 1);
+                quorum_driver.notify(&request.transaction, &Err(qd_error), old_retry_times + 1);
             }
         }
     }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -25,7 +25,7 @@ use sui_types::{
     transaction::{CertifiedTransaction, Transaction, VerifiedTransaction},
 };
 use sui_types::{
-    effects::{TransactionEffectsAPI},
+    effects::TransactionEffectsAPI,
     messages_checkpoint::{CheckpointRequestV2, CheckpointResponseV2},
 };
 use sui_types::{

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -13,7 +13,6 @@ use crate::{authority::AuthorityState, authority_client::AuthorityAPI};
 use async_trait::async_trait;
 use mysten_metrics::spawn_monitored_task;
 use sui_config::genesis::Genesis;
-use sui_types::error::SuiResult;
 use sui_types::messages_grpc::{
     HandleCertificateResponseV2, HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
     SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
@@ -26,8 +25,12 @@ use sui_types::{
     transaction::{CertifiedTransaction, Transaction, VerifiedTransaction},
 };
 use sui_types::{
-    effects::{TransactionEffectsAPI, TransactionEvents},
+    effects::{TransactionEffectsAPI},
     messages_checkpoint::{CheckpointRequestV2, CheckpointResponseV2},
+};
+use sui_types::{
+    error::SuiResult,
+    messages_grpc::{HandleCertificateRequestV3, HandleCertificateResponseV3},
 };
 
 #[derive(Clone, Copy, Default)]
@@ -88,7 +91,31 @@ impl AuthorityAPI for LocalAuthorityClient {
     ) -> Result<HandleCertificateResponseV2, SuiError> {
         let state = self.state.clone();
         let fault_config = self.fault_config;
-        spawn_monitored_task!(Self::handle_certificate(state, certificate, fault_config))
+        let request = HandleCertificateRequestV3 {
+            certificate,
+            include_events: true,
+            include_input_objects: false,
+            include_output_objects: false,
+            include_auxiliary_data: false,
+        };
+        spawn_monitored_task!(Self::handle_certificate(state, request, fault_config))
+            .await
+            .unwrap()
+            .map(|resp| HandleCertificateResponseV2 {
+                signed_effects: resp.effects,
+                events: resp.events.unwrap_or_default(),
+                fastpath_input_objects: vec![],
+            })
+    }
+
+    async fn handle_certificate_v3(
+        &self,
+        request: HandleCertificateRequestV3,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<HandleCertificateResponseV3, SuiError> {
+        let state = self.state.clone();
+        let fault_config = self.fault_config;
+        spawn_monitored_task!(Self::handle_certificate(state, request, fault_config))
             .await
             .unwrap()
     }
@@ -160,9 +187,9 @@ impl LocalAuthorityClient {
     // object transactions as well as owned object transactions.
     async fn handle_certificate(
         state: Arc<AuthorityState>,
-        certificate: CertifiedTransaction,
+        request: HandleCertificateRequestV3,
         fault_config: LocalAuthorityClientFaultConfig,
-    ) -> Result<HandleCertificateResponseV2, SuiError> {
+    ) -> Result<HandleCertificateResponseV3, SuiError> {
         if fault_config.fail_before_handle_confirmation {
             return Err(SuiError::GenericAuthorityError {
                 error: "Mock error before handle_confirmation_transaction".to_owned(),
@@ -170,7 +197,7 @@ impl LocalAuthorityClient {
         }
         // Check existing effects before verifying the cert to allow querying certs finalized
         // from previous epochs.
-        let tx_digest = *certificate.digest();
+        let tx_digest = *request.certificate.digest();
         let epoch_store = state.epoch_store_for_testing();
         let signed_effects = match state
             .get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store)
@@ -179,7 +206,7 @@ impl LocalAuthorityClient {
             _ => {
                 let certificate = epoch_store
                     .signature_verifier
-                    .verify_cert(certificate)
+                    .verify_cert(request.certificate)
                     .await?;
                 //let certificate = certificate.verify(epoch_store.committee())?;
                 state.enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store);
@@ -189,10 +216,14 @@ impl LocalAuthorityClient {
         }
         .into_inner();
 
-        let events = if let Some(digest) = signed_effects.events_digest() {
-            state.get_transaction_events(digest)?
+        let events = if request.include_events {
+            if let Some(digest) = signed_effects.events_digest() {
+                Some(state.get_transaction_events(digest)?)
+            } else {
+                None
+            }
         } else {
-            TransactionEvents::default()
+            None
         };
 
         if fault_config.fail_after_handle_confirmation {
@@ -201,10 +232,22 @@ impl LocalAuthorityClient {
             });
         }
 
-        Ok(HandleCertificateResponseV2 {
-            signed_effects,
+        let input_objects = request
+            .include_input_objects
+            .then(|| state.get_transaction_input_objects(&signed_effects))
+            .and_then(Result::ok);
+
+        let output_objects = request
+            .include_output_objects
+            .then(|| state.get_transaction_output_objects(&signed_effects))
+            .and_then(Result::ok);
+
+        Ok(HandleCertificateResponseV3 {
+            effects: signed_effects,
             events,
-            fastpath_input_objects: vec![], // unused field
+            input_objects,
+            output_objects,
+            auxiliary_data: None, // We don't have any aux data generated presently
         })
     }
 }
@@ -247,6 +290,14 @@ impl AuthorityAPI for MockAuthorityApi {
         _certificate: CertifiedTransaction,
         _client_addr: Option<SocketAddr>,
     ) -> Result<HandleCertificateResponseV2, SuiError> {
+        unimplemented!()
+    }
+
+    async fn handle_certificate_v3(
+        &self,
+        _request: HandleCertificateRequestV3,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<HandleCertificateResponseV3, SuiError> {
         unimplemented!()
     }
 
@@ -332,6 +383,14 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
             tokio::time::sleep(duration).await;
         }
         self.cert_resp_to_return.clone()
+    }
+
+    async fn handle_certificate_v3(
+        &self,
+        _request: HandleCertificateRequestV3,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<HandleCertificateResponseV3, SuiError> {
+        unimplemented!()
     }
 
     async fn handle_object_info_request(

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -34,9 +34,9 @@ use sui_types::effects::{TransactionEffectsAPI, VerifiedCertifiedTransactionEffe
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::quorum_driver_types::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    FinalizedEffects, QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResponse,
-    QuorumDriverResult,
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionRequestV3,
+    ExecuteTransactionResponse, ExecuteTransactionResponseV3, FinalizedEffects,
+    QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
 };
 use sui_types::sui_system_state::SuiSystemState;
 use tokio::sync::broadcast::error::RecvError;
@@ -195,7 +195,11 @@ where
         });
 
         let ticket = self
-            .submit(transaction.clone(), client_addr)
+            .submit(
+                transaction.clone(),
+                ExecuteTransactionRequestV3::new_v2(transaction.clone()),
+                client_addr,
+            )
             .await
             .map_err(|e| {
                 warn!(?tx_digest, "QuorumDriverInternalError: {e:?}");
@@ -229,7 +233,7 @@ where
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
-                        response.events,
+                        response.events.unwrap_or_default(),
                         false,
                     ))));
                 }
@@ -250,15 +254,100 @@ where
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
-                        response.events,
+                        response.events.unwrap_or_default(),
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
-                        response.events,
+                        response.events.unwrap_or_default(),
                         false,
                     )))),
                 }
+            }
+        }
+    }
+
+    // Utilize the handle_certificate_v3 validator api to request input/output objects
+    pub async fn execute_transaction_v3(
+        &self,
+        request: ExecuteTransactionRequestV3,
+        client_addr: Option<SocketAddr>,
+    ) -> Result<ExecuteTransactionResponseV3, QuorumDriverError> {
+        // TODO check if tx is already executed on this node.
+        // Note: since EffectsCert is not stored today, we need to gather that from validators
+        // (and maybe store it for caching purposes)
+        let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
+
+        let transaction = epoch_store
+            .verify_transaction(request.transaction.clone())
+            .map_err(QuorumDriverError::InvalidUserSignature)?;
+        let (_in_flight_metrics_guards, good_response_metrics) = self.update_metrics(&transaction);
+        let tx_digest = *transaction.digest();
+        debug!(?tx_digest, "TO Received transaction execution request.");
+
+        let (_e2e_latency_timer, _txn_finality_timer) = if transaction.contains_shared_object() {
+            (
+                self.metrics.request_latency_shared_obj.start_timer(),
+                self.metrics
+                    .wait_for_finality_latency_shared_obj
+                    .start_timer(),
+            )
+        } else {
+            (
+                self.metrics.request_latency_single_writer.start_timer(),
+                self.metrics
+                    .wait_for_finality_latency_single_writer
+                    .start_timer(),
+            )
+        };
+
+        // TODO: refactor all the gauge and timer metrics with `monitored_scope`
+        let wait_for_finality_gauge = self.metrics.wait_for_finality_in_flight.clone();
+        wait_for_finality_gauge.inc();
+        let _wait_for_finality_gauge = scopeguard::guard(wait_for_finality_gauge, |in_flight| {
+            in_flight.dec();
+        });
+
+        let ticket = self
+            .submit(transaction, request, client_addr)
+            .await
+            .map_err(|e| {
+                warn!(?tx_digest, "QuorumDriverInternalError: {e:?}");
+                QuorumDriverError::QuorumDriverInternalError(e)
+            })?;
+
+        let Ok(result) = timeout(WAIT_FOR_FINALITY_TIMEOUT, ticket).await else {
+            debug!(?tx_digest, "Timeout waiting for transaction finality.");
+            self.metrics.wait_for_finality_timeout.inc();
+            return Err(QuorumDriverError::TimeoutBeforeFinality);
+        };
+
+        drop(_txn_finality_timer);
+        drop(_wait_for_finality_gauge);
+        self.metrics.wait_for_finality_finished.inc();
+
+        match result {
+            Err(err) => {
+                warn!(?tx_digest, "QuorumDriverInternalError: {err:?}");
+                Err(QuorumDriverError::QuorumDriverInternalError(err))
+            }
+            Ok(Err(err)) => Err(err),
+            Ok(Ok(response)) => {
+                good_response_metrics.inc();
+                let QuorumDriverResponse {
+                    effects_cert,
+                    events,
+                    input_objects,
+                    output_objects,
+                    auxiliary_data,
+                } = response;
+                Ok(ExecuteTransactionResponseV3 {
+                    effects: FinalizedEffects::new_from_effects_cert(effects_cert.into()),
+                    events,
+                    input_objects,
+                    output_objects,
+                    auxiliary_data,
+                })
             }
         }
     }
@@ -268,6 +357,7 @@ where
     async fn submit(
         &self,
         transaction: VerifiedTransaction,
+        request: ExecuteTransactionRequestV3,
         client_addr: Option<SocketAddr>,
     ) -> SuiResult<impl Future<Output = SuiResult<QuorumDriverResult>> + '_> {
         let tx_digest = *transaction.digest();
@@ -281,7 +371,7 @@ where
         {
             debug!(?tx_digest, "no pending request in flight, submitting.");
             self.quorum_driver()
-                .submit_transaction_no_ticket(transaction.clone().into(), client_addr)
+                .submit_transaction_no_ticket(request.clone(), client_addr)
                 .await?;
         }
         // It's possible that the transaction effects is already stored in DB at this point.
@@ -302,7 +392,7 @@ where
                         ?tx_digest,
                         "Effects are available in DB, use quorum driver to get a certificate"
                     );
-                    qd.submit_transaction_no_ticket(transaction.into(), client_addr)
+                    qd.submit_transaction_no_ticket(request, client_addr)
                         .await?;
                     Ok(unfinished_quorum_driver_task.await)
                 }
@@ -519,7 +609,19 @@ where
                 let tx_digest = *tx.digest();
                 // It's not impossible we fail to enqueue a task but that's not the end of world.
                 // TODO(william) correctly extract client_addr from logs
-                if let Err(err) = quorum_driver.submit_transaction_no_ticket(tx, None).await {
+                if let Err(err) = quorum_driver
+                    .submit_transaction_no_ticket(
+                        ExecuteTransactionRequestV3 {
+                            transaction: tx,
+                            include_events: true,
+                            include_input_objects: false,
+                            include_output_objects: false,
+                            include_auxiliary_data: false,
+                        },
+                        None,
+                    )
+                    .await
+                {
                     warn!(
                         ?tx_digest,
                         "Failed to enqueue transaction from pending_tx_log, err: {err:?}"

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -305,8 +305,15 @@ async fn execute_transaction_with_fault_configs(
         set_local_client_config(&mut authorities, *index, *config);
     }
 
+    let request = HandleCertificateRequestV3 {
+        certificate: cert.into_cert_for_testing(),
+        include_events: true,
+        include_input_objects: false,
+        include_output_objects: false,
+        include_auxiliary_data: false,
+    };
     authorities
-        .process_certificate(cert.into_cert_for_testing(), Some(client_ip))
+        .process_certificate(request, Some(client_ip))
         .await
         .is_ok()
 }
@@ -371,8 +378,15 @@ async fn test_quorum_map_and_reduce_timeout() {
     // Send request with a very small timeout to trigger timeout error
     authorities.timeouts.pre_quorum_timeout = Duration::from_nanos(0);
     authorities.timeouts.post_quorum_timeout = Duration::from_nanos(0);
+    let request = HandleCertificateRequestV3 {
+        certificate: certificate.clone(),
+        include_events: true,
+        include_input_objects: false,
+        include_output_objects: false,
+        include_auxiliary_data: false,
+    };
     let certified_effects = authorities
-        .process_certificate(certificate.clone(), Some(client_ip))
+        .process_certificate(request, Some(client_ip))
         .await;
     // Ensure it is an error
     assert!(certified_effects.is_err());
@@ -839,8 +853,15 @@ async fn test_handle_certificate_response() {
         .unwrap();
     agg.committee = Arc::new(committee_1);
 
+    let request = HandleCertificateRequestV3 {
+        certificate: cert_epoch_0.clone(),
+        include_events: true,
+        include_input_objects: false,
+        include_output_objects: false,
+        include_auxiliary_data: false,
+    };
     let err = agg
-        .process_certificate(cert_epoch_0.clone(), Some(client_ip))
+        .process_certificate(request, Some(client_ip))
         .await
         .unwrap_err();
     assert_matches!(
@@ -2446,7 +2467,7 @@ fn set_cert_response_with_certified_tx(
 ) {
     let effects = effects_with_tx(*cert.digest());
     for (name, secret) in authority_keys {
-        let resp = HandleCertificateResponseV2 {
+        let resp = sui_types::messages_grpc::HandleCertificateResponseV2 {
             signed_effects: sign_tx_effects(effects.clone(), epoch, *name, secret),
             events: TransactionEvents::default(),
             fastpath_input_objects: vec![],

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -873,13 +873,14 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         QuorumDriverResponse {
             effects_cert: certified_txn_effects,
             events: txn_events,
+            ..
         },
     ) = rx.recv().await.unwrap().unwrap();
     let (cte, events, is_executed_locally) = *res;
     assert_eq!(*tx.digest(), digest);
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
     assert!(is_executed_locally);
-    assert_eq!(events.digest(), txn_events.digest());
+    assert_eq!(events.digest(), txn_events.unwrap_or_default().digest());
     // verify that the node has sequenced and executed the txn
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store.clone()).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForLocalExecution: {:?}", digest, e));
@@ -904,12 +905,13 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         QuorumDriverResponse {
             effects_cert: certified_txn_effects,
             events: txn_events,
+            ..
         },
     ) = rx.recv().await.unwrap().unwrap();
     let (cte, events, is_executed_locally) = *res;
     assert_eq!(*tx.digest(), digest);
     assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
-    assert_eq!(txn_events.digest(), events.digest());
+    assert_eq!(txn_events.unwrap_or_default().digest(), events.digest());
     assert!(!is_executed_locally);
     fullnode
         .state()
@@ -1307,6 +1309,7 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
         QuorumDriverResponse {
             effects_cert: _certified_txn_effects,
             events: _txn_events,
+            ..
         },
     ) = rx.recv().await.unwrap().unwrap();
     Ok(())

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -14,8 +14,8 @@ use sui_test_transaction_builder::{
     batch_make_transfer_transactions, make_transfer_sui_transaction,
 };
 use sui_types::quorum_driver_types::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    FinalizedEffects, QuorumDriverError,
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionRequestV3,
+    ExecuteTransactionResponse, FinalizedEffects, QuorumDriverError,
 };
 use sui_types::transaction::Transaction;
 use test_cluster::TestClusterBuilder;
@@ -59,7 +59,10 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let digest = *txn.digest();
     orchestrator
         .quorum_driver()
-        .submit_transaction_no_ticket(txn, Some(make_socket_addr()))
+        .submit_transaction_no_ticket(
+            ExecuteTransactionRequestV3::new_v2(txn),
+            Some(make_socket_addr()),
+        )
         .await?;
 
     // Wait for data sync to catch up

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -11,8 +11,9 @@ use sui_macros::sim_test;
 use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
 use sui_test_transaction_builder::{
-    batch_make_transfer_transactions, make_transfer_sui_transaction,
+    batch_make_transfer_transactions, make_staking_transaction, make_transfer_sui_transaction,
 };
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::quorum_driver_types::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionRequestV3,
     ExecuteTransactionResponse, FinalizedEffects, QuorumDriverError,
@@ -332,4 +333,147 @@ async fn execute_with_orchestrator(
             Some(make_socket_addr()),
         )
         .await
+}
+
+#[sim_test]
+async fn execute_transaction_v3() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.sui_node;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let registry = Registry::new();
+    // Start orchestrator inside container so that it will be properly shutdown.
+    let orchestrator = handle
+        .with(|node| {
+            TransactiondOrchestrator::new_with_network_clients(
+                node.state(),
+                node.subscribe_to_epoch_change(),
+                temp_dir.path(),
+                &registry,
+            )
+        })
+        .unwrap();
+
+    let txn_count = 1;
+    let mut txns = batch_make_transfer_transactions(context, txn_count).await;
+    assert!(
+        txns.len() >= txn_count,
+        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
+        txn_count,
+    );
+
+    // Quorum driver does not execute txn locally
+    let txn = txns.swap_remove(0);
+
+    let request = ExecuteTransactionRequestV3 {
+        transaction: txn,
+        include_events: true,
+        include_input_objects: true,
+        include_output_objects: true,
+        include_auxiliary_data: false,
+    };
+    let response = orchestrator.execute_transaction_v3(request, None).await?;
+    let fx = &response.effects.effects;
+
+    let mut expected_input_objects = fx.modified_at_versions();
+    expected_input_objects.sort_by_key(|&(id, _version)| id);
+    let mut expected_output_objects = fx
+        .all_changed_objects()
+        .into_iter()
+        .map(|(object_ref, _, _)| object_ref)
+        .collect::<Vec<_>>();
+    expected_output_objects.sort_by_key(|&(id, _version, _digest)| id);
+
+    let mut actual_input_objects_recieved = response
+        .input_objects
+        .unwrap()
+        .iter()
+        .map(|object| (object.id(), object.version()))
+        .collect::<Vec<_>>();
+    actual_input_objects_recieved.sort_by_key(|&(id, _version)| id);
+    assert_eq!(expected_input_objects, actual_input_objects_recieved);
+
+    let mut actual_output_objects_recieved = response
+        .output_objects
+        .unwrap()
+        .iter()
+        .map(|object| (object.id(), object.version(), object.digest()))
+        .collect::<Vec<_>>();
+    actual_output_objects_recieved.sort_by_key(|&(id, _version, _digest)| id);
+    assert_eq!(expected_output_objects, actual_output_objects_recieved);
+
+    Ok(())
+}
+
+#[sim_test]
+async fn execute_transaction_v3_staking_transaction() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.sui_node;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let registry = Registry::new();
+    // Start orchestrator inside container so that it will be properly shutdown.
+    let orchestrator = handle
+        .with(|node| {
+            TransactiondOrchestrator::new_with_network_clients(
+                node.state(),
+                node.subscribe_to_epoch_change(),
+                temp_dir.path(),
+                &registry,
+            )
+        })
+        .unwrap();
+
+    let validator_address = context
+        .get_client()
+        .await?
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await?
+        .active_validators
+        .first()
+        .unwrap()
+        .sui_address;
+    let transaction = make_staking_transaction(context, validator_address).await;
+
+    let request = ExecuteTransactionRequestV3 {
+        transaction,
+        include_events: true,
+        include_input_objects: true,
+        include_output_objects: true,
+        include_auxiliary_data: false,
+    };
+    let response = orchestrator.execute_transaction_v3(request, None).await?;
+    let fx = &response.effects.effects;
+
+    let mut expected_input_objects = fx.modified_at_versions();
+    expected_input_objects.sort_by_key(|&(id, _version)| id);
+    let mut expected_output_objects = fx
+        .all_changed_objects()
+        .into_iter()
+        .map(|(object_ref, _, _)| object_ref)
+        .collect::<Vec<_>>();
+    expected_output_objects.sort_by_key(|&(id, _version, _digest)| id);
+
+    let mut actual_input_objects_recieved = response
+        .input_objects
+        .unwrap()
+        .iter()
+        .map(|object| (object.id(), object.version()))
+        .collect::<Vec<_>>();
+    actual_input_objects_recieved.sort_by_key(|&(id, _version)| id);
+    assert_eq!(expected_input_objects, actual_input_objects_recieved);
+
+    let mut actual_output_objects_recieved = response
+        .output_objects
+        .unwrap()
+        .iter()
+        .map(|object| (object.id(), object.version(), object.digest()))
+        .collect::<Vec<_>>();
+    actual_output_objects_recieved.sort_by_key(|&(id, _version, _digest)| id);
+    assert_eq!(expected_output_objects, actual_output_objects_recieved);
+
+    Ok(())
 }

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -42,6 +42,15 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
+                .name("handle_certificate_v3")
+                .route_name("CertifiedTransactionV3")
+                .input_type("sui_types::messages_grpc::HandleCertificateRequestV3")
+                .output_type("sui_types::messages_grpc::HandleCertificateResponseV3")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            Method::builder()
                 .name("submit_certificate")
                 .route_name("SubmitCertificate")
                 .input_type("sui_types::transaction::CertifiedTransaction")

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -170,6 +170,18 @@ impl Committee {
             .map(|(a, _)| a)
     }
 
+    pub fn choose_multiple_weighted_iter(
+        &self,
+        count: usize,
+    ) -> impl Iterator<Item = &AuthorityName> {
+        self.voting_rights
+            .choose_multiple_weighted(&mut ThreadRng::default(), count, |(_, weight)| {
+                *weight as f64
+            })
+            .unwrap()
+            .map(|(a, _)| a)
+    }
+
     pub fn total_votes(&self) -> StakeUnit {
         TOTAL_VOTING_POWER
     }

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -7,7 +7,7 @@ use crate::effects::{
     SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects,
 };
 use crate::object::Object;
-use crate::transaction::{SenderSignedData, SignedTransaction};
+use crate::transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction};
 use move_core_types::annotated_value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -180,4 +180,40 @@ pub struct VerifiedHandleCertificateResponse {
 pub struct SystemStateRequest {
     // This is needed to make gRPC happy.
     pub _unused: bool,
+}
+
+/// Response type for version 3 of the handle certifacte validator API.
+///
+/// The coorisponding version 3 request type allows for a client to request events as well as
+/// input/output objects from a transaction's execution. Given Validators operate with very
+/// aggressive object pruning, the return of input/output objects is only done immediately after
+/// the transaction has been executed locally on the validator and will not be returned for
+/// requests to previously executed transactions.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HandleCertificateResponseV3 {
+    pub effects: SignedTransactionEffects,
+    pub events: Option<TransactionEvents>,
+    pub input_objects: Option<Vec<Object>>,
+    pub output_objects: Option<Vec<Object>>,
+    pub auxiliary_data: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HandleCertificateRequestV3 {
+    pub certificate: CertifiedTransaction,
+
+    pub include_events: bool,
+    pub include_input_objects: bool,
+    pub include_output_objects: bool,
+    pub include_auxiliary_data: bool,
+}
+
+impl From<HandleCertificateResponseV3> for HandleCertificateResponseV2 {
+    fn from(value: HandleCertificateResponseV3) -> Self {
+        Self {
+            signed_effects: value.effects,
+            events: value.events.unwrap_or_default(),
+            fastpath_input_objects: Vec::new(),
+        }
+    }
 }

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -193,7 +193,18 @@ pub struct SystemStateRequest {
 pub struct HandleCertificateResponseV3 {
     pub effects: SignedTransactionEffects,
     pub events: Option<TransactionEvents>,
+
+    /// If requested, will included all initial versions of objects modified in this transaction.
+    /// This includes owned objects included as input into the transaction as well as the assigned
+    /// versions of shared objects.
+    //
+    // TODO: In the future we may want to include shared objects or child objects which were read
+    // but not modified during exectuion.
     pub input_objects: Option<Vec<Object>>,
+
+    /// If requested, will included all changed objects, including mutated, created and unwrapped
+    /// objects. In other words, all objects that still exist in the object state after this
+    /// transaction.
     pub output_objects: Option<Vec<Object>>,
     pub auxiliary_data: Option<Vec<u8>>,
 }

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -13,6 +13,7 @@ use crate::effects::{
 };
 use crate::error::SuiError;
 use crate::messages_checkpoint::CheckpointSequenceNumber;
+use crate::object::Object;
 use crate::transaction::{Transaction, VerifiedTransaction};
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
@@ -111,7 +112,13 @@ pub struct QuorumDriverRequest {
 #[derive(Debug, Clone)]
 pub struct QuorumDriverResponse {
     pub effects_cert: VerifiedCertifiedTransactionEffects,
-    pub events: TransactionEvents,
+    // pub events: TransactionEvents,
+    pub events: Option<TransactionEvents>,
+    // Input objects will only be populated in the happy path
+    pub input_objects: Option<Vec<Object>>,
+    // Output objects will only be populated in the happy path
+    pub output_objects: Option<Vec<Object>>,
+    pub auxiliary_data: Option<Vec<u8>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -128,6 +135,51 @@ impl ExecuteTransactionRequest {
             TransactionType::SingleWriter
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ExecuteTransactionRequestV3 {
+    pub transaction: Transaction,
+
+    pub include_events: bool,
+    pub include_input_objects: bool,
+    pub include_output_objects: bool,
+    pub include_auxiliary_data: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct VerifiedExecuteTransactionResponseV3 {
+    pub effects: VerifiedCertifiedTransactionEffects,
+    pub events: Option<TransactionEvents>,
+    // Input objects will only be populated in the happy path
+    pub input_objects: Option<Vec<Object>>,
+    // Output objects will only be populated in the happy path
+    pub output_objects: Option<Vec<Object>>,
+    pub auxiliary_data: Option<Vec<u8>>,
+}
+
+impl ExecuteTransactionRequestV3 {
+    pub fn new_v2<T: Into<Transaction>>(transaction: T) -> Self {
+        Self {
+            transaction: transaction.into(),
+            include_events: true,
+            include_input_objects: false,
+            include_output_objects: false,
+            include_auxiliary_data: false,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ExecuteTransactionResponseV3 {
+    pub effects: FinalizedEffects,
+
+    pub events: Option<TransactionEvents>,
+    // Input objects will only be populated in the happy path
+    pub input_objects: Option<Vec<Object>>,
+    // Output objects will only be populated in the happy path
+    pub output_objects: Option<Vec<Object>>,
+    pub auxiliary_data: Option<Vec<u8>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
## Description 

This is a part of the "execution 2.0" effort where we allow for a client to request that a validator provides input/output objects for a certificate that it executes.

This PR does the following:
- Adds a new handle_certificate_v3 api to the Validator interface
- adds support to transaction_orchestrator, quorum_driver, and authority_aggregator to be able to conditionally call handle_certificate_v2/v3 depending on the provided request parameters
- Adds e2e test for ensuring that we can properly call the new api from transaciton_orchestrator -> quorum_driver -> authority_aggregator -> validator and back

The ability for end users to submit transactions and leverage this new mechanism to request input/output objects is not yet exposed (the existing v2 path is still used for all calls into jsonrpc) and such an endpoint will be added to the future REST interface in another PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
