### PR TITLE
[TrafficControl] Dry run mode

### DIFF
--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -41,6 +41,7 @@ pub struct TrafficController {
     tally_channel: mpsc::Sender<TrafficTally>,
     blocklists: Blocklists,
     metrics: Arc<TrafficControllerMetrics>,
+    dry_run_mode: bool,
 }
 
 impl Debug for TrafficController {
@@ -87,6 +88,7 @@ impl TrafficController {
                 proxy_ips: Arc::new(DashMap::new()),
             },
             metrics: metrics.clone(),
+            dry_run_mode: policy_config.dry_run,
         };
         let blocklists = ret.blocklists.clone();
         spawn_monitored_task!(run_tally_loop(
@@ -147,6 +149,10 @@ impl TrafficController {
         );
         let (conn_check, proxy_check) = futures::future::join(connection_check, proxy_check).await;
         conn_check && proxy_check
+    }
+
+    pub fn dry_run_mode(&self) -> bool {
+        self.dry_run_mode
     }
 
     async fn check_and_clear_blocklist(

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -114,6 +114,8 @@ pub struct PolicyConfig {
     pub error_policy_type: PolicyType,
     #[serde(default = "default_channel_capacity")]
     pub channel_capacity: usize,
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
 }
 
 impl Default for PolicyConfig {
@@ -124,6 +126,7 @@ impl Default for PolicyConfig {
             spam_policy_type: PolicyType::NoOp,
             error_policy_type: PolicyType::NoOp,
             channel_capacity: 100,
+            dry_run: default_dry_run(),
         }
     }
 }
@@ -133,4 +136,8 @@ pub fn default_connection_blocklist_ttl_sec() -> u64 {
 }
 pub fn default_channel_capacity() -> usize {
     100
+}
+
+pub fn default_dry_run() -> bool {
+    true
 }


### PR DESCRIPTION
## Description 

Dry run mode runs the policy without enforcing its output (does not block requests, but will still accumulate and log, so we can see the would-be effects on both the node and the request).

Note that this does nothing for BPF enforcement - with dry run enabled, we may still run BPF and populate the BPF blocklist. BPF userspace will itself need to introduce a dry-run mode in order to ignore the blocklist and instead log/bump metrics. Until then, we will need to explicitly not configure traffic controller to delegate to BPF (which will be a less complete dry run).

## Test plan 

Added tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
