### PR TITLE
[bridge] refactor test utils

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -22,13 +22,17 @@ use std::process::Command;
 use std::str::FromStr;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_sdk::wallet_context::WalletContext;
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::bridge::{
     BridgeChainId, BRIDGE_MODULE_NAME, BRIDGE_REGISTER_FOREIGN_TOKEN_FUNCTION_NAME,
 };
 use sui_types::committee::TOTAL_VOTING_POWER;
+use sui_types::crypto::get_key_pair;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{ObjectArg, TransactionData};
 use sui_types::BRIDGE_PACKAGE_ID;
+use tokio::join;
+use tokio::task::JoinHandle;
 
 use tracing::error;
 use tracing::info;
@@ -65,6 +69,220 @@ const USDC_NAME: &str = "USDC";
 const USDT_NAME: &str = "USDT";
 
 pub const TEST_PK: &str = "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
+
+/// A helper struct that holds TestCluster and other Bridge related
+/// structs that are needed for testing.
+pub struct BridgeTestCluster {
+    pub test_cluster: TestCluster,
+    eth_environment: EthBridgeEnvironment,
+    bridge_node_handles: Option<Vec<JoinHandle<()>>>,
+    approved_governance_actions_for_next_start: Option<Vec<Vec<BridgeAction>>>,
+}
+
+pub struct BridgeTestClusterBuilder {
+    with_eth_env: bool,
+    with_bridge_cluster: bool,
+    approved_governance_actions: Option<Vec<Vec<BridgeAction>>>,
+}
+
+impl Default for BridgeTestClusterBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BridgeTestClusterBuilder {
+    pub fn new() -> Self {
+        BridgeTestClusterBuilder {
+            with_eth_env: false,
+            with_bridge_cluster: false,
+            approved_governance_actions: None,
+        }
+    }
+
+    pub fn with_eth_env(mut self, with_eth_env: bool) -> Self {
+        self.with_eth_env = with_eth_env;
+        self
+    }
+
+    pub fn with_bridge_cluster(mut self, with_bridge_cluster: bool) -> Self {
+        self.with_bridge_cluster = with_bridge_cluster;
+        self
+    }
+
+    pub fn with_approved_governance_actions(
+        mut self,
+        approved_governance_actions: Vec<Vec<BridgeAction>>,
+    ) -> Self {
+        self.approved_governance_actions = Some(approved_governance_actions);
+        self
+    }
+
+    pub async fn build(self) -> BridgeTestCluster {
+        let mut bridge_keys = vec![];
+        let mut bridge_keys_copy = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp.copy());
+            bridge_keys_copy.push(kp);
+        }
+        let start_cluster_task = tokio::task::spawn(Self::start_test_cluster(bridge_keys));
+        let start_eth_env_task = tokio::task::spawn(Self::start_eth_env(bridge_keys_copy));
+        let (start_cluster_res, start_eth_env_res) = join!(start_cluster_task, start_eth_env_task);
+        let test_cluster = start_cluster_res.unwrap();
+        let eth_environment = start_eth_env_res.unwrap();
+
+        let mut bridge_node_handles = None;
+        if self.with_bridge_cluster {
+            let approved_governace_actions = self
+                .approved_governance_actions
+                .clone()
+                .unwrap_or(vec![vec![], vec![], vec![], vec![]]);
+            bridge_node_handles = Some(
+                start_bridge_cluster(&test_cluster, &eth_environment, approved_governace_actions)
+                    .await,
+            );
+        }
+
+        BridgeTestCluster {
+            test_cluster,
+            eth_environment,
+            bridge_node_handles,
+            approved_governance_actions_for_next_start: self.approved_governance_actions,
+        }
+    }
+
+    async fn start_test_cluster(bridge_keys: Vec<BridgeAuthorityKeyPair>) -> TestCluster {
+        let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
+            .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
+            .build_with_bridge(bridge_keys, true)
+            .await;
+        info!("Test cluster built");
+        test_cluster
+            .trigger_reconfiguration_if_not_yet_and_assert_bridge_committee_initialized()
+            .await;
+        info!("Bridge committee is finalized");
+        test_cluster
+    }
+
+    async fn start_eth_env(bridge_keys: Vec<BridgeAuthorityKeyPair>) -> EthBridgeEnvironment {
+        let anvil_port = get_available_port("127.0.0.1");
+        let anvil_url = format!("http://127.0.0.1:{anvil_port}");
+        let mut eth_environment = EthBridgeEnvironment::new(&anvil_url, anvil_port)
+            .await
+            .unwrap();
+
+        let (eth_signer, eth_pk_hex) = eth_environment.get_signer(TEST_PK).await.unwrap();
+        let deployed_contracts =
+            deploy_sol_contract(&anvil_url, eth_signer, bridge_keys, eth_pk_hex).await;
+        info!("Deployed contracts: {:?}", deployed_contracts);
+        eth_environment.contracts = Some(deployed_contracts);
+        eth_environment
+    }
+}
+
+impl BridgeTestCluster {
+    pub async fn get_eth_signer_and_private_key(&self) -> anyhow::Result<(EthSigner, String)> {
+        self.eth_environment.get_signer(TEST_PK).await
+    }
+
+    pub async fn get_eth_signer_and_address(&self) -> anyhow::Result<(EthSigner, EthAddress)> {
+        let (eth_signer, _) = self.get_eth_signer_and_private_key().await?;
+        let eth_address = eth_signer.address();
+        Ok((eth_signer, eth_address))
+    }
+
+    pub async fn sui_bridge_client(&self) -> anyhow::Result<SuiBridgeClient> {
+        SuiBridgeClient::new(&self.test_cluster.fullnode_handle.rpc_url).await
+    }
+
+    pub fn sui_client(&self) -> SuiClient {
+        self.test_cluster.fullnode_handle.sui_client.clone()
+    }
+
+    pub fn sui_user_address(&self) -> SuiAddress {
+        self.test_cluster.get_address_0()
+    }
+
+    pub fn contracts(&self) -> &DeployedSolContracts {
+        self.eth_environment.contracts()
+    }
+
+    pub fn sui_bridge_address(&self) -> String {
+        self.eth_environment.contracts().sui_bridge_addrress_hex()
+    }
+
+    pub fn wallet_mut(&mut self) -> &mut WalletContext {
+        self.test_cluster.wallet_mut()
+    }
+
+    pub fn wallet(&mut self) -> &WalletContext {
+        &self.test_cluster.wallet
+    }
+
+    pub fn bridge_authority_key(&self, index: usize) -> BridgeAuthorityKeyPair {
+        self.test_cluster.bridge_authority_keys.as_ref().unwrap()[index].copy()
+    }
+
+    pub fn sui_rpc_url(&self) -> String {
+        self.test_cluster.fullnode_handle.rpc_url.clone()
+    }
+
+    pub fn eth_rpc_url(&self) -> String {
+        self.eth_environment.rpc_url.clone()
+    }
+
+    pub async fn get_mut_bridge_arg(&self) -> Option<ObjectArg> {
+        self.test_cluster.get_mut_bridge_arg().await
+    }
+
+    pub async fn test_transaction_builder_with_sender(
+        &self,
+        sender: SuiAddress,
+    ) -> TestTransactionBuilder {
+        self.test_cluster
+            .test_transaction_builder_with_sender(sender)
+            .await
+    }
+
+    pub async fn wait_for_bridge_cluster_to_be_up(&self, timeout_sec: u64) {
+        self.test_cluster
+            .wait_for_bridge_cluster_to_be_up(timeout_sec)
+            .await;
+    }
+
+    pub async fn sign_and_execute_transaction(
+        &self,
+        tx_data: &TransactionData,
+    ) -> SuiTransactionBlockResponse {
+        self.test_cluster
+            .sign_and_execute_transaction(tx_data)
+            .await
+    }
+
+    pub fn set_approved_governance_actions_for_next_start(
+        &mut self,
+        approved_governance_actions: Vec<Vec<BridgeAction>>,
+    ) {
+        self.approved_governance_actions_for_next_start = Some(approved_governance_actions);
+    }
+
+    pub async fn start_bridge_cluster(&mut self) {
+        assert!(self.bridge_node_handles.is_none());
+        let approved_governace_actions = self
+            .approved_governance_actions_for_next_start
+            .clone()
+            .unwrap_or(vec![vec![], vec![], vec![], vec![]]);
+        self.bridge_node_handles = Some(
+            start_bridge_cluster(
+                &self.test_cluster,
+                &self.eth_environment,
+                approved_governace_actions,
+            )
+            .await,
+        );
+    }
+}
 
 pub async fn publish_coins_return_add_coins_on_sui_action(
     wallet_context: &mut WalletContext,
@@ -218,79 +436,12 @@ struct SolDeployConfig {
     token_prices: Vec<u64>,
 }
 
-pub(crate) async fn initialize_bridge_environment(
-    should_start_bridge_cluster: bool,
-) -> (TestCluster, EthBridgeEnvironment) {
-    let anvil_port = get_available_port("127.0.0.1");
-    let anvil_url = format!("http://127.0.0.1:{anvil_port}");
-    let mut eth_environment = EthBridgeEnvironment::new(&anvil_url, anvil_port)
-        .await
-        .unwrap();
-
-    // Deploy solidity contracts in a separate task
-    let anvil_url_clone = anvil_url.clone();
-    let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
-
-    let mut server_ports = vec![];
-    for _ in 0..3 {
-        server_ports.push(get_available_port("127.0.0.1"));
-    }
-
-    let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
-        .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
-        .build_with_bridge(true)
-        .await;
-    info!("Test cluster built");
-    test_cluster
-        .trigger_reconfiguration_if_not_yet_and_assert_bridge_committee_initialized()
-        .await;
-    info!("Bridge committee is finalized");
-    // TODO: do not block on `build_with_bridge`, return with bridge keys immediately
-    // to parallize the setup.
-    let bridge_authority_keys = test_cluster
-        .bridge_authority_keys
-        .as_ref()
-        .unwrap()
-        .iter()
-        .map(|k| k.copy())
-        .collect::<Vec<_>>();
-
-    let (eth_signer, eth_pk_hex) = eth_environment.get_signer(TEST_PK).await.unwrap();
-    tokio::task::spawn(async move {
-        deploy_sol_contract(
-            &anvil_url_clone,
-            eth_signer,
-            bridge_authority_keys,
-            tx_ack,
-            eth_pk_hex,
-        )
-        .await
-    });
-    let deployed_contracts = rx_ack.await.unwrap();
-    info!("Deployed contracts: {:?}", deployed_contracts);
-    eth_environment.contracts = Some(deployed_contracts);
-
-    // if start bridge cluster is enabled, start the bridge cluster
-    if should_start_bridge_cluster {
-        start_bridge_cluster(
-            &test_cluster,
-            &eth_environment,
-            vec![vec![], vec![], vec![], vec![]],
-        )
-        .await;
-        info!("Started bridge cluster");
-    }
-
-    (test_cluster, eth_environment)
-}
-
 pub(crate) async fn deploy_sol_contract(
     anvil_url: &str,
     eth_signer: EthSigner,
     bridge_authority_keys: Vec<BridgeAuthorityKeyPair>,
-    tx: tokio::sync::oneshot::Sender<DeployedSolContracts>,
     eth_private_key_hex: String,
-) {
+) -> DeployedSolContracts {
     let sol_path = format!("{}/../../bridge/evm", env!("CARGO_MANIFEST_DIR"));
 
     // Write the deploy config to a temp file then provide it to the forge late
@@ -445,7 +596,7 @@ pub(crate) async fn deploy_sol_contract(
         );
         assert!(!eth_bridge_committee.blocklist(eth_address).await.unwrap());
     }
-    tx.send(contracts).unwrap();
+    contracts
 }
 
 #[derive(Debug)]
