### PR TITLE
[suiop] integration test for `suiop service init`

### DIFF
--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -5,7 +5,7 @@ mod iam;
 mod incidents;
 mod lib;
 pub mod pulumi;
-mod service;
+pub mod service;
 
 pub use iam::{iam_cmd, IAMArgs};
 pub use incidents::{incidents_cmd, IncidentsArgs};

--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -69,14 +69,17 @@ fn add_to_sui_dockerfile(path: &Path) -> Result<()> {
 fn add_member_to_workspace(path: &Path) -> Result<()> {
     // test
     let path = path.canonicalize().context("canonicalizing service path")?;
-    let crates_dir = path.parent().unwrap();
+    let crates_dir = path.parent().context("getting path parent").unwrap();
     if !crates_dir.ends_with("sui/crates") {
         panic!("directory wasn't in the sui repo");
     }
     let workspace_toml_path = &crates_dir.join("../Cargo.toml");
     // read the workspace toml
-    let toml_content = fs::read_to_string(workspace_toml_path)?;
-    let mut toml = toml_content.parse::<toml_edit::Document>()?;
+    let toml_content =
+        fs::read_to_string(workspace_toml_path).context("reading workspace cargo file")?;
+    let mut toml = toml_content
+        .parse::<toml_edit::Document>()
+        .context("parsing workspace cargo file")?;
     toml["workspace"]["members"]
         .as_array_mut()
         .unwrap()
@@ -98,7 +101,7 @@ fn add_member_to_workspace(path: &Path) -> Result<()> {
 fn create_rust_service(path: &Path) -> Result<()> {
     info!("creating rust service in {}", path.to_string_lossy());
     // create the dir to ensure we can canonicalize any relative paths
-    create_dir_all(path)?;
+    create_dir_all(path).context("creating rust service dirs")?;
     let is_sui_service = path
         // expand relative paths and symlinks
         .canonicalize()
@@ -111,26 +114,47 @@ fn create_rust_service(path: &Path) -> Result<()> {
     } else {
         "Cargo-ext.toml"
     };
-    let cargo_toml = PROJECT_DIR.get_file(cargo_toml_path).unwrap();
-    let main_rs = PROJECT_DIR.get_file("src/main.rs").unwrap();
+    let cargo_toml = PROJECT_DIR
+        .get_file(cargo_toml_path)
+        .context("getting cargo toml file from boilerplate")
+        .unwrap();
+    let main_rs = PROJECT_DIR
+        .get_file("src/main.rs")
+        .context("getting main.rs file from boilerplate")
+        .unwrap();
     let main_body = main_rs.contents();
-    let cargo_body = std::str::from_utf8(cargo_toml.contents())?;
-    let mut toml_content = cargo_body.parse::<toml_edit::Document>()?;
-    toml_content["package"]["name"] = toml_edit::value(path.file_name().unwrap().to_str().unwrap());
-    create_dir_all(path.join("src"))?;
-    let mut main_file = File::create(path.join("src/main.rs"))?;
-    main_file.write_all(main_body)?;
-    let mut cargo_file = File::create(path.join("Cargo.toml"))?;
-    cargo_file.write_all(toml_content.to_string().as_bytes())?;
+    let cargo_body =
+        std::str::from_utf8(cargo_toml.contents()).context("decoding cargo toml body")?;
+    let mut toml_content = cargo_body
+        .parse::<toml_edit::Document>()
+        .context("parsing cargo toml file")?;
+    toml_content["package"]["name"] = toml_edit::value(
+        path.file_name()
+            .context("peeling tail off of path")
+            .unwrap()
+            .to_str()
+            .context("decoding dir to str")
+            .unwrap(),
+    );
+    create_dir_all(path.join("src")).context("creating src dir")?;
+    let mut main_file = File::create(path.join("src/main.rs")).context("creating main.rs file")?;
+    main_file
+        .write_all(main_body)
+        .context("writing main.rs file")?;
+    let mut cargo_file =
+        File::create(path.join("Cargo.toml")).context("creating cargo toml file")?;
+    cargo_file
+        .write_all(toml_content.to_string().as_bytes())
+        .context("writing cargo toml file")?;
 
     // add the project as a member of the cargo workspace
     if is_sui_service {
-        add_member_to_workspace(path)?;
+        add_member_to_workspace(path).context("adding crate to sui workspace")?;
     }
     // now that the source directory works, let's update/add a dockerfile
     if is_sui_service {
         // update sui-services dockerfile
-        add_to_sui_dockerfile(path)?;
+        add_to_sui_dockerfile(path).context("adding crate to sui services dockerfile")?;
     } else {
         // TODO: create a new dockerfile where the user designates
     }

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod init;
+pub mod init;
 
 use anyhow::Result;
 use clap::Parser;

--- a/crates/suiop-cli/tests/integration_tests.rs
+++ b/crates/suiop-cli/tests/integration_tests.rs
@@ -1,11 +1,13 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::process::Command;
 use suioplib::cli::service::init;
+use tracing::debug;
 
 #[cfg(test)]
 #[test]
-fn test_initialize_service() -> Result<()> {
+fn test_initialize_service_ext() -> Result<()> {
     // create a temp dir to work in
+
     let temp_dir = tempfile::tempdir().expect("creating temp dir");
     let svc_dir = temp_dir.path().join("svc");
     std::fs::create_dir(&svc_dir)?;
@@ -21,7 +23,54 @@ fn test_initialize_service() -> Result<()> {
         .current_dir(svc_dir)
         .output()?;
 
-    println!("cargo build output: {:?}", output);
+    debug!("cargo build output: {:?}", output);
     assert!(output.status.success());
+    Ok(())
+}
+
+#[cfg(test)]
+#[test]
+fn test_initialize_service_sui() -> Result<()> {
+    // create a temp dir to work in
+    let temp_dir = tempfile::tempdir().expect("creating temp dir");
+    let svc_dir = temp_dir.path().join("sui/crates/svc/");
+    std::fs::create_dir_all(&svc_dir).context("creating nested dir")?;
+    debug!("svc_dir: {:?}", svc_dir);
+    // Create a dummy Cargo.toml file at the tempdir/sui level
+    let workspace_toml_path = temp_dir.path().join("sui/Cargo.toml");
+    std::fs::write(
+        &workspace_toml_path,
+        r#"
+[workspace]
+members = []
+  "#,
+    )?;
+    // Create a dummy Dockerfile at the tempdir/sui/docker/sui-services level
+    let sui_services_dockerfile_path = temp_dir.path().join("sui/docker/sui-services/Dockerfile");
+    std::fs::create_dir_all(sui_services_dockerfile_path.parent().unwrap())?;
+    std::fs::write(
+        &sui_services_dockerfile_path,
+        r#"RUN cargo build --release \"#,
+    )?;
+
+    // Run the command to initialize a new service
+    init::bootstrap_service(&init::ServiceLanguage::Rust, &svc_dir).context("bootstrapping")?;
+
+    // Since we can't run `cargo build` in the new directory as it's not
+    // actually in the Sui repo, we'll check that the Cargo.toml file was
+    // created and make sure it got the right contents.
+    assert!(svc_dir.join("Cargo.toml").exists());
+    // Output Cargo.toml contents
+    let toml_content = std::fs::read_to_string(&svc_dir.join("Cargo.toml"))?;
+    // Boilerplate Cargo.toml contents
+    let cargo_sui_toml_content =
+        std::fs::read_to_string("../mysten-service-boilerplate/Cargo-sui.toml")
+            .context("reading cargo toml from boilerplate")?;
+
+    assert_eq!(
+        toml_content,
+        // replace the service name, everything else should be the same
+        cargo_sui_toml_content.replace("service-boilerplate", "svc")
+    );
     Ok(())
 }

--- a/crates/suiop-cli/tests/integration_tests.rs
+++ b/crates/suiop-cli/tests/integration_tests.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use std::process::Command;
+use suioplib::cli::service::init;
+
+#[cfg(test)]
+#[test]
+fn test_initialize_service() -> Result<()> {
+    // create a temp dir to work in
+    let temp_dir = tempfile::tempdir().expect("creating temp dir");
+    let svc_dir = temp_dir.path().join("svc");
+    std::fs::create_dir(&svc_dir)?;
+
+    // Run the command to initialize a new service
+    init::bootstrap_service(&init::ServiceLanguage::Rust, &svc_dir)?;
+    // Check that the Cargo.toml file was created
+    assert!(svc_dir.join("Cargo.toml").exists());
+
+    // Check that we can run `cargo build` in the new directory
+    let output = Command::new("cargo")
+        .arg("build")
+        .current_dir(svc_dir)
+        .output()?;
+
+    println!("cargo build output: {:?}", output);
+    assert!(output.status.success());
+    Ok(())
+}

--- a/crates/suiop-cli/tests/integration_tests.rs
+++ b/crates/suiop-cli/tests/integration_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use std::process::Command;
 use suioplib::cli::service::init;
@@ -39,7 +42,7 @@ fn test_initialize_service_sui() -> Result<()> {
     // Create a dummy Cargo.toml file at the tempdir/sui level
     let workspace_toml_path = temp_dir.path().join("sui/Cargo.toml");
     std::fs::write(
-        &workspace_toml_path,
+        workspace_toml_path,
         r#"
 [workspace]
 members = []
@@ -61,7 +64,7 @@ members = []
     // created and make sure it got the right contents.
     assert!(svc_dir.join("Cargo.toml").exists());
     // Output Cargo.toml contents
-    let toml_content = std::fs::read_to_string(&svc_dir.join("Cargo.toml"))?;
+    let toml_content = std::fs::read_to_string(svc_dir.join("Cargo.toml"))?;
     // Boilerplate Cargo.toml contents
     let cargo_sui_toml_content =
         std::fs::read_to_string("../mysten-service-boilerplate/Cargo-sui.toml")


### PR DESCRIPTION
## Description 

Add a couple of simple integration tests to verify that we can initialize a new service based on the boilerplate code in the sui repo and externally.

## Test plan 

```
» cargo test
   Compiling suiop-cli v0.1.9 (/Users/jkjensen/mysten/sui/crates/suiop-cli)
    Finished test [unoptimized + debuginfo] target(s) in 2.04s
     Running unittests src/lib.rs (/Users/jkjensen/mysten/sui/target/debug/deps/suioplib-b060133edb7a006f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (/Users/jkjensen/mysten/sui/target/debug/deps/suiop-3e180845c83f7297)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_tests.rs (/Users/jkjensen/mysten/sui/target/debug/deps/integration_tests-06d2990820385322)

running 2 tests
test test_initialize_service_sui ... ok
test test_initialize_service_ext ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.39s

   Doc-tests suioplib

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
