### PR TITLE
[graphql] Add support for clever error resolution in graphql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13337,6 +13337,7 @@ dependencies = [
  "insta",
  "lru 0.10.0",
  "move-binary-format",
+ "move-command-line-common",
  "move-compiler",
  "move-core-types",
  "serde",

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
@@ -1,0 +1,248 @@
+processed 29 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-81:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9477200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 83-83:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 9223372161408827393
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("callU8") }, 9223372161408827393), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372161408827393), message: Some("P0::m::callU8 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 3 'run'. lines 85-85:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 9223372174293860355
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("callU16") }, 9223372174293860355), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372174293860355), message: Some("P0::m::callU16 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
+
+task 4 'run'. lines 87-87:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 9223372187178893317
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("callU32") }, 9223372187178893317), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372187178893317), message: Some("P0::m::callU32 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
+
+task 5 'run'. lines 89-89:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 9223372200063926279
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 3, instruction: 1, function_name: Some("callU64") }, 9223372200063926279), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372200063926279), message: Some("P0::m::callU64 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
+
+task 6 'run'. lines 91-91:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 9223372212948959241
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("callU128") }, 9223372212948959241), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372212948959241), message: Some("P0::m::callU128 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
+
+task 7 'run'. lines 93-93:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 9223372225833992203
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("callU256") }, 9223372225833992203), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372225833992203), message: Some("P0::m::callU256 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
+
+task 8 'run'. lines 95-95:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 9223372238719156239
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("callAddress") }, 9223372238719156239), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372238719156239), message: Some("P0::m::callAddress at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
+
+task 9 'run'. lines 97-97:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 9223372251604189201
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 9223372251604189201), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372251604189201), message: Some("P0::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+
+task 10 'run'. lines 99-99:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callBytevec (function index 8) at offset 1, Abort Code: 9223372264489222163
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callBytevec") }, 9223372264489222163), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372264489222163), message: Some("P0::m::callBytevec at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+
+task 11 'run'. lines 101-101:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 9, instruction: 1, function_name: Some("normalAbort") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("P0::m::normalAbort at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
+
+task 12 'run'. lines 103-103:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 10) at offset 1, Abort Code: 9223372294552813567
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 10, instruction: 1, function_name: Some("assertLineNo") }, 9223372294552813567), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372294552813567), message: Some("P0::m::assertLineNo at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
+
+task 13 'create-checkpoint'. lines 105-105:
+Checkpoint created: 1
+
+task 14 'run-graphql'. lines 107-117:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU8' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU8' at source line 29\n0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU16' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU16' at source line 32\n0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU32' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU32' at source line 35\n0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU64' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU64' at source line 38\n0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU128' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU128' at source line 41\n0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU256' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU256' at source line 44\n0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAAddress' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callAddress' at source line 47\n0x0000000000000000000000000000000000000000000000000000000000000000"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAString' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callString' at source line 50\nThis is a string"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImNotAString' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callBytevec' at source line 53\n\u0001\u0002\u0003\u0004\u0005"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\nMove Runtime Abort. Location: b9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\nError from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'assertLineNo' at source line 59"
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 15 'upgrade'. lines 119-197:
+created: object(15,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 9530400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 16 'run'. lines 199-199:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU8 (function index 0) at offset 1, Abort Code: 9223372659625033729
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("callU8") }, 9223372659625033729), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372659625033729), message: Some("fake(1,0)::m::callU8 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 17 'run'. lines 201-201:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU16 (function index 1) at offset 1, Abort Code: 9223372672510066691
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("callU16") }, 9223372672510066691), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372672510066691), message: Some("fake(1,0)::m::callU16 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
+
+task 18 'run'. lines 203-203:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU32 (function index 2) at offset 1, Abort Code: 9223372685395099653
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("callU32") }, 9223372685395099653), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372685395099653), message: Some("fake(1,0)::m::callU32 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
+
+task 19 'run'. lines 205-205:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU64 (function index 3) at offset 1, Abort Code: 9223372698280132615
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 3, instruction: 1, function_name: Some("callU64") }, 9223372698280132615), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372698280132615), message: Some("fake(1,0)::m::callU64 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
+
+task 20 'run'. lines 207-207:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU128 (function index 4) at offset 1, Abort Code: 9223372711165165577
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("callU128") }, 9223372711165165577), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372711165165577), message: Some("fake(1,0)::m::callU128 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
+
+task 21 'run'. lines 209-209:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU256 (function index 5) at offset 1, Abort Code: 9223372724050198539
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("callU256") }, 9223372724050198539), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372724050198539), message: Some("fake(1,0)::m::callU256 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
+
+task 22 'run'. lines 211-211:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callAddress (function index 6) at offset 1, Abort Code: 9223372736935362575
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("callAddress") }, 9223372736935362575), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372736935362575), message: Some("fake(1,0)::m::callAddress at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
+
+task 23 'run'. lines 213-213:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callString (function index 7) at offset 1, Abort Code: 9223372749820395537
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 9223372749820395537), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372749820395537), message: Some("fake(1,0)::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+
+task 24 'run'. lines 215-215:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callBytevec (function index 8) at offset 1, Abort Code: 9223372762705428499
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callBytevec") }, 9223372762705428499), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372762705428499), message: Some("fake(1,0)::m::callBytevec at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+
+task 25 'run'. lines 217-217:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::normalAbort (function index 9) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 9, instruction: 1, function_name: Some("normalAbort") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("fake(1,0)::m::normalAbort at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
+
+task 26 'run'. lines 219-219:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::assertLineNo (function index 10) at offset 1, Abort Code: 9223372792769019903
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 10, instruction: 1, function_name: Some("assertLineNo") }, 9223372792769019903), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372792769019903), message: Some("fake(1,0)::m::assertLineNo at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
+
+task 27 'create-checkpoint'. lines 221-221:
+Checkpoint created: 2
+
+task 28 'run-graphql'. lines 223-233:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU32' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU32' at source line 151\n1"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU64' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU64' at source line 154\n1"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU128' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU128' at source line 157\n1"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAU256' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU256' at source line 160\n1"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAAddress' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callAddress' at source line 163\n0x0000000000000000000000000000000000000000000000000000000000000001"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImAString' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callString' at source line 166\nThis is a string in v2"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\n'ImNotAString' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callBytevec' at source line 169\n\u0001\u0002\u0003\u0004\u0005\u0006"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\nMove Runtime Abort. Location: 37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command\nError from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'assertLineNo' at source line 175"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-81:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 9477200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9484800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 83-83:
 Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 9223372161408827393
@@ -63,67 +63,67 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU8' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU8' at source line 29\n0"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU8' (line 29), 'ImAU8': 0"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU16' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU16' at source line 32\n0"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU16' (line 32), 'ImAU16': 1"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU32' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU32' at source line 35\n0"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU32' (line 35), 'ImAU32': 2"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU64' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU64' at source line 38\n0"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU64' (line 38), 'ImAU64': 3"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU128' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU128' at source line 41\n0"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU128' (line 41), 'ImAU128': 4"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU256' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callU256' at source line 44\n0"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU256' (line 44), 'ImAU256': 5"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAAddress' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callAddress' at source line 47\n0x0000000000000000000000000000000000000000000000000000000000000000"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callAddress' (line 47), 'ImAnAddress': 0x0000000000000000000000000000000000000000000000000000000000000006"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAString' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callString' at source line 50\nThis is a string"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callString' (line 50), 'ImAString': This is a string"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImNotAString' from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'callBytevec' at source line 53\n\u0001\u0002\u0003\u0004\u0005"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callBytevec' (line 53), 'ImNotAString': \u0001\u0002\u0003\u0004\u0005"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\nMove Runtime Abort. Location: b9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
+            "errors": "Error in 1st command, Move Runtime Abort. Location: 549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\nError from module '0xb9092b0c2580b96bded4464f1668697ff34aa53a3b62aef7be0a03d1fc9ea1e7::m' in function 'assertLineNo' at source line 59"
+            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::assertLineNo' (line 59)"
           }
         }
       ]