@@ -498,8 +649,7 @@ pub(crate) async fn start_bridge_cluster(
     test_cluster: &TestCluster,
     eth_environment: &EthBridgeEnvironment,
     approved_governance_actions: Vec<Vec<BridgeAction>>,
-) {
-    // TODO: move this to TestCluster
+) -> Vec<JoinHandle<()>> {
     let bridge_authority_keys = test_cluster
         .bridge_authority_keys
         .as_ref()
@@ -520,6 +670,7 @@ pub(crate) async fn start_bridge_cluster(
         .unwrap()
         .sui_bridge_addrress_hex();
 
+    let mut handles = vec![];
     for (i, ((kp, server_listen_port), approved_governance_actions)) in bridge_authority_keys
         .iter()
         .zip(bridge_server_ports.iter())
@@ -565,11 +716,9 @@ pub(crate) async fn start_bridge_cluster(
         };
         // Spawn bridge node in memory
         let config_clone = config.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-            run_bridge_node(config_clone).await.unwrap();
-        });
+        handles.push(run_bridge_node(config_clone).await.unwrap());
     }
+    handles
 }
 
 pub(crate) async fn get_signatures(

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -172,7 +172,7 @@ impl BridgeTestClusterBuilder {
             .await
             .unwrap();
         // Give anvil a bit of time to start
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
         let (eth_signer, eth_pk_hex) = eth_environment
             .get_signer(TEST_PK)
             .await
@@ -691,9 +691,10 @@ pub(crate) async fn start_bridge_cluster(
         std::fs::write(authority_key_path.clone(), base64_encoded).unwrap();
 
         let client_sui_address = SuiAddress::from(kp.public());
+        let sender_address = test_cluster.get_address_0();
         // send some gas to this address
         test_cluster
-            .transfer_sui_must_exceed(client_sui_address, 1000000000)
+            .transfer_sui_must_exceed(sender_address, client_sui_address, 1000000000)
             .await;
 
         let config = BridgeNodeConfig {

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -171,8 +171,12 @@ impl BridgeTestClusterBuilder {
         let mut eth_environment = EthBridgeEnvironment::new(&anvil_url, anvil_port)
             .await
             .unwrap();
-
-        let (eth_signer, eth_pk_hex) = eth_environment.get_signer(TEST_PK).await.unwrap();
+        // Give anvil a bit of time to start
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        let (eth_signer, eth_pk_hex) = eth_environment
+            .get_signer(TEST_PK)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to get eth signer from anvil at {anvil_url}: {e}"));
         let deployed_contracts =
             deploy_sol_contract(&anvil_url, eth_signer, bridge_keys, eth_pk_hex).await;
         info!("Deployed contracts: {:?}", deployed_contracts);

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -58,5 +58,5 @@ async fn main() -> anyhow::Result<()> {
         .with_prom_registry(&prometheus_registry)
         .init();
 
-    run_bridge_node(config).await
+    Ok(run_bridge_node(config).await?.await?)
 }

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -22,7 +22,6 @@ use sui_types::{bridge::BRIDGE_MODULE_NAME, event::EventID, Identifier};
 use tokio::task::JoinHandle;
 use tracing::info;
 
-// pub async fn run_bridge_node(config: BridgeNodeConfig, shutdown_notify: Option<Arc<Notify>>) -> anyhow::Result<()> {
 pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<JoinHandle<()>> {
     let (server_config, client_config) = config.validate().await?;
 
@@ -46,7 +45,6 @@ pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<JoinHan
             server_config.eth_client,
             server_config.approved_governance_actions,
         ),
-        // shutdown_notify,
     ))
 }
 
@@ -309,7 +307,6 @@ mod tests {
     #[tokio::test]
     async fn test_starting_bridge_node() {
         telemetry_subscribers::init_for_testing();
-        // let (bridge_test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
         let bridge_test_cluster = setup().await;
         let kp = bridge_test_cluster.bridge_authority_key(0);
 
@@ -317,7 +314,6 @@ mod tests {
         let tmp_dir = tempdir().unwrap().into_path();
         let authority_key_path = "test_starting_bridge_node_bridge_authority_key";
         let server_listen_port = get_available_port("127.0.0.1");
-        // let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
         let base64_encoded = kp.encode_base64();
         std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
 
@@ -355,7 +351,6 @@ mod tests {
     #[tokio::test]
     async fn test_starting_bridge_node_with_client() {
         telemetry_subscribers::init_for_testing();
-        // let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
         let bridge_test_cluster = setup().await;
         let kp = bridge_test_cluster.bridge_authority_key(0);
 
@@ -369,10 +364,11 @@ mod tests {
         std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
 
         let client_sui_address = SuiAddress::from(kp.public());
+        let sender_address = bridge_test_cluster.sui_user_address();
         // send some gas to this address
         bridge_test_cluster
             .test_cluster
-            .transfer_sui_must_exceed(client_sui_address, 1000000000)
+            .transfer_sui_must_exceed(sender_address, client_sui_address, 1000000000)
             .await;
 
         let config = BridgeNodeConfig {
@@ -436,11 +432,11 @@ mod tests {
             "test_starting_bridge_node_with_client_and_separate_client_key_bridge_client_key";
         std::fs::write(tmp_dir.join(client_key_path), kp.encode_base64()).unwrap();
         let client_sui_address = SuiAddress::from(&kp.public());
-
+        let sender_address = bridge_test_cluster.sui_user_address();
         // send some gas to this address
         let gas_obj = bridge_test_cluster
             .test_cluster
-            .transfer_sui_must_exceed(client_sui_address, 1000000000)
+            .transfer_sui_must_exceed(sender_address, client_sui_address, 1000000000)
             .await;
 
         let config = BridgeNodeConfig {

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -22,7 +22,8 @@ use sui_types::{bridge::BRIDGE_MODULE_NAME, event::EventID, Identifier};
 use tokio::task::JoinHandle;
 use tracing::info;
 
-pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<()> {
+// pub async fn run_bridge_node(config: BridgeNodeConfig, shutdown_notify: Option<Arc<Notify>>) -> anyhow::Result<()> {
+pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<JoinHandle<()>> {
     let (server_config, client_config) = config.validate().await?;
 
     // Start Client
@@ -37,7 +38,7 @@ pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<()> {
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         server_config.server_listen_port,
     );
-    run_server(
+    Ok(run_server(
         &socket_address,
         BridgeRequestHandler::new(
             server_config.key,
@@ -45,10 +46,8 @@ pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<()> {
             server_config.eth_client,
             server_config.approved_governance_actions,
         ),
-    )
-    .await;
-
-    Ok(())
+        // shutdown_notify,
+    ))
 }
 
 // TODO: is there a way to clean up the overrides after it's stored in DB?
@@ -178,16 +177,14 @@ fn get_eth_contracts_to_watch(
 #[cfg(test)]
 mod tests {
     use ethers::types::Address as EthAddress;
-    use std::process::Child;
 
     use super::*;
     use crate::config::BridgeNodeConfig;
     use crate::config::EthConfig;
     use crate::config::SuiConfig;
-    use crate::e2e_tests::test_utils::deploy_sol_contract;
-    use crate::e2e_tests::test_utils::get_eth_signer_client_e2e_test_only;
     use crate::e2e_tests::test_utils::wait_for_server_to_be_up;
-    use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
+    use crate::e2e_tests::test_utils::BridgeTestCluster;
+    use crate::e2e_tests::test_utils::BridgeTestClusterBuilder;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use sui_config::local_ip_utils::get_available_port;
     use sui_types::base_types::SuiAddress;
@@ -199,7 +196,6 @@ mod tests {
     use sui_types::digests::TransactionDigest;
     use sui_types::event::EventID;
     use tempfile::tempdir;
-    use test_cluster::TestClusterBuilder;
 
     #[tokio::test]
     async fn test_get_eth_contracts_to_watch() {
@@ -313,13 +309,15 @@ mod tests {
     #[tokio::test]
     async fn test_starting_bridge_node() {
         telemetry_subscribers::init_for_testing();
-        let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
+        // let (bridge_test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
+        let bridge_test_cluster = setup().await;
+        let kp = bridge_test_cluster.bridge_authority_key(0);
 
         // prepare node config (server only)
         let tmp_dir = tempdir().unwrap().into_path();
         let authority_key_path = "test_starting_bridge_node_bridge_authority_key";
         let server_listen_port = get_available_port("127.0.0.1");
-        let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
+        // let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
         let base64_encoded = kp.encode_base64();
         std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
 
@@ -328,15 +326,15 @@ mod tests {
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
             sui: SuiConfig {
-                sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+                sui_rpc_url: bridge_test_cluster.sui_rpc_url(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
                 bridge_client_key_path_base64_sui_key: None,
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: None,
             },
             eth: EthConfig {
-                eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
-                eth_bridge_proxy_address: format!("{:#x}", bridge_contract_address),
+                eth_rpc_url: bridge_test_cluster.eth_rpc_url(),
+                eth_bridge_proxy_address: bridge_test_cluster.sui_bridge_address(),
                 eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
                 eth_contracts_start_block_fallback: None,
                 eth_contracts_start_block_override: None,
@@ -346,21 +344,20 @@ mod tests {
             db_path: None,
         };
         // Spawn bridge node in memory
-        tokio::spawn(async move {
-            run_bridge_node(config).await.unwrap();
-        });
+        let _handle = run_bridge_node(config).await.unwrap();
 
         let server_url = format!("http://127.0.0.1:{}", server_listen_port);
         // Now we expect to see the server to be up and running.
         let res = wait_for_server_to_be_up(server_url, 5).await;
-        child.kill().unwrap();
         res.unwrap();
     }
 
     #[tokio::test]
     async fn test_starting_bridge_node_with_client() {
         telemetry_subscribers::init_for_testing();
-        let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
+        // let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
+        let bridge_test_cluster = setup().await;
+        let kp = bridge_test_cluster.bridge_authority_key(0);
 
         // prepare node config (server + client)
         let tmp_dir = tempdir().unwrap().into_path();
@@ -368,13 +365,13 @@ mod tests {
         let authority_key_path = "test_starting_bridge_node_with_client_bridge_authority_key";
         let server_listen_port = get_available_port("127.0.0.1");
 
-        let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
         let base64_encoded = kp.encode_base64();
         std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
 
         let client_sui_address = SuiAddress::from(kp.public());
         // send some gas to this address
-        test_cluster
+        bridge_test_cluster
+            .test_cluster
             .transfer_sui_must_exceed(client_sui_address, 1000000000)
             .await;
 
@@ -383,7 +380,7 @@ mod tests {
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
             sui: SuiConfig {
-                sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+                sui_rpc_url: bridge_test_cluster.sui_rpc_url(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
                 bridge_client_key_path_base64_sui_key: None,
                 bridge_client_gas_object: None,
@@ -393,8 +390,8 @@ mod tests {
                 }),
             },
             eth: EthConfig {
-                eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
-                eth_bridge_proxy_address: format!("{:#x}", bridge_contract_address),
+                eth_rpc_url: bridge_test_cluster.eth_rpc_url(),
+                eth_bridge_proxy_address: bridge_test_cluster.sui_bridge_address(),
                 eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
                 eth_contracts_start_block_fallback: Some(0),
                 eth_contracts_start_block_override: None,
@@ -404,24 +401,21 @@ mod tests {
             db_path: Some(db_path),
         };
         // Spawn bridge node in memory
-        let config_clone = config.clone();
-        tokio::spawn(async move {
-            run_bridge_node(config_clone).await.unwrap();
-        });
+        let _handle = run_bridge_node(config).await.unwrap();
 
         let server_url = format!("http://127.0.0.1:{}", server_listen_port);
         // Now we expect to see the server to be up and running.
         // client components are spawned earlier than server, so as long as the server is up,
         // we know the client components are already running.
         let res = wait_for_server_to_be_up(server_url, 5).await;
-        child.kill().unwrap();
         res.unwrap();
     }
 
     #[tokio::test]
     async fn test_starting_bridge_node_with_client_and_separate_client_key() {
         telemetry_subscribers::init_for_testing();
-        let (test_cluster, anvil_port, mut child, bridge_contract_address) = setup().await;
+        let bridge_test_cluster = setup().await;
+        let kp = bridge_test_cluster.bridge_authority_key(0);
 
         // prepare node config (server + client)
         let tmp_dir = tempdir().unwrap().into_path();
@@ -432,7 +426,6 @@ mod tests {
         let server_listen_port = get_available_port("127.0.0.1");
 
         // prepare bridge authority key
-        let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
         let base64_encoded = kp.encode_base64();
         std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
 
@@ -445,7 +438,8 @@ mod tests {
         let client_sui_address = SuiAddress::from(&kp.public());
 
         // send some gas to this address
-        let gas_obj = test_cluster
+        let gas_obj = bridge_test_cluster
+            .test_cluster
             .transfer_sui_must_exceed(client_sui_address, 1000000000)
             .await;
 
@@ -454,7 +448,7 @@ mod tests {
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
             sui: SuiConfig {
-                sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+                sui_rpc_url: bridge_test_cluster.sui_rpc_url(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
                 bridge_client_key_path_base64_sui_key: Some(tmp_dir.join(client_key_path)),
                 bridge_client_gas_object: Some(gas_obj),
@@ -464,8 +458,8 @@ mod tests {
                 }),
             },
             eth: EthConfig {
-                eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
-                eth_bridge_proxy_address: format!("{:#x}", bridge_contract_address),
+                eth_rpc_url: bridge_test_cluster.eth_rpc_url(),
+                eth_bridge_proxy_address: bridge_test_cluster.sui_bridge_address(),
                 eth_bridge_chain_id: BridgeChainId::EthCustom as u8,
                 eth_contracts_start_block_fallback: Some(0),
                 eth_contracts_start_block_override: Some(0),
@@ -475,66 +469,21 @@ mod tests {
             db_path: Some(db_path),
         };
         // Spawn bridge node in memory
-        let config_clone = config.clone();
-        tokio::spawn(async move {
-            run_bridge_node(config_clone).await.unwrap();
-        });
+        let _handle = run_bridge_node(config).await.unwrap();
 
         let server_url = format!("http://127.0.0.1:{}", server_listen_port);
         // Now we expect to see the server to be up and running.
         // client components are spawned earlier than server, so as long as the server is up,
         // we know the client components are already running.
         let res = wait_for_server_to_be_up(server_url, 5).await;
-        child.kill().unwrap();
         res.unwrap();
     }
 
-    async fn setup() -> (test_cluster::TestCluster, u16, Child, EthAddress) {
-        // Start eth node with anvil
-        let anvil_port = get_available_port("127.0.0.1");
-        let eth_node_process = std::process::Command::new("anvil")
-            .arg("--port")
-            .arg(anvil_port.to_string())
-            .spawn()
-            .expect("Failed to start anvil");
-
-        let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
-            .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
-            .build_with_bridge(true)
-            .await;
-
-        test_cluster
-            .trigger_reconfiguration_if_not_yet_and_assert_bridge_committee_initialized()
-            .await;
-
-        let (tx_ack, rx_ack) = tokio::sync::oneshot::channel();
-        let bridge_authority_keys = test_cluster
-            .bridge_authority_keys
-            .as_ref()
-            .unwrap()
-            .iter()
-            .map(|k| k.copy())
-            .collect::<Vec<_>>();
-        let anvil_url = format!("http://127.0.0.1:{}", anvil_port);
-        let (eth_signer_0, eth_private_key_hex_0) = get_eth_signer_client_e2e_test_only(&anvil_url)
+    async fn setup() -> BridgeTestCluster {
+        BridgeTestClusterBuilder::new()
+            .with_eth_env(true)
+            .with_bridge_cluster(false)
+            .build()
             .await
-            .unwrap();
-        tokio::task::spawn(async move {
-            deploy_sol_contract(
-                &anvil_url,
-                eth_signer_0,
-                bridge_authority_keys,
-                tx_ack,
-                eth_private_key_hex_0,
-            )
-            .await
-        });
-        let address = rx_ack.await.unwrap();
-        (
-            test_cluster,
-            anvil_port,
-            eth_node_process,
-            address.sui_bridge,
-        )
     }
 }

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::inconsistent_digit_grouping)]
-
 use crate::{
     crypto::BridgeAuthorityPublicKeyBytes,
     error::BridgeError,
@@ -54,11 +53,15 @@ pub const ADD_TOKENS_ON_SUI_PATH: &str =
 pub const ADD_TOKENS_ON_EVM_PATH: &str =
     "/sign/add_tokens_on_evm/:chain_id/:nonce/:native/:token_ids/:token_addresses/:token_sui_decimals/:token_prices";
 
-pub async fn run_server(socket_address: &SocketAddr, handler: BridgeRequestHandler) {
-    axum::Server::bind(socket_address)
-        .serve(make_router(Arc::new(handler)).into_make_service())
-        .await
-        .unwrap();
+pub fn run_server(
+    socket_address: &SocketAddr,
+    handler: BridgeRequestHandler,
+) -> tokio::task::JoinHandle<()> {
+    let service = axum::Server::bind(socket_address)
+        .serve(make_router(Arc::new(handler)).into_make_service());
+    tokio::spawn(async move {
+        service.await.unwrap();
+    })
 }
 
 pub(crate) fn make_router(

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -604,6 +604,7 @@ impl SuiClientInner for SuiSdkClient {
 
 #[cfg(test)]
 mod tests {
+    use crate::crypto::BridgeAuthorityKeyPair;
     use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
     use crate::{
         events::{EmittedSuiToEthTokenBridgeV1, MoveTokenBridgeEvent},
@@ -753,9 +754,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_action_onchain_status_for_sui_to_eth_transfer() {
         telemetry_subscribers::init_for_testing();
+        let mut bridge_keys = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp);
+        }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
-            .build_with_bridge(true)
+            .build_with_bridge(bridge_keys, true)
             .await;
 
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -584,6 +584,7 @@ pub fn build_committee_register_transaction(
 
 #[cfg(test)]
 mod tests {
+    use crate::crypto::BridgeAuthorityKeyPair;
     use crate::sui_client::SuiClient;
     use crate::types::BridgeAction;
     use crate::types::EmergencyAction;
@@ -600,15 +601,21 @@ mod tests {
     use ethers::types::Address as EthAddress;
     use std::collections::HashMap;
     use sui_types::bridge::{BridgeChainId, TOKEN_ID_BTC, TOKEN_ID_USDC};
+    use sui_types::crypto::get_key_pair;
     use sui_types::crypto::ToFromBytes;
     use test_cluster::TestClusterBuilder;
 
     #[tokio::test]
     async fn test_build_sui_transaction_for_token_transfer() {
         telemetry_subscribers::init_for_testing();
+        let mut bridge_keys = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp);
+        }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
-            .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
-            .build_with_bridge(true)
+            .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
+            .build_with_bridge(bridge_keys, true)
             .await;
 
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
@@ -677,9 +684,14 @@ mod tests {
     #[tokio::test]
     async fn test_build_sui_transaction_for_emergency_op() {
         telemetry_subscribers::init_for_testing();
+        let mut bridge_keys = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp);
+        }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
-            .build_with_bridge(true)
+            .build_with_bridge(bridge_keys, true)
             .await;
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
@@ -741,9 +753,14 @@ mod tests {
     #[tokio::test]
     async fn test_build_sui_transaction_for_committee_blocklist() {
         telemetry_subscribers::init_for_testing();
+        let mut bridge_keys = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp);
+        }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
-            .build_with_bridge(true)
+            .build_with_bridge(bridge_keys, true)
             .await;
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
@@ -824,9 +841,14 @@ mod tests {
     #[tokio::test]
     async fn test_build_sui_transaction_for_limit_update() {
         telemetry_subscribers::init_for_testing();
+        let mut bridge_keys = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp);
+        }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
-            .build_with_bridge(true)
+            .build_with_bridge(bridge_keys, true)
             .await;
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
@@ -888,9 +910,14 @@ mod tests {
     #[tokio::test]
     async fn test_build_sui_transaction_for_price_update() {
         telemetry_subscribers::init_for_testing();
+        let mut bridge_keys = vec![];
+        for _ in 0..=3 {
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            bridge_keys.push(kp);
+        }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
-            .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
-            .build_with_bridge(true)
+            .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
+            .build_with_bridge(bridge_keys, true)
             .await;
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await

--- a/crates/sui-e2e-tests/tests/bridge_tests.rs
+++ b/crates/sui-e2e-tests/tests/bridge_tests.rs
@@ -1,11 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use sui_bridge::crypto::BridgeAuthorityKeyPair;
 use sui_bridge::BRIDGE_ENABLE_PROTOCOL_VERSION;
 use sui_json_rpc_api::BridgeReadApiClient;
 use sui_macros::sim_test;
 use sui_types::bridge::get_bridge;
 use sui_types::bridge::BridgeTrait;
+use sui_types::crypto::get_key_pair;
 use sui_types::SUI_BRIDGE_OBJECT_ID;
 use test_cluster::TestClusterBuilder;
 
@@ -53,9 +55,14 @@ async fn test_create_bridge_state_object() {
 #[tokio::test]
 async fn test_committee_registration() {
     telemetry_subscribers::init_for_testing();
+    let mut bridge_keys = vec![];
+    for _ in 0..=3 {
+        let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+        bridge_keys.push(kp);
+    }
     let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
-        .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
-        .build_with_bridge(false)
+        .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
+        .build_with_bridge(bridge_keys, false)
         .await;
 
     let bridge = get_bridge(


### PR DESCRIPTION
## Description 

This PR:
1. refactors e2e test utils by introducing `BridgeTestClusterBuilder` and `BridgeTestCluster`
2. enables the ability to drop spawned BridgeNodes, and restart them (not in this PR, but this PR makes it easy to do)
3. speeds up the setup by doing things in parallel. This probably cuts at least 20 seconds for each test.

## Test plan 

existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
