### PR TITLE
[indexer] modify IndexerConfig logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10873,6 +10873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12759,6 +12768,7 @@ dependencies = [
  "prometheus",
  "rayon",
  "regex",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -53,6 +53,7 @@ move-binary-format.workspace = true
 
 diesel_migrations.workspace = true
 cached.workspace = true
+secrecy = "0.8.0"
 
 [features]
 pg_integration = []

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -91,7 +91,7 @@ impl IndexerConfig {
     pub fn base_connection_url(&self) -> Result<String, anyhow::Error> {
         let url_secret = self.get_db_url()?;
         let url_str = url_secret.expose_secret();
-        let url = Url::parse(&url_str).expect("Failed to parse URL");
+        let url = Url::parse(url_str).expect("Failed to parse URL");
         Ok(format!(
             "{}://{}:{}@{}:{}/",
             url.scheme(),

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -11,6 +11,7 @@ use jsonrpsee::http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuild
 use metrics::IndexerMetrics;
 use mysten_metrics::spawn_monitored_task;
 use prometheus::Registry;
+use secrecy::{ExposeSecret, Secret};
 use std::path::PathBuf;
 use system_package_task::SystemPackageTask;
 use tokio::runtime::Handle;
@@ -52,11 +53,11 @@ pub mod types;
 )]
 pub struct IndexerConfig {
     #[clap(long)]
-    pub db_url: Option<String>,
+    pub db_url: Option<Secret<String>>,
     #[clap(long)]
     pub db_user_name: Option<String>,
     #[clap(long)]
-    pub db_password: Option<String>,
+    pub db_password: Option<Secret<String>>,
     #[clap(long)]
     pub db_host: Option<String>,
     #[clap(long)]
@@ -88,7 +89,8 @@ pub struct IndexerConfig {
 impl IndexerConfig {
     /// returns connection url without the db name
     pub fn base_connection_url(&self) -> Result<String, anyhow::Error> {
-        let url_str = self.get_db_url()?;
+        let url_secret = self.get_db_url()?;
+        let url_str = url_secret.expose_secret();
         let url = Url::parse(&url_str).expect("Failed to parse URL");
         Ok(format!(
             "{}://{}:{}@{}:{}/",
@@ -100,14 +102,14 @@ impl IndexerConfig {
         ))
     }
 
-    pub fn get_db_url(&self) -> Result<String, anyhow::Error> {
+    pub fn get_db_url(&self) -> Result<Secret<String>, anyhow::Error> {
         match (&self.db_url, &self.db_user_name, &self.db_password, &self.db_host, &self.db_port, &self.db_name) {
             (Some(db_url), _, _, _, _, _) => Ok(db_url.clone()),
             (None, Some(db_user_name), Some(db_password), Some(db_host), Some(db_port), Some(db_name)) => {
-                Ok(format!(
+                Ok(secrecy::Secret::new(format!(
                     "postgres://{}:{}@{}:{}/{}",
-                    db_user_name, db_password, db_host, db_port, db_name
-                ))
+                    db_user_name, db_password.expose_secret(), db_host, db_port, db_name
+                )))
             }
             _ => Err(anyhow!("Invalid db connection config, either db_url or (db_user_name, db_password, db_host, db_port, db_name) must be provided")),
         }
@@ -117,7 +119,9 @@ impl IndexerConfig {
 impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
-            db_url: Some("postgres://postgres:postgres@localhost:5432/sui_indexer".to_string()),
+            db_url: Some(secrecy::Secret::new(
+                "postgres://postgres:postgres@localhost:5432/sui_indexer".to_string(),
+            )),
             db_user_name: None,
             db_password: None,
             db_host: None,

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use secrecy::ExposeSecret;
 use tracing::{error, info};
 
 use sui_indexer::db::{get_pg_pool_connection, new_pg_connection_pool, reset_database};
@@ -22,12 +23,14 @@ async fn main() -> Result<(), IndexerError> {
     let indexer_config = IndexerConfig::parse();
     info!("Parsed indexer config: {:#?}", indexer_config);
 
-    let db_url = indexer_config.get_db_url().map_err(|e| {
+    let db_url_secret = indexer_config.get_db_url().map_err(|e| {
         IndexerError::PgPoolConnectionError(format!(
             "Failed parsing database url with error {:?}",
             e
         ))
     })?;
+
+    let db_url = db_url_secret.expose_secret();
     let blocking_cp = new_pg_connection_pool(&db_url, None).map_err(|e| {
         error!(
             "Failed creating Postgres connection pool with error {:?}",
@@ -90,7 +93,7 @@ async fn main() -> Result<(), IndexerError> {
         let store = PgIndexerStore::new(blocking_cp, indexer_metrics.clone());
         return Indexer::start_writer(&indexer_config, store, indexer_metrics).await;
     } else if indexer_config.rpc_server_worker {
-        return Indexer::start_reader(&indexer_config, &registry, db_url).await;
+        return Indexer::start_reader(&indexer_config, &registry, db_url.to_string()).await;
     }
     Ok(())
 }

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), IndexerError> {
     })?;
 
     let db_url = db_url_secret.expose_secret();
-    let blocking_cp = new_pg_connection_pool(&db_url, None).map_err(|e| {
+    let blocking_cp = new_pg_connection_pool(db_url, None).map_err(|e| {
         error!(
             "Failed creating Postgres connection pool with error {:?}",
             e

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -3,6 +3,7 @@
 
 use diesel::connection::SimpleConnection;
 use mysten_metrics::init_metrics;
+use secrecy::ExposeSecret;
 use tokio::task::JoinHandle;
 
 use std::env;
@@ -81,7 +82,7 @@ pub async fn start_test_indexer_impl(
 
     // Default writer mode
     let mut config = IndexerConfig {
-        db_url: Some(db_url.clone()),
+        db_url: Some(db_url.clone().into()),
         rpc_client_url: rpc_url,
         reset_db: true,
         fullnode_sync_worker: true,
@@ -100,7 +101,7 @@ pub async fn start_test_indexer_impl(
 
     if let Some(new_database) = new_database {
         // Switch to default to create a new database
-        let (default_db_url, _) = replace_db_name(&parsed_url, "postgres");
+        let (default_db_url, _) = replace_db_name(&parsed_url.expose_secret(), "postgres");
 
         // Open in default mode
         let blocking_pool =
@@ -116,11 +117,14 @@ pub async fn start_test_indexer_impl(
         default_conn
             .batch_execute(&format!("CREATE DATABASE {}", new_database))
             .unwrap();
-        parsed_url = replace_db_name(&parsed_url, &new_database).0;
+        parsed_url = replace_db_name(&parsed_url.expose_secret(), &new_database)
+            .0
+            .into();
     }
 
     let blocking_pool =
-        new_pg_connection_pool_with_config(&parsed_url, Some(5), pool_config).unwrap();
+        new_pg_connection_pool_with_config(&parsed_url.expose_secret(), Some(5), pool_config)
+            .unwrap();
     let store = PgIndexerStore::new(blocking_pool.clone(), indexer_metrics.clone());
 
     let handle = match reader_writer_config {

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -101,7 +101,7 @@ pub async fn start_test_indexer_impl(
 
     if let Some(new_database) = new_database {
         // Switch to default to create a new database
-        let (default_db_url, _) = replace_db_name(&parsed_url.expose_secret(), "postgres");
+        let (default_db_url, _) = replace_db_name(parsed_url.expose_secret(), "postgres");
 
         // Open in default mode
         let blocking_pool =
@@ -117,13 +117,13 @@ pub async fn start_test_indexer_impl(
         default_conn
             .batch_execute(&format!("CREATE DATABASE {}", new_database))
             .unwrap();
-        parsed_url = replace_db_name(&parsed_url.expose_secret(), &new_database)
+        parsed_url = replace_db_name(parsed_url.expose_secret(), &new_database)
             .0
             .into();
     }
 
     let blocking_pool =
-        new_pg_connection_pool_with_config(&parsed_url.expose_secret(), Some(5), pool_config)
+        new_pg_connection_pool_with_config(parsed_url.expose_secret(), Some(5), pool_config)
             .unwrap();
     let store = PgIndexerStore::new(blocking_pool.clone(), indexer_metrics.clone());
 


### PR DESCRIPTION
## Description 

There are instances where we some sensitive information is logged. This PR should resolve this issue.

## Test plan 

Ran unit-tests and ran against a local DB on my laptop. The log output is below. I tried with db_url args and individual db args.

```
cargo run --bin sui-indexer -- --db-url "postgresql://postgres:postgres@localhost:5432/sui_indexer" --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker
    2024-04-23T00:50:44.350678Z  INFO sui_indexer: Parsed indexer config: IndexerConfig {
    db_url: Some(
        Secret([REDACTED alloc::string::String]),
    ),
    db_user_name: None,
    db_password: None,
    db_host: None,
    db_port: None,
    db_name: None,
    rpc_client_url: "https://fullnode.devnet.sui.io:443",
    remote_store_url: Some(
        "https://checkpoints.mainnet.sui.io",
    ),
    client_metric_host: "0.0.0.0",
    client_metric_port: 9184,
    rpc_server_url: "0.0.0.0",
    rpc_server_port: 9000,
    reset_db: false,
    fullnode_sync_worker: true,
    rpc_server_worker: false,
    data_ingestion_path: None,
}
```


```
cargo run --bin sui-indexer -- --db-user-name=postgres --db-password=postgres --db-host=localhost --db-port=5432 --db-name=sui_indexer  --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker
2024-04-23T00:52:53.748420Z  INFO sui_indexer: Parsed indexer config: IndexerConfig {
    db_url: None,
    db_user_name: Some(
        "postgres",
    ),
    db_password: Some(
        Secret([REDACTED alloc::string::String]),
    ),
    db_host: Some(
        "localhost",
    ),
    db_port: Some(
        5432,
    ),
    db_name: Some(
        "sui_indexer",
    ),
    rpc_client_url: "https://fullnode.devnet.sui.io:443",
    remote_store_url: Some(
        "https://checkpoints.mainnet.sui.io",
    ),
    client_metric_host: "0.0.0.0",
    client_metric_port: 9184,
    rpc_server_url: "0.0.0.0",
    rpc_server_port: 9000,
    reset_db: false,
    fullnode_sync_worker: true,
    rpc_server_worker: false,
    data_ingestion_path: None,
}
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