@@ -134,7 +134,7 @@ Response: {
 task 15 'upgrade'. lines 119-197:
 created: object(15,0)
 mutated: object(0,0), object(1,1)
-gas summary: computation_cost: 1000000, storage_cost: 9530400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+gas summary: computation_cost: 1000000, storage_cost: 9538000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
 task 16 'run'. lines 199-199:
 Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU8 (function index 0) at offset 1, Abort Code: 9223372659625033729
@@ -191,55 +191,55 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU32' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU32' at source line 151\n1"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU32' (line 151), 'ImAU32': 9"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU64' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU64' at source line 154\n1"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU64' (line 154), 'ImAU64': 10"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU128' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU128' at source line 157\n1"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU128' (line 157), 'ImAU128': 11"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAU256' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callU256' at source line 160\n1"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU256' (line 160), 'ImAU256': 12"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAAddress' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callAddress' at source line 163\n0x0000000000000000000000000000000000000000000000000000000000000001"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callAddress' (line 163), 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImAString' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callString' at source line 166\nThis is a string in v2"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callString' (line 166), 'ImAString': This is a string in v2"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\n'ImNotAString' from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'callBytevec' at source line 169\n\u0001\u0002\u0003\u0004\u0005\u0006"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callBytevec' (line 169), 'ImNotAString': \u0001\u0002\u0003\u0004\u0005\u0006"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\nMove Runtime Abort. Location: 37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
+            "errors": "Error in 1st command, Move Runtime Abort. Location: c1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command\nError from module '0x37bf9a78d7cedde7ae91de9f1a76a663146693a152b93e24aa7b96c3dc86b012::m' in function 'assertLineNo' at source line 175"
+            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::assertLineNo' (line 175)"
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-81:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 9484800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9743200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 83-83:
 Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 9223372161408827393
@@ -41,8 +41,8 @@ Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callStri
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 9223372251604189201), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372251604189201), message: Some("P0::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
 
 task 10 'run'. lines 99-99:
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callBytevec (function index 8) at offset 1, Abort Code: 9223372264489222163
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callBytevec") }, 9223372264489222163), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372264489222163), message: Some("P0::m::callBytevec at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 9223372264489222163
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callU64vec") }, 9223372264489222163), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372264489222163), message: Some("P0::m::callU64vec at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
 
 task 11 'run'. lines 101-101:
 Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0
@@ -63,67 +63,67 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU8' (line 29), 'ImAU8': 0"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU8' (line 29), abort 'ImAU8': 0"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU16' (line 32), 'ImAU16': 1"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU16' (line 32), abort 'ImAU16': 1"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU32' (line 35), 'ImAU32': 2"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU32' (line 35), abort 'ImAU32': 2"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU64' (line 38), 'ImAU64': 3"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU64' (line 38), abort 'ImAU64': 3"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU128' (line 41), 'ImAU128': 4"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU128' (line 41), abort 'ImAU128': 4"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callU256' (line 44), 'ImAU256': 5"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU256' (line 44), abort 'ImAU256': 5"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callAddress' (line 47), 'ImAnAddress': 0x0000000000000000000000000000000000000000000000000000000000000006"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callAddress' (line 47), abort 'ImAnAddress': 0x0000000000000000000000000000000000000000000000000000000000000006"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callString' (line 50), 'ImAString': This is a string"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callString' (line 50), abort 'ImAString': This is a string"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::callBytevec' (line 53), 'ImNotAString': \u0001\u0002\u0003\u0004\u0005"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU64vec' (line 53), abort 'ImNotAString': BQEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAA="
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, Move Runtime Abort. Location: 549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::normalAbort' (instruction 1), abort code: 0"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0x549be5f8d75cf6ec1eedf3f3e5ce807ccbba27074c87b70f82eb656dcf40edf9::m::assertLineNo' (line 59)"
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::assertLineNo' (line 59)"
           }
         }
       ]
