### PR TITLE
[GraphQL/DataLoader] Data Loader for Package Resolver

### DIFF
--- a/crates/sui-analytics-indexer/src/package_store.rs
+++ b/crates/sui-analytics-indexer/src/package_store.rs
@@ -32,7 +32,7 @@ impl From<Error> for PackageResolverError {
         match source {
             Error::TypedStore(store_error) => Self::Store {
                 store: STORE,
-                source: Box::new(store_error),
+                source: Arc::new(store_error),
             },
         }
     }
@@ -114,7 +114,7 @@ impl LocalDBPackageStore {
 impl PackageStore for LocalDBPackageStore {
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
         let object = self.get(id).await?;
-        Ok(Arc::new(Package::read(&object)?))
+        Ok(Arc::new(Package::read_from_object(&object)?))
     }
 }
 

--- a/crates/sui-graphql-rpc/src/data/package_resolver.rs
+++ b/crates/sui-graphql-rpc/src/data/package_resolver.rs
@@ -1,21 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
+use async_graphql::dataloader::Loader;
 use async_trait::async_trait;
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
+use diesel::{ExpressionMethods, QueryDsl};
 use move_core_types::account_address::AccountAddress;
-use sui_indexer::schema::objects;
+use sui_indexer::models::packages::StoredPackage;
+use sui_indexer::schema::packages;
 use sui_package_resolver::Resolver;
 use sui_package_resolver::{
     error::Error as PackageResolverError, Package, PackageStore, PackageStoreWithLruCache, Result,
 };
-use sui_types::object::Object;
 
-use crate::error::Error;
-
-use super::{Db, DbConnection, QueryExecutor};
+use super::{DataLoader, Db, DbConnection, QueryExecutor};
 
 const STORE: &str = "PostgresDB";
 
@@ -24,43 +24,67 @@ pub(crate) type PackageResolver = Arc<Resolver<PackageCache>>;
 
 /// Store which fetches package for the given address from the backend db on every call
 /// to `fetch`
