### PR TITLE
[Consensus] ensure commit timestamps are monotonic

### DIFF
--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -38,12 +38,12 @@ pub(crate) const MINIMUM_WAVE_LENGTH: Round = 3;
 /// round, at least one voting round, and one decision round.
 pub(crate) type WaveNumber = u32;
 
-/// Versioned representation of a consensus commit.
+/// [`Commit`] summarizes [`CommittedSubDag`] for storage and network communications.
 ///
-/// Commit is used to persist commit metadata for recovery. It is also exchanged over the network.
-/// To balance being functional and succinct, a field must meet these requirements to be added
-/// to the struct:
-/// - helps with recoverying CommittedSubDag locally and for peers catching up.
+/// Validators should be able to reconstruct a sequence of CommittedSubDag from the
+/// corresponding Commit, CommitData and blocks contained in the Commit.
+/// A field must meet these requirements to be added to Commit:
+/// - helps with recovering CommittedSubDag locally and for peers catching up.
 /// - cannot be derived from a sequence of Commits and other persisted values.
 ///
 /// For example, transactions in blocks should not be included in Commit, because they can be
@@ -265,8 +265,12 @@ impl fmt::Debug for CommitRef {
 // Represents a vote on a Commit.
 pub type CommitVote = CommitRef;
 
-/// The output of consensus is an ordered list of [`CommittedSubDag`]. The application
-/// can arbitrarily sort the blocks within each sub-dag (but using a deterministic algorithm).
+/// The output of consensus to execution is an ordered list of [`CommittedSubDag`].
+/// Each CommittedSubDag contains the information needed to execution transactions in
+/// the consensus commit.
+///
+/// The application processing CommittedSubDag can arbitrarily sort the blocks within
+/// each sub-dag (but using a deterministic algorithm).
 #[derive(Clone, PartialEq)]
 pub struct CommittedSubDag {
     /// A reference to the leader of the sub-dag

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -116,8 +116,13 @@ impl CommitObserver {
         for commit in unsent_commits {
             // Commit index must be continuous.
             assert_eq!(commit.index(), last_sent_commit_index + 1);
-
-            let committed_subdag = load_committed_subdag_from_store(self.store.as_ref(), commit);
+            let commit_info = self
+                .store
+                .read_commit_info(commit.index())
+                .unwrap()
+                .unwrap();
+            let committed_subdag =
+                load_committed_subdag_from_store(self.store.as_ref(), commit, commit_info);
             self.sender.send(committed_subdag).unwrap_or_else(|e| {
                 panic!(
                     "Failed to send commit during recovery, probably due to shutdown: {:?}",
@@ -225,7 +230,10 @@ mod tests {
         for (idx, subdag) in commits.iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
-            assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
+            assert!(leaders[idx].timestamp_ms() <= subdag.timestamp_ms);
+            if idx > 0 {
+                assert!(commits[idx - 1].timestamp_ms <= subdag.timestamp_ms);
+            }
             if idx == 0 {
                 // First subdag includes the leader block plus all ancestor blocks
                 // of the leader minus the genesis round blocks

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -116,13 +116,7 @@ impl CommitObserver {
         for commit in unsent_commits {
             // Commit index must be continuous.
             assert_eq!(commit.index(), last_sent_commit_index + 1);
-            let commit_info = self
-                .store
-                .read_commit_info(commit.index())
-                .unwrap()
-                .unwrap();
-            let committed_subdag =
-                load_committed_subdag_from_store(self.store.as_ref(), commit, commit_info);
+            let committed_subdag = load_committed_subdag_from_store(self.store.as_ref(), commit);
             self.sender.send(committed_subdag).unwrap_or_else(|e| {
                 panic!(
                     "Failed to send commit during recovery, probably due to shutdown: {:?}",
@@ -230,10 +224,14 @@ mod tests {
         for (idx, subdag) in commits.iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
-            assert!(leaders[idx].timestamp_ms() <= subdag.timestamp_ms);
-            if idx > 0 {
-                assert!(commits[idx - 1].timestamp_ms <= subdag.timestamp_ms);
-            }
+            let expected_ts = if idx == 0 {
+                leaders[idx].timestamp_ms()
+            } else {
+                leaders[idx]
+                    .timestamp_ms()
+                    .max(commits[idx - 1].timestamp_ms)
+            };
+            assert_eq!(expected_ts, subdag.timestamp_ms);
             if idx == 0 {
                 // First subdag includes the leader block plus all ancestor blocks
                 // of the leader minus the genesis round blocks

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -108,6 +108,7 @@ impl Linearizer {
             let commit = Commit::new(
                 sub_dag.commit_index,
                 last_commit_digest,
+                sub_dag.timestamp_ms,
                 sub_dag.leader,
                 sub_dag
                     .blocks
@@ -125,7 +126,7 @@ impl Linearizer {
             let commit = TrustedCommit::new_trusted(commit, serialized);
 
             // Buffer commit in dag state for persistence later.
-            // This also updates the last commit properties, including rounds and timestamp, in the dag state.
+            // This also updates the last committed rounds.
             self.dag_state.write().add_commit(commit.clone());
 
             committed_sub_dags.push(sub_dag);
@@ -259,6 +260,7 @@ mod tests {
         let first_commit_data = TrustedCommit::new_for_test(
             last_commit_index,
             CommitDigest::MIN,
+            0,
             first_leader.reference(),
             blocks.clone(),
         );
@@ -310,6 +312,7 @@ mod tests {
         let expected_second_commit = TrustedCommit::new_for_test(
             last_commit_index,
             CommitDigest::MIN,
+            0,
             second_leader.reference(),
             blocks.clone(),
         );

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -205,19 +205,6 @@ impl Store for MemStore {
         Ok(votes)
     }
 
-    fn read_commit_info(&self, commit_index: CommitIndex) -> ConsensusResult<Option<CommitInfo>> {
-        let inner = self.inner.read();
-        let info = inner
-            .commit_info
-            .range((
-                Included((commit_index, CommitDigest::MIN)),
-                Included((commit_index, CommitDigest::MAX)),
-            ))
-            .map(|(_, info)| info.clone())
-            .next();
-        Ok(info)
-    }
-
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
         let inner = self.inner.read();
         Ok(inner

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -15,7 +15,7 @@ use parking_lot::RwLock;
 use super::{CommitInfo, Store, WriteBatch};
 use crate::{
     block::{BlockAPI as _, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
-    commit::{CommitAPI as _, CommitDigest, CommitIndex, TrustedCommit},
+    commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRef, TrustedCommit},
     error::ConsensusResult,
 };
 
@@ -74,12 +74,13 @@ impl Store for MemStore {
                     .commits
                     .insert((commit.index(), commit.digest()), commit);
             }
-            let commit_info = CommitInfo {
-                last_committed_rounds: write_batch.last_committed_rounds,
-            };
-            inner
-                .commit_info
-                .insert((last_commit.index(), last_commit.digest()), commit_info);
+            // CommitInfo can be unavailable in tests, or when we decide to skip writing it.
+            if let Some(last_commit_info) = write_batch.last_commit_info {
+                inner.commit_info.insert(
+                    (last_commit.index(), last_commit.digest()),
+                    last_commit_info,
+                );
+            }
         }
         Ok(())
     }
@@ -204,8 +205,24 @@ impl Store for MemStore {
         Ok(votes)
     }
 
-    fn read_last_commit_info(&self) -> ConsensusResult<Option<CommitInfo>> {
+    fn read_commit_info(&self, commit_index: CommitIndex) -> ConsensusResult<Option<CommitInfo>> {
         let inner = self.inner.read();
-        Ok(inner.commit_info.last_key_value().map(|(_k, v)| v.clone()))
+        let info = inner
+            .commit_info
+            .range((
+                Included((commit_index, CommitDigest::MIN)),
+                Included((commit_index, CommitDigest::MAX)),
+            ))
+            .map(|(_, info)| info.clone())
+            .next();
+        Ok(info)
+    }
+
+    fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
+        let inner = self.inner.read();
+        Ok(inner
+            .commit_info
+            .last_key_value()
+            .map(|(k, v)| (CommitRef::new(k.0, k.1), v.clone())))
     }
 }

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -13,7 +13,7 @@ use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    block::{BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock},
+    block::{BlockRef, Round, Slot, VerifiedBlock},
     commit::{CommitIndex, CommitRef, TrustedCommit},
     error::ConsensusResult,
 };
@@ -58,9 +58,6 @@ pub(crate) trait Store: Send + Sync {
     /// Reads all blocks voting on a particular commit.
     fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>>;
 
-    /// Reads the commit info at the given commit index.
-    fn read_commit_info(&self, commit_index: CommitIndex) -> ConsensusResult<Option<CommitInfo>>;
-
     /// Reads the last commit info, written atomically with the last commit.
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>>;
 }
@@ -101,22 +98,19 @@ impl WriteBatch {
     }
 }
 
-/// Per-commit properties that can be derived and do not need to be part of the Commit struct.
-/// Only the latest version is needed for CommitInfo, but more versions are stored for
-/// debugging and potentially restoring from an earlier state.
+/// Per-commit properties that can be regenerated from past values, and do not need to be part of
+/// the Commit struct.
+/// Only the latest version is needed for recovery, but more versions are stored for debugging,
+/// and potentially restoring from an earlier state.
 // TODO: version this struct.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct CommitInfo {
     pub(crate) committed_rounds: Vec<Round>,
-    pub(crate) timestamp_ms: BlockTimestampMs,
 }
 
 impl CommitInfo {
     // Returns a new CommitInfo.
-    pub(crate) fn new(committed_rounds: Vec<Round>, timestamp_ms: BlockTimestampMs) -> Self {
-        CommitInfo {
-            committed_rounds,
-            timestamp_ms,
-        }
+    pub(crate) fn new(committed_rounds: Vec<Round>) -> Self {
+        CommitInfo { committed_rounds }
     }
 }

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -112,7 +112,7 @@ pub(crate) struct CommitInfo {
 }
 
 impl CommitInfo {
-    // Returns an new CommitInfo.
+    // Returns a new CommitInfo.
     pub(crate) fn new(committed_rounds: Vec<Round>, timestamp_ms: BlockTimestampMs) -> Self {
         CommitInfo {
             committed_rounds,

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -13,8 +13,8 @@ use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    block::{BlockRef, Round, Slot, VerifiedBlock},
-    commit::{CommitIndex, TrustedCommit},
+    block::{BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock},
+    commit::{CommitIndex, CommitRef, TrustedCommit},
     error::ConsensusResult,
 };
 
@@ -58,8 +58,11 @@ pub(crate) trait Store: Send + Sync {
     /// Reads all blocks voting on a particular commit.
     fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>>;
 
-    /// Reads the last commit info, including last committed round per authority.
-    fn read_last_commit_info(&self) -> ConsensusResult<Option<CommitInfo>>;
+    /// Reads the commit info at the given commit index.
+    fn read_commit_info(&self, commit_index: CommitIndex) -> ConsensusResult<Option<CommitInfo>>;
+
+    /// Reads the last commit info, written atomically with the last commit.
+    fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>>;
 }
 
 /// Represents data to be written to the store together atomically.
@@ -67,19 +70,19 @@ pub(crate) trait Store: Send + Sync {
 pub(crate) struct WriteBatch {
     pub(crate) blocks: Vec<VerifiedBlock>,
     pub(crate) commits: Vec<TrustedCommit>,
-    pub(crate) last_committed_rounds: Vec<Round>,
+    pub(crate) last_commit_info: Option<CommitInfo>,
 }
 
 impl WriteBatch {
     pub(crate) fn new(
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
-        last_committed_rounds: Vec<Round>,
+        last_commit_info: Option<CommitInfo>,
     ) -> Self {
         WriteBatch {
             blocks,
             commits,
-            last_committed_rounds,
+            last_commit_info,
         }
     }
 
@@ -100,9 +103,20 @@ impl WriteBatch {
 
 /// Per-commit properties that can be derived and do not need to be part of the Commit struct.
 /// Only the latest version is needed for CommitInfo, but more versions are stored for
-/// debugging and potential recovery.
+/// debugging and potentially restoring from an earlier state.
 // TODO: version this struct.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct CommitInfo {
-    pub(crate) last_committed_rounds: Vec<Round>,
+    pub(crate) committed_rounds: Vec<Round>,
+    pub(crate) timestamp_ms: BlockTimestampMs,
+}
+
+impl CommitInfo {
+    // Returns an new CommitInfo.
+    pub(crate) fn new(committed_rounds: Vec<Round>, timestamp_ms: BlockTimestampMs) -> Self {
+        CommitInfo {
+            committed_rounds,
+            timestamp_ms,
+        }
+    }
 }

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -37,7 +37,7 @@ pub(crate) struct RocksDBStore {
     /// Collects votes on commits.
     /// TODO: batch multiple votes into a single row.
     commit_votes: DBMap<(CommitIndex, CommitDigest, BlockRef), ()>,
-    /// Stores info related to Commit that helps recovering CommittedSubDag.
+    /// Stores info related to Commit that helps recovery.
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
 }
 
@@ -293,20 +293,6 @@ impl Store for RocksDBStore {
             votes.push(block_ref);
         }
         Ok(votes)
-    }
-
-    fn read_commit_info(&self, commit_index: CommitIndex) -> ConsensusResult<Option<CommitInfo>> {
-        let Some(info) = self
-            .commit_info
-            .safe_range_iter((
-                Included((commit_index, CommitDigest::MIN)),
-                Included((commit_index, CommitDigest::MAX)),
-            ))
-            .next()
-        else {
-            return Ok(None);
-        };
-        Ok(Some(info?.1))
     }
 
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -19,7 +19,7 @@ use typed_store::{
 
 use super::{CommitInfo, Store, WriteBatch};
 use crate::block::Slot;
-use crate::commit::{CommitAPI as _, CommitDigest, TrustedCommit};
+use crate::commit::{CommitAPI as _, CommitDigest, CommitRef, TrustedCommit};
 use crate::{
     block::{BlockAPI as _, BlockDigest, BlockRef, Round, SignedBlock, VerifiedBlock},
     commit::CommitIndex,
@@ -32,12 +32,12 @@ pub(crate) struct RocksDBStore {
     blocks: DBMap<(Round, AuthorityIndex, BlockDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockDigest), ()>,
-    /// Maps commit index to content.
+    /// Maps commit index to Commit.
     commits: DBMap<(CommitIndex, CommitDigest), Bytes>,
     /// Collects votes on commits.
     /// TODO: batch multiple votes into a single row.
     commit_votes: DBMap<(CommitIndex, CommitDigest, BlockRef), ()>,
-    /// Stores the latest values of a few properties.
+    /// Stores info related to Commit that helps recovering CommittedSubDag.
     commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
 }
 
@@ -135,15 +135,18 @@ impl Store for RocksDBStore {
                     )
                     .map_err(ConsensusError::RocksDBFailure)?;
             }
-            let commit_info = CommitInfo {
-                last_committed_rounds: write_batch.last_committed_rounds,
-            };
-            batch
-                .insert_batch(
-                    &self.commit_info,
-                    [((last_commit.index(), last_commit.digest()), commit_info)],
-                )
-                .map_err(ConsensusError::RocksDBFailure)?;
+            // CommitInfo can be unavailable in tests, or when we decide to skip writing it.
+            if let Some(last_commit_info) = write_batch.last_commit_info {
+                batch
+                    .insert_batch(
+                        &self.commit_info,
+                        [(
+                            (last_commit.index(), last_commit.digest()),
+                            last_commit_info,
+                        )],
+                    )
+                    .map_err(ConsensusError::RocksDBFailure)?;
+            }
         }
         batch.write()?;
         Ok(())
@@ -292,11 +295,25 @@ impl Store for RocksDBStore {
         Ok(votes)
     }
 
-    fn read_last_commit_info(&self) -> ConsensusResult<Option<CommitInfo>> {
+    fn read_commit_info(&self, commit_index: CommitIndex) -> ConsensusResult<Option<CommitInfo>> {
+        let Some(info) = self
+            .commit_info
+            .safe_range_iter((
+                Included((commit_index, CommitDigest::MIN)),
+                Included((commit_index, CommitDigest::MAX)),
+            ))
+            .next()
+        else {
+            return Ok(None);
+        };
+        Ok(Some(info?.1))
+    }
+
+    fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
         let Some(result) = self.commit_info.safe_iter().skip_to_last().next() else {
             return Ok(None);
         };
-        let (_, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;
-        Ok(Some(commit_info))
+        let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;
+        Ok(Some((CommitRef::new(key.0, key.1), commit_info)))
     }
 }

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -218,24 +218,28 @@ async fn read_and_scan_commits(
         TrustedCommit::new_for_test(
             1,
             CommitDigest::MIN,
+            1,
             BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
         TrustedCommit::new_for_test(
             2,
             CommitDigest::MIN,
+            2,
             BlockRef::new(2, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
         TrustedCommit::new_for_test(
             3,
             CommitDigest::MIN,
+            3,
             BlockRef::new(3, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
         TrustedCommit::new_for_test(
             4,
             CommitDigest::MIN,
+            4,
             BlockRef::new(4, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -48,7 +48,7 @@ pub(crate) fn build_dag(
             .authorities()
             .map(|authority| {
                 let author_idx = authority.0.value() as u32;
-                // Test the case where a block from round R+1 can have small timestamp than a block from round R.
+                // Test the case where a block from round R+1 has smaller timestamp than a block from round R.
                 let ts = round as BlockTimestampMs / 2 * num_authorities as BlockTimestampMs
                     + author_idx as BlockTimestampMs;
                 let block = VerifiedBlock::new_for_test(

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -40,6 +40,7 @@ pub(crate) fn build_dag(
             .collect::<Vec<_>>(),
     };
 
+    let num_authorities = context.committee.size();
     let starting_round = ancestors.first().unwrap().round + 1;
     for round in starting_round..=stop {
         let (references, blocks): (Vec<_>, Vec<_>) = context
@@ -47,10 +48,12 @@ pub(crate) fn build_dag(
             .authorities()
             .map(|authority| {
                 let author_idx = authority.0.value() as u32;
-                let base_ts = round as BlockTimestampMs * 1000;
+                // Test the case where a block from round R+1 can have small timestamp than a block from round R.
+                let ts = round as BlockTimestampMs / 2 * num_authorities as BlockTimestampMs
+                    + author_idx as BlockTimestampMs;
                 let block = VerifiedBlock::new_for_test(
                     TestBlock::new(round, author_idx)
-                        .set_timestamp_ms(base_ts + author_idx as u64)
+                        .set_timestamp_ms(ts)
                         .set_ancestors(ancestors.clone())
                         .build(),
                 );


### PR DESCRIPTION
## Description 

This makes consuming commit timestamp easier.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
