### PR TITLE
[pick][GraphQL] Checkpoint Viewed At parameter is always mandatory (#17254)

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -445,8 +445,63 @@ Response: {
                   {
                     "contents": {
                       "json": {
+                        "id": "0x322b8b6b593ee9f7ba1b890fd85bfcdf3220ba355913b2f0854f53cf3b9f981f",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x36b4654e492fb00735d906a31a8d27d0b223af670e2da19faae21b3444adda17",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x4eca0e28307fdf845a1bfbcd88c1b3a2dfa62ba390d60e449d692ec93a0b5626",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x53bd999452be09411b450ca0f42907050e1aaa503e13292ed0bf6c1b0d61aca3",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
                         "id": "0xb6a8280e5340090cb899765ff8e42d98839073f25b34b1cdda6ec283f9b6d8fb",
-                        "value": "0"
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xf95fb6baff9cc4e9bd40878b04d9898ec0bcbbe0dd0022908b2b4c20ee180b6b",
+                        "value": "6"
                       },
                       "type": {
                         "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
@@ -579,8 +634,41 @@ Response: {
                   {
                     "contents": {
                       "json": {
+                        "id": "0x4eca0e28307fdf845a1bfbcd88c1b3a2dfa62ba390d60e449d692ec93a0b5626",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x53bd999452be09411b450ca0f42907050e1aaa503e13292ed0bf6c1b0d61aca3",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
                         "id": "0xb6a8280e5340090cb899765ff8e42d98839073f25b34b1cdda6ec283f9b6d8fb",
-                        "value": "100"
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xf95fb6baff9cc4e9bd40878b04d9898ec0bcbbe0dd0022908b2b4c20ee180b6b",
+                        "value": "6"
                       },
                       "type": {
                         "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
@@ -1196,7 +1284,78 @@ Response: {
             }
           },
           "gasInput": {
-            "gasSponsor": null
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x322b8b6b593ee9f7ba1b890fd85bfcdf3220ba355913b2f0854f53cf3b9f981f",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x36b4654e492fb00735d906a31a8d27d0b223af670e2da19faae21b3444adda17",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x4eca0e28307fdf845a1bfbcd88c1b3a2dfa62ba390d60e449d692ec93a0b5626",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x53bd999452be09411b450ca0f42907050e1aaa503e13292ed0bf6c1b0d61aca3",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb6a8280e5340090cb899765ff8e42d98839073f25b34b1cdda6ec283f9b6d8fb",
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xf95fb6baff9cc4e9bd40878b04d9898ec0bcbbe0dd0022908b2b4c20ee180b6b",
+                        "value": "6"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
           }
         },
         {
@@ -1301,8 +1460,41 @@ Response: {
                   {
                     "contents": {
                       "json": {
+                        "id": "0x4eca0e28307fdf845a1bfbcd88c1b3a2dfa62ba390d60e449d692ec93a0b5626",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x53bd999452be09411b450ca0f42907050e1aaa503e13292ed0bf6c1b0d61aca3",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
                         "id": "0xb6a8280e5340090cb899765ff8e42d98839073f25b34b1cdda6ec283f9b6d8fb",
-                        "value": "100"
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xf95fb6baff9cc4e9bd40878b04d9898ec0bcbbe0dd0022908b2b4c20ee180b6b",
+                        "value": "6"
                       },
                       "type": {
                         "repr": "0x45b4ff6622b6d8d769b29f6667ad76e91cc74eabba61631e3b802a2607354457::M1::Object"
@@ -1464,27 +1656,5 @@ Response: {
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 21,
-          "column": 11
-        }
-      ],
-      "path": [
-        "all_transactions",
-        "nodes",
-        0,
-        "gasInput",
-        "gasSponsor",
-        "objects"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -5,9 +5,8 @@ use async_graphql::connection::CursorType;
 use serde::{Deserialize, Serialize};
 use sui_indexer::models_v2::objects::StoredHistoryObject;
 
-use crate::data::Conn;
 use crate::raw_query::RawQuery;
-use crate::types::checkpoint::Checkpoint;
+use crate::types::available_range::AvailableRange;
 use crate::types::cursor::{JsonCursor, Page};
 use crate::types::object::Cursor;
 use crate::{filter, query};
@@ -61,10 +60,10 @@ impl Checkpointed for JsonCursor<ConsistentNamedCursor> {
 }
 
 /// Constructs a `RawQuery` against the `objects_snapshot` and `objects_history` table to fetch
-/// objects that satisfy some filtering criteria `filter_fn` within the provided checkpoint range
-/// `lhs` and `rhs`. The `objects_snapshot` table contains the latest versions of objects up to a
-/// checkpoint sequence number, and `objects_history` captures changes after that, so a query to
-/// both tables is necessary to handle these object states:
+/// objects that satisfy some filtering criteria `filter_fn` within the provided checkpoint `range`.
+/// The `objects_snapshot` table contains the latest versions of objects up to a checkpoint sequence
+/// number, and `objects_history` captures changes after that, so a query to both tables is
+/// necessary to handle these object states:
 /// 1) In snapshot, not in history - occurs when an object gets snapshotted and then has not been
 ///    modified since
 /// 2) In history, not in snapshot - occurs when a new object is created
@@ -96,8 +95,7 @@ impl Checkpointed for JsonCursor<ConsistentNamedCursor> {
 /// creation.
 pub(crate) fn build_objects_query(
     view: View,
-    lhs: i64,
-    rhs: i64,
+    range: AvailableRange,
     page: &Page<Cursor>,
     filter_fn: impl Fn(RawQuery) -> RawQuery,
     newer_criteria: impl Fn(RawQuery) -> RawQuery,
@@ -105,7 +103,10 @@ pub(crate) fn build_objects_query(
     // Subquery to be used in `LEFT JOIN` against the inner queries for more recent object versions
     let newer = newer_criteria(filter!(
         query!("SELECT object_id, object_version FROM objects_history"),
-        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+        format!(
+            r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
+            range.first, range.last
+        )
     ));
 
     let mut snapshot_objs_inner = query!("SELECT * FROM objects_snapshot");
@@ -147,7 +148,10 @@ pub(crate) fn build_objects_query(
             // Additionally bound the inner `objects_history` query by the checkpoint range
             history_objs_inner = filter!(
                 history_objs_inner,
-                format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+                format!(
+                    r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
+                    range.first, range.last
+                )
             );
 
             let mut history_objs = query!(
@@ -186,25 +190,4 @@ pub(crate) fn build_objects_query(
     .order_by("object_version DESC");
 
     query!("SELECT * FROM ({}) candidates", query)
-}
-
-/// Given a `checkpoint_viewed_at` representing the checkpoint sequence number when the query was
-/// made, check whether the value falls under the current available range of the database. Returns
-/// `None` if the `checkpoint_viewed_at` lies outside the range, otherwise return a tuple consisting
-/// of the available range's lower bound and the `checkpoint_viewed_at`, or the upper bound of the
-/// database if `checkpoint_viewed_at` is `None`.
-pub(crate) fn consistent_range(
-    conn: &mut Conn,
-    checkpoint_viewed_at: Option<u64>,
-) -> Result<Option<(u64, u64)>, diesel::result::Error> {
-    let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-    if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-        if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-            return Ok(None);
-        }
-        rhs = checkpoint_viewed_at;
-    }
-
-    Ok(Some((lhs, rhs)))
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -147,7 +147,7 @@ pub(crate) fn convert_to_validators(
                     .cloned()
                     .map(|a| Address {
                         address: SuiAddress::from(a),
-                        checkpoint_viewed_at: Some(checkpoint_viewed_at),
+                        checkpoint_viewed_at,
                     })
                     .collect()
             });

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -19,9 +19,8 @@ use async_graphql::{connection::Connection, *};
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub(crate) struct Address {
     pub address: SuiAddress,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number at which this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// The possible relationship types for a transaction block: sign, sent, received, or paid.

--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -1,8 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::data::{Conn, Db, DbConnection, QueryExecutor};
+use crate::error::Error;
+
 use super::checkpoint::{Checkpoint, CheckpointId};
 use async_graphql::*;
+use diesel::{CombineDsl, ExpressionMethods, QueryDsl, QueryResult};
+use sui_indexer::schema_v2::{checkpoints, objects_snapshot};
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub(crate) struct AvailableRange {
@@ -10,19 +15,78 @@ pub(crate) struct AvailableRange {
     pub last: u64,
 }
 
-// TODO: do both in one query?
 /// Range of checkpoints that the RPC is guaranteed to produce a consistent response for.
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.first), Some(self.last))
+        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.first), self.last)
             .await
             .extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.last), Some(self.last))
+        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.last), self.last)
             .await
             .extend()
+    }
+}
+
+impl AvailableRange {
+    /// Look up the available range when viewing the data consistently at `checkpoint_viewed_at`.
+    pub(crate) async fn query(db: &Db, checkpoint_viewed_at: u64) -> Result<Self, Error> {
+        let Some(range): Option<Self> = db
+            .execute(move |conn| Self::result(conn, checkpoint_viewed_at))
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch available range: {e}")))?
+        else {
+            return Err(Error::Client(format!(
+                "Requesting data at checkpoint {checkpoint_viewed_at}, outside the available \
+                 range.",
+            )));
+        };
+
+        Ok(range)
+    }
+
+    /// Look up the available range when viewing the data consistently at `checkpoint_viewed_at`.
+    /// Made available on the `Conn` type to make it easier to call as part of other queries.
+    ///
+    /// Returns an error if there was an issue querying the database, Ok(None) if the checkpoint
+    /// being viewed is not in the database's available range, or Ok(Some(AvailableRange))
+    /// otherwise.
+    pub(crate) fn result(conn: &mut Conn, checkpoint_viewed_at: u64) -> QueryResult<Option<Self>> {
+        use checkpoints::dsl as checkpoints;
+        use objects_snapshot::dsl as snapshots;
+
+        let checkpoint_range: Vec<i64> = conn.results(move || {
+            let rhs = checkpoints::checkpoints
+                .select(checkpoints::sequence_number)
+                .order(checkpoints::sequence_number.desc())
+                .limit(1);
+
+            let lhs = snapshots::objects_snapshot
+                .select(snapshots::checkpoint_sequence_number)
+                .order(snapshots::checkpoint_sequence_number.desc())
+                .limit(1);
+
+            lhs.union(rhs)
+        })?;
+
+        let (first, mut last) = match checkpoint_range.as_slice() {
+            [] => (0, 0),
+            [single_value] => (0, *single_value as u64),
+            values => {
+                let min_value = *values.iter().min().unwrap();
+                let max_value = *values.iter().max().unwrap();
+                (min_value as u64, max_value as u64)
+            }
+        };
+
+        if checkpoint_viewed_at < first || last < checkpoint_viewed_at {
+            return Ok(None);
+        }
+
+        last = checkpoint_viewed_at;
+        Ok(Some(Self { first, last }))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -24,7 +24,7 @@ impl BalanceChange {
         match self.stored.owner {
             O::AddressOwner(addr) | O::ObjectOwner(addr) => Some(Owner {
                 address: SuiAddress::from(addr),
-                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+                checkpoint_viewed_at: self.checkpoint_viewed_at,
             }),
 
             O::Shared { .. } | O::Immutable => None,
@@ -44,9 +44,8 @@ impl BalanceChange {
 
 impl BalanceChange {
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this
-    /// `BalanceChange` was queried for, or `None` if the data was requested at the latest
-    /// checkpoint. This is stored on `BalanceChange` so that when viewing that entity's state, it
-    /// will be as if it was read at the same checkpoint.
+    /// `BalanceChange` was queried for. This is stored on `BalanceChange` so that when viewing that
+    /// entity's state, it will be as if it was read at the same checkpoint.
     pub(crate) fn read(bytes: &[u8], checkpoint_viewed_at: u64) -> Result<Self, Error> {
         let stored = bcs::from_bytes(bytes)
             .map_err(|e| Error::Internal(format!("Error deserializing BalanceChange: {e}")))?;

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -22,13 +22,10 @@ use async_graphql::{
     dataloader::{DataLoader, Loader},
     *,
 };
-use diesel::{CombineDsl, ExpressionMethods, OptionalExtension, QueryDsl};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use serde::{Deserialize, Serialize};
-use sui_indexer::{
-    models_v2::checkpoints::StoredCheckpoint,
-    schema_v2::{checkpoints, objects_snapshot},
-};
+use sui_indexer::{models_v2::checkpoints::StoredCheckpoint, schema_v2::checkpoints};
 use sui_types::messages_checkpoint::CheckpointDigest;
 
 /// Filter either by the digest, or the sequence number, or neither, to get the latest checkpoint.
@@ -46,7 +43,7 @@ struct SeqNumKey {
     /// The digest is not used for fetching, but is used as an additional filter, to correctly
     /// implement a request that sets both a sequence number and a digest.
     pub digest: Option<Digest>,
-    pub checkpoint_viewed_at: Option<u64>,
+    pub checkpoint_viewed_at: u64,
 }
 
 /// DataLoader key for fetching a `Checkpoint` by its digest, optionally constrained by a
@@ -54,7 +51,7 @@ struct SeqNumKey {
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 struct DigestKey {
     pub digest: Digest,
-    pub checkpoint_viewed_at: Option<u64>,
+    pub checkpoint_viewed_at: u64,
 }
 
 #[derive(Clone)]
@@ -62,9 +59,8 @@ pub(crate) struct Checkpoint {
     /// Representation of transaction data in the Indexer's Store. The indexer stores the
     /// transaction data and its effects together, in one table.
     pub stored: StoredCheckpoint,
-    // The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
-    // requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint_sequence_number at which this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 pub(crate) type Cursor = cursor::JsonCursor<CheckpointCursor>;
@@ -209,7 +205,7 @@ impl Checkpoint {
     pub(crate) async fn query(
         ctx: &Context<'_>,
         filter: CheckpointId,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         match filter {
             CheckpointId {
@@ -247,35 +243,24 @@ impl Checkpoint {
     /// Look up the latest `Checkpoint` from the database, optionally filtered by a consistency
     /// cursor (querying for a consistency cursor in the past looks for the latest checkpoint as of
     /// that cursor).
-    async fn query_latest_at(
-        db: &Db,
-        checkpoint_viewed_at: Option<u64>,
-    ) -> Result<Option<Self>, Error> {
+    async fn query_latest_at(db: &Db, checkpoint_viewed_at: u64) -> Result<Option<Self>, Error> {
         use checkpoints::dsl;
 
-        let (stored, checkpoint_viewed_at): (Option<StoredCheckpoint>, u64) = db
-            .execute_repeatable(move |conn| {
-                let checkpoint_viewed_at = match checkpoint_viewed_at {
-                    Some(value) => Ok(value),
-                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
-                }?;
-
-                let stored = conn
-                    .first(move || {
-                        dsl::checkpoints
-                            .filter(dsl::sequence_number.le(checkpoint_viewed_at as i64))
-                            .order_by(dsl::sequence_number.desc())
-                    })
-                    .optional()?;
-
-                Ok::<_, diesel::result::Error>((stored, checkpoint_viewed_at))
+        let stored: Option<StoredCheckpoint> = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .filter(dsl::sequence_number.le(checkpoint_viewed_at as i64))
+                        .order_by(dsl::sequence_number.desc())
+                })
+                .optional()
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoint: {e}")))?;
 
         Ok(stored.map(|stored| Checkpoint {
             stored,
-            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            checkpoint_viewed_at,
         }))
     }
 
@@ -296,38 +281,14 @@ impl Checkpoint {
         Ok(stored as u64)
     }
 
-    pub(crate) async fn query_latest_checkpoint_sequence_number(db: &Db) -> Result<u64, Error> {
-        db.execute(move |conn| Checkpoint::latest_checkpoint_sequence_number(conn))
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch checkpoint: {e}")))
-    }
-
-    /// Queries the database for the upper bound of the available range supported by the graphql
-    /// server. This method takes a connection, so that it can be used in an execute_repeatable
-    /// transaction.
-    pub(crate) fn latest_checkpoint_sequence_number(
-        conn: &mut Conn,
-    ) -> Result<u64, diesel::result::Error> {
-        use checkpoints::dsl;
-
-        let result: i64 = conn.first(move || {
-            dsl::checkpoints
-                .select(dsl::sequence_number)
-                .order_by(dsl::sequence_number.desc())
-        })?;
-
-        Ok(result as u64)
-    }
-
     /// Query the database for a `page` of checkpoints. The Page uses the checkpoint sequence number
     /// of the stored checkpoint and the checkpoint at which this was viewed at as the cursor, and
     /// can optionally be further `filter`-ed by an epoch number (to only return checkpoints within
     /// that epoch).
     ///
-    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
-    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
-    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
-    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// The `checkpoint_viewed_at` parameter represents the checkpoint sequence number at which this
+    /// page was queried for. Each entity returned in the connection will inherit this checkpoint,
+    /// so that when viewing that entity's state, it will be from the reference of this
     /// checkpoint_viewed_at parameter.
     ///
     /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
@@ -336,20 +297,15 @@ impl Checkpoint {
         db: &Db,
         page: Page<Cursor>,
         filter: Option<u64>,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Checkpoint>, Error> {
         use checkpoints::dsl;
         let cursor_viewed_at = page.validate_cursor_consistency()?;
-        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let ((prev, next, results), rhs) = db
-            .execute_repeatable(move |conn| {
-                let checkpoint_viewed_at = match checkpoint_viewed_at {
-                    Some(value) => Ok(value),
-                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
-                }?;
-
-                let result = page.paginate_query::<StoredCheckpoint, _, _, _>(
+        let (prev, next, results) = db
+            .execute(move |conn| {
+                page.paginate_query::<StoredCheckpoint, _, _, _>(
                     conn,
                     checkpoint_viewed_at,
                     move || {
@@ -360,59 +316,25 @@ impl Checkpoint {
                         }
                         query
                     },
-                )?;
-
-                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
+                )
             })
             .await?;
 
         // Defer to the provided checkpoint_viewed_at, but if it is not provided, use the
         // current available range. This sets a consistent upper bound for the nested queries.
         let mut conn = Connection::new(prev, next);
-        let checkpoint_viewed_at = checkpoint_viewed_at.unwrap_or(rhs);
         for stored in results {
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             conn.edges.push(Edge::new(
                 cursor,
                 Checkpoint {
                     stored,
-                    checkpoint_viewed_at: Some(checkpoint_viewed_at),
+                    checkpoint_viewed_at,
                 },
             ));
         }
 
         Ok(conn)
-    }
-
-    /// Queries the database for the available range supported by the graphql server. This method
-    /// takes a connection, so that it can be used in an execute_repeatable transaction.
-    pub(crate) fn available_range(conn: &mut Conn) -> Result<(u64, u64), diesel::result::Error> {
-        use checkpoints::dsl as checkpoints;
-        use objects_snapshot::dsl as snapshots;
-
-        let checkpoint_range: Vec<i64> = conn.results(move || {
-            let rhs = checkpoints::checkpoints
-                .select(checkpoints::sequence_number)
-                .order(checkpoints::sequence_number.desc())
-                .limit(1);
-
-            let lhs = snapshots::objects_snapshot
-                .select(snapshots::checkpoint_sequence_number)
-                .order(snapshots::checkpoint_sequence_number.desc())
-                .limit(1);
-
-            lhs.union(rhs)
-        })?;
-
-        Ok(match checkpoint_range.as_slice() {
-            [] => (0, 0),
-            [single_value] => (0, *single_value as u64),
-            values => {
-                let min_value = *values.iter().min().unwrap();
-                let max_value = *values.iter().max().unwrap();
-                (min_value as u64, max_value as u64)
-            }
-        })
     }
 }
 
@@ -463,12 +385,9 @@ impl Loader<SeqNumKey> for Db {
         let checkpoint_ids: BTreeSet<_> = keys
             .iter()
             .filter_map(|key| {
-                if let Some(viewed_at) = key.checkpoint_viewed_at {
-                    // Filter out keys querying for checkpoints after their own consistency cursor.
-                    (viewed_at >= key.sequence_number).then_some(key.sequence_number as i64)
-                } else {
-                    Some(key.sequence_number as i64)
-                }
+                // Filter out keys querying for checkpoints after their own consistency cursor.
+                (key.checkpoint_viewed_at >= key.sequence_number)
+                    .then_some(key.sequence_number as i64)
             })
             .collect();
 
@@ -534,23 +453,23 @@ impl Loader<DigestKey> for Db {
         Ok(keys
             .iter()
             .filter_map(|key| {
-                let stored = checkpoint_id_to_stored
-                    .get(key.digest.as_slice())
-                    .cloned()?;
+                let DigestKey {
+                    digest,
+                    checkpoint_viewed_at,
+                } = *key;
+
+                let stored = checkpoint_id_to_stored.get(digest.as_slice()).cloned()?;
+
                 let checkpoint = Checkpoint {
                     stored,
-                    checkpoint_viewed_at: key.checkpoint_viewed_at,
+                    checkpoint_viewed_at,
                 };
 
                 // Filter by key's checkpoint viewed at here. Doing this in memory because it should
                 // be quite rare that this query actually filters something, but encoding it in SQL
                 // is complicated.
                 let seq_num = checkpoint.stored.sequence_number as u64;
-                if matches!(key.checkpoint_viewed_at, Some(cp) if cp < seq_num) {
-                    None
-                } else {
-                    Some((*key, checkpoint))
-                }
+                (checkpoint_viewed_at >= seq_num).then_some((*key, checkpoint))
             })
             .collect())
     }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::consistency::{build_objects_query, consistent_range, View};
+use crate::consistency::{build_objects_query, View};
 use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
 use crate::filter;
 use crate::raw_query::RawQuery;
 
+use super::available_range::AvailableRange;
 use super::balance::{self, Balance};
 use super::base64::Base64;
 use super::big_int::BigInt;
@@ -298,31 +299,28 @@ impl Coin {
         page: Page<object::Cursor>,
         coin_type: TypeTag,
         owner: Option<SuiAddress>,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Coin>, Error> {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
         let cursor_viewed_at = page.validate_cursor_consistency()?;
-        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let response = db
+        let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
-                let result = page.paginate_raw_query::<StoredHistoryObject>(
+                Ok(Some(page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
-                    rhs,
-                    coins_query(coin_type, owner, lhs as i64, rhs as i64, &page),
-                )?;
-
-                Ok(Some((result, rhs)))
+                    checkpoint_viewed_at,
+                    coins_query(coin_type, owner, range, &page),
+                )?))
             })
-            .await?;
-
-        let Some(((prev, next, results), checkpoint_viewed_at)) = response else {
+            .await?
+        else {
             return Err(Error::Client(
                 "Requested data is outside the available range".to_string(),
             ));
@@ -334,8 +332,7 @@ impl Coin {
             // To maintain consistency, the returned cursor should have the same upper-bound as the
             // checkpoint found on the cursor.
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
-            let object =
-                Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
+            let object = Object::try_from_stored_history_object(stored, checkpoint_viewed_at)?;
 
             let move_ = MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(
@@ -377,14 +374,12 @@ impl TryFrom<&MoveObject> for Coin {
 fn coins_query(
     coin_type: TypeTag,
     owner: Option<SuiAddress>,
-    lhs: i64,
-    rhs: i64,
+    range: AvailableRange,
     page: &Page<object::Cursor>,
 ) -> RawQuery {
     build_objects_query(
         View::Consistent,
-        lhs,
-        rhs,
+        range,
         page,
         move |query| apply_filter(query, &coin_type, owner),
         move |newer| newer,

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -159,6 +159,16 @@ impl<C> Page<C> {
         Ok(page)
     }
 
+    /// A page that just limits the the number of results, without applying any other bounds.
+    pub(crate) fn bounded(limit: u64) -> Self {
+        Page {
+            after: None,
+            before: None,
+            limit,
+            end: End::Front,
+        }
+    }
+
     pub(crate) fn after(&self) -> Option<&C> {
         self.after.as_ref()
     }

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -8,13 +8,14 @@ use sui_indexer::models_v2::objects::StoredHistoryObject;
 use sui_indexer::types_v2::OwnerType;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
+use super::available_range::AvailableRange;
 use super::cursor::{Page, Target};
 use super::object::{self, deserialize_move_struct, Object, ObjectKind, ObjectLookupKey};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
-use crate::consistency::{build_objects_query, consistent_range, View};
+use crate::consistency::{build_objects_query, View};
 use crate::data::package_resolver::PackageResolver;
 use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
@@ -156,7 +157,7 @@ impl DynamicField {
         parent_version: Option<u64>,
         name: DynamicFieldName,
         kind: DynamicFieldType,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<DynamicField>, Error> {
         let type_ = match kind {
             DynamicFieldType::DynamicField => name.type_.0,
@@ -169,10 +170,9 @@ impl DynamicField {
             .map_err(|e| Error::Internal(format!("Failed to derive dynamic field id: {e}")))?;
 
         use ObjectLookupKey as K;
-        let key = match (parent_version, checkpoint_viewed_at) {
-            (None, None) => K::Latest,
-            (None, Some(checkpoint_viewed_at)) => K::LatestAt(checkpoint_viewed_at),
-            (Some(version), checkpoint_viewed_at) => K::LatestAtParentVersion {
+        let key = match parent_version {
+            None => K::LatestAt(checkpoint_viewed_at),
+            Some(version) => K::LatestAtParentVersion {
                 version,
                 checkpoint_viewed_at,
             },
@@ -193,27 +193,25 @@ impl DynamicField {
         page: Page<object::Cursor>,
         parent: SuiAddress,
         parent_version: Option<u64>,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, DynamicField>, Error> {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
         let cursor_viewed_at = page.validate_cursor_consistency()?;
-        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let Some(((prev, next, results), checkpoint_viewed_at)) = db
+        let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
-                let result = page.paginate_raw_query::<StoredHistoryObject>(
+                Ok(Some(page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
-                    rhs,
-                    dynamic_fields_query(parent, parent_version, lhs as i64, rhs as i64, &page),
-                )?;
-
-                Ok(Some((result, rhs)))
+                    checkpoint_viewed_at,
+                    dynamic_fields_query(parent, parent_version, range, &page),
+                )?))
             })
             .await?
         else {
@@ -229,8 +227,7 @@ impl DynamicField {
             // checkpoint found on the cursor.
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
 
-            let object =
-                Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
+            let object = Object::try_from_stored_history_object(stored, checkpoint_viewed_at)?;
 
             let move_ = MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(
@@ -240,7 +237,6 @@ impl DynamicField {
             })?;
 
             let dynamic_field = DynamicField::try_from(move_)?;
-
             conn.edges.push(Edge::new(cursor, dynamic_field));
         }
 
@@ -255,11 +251,6 @@ impl TryFrom<MoveObject> for DynamicField {
         let super_ = &stored.super_;
 
         let (df_object_id, df_kind) = match &super_.kind {
-            ObjectKind::Live(_, stored) => stored
-                .df_object_id
-                .as_ref()
-                .map(|id| (id, stored.df_kind))
-                .ok_or_else(|| Error::Internal("Object is not a dynamic field.".to_string()))?,
             ObjectKind::Historical(_, stored) => stored
                 .df_object_id
                 .as_ref()
@@ -326,14 +317,12 @@ pub fn extract_field_from_move_struct(
 fn dynamic_fields_query(
     parent: SuiAddress,
     parent_version: Option<u64>,
-    lhs: i64,
-    rhs: i64,
+    range: AvailableRange,
     page: &Page<object::Cursor>,
 ) -> RawQuery {
     build_objects_query(
         View::Consistent,
-        lhs,
-        rhs,
+        range,
         page,
         move |query| apply_filter(query, parent, parent_version),
         move |newer| {

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -6,9 +6,10 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use crate::context_data::db_data_provider::{convert_to_validators, PgManager};
 use crate::data::{Db, DbConnection, QueryExecutor};
 use crate::error::Error;
+use crate::server::watermark_task::Watermark;
 
 use super::big_int::BigInt;
-use super::checkpoint::{self, Checkpoint, CheckpointId};
+use super::checkpoint::{self, Checkpoint};
 use super::cursor::Page;
 use super::date_time::DateTime;
 use super::protocol_config::ProtocolConfigs;
@@ -27,7 +28,7 @@ use sui_types::messages_checkpoint::CheckpointCommitment as EpochCommitment;
 #[derive(Clone)]
 pub(crate) struct Epoch {
     pub stored: QueryableEpochInfo,
-    pub checkpoint_viewed_at: Option<u64>,
+    pub checkpoint_viewed_at: u64,
 }
 
 /// DataLoader key for fetching an `Epoch` by its ID, optionally constrained by a consistency
@@ -35,7 +36,7 @@ pub(crate) struct Epoch {
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 struct EpochKey {
     pub epoch_id: u64,
-    pub checkpoint_viewed_at: Option<u64>,
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Operation of the Sui network is temporally partitioned into non-overlapping epochs,
@@ -64,13 +65,11 @@ impl Epoch {
             .fetch_sui_system_state(Some(self.stored.epoch as u64))
             .await?;
 
-        let checkpoint_viewed_at = match self.checkpoint_viewed_at {
-            Some(value) => Ok(value),
-            None => Checkpoint::query_latest_checkpoint_sequence_number(ctx.data_unchecked()).await,
-        }?;
-
-        let active_validators =
-            convert_to_validators(system_state.active_validators, None, checkpoint_viewed_at);
+        let active_validators = convert_to_validators(
+            system_state.active_validators,
+            None,
+            self.checkpoint_viewed_at,
+        );
         let validator_set = ValidatorSet {
             total_stake: Some(BigInt::from(self.stored.total_stake)),
             active_validators: Some(active_validators),
@@ -83,7 +82,7 @@ impl Epoch {
             inactive_pools_size: Some(system_state.inactive_pools_size),
             validator_candidates_id: Some(system_state.validator_candidates_id.into()),
             validator_candidates_size: Some(system_state.validator_candidates_size),
-            checkpoint_viewed_at,
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
         };
         Ok(Some(validator_set))
     }
@@ -105,13 +104,12 @@ impl Epoch {
     async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<BigInt>> {
         let last = match self.stored.last_checkpoint_id {
             Some(last) => last as u64,
-            None => Checkpoint::query(ctx, CheckpointId::default(), None)
-                .await
-                .extend()?
-                .map_or(self.stored.first_checkpoint_id as u64, |c| {
-                    c.sequence_number_impl()
-                }),
+            None => {
+                let Watermark { checkpoint, .. } = *ctx.data_unchecked();
+                checkpoint
+            }
         };
+
         Ok(Some(BigInt::from(
             last - self.stored.first_checkpoint_id as u64,
         )))
@@ -273,7 +271,7 @@ impl Epoch {
     pub(crate) async fn query(
         ctx: &Context<'_>,
         filter: Option<u64>,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         if let Some(epoch_id) = filter {
             let dl: &DataLoader<Db> = ctx.data_unchecked();
@@ -292,43 +290,29 @@ impl Epoch {
     /// cursor).
     pub(crate) async fn query_latest_at(
         db: &Db,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         use epochs::dsl;
 
-        let (stored, checkpoint_viewed_at): (Option<QueryableEpochInfo>, u64) = db
-            .execute_repeatable(move |conn| {
-                let checkpoint_viewed_at = match checkpoint_viewed_at {
-                    Some(value) => Ok(value),
-                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
-                }?;
-
-                let stored = conn
-                    .first(move || {
-                        let mut query = dsl::epochs
-                            .select(QueryableEpochInfo::as_select())
-                            .order_by(dsl::epoch.desc())
-                            .into_boxed();
-
-                        // Bound the query on `checkpoint_viewed_at` by filtering for the epoch
-                        // whose `first_checkpoint_id <= checkpoint_viewed_at`, selecting the epoch
-                        // with the largest `first_checkpoint_id` among the filtered set.
-                        query = query
-                            .filter(dsl::first_checkpoint_id.le(checkpoint_viewed_at as i64))
-                            .order_by(dsl::first_checkpoint_id.desc());
-
-                        query
-                    })
-                    .optional()?;
-
-                Ok::<_, diesel::result::Error>((stored, checkpoint_viewed_at))
+        let stored: Option<QueryableEpochInfo> = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    // Bound the query on `checkpoint_viewed_at` by filtering for the epoch
+                    // whose `first_checkpoint_id <= checkpoint_viewed_at`, selecting the epoch
+                    // with the largest `first_checkpoint_id` among the filtered set.
+                    dsl::epochs
+                        .select(QueryableEpochInfo::as_select())
+                        .filter(dsl::first_checkpoint_id.le(checkpoint_viewed_at as i64))
+                        .order_by(dsl::first_checkpoint_id.desc())
+                })
+                .optional()
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch epoch: {e}")))?;
 
         Ok(stored.map(|stored| Epoch {
             stored,
-            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            checkpoint_viewed_at,
         }))
     }
 }
@@ -372,11 +356,7 @@ impl Loader<EpochKey> for Db {
                 // encode it in the SQL query makes the query much simpler and therefore easier for
                 // the DB to plan.
                 let start = epoch.stored.first_checkpoint_id as u64;
-                if matches!(key.checkpoint_viewed_at, Some(cp) if cp < start) {
-                    None
-                } else {
-                    Some((*key, epoch))
-                }
+                (key.checkpoint_viewed_at >= start).then_some((*key, epoch))
             })
             .collect())
     }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,7 +3,6 @@
 
 use std::str::FromStr;
 
-use super::checkpoint::Checkpoint;
 use super::cursor::{self, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
@@ -117,7 +116,7 @@ impl Event {
 
         Ok(Some(Address {
             address: self.native.sender.into(),
-            checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
         }))
     }
 
@@ -144,9 +143,8 @@ impl Event {
     /// checkpoint sequence numbers as the cursor to determine the correct page of results. The
     /// query can optionally be further `filter`-ed by the `EventFilter`.
     ///
-    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
-    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
-    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// The `checkpoint_viewed_at` parameter is represents the checkpoint sequence number at which
+    /// this page was queried for. Each entity returned in the connection will inherit this
     /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
     /// checkpoint_viewed_at parameter.
     ///
@@ -156,75 +154,63 @@ impl Event {
         db: &Db,
         page: Page<Cursor>,
         filter: EventFilter,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Event>, Error> {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
-        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let ((prev, next, results), checkpoint_viewed_at) = db
-            .execute_repeatable(move |conn| {
-                let checkpoint_viewed_at = match checkpoint_viewed_at {
-                    Some(value) => Ok(value),
-                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
-                }?;
+        let (prev, next, results) = db
+            .execute(move |conn| {
+                page.paginate_query::<StoredEvent, _, _, _>(conn, checkpoint_viewed_at, move || {
+                    let mut query = events::dsl::events.into_boxed();
 
-                let result = page.paginate_query::<StoredEvent, _, _, _>(
-                    conn,
-                    checkpoint_viewed_at,
-                    move || {
-                        let mut query = events::dsl::events.into_boxed();
+                    // Bound events by the provided `checkpoint_viewed_at`. From EXPLAIN
+                    // ANALYZE, using the checkpoint sequence number directly instead of
+                    // translating into a transaction sequence number bound is more efficient.
+                    query = query.filter(
+                        events::dsl::checkpoint_sequence_number.le(checkpoint_viewed_at as i64),
+                    );
 
-                        // Bound events by the provided `checkpoint_viewed_at`. From EXPLAIN
-                        // ANALYZE, using the checkpoint sequence number directly instead of
-                        // translating into a transaction sequence number bound is more efficient.
+                    // The transactions table doesn't have an index on the senders column, so use
+                    // `tx_senders`.
+                    if let Some(sender) = &filter.sender {
                         query = query.filter(
-                            events::dsl::checkpoint_sequence_number.le(checkpoint_viewed_at as i64),
-                        );
+                            events::dsl::tx_sequence_number.eq_any(
+                                tx_senders::dsl::tx_senders
+                                    .select(tx_senders::dsl::tx_sequence_number)
+                                    .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
+                            ),
+                        )
+                    }
 
-                        // The transactions table doesn't have an index on the senders column, so use
-                        // `tx_senders`.
-                        if let Some(sender) = &filter.sender {
-                            query = query.filter(
-                                events::dsl::tx_sequence_number.eq_any(
-                                    tx_senders::dsl::tx_senders
-                                        .select(tx_senders::dsl::tx_sequence_number)
-                                        .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
-                                ),
-                            )
-                        }
+                    if let Some(digest) = &filter.transaction_digest {
+                        // Since the event filter takes in a single tx_digest, we know that
+                        // there will only be one corresponding transaction. We can use
+                        // single_value() to tell the query planner that we expect only one
+                        // instead of a range of values, which will subsequently speed up query
+                        // execution time.
+                        query = query.filter(
+                            events::dsl::tx_sequence_number.nullable().eq(
+                                transactions::dsl::transactions
+                                    .select(transactions::dsl::tx_sequence_number)
+                                    .filter(
+                                        transactions::dsl::transaction_digest.eq(digest.to_vec()),
+                                    )
+                                    .single_value(),
+                            ),
+                        )
+                    }
 
-                        if let Some(digest) = &filter.transaction_digest {
-                            // Since the event filter takes in a single tx_digest, we know that
-                            // there will only be one corresponding transaction. We can use
-                            // single_value() to tell the query planner that we expect only one
-                            // instead of a range of values, which will subsequently speed up query
-                            // execution time.
-                            query = query.filter(
-                                events::dsl::tx_sequence_number.nullable().eq(
-                                    transactions::dsl::transactions
-                                        .select(transactions::dsl::tx_sequence_number)
-                                        .filter(
-                                            transactions::dsl::transaction_digest
-                                                .eq(digest.to_vec()),
-                                        )
-                                        .single_value(),
-                                ),
-                            )
-                        }
+                    if let Some(module) = &filter.emitting_module {
+                        query = module.apply(query, events::dsl::package, events::dsl::module);
+                    }
 
-                        if let Some(module) = &filter.emitting_module {
-                            query = module.apply(query, events::dsl::package, events::dsl::module);
-                        }
+                    if let Some(type_) = &filter.event_type {
+                        query = type_.apply(query, events::dsl::event_type);
+                    }
 
-                        if let Some(type_) = &filter.event_type {
-                            query = type_.apply(query, events::dsl::event_type);
-                        }
-
-                        query
-                    },
-                )?;
-
-                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
+                    query
+                })
             })
             .await?;
 

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -22,9 +22,8 @@ pub(crate) struct GasInput {
     pub price: u64,
     pub budget: u64,
     pub payment_obj_keys: Vec<ObjectKey>,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number at which this was viewed at
+    pub checkpoint_viewed_at: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -135,7 +134,7 @@ impl GasEffects {
             self.object_id,
             ObjectLookupKey::VersionAt {
                 version: self.object_version,
-                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+                checkpoint_viewed_at: self.checkpoint_viewed_at,
             },
         )
         .await
@@ -149,9 +148,8 @@ impl GasEffects {
 
 impl GasEffects {
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `GasEffects`
-    /// was queried for, or `None` if the data was requested at the latest checkpoint. This is
-    /// stored on `GasEffects` so that when viewing that entity's state, it will be as if it was
-    /// read at the same checkpoint.
+    /// was queried for. This is stored on `GasEffects` so that when viewing that entity's state, it
+    /// will be as if it was read at the same checkpoint.
     pub(crate) fn from(effects: &NativeTransactionEffects, checkpoint_viewed_at: u64) -> Self {
         let ((id, version, _digest), _owner) = effects.gas_object();
         Self {
@@ -165,10 +163,9 @@ impl GasEffects {
 
 impl GasInput {
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `GasInput`
-    /// was queried for, or `None` if the data was requested at the latest checkpoint. This is
-    /// stored on `GasInput` so that when viewing that entity's state, it will be as if it was read
-    /// at the same checkpoint.
-    pub(crate) fn from(s: &GasData, checkpoint_viewed_at: Option<u64>) -> Self {
+    /// was queried for. This is stored on `GasInput` so that when viewing that entity's state, it
+    /// will be as if it was read at the same checkpoint.
+    pub(crate) fn from(s: &GasData, checkpoint_viewed_at: u64) -> Self {
         Self {
             owner: s.owner.into(),
             price: s.price,

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -437,14 +437,13 @@ impl MoveObject {
     /// Query the database for a `page` of Move objects, optionally `filter`-ed.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this page was
-    /// queried for, or `None` if the data was requested at the latest checkpoint. Each entity
-    /// returned in the connection will inherit this checkpoint, so that when viewing that entity's
-    /// state, it will be as if it was read at the same checkpoint.
+    /// queried for. Each entity returned in the connection will inherit this checkpoint, so that
+    /// when viewing that entity's state, it will be as if it was read at the same checkpoint.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<object::Cursor>,
         filter: ObjectFilter,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, MoveObject>, Error> {
         Object::paginate_subtype(db, page, filter, checkpoint_viewed_at, |object| {
             let address = object.address;

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -20,7 +20,6 @@ use super::type_filter::ExactTypeFilter;
 use crate::consistency::ConsistentNamedCursor;
 use crate::data::Db;
 use crate::error::Error;
-use crate::types::checkpoint::Checkpoint;
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
 use sui_package_resolver::{error::Error as PackageCacheError, Package as ParsedMovePackage};
@@ -424,21 +423,16 @@ impl MovePackage {
             return Ok(None);
         };
 
-        let checkpoint_viewed_at = match object.checkpoint_viewed_at {
-            Some(value) => Ok(value),
-            None => Checkpoint::query_latest_checkpoint_sequence_number(db).await,
-        }?;
-
-        Ok(Some(
-            MovePackage::try_from(&object, checkpoint_viewed_at)
-                .map_err(|_| Error::Internal(format!("{address} is not a package")))?,
-        ))
+        Ok(Some(MovePackage::try_from(&object).map_err(|_| {
+            Error::Internal(format!("{address} is not a package"))
+        })?))
     }
+}
 
-    pub(crate) fn try_from(
-        object: &Object,
-        checkpoint_viewed_at: u64,
-    ) -> Result<Self, MovePackageDowncastError> {
+impl TryFrom<&Object> for MovePackage {
+    type Error = MovePackageDowncastError;
+
+    fn try_from(object: &Object) -> Result<Self, MovePackageDowncastError> {
         let Some(native) = object.native_impl() else {
             return Err(MovePackageDowncastError);
         };
@@ -447,7 +441,7 @@ impl MovePackage {
             Ok(Self {
                 super_: object.clone(),
                 native: move_package.clone(),
-                checkpoint_viewed_at,
+                checkpoint_viewed_at: object.checkpoint_viewed_at,
             })
         } else {
             Err(MovePackageDowncastError)

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -4,9 +4,9 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
+use super::available_range::AvailableRange;
 use super::balance::{self, Balance};
 use super::big_int::BigInt;
-use super::checkpoint::Checkpoint;
 use super::coin::Coin;
 use super::coin_metadata::CoinMetadata;
 use super::cursor::{self, Page, Paginated, RawPaginated, Target};
@@ -22,7 +22,7 @@ use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
-use crate::consistency::{build_objects_query, consistent_range, Checkpointed, View};
+use crate::consistency::{build_objects_query, Checkpointed, View};
 use crate::data::package_resolver::PackageResolver;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
@@ -51,20 +51,18 @@ use sui_types::TypeTag;
 pub(crate) struct Object {
     pub address: SuiAddress,
     pub kind: ObjectKind,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number at which this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Type to implement GraphQL fields that are shared by all Objects.
 pub(crate) struct ObjectImpl<'o>(pub &'o Object);
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ObjectKind {
     /// An object loaded from serialized data, such as the contents of a transaction.
     NotIndexed(NativeObject),
-    /// An object fetched from the live objects table.
-    Live(NativeObject, StoredObject),
     /// An object fetched from the snapshot or historical objects table.
     Historical(NativeObject, StoredHistoryObject),
     /// The object is wrapped or deleted and only partial information can be loaded from the
@@ -172,21 +170,18 @@ pub struct AddressOwner {
 }
 
 pub(crate) enum ObjectLookupKey {
-    Latest,
     LatestAt(u64),
     VersionAt {
         version: u64,
-        /// The checkpoint sequence number at which this was viewed at, or None if the data was
-        /// requested at the latest checkpoint.
-        checkpoint_viewed_at: Option<u64>,
+        /// The checkpoint sequence number at which this was viewed at.
+        checkpoint_viewed_at: u64,
     },
     LatestAtParentVersion {
         /// The parent version to be used as the upper bound for the query. Look for the latest
         /// version of a child object that is less than or equal to this upper bound.
         version: u64,
-        /// The checkpoint sequence number at which this was viewed at, or None if the data was
-        /// requested at the latest checkpoint.
-        checkpoint_viewed_at: Option<u64>,
+        /// The checkpoint sequence number at which this was viewed at
+        checkpoint_viewed_at: u64,
     },
 }
 
@@ -488,16 +483,8 @@ impl Object {
     }
 
     /// Attempts to convert the object into a MovePackage
-    async fn as_move_package(&self, ctx: &Context<'_>) -> Option<MovePackage> {
-        let Some(checkpoint_viewed_at) = match self.checkpoint_viewed_at {
-            Some(value) => Ok(value),
-            None => Checkpoint::query_latest_checkpoint_sequence_number(ctx.data_unchecked()).await,
-        }
-        .ok() else {
-            return None;
-        };
-
-        MovePackage::try_from(self, checkpoint_viewed_at).ok()
+    async fn as_move_package(&self) -> Option<MovePackage> {
+        MovePackage::try_from(self).ok()
     }
 }
 
@@ -538,7 +525,7 @@ impl ObjectImpl<'_> {
                 let parent = Object::query(
                     ctx.data_unchecked(),
                     address.into(),
-                    ObjectLookupKey::Latest,
+                    ObjectLookupKey::LatestAt(self.0.checkpoint_viewed_at),
                 )
                 .await
                 .ok()
@@ -613,8 +600,6 @@ impl ObjectImpl<'_> {
         use ObjectKind as K;
         Ok(match &self.0.kind {
             K::WrappedOrDeleted(_) => None,
-            K::Live(_, stored) => Some(Base64::from(&stored.serialized_object)),
-
             // WrappedOrDeleted objects are also read from the historical objects table, and they do
             // not have a serialized object, so the column is also nullable for stored historical
             // objects.
@@ -666,13 +651,12 @@ impl Object {
     /// Construct a GraphQL object from a native object, without its stored (indexed) counterpart.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `Object` was
-    /// constructed in, or `None` if the data was requested at the latest checkpoint. This is
-    /// stored on `Object` so that when viewing that entity's state, it will be as if it was
-    /// read at the same checkpoint.
+    /// constructed in. This is stored on `Object` so that when viewing that entity's state, it will
+    /// be as if it was read at the same checkpoint.
     pub(crate) fn from_native(
         address: SuiAddress,
         native: NativeObject,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Object {
         Object {
             address,
@@ -685,7 +669,7 @@ impl Object {
         use ObjectKind as K;
 
         match &self.kind {
-            K::Live(native, _) | K::NotIndexed(native) | K::Historical(native, _) => Some(native),
+            K::NotIndexed(native) | K::Historical(native, _) => Some(native),
             K::WrappedOrDeleted(_) => None,
         }
     }
@@ -694,9 +678,7 @@ impl Object {
         use ObjectKind as K;
 
         match &self.kind {
-            K::Live(native, _) | K::NotIndexed(native) | K::Historical(native, _) => {
-                native.version().value()
-            }
+            K::NotIndexed(native) | K::Historical(native, _) => native.version().value(),
             K::WrappedOrDeleted(stored) => stored.object_version as u64,
         }
     }
@@ -704,14 +686,13 @@ impl Object {
     /// Query the database for a `page` of objects, optionally `filter`-ed.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this page was
-    /// queried for, or `None` if the data was requested at the latest checkpoint. Each entity
-    /// returned in the connection will inherit this checkpoint, so that when viewing that entity's
-    /// state, it will be as if it was read at the same checkpoint.
+    /// queried for. Each entity returned in the connection will inherit this checkpoint, so that
+    /// when viewing that entity's state, it will be as if it was read at the same checkpoint.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: ObjectFilter,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Object>, Error> {
         Self::paginate_subtype(db, page, filter, checkpoint_viewed_at, Ok).await
     }
@@ -722,9 +703,8 @@ impl Object {
     /// to fail, if the downcast has failed.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this page was
-    /// queried for, or `None` if the data was requested at the latest checkpoint. Each entity
-    /// returned in the connection will inherit this checkpoint, so that when viewing that entity's
-    /// state, it will be as if it was read at the same checkpoint.
+    /// queried for. Each entity returned in the connection will inherit this checkpoint, so that
+    /// when viewing that entity's state, it will be as if it was read at the same checkpoint.
     ///
     /// If a `Page<Cursor>` is also provided, then this function will defer to the
     /// `checkpoint_viewed_at` in the cursors. Otherwise, use the value from the parameter, or set
@@ -734,45 +714,40 @@ impl Object {
         db: &Db,
         page: Page<Cursor>,
         filter: ObjectFilter,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
         downcast: impl Fn(Object) -> Result<T, Error>,
     ) -> Result<Connection<String, T>, Error> {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
         let cursor_viewed_at = page.validate_cursor_consistency()?;
-        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let response = db
+        let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
-                let result = page.paginate_raw_query::<StoredHistoryObject>(
+                Ok(Some(page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
-                    rhs,
-                    objects_query(&filter, lhs as i64, rhs as i64, &page),
-                )?;
-
-                Ok(Some((result, rhs)))
+                    checkpoint_viewed_at,
+                    objects_query(&filter, range, &page),
+                )?))
             })
-            .await?;
-
-        let Some(((prev, next, results), checkpoint_viewed_at)) = response else {
+            .await?
+        else {
             return Err(Error::Client(
                 "Requested data is outside the available range".to_string(),
             ));
         };
 
         let mut conn: Connection<String, T> = Connection::new(prev, next);
-
         for stored in results {
             // To maintain consistency, the returned cursor should have the same upper-bound as the
             // checkpoint found on the cursor.
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
-            let object =
-                Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
+            let object = Object::try_from_stored_history_object(stored, checkpoint_viewed_at)?;
             conn.edges.push(Edge::new(cursor, downcast(object)?));
         }
 
@@ -783,14 +758,13 @@ impl Object {
     /// against the latest checkpoint.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `Object` was
-    /// queried in, or `None` if the data was requested at the latest checkpoint. This is stored on
-    /// `Object` so that when viewing that entity's state, it will be as if it was read at the same
-    /// checkpoint.
+    /// queried in. This is stored on `Object` so that when viewing that entity's state, it will be
+    /// as if it was read at the same checkpoint.
     async fn query_at_version(
         db: &Db,
         address: SuiAddress,
         version: u64,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         use objects_history::dsl as history;
         use objects_snapshot::dsl as snapshot;
@@ -799,7 +773,7 @@ impl Object {
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
@@ -815,13 +789,17 @@ impl Object {
                     let historical_query = history::objects_history
                         .filter(history::object_id.eq(address.into_vec()))
                         .filter(history::object_version.eq(version))
-                        .filter(history::checkpoint_sequence_number.between(lhs as i64, rhs as i64))
+                        .filter(
+                            history::checkpoint_sequence_number
+                                .between(range.first as i64, range.last as i64),
+                        )
                         .order_by(history::object_version.desc())
                         .limit(1);
 
                     snapshot_query.union(historical_query)
                 })
-                .optional() // Return optional to match the state when checkpoint_viewed_at is out of range
+                // Return optional to match the state when checkpoint_viewed_at is out of range
+                .optional()
             })
             .await?;
 
@@ -829,7 +807,8 @@ impl Object {
             return Ok(None);
         };
 
-        // Select the max by key after the union query, because Diesel currently does not support order_by on union
+        // Select the max by key after the union query, because Diesel currently does not support
+        // order_by on union
         stored_objs
             .into_iter()
             .max_by_key(|o| o.object_version)
@@ -840,23 +819,21 @@ impl Object {
     /// Query for the latest version of an object bounded by the provided `parent_version`.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `Object` was
-    /// queried in, or `None` if the data was requested at the latest checkpoint. This is stored on
-    /// `Object` so that when viewing that entity's state, it will be as if it was read at the same
-    /// checkpoint.
+    /// queried in. This is stored on `Object` so that when viewing that entity's state, it will be
+    /// as if it was read at the same checkpoint.
     async fn query_latest_at_version(
         db: &Db,
         address: SuiAddress,
         parent_version: u64,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         use objects_history::dsl as history;
         use objects_snapshot::dsl as snapshot;
 
         let version = parent_version as i64;
-
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
@@ -872,13 +849,17 @@ impl Object {
                     let historical_query = history::objects_history
                         .filter(history::object_id.eq(address.into_vec()))
                         .filter(history::object_version.le(version))
-                        .filter(history::checkpoint_sequence_number.between(lhs as i64, rhs as i64))
+                        .filter(
+                            history::checkpoint_sequence_number
+                                .between(range.first as i64, range.last as i64),
+                        )
                         .order_by(history::object_version.desc())
                         .limit(1);
 
                     snapshot_query.union(historical_query)
                 })
-                .optional() // Return optional to match the state when checkpoint_viewed_at is out of range
+                // Return optional to match the state when checkpoint_viewed_at is out of range
+                .optional()
             })
             .await?;
 
@@ -900,14 +881,14 @@ impl Object {
     async fn query_latest_at_checkpoint(
         db: &Db,
         address: SuiAddress,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         use objects_history::dsl as history;
         use objects_snapshot::dsl as snapshot;
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
@@ -921,13 +902,17 @@ impl Object {
 
                     let historical_query = history::objects_history
                         .filter(history::object_id.eq(address.into_vec()))
-                        .filter(history::checkpoint_sequence_number.between(lhs as i64, rhs as i64))
+                        .filter(
+                            history::checkpoint_sequence_number
+                                .between(range.first as i64, range.last as i64),
+                        )
                         .order_by(history::object_version.desc())
                         .limit(1);
 
                     snapshot_query.union(historical_query)
                 })
-                .optional() // Return optional to match the state when checkpoint_viewed_at is out of range
+                // Return optional to match the state when checkpoint_viewed_at is out of range
+                .optional()
             })
             .await?;
 
@@ -935,7 +920,8 @@ impl Object {
             return Ok(None);
         };
 
-        // Select the max by key after the union query, because Diesel currently does not support order_by on union
+        // Select the max by key after the union query, because Diesel currently does not support
+        // order_by on union
         stored_objs
             .into_iter()
             .max_by_key(|o| o.object_version)
@@ -949,10 +935,8 @@ impl Object {
         key: ObjectLookupKey,
     ) -> Result<Option<Self>, Error> {
         match key {
-            ObjectLookupKey::Latest => Self::query_latest_at_checkpoint(db, address, None).await,
             ObjectLookupKey::LatestAt(checkpoint_sequence_number) => {
-                Self::query_latest_at_checkpoint(db, address, Some(checkpoint_sequence_number))
-                    .await
+                Self::query_latest_at_checkpoint(db, address, checkpoint_sequence_number).await
             }
             ObjectLookupKey::VersionAt {
                 version,
@@ -969,52 +953,27 @@ impl Object {
     /// Query for a singleton object identified by its type. Note: the object is assumed to be a
     /// singleton (we either find at least one object with this type and then return it, or return
     /// nothing).
-    pub(crate) async fn query_singleton(db: &Db, type_: TypeTag) -> Result<Option<Object>, Error> {
-        use objects::dsl;
+    pub(crate) async fn query_singleton(
+        db: &Db,
+        type_: TypeTag,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Option<Object>, Error> {
+        let filter = ObjectFilter {
+            type_: Some(TypeFilter::ByType(type_)),
+            ..Default::default()
+        };
 
-        let stored_obj: Option<StoredObject> = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    dsl::objects.filter(
-                        dsl::object_type.eq(type_.to_canonical_string(/* with_prefix */ true)),
-                    )
-                })
-                .optional()
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch singleton: {e}")))?;
+        let connection = Self::paginate(db, Page::bounded(1), filter, checkpoint_viewed_at).await?;
 
-        stored_obj
-            .map(|obj| Object::try_from_stored_object(obj, None))
-            .transpose()
+        Ok(connection.edges.into_iter().next().map(|edge| edge.node))
     }
 
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `Object` was
-    /// constructed in, or `None` if the data was requested at the latest checkpoint. This is
-    /// stored on `Object` so that when viewing that entity's state, it will be as if it was read at
-    /// the same checkpoint.
-    pub(crate) fn try_from_stored_object(
-        stored_object: StoredObject,
-        checkpoint_viewed_at: Option<u64>,
-    ) -> Result<Self, Error> {
-        let address = addr(&stored_object.object_id)?;
-        let native_object = bcs::from_bytes(&stored_object.serialized_object)
-            .map_err(|_| Error::Internal(format!("Failed to deserialize object {address}")))?;
-
-        Ok(Self {
-            address,
-            kind: ObjectKind::Live(native_object, stored_object),
-            checkpoint_viewed_at,
-        })
-    }
-
-    /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this `Object` was
-    /// constructed in, or `None` if the data was requested at the latest checkpoint. This is
-    /// stored on `Object` so that when viewing that entity's state, it will be as if it was read at
-    /// the same checkpoint.
+    /// constructed in. This is stored on `Object` so that when viewing that entity's state, it will
+    /// be as if it was read at the same checkpoint.
     pub(crate) fn try_from_stored_history_object(
         history_object: StoredHistoryObject,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Self, Error> {
         let address = addr(&history_object.object_id)?;
 
@@ -1304,7 +1263,6 @@ impl From<&ObjectKind> for ObjectStatus {
     fn from(kind: &ObjectKind) -> Self {
         match kind {
             ObjectKind::NotIndexed(_) => ObjectStatus::NotIndexed,
-            ObjectKind::Live(_, _) => ObjectStatus::Live,
             ObjectKind::Historical(_, _) => ObjectStatus::Historical,
             ObjectKind::WrappedOrDeleted(_) => ObjectStatus::WrappedOrDeleted,
         }
@@ -1362,7 +1320,7 @@ pub(crate) async fn deserialize_move_struct(
 /// Constructs a raw query to fetch objects from the database. Objects are filtered out if they
 /// satisfy the criteria but have a later version in the same checkpoint. If object keys are
 /// provided, or no filters are specified at all, then this final condition is not applied.
-fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
+fn objects_query(filter: &ObjectFilter, range: AvailableRange, page: &Page<Cursor>) -> RawQuery
 where
 {
     let view = if filter.object_keys.is_some() || !filter.has_filters() {
@@ -1373,8 +1331,7 @@ where
 
     build_objects_query(
         view,
-        lhs,
-        rhs,
+        range,
         page,
         move |query| filter.apply(query),
         move |newer| newer,

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -34,7 +34,7 @@ impl ObjectChange {
             self.native.id.into(),
             ObjectLookupKey::VersionAt {
                 version: version.value(),
-                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+                checkpoint_viewed_at: self.checkpoint_viewed_at,
             },
         )
         .await
@@ -52,7 +52,7 @@ impl ObjectChange {
             self.native.id.into(),
             ObjectLookupKey::VersionAt {
                 version: version.value(),
-                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+                checkpoint_viewed_at: self.checkpoint_viewed_at,
             },
         )
         .await

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -43,7 +43,7 @@ impl ObjectRead {
             self.address_impl(),
             ObjectLookupKey::VersionAt {
                 version: self.version_impl(),
-                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+                checkpoint_viewed_at: self.checkpoint_viewed_at,
             },
         )
         .await

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -27,17 +27,15 @@ use sui_types::gas_coin::GAS;
 #[derive(Clone, Debug)]
 pub(crate) struct Owner {
     pub address: SuiAddress,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number at which this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Type to implement GraphQL fields that are shared by all Owners.
 pub(crate) struct OwnerImpl {
     pub address: SuiAddress,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number at which this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Interface implemented by GraphQL types representing entities that can own objects. Object owners
@@ -234,10 +232,7 @@ impl Owner {
         Object::query(
             ctx.data_unchecked(),
             self.address,
-            match self.checkpoint_viewed_at {
-                Some(checkpoint_viewed_at) => ObjectLookupKey::LatestAt(checkpoint_viewed_at),
-                None => ObjectLookupKey::Latest,
-            },
+            ObjectLookupKey::LatestAt(self.checkpoint_viewed_at),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -34,14 +34,12 @@ use super::{
     transaction_metadata::TransactionMetadata,
     type_filter::ExactTypeFilter,
 };
-use crate::consistency::consistent_range;
-use crate::data::QueryExecutor;
 use crate::server::watermark_task::Watermark;
 use crate::types::base64::Base64 as GraphQLBase64;
 use crate::types::zklogin_verify_signature::verify_zklogin_signature;
 use crate::types::zklogin_verify_signature::ZkLoginIntentScope;
 use crate::types::zklogin_verify_signature::ZkLoginVerifyResult;
-use crate::{config::ServiceConfig, data::Db, error::Error, mutation::Mutation};
+use crate::{config::ServiceConfig, error::Error, mutation::Mutation};
 
 pub(crate) struct Query;
 pub(crate) type SuiGraphQLSchema = async_graphql::Schema<Query, Mutation, EmptySubscription>;
@@ -61,19 +59,9 @@ impl Query {
     /// that can be tied to a particular checkpoint).
     async fn available_range(&self, ctx: &Context<'_>) -> Result<AvailableRange> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-        let result = ctx
-            .data_unchecked::<Db>()
-            .execute(move |conn| consistent_range(conn, Some(checkpoint)))
+        AvailableRange::query(ctx.data_unchecked(), checkpoint)
             .await
-            .extend()?;
-
-        match result {
-            Some((first, last)) => Ok(AvailableRange { first, last }),
-            None => Err(Error::Internal(
-                "Checkpoint watermark outside of available range from database".to_string(),
-            )
-            .extend()),
-        }
+            .extend()
     }
 
     /// Configuration for this RPC service
@@ -188,10 +176,9 @@ impl Query {
 
     async fn owner(&self, ctx: &Context<'_>, address: SuiAddress) -> Result<Option<Owner>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-
         Ok(Some(Owner {
             address,
-            checkpoint_viewed_at: Some(checkpoint),
+            checkpoint_viewed_at: checkpoint,
         }))
     }
 
@@ -211,7 +198,7 @@ impl Query {
                 address,
                 ObjectLookupKey::VersionAt {
                     version,
-                    checkpoint_viewed_at: Some(checkpoint),
+                    checkpoint_viewed_at: checkpoint,
                 },
             )
             .await
@@ -232,7 +219,7 @@ impl Query {
 
         Ok(Some(Address {
             address,
-            checkpoint_viewed_at: Some(checkpoint),
+            checkpoint_viewed_at: checkpoint,
         }))
     }
 
@@ -249,8 +236,7 @@ impl Query {
     /// Fetch epoch information by ID (defaults to the latest epoch).
     async fn epoch(&self, ctx: &Context<'_>, id: Option<u64>) -> Result<Option<Epoch>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-
-        Epoch::query(ctx, id, Some(checkpoint)).await.extend()
+        Epoch::query(ctx, id, checkpoint).await.extend()
     }
 
     /// Fetch checkpoint information by sequence number or digest (defaults to the latest available
@@ -261,8 +247,7 @@ impl Query {
         id: Option<CheckpointId>,
     ) -> Result<Option<Checkpoint>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-
-        Checkpoint::query(ctx, id.unwrap_or_default(), Some(checkpoint))
+        Checkpoint::query(ctx, id.unwrap_or_default(), checkpoint)
             .await
             .extend()
     }
@@ -274,8 +259,7 @@ impl Query {
         digest: Digest,
     ) -> Result<Option<TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-
-        TransactionBlock::query(ctx.data_unchecked(), digest, Some(checkpoint))
+        TransactionBlock::query(ctx.data_unchecked(), digest, checkpoint)
             .await
             .extend()
     }
@@ -302,7 +286,7 @@ impl Query {
             page,
             coin,
             /* owner */ None,
-            Some(checkpoint),
+            checkpoint,
         )
         .await
         .extend()
@@ -324,7 +308,7 @@ impl Query {
             ctx.data_unchecked(),
             page,
             /* epoch */ None,
-            Some(checkpoint),
+            checkpoint,
         )
         .await
         .extend()
@@ -347,7 +331,7 @@ impl Query {
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            Some(checkpoint),
+            checkpoint,
         )
         .await
         .extend()
@@ -370,7 +354,7 @@ impl Query {
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            Some(checkpoint),
+            checkpoint,
         )
         .await
         .extend()
@@ -393,7 +377,7 @@ impl Query {
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            Some(checkpoint),
+            checkpoint,
         )
         .await
         .extend()
@@ -419,13 +403,13 @@ impl Query {
     ) -> Result<Option<Address>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
         Ok(
-            SuinsRegistration::resolve_to_record(ctx, &domain, Some(checkpoint))
+            SuinsRegistration::resolve_to_record(ctx, &domain, checkpoint)
                 .await
                 .extend()?
                 .and_then(|r| r.target_address)
                 .map(|a| Address {
                     address: a.into(),
-                    checkpoint_viewed_at: Some(checkpoint),
+                    checkpoint_viewed_at: checkpoint,
                 }),
         )
     }
@@ -436,7 +420,8 @@ impl Query {
         ctx: &Context<'_>,
         coin_type: ExactTypeFilter,
     ) -> Result<Option<CoinMetadata>> {
-        CoinMetadata::query(ctx.data_unchecked(), coin_type.0)
+        let Watermark { checkpoint, .. } = *ctx.data()?;
+        CoinMetadata::query(ctx.data_unchecked(), coin_type.0, checkpoint)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -358,14 +358,13 @@ impl StakedSui {
     /// for `Object`, and is further filtered to a particular `owner`.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this page was
-    /// queried for, or `None` if the data was requested at the latest checkpoint. Each entity
-    /// returned in the connection will inherit this checkpoint, so that when viewing that entity's
-    /// state, it will be as if it was read at the same checkpoint.
+    /// queried for. Each entity returned in the connection will inherit this checkpoint, so that
+    /// when viewing that entity's state, it will be as if it was read at the same checkpoint.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<object::Cursor>,
         owner: SuiAddress,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, StakedSui>, Error> {
         let type_: StructTag = MoveObjectType::staked_sui().into();
 

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -4,6 +4,7 @@
 use std::str::FromStr;
 
 use super::{
+    available_range::AvailableRange,
     balance::{self, Balance},
     base64::Base64,
     big_int::BigInt,
@@ -23,7 +24,7 @@ use super::{
     type_filter::ExactTypeFilter,
 };
 use crate::{
-    consistency::{build_objects_query, consistent_range, View},
+    consistency::{build_objects_query, View},
     data::{Db, DbConnection, QueryExecutor},
     error::Error,
 };
@@ -329,7 +330,7 @@ impl SuinsRegistration {
     /// the domain name registry, and its type.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this was queried
-    /// for, or `None` if the data was requested at the latest checkpoint.
+    /// for.
     ///
     /// The `NameRecord` is returned only if it has not expired as of the `checkpoint_viewed_at` or
     /// latest checkpoint's timestamp.
@@ -338,7 +339,7 @@ impl SuinsRegistration {
     pub(crate) async fn resolve_to_record(
         ctx: &Context<'_>,
         domain: &Domain,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<NameRecord>, Error> {
         // Query for the domain's NameRecord and parent NameRecord if applicable. The checkpoint's
         // timestamp is also fetched. These values are used to determine if the domain is expired.
@@ -384,11 +385,11 @@ impl SuinsRegistration {
     /// name registry, and its type.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this was queried
-    /// for, or `None` if the data was requested at the latest checkpoint.
+    /// for.
     pub(crate) async fn reverse_resolve_to_name(
         ctx: &Context<'_>,
         address: SuiAddress,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<NativeDomain>, Error> {
         let config: &NameServiceConfig = ctx.data_unchecked();
 
@@ -397,10 +398,7 @@ impl SuinsRegistration {
         let Some(object) = MoveObject::query(
             ctx.data_unchecked(),
             reverse_record_id.into(),
-            match checkpoint_viewed_at {
-                Some(checkpoint_viewed_at) => ObjectLookupKey::LatestAt(checkpoint_viewed_at),
-                None => ObjectLookupKey::Latest,
-            },
+            ObjectLookupKey::LatestAt(checkpoint_viewed_at),
         )
         .await?
         else {
@@ -428,7 +426,7 @@ impl SuinsRegistration {
     async fn query_domain_expiration(
         ctx: &Context<'_>,
         domain: &Domain,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<DomainExpiration>, Error> {
         let config: &NameServiceConfig = ctx.data_unchecked();
         let db: &Db = ctx.data_unchecked();
@@ -458,18 +456,17 @@ impl SuinsRegistration {
             ..Default::default()
         };
 
-        let response = db
+        let Some((checkpoint_timestamp_ms, results)) = db
             .execute_repeatable(move |conn| {
-                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
-                let timestamp_ms = Checkpoint::query_timestamp(conn, rhs)?;
+                let timestamp_ms = Checkpoint::query_timestamp(conn, checkpoint_viewed_at)?;
 
                 let sql = build_objects_query(
                     View::Consistent,
-                    lhs as i64,
-                    rhs as i64,
+                    range,
                     &page,
                     move |query| filter.apply(query),
                     move |newer| newer,
@@ -480,9 +477,8 @@ impl SuinsRegistration {
 
                 Ok(Some((timestamp_ms, objects)))
             })
-            .await?;
-
-        let Some((checkpoint_timestamp_ms, results)) = response else {
+            .await?
+        else {
             return Err(Error::Client(
                 "Requested data is outside the available range".to_string(),
             ));
@@ -498,7 +494,7 @@ impl SuinsRegistration {
         // name_record. We then assign it to the correct field on `domain_expiration` based on the
         // address.
         for result in results {
-            let object = Object::try_from_stored_history_object(result, None)?;
+            let object = Object::try_from_stored_history_object(result, checkpoint_viewed_at)?;
             let move_object = MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(
                     "Expected {0} to be a NameRecord, but it's not a Move Object.",
@@ -523,15 +519,14 @@ impl SuinsRegistration {
     /// where to find the domain name registry and its type.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this page was
-    /// queried for, or `None` if the data was requested at the latest checkpoint. Each entity
-    /// returned in the connection will inherit this checkpoint, so that when viewing that entity's
-    /// state, it will be as if it was read at the same checkpoint.
+    /// queried for. Each entity returned in the connection will inherit this checkpoint, so that
+    /// when viewing that entity's state, it will be as if it was read at the same checkpoint.
     pub(crate) async fn paginate(
         db: &Db,
         config: &NameServiceConfig,
         page: Page<object::Cursor>,
         owner: SuiAddress,
-        checkpoint_viewed_at: Option<u64>,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, SuinsRegistration>, Error> {
         let type_ = SuinsRegistration::type_(config.package_address.into());
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -374,7 +374,7 @@ impl TransactionBlockEffects {
         Epoch::query(
             ctx,
             Some(self.native().executed_epoch()),
-            Some(self.checkpoint_viewed_at),
+            self.checkpoint_viewed_at,
         )
         .await
         .extend()
@@ -390,7 +390,7 @@ impl TransactionBlockEffects {
         Checkpoint::query(
             ctx,
             CheckpointId::by_seq_num(stored_tx.checkpoint_sequence_number as u64),
-            Some(self.checkpoint_viewed_at),
+            self.checkpoint_viewed_at,
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -40,13 +40,9 @@ struct ActiveJwk {
 impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx,
-            Some(self.native.epoch),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(self.native.epoch), self.checkpoint_viewed_at)
+            .await
+            .extend()
     }
 
     /// Consensus round of the authenticator state update.
@@ -130,12 +126,8 @@ impl ActiveJwk {
 
     /// The most recent epoch in which the JWK was validated.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx,
-            Some(self.native.epoch),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(self.native.epoch), self.checkpoint_viewed_at)
+            .await
+            .extend()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -34,7 +34,7 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx, Some(self.epoch), Some(self.checkpoint_viewed_at))
+        Epoch::query(ctx, Some(self.epoch), self.checkpoint_viewed_at)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -125,13 +125,9 @@ impl EndOfEpochTransaction {
 impl ChangeEpochTransaction {
     /// The next (to become) epoch.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx,
-            Some(self.native.epoch),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(self.native.epoch), self.checkpoint_viewed_at)
+            .await
+            .extend()
     }
 
     /// The protocol version in effect in the new epoch.
@@ -207,8 +203,8 @@ impl ChangeEpochTransaction {
             );
 
             let runtime_id = native.id();
-            let object = Object::from_native(SuiAddress::from(runtime_id), native, Some(c.c));
-            let package = MovePackage::try_from(&object, self.checkpoint_viewed_at)
+            let object = Object::from_native(SuiAddress::from(runtime_id), native, c.c);
+            let package = MovePackage::try_from(&object)
                 .map_err(|_| Error::Internal("Failed to create system package".to_string()))
                 .extend()?;
 
@@ -223,13 +219,9 @@ impl ChangeEpochTransaction {
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
     async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx,
-            Some(self.native.min_epoch),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(self.native.min_epoch), self.checkpoint_viewed_at)
+            .await
+            .extend()
     }
 
     /// The initial version that the AuthenticatorStateUpdate was shared at.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -58,7 +58,7 @@ impl GenesisTransaction {
             let native =
                 NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
 
-            let object = Object::from_native(SuiAddress::from(native.id()), native, Some(c.c));
+            let object = Object::from_native(SuiAddress::from(native.id()), native, c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), object));
         }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -17,13 +17,9 @@ pub(crate) struct RandomnessStateUpdateTransaction {
 impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx,
-            Some(self.native.epoch),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(self.native.epoch), self.checkpoint_viewed_at)
+            .await
+            .extend()
     }
 
     /// Randomness round of the update.

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -32,7 +32,7 @@ impl Validator {
     async fn address(&self) -> Address {
         Address {
             address: SuiAddress::from(self.validator_summary.sui_address),
-            checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
         }
     }
 
@@ -243,7 +243,7 @@ impl Validator {
                 c.encode_cursor(),
                 Address {
                     address: addresses[c.ix].address,
-                    checkpoint_viewed_at: Some(c.c),
+                    checkpoint_viewed_at: c.c,
                 },
             ));
         }

--- a/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
+++ b/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
@@ -3,6 +3,7 @@
 
 use crate::config::{ZkLoginConfig, ZkLoginEnv as LocalZkLoginEnv};
 use crate::error::Error;
+use crate::server::watermark_task::Watermark;
 use crate::types::base64::Base64;
 use crate::types::dynamic_field::{DynamicField, DynamicFieldName};
 use crate::types::epoch::Epoch;
@@ -51,8 +52,10 @@ pub(crate) async fn verify_zklogin_signature(
     intent_scope: ZkLoginIntentScope,
     author: SuiAddress,
 ) -> Result<ZkLoginVerifyResult, Error> {
+    let Watermark { checkpoint, .. } = *ctx.data_unchecked();
+
     // get current epoch from db.
-    let Some(curr_epoch) = Epoch::query(ctx, None, None).await? else {
+    let Some(curr_epoch) = Epoch::query(ctx, None, checkpoint).await? else {
         return Err(Error::Internal(
             "Cannot get current epoch from db".to_string(),
         ));
@@ -83,7 +86,7 @@ pub(crate) async fn verify_zklogin_signature(
             bcs: Base64(bcs::to_bytes(&1u64).unwrap()),
         },
         DynamicFieldType::DynamicField,
-        None,
+        checkpoint,
     )
     .await
     .map_err(|e| as_jwks_read_error(e.to_string()))?;


### PR DESCRIPTION
## Description

Now that we have a watermark task, we can (and should) always pin every entity to a checkpoint it was viewed at. This PR makes this impossible to avoid by making the `checkpoint_viewed_at` field non-optional everywhere.

This PR also employs the following clean-ups:

- `checkpoint_viewed_at` is non-optional everywhere, including e.g. when looking up singleton objects.
- Consolidate logic around consistent/available range in the `available_range` module, use the `AvailableRange` type when constructing object queries.
- Remove the `Live` object table kind -- we now don't query it except for via the package loader.
- `Object` to `MovePackage` no longer needs to accept a separate `checkpoint_viewed_at` because the one inside the object will be non-optional.

Finally, it also fixes a bug with consistency for transaction block gas inputs. Previously the transaction's sequence number was used as the consistent cursor for the gas input, even though the transaction had its own `checkpoint_viewed_at` cursor (which is what we should have been using). Fixing this also fixes the
`consistency/tx_address_objects` test.

## Test plan

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests --features pg_integration
```

## Stack

- #17183

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: