### PR TITLE
[TrafficControl] Efficient traffic policy via Count Min Sketch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,6 +2791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "count-min-sketch"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca319fe30d7b68949da20d78b612215708af87157d49665a4545dadcc20fecc7"
+dependencies = [
+ "rand 0.8.5",
+ "siphasher",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12225,6 +12235,7 @@ dependencies = [
  "clap",
  "consensus-config",
  "consensus-core",
+ "count-min-sketch",
  "criterion",
  "dashmap",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,6 +294,7 @@ color-eyre = "0.6.2"
 comfy-table = "6.1.3"
 console-subscriber = "0.2"
 const-str = "0.5.3"
+count-min-sketch = "0.1.7"
 criterion = { version = "0.5.0", features = [
   "async",
   "async_tokio",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -16,6 +16,7 @@ bytes.workspace = true
 chrono.workspace = true
 consensus-core.workspace = true
 consensus-config.workspace = true
+count-min-sketch.workspace = true
 dashmap.workspace = true
 diffy = { version = "0.3", default-features = false }
 either.workspace = true

--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -4,11 +4,96 @@
 
 use std::{collections::HashMap, net::IpAddr, sync::Arc};
 
+use count_min_sketch::CountMinSketch32;
 use mysten_metrics::spawn_monitored_task;
 use parking_lot::RwLock;
+use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::time::SystemTime;
-use sui_types::traffic_control::{PolicyConfig, PolicyType, ServiceResponse};
+use std::time::{Instant, SystemTime};
+use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType, ServiceResponse};
+
+pub struct TrafficSketch {
+    /// Circular buffer Count Min Sketches representing a sliding window
+    /// of traffic data. Note that the 32 in CountMinSketch32 represents
+    /// the number of bits used to represent the count in the sketch. Since
+    /// we only count on a sketch for a window of `update_interval`, we only
+    /// need enough precision to represent the max expected unique IP addresses
+    /// we may see in that window. For a 10 second period, we might conservatively
+    /// expect 100,000, which can be represented in 17 bits, but not 16. We can
+    /// potentially lower the memory consumption by using CountMinSketch16, which
+    /// will reliably support up to ~65,000 unique IP addresses in the window.
+    sketches: VecDeque<CountMinSketch32<IpAddr>>,
+    window_size_secs: u64,
+    update_interval_secs: u64,
+    last_reset_time: Instant,
+    current_sketch_index: usize,
+}
+
+impl TrafficSketch {
+    pub fn new(
+        window_size_secs: u64,
+        update_interval_secs: u64,
+        sketch_capacity: usize,
+        sketch_probability: f64,
+        sketch_tolerance: f64,
+    ) -> Self {
+        let num_sketches = window_size_secs / update_interval_secs;
+        assert!(
+            window_size_secs < 600,
+            "window_size_secs too large. Max 600 seconds"
+        );
+        assert!(
+            update_interval_secs < window_size_secs,
+            "Update interval may not be larger than window size"
+        );
+        assert!(
+            update_interval_secs >= 1,
+            "Update interval too short, must be at least 1 second"
+        );
+        assert!(num_sketches <= 10, "Given parameters require too many sketches to be stored. Reduce window size or increase update interval.");
+        let mut sketches = VecDeque::with_capacity(num_sketches as usize);
+        for _ in 0..num_sketches {
+            sketches.push_back(
+                CountMinSketch32::<IpAddr>::new(
+                    sketch_capacity,
+                    sketch_probability,
+                    sketch_tolerance,
+                )
+                .expect("Failed to create CountMinSketch32"),
+            );
+        }
+        Self {
+            sketches,
+            window_size_secs,
+            update_interval_secs,
+            last_reset_time: Instant::now(),
+            current_sketch_index: 0,
+        }
+    }
+
+    fn increment_count(&mut self, ip: IpAddr) {
+        // reset all expired intervals
+        let current_time = Instant::now();
+        let mut elapsed = current_time.duration_since(self.last_reset_time).as_secs();
+        while elapsed >= self.update_interval_secs {
+            self.rotate_window();
+            elapsed -= self.update_interval_secs;
+        }
+        // Increment in the current active sketch
+        self.sketches[self.current_sketch_index].increment(&ip);
+    }
+
+    fn get_request_rate(&self, ip: &IpAddr) -> f64 {
+        let count: u32 = self.sketches.iter().map(|sketch| sketch.estimate(ip)).sum();
+        count as f64 / self.window_size_secs as f64
+    }
+
+    fn rotate_window(&mut self) {
+        self.current_sketch_index = (self.current_sketch_index + 1) % self.sketches.len();
+        self.sketches[self.current_sketch_index].clear();
+        self.last_reset_time = Instant::now();
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct TrafficTally {
@@ -33,9 +118,10 @@ pub trait Policy {
 
 // Nonserializable representation, also note that inner types are
 // not object safe, so we can't use a trait object instead
-#[derive(Clone)]
 pub enum TrafficControlPolicy {
+    FreqThreshold(FreqThresholdPolicy),
     NoOp(NoOpPolicy),
+    // Test policies below this point
     TestNConnIP(TestNConnIPPolicy),
     TestInspectIp(TestInspectIpPolicy),
     TestPanicOnInvocation(TestPanicOnInvocationPolicy),
@@ -45,6 +131,7 @@ impl Policy for TrafficControlPolicy {
     fn handle_tally(&mut self, tally: TrafficTally) -> PolicyResponse {
         match self {
             TrafficControlPolicy::NoOp(policy) => policy.handle_tally(tally),
+            TrafficControlPolicy::FreqThreshold(policy) => policy.handle_tally(tally),
             TrafficControlPolicy::TestNConnIP(policy) => policy.handle_tally(tally),
             TrafficControlPolicy::TestInspectIp(policy) => policy.handle_tally(tally),
             TrafficControlPolicy::TestPanicOnInvocation(policy) => policy.handle_tally(tally),
@@ -54,6 +141,7 @@ impl Policy for TrafficControlPolicy {
     fn policy_config(&self) -> &PolicyConfig {
         match self {
             TrafficControlPolicy::NoOp(policy) => policy.policy_config(),
+            TrafficControlPolicy::FreqThreshold(policy) => policy.policy_config(),
             TrafficControlPolicy::TestNConnIP(policy) => policy.policy_config(),
             TrafficControlPolicy::TestInspectIp(policy) => policy.policy_config(),
             TrafficControlPolicy::TestPanicOnInvocation(policy) => policy.policy_config(),
@@ -71,6 +159,9 @@ impl TrafficControlPolicy {
     pub async fn from_config(policy_type: PolicyType, policy_config: PolicyConfig) -> Self {
         match policy_type {
             PolicyType::NoOp => Self::NoOp(NoOpPolicy::new(policy_config)),
+            PolicyType::FreqThreshold(freq_threshold_config) => Self::FreqThreshold(
+                FreqThresholdPolicy::new(policy_config, freq_threshold_config),
+            ),
             PolicyType::TestNConnIP(n) => {
                 Self::TestNConnIP(TestNConnIPPolicy::new(policy_config, n).await)
             }
@@ -83,6 +174,60 @@ impl TrafficControlPolicy {
         }
     }
 }
+
+////////////// *** Policy definitions *** //////////////
+
+pub struct FreqThresholdPolicy {
+    config: PolicyConfig,
+    sketch: TrafficSketch,
+    threshold: u64,
+}
+
+impl FreqThresholdPolicy {
+    pub fn new(
+        config: PolicyConfig,
+        FreqThresholdConfig {
+            threshold,
+            window_size_secs,
+            update_interval_secs,
+            sketch_capacity,
+            sketch_probability,
+            sketch_tolerance,
+        }: FreqThresholdConfig,
+    ) -> Self {
+        let sketch = TrafficSketch::new(
+            window_size_secs,
+            update_interval_secs,
+            sketch_capacity,
+            sketch_probability,
+            sketch_tolerance,
+        );
+        Self {
+            config,
+            sketch,
+            threshold,
+        }
+    }
+
+    fn handle_tally(&mut self, tally: TrafficTally) -> PolicyResponse {
+        if let Some(ip) = tally.connection_ip {
+            self.sketch.increment_count(ip);
+            if self.sketch.get_request_rate(&ip) >= self.threshold as f64 {
+                return PolicyResponse {
+                    block_connection_ip: Some(ip),
+                    block_proxy_ip: None,
+                };
+            }
+        }
+        PolicyResponse::default()
+    }
+
+    fn policy_config(&self) -> &PolicyConfig {
+        &self.config
+    }
+}
+
+////////////// *** Test policies below this point *** //////////////
 
 #[derive(Clone)]
 pub struct NoOpPolicy {
@@ -102,8 +247,6 @@ impl NoOpPolicy {
         &self.config
     }
 }
-
-////////////// *** Test policies below this point *** //////////////
 
 #[derive(Clone)]
 pub struct TestNConnIPPolicy {
@@ -199,5 +342,85 @@ impl TestPanicOnInvocationPolicy {
 
     fn policy_config(&self) -> &PolicyConfig {
         &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[tokio::test]
+    async fn test_freq_threshold_policy() {
+        // Create freq policy that will block on average frequency 2 requests per second
+        // as observed over a 5 second window
+        let mut policy = TrafficControlPolicy::FreqThreshold(FreqThresholdPolicy::new(
+            PolicyConfig::default(),
+            FreqThresholdConfig {
+                threshold: 2,
+                window_size_secs: 5,
+                update_interval_secs: 1,
+                ..Default::default()
+            },
+        ));
+        let alice = TrafficTally {
+            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+            proxy_ip: None,
+            result: ServiceResponse::Validator(Ok(())),
+            timestamp: SystemTime::now(),
+        };
+        let bob = TrafficTally {
+            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
+            proxy_ip: None,
+            result: ServiceResponse::Validator(Ok(())),
+            timestamp: SystemTime::now(),
+        };
+
+        // initial 2 tallies for alice, should not block
+        for _ in 0..2 {
+            let response = policy.handle_tally(alice.clone());
+            assert_eq!(response.block_connection_ip, None);
+            assert_eq!(response.block_proxy_ip, None);
+        }
+
+        // meanwhile bob spams 10 requests at once and is blocked
+        for _ in 0..9 {
+            let response = policy.handle_tally(bob.clone());
+            assert_eq!(response.block_connection_ip, None);
+            assert_eq!(response.block_proxy_ip, None);
+        }
+        let response = policy.handle_tally(bob.clone());
+        assert_eq!(response.block_proxy_ip, None);
+        assert_eq!(response.block_connection_ip, bob.connection_ip);
+
+        // 2 more tallies, so far we are above 2 talles
+        // per second, but over the average window of 5 seconds
+        // we are still below the threshold. Should not block
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        for _ in 0..2 {
+            let response = policy.handle_tally(alice.clone());
+            assert_eq!(response.block_connection_ip, None);
+            assert_eq!(response.block_proxy_ip, None);
+        }
+        // bob is no longer blocked, as we moved past the bursty traffic
+        // in the sliding window
+        let _ = policy.handle_tally(bob.clone());
+        let response = policy.handle_tally(bob.clone());
+        assert_eq!(response.block_proxy_ip, None);
+        assert_eq!(response.block_connection_ip, None);
+
+        // close to threshold for alice, but still below
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        for _ in 0..5 {
+            let response = policy.handle_tally(alice.clone());
+            assert_eq!(response.block_connection_ip, None);
+            assert_eq!(response.block_proxy_ip, None);
+        }
+
+        // should block alice now
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let response = policy.handle_tally(alice.clone());
+        assert_eq!(response.block_connection_ip, alice.connection_ip);
+        assert_eq!(response.block_proxy_ip, None);
     }
 }

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -9,6 +9,13 @@ use serde_with::serde_as;
 use std::{fmt::Debug, path::PathBuf};
 
 const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
+// These values set to loosely attempt to limit
+// memory usage for a single sketch to ~20MB
+// For reference, see
+// https://github.com/jedisct1/rust-count-min-sketch/blob/master/src/lib.rs
+const DEFAULT_SKETCH_CAPACITY: usize = 100_000;
+const DEFAULT_SKETCH_PROBABILITY: f64 = 0.999;
+const DEFAULT_SKETCH_TOLERANCE: f64 = 0.2;
 
 #[derive(Clone, Debug)]
 pub enum ServiceResponse {
@@ -77,6 +84,61 @@ fn default_drain_timeout() -> u64 {
     TRAFFIC_SINK_TIMEOUT_SEC
 }
 
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct FreqThresholdConfig {
+    #[serde(default = "default_threshold")]
+    pub threshold: u64,
+    #[serde(default = "default_window_size_secs")]
+    pub window_size_secs: u64,
+    #[serde(default = "default_update_interval_secs")]
+    pub update_interval_secs: u64,
+    #[serde(default = "default_sketch_capacity")]
+    pub sketch_capacity: usize,
+    #[serde(default = "default_sketch_probability")]
+    pub sketch_probability: f64,
+    #[serde(default = "default_sketch_tolerance")]
+    pub sketch_tolerance: f64,
+}
+
+impl Default for FreqThresholdConfig {
+    fn default() -> Self {
+        Self {
+            threshold: default_threshold(),
+            window_size_secs: default_window_size_secs(),
+            update_interval_secs: default_update_interval_secs(),
+            sketch_capacity: default_sketch_capacity(),
+            sketch_probability: default_sketch_probability(),
+            sketch_tolerance: default_sketch_tolerance(),
+        }
+    }
+}
+
+fn default_threshold() -> u64 {
+    10
+}
+
+fn default_window_size_secs() -> u64 {
+    30
+}
+
+fn default_update_interval_secs() -> u64 {
+    5
+}
+
+fn default_sketch_capacity() -> usize {
+    DEFAULT_SKETCH_CAPACITY
+}
+
+fn default_sketch_probability() -> f64 {
+    DEFAULT_SKETCH_PROBABILITY
+}
+
+fn default_sketch_tolerance() -> f64 {
+    DEFAULT_SKETCH_TOLERANCE
+}
+
 // Serializable representation of policy types, used in config
 // in order to easily change in tests or to killswitch
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
@@ -84,6 +146,11 @@ pub enum PolicyType {
     /// Does nothing
     #[default]
     NoOp,
+
+    /// Blocks connection_ip after reaching a tally frequency (tallies per second)
+    /// of `threshold`, as calculated over an average window of `window_size_secs`
+    /// with granularity of `update_interval_secs`
+    FreqThreshold(FreqThresholdConfig),
 
     /* Below this point are test policies, and thus should not be used in production */
     ///

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -8,14 +8,15 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{fmt::Debug, path::PathBuf};
 
-const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 // These values set to loosely attempt to limit
 // memory usage for a single sketch to ~20MB
 // For reference, see
 // https://github.com/jedisct1/rust-count-min-sketch/blob/master/src/lib.rs
-const DEFAULT_SKETCH_CAPACITY: usize = 100_000;
-const DEFAULT_SKETCH_PROBABILITY: f64 = 0.999;
-const DEFAULT_SKETCH_TOLERANCE: f64 = 0.2;
+pub const DEFAULT_SKETCH_CAPACITY: usize = 50_000;
+pub const DEFAULT_SKETCH_PROBABILITY: f64 = 0.999;
+pub const DEFAULT_SKETCH_TOLERANCE: f64 = 0.2;
+
+const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 
 #[derive(Clone, Debug)]
 pub enum ServiceResponse {


### PR DESCRIPTION
## Description 

Introduce Count Min Sketch based traffic control policy. Count min sketch, also known as counting bloom filter, allows for estimating frequency counts on an unbounded stream via repeated hashing, within some threshold with some probability (configurable). Memory is bounded, and current settings attempt to limit to around 20MB per sketch.

In order to introduce a time based frequency, rather than a count (as is required for "rate" limiting), we introduce a sliding window of count min sketches, implemented as a circular buffer. A window of `n` time slots, each of `t` seconds, will consider all estimated tallies in the last `n * t` seconds, and get the rate by dividing by window length. This allows for the frequency to decay with granularity `t`. 

## Test plan 

Added unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
