### PR TITLE
[move-2024][docs] Update e2e-counter.mdx to move 2024 syntax

### DIFF
--- a/docs/content/guides/developer/app-examples/e2e-counter.mdx
+++ b/docs/content/guides/developer/app-examples/e2e-counter.mdx
@@ -53,12 +53,8 @@ Add your Move code under `sources` by creating a new `counter.move` file:
 
 ```move
 module counter::counter {
-    use sui::transfer;
-    use sui::object::{Self, UID};
-    use sui::tx_context::{Self, TxContext};
-
     /// A shared counter.
-    struct Counter has key {
+    public struct Counter has key {
         id: UID,
         owner: address,
         value: u64
@@ -68,7 +64,7 @@ module counter::counter {
     public fun create(ctx: &mut TxContext) {
         transfer::share_object(Counter {
             id: object::new(ctx),
-            owner: tx_context::sender(ctx),
+            owner: ctx.sender(),
             value: 0
         })
     }
@@ -80,7 +76,7 @@ module counter::counter {
 
     /// Set value (only runnable by the Counter owner)
     public fun set_value(counter: &mut Counter, value: u64, ctx: &TxContext) {
-        assert!(counter.owner == tx_context::sender(ctx), 0);
+        assert!(counter.owner == ctx.sender(), 0);
         counter.value = value;
     }
 }


### PR DESCRIPTION
## Description 

This updates the `counter` doc example to be use Move 2024 syntax.

## Test plan 

👀  plus local project creation / test to ensure it works

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
