### PR TITLE
[replay] Support state persist in batch replay

### DIFF
--- a/crates/sui-replay/src/batch_replay.rs
+++ b/crates/sui-replay/src/batch_replay.rs
@@ -7,6 +7,7 @@ use futures::future::join_all;
 use futures::FutureExt;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use sui_config::node::ExpensiveSafetyCheckConfig;
@@ -24,6 +25,7 @@ pub async fn batch_replay(
     expensive_safety_check_config: ExpensiveSafetyCheckConfig,
     use_authority: bool,
     terminate_early: bool,
+    persist_path: Option<PathBuf>,
 ) {
     let provider = Arc::new(TransactionDigestProvider::new(tx_digests));
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -34,6 +36,7 @@ pub async fn batch_replay(
         let expensive_safety_check_config = expensive_safety_check_config.clone();
         let rpc_url_ref = rpc_url.as_ref();
         let cancel = cancel.clone();
+        let persist_path_ref = persist_path.as_ref();
         tasks.push(run_task(
             provider,
             rpc_url_ref,
@@ -41,6 +44,7 @@ pub async fn batch_replay(
             use_authority,
             terminate_early,
             cancel,
+            persist_path_ref,
         ));
     }
     let all_failed_transactions: Vec<_> = join_all(tasks).await.into_iter().flatten().collect();
@@ -101,6 +105,7 @@ async fn run_task(
     use_authority: bool,
     terminate_early: bool,
     cancel: tokio_util::sync::CancellationToken,
+    persist_path: Option<&PathBuf>,
 ) -> Vec<ReplayEngineError> {
     let total_count = tx_digest_provider.get_total_count();
     let mut failed_transactions = vec![];
@@ -113,6 +118,16 @@ async fn run_task(
             "[{}/{}] Replaying transaction {:?}...",
             index, total_count, digest
         );
+        let sandbox_persist_path = persist_path.map(|path| path.join(format!("{}.json", digest)));
+        if let Some(p) = sandbox_persist_path.as_ref() {
+            if p.exists() {
+                info!(
+                    "Skipping transaction {:?} as it has been replayed before",
+                    digest
+                );
+                continue;
+            }
+        }
         let async_func = execute_transaction(
             &mut executor,
             &digest,
@@ -126,15 +141,22 @@ async fn run_task(
                 break;
             }
         };
-        if let Err(err) = result {
-            error!("Replaying transaction {:?} forked: {:?}", digest, err);
-            if terminate_early {
-                cancel.cancel();
-                failed_transactions.push(err);
-                break;
+        match result {
+            Err(err) => {
+                failed_transactions.push(err.clone());
+                error!("Replaying transaction {:?} forked: {:?}", digest, err);
+                if terminate_early {
+                    cancel.cancel();
+                    break;
+                }
             }
-        } else {
-            info!("Replaying transaction {:?} succeeded", digest);
+            Ok(sandbox_state) => {
+                info!("Replaying transaction {:?} succeeded", digest);
+                if let Some(p) = sandbox_persist_path {
+                    let out = serde_json::to_string(&sandbox_state).unwrap();
+                    std::fs::write(p, out).unwrap();
+                }
+            }
         }
     }
     failed_transactions

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -113,6 +113,12 @@ pub enum ReplayToolCommand {
             help = "Number of tasks to run in parallel"
         )]
         num_tasks: u64,
+        #[arg(
+            long,
+            help = "If provided, dump the state of the execution to a file in the given directory. \
+            This will allow faster replay next time."
+        )]
+        persist_path: Option<PathBuf>,
     },
 
     /// Replay a transaction from a node state dump
@@ -263,6 +269,7 @@ pub async fn execute_replay_command(
             path,
             terminate_early,
             num_tasks,
+            persist_path,
         } => {
             let file = std::fs::File::open(path).unwrap();
             let buf_reader = std::io::BufReader::new(file);
@@ -279,6 +286,7 @@ pub async fn execute_replay_command(
                 safety,
                 use_authority,
                 terminate_early,
+                persist_path,
             )
             .await;
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -845,6 +845,7 @@ impl SuiClientCommands {
                     path,
                     terminate_early,
                     num_tasks: 16,
+                    persist_path: None,
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =


### PR DESCRIPTION
## Description 

Add the ability to persist the state into files during batch replay.
It skips transactions that are already persisted.

## Test plan 

Run it on a list of transactions.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
