### PR TITLE
[GraphQL] Remove "Live" ObjectKind, rename "Historical" to "Indexed"

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/object_at_version.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/object_at_version.exp
@@ -20,7 +20,7 @@ task 4 'run-graphql'. lines 62-75:
 Response: {
   "data": {
     "object": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 3,
       "asMoveObject": {
         "contents": {
@@ -45,7 +45,7 @@ task 7 'run-graphql'. lines 81-107:
 Response: {
   "data": {
     "latest_version": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 4,
       "asMoveObject": {
         "contents": {
@@ -57,7 +57,7 @@ Response: {
       }
     },
     "previous_version": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 3,
       "asMoveObject": {
         "contents": {
@@ -89,7 +89,7 @@ Response: {
       "asMoveObject": null
     },
     "previous_version": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 4,
       "asMoveObject": {
         "contents": {
@@ -116,7 +116,7 @@ task 13 'run-graphql'. lines 145-183:
 Response: {
   "data": {
     "latest_unwrapped": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 6,
       "asMoveObject": {
         "contents": {
@@ -133,7 +133,7 @@ Response: {
       "asMoveObject": null
     },
     "first_version": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 3,
       "asMoveObject": {
         "contents": {
@@ -181,7 +181,7 @@ task 19 'run-graphql'. lines 221-259:
 Response: {
   "data": {
     "object_within_available_range": {
-      "status": "HISTORICAL",
+      "status": "INDEXED",
       "version": 6,
       "asMoveObject": {
         "contents": {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2490,18 +2490,14 @@ input ObjectKey {
 
 enum ObjectKind {
 	"""
-	The object is loaded from serialized data, such as the contents of a transaction.
+	The object is loaded from serialized data, such as the contents of a transaction that hasn't
+	been indexed yet.
 	"""
 	NOT_INDEXED
 	"""
-	The object is currently live and is not deleted or wrapped.
+	The object is fetched from the index.
 	"""
-	LIVE
-	"""
-	The object is referenced at some version, and thus is fetched from the snapshot or
-	historical objects table.
-	"""
-	HISTORICAL
+	INDEXED
 	"""
 	The object is deleted or wrapped and only partial information can be loaded from the
 	indexer.

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -251,7 +251,7 @@ impl TryFrom<MoveObject> for DynamicField {
         let super_ = &stored.super_;
 
         let (df_object_id, df_kind) = match &super_.kind {
-            ObjectKind::Historical(_, stored) => stored
+            ObjectKind::Indexed(_, stored) => stored
                 .df_object_id
                 .as_ref()
                 .map(|id| (id, stored.df_kind))

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2494,18 +2494,14 @@ input ObjectKey {
 
 enum ObjectKind {
 	"""
-	The object is loaded from serialized data, such as the contents of a transaction.
+	The object is loaded from serialized data, such as the contents of a transaction that hasn't
+	been indexed yet.
 	"""
 	NOT_INDEXED
 	"""
-	The object is currently live and is not deleted or wrapped.
+	The object is fetched from the index.
 	"""
-	LIVE
-	"""
-	The object is referenced at some version, and thus is fetched from the snapshot or
-	historical objects table.
-	"""
-	HISTORICAL
+	INDEXED
 	"""
 	The object is deleted or wrapped and only partial information can be loaded from the
 	indexer.
@@ -4179,3 +4175,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+


### PR DESCRIPTION
## Description

With the removal of direct accesses to the `objects` table, the nomenclature we use around object kinds ("not indexed", "live", "historical", "deleted or wrapped") is less relevant. In particular, we never use "live" and the name "historical" is confusing because even the latest version of the object may be considered "historical".

This PR removes the "live" kind, and renames "historical" to "indexed" to better reflect how the users of GraphQL perceive the kinds of objects, rather than how the data is stored in the indexer's tables.

## Test plan

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests --features pg_integration
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: There is no longer a `Live` or `Historical`, `ObjectKind`, they have been merged into a single `Indexed` kind representing any object that has been fetched from the index (as opposed to an object that we have information about but that hasn't been indexed yet, or an object that has been deleted or wrapped so is not available).
- [ ] CLI: 
- [ ] Rust SDK: 