-pub struct DbPackageStore(Db);
+pub struct DbPackageStore(DataLoader);
+
+/// DataLoader key for fetching the latest version of a `Package` by its ID.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+struct PackageKey(AccountAddress);
 
 impl DbPackageStore {
-    pub fn new(db: Db) -> Self {
-        Self(db)
+    pub fn new(loader: DataLoader) -> Self {
+        Self(loader)
     }
 }
 
 #[async_trait]
 impl PackageStore for DbPackageStore {
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
-        let Self(db) = self;
-        let bcs: Option<Vec<u8>> = db
+        let Self(DataLoader(loader)) = self;
+        let Some(package) = loader.load_one(PackageKey(id)).await? else {
+            return Err(PackageResolverError::PackageNotFound(id));
+        };
+
+        Ok(package)
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<PackageKey> for Db {
+    type Value = Arc<Package>;
+    type Error = PackageResolverError;
+
+    async fn load(&self, keys: &[PackageKey]) -> Result<HashMap<PackageKey, Arc<Package>>> {
+        use packages::dsl;
+
+        let ids: BTreeSet<_> = keys.iter().map(|PackageKey(id)| id.to_vec()).collect();
+        let stored_packages: Vec<StoredPackage> = self
             .execute(move |conn| {
-                conn.result(move || {
-                    objects::dsl::objects
-                        .select(objects::dsl::serialized_object)
-                        .filter(objects::dsl::object_id.eq(id.to_vec()))
+                conn.results(move || {
+                    dsl::packages.filter(dsl::package_id.eq_any(ids.iter().cloned()))
                 })
-                .optional()
             })
-            .await?;
+            .await
+            .map_err(|e| PackageResolverError::Store {
+                store: STORE,
+                source: Arc::new(e),
+            })?;
 
-        if let Some(bcs) = bcs {
-            let object = bcs::from_bytes::<Object>(&bcs)?;
-            Ok(Arc::new(Package::read(&object)?))
-        } else {
-            Err(PackageResolverError::PackageNotFound(id))
+        let mut id_to_package = HashMap::new();
+        for stored_package in stored_packages {
+            let move_package = bcs::from_bytes(&stored_package.move_package)?;
+            let package = Package::read_from_package(&move_package)?;
+            id_to_package.insert(PackageKey(*move_package.id()), Arc::new(package));
         }
+
+        Ok(id_to_package)
     }
 }
 
-impl From<Error> for PackageResolverError {
-    fn from(source: Error) -> Self {
-        Self::Store {
-            store: STORE,
-            source: Box::new(source),
-        }
-    }
-}
+// impl From<Error> for PackageResolverError {
+//     fn from(source: Error) -> Self {
+//         Self::Store {
+//             store: STORE,
+//             source: Arc::new(source),
+//         }
+//     }
+// }

--- a/crates/sui-graphql-rpc/src/data/package_resolver.rs
+++ b/crates/sui-graphql-rpc/src/data/package_resolver.rs
@@ -79,12 +79,3 @@ impl Loader<PackageKey> for Db {
         Ok(id_to_package)
     }
 }
-
-// impl From<Error> for PackageResolverError {
-//     fn from(source: Error) -> Self {
-//         Self::Store {
-//             store: STORE,
-//             source: Arc::new(source),
-//         }
-//     }
-// }

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -14,12 +14,12 @@ use super::{
 };
 use crate::consistency::Checkpointed;
 use crate::{
-    data::{self, Conn, Db, DbConnection, QueryExecutor},
+    data::{self, Conn, DataLoader, Db, DbConnection, QueryExecutor},
     error::Error,
 };
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
-    dataloader::{DataLoader, Loader},
+    dataloader::Loader,
     *,
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
@@ -212,7 +212,7 @@ impl Checkpoint {
                 sequence_number: Some(sequence_number),
                 digest,
             } => {
-                let dl: &DataLoader<Db> = ctx.data_unchecked();
+                let DataLoader(dl) = ctx.data_unchecked();
                 dl.load_one(SeqNumKey {
                     sequence_number,
                     digest,
@@ -225,7 +225,7 @@ impl Checkpoint {
                 sequence_number: None,
                 digest: Some(digest),
             } => {
-                let dl: &DataLoader<Db> = ctx.data_unchecked();
+                let DataLoader(dl) = ctx.data_unchecked();
                 dl.load_one(DigestKey {
                     digest,
                     checkpoint_viewed_at,

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -4,7 +4,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::context_data::db_data_provider::{convert_to_validators, PgManager};
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::{DataLoader, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::server::watermark_task::Watermark;
 
@@ -17,7 +17,7 @@ use super::system_state_summary::SystemStateSummary;
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::validator_set::ValidatorSet;
 use async_graphql::connection::Connection;
-use async_graphql::dataloader::{DataLoader, Loader};
+use async_graphql::dataloader::Loader;
 use async_graphql::*;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::{Base58, Encoding};
@@ -274,7 +274,7 @@ impl Epoch {
         checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         if let Some(epoch_id) = filter {
-            let dl: &DataLoader<Db> = ctx.data_unchecked();
+            let DataLoader(dl) = ctx.data_unchecked();
             dl.load_one(EpochKey {
                 epoch_id,
                 checkpoint_viewed_at,

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -388,15 +388,7 @@ impl MovePackage {
 
 impl MovePackage {
     fn parsed_package(&self) -> Result<ParsedMovePackage, Error> {
-        // TODO: Leverage the package cache (attempt to read from it, and if that doesn't succeed,
-        // write back the parsed Package to the cache as well.)
-        let Some(native) = self.super_.native_impl() else {
-            return Err(Error::Internal(
-                "No native representation of package to parse.".to_string(),
-            ));
-        };
-
-        ParsedMovePackage::read(native)
+        ParsedMovePackage::read_from_package(&self.native)
             .map_err(|e| Error::Internal(format!("Error reading package: {e}")))
     }
 

--- a/crates/sui-light-client/src/main.rs
+++ b/crates/sui-light-client/src/main.rs
@@ -57,7 +57,7 @@ impl PackageStore for RemotePackageStore {
     /// some way.
     async fn fetch(&self, id: AccountAddress) -> ResolverResult<Arc<Package>> {
         let object = get_verified_object(&self.config, id.into()).await.unwrap();
-        let package = Package::read(&object).unwrap();
+        let package = Package::read_from_object(&object).unwrap();
         Ok(Arc::new(package))
     }
 }

--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -1,12 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use move_binary_format::errors::VMError;
 use move_core_types::account_address::AccountAddress;
 use sui_types::TypeTag;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("{0}")]
     Bcs(#[from] bcs::Error),
@@ -14,7 +16,7 @@ pub enum Error {
     #[error("Store {} error: {}", store, source)]
     Store {
         store: &'static str,
-        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
     },
 
     #[error("{0}")]
@@ -76,7 +78,7 @@ pub enum Error {
     UnexpectedSigner,
 
     #[error("Unexpected error: {0}")]
-    UnexpectedError(Box<dyn std::error::Error + Send + Sync + 'static>),
+    UnexpectedError(Arc<dyn std::error::Error + Send + Sync + 'static>),
 
     #[error("Type layout nesting exceeded limit of {0}")]
     ValueNesting(usize),


### PR DESCRIPTION
## Description

Use a DataLoader to serve fetches from the package store, so that when concurrent threads request the same package be fetched, we can batch them and avoid multiple round trips to the DB.

## Test plan

Try the following query before and after the change:

```graphql
query {
  owner(
    address: "0x029170bfa0a1677054263424fe4f9960c7cf05d359f6241333994c8830772bdb"
  ) {
    dynamicFields(first: 50) {
      pageInfo {
        hasNextPage
        endCursor
      }
      nodes {
        name {
          type {
            repr
          }
          json
        }
        value {
          ... on MoveValue {
            type {
              repr
            }
            json
          }
          ... on MoveObject {
            contents {
              json
              type {
                repr
              }
            }
          }
        }
      }
    }
  }
}
```

Before this change, the above request made about 90 DB roundtrips, and after the change, it takes about 5, not including checkpoint watermark fetches.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
