### PR TITLE
[move-2024][migration] Update `games` to use Move 2024 Syntax

### DIFF
--- a/sui_programmability/examples/games/sources/drand_based_lottery.move
+++ b/sui_programmability/examples/games/sources/drand_based_lottery.move
@@ -123,7 +123,7 @@ module games::drand_based_lottery {
     /// The winner can redeem its ticket.
     public entry fun redeem(ticket: &Ticket, game: &Game, ctx: &mut TxContext) {
         assert!(object::id(game) == ticket.game_id, EInvalidTicket);
-        assert!(option::contains(&game.winner, &ticket.participant_index), EInvalidTicket);
+        assert!(game.winner.contains(&ticket.participant_index), EInvalidTicket);
 
         let winner = GameWinner {
             id: object::new(ctx),

--- a/sui_programmability/examples/games/sources/drand_based_lottery.move
+++ b/sui_programmability/examples/games/sources/drand_based_lottery.move
@@ -117,7 +117,7 @@ module games::drand_based_lottery {
             participant_index: game.participants,
         };
         game.participants = game.participants + 1;
-        transfer::public_transfer(ticket, tx_context::sender(ctx));
+        transfer::public_transfer(ticket, ctx.sender());
     }
 
     /// The winner can redeem its ticket.
@@ -129,7 +129,7 @@ module games::drand_based_lottery {
             id: object::new(ctx),
             game_id: ticket.game_id,
         };
-        transfer::public_transfer(winner, tx_context::sender(ctx));
+        transfer::public_transfer(winner, ctx.sender());
     }
 
     // Note that a ticket can be deleted before the game was completed.

--- a/sui_programmability/examples/games/sources/drand_based_scratch_card.move
+++ b/sui_programmability/examples/games/sources/drand_based_scratch_card.move
@@ -81,21 +81,21 @@ module games::drand_based_scratch_card {
         base_drand_round: u64,
         ctx: &mut TxContext
     ) {
-        let amount = coin::value(&reward);
+        let amount = reward.value();
         assert!(amount > 0 && amount % reward_factor == 0 , EInvalidReward);
 
         let game = Game {
             id: object::new(ctx),
-            reward_amount: coin::value(&reward),
-            creator: tx_context::sender(ctx),
+            reward_amount: reward.value(),
+            creator: ctx.sender(),
             reward_factor,
-            base_epoch: tx_context::epoch(ctx),
+            base_epoch: ctx.epoch(),
             base_drand_round,
         };
         let reward = Reward {
             id: object::new(ctx),
             game_id: object::id(&game),
-            balance: coin::into_balance(reward),
+            balance: reward.into_balance(),
         };
         transfer::freeze_object(game);
         transfer::share_object(reward);
@@ -105,14 +105,14 @@ module games::drand_based_scratch_card {
     /// the game was created.
     /// Note that the reward might have been withdrawn already. It's the user's responsibility to verify that.
     public entry fun buy_ticket(coin: Coin<SUI>, game: &Game, ctx: &mut TxContext) {
-        assert!(coin::value(&coin) * game.reward_factor == game.reward_amount, EInvalidDeposit);
-        assert!(tx_context::epoch(ctx) == game.base_epoch, EInvalidEpoch);
+        assert!(coin.value() * game.reward_factor == game.reward_amount, EInvalidDeposit);
+        assert!(ctx.epoch() == game.base_epoch, EInvalidEpoch);
         let ticket = Ticket {
             id: object::new(ctx),
             game_id: object::id(game),
         };
         transfer::public_transfer(coin, game.creator);
-        transfer::public_transfer(ticket, tx_context::sender(ctx));
+        transfer::public_transfer(ticket, ctx.sender());
     }
 
     public entry fun evaluate(
@@ -128,7 +128,7 @@ module games::drand_based_scratch_card {
         // as the adversary can control the values of ticket id. (For this particular game this attack is not
         // devastating, but for similar games it might be.)
         let random_key = drand_lib::derive_randomness(drand_sig);
-        let randomness = hmac_sha3_256(&random_key, &object::id_to_bytes(&object::id(&ticket)));
+        let randomness = hmac_sha3_256(&random_key, &object::id(&ticket).to_bytes());
         let is_winner = (drand_lib::safe_selection(game.reward_factor, &randomness) == 0);
 
         if (is_winner) {
@@ -136,7 +136,7 @@ module games::drand_based_scratch_card {
                 id: object::new(ctx),
                 game_id: object::id(game),
             };
-            transfer::public_transfer(winner, tx_context::sender(ctx));
+            transfer::public_transfer(winner, ctx.sender());
         };
         // Delete the ticket.
         let Ticket { id, game_id:  _} = ticket;
@@ -145,9 +145,9 @@ module games::drand_based_scratch_card {
 
     public entry fun take_reward(winner: Winner, reward: &mut Reward, ctx: &mut TxContext) {
         assert!(winner.game_id == reward.game_id, EInvalidTicket);
-        let full_balance = balance::value(&reward.balance);
+        let full_balance = reward.balance.value();
         if (full_balance > 0) {
-            transfer::public_transfer(coin::take(&mut reward.balance, full_balance, ctx), tx_context::sender(ctx));
+            transfer::public_transfer(coin::take(&mut reward.balance, full_balance, ctx), ctx.sender());
         };
         let Winner { id, game_id:  _} = winner;
         object::delete(id);
@@ -155,12 +155,12 @@ module games::drand_based_scratch_card {
 
     /// Can be called in case the reward was not withdrawn, to return the coins to the creator.
     public entry fun redeem(reward: &mut Reward, game: &Game, ctx: &mut TxContext) {
-        assert!(balance::value(&reward.balance) > 0, EInvalidReward);
+        assert!(reward.balance.value() > 0, EInvalidReward);
         assert!(object::id(game) == reward.game_id, EInvalidGame);
         // Since we define the game to take 24h+25h, a game that is created in epoch x may be completed in epochs
         // x+2 or x+3.
-        assert!(game.base_epoch + 3 < tx_context::epoch(ctx), ETooSoonToRedeem);
-        let full_balance = balance::value(&reward.balance);
+        assert!(game.base_epoch + 3 < ctx.epoch(), ETooSoonToRedeem);
+        let full_balance = reward.balance.value();
         transfer::public_transfer(coin::take(&mut reward.balance, full_balance, ctx), game.creator);
     }
 

--- a/sui_programmability/examples/games/sources/drand_based_scratch_card.move
+++ b/sui_programmability/examples/games/sources/drand_based_scratch_card.move
@@ -26,7 +26,6 @@
 module games::drand_based_scratch_card {
     use games::drand_lib;
     use sui::balance::Balance;
-    use sui::balance::{Self};
     use sui::coin::{Self, Coin};
     use sui::hmac::hmac_sha3_256;
 

--- a/sui_programmability/examples/games/sources/drand_lib.move
+++ b/sui_programmability/examples/games/sources/drand_lib.move
@@ -43,7 +43,7 @@ module games::drand_lib {
         // Note that this loop never copies the last byte of round_bytes, though it is not expected to ever be non-zero.
         while (i > 0) {
             let curr_byte = round % 0x100;
-            let curr_element = vector::borrow_mut(&mut round_bytes, i);
+            let curr_element = &mut round_bytes[i];
             *curr_element = (curr_byte as u8);
             round = round >> 8;
             i = i - 1;
@@ -64,12 +64,12 @@ module games::drand_lib {
     // Converts the first 16 bytes of rnd to a u128 number and outputs its modulo with input n.
     // Since n is u64, the output is at most 2^{-64} biased assuming rnd is uniformly random.
     public fun safe_selection(n: u64, rnd: &vector<u8>): u64 {
-        assert!(vector::length(rnd) >= 16, EInvalidRndLength);
+        assert!(rnd.length() >= 16, EInvalidRndLength);
         let mut m: u128 = 0;
         let mut i = 0;
         while (i < 16) {
             m = m << 8;
-            let curr_byte = *vector::borrow(rnd, i);
+            let curr_byte = rnd[i];
             m = m + (curr_byte as u128);
             i = i + 1;
         };

--- a/sui_programmability/examples/games/sources/hero.move
+++ b/sui_programmability/examples/games/sources/hero.move
@@ -4,7 +4,7 @@
 /// Example of a game character with basic attributes, inventory, and
 /// associated logic.
 module games::hero {
-    use sui::coin::{Self, Coin};
+    use sui::coin::Coin;
     use sui::event;
     use sui::math;
     use sui::sui::SUI;
@@ -380,7 +380,7 @@ module games::hero {
             test_scenario::return_immutable(game);
         };
         // Player slays the boar!
-        scenario/next_tx(player);
+        scenario.next_tx(player);
         {
             let game = scenario.take_immutable<GameInfo>();
             let game_ref = &game;

--- a/sui_programmability/examples/games/sources/hero.move
+++ b/sui_programmability/examples/games/sources/hero.move
@@ -199,7 +199,7 @@ module games::hero {
         (hero.experience * hero.hp) + sword_strength
     }
 
-    public use fun level_up_sword as Sword.level_up;
+    use fun level_up_sword as Sword.level_up;
 
     fun level_up_sword(sword: &mut Sword, amount: u64) {
         sword.strength = sword.strength + amount

--- a/sui_programmability/examples/games/sources/hero.move
+++ b/sui_programmability/examples/games/sources/hero.move
@@ -349,6 +349,7 @@ module games::hero {
     #[test]
     fun slay_boar_test() {
         use sui::test_scenario;
+        use sui::coin;
 
         let admin = @0xAD014;
         let player = @0x0;

--- a/sui_programmability/examples/games/sources/raffles.move
+++ b/sui_programmability/examples/games/sources/raffles.move
@@ -11,9 +11,9 @@
 
 module games::raffle_with_tickets {
     use sui::balance::{Self, Balance};
-    use sui::clock::{Self, Clock};
+    use sui::clock::Clock;
     use sui::coin::{Self, Coin};
-    use sui::random::{Self, Random, new_generator};
+    use sui::random::{Random, new_generator};
     use sui::sui::SUI;
 
     /// Error codes
@@ -91,7 +91,7 @@ module games::raffle_with_tickets {
 
         let Game { id, cost_in_sui: _, participants: _, end_time: _, winner: _, balance } = game;
         object::delete(id);
-        let reward = coin::from_balance(balance, ctx);
+        let reward = balance.into_coin(ctx);
         reward
     }
 
@@ -122,16 +122,16 @@ module games::raffle_with_tickets {
 
     #[test_only]
     public fun get_balance(game: &Game): u64 {
-        balance::value(&game.balance)
+        game.balance.value()
     }
 }
 
 
 module games::small_raffle {
     use sui::balance::{Self, Balance};
-    use sui::clock::{Self, Clock};
+    use sui::clock::Clock;
     use sui::coin::{Self, Coin};
-    use sui::random::{Self, Random, new_generator};
+    use sui::random::{Random, new_generator};
     use sui::sui::SUI;
     use sui::table::{Self, Table};
     use sui::tx_context::sender;
@@ -173,36 +173,36 @@ module games::small_raffle {
     /// functions are allowed, the calling function might abort the transaction depending on the winner.)
     /// Gas based attacks are not possible since the gas cost of this function is independent of the winner.
     entry fun close(game: Game, r: &Random, clock: &Clock, ctx: &mut TxContext) {
-        assert!(game.end_time <= clock::timestamp_ms(clock), EGameInProgress);
+        assert!(game.end_time <= clock.timestamp_ms(), EGameInProgress);
         let Game { id, cost_in_sui: _, participants, end_time: _, balance, mut participants_table } = game;
         if (participants > 0) {
             let mut generator = new_generator(r, ctx);
-            let winner = random::generate_u32_in_range(&mut generator, 1, participants);
-            let winner_address = *table::borrow(&participants_table, winner);
+            let winner = generator.generate_u32_in_range(1, participants);
+            let winner_address = participants_table[winner];
             let reward = coin::from_balance(balance, ctx);
             transfer::public_transfer(reward, winner_address);
         } else {
-            balance::destroy_zero(balance);
+            balance.destroy_zero();
         };
 
         let mut i = 1;
         while (i <= participants) {
-            table::remove(&mut participants_table, i);
+            participants_table.remove(i);
             i = i + 1;
         };
-        table::destroy_empty(participants_table);
+        participants_table.destroy_empty();
         object::delete(id);
     }
 
     /// Anyone can play.
     public fun play(game: &mut Game, coin: Coin<SUI>, clock: &Clock, ctx: &mut TxContext) {
-        assert!(game.end_time > clock::timestamp_ms(clock), EGameAlreadyCompleted);
-        assert!(coin::value(&coin) == game.cost_in_sui, EInvalidAmount);
+        assert!(game.end_time > clock.timestamp_ms(), EGameAlreadyCompleted);
+        assert!(coin.value() == game.cost_in_sui, EInvalidAmount);
         assert!(game.participants < MaxParticipants, EReachedMaxParticipants);
 
         game.participants = game.participants + 1;
         coin::put(&mut game.balance, coin);
-        table::add(&mut game.participants_table, game.participants, ctx.sender());
+        game.participants_table.add(game.participants, ctx.sender());
     }
 
     #[test_only]
@@ -222,6 +222,6 @@ module games::small_raffle {
 
     #[test_only]
     public fun get_balance(game: &Game): u64 {
-        balance::value(&game.balance)
+        game.balance.value()
     }
 }

--- a/sui_programmability/examples/games/sources/raffles.move
+++ b/sui_programmability/examples/games/sources/raffles.move
@@ -63,7 +63,7 @@ module games::raffle_with_tickets {
         assert!(game.end_time <= clock.timestamp_ms(), EGameInProgress);
         assert!(game.winner.is_none(), EGameAlreadyCompleted);
         assert!(game.participants > 0, ENoParticipants);
-        let mut generator = new_generator(r, ctx);
+        let mut generator = r.new_generator(ctx);
         let winner = generator.generate_u32_in_range(1, game.participants);
         game.winner = option::some(winner);
     }
@@ -176,7 +176,7 @@ module games::small_raffle {
         assert!(game.end_time <= clock.timestamp_ms(), EGameInProgress);
         let Game { id, cost_in_sui: _, participants, end_time: _, balance, mut participants_table } = game;
         if (participants > 0) {
-            let mut generator = new_generator(r, ctx);
+            let mut generator = r.new_generator(ctx);
             let winner = generator.generate_u32_in_range(1, participants);
             let winner_address = participants_table[winner];
             let reward = coin::from_balance(balance, ctx);

--- a/sui_programmability/examples/games/sources/rock_paper_scissors.move
+++ b/sui_programmability/examples/games/sources/rock_paper_scissors.move
@@ -91,8 +91,8 @@ module games::rock_paper_scissors {
     /// entry point and limits the ability to select a winner, if one of the secrets hasn't
     /// been revealed yet.
     public fun status(game: &Game): u8 {
-        let h1_len = vector::length(&game.hash_one);
-        let h2_len = vector::length(&game.hash_two);
+        let h1_len = game.hash_one.length();
+        let h2_len = game.hash_two.length();
 
         if (game.gesture_one != NONE && game.gesture_two != NONE) {
             STATUS_REVEALED
@@ -123,7 +123,7 @@ module games::rock_paper_scissors {
             hash_two: vector[],
             gesture_one: NONE,
             gesture_two: NONE,
-        }, tx_context::sender(ctx));
+        }, ctx.sender());
     }
 
     /// Transfer [`PlayerTurn`] to the game owner. Nobody at this point knows what move
@@ -134,7 +134,7 @@ module games::rock_paper_scissors {
         transfer::transfer(PlayerTurn {
             hash,
             id: object::new(ctx),
-            player: tx_context::sender(ctx),
+            player: ctx.sender(),
         }, at);
     }
 
@@ -147,9 +147,9 @@ module games::rock_paper_scissors {
         assert!(status == STATUS_HASH_SUBMISSION || status == STATUS_READY, 0);
         assert!(game.player_one == player || game.player_two == player, 0);
 
-        if (player == game.player_one && vector::length(&game.hash_one) == 0) {
+        if (player == game.player_one && game.hash_one.length() == 0) {
             game.hash_one = hash;
-        } else if (player == game.player_two && vector::length(&game.hash_two) == 0) {
+        } else if (player == game.player_two && game.hash_two.length() == 0) {
             game.hash_two = hash;
         } else {
             abort 0 // unreachable!()
@@ -164,7 +164,7 @@ module games::rock_paper_scissors {
         transfer::transfer(Secret {
             id: object::new(ctx),
             salt,
-            player: tx_context::sender(ctx),
+            player: ctx.sender(),
         }, at);
     }
 
@@ -213,7 +213,7 @@ module games::rock_paper_scissors {
         } else if (p2_wins) {
             transfer::public_transfer(prize, player_two)
         } else {
-            transfer::public_transfer(prize, tx_context::sender(ctx))
+            transfer::public_transfer(prize, ctx.sender())
         };
     }
 
@@ -247,7 +247,7 @@ module games::rock_paper_scissors {
     /// that nobody knows the gesture until the end, but at the same time each player commits
     /// to the result with his hash;
     fun hash(gesture: u8, mut salt: vector<u8>): vector<u8> {
-        vector::push_back(&mut salt, gesture);
+        salt.push_back(gesture);
         hash::sha2_256(salt)
     }
 }

--- a/sui_programmability/examples/games/sources/sea_hero.move
+++ b/sui_programmability/examples/games/sources/sea_hero.move
@@ -9,7 +9,7 @@
 /// Note that this mod does not require special permissions from `Hero` module;
 /// anyone is free to create a mod like this.
 module games::sea_hero {
-    use games::hero::{Self, Hero};
+    use games::hero::Hero;
 
     use sui::balance::{Self, Balance, Supply};
 
@@ -59,7 +59,7 @@ module games::sea_hero {
                 token_supply_max: 1000000,
                 monster_max: 10,
             },
-            tx_context::sender(ctx)
+            ctx.sender()
         )
     }
 
@@ -74,7 +74,7 @@ module games::sea_hero {
         // Hero needs strength greater than the reward value to defeat the
         // monster
         assert!(
-            hero::hero_strength(hero) >= balance::value(&reward),
+            hero.hero_strength() >= reward.value(),
             EHERO_NOT_STRONG_ENOUGH
         );
 
@@ -91,7 +91,7 @@ module games::sea_hero {
         recipient: address,
         ctx: &mut TxContext
     ) {
-        let current_coin_supply = balance::supply_value(&admin.supply);
+        let current_coin_supply = admin.supply.supply_value();
         let token_supply_max = admin.token_supply_max;
         // TODO: create error codes
         // ensure token supply cap is respected
@@ -102,7 +102,7 @@ module games::sea_hero {
 
         let monster = SeaMonster {
             id: object::new(ctx),
-            reward: balance::increase_supply(&mut admin.supply, reward_amount),
+            reward: admin.supply.increase_supply(reward_amount),
         };
         admin.monsters_created = admin.monsters_created + 1;
 
@@ -111,6 +111,6 @@ module games::sea_hero {
 
     /// Reward a hero will reap from slaying this monster
     public fun monster_reward(monster: &SeaMonster): u64 {
-        balance::value(&monster.reward)
+        monster.reward.value()
     }
 }

--- a/sui_programmability/examples/games/sources/sea_hero.move
+++ b/sui_programmability/examples/games/sources/sea_hero.move
@@ -74,7 +74,7 @@ module games::sea_hero {
         // Hero needs strength greater than the reward value to defeat the
         // monster
         assert!(
-            hero.hero_strength() >= reward.value(),
+            hero.strength() >= reward.value(),
             EHERO_NOT_STRONG_ENOUGH
         );
 

--- a/sui_programmability/examples/games/sources/sea_hero_helper.move
+++ b/sui_programmability/examples/games/sources/sea_hero_helper.move
@@ -42,14 +42,14 @@ module games::sea_hero_helper {
         // make sure the advertised reward is not too large + that the owner
         // gets a nonzero reward
         assert!(
-            sea_hero::monster_reward(&monster) > helper_reward,
+            monster.monster_reward() > helper_reward,
             EINVALID_HELPER_REWARD
         );
         transfer::transfer(
             HelpMeSlayThisMonster {
                 id: object::new(ctx),
                 monster,
-                monster_owner: tx_context::sender(ctx),
+                monster_owner: ctx.sender(),
                 helper_reward
             },
             helper
@@ -70,7 +70,7 @@ module games::sea_hero_helper {
         object::delete(id);
         let mut owner_reward = sea_hero::slay(hero, monster);
         let helper_reward = coin::take(&mut owner_reward, helper_reward, ctx);
-        transfer::public_transfer(coin::from_balance(owner_reward, ctx), monster_owner);
+        transfer::public_transfer(owner_reward.into_coin(ctx), monster_owner);
         helper_reward
     }
 
@@ -90,6 +90,6 @@ module games::sea_hero_helper {
     /// Return the number of coins that `wrapper.owner` will earn if the
     /// the helper slays the monster in `wrapper.
     public fun owner_reward(wrapper: &HelpMeSlayThisMonster): u64 {
-        sea_hero::monster_reward(&wrapper.monster) - wrapper.helper_reward
+        wrapper.monster.monster_reward() - wrapper.helper_reward
     }
 }

--- a/sui_programmability/examples/games/sources/shared_tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/shared_tic_tac_toe.move
@@ -82,9 +82,9 @@ module games::shared_tic_tac_toe {
         assert!(row < 3 && col < 3, EInvalidLocation);
         assert!(game.game_status == IN_PROGRESS, EGameEnded);
         let addr = get_cur_turn_address(game);
-        assert!(addr == tx_context::sender(ctx), EInvalidTurn);
+        assert!(addr == ctx.sender(), EInvalidTurn);
 
-        let cell = vector::borrow_mut(vector::borrow_mut(&mut game.gameboard, (row as u64)), (col as u64));
+        let cell = &mut game.gameboard[row as u64][col as u64];
         assert!(*cell == MARK_EMPTY, ECellOccupied);
 
         *cell = game.cur_turn % 2;
@@ -125,7 +125,7 @@ module games::shared_tic_tac_toe {
     }
 
     fun get_cell(game: &TicTacToe, row: u64, col: u64): u8 {
-        *vector::borrow(vector::borrow(&game.gameboard, row), col)
+        game.gameboard[row][col]
     }
 
     fun update_winner(game: &mut TicTacToe) {
@@ -160,9 +160,9 @@ module games::shared_tic_tac_toe {
     }
 
     fun get_winner_if_all_equal(game: &TicTacToe, row1: u64, col1: u64, row2: u64, col2: u64, row3: u64, col3: u64): u8 {
-        let cell1 = get_cell(game, row1, col1);
-        let cell2 = get_cell(game, row2, col2);
-        let cell3 = get_cell(game, row3, col3);
+        let cell1 = game.get_cell(row1, col1);
+        let cell2 = game.get_cell(row2, col2);
+        let cell3 = game.get_cell(row3, col3);
         if (cell1 == cell2 && cell1 == cell3) cell1 else MARK_EMPTY
     }
 }

--- a/sui_programmability/examples/games/sources/shared_tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/shared_tic_tac_toe.move
@@ -81,14 +81,14 @@ module games::shared_tic_tac_toe {
     public entry fun place_mark(game: &mut TicTacToe, row: u8, col: u8, ctx: &mut TxContext) {
         assert!(row < 3 && col < 3, EInvalidLocation);
         assert!(game.game_status == IN_PROGRESS, EGameEnded);
-        let addr = get_cur_turn_address(game);
+        let addr = game.get_cur_turn_address();
         assert!(addr == ctx.sender(), EInvalidTurn);
 
         let cell = &mut game.gameboard[row as u64][col as u64];
         assert!(*cell == MARK_EMPTY, ECellOccupied);
 
         *cell = game.cur_turn % 2;
-        update_winner(game);
+        game.update_winner();
         game.cur_turn = game.cur_turn + 1;
 
         if (game.game_status != IN_PROGRESS) {

--- a/sui_programmability/examples/games/sources/slot_machine.move
+++ b/sui_programmability/examples/games/sources/slot_machine.move
@@ -9,10 +9,10 @@
 /// Anyone can play the game by betting on X SUI. They win X with probability 49% and lose the X SUI otherwise.
 ///
 module games::slot_machine {
-    use sui::balance::{Self, Balance};
+    use sui::balance::Balance;
     use sui::coin::{Self, Coin};
     use sui::math;
-    use sui::random::{Self, Random, new_generator};
+    use sui::random::{Random, new_generator};
     use sui::sui::SUI;
 
     /// Error codes
@@ -33,53 +33,53 @@ module games::slot_machine {
         reward: Coin<SUI>,
         ctx: &mut TxContext,
     ) {
-        let amount = coin::value(&reward);
+        let amount = reward.value();
         assert!(amount > 0, EInvalidAmount);
         transfer::share_object(Game {
             id: object::new(ctx),
-            creator: tx_context::sender(ctx),
-            epoch: tx_context::epoch(ctx),
-            balance: coin::into_balance(reward),
+            creator: ctx.sender(),
+            epoch: ctx.epoch(),
+            balance: reward.into_balance(),
         });
     }
 
     /// Creator can withdraw remaining balance if the game is over.
     public fun close(game: Game, ctx: &mut TxContext): Coin<SUI> {
-        assert!(tx_context::epoch(ctx) > game.epoch, EInvalidEpoch);
-        assert!(tx_context::sender(ctx) == game.creator, EInvalidSender);
+        assert!(ctx.epoch() > game.epoch, EInvalidEpoch);
+        assert!(ctx.sender() == game.creator, EInvalidSender);
         let Game { id, creator: _, epoch: _, balance } = game;
         object::delete(id);
-        coin::from_balance(balance, ctx)
+        balance.into_coin(ctx)
     }
 
     /// Play one turn of the game.
     ///
     /// The function consumes the same amount of gas independently of the random outcome.
     entry fun play(game: &mut Game, r: &Random, coin: &mut Coin<SUI>, ctx: &mut TxContext) {
-        assert!(tx_context::epoch(ctx) == game.epoch, EInvalidEpoch);
-        assert!(coin::value(coin) > 0, EInvalidAmount);
+        assert!(ctx.epoch() == game.epoch, EInvalidEpoch);
+        assert!(coin.value() > 0, EInvalidAmount);
 
         // play the game
         let mut generator = new_generator(r, ctx);
-        let bet = random::generate_u8_in_range(&mut generator, 1, 100);
+        let bet = generator.generate_u8_in_range(1, 100);
         let lost = bet / 50; // 0 with probability 49%, and 1 or 2 with probability 51%
         let won = (2 - lost) / 2; // 1 with probability 49%, and 0 with probability 51%
 
         // move the bet amount from the user's coin to the game's balance
-        let coin_value = coin::value(coin);
-        let bet_amount = math::min(coin_value, balance::value(&game.balance));
-        coin::put(&mut game.balance, coin::split(coin, bet_amount, ctx));
+        let coin_value = coin.value();
+        let bet_amount = math::min(coin_value, game.balance.value());
+        coin::put(&mut game.balance, coin.split(bet_amount, ctx));
 
         // move the reward to the user's coin
         let reward = 2 * (won as u64) * bet_amount;
         // the assumption here is that the next line does not consumes more gas when called with zero reward than with
         // non-zero reward
-        coin::join(coin, coin::take(&mut game.balance, reward, ctx));
+        coin.join(coin::take(&mut game.balance, reward, ctx));
     }
 
     #[test_only]
     public fun get_balance(game: &Game): u64 {
-        balance::value(&game.balance)
+        game.balance.value()
     }
 
     #[test_only]

--- a/sui_programmability/examples/games/sources/tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/tic_tac_toe.move
@@ -76,9 +76,9 @@ module games::tic_tac_toe {
         let id = object::new(ctx);
         let game_id = object::uid_to_inner(&id);
         let gameboard = vector[
-            vector[option::none(), option::none(), option::none()],
-            vector[option::none(), option::none(), option::none()],
-            vector[option::none(), option::none(), option::none()],
+            vector[.none(), .none(), .none()],
+            vector[.none(), .none(), .none()],
+            vector[.none(), .none(), .none()],
         ];
         let game = TicTacToe {
             id,
@@ -88,7 +88,7 @@ module games::tic_tac_toe {
             x_address: x_address,
             o_address: o_address,
         };
-        transfer::transfer(game, tx_context::sender(ctx));
+        transfer::transfer(game, ctx.sender());
         let cap = MarkMintCap {
             id: object::new(ctx),
             game_id,
@@ -134,13 +134,13 @@ module games::tic_tac_toe {
             return
         };
         let cell = get_cell_mut_ref(game, mark.row, mark.col);
-        if (option::is_some(cell)) {
+        if (cell.is_some()) {
             // There is already a mark in the desired location.
             // Destroy the mark.
             delete_mark(mark);
             return
         };
-        option::fill(cell, mark);
+        cell.fill(mark);
         update_winner(game);
         game.cur_turn = game.cur_turn + 1;
 
@@ -157,19 +157,19 @@ module games::tic_tac_toe {
 
     public entry fun delete_game(game: TicTacToe) {
         let TicTacToe { id, mut gameboard, cur_turn: _, game_status: _, x_address: _, o_address: _ } = game;
-        while (vector::length(&gameboard) > 0) {
-            let mut row = vector::pop_back(&mut gameboard);
-            while (vector::length(&row) > 0) {
-                let mut element = vector::pop_back(&mut row);
-                if (option::is_some(&element)) {
-                    let mark = option::extract(&mut element);
+        while (gameboard.length() > 0) {
+            let mut row = gameboard.pop_back();
+            while (row.length() > 0) {
+                let mut element = row.pop_back();
+                if (element.is_some()) {
+                    let mark = element.extract();
                     delete_mark(mark);
                 };
-                option::destroy_none(element);
+                element.destroy_none();
             };
-            vector::destroy_empty(row);
+            row.destroy_empty();
         };
-        vector::destroy_empty(gameboard);
+        gameboard.destroy_empty();
         object::delete(id);
     }
 
@@ -194,7 +194,7 @@ module games::tic_tac_toe {
         cap.remaining_supply = cap.remaining_supply - 1;
         Mark {
             id: object::new(ctx),
-            player: tx_context::sender(ctx),
+            player: ctx.sender(),
             row,
             col,
         }
@@ -209,11 +209,11 @@ module games::tic_tac_toe {
     }
 
     fun get_cell_ref(game: &TicTacToe, row: u64, col: u64): &Option<Mark> {
-        vector::borrow(vector::borrow(&game.gameboard, row), col)
+        &game.gameboard[row][col]
     }
 
     fun get_cell_mut_ref(game: &mut TicTacToe, row: u64, col: u64): &mut Option<Mark> {
-        vector::borrow_mut(vector::borrow_mut(&mut game.gameboard, row), col)
+        &mut game.gameboard[row][col]
     }
 
     fun update_winner(game: &mut TicTacToe) {
@@ -242,8 +242,8 @@ module games::tic_tac_toe {
             return
         };
         let mut result = check_all_equal(game, row1, col1, row2, col2, row3, col3);
-        if (option::is_some(&result)) {
-            let winner = option::extract(&mut result);
+        if (result.is_some()) {
+            let winner = result.extract();
             game.game_status = if (&winner == &game.x_address) {
                 X_WIN
             } else {
@@ -256,15 +256,15 @@ module games::tic_tac_toe {
         let cell1 = get_cell_ref(game, row1, col1);
         let cell2 = get_cell_ref(game, row2, col2);
         let cell3 = get_cell_ref(game, row3, col3);
-        if (option::is_some(cell1) && option::is_some(cell2) && option::is_some(cell3)) {
-            let cell1_player = *&option::borrow(cell1).player;
-            let cell2_player = *&option::borrow(cell2).player;
-            let cell3_player = *&option::borrow(cell3).player;
+        if (cell1.is_some() && cell2.is_some() && cell3.is_some()) {
+            let cell1_player = *cell1.borrow().player;
+            let cell2_player = *cell2.borrow().player;
+            let cell3_player = *cell3.borrow().player;
             if (&cell1_player == &cell2_player && &cell1_player == &cell3_player) {
                 return option::some(cell1_player)
             };
         };
-        option::none()
+        .none()
     }
 
     fun delete_mark(mark: Mark) {

--- a/sui_programmability/examples/games/sources/tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/tic_tac_toe.move
@@ -128,20 +128,20 @@ module games::tic_tac_toe {
     public entry fun place_mark(game: &mut TicTacToe, mark: Mark, ctx: &mut TxContext) {
         // If we are placing the mark at the wrong turn, or if game has ended,
         // destroy the mark.
-        let addr = get_cur_turn_address(game);
+        let addr = game.get_cur_turn_address();
         if (game.game_status != IN_PROGRESS || &addr != &mark.player) {
-            delete_mark(mark);
+            mark.delete();
             return
         };
         let cell = get_cell_mut_ref(game, mark.row, mark.col);
         if (cell.is_some()) {
             // There is already a mark in the desired location.
             // Destroy the mark.
-            delete_mark(mark);
+            mark.delete();
             return
         };
         cell.fill(mark);
-        update_winner(game);
+        game.update_winner();
         game.cur_turn = game.cur_turn + 1;
 
         if (game.game_status != IN_PROGRESS) {
@@ -163,7 +163,7 @@ module games::tic_tac_toe {
                 let mut element = row.pop_back();
                 if (element.is_some()) {
                     let mark = element.extract();
-                    delete_mark(mark);
+                    mark.delete();
                 };
                 element.destroy_none();
             };
@@ -266,6 +266,8 @@ module games::tic_tac_toe {
         };
         option::none()
     }
+
+    use fun delete_mark as Mark.delete;
 
     fun delete_mark(mark: Mark) {
         let Mark { id, player: _, row: _, col: _ } = mark;

--- a/sui_programmability/examples/games/sources/tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/tic_tac_toe.move
@@ -76,9 +76,9 @@ module games::tic_tac_toe {
         let id = object::new(ctx);
         let game_id = object::uid_to_inner(&id);
         let gameboard = vector[
-            vector[.none(), .none(), .none()],
-            vector[.none(), .none(), .none()],
-            vector[.none(), .none(), .none()],
+            vector[option::none(), option::none(), option::none()],
+            vector[option::none(), option::none(), option::none()],
+            vector[option::none(), option::none(), option::none()],
         ];
         let game = TicTacToe {
             id,
@@ -257,14 +257,14 @@ module games::tic_tac_toe {
         let cell2 = get_cell_ref(game, row2, col2);
         let cell3 = get_cell_ref(game, row3, col3);
         if (cell1.is_some() && cell2.is_some() && cell3.is_some()) {
-            let cell1_player = *cell1.borrow().player;
-            let cell2_player = *cell2.borrow().player;
-            let cell3_player = *cell3.borrow().player;
+            let cell1_player = cell1.borrow().player;
+            let cell2_player = cell2.borrow().player;
+            let cell3_player = cell3.borrow().player;
             if (&cell1_player == &cell2_player && &cell1_player == &cell3_player) {
                 return option::some(cell1_player)
             };
         };
-        .none()
+        option::none()
     }
 
     fun delete_mark(mark: Mark) {

--- a/sui_programmability/examples/games/sources/tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/tic_tac_toe.move
@@ -74,7 +74,7 @@ module games::tic_tac_toe {
         // TODO: Validate sender address, only GameAdmin can create games.
 
         let id = object::new(ctx);
-        let game_id = object::uid_to_inner(&id);
+        let game_id = id.to_inner();
         let gameboard = vector[
             vector[option::none(), option::none(), option::none()],
             vector[option::none(), option::none(), option::none()],

--- a/sui_programmability/examples/games/tests/drand_based_lottery_tests.move
+++ b/sui_programmability/examples/games/tests/drand_based_lottery_tests.move
@@ -42,8 +42,7 @@ module games::drand_based_lottery_tests {
         let user3 = @0x2;
         let user4 = @0x3;
 
-        let mut scenario_val = test_scenario::begin(user1);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(user1);
 
         drand_based_lottery::create(10, scenario.ctx());
         scenario.next_tx(user1);
@@ -94,6 +93,6 @@ module games::drand_based_lottery_tests {
         test_scenario::return_to_address(user2, ticket);
 
         test_scenario::return_shared(game_val);
-        scenario_val.end();
+        scenario.end();
     }
 }

--- a/sui_programmability/examples/games/tests/drand_based_lottery_tests.move
+++ b/sui_programmability/examples/games/tests/drand_based_lottery_tests.move
@@ -45,57 +45,55 @@ module games::drand_based_lottery_tests {
         let mut scenario_val = test_scenario::begin(user1);
         let scenario = &mut scenario_val;
 
-        drand_based_lottery::create(10, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let mut game_val = test_scenario::take_shared<Game>(scenario);
+        drand_based_lottery::create(10, scenario.ctx());
+        scenario.next_tx(user1);
+        let mut game_val = scenario.take_shared<Game>();
         let game = &mut game_val;
 
         // User1 buys a ticket.
-        test_scenario::next_tx(scenario, user1);
-        drand_based_lottery::participate(game, test_scenario::ctx(scenario));
+        scenario.next_tx(user1);
+        game.participate(scenario.ctx());
         // User2 buys a ticket.
-        test_scenario::next_tx(scenario, user2);
-        drand_based_lottery::participate(game, test_scenario::ctx(scenario));
+        scenario.next_tx(user2);
+        game.participate(scenario.ctx());
         // User3 buys a tcket
-        test_scenario::next_tx(scenario, user3);
-        drand_based_lottery::participate(game, test_scenario::ctx(scenario));
+        scenario.next_tx(user3);
+        game.participate(scenario.ctx());
         // User4 buys a tcket
-        test_scenario::next_tx(scenario, user4);
-        drand_based_lottery::participate(game, test_scenario::ctx(scenario));
+        scenario.next_tx(user4);
+        game.participate(scenario.ctx());
 
         // User 2 closes the game.
-        test_scenario::next_tx(scenario, user2);
+        scenario.next_tx(user2);
         // Taken from the output of
         // curl https://drand.cloudflare.com/52db9ba70e0cc0f6eaf7803dd07447a1f5477735fd3f661792ba94600c84e971/public/8
-        drand_based_lottery::close(
-            game,
+        game.close(
             x"a0c06b9964123d2e6036aa004c140fc301f4edd3ea6b8396a15dfd7dfd70cc0dce0b4a97245995767ab72cf59de58c47",
         );
 
         // User3 completes the game.
-        test_scenario::next_tx(scenario, user3);
+        scenario.next_tx(user3);
         // Taken from theoutput of
         // curl https://drand.cloudflare.com/52db9ba70e0cc0f6eaf7803dd07447a1f5477735fd3f661792ba94600c84e971/public/10
-        drand_based_lottery::complete(
-            game,
+        game.complete(
             x"ac415e508c484053efed1c6c330e3ae0bf20185b66ed088864dac1ff7d6f927610824986390d3239dac4dd73e6f865f5",
         );
 
         // User2 is the winner since the mod of the hash results in 1.
-        test_scenario::next_tx(scenario, user2);
+        scenario.next_tx(user2);
         assert!(!test_scenario::has_most_recent_for_address<GameWinner>(user2), 1);
-        let ticket = test_scenario::take_from_address<Ticket>(scenario, user2);
-        let ticket_game_id = *drand_based_lottery::get_ticket_game_id(&ticket);
-        drand_based_lottery::redeem(&ticket, &game_val, test_scenario::ctx(scenario));
-        drand_based_lottery::delete_ticket(ticket);
+        let ticket = scenario.take_from_address<Ticket>(user2);
+        let ticket_game_id = *ticket.get_ticket_game_id();
+        ticket.redeem(&game_val, scenario.ctx());
+        ticket.delete_ticket();
 
         // Make sure User2 now has a winner ticket for the right game id.
-        test_scenario::next_tx(scenario, user2);
-        let ticket = test_scenario::take_from_address<GameWinner>(scenario, user2);
-        assert!(drand_based_lottery::get_game_winner_game_id(&ticket) == &ticket_game_id, 1);
+        scenario.next_tx(user2);
+        let ticket = scenario.take_from_address<GameWinner>(user2);
+        assert!(ticket.get_game_winner_game_id() == &ticket_game_id, 1);
         test_scenario::return_to_address(user2, ticket);
 
         test_scenario::return_shared(game_val);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }

--- a/sui_programmability/examples/games/tests/drand_based_scratch_card_tests.move
+++ b/sui_programmability/examples/games/tests/drand_based_scratch_card_tests.move
@@ -19,12 +19,11 @@ module games::drand_based_scratch_card_tests {
         let user1 = @0x0;
         let user2 = @0x1;
 
-        let mut scenario_val = test_scenario::begin(user1);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(user1);
 
         // Create the game and get back the output objects.
-        mint(user1, 10, scenario);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        mint(user1, 10, &mut scenario);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
         drand_based_scratch_card::create(coin1, 10, 10, scenario.ctx());
         scenario.next_tx(user1);
         let game = scenario.take_immutable<drand_based_scratch_card::Game>();
@@ -37,7 +36,7 @@ module games::drand_based_scratch_card_tests {
         loop {
             // User2 buys a ticket.
             scenario.next_tx(user2);
-            mint(user2, 1, scenario);
+            mint(user2, 1, &mut scenario);
             let coin2 = scenario.take_from_sender<Coin<SUI>>();
             drand_based_scratch_card::buy_ticket(coin2, &game, scenario.ctx());
             scenario.next_tx(user1);
@@ -74,23 +73,22 @@ module games::drand_based_scratch_card_tests {
 
         test_scenario::return_shared(reward_val);
         test_scenario::return_immutable(game);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun test_play_drand_scratch_card_without_winner() {
         let user1 = @0x0;
 
-        let mut scenario_val = test_scenario::begin(user1);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(user1);
 
         // Create the game and get back the output objects.
-        mint(user1, 10, scenario);
+        mint(user1, 10, &mut scenario);
         let coin1 = scenario.take_from_sender<Coin<SUI>>();
         drand_based_scratch_card::create(coin1, 10, 10, scenario.ctx());
         scenario.next_tx(user1);
         let game = scenario.take_immutable<drand_based_scratch_card::Game>();
-        let mut reward_val = scenario.take_shared<drand_based_scratch_card::Reward>();
+        let mut reward = scenario.take_shared<drand_based_scratch_card::Reward>();
 
         // More 4 epochs forward.
         scenario.next_epoch(user1);
@@ -99,15 +97,14 @@ module games::drand_based_scratch_card_tests {
         scenario.next_epoch(user1);
 
         // Take back the reward.
-        let reward = &mut reward_val;
         reward.redeem(&game, scenario.ctx());
         scenario.next_tx(user1);
         let coin1 = scenario.take_from_sender<Coin<SUI>>();
         assert!(coin1.value() == 10, 1);
         scenario.return_to_sender(coin1);
 
-        test_scenario::return_shared(reward_val);
+        test_scenario::return_shared(reward);
         test_scenario::return_immutable(game);
-        scenario_val.end();
+        scenario.end();
     }
 }

--- a/sui_programmability/examples/games/tests/drand_based_scratch_card_tests.move
+++ b/sui_programmability/examples/games/tests/drand_based_scratch_card_tests.move
@@ -10,8 +10,8 @@ module games::drand_based_scratch_card_tests {
     use games::drand_based_scratch_card;
 
     fun mint(addr: address, amount: u64, scenario: &mut Scenario) {
-        transfer::public_transfer(coin::mint_for_testing<SUI>(amount, test_scenario::ctx(scenario)), addr);
-        test_scenario::next_tx(scenario, addr);
+        transfer::public_transfer(coin::mint_for_testing<SUI>(amount, scenario.ctx()), addr);
+        scenario.next_tx(addr);
     }
 
     #[test]
@@ -25,37 +25,36 @@ module games::drand_based_scratch_card_tests {
         // Create the game and get back the output objects.
         mint(user1, 10, scenario);
         let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        drand_based_scratch_card::create(coin1, 10, 10, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let game = test_scenario::take_immutable<drand_based_scratch_card::Game>(scenario);
-        let mut reward_val = test_scenario::take_shared<drand_based_scratch_card::Reward>(scenario);
-        let drand_final_round = drand_based_scratch_card::end_of_game_round(drand_based_scratch_card::get_game_base_drand_round(&game));
+        drand_based_scratch_card::create(coin1, 10, 10, scenario.ctx());
+        scenario.next_tx(user1);
+        let game = scenario.take_immutable<drand_based_scratch_card::Game>();
+        let mut reward_val = scenario.take_shared<drand_based_scratch_card::Reward>();
+        let drand_final_round = drand_based_scratch_card::end_of_game_round(game.get_game_base_drand_round());
         assert!(drand_final_round == 58810, 1);
 
         // Since everything here is deterministic, we know that the 49th ticket will be a winner.
         let mut i = 0;
         loop {
             // User2 buys a ticket.
-            test_scenario::next_tx(scenario, user2);
+            scenario.next_tx(user2);
             mint(user2, 1, scenario);
-            let coin2 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-            drand_based_scratch_card::buy_ticket(coin2, &game, test_scenario::ctx(scenario));
-            test_scenario::next_tx(scenario, user1);
-            let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-            assert!(coin::value(&coin1) == 1, 1);
-            test_scenario::return_to_sender(scenario, coin1);
-            test_scenario::next_tx(scenario, user2);
-            let ticket = test_scenario::take_from_sender<drand_based_scratch_card::Ticket>(scenario);
+            let coin2 = scenario.take_from_sender<Coin<SUI>>();
+            drand_based_scratch_card::buy_ticket(coin2, &game, scenario.ctx());
+            scenario.next_tx(user1);
+            let coin1 = scenario.take_from_sender<Coin<SUI>>();
+            assert!(coin1.value() == 1, 1);
+            scenario.return_to_sender(coin1);
+            scenario.next_tx(user2);
+            let ticket = scenario.take_from_sender<drand_based_scratch_card::Ticket>();
             // Generated using:
             // curl https://drand.cloudflare.com/52db9ba70e0cc0f6eaf7803dd07447a1f5477735fd3f661792ba94600c84e971/public/58810
-            drand_based_scratch_card::evaluate(
-                ticket,
+            ticket.evaluate(
                 &game,
                 x"876b8586ed9522abd0ca596d6e214e9a7e9bedc4a2e9698d27970e892287268062aba93fd1a7c24fcc188a4c7f0a0e98",
-                test_scenario::ctx(scenario)
+                scenario.ctx()
             );
-            test_scenario::next_tx(scenario, user2);
-            if (test_scenario::has_most_recent_for_sender<drand_based_scratch_card::Winner>(scenario)) {
+            scenario.next_tx(user2);
+            if (scenario.has_most_recent_for_sender<drand_based_scratch_card::Winner>()) {
                 break
             };
             i = i + 1;
@@ -64,18 +63,18 @@ module games::drand_based_scratch_card_tests {
         assert!(i == 3, 1);
 
         // Claim the reward.
-        let winner = test_scenario::take_from_sender<drand_based_scratch_card::Winner>(scenario);
-        test_scenario::next_tx(scenario, user2);
+        let winner = scenario.take_from_sender<drand_based_scratch_card::Winner>();
+        scenario.next_tx(user2);
         let reward = &mut reward_val;
-        drand_based_scratch_card::take_reward(winner, reward, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user2);
-        let coin2 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        assert!(coin::value(&coin2) == 10, 1);
-        test_scenario::return_to_sender(scenario, coin2);
+        winner.take_reward(reward, scenario.ctx());
+        scenario.next_tx(user2);
+        let coin2 = scenario.take_from_sender<Coin<SUI>>();
+        assert!(coin2.value() == 10, 1);
+        scenario.return_to_sender(coin2);
 
         test_scenario::return_shared(reward_val);
         test_scenario::return_immutable(game);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -87,28 +86,28 @@ module games::drand_based_scratch_card_tests {
 
         // Create the game and get back the output objects.
         mint(user1, 10, scenario);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        drand_based_scratch_card::create(coin1, 10, 10, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let game = test_scenario::take_immutable<drand_based_scratch_card::Game>(scenario);
-        let mut reward_val = test_scenario::take_shared<drand_based_scratch_card::Reward>(scenario);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
+        drand_based_scratch_card::create(coin1, 10, 10, scenario.ctx());
+        scenario.next_tx(user1);
+        let game = scenario.take_immutable<drand_based_scratch_card::Game>();
+        let mut reward_val = scenario.take_shared<drand_based_scratch_card::Reward>();
 
         // More 4 epochs forward.
-        test_scenario::next_epoch(scenario, user1);
-        test_scenario::next_epoch(scenario, user1);
-        test_scenario::next_epoch(scenario, user1);
-        test_scenario::next_epoch(scenario, user1);
+        scenario.next_epoch(user1);
+        scenario.next_epoch(user1);
+        scenario.next_epoch(user1);
+        scenario.next_epoch(user1);
 
         // Take back the reward.
         let reward = &mut reward_val;
-        drand_based_scratch_card::redeem(reward, &game, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        assert!(coin::value(&coin1) == 10, 1);
-        test_scenario::return_to_sender(scenario, coin1);
+        reward.redeem(&game, scenario.ctx());
+        scenario.next_tx(user1);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
+        assert!(coin1.value() == 10, 1);
+        scenario.return_to_sender(coin1);
 
         test_scenario::return_shared(reward_val);
         test_scenario::return_immutable(game);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }

--- a/sui_programmability/examples/games/tests/raffles_tests.move
+++ b/sui_programmability/examples/games/tests/raffles_tests.move
@@ -13,8 +13,8 @@ module games::raffles_tests {
     use games::raffle_with_tickets;
 
     fun mint(addr: address, amount: u64, scenario: &mut Scenario) {
-        transfer::public_transfer(coin::mint_for_testing<SUI>(amount, test_scenario::ctx(scenario)), addr);
-        test_scenario::next_tx(scenario, addr);
+        transfer::public_transfer(coin::mint_for_testing<SUI>(amount, scenario.ctx()), addr);
+        scenario.next_tx(addr);
     }
 
     #[test]
@@ -28,74 +28,74 @@ module games::raffles_tests {
         let scenario = &mut scenario_val;
 
         // Setup randomness
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(user1);
+        let mut random_state = scenario.take_shared<Random>();
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         // Create the game and get back the output objects.
         mint(user1, 1000, scenario);
         let end_time = 100;
-        raffle_with_tickets::create(end_time, 10, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let mut game = test_scenario::take_shared<raffle_with_tickets::Game>(scenario);
-        assert!(raffle_with_tickets::get_cost_in_sui(&game) == 10, 1);
-        assert!(raffle_with_tickets::get_participants(&game) == 0, 1);
-        assert!(raffle_with_tickets::get_end_time(&game) == end_time, 1);
-        assert!(raffle_with_tickets::get_winner(&game) == option::none(), 1);
-        assert!(raffle_with_tickets::get_balance(&game) == 0, 1);
+        raffle_with_tickets::create(end_time, 10, scenario.ctx());
+        scenario.next_tx(user1);
+        let mut game = scenario.take_shared<raffle_with_tickets::Game>();
+        assert!(game.get_cost_in_sui() == 10, 1);
+        assert!(game.get_participants() == 0, 1);
+        assert!(game.get_end_time() == end_time, 1);
+        assert!(game.get_winner() == option::none(), 1);
+        assert!(game.get_balance() == 0, 1);
 
-        let mut clock = clock::create_for_testing(test_scenario::ctx(scenario));
-        clock::set_for_testing(&mut clock, 10);
+        let mut clock = clock::create_for_testing(scenario.ctx());
+        clock.set_for_testing(10);
 
         // Play with 4 users (everything here is deterministic)
-        test_scenario::next_tx(scenario, user1);
+        scenario.next_tx(user1);
         mint(user1, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        let t1 = raffle_with_tickets::buy_ticket(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(raffle_with_tickets::get_participants(&game) == 1, 1);
-        raffle_with_tickets::destroy_ticket(t1); // loser
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        let t1 = game.buy_ticket(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 1, 1);
+        t1.destroy_ticket(); // loser
 
-        test_scenario::next_tx(scenario, user2);
+        scenario.next_tx(user2);
         mint(user2, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        let t2 = raffle_with_tickets::buy_ticket(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(raffle_with_tickets::get_participants(&game) == 2, 1);
-        raffle_with_tickets::destroy_ticket(t2); // loser
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        let t2 = game.buy_ticket(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 2, 1);
+        t2.destroy_ticket(); // loser
 
-        test_scenario::next_tx(scenario, user3);
+        scenario.next_tx(user3);
         mint(user3, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        let t3 = raffle_with_tickets::buy_ticket(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(raffle_with_tickets::get_participants(&game) == 3, 1);
-        raffle_with_tickets::destroy_ticket(t3); // loser
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        let t3 = game.buy_ticket(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 3, 1);
+        t3.destroy_ticket(); // loser
 
-        test_scenario::next_tx(scenario, user4);
+        scenario.next_tx(user4);
         mint(user4, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        let t4 = raffle_with_tickets::buy_ticket(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(raffle_with_tickets::get_participants(&game) == 4, 1);
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        let t4 = game.buy_ticket(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 4, 1);
         // this is the winner
 
         // Determine the winner (-> user3)
-        clock::set_for_testing(&mut clock, 101);
-        raffle_with_tickets::determine_winner(&mut game, &random_state, &clock, test_scenario::ctx(scenario));
-        assert!(raffle_with_tickets::get_winner(&game) == option::some(4), 1);
-        assert!(raffle_with_tickets::get_balance(&game) == 40, 1);
-        clock::destroy_for_testing(clock);
+        clock.set_for_testing(101);
+        game.determine_winner(&random_state, &clock, scenario.ctx());
+        assert!(game.get_winner() == option::some(4), 1);
+        assert!(game.get_balance() == 40, 1);
+        clock.destroy_for_testing();
 
         // Take the reward
-        let coin = raffle_with_tickets::redeem(t4, game, test_scenario::ctx(scenario));
-        assert!(coin::value(&coin) == 40, 1);
-        coin::burn_for_testing(coin);
+        let coin = t4.redeem(game, scenario.ctx());
+        assert!(coin.value() == 40, 1);
+        coin.burn_for_testing();
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -109,67 +109,67 @@ module games::raffles_tests {
         let scenario = &mut scenario_val;
 
         // Setup randomness
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(user1);
+        let mut random_state = scenario.take_shared<Random>();
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         // Create the game and get back the output objects.
         mint(user1, 1000, scenario);
         let end_time = 100;
-        small_raffle::create(end_time, 10, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, user1);
-        let mut game = test_scenario::take_shared<small_raffle::Game>(scenario);
-        assert!(small_raffle::get_cost_in_sui(&game) == 10, 1);
-        assert!(small_raffle::get_participants(&game) == 0, 1);
-        assert!(small_raffle::get_end_time(&game) == end_time, 1);
-        assert!(small_raffle::get_balance(&game) == 0, 1);
+        small_raffle::create(end_time, 10, scenario.ctx());
+        scenario.next_tx(user1);
+        let mut game = scenario.take_shared<small_raffle::Game>();
+        assert!(game.get_cost_in_sui() == 10, 1);
+        assert!(game.get_participants() == 0, 1);
+        assert!(game.get_end_time() == end_time, 1);
+        assert!(game.get_balance() == 0, 1);
 
-        let mut clock = clock::create_for_testing(test_scenario::ctx(scenario));
-        clock::set_for_testing(&mut clock, 10);
+        let mut clock = clock::create_for_testing(scenario.ctx());
+        clock.set_for_testing(10);
 
         // Play with 4 users (everything here is deterministic)
-        test_scenario::next_tx(scenario, user1);
+        scenario.next_tx(user1);
         mint(user1, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        small_raffle::play(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(small_raffle::get_participants(&game) == 1, 1);
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        game.play(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 1, 1);
 
-        test_scenario::next_tx(scenario, user2);
+        scenario.next_tx(user2);
         mint(user2, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        small_raffle::play(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(small_raffle::get_participants(&game) == 2, 1);
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        game.play(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 2, 1);
 
-        test_scenario::next_tx(scenario, user3);
+        scenario.next_tx(user3);
         mint(user3, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        small_raffle::play(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(small_raffle::get_participants(&game) == 3, 1);
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        game.play(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 3, 1);
 
-        test_scenario::next_tx(scenario, user4);
+        scenario.next_tx(user4);
         mint(user4, 10, scenario);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        small_raffle::play(&mut game, coin, &clock, test_scenario::ctx(scenario));
-        assert!(small_raffle::get_participants(&game) == 4, 1);
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        game.play(coin, &clock, scenario.ctx());
+        assert!(game.get_participants() == 4, 1);
 
         // Determine the winner (-> user4)
-        clock::set_for_testing(&mut clock, 101);
-        small_raffle::close(game, &random_state, &clock, test_scenario::ctx(scenario));
-        clock::destroy_for_testing(clock);
+        clock.set_for_testing(101);
+        game.close(&random_state, &clock, scenario.ctx());
+        clock.destroy_for_testing();
 
         // Check that received the reward
-        test_scenario::next_tx(scenario, user4);
-        let coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        assert!(coin::value(&coin) == 40, 1);
-        coin::burn_for_testing(coin);
+        scenario.next_tx(user4);
+        let coin = scenario.take_from_sender<Coin<SUI>>();
+        assert!(coin.value() == 40, 1);
+        coin.burn_for_testing();
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }

--- a/sui_programmability/examples/games/tests/rock_paper_scissors_tests.move
+++ b/sui_programmability/examples/games/tests/rock_paper_scissors_tests.move
@@ -18,93 +18,93 @@ module games::rock_paper_scissors_tests {
         let scenario = &mut scenario_val;
 
         // Let the game begin!
-        game::new_game(mr_spock, mr_lizard, test_scenario::ctx(scenario));
+        game::new_game(mr_spock, mr_lizard, scenario.ctx());
 
         // Mr Spock makes his move. He does it secretly and hashes the gesture with a salt
         // so that only he knows what it is.
-        test_scenario::next_tx(scenario, mr_spock);
+        scenario.next_tx(mr_spock);
         {
             let hash = hash(game::rock(), b"my_phaser_never_failed_me!");
-            game::player_turn(the_main_guy, hash, test_scenario::ctx(scenario));
+            game::player_turn(the_main_guy, hash, scenario.ctx());
         };
 
         // Now it's time for The Main Guy to accept his turn.
-        test_scenario::next_tx(scenario, the_main_guy);
+        scenario.next_tx(the_main_guy);
         {
-            let mut game = test_scenario::take_from_sender<Game>(scenario);
-            let cap = test_scenario::take_from_sender<PlayerTurn>(scenario);
+            let mut game = scenario.take_from_sender<Game>();
+            let cap = scenario.take_from_sender<PlayerTurn>();
 
-            assert!(game::status(&game) == 0, 0); // STATUS_READY
+            assert!(game.status() == 0, 0); // STATUS_READY
 
-            game::add_hash(&mut game, cap);
+            game.add_hash(cap);
 
-            assert!(game::status(&game) == 1, 0); // STATUS_HASH_SUBMISSION
+            assert!(game.status() == 1, 0); // STATUS_HASH_SUBMISSION
 
-            test_scenario::return_to_sender(scenario, game);
+            scenario.return_to_sender(game);
         };
 
         // Same for Mr Lizard. He uses his secret phrase to encode his turn.
-        test_scenario::next_tx(scenario, mr_lizard);
+        scenario.next_tx(mr_lizard);
         {
             let hash = hash(game::scissors(), b"sssssss_you_are_dead!");
-            game::player_turn(the_main_guy, hash, test_scenario::ctx(scenario));
+            game::player_turn(the_main_guy, hash, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, the_main_guy);
+        scenario.next_tx(the_main_guy);
         {
-            let mut game = test_scenario::take_from_sender<Game>(scenario);
-            let cap = test_scenario::take_from_sender<PlayerTurn>(scenario);
-            game::add_hash(&mut game, cap);
+            let mut game = scenario.take_from_sender<Game>();
+            let cap = scenario.take_from_sender<PlayerTurn>();
+            game.add_hash(cap);
 
-            assert!(game::status(&game) == 2, 0); // STATUS_HASHES_SUBMITTED
+            assert!(game.status() == 2, 0); // STATUS_HASHES_SUBMITTED
 
-            test_scenario::return_to_sender(scenario, game);
+            scenario.return_to_sender(game);
         };
 
         // Now that both sides made their moves, it's time for  Mr Spock and Mr Lizard to
         // reveal their secrets. The Main Guy will then be able to determine the winner. Who's
         // gonna win The Prize? We'll see in a bit!
-        test_scenario::next_tx(scenario, mr_spock);
-        game::reveal(the_main_guy, b"my_phaser_never_failed_me!", test_scenario::ctx(scenario));
+        scenario.next_tx(mr_spock);
+        game::reveal(the_main_guy, b"my_phaser_never_failed_me!", scenario.ctx());
 
-        test_scenario::next_tx(scenario, the_main_guy);
+        scenario.next_tx(the_main_guy);
         {
-            let mut game = test_scenario::take_from_sender<Game>(scenario);
-            let secret = test_scenario::take_from_sender<Secret>(scenario);
-            game::match_secret(&mut game, secret);
+            let mut game = scenario.take_from_sender<Game>();
+            let secret = scenario.take_from_sender<Secret>();
+            game.match_secret(secret);
 
-            assert!(game::status(&game) == 3, 0); // STATUS_REVEALING
+            assert!(game.status() == 3, 0); // STATUS_REVEALING
 
-            test_scenario::return_to_sender(scenario, game);
+            scenario.return_to_sender(game);
         };
 
-        test_scenario::next_tx(scenario, mr_lizard);
-        game::reveal(the_main_guy, b"sssssss_you_are_dead!", test_scenario::ctx(scenario));
+        scenario.next_tx(mr_lizard);
+        game::reveal(the_main_guy, b"sssssss_you_are_dead!", scenario.ctx());
 
         // The final step. The Main Guy matches and reveals the secret of the Mr Lizard and
         // calls the [`select_winner`] function to release The Prize.
-        test_scenario::next_tx(scenario, the_main_guy);
+        scenario.next_tx(the_main_guy);
         {
-            let mut game = test_scenario::take_from_sender<Game>(scenario);
-            let secret = test_scenario::take_from_sender<Secret>(scenario);
-            game::match_secret(&mut game, secret);
+            let mut game = scenario.take_from_sender<Game>();
+            let secret = scenario.take_from_sender<Secret>();
+            game.match_secret(secret);
 
-            assert!(game::status(&game) == 4, 0); // STATUS_REVEALED
+            assert!(game.status() == 4, 0); // STATUS_REVEALED
 
-            game::select_winner(game, test_scenario::ctx(scenario));
+            game.select_winner(scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, mr_spock);
+        scenario.next_tx(mr_spock);
         // If it works, then MrSpock is in possession of the prize;
-        let prize = test_scenario::take_from_sender<ThePrize>(scenario);
+        let prize = scenario.take_from_sender<ThePrize>();
         // Don't forget to give it back!
-        test_scenario::return_to_sender(scenario, prize);
-        test_scenario::end(scenario_val);
+        scenario.return_to_sender(prize);
+        scenario_val.end();
     }
 
     // Copy of the hashing function from the main module.
     fun hash(gesture: u8, mut salt: vector<u8>): vector<u8> {
-        vector::push_back(&mut salt, gesture);
+        salt.push_back(gesture);
         hash::sha2_256(salt)
     }
 }

--- a/sui_programmability/examples/games/tests/rock_paper_scissors_tests.move
+++ b/sui_programmability/examples/games/tests/rock_paper_scissors_tests.move
@@ -14,8 +14,7 @@ module games::rock_paper_scissors_tests {
         let mr_lizard = @0xA55555;
         let mr_spock = @0x590C;
 
-        let mut scenario_val = test_scenario::begin(the_main_guy);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(the_main_guy);
 
         // Let the game begin!
         game::new_game(mr_spock, mr_lizard, scenario.ctx());
@@ -99,7 +98,7 @@ module games::rock_paper_scissors_tests {
         let prize = scenario.take_from_sender<ThePrize>();
         // Don't forget to give it back!
         scenario.return_to_sender(prize);
-        scenario_val.end();
+        scenario.end();
     }
 
     // Copy of the hashing function from the main module.

--- a/sui_programmability/examples/games/tests/shared_tic_tac_toe_tests.move
+++ b/sui_programmability/examples/games/tests/shared_tic_tac_toe_tests.move
@@ -18,7 +18,7 @@ module games::shared_tic_tac_toe_tests {
         // Anyone can create a game, because the game object will be eventually shared.
         let mut scenario_val = test_scenario::begin(player_x);
         let scenario = &mut scenario_val;
-        shared_tic_tac_toe::create_game(copy player_x, copy player_o, test_scenario::ctx(scenario));
+        shared_tic_tac_toe::create_game(copy player_x, copy player_o, scenario.ctx());
         // Player1 places an X in (1, 1).
         place_mark(1, 1, player_x, scenario);
         /*
@@ -69,19 +69,19 @@ module games::shared_tic_tac_toe_tests {
         assert!(status == X_WIN, 2);
 
         // X has the Trophy
-        test_scenario::next_tx(scenario, player_x);
+        scenario.next_tx(player_x);
         assert!(
-            test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
 
-        test_scenario::next_tx(scenario, player_o);
+        scenario.next_tx(player_o);
         // O has no Trophy
         assert!(
-            !test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            !scenario.has_most_recent_for_sender<Trophy>(),
             2
         );
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
 
@@ -93,7 +93,7 @@ module games::shared_tic_tac_toe_tests {
         // Anyone can create a game, because the game object will be eventually shared.
         let mut scenario_val = test_scenario::begin(player_x);
         let scenario = &mut scenario_val;
-        shared_tic_tac_toe::create_game(copy player_x, copy player_o, test_scenario::ctx(scenario));
+        shared_tic_tac_toe::create_game(copy player_x, copy player_o, scenario.ctx());
         // Player1 places an X in (0, 1).
         let mut status = place_mark(0, 1, player_x, scenario);
         assert!(status == IN_PROGRESS, 1);
@@ -187,17 +187,17 @@ module games::shared_tic_tac_toe_tests {
         assert!(status == DRAW, 2);
 
         // No one has the trophy
-        test_scenario::next_tx(scenario, player_x);
+        scenario.next_tx(player_x);
         assert!(
-            !test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            !scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
-        test_scenario::next_tx(scenario, player_o);
+        scenario.next_tx(player_o);
         assert!(
-            !test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            !scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
 
@@ -209,13 +209,13 @@ module games::shared_tic_tac_toe_tests {
     ): u8  {
         // The gameboard is now a shared object.
         // Any player can place a mark on it directly.
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         let status;
         {
-            let mut game_val = test_scenario::take_shared<TicTacToe>(scenario);
+            let mut game_val = scenario.take_shared<TicTacToe>();
             let game = &mut game_val;
-            shared_tic_tac_toe::place_mark(game, row, col, test_scenario::ctx(scenario));
-            status = shared_tic_tac_toe::get_status(game);
+            game.place_mark(row, col, scenario.ctx());
+            status = game.get_status();
             test_scenario::return_shared(game_val);
         };
         status

--- a/sui_programmability/examples/games/tests/tic_tac_toe_tests.move
+++ b/sui_programmability/examples/games/tests/tic_tac_toe_tests.move
@@ -19,7 +19,7 @@ module games::tic_tac_toe_tests {
         let mut scenario_val = test_scenario::begin(admin);
         let scenario = &mut scenario_val;
         // Admin creates a game
-        tic_tac_toe::create_game(copy player_x, copy player_o, scenario.ctx());
+        tic_tac_toe::create_game(player_x, player_o, scenario.ctx());
         // Player1 places an X in (1, 1).
         place_mark(1, 1, admin, player_x, scenario);
         /*
@@ -96,7 +96,7 @@ module games::tic_tac_toe_tests {
         let mut scenario_val = test_scenario::begin(admin);
         let scenario = &mut scenario_val;
 
-        tic_tac_toe::create_game(copy player_x, copy player_o, scenario.ctx());
+        tic_tac_toe::create_game(player_x, player_o, scenario.ctx());
         // Player1 places an X in (0, 1).
         let mut status = place_mark(0, 1, admin, player_x, scenario);
         assert!(status == IN_PROGRESS, 1);

--- a/sui_programmability/examples/games/tests/tic_tac_toe_tests.move
+++ b/sui_programmability/examples/games/tests/tic_tac_toe_tests.move
@@ -19,7 +19,7 @@ module games::tic_tac_toe_tests {
         let mut scenario_val = test_scenario::begin(admin);
         let scenario = &mut scenario_val;
         // Admin creates a game
-        tic_tac_toe::create_game(copy player_x, copy player_o, test_scenario::ctx(scenario));
+        tic_tac_toe::create_game(copy player_x, copy player_o, scenario.ctx());
         // Player1 places an X in (1, 1).
         place_mark(1, 1, admin, player_x, scenario);
         /*
@@ -71,19 +71,19 @@ module games::tic_tac_toe_tests {
         assert!(status == X_WIN, 2);
 
         // X has the trophy
-        test_scenario::next_tx(scenario, player_x);
+        scenario.next_tx(player_x);
         assert!(
-            test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
 
-        test_scenario::next_tx(scenario, player_o);
+        scenario.next_tx(player_o);
         // O has no Trophy
         assert!(
-            !test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            !scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
 
@@ -96,7 +96,7 @@ module games::tic_tac_toe_tests {
         let mut scenario_val = test_scenario::begin(admin);
         let scenario = &mut scenario_val;
 
-        tic_tac_toe::create_game(copy player_x, copy player_o, test_scenario::ctx(scenario));
+        tic_tac_toe::create_game(copy player_x, copy player_o, scenario.ctx());
         // Player1 places an X in (0, 1).
         let mut status = place_mark(0, 1, admin, player_x, scenario);
         assert!(status == IN_PROGRESS, 1);
@@ -190,17 +190,17 @@ module games::tic_tac_toe_tests {
         assert!(status == DRAW, 2);
 
         // No one has the trophy
-        test_scenario::next_tx(scenario, player_x);
+        scenario.next_tx(player_x);
         assert!(
-            !test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            !scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
-        test_scenario::next_tx(scenario, player_o);
+        scenario.next_tx(player_o);
         assert!(
-            !test_scenario::has_most_recent_for_sender<Trophy>(scenario),
+            !scenario.has_most_recent_for_sender<Trophy>(),
             1
         );
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun place_mark(
@@ -211,24 +211,24 @@ module games::tic_tac_toe_tests {
         scenario: &mut Scenario,
     ): u8  {
         // Step 1: player creates a mark and sends it to the game.
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         {
-            let mut cap = test_scenario::take_from_sender<MarkMintCap>(scenario);
-            tic_tac_toe::send_mark_to_game(&mut cap, admin, row, col, test_scenario::ctx(scenario));
-            test_scenario::return_to_sender(scenario, cap);
+            let mut cap = scenario.take_from_sender<MarkMintCap>();
+            cap.send_mark_to_game(admin, row, col, scenario.ctx());
+            scenario.return_to_sender(cap);
         };
         // Step 2: Admin places the received mark on the game board.
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         let status;
         {
-            let mut game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            assert!(tic_tac_toe::mark_player(&mark) == &player, 0);
-            assert!(tic_tac_toe::mark_row(&mark) == row, 1);
-            assert!(tic_tac_toe::mark_col(&mark) == col, 2);
-            tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
-            status = tic_tac_toe::get_status(&game);
-            test_scenario::return_to_sender(scenario, game);
+            let mut game = scenario.take_from_sender<TicTacToe>();
+            let mark = scenario.take_from_sender<Mark>();
+            assert!(mark.mark_player() == &player, 0);
+            assert!(mark.mark_row() == row, 1);
+            assert!(mark.mark_col() == col, 2);
+            game.place_mark(mark, scenario.ctx());
+            status = game.get_status();
+            scenario.return_to_sender(game);
         };
         // return the game status
         status


### PR DESCRIPTION
## Description 

Updates the `games` examples directory to use Move 2024 syntax

## Test plan 

Local disassembly testing, plus all the tests still work. Would appreciate a careful review, though!

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
