### PR TITLE
[bridge] add more sui events emitted in bridge.move

### DIFF
--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -6,6 +6,7 @@ use crate::{
     client::bridge_authority_aggregator::BridgeAuthorityAggregator,
     config::{BridgeClientConfig, BridgeNodeConfig},
     eth_syncer::EthSyncer,
+    events::init_all_struct_tags,
     orchestrator::BridgeOrchestrator,
     server::{handler::BridgeRequestHandler, run_server},
     storage::BridgeOrchestratorTables,
@@ -23,6 +24,7 @@ use tokio::task::JoinHandle;
 use tracing::info;
 
 pub async fn run_bridge_node(config: BridgeNodeConfig) -> anyhow::Result<JoinHandle<()>> {
+    init_all_struct_tags();
     let (server_config, client_config) = config.validate().await?;
 
     // Start Client

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -565,7 +565,7 @@ impl SuiClientInner for SuiSdkClient {
     ) -> Result<SuiTransactionBlockResponse, BridgeError> {
         match self.quorum_driver_api().execute_transaction_block(
             tx,
-            SuiTransactionBlockResponseOptions::new().with_effects(),
+            SuiTransactionBlockResponseOptions::new().with_effects().with_events(),
             Some(sui_types::quorum_driver_types::ExecuteTransactionRequestType::WaitForEffectsCert),
         ).await {
             Ok(response) => Ok(response),

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -305,15 +305,18 @@ pub async fn bridge_token(
     let signed_tn = context.sign_transaction(&tx);
     let resp = context.execute_transaction_must_succeed(signed_tn).await;
     let events = resp.events.unwrap();
-    let mut bridge_events = events
+    let bridge_events = events
         .data
         .iter()
         .filter_map(|event| SuiBridgeEvent::try_from_sui_event(event).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(bridge_events.len(), 1);
-    match bridge_events.remove(0) {
-        SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => event,
-    }
+    bridge_events
+        .iter()
+        .find_map(|e| match e {
+            SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => Some(event.clone()),
+            _ => None,
+        })
+        .unwrap()
 }
 
 /// Returns a VerifiedCertifiedBridgeAction with signatures from the given

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -419,7 +419,7 @@ pub struct MoveTypeCommitteeMember {
 }
 
 /// Rust version of the Move message::BridgeMessageKey type.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct MoveTypeBridgeMessageKey {
     pub source_chain: u8,
     pub message_type: u8,


### PR DESCRIPTION
## Description 

This PR adds more events in Rust to match those emitted in bridge.move. This is one extra step towards the monitoring system on bridge node.
Also adds two two handy functions `new_bridge_transactions` and `new_bridge_events` to help observe bridge transactions/events.


## Test plan 

unit tests + integration tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
