### PR TITLE
[suiop] stub out docker command for dockerfile generation

### DIFF
--- a/crates/suiop-cli/src/cli/docker/mod.rs
+++ b/crates/suiop-cli/src/cli/docker/mod.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use tracing::{error, info};
+
+#[derive(Parser, Debug, Clone)]
+pub struct DockerArgs {
+    #[command(subcommand)]
+    action: DockerAction,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum DockerAction {
+    #[command(name = "generate", aliases=["g"])]
+    Generate {},
+}
+
+pub async fn docker_cmd(args: &DockerArgs) -> Result<()> {
+    match &args.action {
+        DockerAction::Generate {} => {
+            info!("Generating Dockerfile");
+            Ok(())
+        }
+    }
+}

--- a/crates/suiop-cli/src/cli/docker/mod.rs
+++ b/crates/suiop-cli/src/cli/docker/mod.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use clap::Parser;
-use tracing::{error, info};
+use tracing::info;
 
 #[derive(Parser, Debug, Clone)]
 pub struct DockerArgs {

--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -1,12 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod docker;
 mod iam;
 mod incidents;
 mod lib;
 pub mod pulumi;
 pub mod service;
 
+pub use docker::{docker_cmd, DockerArgs};
 pub use iam::{iam_cmd, IAMArgs};
 pub use incidents::{incidents_cmd, IncidentsArgs};
 pub use pulumi::{pulumi_cmd, PulumiArgs};

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -4,8 +4,8 @@
 use anyhow::Result;
 use clap::Parser;
 use suioplib::cli::{
-    iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, IAMArgs, IncidentsArgs, PulumiArgs,
-    ServiceArgs,
+    docker_cmd, iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, DockerArgs, IAMArgs,
+    IncidentsArgs, PulumiArgs, ServiceArgs,
 };
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
@@ -22,14 +22,16 @@ pub(crate) struct SuiOpArgs {
 
 #[derive(clap::Subcommand, Debug)]
 pub(crate) enum Resource {
+    #[clap()]
+    Docker(DockerArgs),
+    #[clap()]
+    Iam(IAMArgs),
     #[clap(aliases = ["inc", "i"])]
     Incidents(IncidentsArgs),
     #[clap(aliases = ["p"])]
     Pulumi(PulumiArgs),
     #[clap(aliases = ["s", "svc"])]
     Service(ServiceArgs),
-    #[clap()]
-    Iam(IAMArgs),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -46,6 +48,12 @@ async fn main() -> Result<()> {
 
     let args = SuiOpArgs::parse();
     match args.resource {
+        Resource::Docker(args) => {
+            docker_cmd(&args).await?;
+        }
+        Resource::Iam(args) => {
+            iam_cmd(&args).await?;
+        }
         Resource::Incidents(args) => {
             incidents_cmd(&args).await?;
         }
@@ -54,9 +62,6 @@ async fn main() -> Result<()> {
         }
         Resource::Service(args) => {
             service_cmd(&args).await?;
-        }
-        Resource::Iam(args) => {
-            iam_cmd(&args).await?;
         }
     }
 


### PR DESCRIPTION
## Description 

First bit of making service platform tooling work for ts services – generate dockerfiles for existing projects.

## Test plan 

```bash
cr -- docker g
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
   Compiling suiop-cli v0.1.9 (/Users/jkjensen/mysten/sui/crates/suiop-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 5.02s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop docker g`
2024-04-25T20:13:11.901549Z  INFO suioplib::cli::docker: Generating Dockerfile
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
