### PR TITLE
[Consensus 2.0] extract timestamp method to a Clock component.

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -9,6 +9,7 @@ use prometheus::Registry;
 use sui_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use tracing::info;
 
+use crate::context::Clock;
 use crate::{
     authority_service::AuthorityService,
     block_manager::BlockManager,
@@ -158,6 +159,7 @@ where
             parameters,
             protocol_config,
             initialise_metrics(registry),
+            Arc::new(Clock::new()),
         ));
         let start_time = Instant::now();
 
@@ -347,7 +349,7 @@ mod tests {
     use super::*;
     use crate::{
         authority_node::AuthorityService,
-        block::{timestamp_utc_ms, BlockAPI as _, BlockRef, Round, TestBlock, VerifiedBlock},
+        block::{BlockAPI as _, BlockRef, Round, TestBlock, VerifiedBlock},
         block_verifier::NoopBlockVerifier,
         context::Context,
         core_thread::{CoreError, CoreThreadDispatcher},
@@ -511,7 +513,7 @@ mod tests {
         ));
 
         // Test delaying blocks with time drift.
-        let now = timestamp_utc_ms();
+        let now = context.clock.timestamp_utc_ms();
         let max_drift = context.parameters.max_forward_time_drift;
         let input_block = VerifiedBlock::new_for_test(
             TestBlock::new(9, 0)

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -9,7 +9,6 @@ use prometheus::Registry;
 use sui_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use tracing::info;
 
-use crate::context::Clock;
 use crate::{
     authority_service::AuthorityService,
     block_manager::BlockManager,
@@ -17,7 +16,7 @@ use crate::{
     broadcaster::Broadcaster,
     commit_observer::CommitObserver,
     commit_syncer::{CommitSyncer, CommitVoteMonitor},
-    context::Context,
+    context::{Clock, Context},
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
 
 use crate::{
-    block::{timestamp_utc_ms, BlockAPI as _, BlockRef, SignedBlock, VerifiedBlock, GENESIS_ROUND},
+    block::{BlockAPI as _, BlockRef, SignedBlock, VerifiedBlock, GENESIS_ROUND},
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, TrustedCommit},
     commit_syncer::CommitVoteMonitor,
@@ -108,7 +108,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
 
         // Reject block with timestamp too far in the future.
-        let now = timestamp_utc_ms();
+        let now = self.context.clock.timestamp_utc_ms();
         let forward_time_drift =
             Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
         if forward_time_drift > self.context.parameters.max_forward_time_drift {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -5,8 +5,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     ops::Deref,
-    sync::{Arc, OnceLock},
-    time::{Instant, SystemTime},
+    sync::Arc,
 };
 
 use bytes::Bytes;
@@ -30,25 +29,6 @@ pub(crate) const GENESIS_ROUND: Round = 0;
 
 /// Block proposal timestamp in milliseconds.
 pub type BlockTimestampMs = u64;
-
-// Returns the current time expressed as UNIX timestamp in milliseconds.
-// Calculated with Rust Instant to ensure monotonicity.
-pub(crate) fn timestamp_utc_ms() -> BlockTimestampMs {
-    static UNIX_EPOCH: OnceLock<Instant> = OnceLock::new();
-    let unix_epoch_instant = UNIX_EPOCH.get_or_init(|| {
-        let now = Instant::now();
-        let duration_since_unix_epoch =
-            match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(d) => d,
-                Err(e) => panic!("SystemTime before UNIX EPOCH! {e}"),
-            };
-        now.checked_sub(duration_since_unix_epoch).unwrap()
-    });
-    Instant::now()
-        .checked_duration_since(*unix_epoch_instant)
-        .unwrap()
-        .as_millis() as BlockTimestampMs
-}
 
 /// Sui transaction in serialised bytes
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -8,7 +8,7 @@ use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    block::{timestamp_utc_ms, BlockAPI, VerifiedBlock},
+    block::{BlockAPI, VerifiedBlock},
     commit::{load_committed_subdag_from_store, CommitAPI, CommitIndex, CommittedSubDag},
     context::Context,
     dag_state::DagState,
@@ -130,7 +130,7 @@ impl CommitObserver {
     }
 
     fn report_metrics(&self, committed: &[CommittedSubDag]) {
-        let utc_now = timestamp_utc_ms();
+        let utc_now = self.context.clock.timestamp_utc_ms();
         let mut total = 0;
         for block in committed.iter().flat_map(|dag| &dag.blocks) {
             let latency_ms = utc_now

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -45,7 +45,7 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
-    block::{timestamp_utc_ms, BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
+    block::{BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
     block_verifier::BlockVerifier,
     commit::{
         Commit, CommitAPI as _, CommitDigest, CommitRef, TrustedCommit, GENESIS_COMMIT_INDEX,
@@ -454,7 +454,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
 
         // 8. Make sure fetched block timestamps are lower than current time.
         for block in &fetched_blocks {
-            let now_ms = timestamp_utc_ms();
+            let now_ms = inner.context.clock.timestamp_utc_ms();
             let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
             if forward_drift == 0 {
                 continue;

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::time::{Instant, SystemTime};
 
+use crate::block::BlockTimestampMs;
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 #[cfg(test)]
 use consensus_config::{NetworkKeyPair, ProtocolKeyPair};
@@ -28,6 +30,8 @@ pub(crate) struct Context {
     pub protocol_config: ProtocolConfig,
     /// Metrics of this authority.
     pub metrics: Arc<Metrics>,
+    /// Access to local clock
+    pub clock: Arc<Clock>,
 }
 
 impl Context {
@@ -37,6 +41,7 @@ impl Context {
         parameters: Parameters,
         protocol_config: ProtocolConfig,
         metrics: Arc<Metrics>,
+        clock: Arc<Clock>,
     ) -> Self {
         Self {
             own_index,
@@ -44,6 +49,7 @@ impl Context {
             parameters,
             protocol_config,
             metrics,
+            clock,
         }
     }
 
@@ -56,6 +62,7 @@ impl Context {
             consensus_config::local_committee_and_keys(0, vec![1; committee_size]);
         let metrics = test_metrics();
         let temp_dir = TempDir::new().unwrap();
+        let clock = Arc::new(Clock::new());
 
         let context = Context::new(
             AuthorityIndex::new_for_test(0),
@@ -66,6 +73,7 @@ impl Context {
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),
             metrics,
+            clock,
         );
         (context, keypairs)
     }
@@ -86,5 +94,37 @@ impl Context {
     pub(crate) fn with_parameters(mut self, parameters: Parameters) -> Self {
         self.parameters = parameters;
         self
+    }
+}
+
+/// A clock that allows to derive the current UNIX system timestamp while guaranteeing that
+/// timestamp will be monotonically incremented having tolerance to ntp and system clock changes and corrections.
+/// Explicitly avoid to make `[Clock]` cloneable to ensure that a single instance is shared behind an `[Arc]`
+/// wherever is needed in order to make sure that consecutive calls to receive the system timestamp
+/// will remain monotonically increasing.
+pub(crate) struct Clock {
+    unix_epoch_instant: Instant,
+}
+
+impl Clock {
+    pub fn new() -> Self {
+        let now = Instant::now();
+        let duration_since_unix_epoch =
+            match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                Ok(d) => d,
+                Err(e) => panic!("SystemTime before UNIX EPOCH! {e}"),
+            };
+        let unix_epoch_instant = now.checked_sub(duration_since_unix_epoch).unwrap();
+
+        Self { unix_epoch_instant }
+    }
+
+    // Returns the current time expressed as UNIX timestamp in milliseconds.
+    // Calculated with Rust Instant to ensure monotonicity.
+    pub(crate) fn timestamp_utc_ms(&self) -> BlockTimestampMs {
+        Instant::now()
+            .checked_duration_since(self.unix_epoch_instant)
+            .unwrap()
+            .as_millis() as BlockTimestampMs
     }
 }

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 #[cfg(test)]
@@ -10,7 +10,6 @@ use consensus_config::{NetworkKeyPair, ProtocolKeyPair};
 use sui_protocol_config::ProtocolConfig;
 #[cfg(test)]
 use tempfile::TempDir;
-use tokio::time::Instant;
 
 use crate::block::BlockTimestampMs;
 #[cfg(test)]

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -2,16 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
-use crate::block::BlockTimestampMs;
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 #[cfg(test)]
 use consensus_config::{NetworkKeyPair, ProtocolKeyPair};
 use sui_protocol_config::ProtocolConfig;
 #[cfg(test)]
 use tempfile::TempDir;
+use tokio::time::Instant;
 
+use crate::block::BlockTimestampMs;
 #[cfg(test)]
 use crate::metrics::test_metrics;
 use crate::metrics::Metrics;

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1082,25 +1082,6 @@ mod test {
     async fn test_core_try_new_block_leader_timeout() {
         telemetry_subscribers::init_for_testing();
 
-        // Since we run the test with started_paused = true, any time-dependent operations using Tokio's time
-        // facilities, such as tokio::time::sleep or tokio::time::Instant, will not advance. So practically each
-        // Core's clock will have initialised potentially with different values but it never advances.
-        // To ensure that blocks won't get rejected by cores we'll need to manually wait for the time
-        // diff before processing them. By calling the `tokio::time::sleep` we implicitly also advance the
-        // tokio clock.
-        async fn wait_blocks(blocks: &[VerifiedBlock], context: &Context) {
-            // Simulate the time wait before processing a block to ensure that block.timestamp <= now
-            let now = context.clock.timestamp_utc_ms();
-            let max_timestamp = blocks
-                .iter()
-                .max_by_key(|block| block.timestamp_ms() as BlockTimestampMs)
-                .map(|block| block.timestamp_ms())
-                .unwrap_or(0);
-
-            let wait_time = Duration::from_millis(max_timestamp.saturating_sub(now));
-            sleep(wait_time).await;
-        }
-
         // Create the cores for all authorities
         let mut all_cores = create_cores(vec![1, 1, 1, 1]);
 
@@ -1116,8 +1097,6 @@ mod test {
             let mut this_round_blocks = Vec::new();
 
             for (core, _signal_receivers, _, _, _) in cores.iter_mut() {
-                wait_blocks(&last_round_blocks, &core.context).await;
-
                 core.add_blocks(last_round_blocks.clone()).unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -1142,8 +1121,6 @@ mod test {
         // Try to create the blocks for round 4 by calling the try_propose() method. No block should be created as the
         // leader - authority 3 - hasn't proposed any block.
         for (core, _, _, _, _) in cores.iter_mut() {
-            wait_blocks(&last_round_blocks, &core.context).await;
-
             core.add_blocks(last_round_blocks.clone()).unwrap();
             assert!(core.try_propose(false).unwrap().is_none());
         }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1082,6 +1082,25 @@ mod test {
     async fn test_core_try_new_block_leader_timeout() {
         telemetry_subscribers::init_for_testing();
 
+        // Since we run the test with started_paused = true, any time-dependent operations using Tokio's time
+        // facilities, such as tokio::time::sleep or tokio::time::Instant, will not advance. So practically each
+        // Core's clock will have initialised potentially with different values but it never advances.
+        // To ensure that blocks won't get rejected by cores we'll need to manually wait for the time
+        // diff before processing them. By calling the `tokio::time::sleep` we implicitly also advance the
+        // tokio clock.
+        async fn wait_blocks(blocks: &[VerifiedBlock], context: &Context) {
+            // Simulate the time wait before processing a block to ensure that block.timestamp <= now
+            let now = context.clock.timestamp_utc_ms();
+            let max_timestamp = blocks
+                .iter()
+                .max_by_key(|block| block.timestamp_ms() as BlockTimestampMs)
+                .map(|block| block.timestamp_ms())
+                .unwrap_or(0);
+
+            let wait_time = Duration::from_millis(max_timestamp.saturating_sub(now));
+            sleep(wait_time).await;
+        }
+
         // Create the cores for all authorities
         let mut all_cores = create_cores(vec![1, 1, 1, 1]);
 
@@ -1092,11 +1111,13 @@ mod test {
         let (_last_core, cores) = all_cores.split_last_mut().unwrap();
 
         // Now iterate over a few rounds and ensure the corresponding signals are created while network advances
-        let mut last_round_blocks = Vec::new();
+        let mut last_round_blocks = Vec::<VerifiedBlock>::new();
         for round in 1..=3 {
             let mut this_round_blocks = Vec::new();
 
             for (core, _signal_receivers, _, _, _) in cores.iter_mut() {
+                wait_blocks(&last_round_blocks, &core.context).await;
+
                 core.add_blocks(last_round_blocks.clone()).unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -1121,6 +1142,8 @@ mod test {
         // Try to create the blocks for round 4 by calling the try_propose() method. No block should be created as the
         // leader - authority 3 - hasn't proposed any block.
         for (core, _, _, _, _) in cores.iter_mut() {
+            wait_blocks(&last_round_blocks, &core.context).await;
+
             core.add_blocks(last_round_blocks.clone()).unwrap();
             assert!(core.try_propose(false).unwrap().is_none());
         }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -15,8 +15,8 @@ use tracing::{debug, error};
 
 use crate::{
     block::{
-        genesis_blocks, timestamp_utc_ms, BlockAPI, BlockDigest, BlockRef, BlockTimestampMs, Round,
-        Slot, VerifiedBlock, GENESIS_ROUND,
+        genesis_blocks, BlockAPI, BlockDigest, BlockRef, BlockTimestampMs, Round, Slot,
+        VerifiedBlock, GENESIS_ROUND,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitVote, TrustedCommit},
     context::Context,
@@ -143,7 +143,7 @@ impl DagState {
             return;
         }
 
-        let now = timestamp_utc_ms();
+        let now = self.context.clock.timestamp_utc_ms();
         if block.timestamp_ms() > now {
             panic!(
                 "Block {:?} cannot be accepted! Block timestamp {} is greater than local timestamp {}.",

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -18,7 +18,7 @@ use tokio::task::JoinSet;
 use tokio::time::{sleep, sleep_until, timeout, Instant};
 use tracing::{debug, error, info, warn};
 
-use crate::block::{timestamp_utc_ms, BlockRef, SignedBlock, VerifiedBlock};
+use crate::block::{BlockRef, SignedBlock, VerifiedBlock};
 use crate::block_verifier::BlockVerifier;
 use crate::context::Context;
 use crate::core_thread::CoreThreadDispatcher;
@@ -553,7 +553,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
             // Dropping is ok because the block will be refetched.
             // TODO: improve efficiency, maybe suspend and continue processing the block asynchronously.
-            let now = timestamp_utc_ms();
+            let now = context.clock.timestamp_utc_ms();
             if now < verified_block.timestamp_ms() {
                 warn!(
                     "Fetched block {} timestamp {} is in the future (now={}). Ignoring.",


### PR DESCRIPTION
## Description 

This PR refactors the method to retrieve the current system timestamp and instead creates a dedicated Clock obj to facilitate the functionality. The refactor will fix the failing sim tests [here](https://github.com/MystenLabs/sui/actions/runs/8813919886)

The static initialisation of the unix epoch instant is creating issues with simulation testing framework which is not allowing the re-initalisation from one iteration to another, and effectively making simtests with multiple iterations fail. Different iterations are initialised with different dates, thus making a test run with multiple iterations going back and forth in time effectively making Mysticeti producing timestamps from the first run (which intialised the static context). Failures here: https://github.com/MystenLabs/sui/actions/runs/8813919886

With the new approach we don't deal with any static initialisation but we rather construct from the beginning when the consensus authority node gets created. In the future we can also easily mock the Clock object as well for tests. Also putting the `Clock` behind the `Context` it made the whole integration very seamless.

## Test plan 

CI/Simulation tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
