### PR TITLE
Use highest completed randomness round to recover state after restart

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -489,6 +489,8 @@ pub struct AuthorityEpochTables {
     pub(crate) randomness_rounds_pending: DBMap<RandomnessRound, ()>,
     /// Holds the value of the next RandomnessRound to be generated.
     pub(crate) randomness_next_round: DBMap<u64, RandomnessRound>,
+    /// Holds the value of the highest completed RandomnessRound (as reported to RandomnessReporter).
+    pub(crate) randomness_highest_completed_round: DBMap<u64, RandomnessRound>,
 }
 
 // TODO: move deferral related data structures to authority_per_epoch_store_util.rs

--- a/crates/sui-network/src/randomness/builder.rs
+++ b/crates/sui-network/src/randomness/builder.rs
@@ -133,6 +133,7 @@ impl UnstartedRandomness {
                 received_partial_sigs: BTreeMap::new(),
                 completed_sigs: BTreeSet::new(),
                 completed_rounds: BTreeSet::new(),
+                recovered_last_completed_round: None,
             },
             handle,
         )


### PR DESCRIPTION
## Description 

Adds code to keep track of the highest completed RandomnessRound during an epoch. On restart, we report this to the randomness network loop so it can recover state used to decide for which rounds to accept partial sigs.

## Test plan 

Added unit test.