### PR TITLE
Tweak p2p network concurrency settings

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -110,25 +110,25 @@ pub struct StateSyncConfig {
 
     /// Size of the StateSync actor's mailbox.
     ///
-    /// If unspecified, this will default to `2,048`.
+    /// If unspecified, this will default to `1,024`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mailbox_capacity: Option<usize>,
 
     /// Size of the broadcast channel use for notifying other systems of newly sync'ed checkpoints.
     ///
-    /// If unspecified, this will default to `2,048`.
+    /// If unspecified, this will default to `1,024`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub synced_checkpoint_broadcast_channel_capacity: Option<usize>,
 
     /// Set the upper bound on the number of checkpoint headers to be downloaded concurrently.
     ///
-    /// If unspecified, this will default to `2,000`.
+    /// If unspecified, this will default to `400`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint_header_download_concurrency: Option<usize>,
 
     /// Set the upper bound on the number of checkpoint contents to be downloaded concurrently.
     ///
-    /// If unspecified, this will default to `2,000`.
+    /// If unspecified, this will default to `400`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint_content_download_concurrency: Option<usize>,
 
@@ -192,27 +192,27 @@ impl StateSyncConfig {
     }
 
     pub fn mailbox_capacity(&self) -> usize {
-        const MAILBOX_CAPACITY: usize = 2_048;
+        const MAILBOX_CAPACITY: usize = 1_024;
 
         self.mailbox_capacity.unwrap_or(MAILBOX_CAPACITY)
     }
 
     pub fn synced_checkpoint_broadcast_channel_capacity(&self) -> usize {
-        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 2_048;
+        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 1_024;
 
         self.synced_checkpoint_broadcast_channel_capacity
             .unwrap_or(SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY)
     }
 
     pub fn checkpoint_header_download_concurrency(&self) -> usize {
-        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 2_000;
+        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 400;
 
         self.checkpoint_header_download_concurrency
             .unwrap_or(CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY)
     }
 
     pub fn checkpoint_content_download_concurrency(&self) -> usize {
-        const CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY: usize = 2_000;
+        const CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY: usize = 400;
 
         self.checkpoint_content_download_concurrency
             .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY)
@@ -333,13 +333,13 @@ pub struct RandomnessConfig {
     /// Maximum number of rounds ahead of our most recent completed round for which we should
     /// accept partial signatures from other validators.
     ///
-    /// If unspecified, this will default to 200.
+    /// If unspecified, this will default to 100.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_partial_sigs_rounds_ahead: Option<u64>,
 
     /// Maximum number of rounds for which partial signatures should be concurrently sent.
     ///
-    /// If unspecified, this will default to 200.
+    /// If unspecified, this will default to 100.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_partial_sigs_concurrent_sends: Option<usize>,
 
@@ -358,21 +358,21 @@ pub struct RandomnessConfig {
 
     /// Per-peer inflight limit for the SendPartialSignatures RPC.
     ///
-    /// If unspecified, this will default to 200.
+    /// If unspecified, this will default to 100.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub send_partial_signatures_inflight_limit: Option<usize>,
 }
 
 impl RandomnessConfig {
     pub fn max_partial_sigs_rounds_ahead(&self) -> u64 {
-        const MAX_PARTIAL_SIGS_ROUNDS_AHEAD: u64 = 200;
+        const MAX_PARTIAL_SIGS_ROUNDS_AHEAD: u64 = 100;
 
         self.max_partial_sigs_rounds_ahead
             .unwrap_or(MAX_PARTIAL_SIGS_ROUNDS_AHEAD)
     }
 
     pub fn max_partial_sigs_concurrent_sends(&self) -> usize {
-        const MAX_PARTIAL_SIGS_CONCURRENT_SENDS: usize = 200;
+        const MAX_PARTIAL_SIGS_CONCURRENT_SENDS: usize = 100;
 
         self.max_partial_sigs_concurrent_sends
             .unwrap_or(MAX_PARTIAL_SIGS_CONCURRENT_SENDS)
@@ -393,7 +393,7 @@ impl RandomnessConfig {
     }
 
     pub fn send_partial_signatures_inflight_limit(&self) -> usize {
-        const SEND_PARTIAL_SIGNATURES_INFLIGHT_LIMIT: usize = 200;
+        const SEND_PARTIAL_SIGNATURES_INFLIGHT_LIMIT: usize = 100;
 
         self.send_partial_signatures_inflight_limit
             .unwrap_or(SEND_PARTIAL_SIGNATURES_INFLIGHT_LIMIT)

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1024,6 +1024,12 @@ impl SuiNode {
 
             // Set high-performance defaults for quinn transport.
             // With 200MiB buffer size and ~500ms RTT, max throughput ~400MiB/s.
+            if quic_config.max_concurrent_bidi_streams.is_none() {
+                quic_config.max_concurrent_bidi_streams = Some(500);
+            }
+            if quic_config.max_concurrent_uni_streams.is_none() {
+                quic_config.max_concurrent_uni_streams = Some(500);
+            }
             if quic_config.stream_receive_window.is_none() {
                 quic_config.stream_receive_window = Some(100 << 20);
             }


### PR DESCRIPTION
Bring max concurrency limits down to more reasonable numbers, also increases Quinn max streams to accommodate the new limits.