### PR TITLE
[Docs] Clarify EventFilter subscription/query differences

### DIFF
--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -209,7 +209,7 @@ async fn main() -> Result<()> {
 
 To filter the events returned from your queries, use the following data structures.
 
-:::caution
+:::info
 
 This set of filters applies only to event querying APIs. It differs from the filters offered for the subscriptions API (see following section). In particular, it does not support combinations like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, and `"Not": _`. 
 
@@ -232,7 +232,7 @@ This set of filters applies only to event querying APIs. It differs from the fil
 
 To create a subscription, you can set a filter to return only the set of events you're interested in listening for. 
 
-:::caution
+:::info
 
 This set of filters applies only to event subscription APIs. It differs from the filters offered for the query API (see previous section). In particular, it supports combinations like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, and `"Not": _`. 
 

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -211,7 +211,7 @@ To filter the events returned from your queries, use the following data structur
 
 :::caution
 
-This set of filters only applies to **Event querying APIs**. It differs from the filters offered for the subscriptions API (see following section), and in particular it **does not** support combinations, like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, or `"Not": _`. 
+This set of filters applies only to event querying APIs. It differs from the filters offered for the subscriptions API (see following section). In particular, it does not support combinations like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, and `"Not": _`. 
 
 :::
 

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -207,7 +207,13 @@ async fn main() -> Result<()> {
 
 ## Filtering event queries
 
-To filter the events returned from your queries, use the following data structures. Currently, you cannot combine filters.
+To filter the events returned from your queries, use the following data structures.
+
+:::caution
+
+This set of filters only applies to **Event querying APIs**. It differs from the filters offered for the subscriptions API (see following section), and in particular it **does not** support combinations, like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, or `"Not": _`. 
+
+:::
 
 | Query         | Description                                              | JSON-RPC Parameter Example                                                                          |
 | ------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -224,7 +230,14 @@ To filter the events returned from your queries, use the following data structur
 
 ## Filtering events for subscription
 
-To create a subscription, you can set a filter to return only the set of events you're interested in listening for. Unlike filtering event queries, you are able to combine subscription filters.
+To create a subscription, you can set a filter to return only the set of events you're interested in listening for. 
+
+:::caution
+
+This set of filters only applies to **Event subscription APIs**. It differs from the filters offered for the query API (see previous section), and in particular it **does** support combinations, like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, or `"Not": _`. 
+
+:::
+
 
 | Filter            | Description                                           | JSON-RPC Parameter Example                                                                 |
 | ----------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------ |

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -234,7 +234,7 @@ To create a subscription, you can set a filter to return only the set of events 
 
 :::caution
 
-This set of filters only applies to **Event subscription APIs**. It differs from the filters offered for the query API (see previous section), and in particular it **does** support combinations, like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, or `"Not": _`. 
+This set of filters applies only to event subscription APIs. It differs from the filters offered for the query API (see previous section). In particular, it supports combinations like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, and `"Not": _`. 
 
 :::
 


### PR DESCRIPTION
## Description

Make it clearer that there is a difference between the subscriptions API and the query API for events right now.

## Test plan 

:eyes:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