@@ -134,7 +134,7 @@ Response: {
 task 15 'upgrade'. lines 119-197:
 created: object(15,0)
 mutated: object(0,0), object(1,1)
-gas summary: computation_cost: 1000000, storage_cost: 9538000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+gas summary: computation_cost: 1000000, storage_cost: 9849600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
 task 16 'run'. lines 199-199:
 Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU8 (function index 0) at offset 1, Abort Code: 9223372659625033729
@@ -169,8 +169,8 @@ Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::c
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 9223372749820395537), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372749820395537), message: Some("fake(1,0)::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
 
 task 24 'run'. lines 215-215:
-Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callBytevec (function index 8) at offset 1, Abort Code: 9223372762705428499
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callBytevec") }, 9223372762705428499), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372762705428499), message: Some("fake(1,0)::m::callBytevec at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU64vec (function index 8) at offset 1, Abort Code: 9223372762705428499
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callU64vec") }, 9223372762705428499), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372762705428499), message: Some("fake(1,0)::m::callU64vec at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
 
 task 25 'run'. lines 217-217:
 Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::normalAbort (function index 9) at offset 1, Abort Code: 0
@@ -191,55 +191,55 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU32' (line 151), 'ImAU32': 9"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU32' (line 151), abort 'ImAU32': 9"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU64' (line 154), 'ImAU64': 10"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU64' (line 154), abort 'ImAU64': 10"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU128' (line 157), 'ImAU128': 11"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU128' (line 157), abort 'ImAU128': 11"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callU256' (line 160), 'ImAU256': 12"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU256' (line 160), abort 'ImAU256': 12"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callAddress' (line 163), 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callAddress' (line 163), abort 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callString' (line 166), 'ImAString': This is a string in v2"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callString' (line 166), abort 'ImAString': This is a string in v2"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::callBytevec' (line 169), 'ImNotAString': \u0001\u0002\u0003\u0004\u0005\u0006"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU64vec' (line 169), abort 'ImNotAString': BgEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAAGAAAAAAAAAA=="
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, Move Runtime Abort. Location: c1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::normalAbort (function index 9) at offset 1, Abort Code: 0"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::normalAbort' (instruction 1), abort code: 0"
           }
         },
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, from '0xc1677ea77d86a83505d0d6fbd5fc5c2d44a2a7457a34499b7d5e4288a41ef7d1::m::assertLineNo' (line 175)"
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::assertLineNo' (line 175)"
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
@@ -1,0 +1,233 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 --accounts A --simulator 
+
+//# publish --upgradeable --sender A
+module P0::m {
+    #[error]
+    const ImAU8: u8 = 0;
+
+    #[error]
+    const ImAU16: u16 = 0;
+
+    #[error]
+    const ImAU32: u32 = 0;
+
+    #[error]
+    const ImAU64: u64 = 0;
+
+    #[error]
+    const ImAU128: u128 = 0;
+
+    #[error]
+    const ImAU256: u256 = 0;
+
+    #[error]
+    const ImABool: bool = true;
+
+    #[error]
+    const ImAAddress: address = @0;
+
+    #[error]
+    const ImAString: vector<u8> = b"This is a string";
+
+    #[error]
+    const ImNotAString: vector<u8> = vector[1,2,3,4,5];
+
+    public fun callU8() {
+        abort ImAU8
+    }
+
+    public fun callU16() {
+        abort ImAU16
+    }
+
+    public fun callU32() {
+        abort ImAU32
+    }
+
+    public fun callU64() {
+        abort ImAU64
+    }
+
+    public fun callU128() {
+        abort ImAU128
+    }
+
+    public fun callU256() {
+        abort ImAU256
+    }
+
+    public fun callAddress() {
+        abort ImAAddress
+    }
+
+    public fun callString() {
+        abort ImAString
+    }
+
+    public fun callBytevec() {
+        abort ImNotAString
+    }
+
+    public fun normalAbort() {
+        abort 0
+    }
+
+    public fun assertLineNo() {
+        assert!(false);
+    }
+}
+
+//# run P0::m::callU8
+
+//# run P0::m::callU16
+
+//# run P0::m::callU32
+
+//# run P0::m::callU64
+
+//# run P0::m::callU128
+
+//# run P0::m::callU256
+
+//# run P0::m::callAddress
+
+//# run P0::m::callString
+
+//# run P0::m::callBytevec
+
+//# run P0::m::normalAbort
+
+//# run P0::m::assertLineNo
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(last: 11) {
+    nodes {
+      effects {
+        status
+        errors
+      }
+    }
+  }
+}
+
+//# upgrade --package P0 --upgrade-capability 1,1 --sender A
+// Upgrade the module with new error values but using the same constant names
+// (etc) to make sure we properly resolve the module location for clever
+// errors.
+module P0::m {
+    #[error]
+    const ImAU8: u8 = 1;
+
+    #[error]
+    const ImAU16: u16 = 1;
+
+    #[error]
+    const ImAU32: u32 = 1;
+
+    #[error]
+    const ImAU64: u64 = 1;
+
+    #[error]
+    const ImAU128: u128 = 1;
+
+    #[error]
+    const ImAU256: u256 = 1;
+
+    #[error]
+    const ImABool: bool = false;
+
+    #[error]
+    const ImAAddress: address = @1;
+
+    #[error]
+    const ImAString: vector<u8> = b"This is a string in v2";
+
+    #[error]
+    const ImNotAString: vector<u8> = vector[1,2,3,4,5, 6];
+
+    public fun callU8() {
+        abort ImAU8
+    }
+
+    public fun callU16() {
+        abort ImAU16
+    }
+
+    public fun callU32() {
+        abort ImAU32
+    }
+
+    public fun callU64() {
+        abort ImAU64
+    }
+
+    public fun callU128() {
+        abort ImAU128
+    }
+
+    public fun callU256() {
+        abort ImAU256
+    }
+
+    public fun callAddress() {
+        abort ImAAddress
+    }
+
+    public fun callString() {
+        abort ImAString
+    }
+
+    public fun callBytevec() {
+        abort ImNotAString
+    }
+
+    public fun normalAbort() {
+        abort 0
+    }
+
+    public fun assertLineNo() {
+        assert!(false);
+    }
+}
+
+//# run P0::m::callU8
+
+//# run P0::m::callU16
+
+//# run P0::m::callU32
+
+//# run P0::m::callU64
+
+//# run P0::m::callU128
+
+//# run P0::m::callU256
+
+//# run P0::m::callAddress
+
+//# run P0::m::callString
+
+//# run P0::m::callBytevec
+
+//# run P0::m::normalAbort
+
+//# run P0::m::assertLineNo
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(last: 9) {
+    nodes {
+      effects {
+        status
+        errors
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
@@ -33,7 +33,7 @@ module P0::m {
     const ImAString: vector<u8> = b"This is a string";
 
     #[error]
-    const ImNotAString: vector<u8> = vector[1,2,3,4,5];
+    const ImNotAString: vector<u64> = vector[1,2,3,4,5];
 
     public fun callU8() {
         abort ImAU8
@@ -67,7 +67,7 @@ module P0::m {
         abort ImAString
     }
 
-    public fun callBytevec() {
+    public fun callU64vec() {
         abort ImNotAString
     }
 
@@ -96,7 +96,7 @@ module P0::m {
 
 //# run P0::m::callString
 
-//# run P0::m::callBytevec
+//# run P0::m::callU64vec
 
 //# run P0::m::normalAbort
 
@@ -149,7 +149,7 @@ module P0::m {
     const ImAString: vector<u8> = b"This is a string in v2";
 
     #[error]
-    const ImNotAString: vector<u8> = vector[1,2,3,4,5,6];
+    const ImNotAString: vector<u64> = vector[1,2,3,4,5,6];
 
     public fun callU8() {
         abort ImAU8
@@ -183,7 +183,7 @@ module P0::m {
         abort ImAString
     }
 
-    public fun callBytevec() {
+    public fun callU64vec() {
         abort ImNotAString
     }
 
@@ -212,7 +212,7 @@ module P0::m {
 
 //# run P0::m::callString
 
-//# run P0::m::callBytevec
+//# run P0::m::callU64vec
 
 //# run P0::m::normalAbort
 

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
@@ -9,25 +9,25 @@ module P0::m {
     const ImAU8: u8 = 0;
 
     #[error]
-    const ImAU16: u16 = 0;
+    const ImAU16: u16 = 1;
 
     #[error]
-    const ImAU32: u32 = 0;
+    const ImAU32: u32 = 2;
 
     #[error]
-    const ImAU64: u64 = 0;
+    const ImAU64: u64 = 3;
 
     #[error]
-    const ImAU128: u128 = 0;
+    const ImAU128: u128 = 4;
 
     #[error]
-    const ImAU256: u256 = 0;
+    const ImAU256: u256 = 5;
 
     #[error]
     const ImABool: bool = true;
 
     #[error]
-    const ImAAddress: address = @0;
+    const ImAnAddress: address = @6;
 
     #[error]
     const ImAString: vector<u8> = b"This is a string";
@@ -60,7 +60,7 @@ module P0::m {
     }
 
     public fun callAddress() {
-        abort ImAAddress
+        abort ImAnAddress
     }
 
     public fun callString() {
@@ -122,34 +122,34 @@ module P0::m {
 // errors.
 module P0::m {
     #[error]
-    const ImAU8: u8 = 1;
+    const ImAU8: u8 = 7;
 
     #[error]
-    const ImAU16: u16 = 1;
+    const ImAU16: u16 = 8;
 
     #[error]
-    const ImAU32: u32 = 1;
+    const ImAU32: u32 = 9;
 
     #[error]
-    const ImAU64: u64 = 1;
+    const ImAU64: u64 = 10;
 
     #[error]
-    const ImAU128: u128 = 1;
+    const ImAU128: u128 = 11;
 
     #[error]
-    const ImAU256: u256 = 1;
+    const ImAU256: u256 = 12;
 
     #[error]
     const ImABool: bool = false;
 
     #[error]
-    const ImAAddress: address = @1;
+    const ImAnAddress: address = @13;
 
     #[error]
     const ImAString: vector<u8> = b"This is a string in v2";
 
     #[error]
-    const ImNotAString: vector<u8> = vector[1,2,3,4,5, 6];
+    const ImNotAString: vector<u8> = vector[1,2,3,4,5,6];
 
     public fun callU8() {
         abort ImAU8
@@ -176,7 +176,7 @@ module P0::m {
     }
 
     public fun callAddress() {
-        abort ImAAddress
+        abort ImAnAddress
     }
 
     public fun callString() {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
@@ -20,7 +20,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 1st command, Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42"
+            "errors": "Error in 1st command, from '0x83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom' (instruction 1), abort code: 42"
           }
         }
       ]
@@ -43,7 +43,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Error in 3rd command, Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42"
+            "errors": "Error in 3rd command, from '0x83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom' (instruction 1), abort code: 42"
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
@@ -20,7 +20,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42 in 1st command."
+            "errors": "Error in 1st command, Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42"
           }
         }
       ]
@@ -43,7 +43,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42 in 3rd command."
+            "errors": "Error in 3rd command, Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42"
           }
         }
       ]

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3705,8 +3705,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
-	If the error is a MoveAbort, the error message will be resolved to a human-readable form if
-	possible, otherwise it will fall back to simply displaying the Move abort code and location.
+	If the error is a Move abort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to displaying the abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3705,6 +3705,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
+	If the error is a MoveAbort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to simply displaying the Move abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3709,6 +3709,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
+	If the error is a MoveAbort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to simply displaying the Move abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3709,8 +3709,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
-	If the error is a MoveAbort, the error message will be resolved to a human-readable form if
-	possible, otherwise it will fall back to simply displaying the Move abort code and location.
+	If the error is a Move abort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to displaying the abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-package-resolver/Cargo.toml
+++ b/crates/sui-package-resolver/Cargo.toml
@@ -13,6 +13,7 @@ async-trait.workspace = true
 bcs.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
+move-command-line-common.workspace = true
 sui-types.workspace = true
 thiserror.workspace = true
 sui-rest-api.workspace = true

--- a/crates/sui-package-resolver/Cargo.toml
+++ b/crates/sui-package-resolver/Cargo.toml
@@ -13,6 +13,9 @@ async-trait.workspace = true
 bcs.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
+# TODO: `move-command-line-common` is used for `ErrorBitset`. We should
+# refactor the crate into a `move-utils` at some point and use that instead
+# here once we do.
 move-command-line-common.workspace = true
 sui-types.workspace = true
 thiserror.workspace = true

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -332,7 +332,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
                     AccountAddress::ZERO.into_bytes(),
                     NumberFormat::Hex,
                 )),
-                Some(Edition::E2024_ALPHA),
+                Some(Edition::DEVELOPMENT),
                 flavor.or(Some(Flavor::Sui)),
             ),
             package_upgrade_mapping: BTreeMap::new(),


### PR DESCRIPTION
## Description 

Adds support for clever errors to GraphQL. So now, if you have code like the following:
```move
module p::m {
   #[error]
    const ENotFound: vector<u8> = b"Element was unable to be found in the vector"

    public fun abort() {
        assert!(false, ENotFound); // Can also be an `abort ENotFound` 
    }
}
```

This will result in a humand-readable output from graphql:
```
Error in 1st command
'ENotFound' from module '0x8fd7251015bfd1dc4283bb3d38dc95a2769f75d621c871a81bb9c191a2860aaf::m' in function 'abort' at source line 6
The element was unable to be found in the vector
```

## Test plan 

Added tests for all supported constant types, along with tests to make sure that we properly handle package upgrades and resolving to the correct version of a package when resolving clever errors.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [X] GraphQL: Adds support for more understandable and ergonomic Move error codes in Move 2024.
- [ ] CLI: 
- [ ] Rust SDK: 
