### PR TITLE
[move][bug] Fix binop ordering

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2128,6 +2128,7 @@ impl ProtocolConfig {
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
                         cfg.feature_flags.consensus_network = ConsensusNetwork::Tonic;
                     }
+                    // Also bumps framework snapshot to fix binop issue.
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x4be39a6ede59f5cee33abcda22bc17d7903a0c27e0ab9da0855460daaf96e158"
+            id: "0x93d24898fb529aef7433a35b7a4de05036b087aac96f33aa6ebea11bca918873"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xec97f266df64ad048dafd1e640d54c0f8771513850614823bacb372b01365615"
+      operation_cap_id: "0xad75a4f0dafa36f6c37a08501501279213d930189bdbdedf0f9c98ff5f718322"
       gas_price: 1000
       staking_pool:
-        id: "0xc2751c775526f72a8b0737af27521c4d95c2f23233332f31554f8f29d3e51ac8"
+        id: "0xb580917d26a325db5527c08cab34dbdb767e56b5840e2e4fa599222f86977d2b"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x3e8689c51b489075ca7e69e49c764f1f1a59f8fc4bd6e8f0bc1528bf90bcbd8d"
+          id: "0xee81da2200b48ee373e8d9d14340461459c713aaf7c4eae88f916420ceeb1236"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x7d0312336185198bc21b4b7d51e71db367a09c2440132a517225ab5897495deb"
+            id: "0x5b3cbb226c5ab748b3e62cec6b7446f85768214806256c5eb605bddd2287a374"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xfb6a86939403444c6fa59dbfd4a4c84c4f81948a7354e5bf5f0d1319f587ec61"
+          id: "0x74ae2314dbd1cd1ddc0497d9616b58d117253754175fb99136b4d7c70a1e17b1"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xfa05253a24d85d1fdfbb5bdd6c0aa1cee765790148d9b27eb1361128cb8893d3"
+      id: "0xbdacc1af1f90dc7c36e5c5ec67a115caf5f366761279fd4647ff6417c7efb791"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xd43d8f08046ea55cd81c422b9403d4cd33213b6192032adfc70fbf35a5a1aa75"
+    id: "0x47040d1659ed168e3ead94614b16680604d7983d17b25ab1351de356a30c7488"
     size: 1
   inactive_validators:
-    id: "0x058c876d817f310c879296e35800dd4d04b916319365337dcc77f9e0683e7f69"
+    id: "0x3f371596e9faed0adfa565d83749e12dbd3d6bb97f97e3863dd2dfdb24ee7cf3"
     size: 0
   validator_candidates:
-    id: "0x2de92758d490bc3d81bb86e9801121b166e56c0fc346d351dc2562f798c0b8a8"
+    id: "0xf07d7fd23b6ab04c1634b2bfc89cd15f11771e7bfc4675a0cee9f5cd1f36fd04"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x4095e32ea0798e339a7092d03bfa670281f26c3a479a4ef7ca0e78fda1aa2036"
+      id: "0x9788679b8a4eb68ebe565041337b029d1192b2ae3883c531b665dd53b54dedcf"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x173a51ac504cbd81406ddcce231e4f0995951f484c4a2aafeea6858937b07db3"
+      id: "0x0e39e3baeb1a652db096a6510bcd8b3eeac0ea729729251692c1d545d158443e"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x4f1e56ab2637fe83f84cb249f8f846ec38e76fb2c5403fcf14b358a587c5d136"
+      id: "0x1a73c2836d39587c63685aeac9dd86e618bd4651055c17a03f986020110df0d9"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x317fe9d0bae47d2226bfb2f93af144cfda61c93fc2febce2613ef5d44df83d44"
+    id: "0x589a4beca826b64ddfaaa96b69b0e0eb009259b31a825f4d2a9b47d57211a5f4"
   size: 0
+

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.exp
@@ -1,0 +1,64 @@
+processed 8 tasks
+
+task 1 'run'. lines 14-20:
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(2),
+    location: 0x42::test0,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 2 'run'. lines 22-29:
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(1),
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 3 'run'. lines 31-37:
+Error: Function execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::test2,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}
+
+task 4 'run'. lines 39-45:
+Error: Function execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::test3,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}
+
+task 5 'run'. lines 47-53:
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(0),
+    location: 0x42::test4,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 6 'run'. lines 55-61:
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(0),
+    location: 0x42::test5,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 7 'run'. lines 63-69:
+Error: Function execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::test37,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.move
@@ -1,0 +1,70 @@
+//# publish
+module 0x42::m {
+    public fun aborter(x: u64): u64 {
+        abort x
+    }
+
+    public fun add3(x: u64, y: u64, z: u64): u64 {
+        x + y + z
+    }
+}
+
+// All of these should abort
+
+//# run
+module 0x42::test0 {
+    // abort with 2
+    public fun main(): u64 {
+        if (false) {0x42::m::aborter(1)} else {abort 2} + {abort 3; 0}
+    }
+}
+
+//# run
+module 0x42::test1 {
+    // abort with 1
+    public fun main(): u64 {
+        let x = 1;
+        0x42::m::aborter(x) + {x = x + 1; 0x42::m::aborter(x + 100); x} + x
+    }
+}
+
+//# run
+module 0x42::test2 {
+    // aborts with bad math
+    public fun main(): u8 {
+        abort (1u64 - 10u64)
+    }
+}
+
+//# run
+module 0x42::test3 {
+    // aborts with bad math
+    public fun main(): u8 {
+        {250u8 + 50u8} + {abort 55; 5u8}
+    }
+}
+
+//# run
+module 0x42::test4 {
+    // aborts with 0
+    public fun test(): u64 {
+        0x42::m::add3(abort 0, {abort 14; 0}, 0)
+    }
+}
+
+//# run
+module 0x42::test5 {
+    //abort with 0
+    public fun test(): u64 {
+        (abort 0) + {(abort 14); 0} + 0
+    }
+}
+
+//# run
+module 0x42::test37 {
+    // aborts with bad math
+    public fun main(): u8 {
+        {250u8 + 50u8} + {return 55; 5u8}
+    }
+}
+

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_call_struct.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_call_struct.exp
@@ -1,0 +1,1 @@
+processed 8 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_call_struct.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_call_struct.move
@@ -1,0 +1,94 @@
+//# publish
+module 0x42::m {
+    struct S has drop {
+        x: u64,
+        y: u64,
+        z: u64,
+    }
+
+    fun inc_x(self: &mut S) {
+        self.x = self.x + 1;
+    }
+
+    public fun test1(): u64 {
+        let s = S { x: 1, y: 2, z: 3 };
+        s.x + {inc_x(&mut s); s.x} + {inc_x(&mut s); s.x}
+    }
+
+    fun inc_xx(self: &mut S, by: u64) {
+        self.x = self.x + by;
+    }
+
+    public fun test2(): u64 {
+        let s = S { x: 1, y: 2, z: 3 };
+        s.x + {inc_xx(&mut s, 3); s.x} + {inc_xx(&mut s, 11); s.x}
+    }
+
+    public fun test3(): u64 {
+        let x = 1;
+        let S {y, x, z} = S { x, y: {x = x + 1; x}, z: {x = x + 1; x} };
+        x + y + z
+    }
+
+    fun inc(x: &mut u64): u64 {
+        *x = *x + 1;
+        *x
+    }
+
+    fun inc_by(x: &mut u64, y: u64): u64 {
+        *x = *x + y;
+        *x
+    }
+
+    public fun test4(): u64 {
+        let x = 1;
+        let s = S { x, y: inc(&mut x), z: inc(&mut x) };
+        let x;
+        let y;
+        let z;
+        S {x, y, z} = s;
+        x + y + z
+    }
+
+    public fun test5(): u64 {
+        let x = 1;
+        let s = S { x, y: {x = x + 1; x}, z: {x = x + 1; x} };
+        let S {x, y, z} = s;
+        x + y + z
+    }
+
+    public fun test6(): u64 {
+        let x = 1;
+        let S {x, y, z} = S { x, y: inc_by(&mut x, 7), z: inc_by(&mut x, 11) };
+        x + y + z
+    }
+
+    public fun test7(): u64 {
+        let x = 1;
+        let S {x, y, z} = S { x, y: {x = x + 1; x}, z: {x = x + 1; x} };
+        x + y + z
+    }
+}
+
+//# run
+module 0x042::test1 { public fun main() { assert!(0x42::m::test1() == 6, 1); } }
+
+//# run
+module 0x042::test2 { public fun main() { assert!(0x42::m::test2() == 20, 2); } }
+
+//# run
+module 0x042::test3 { public fun main() { assert!(0x42::m::test3() == 6, 3); } }
+
+//# run
+module 0x042::test4 { public fun main() { assert!(0x42::m::test4() == 6, 4); } }
+
+//# run
+module 0x042::test5 { public fun main() { assert!(0x42::m::test5() == 6, 5); } }
+
+//# run
+module 0x042::test6 { public fun main() { assert!(0x42::m::test6() == 28, 6); } }
+
+//# run
+module 0x042::test7 { public fun main() { assert!(0x42::m::test7() == 6, 7); } }
+
+

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_calls.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_calls.exp
@@ -1,0 +1,1 @@
+processed 40 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_calls.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_calls.move
@@ -1,0 +1,352 @@
+//# publish
+module 0x42::m {
+
+    fun and(x: bool, y: bool): bool {
+        x && y
+    }
+
+    fun add(a: u64, b: u64): u64 {
+        a + b
+    }
+
+    fun sub(a: u64, b: u64): u64 {
+        a - b
+    }
+
+    fun inc_by(x: &mut u64, y: u64): u64 {
+        *x = *x + y;
+        *x
+    }
+
+    fun inc(x: &mut u64): u64 {
+        *x = *x + 1;
+        *x
+    }
+
+    public fun test00(): u64 {
+        let a = 1;
+        a + {a = a + 1; a}
+    }
+
+    public fun test01(): bool {
+        let x = 1;
+        and({x = x - 1; x == 0}, {x = x + 3; x == 3}) && {x = x * 2; x == 6}
+    }
+
+    public fun test02(): u64 {
+        let x = 10;
+        let y = 20;
+        {let (x, y) = (y, x + 1); x + y} + {let (x, y) = (y * 2, x - 1); y / x}
+    }
+
+    public fun test03(): u64 {
+        let x = 1;
+        add(add({x = x - 1; x + 8}, {x = x + 3; x - 3}), add({x = x * 2; x * 2}, {x = x + 1; x}))
+    }
+
+    public fun test04(): u64 {
+        let x = 1;
+        add({x = x - 1; x + 8}, {x = x + 3; x - 3}) + add({x = x * 2; x * 2}, {x = x + 1; x})
+    }
+
+    public fun test05(): u64 {
+        let _x = 1;
+        {let y = _x + 2; _x = _x + 5; y} +
+            {let y = _x; _x = _x - 1; y} +
+            {let y = _x; _x = _x * 2; y}
+    }
+
+    public fun test06(): u64 {
+        let x = 1;
+        inc_by(&mut x, 5) + inc_by(&mut x, 6) + inc_by(&mut x, 7)
+    }
+
+    public fun test07(): u64 {
+        let x = 1;
+        add({x = x - 1; x + 8}, {x = x + 3; x - 3}) + {x = x * 2; x * 2}
+    }
+
+    public fun test08(): u64 {
+        let x = 158;
+        {x = x - 1; x + 8} + add({x = x + 3; x - 3}, {x = x * 2; x * 2})
+    }
+
+    public fun test09(): u64 {
+        let x = 146;
+        add({x = sub(x, 1); x + 8}, {x = x + 3; x - 3}) + {x = x * 2; x * 2}
+    }
+
+    public fun test10(): u64 {
+        let x = 122;
+        {x = x - 1; x + 8} + {x = x + 3; x - 3} + {x = x * 2; x * 2}
+    }
+
+    #[allow(dead_code)]
+    public fun test11(): u64 {
+        let x = 1;
+        {return x; x + 1} + {x = x + 1; x} + {x = x + 1; x}
+    }
+
+    #[allow(dead_code)]
+    public fun test12(): u64 {
+        let x = 1;
+        {x = x + 1; x = x + 1; x } + {x = x + 1; return x; x } + {x = x + 1; x = x + 1; x }
+    }
+
+    public fun test13(): u64 {
+        let x = 1;
+        {let one = 1; x = x + one; x} +
+            {{let two = 2; x = x + two; x} + {let three = 3; x = x + three; x} + x} +
+            {x = x + 1; x = x + 1; x }
+    }
+
+    public fun test14(): u64 {
+        let x = 1;
+        {x = x + 1; x = x + 1; x } + {x = x + 1; x = x + 1; x } + {x = x + 1; x = x + 1; x}
+    }
+
+    public fun test15(): u64 {
+        let x = 1;
+        inc(&mut x) +
+            { inc(&mut x); inc(&mut x) + inc(&mut x) } +
+            { inc(&mut x); inc(&mut x); inc(&mut x) }
+    }
+
+    public fun test16(): u64 {
+        let x = 1;
+        inc(&mut {x = x + 1; x}) +
+            { inc(&mut x); inc(&mut x) + inc(&mut x) } +
+            { inc(&mut x); inc(&mut x); inc(&mut x) }
+    }
+
+    public fun test17(p: u64): u64 {
+        let x = p;
+        (x + 1) + {x = x + 1; x + 1} + {x = x + 1; x + 1}
+    }
+
+    public fun test18(p: bool): u64 {
+        let x = 1;
+        if (p) {x} else {x = x + 1; x} + if (!p) {x} else {x = x + 1; x} + if (!p) {x} else {x = x + 1; x}
+    }
+
+    public fun test19(): u64 {
+        let x = 1;
+        x + {x = {x + {x = x + 1; x} + {x = x + 1; x}}; x} + {x = {x + {x = x + 1; x} + {x = x + 1; x}}; x}
+    }
+
+   public fun test20(p: bool): bool {
+        (!p && {p = p && false; p}) || {p = !p; !p}
+    }
+
+    public fun test21(): bool {
+        let x = 1;
+        {x = x << 1; x} < {x = x << 1; x}
+    }
+
+    public fun test22(p: u64): vector<u64> {
+        vector[p, {p = p + 1; p}, {p = p + 1; p}]
+    }
+
+    fun add2(x: u64, y: u64): u64 {
+        x + y
+    }
+
+    fun add3(x: u64, y: u64, z: u64): u64 {
+        x + y + z
+    }
+
+    public fun test23(): u64 {
+        let x = 1;
+        add3(x, {x = add2(x, 1); x}, {x = add2(x, 1); x})
+    }
+
+    public fun test24(): u64 {
+        let x = 1;
+        x + add3(x, {x = inc(&mut x); add3(x, {x = x + 1; x}, {x = x + 1; x})}, {x = inc(&mut x); add3({x = x + 1; x}, x, {x = x + 1; x})}) + {x = inc(&mut x) + 1; x}
+    }
+
+    public fun test25(): u64 {
+        let x = 1;
+        x + add3(x, {x = inc_by(&mut x, 3); add3(x, {x = x + 1; x}, {x = x + 1; x})}, {x = inc(&mut x); add3({x = x + 1; x}, x, {x = x + 1; x})}) + {x = inc_by(&mut x, 47) + 1; x}
+    }
+
+     public fun test26(): u64 {
+        let x = 1;
+        x + {x = inc(&mut x) + 1; x} + {x = inc(&mut x) + 1; x}
+    }
+
+    public fun test27(): u64 {
+        let a = 1;
+        let x;
+        let y;
+        let z;
+        (x, y, z) = (a, {a = a + 1; a}, {a = a + 1; a});
+        x + y + z
+    }
+
+    public fun test28(): u64 {
+        let x = 1;
+        x + inc_by(&mut x, 7) + inc_by(&mut x, 11)
+    }
+
+    public fun test29(): u64 {
+        let x = 1;
+        let (a, b, c) = (x + 1, {x = x + 1; x + 7}, {x = x + 1; x - 3});
+        a + b + c
+    }
+
+    public fun test30(): u64 {
+        let x = 1;
+        (x + {x = x + 1; x - 1}) + {x = x + 1; x * 2}
+    }
+
+    public fun test31(): u64 {
+        let x = 1;
+        {x + {x = x + 1; x}} + {x = x + 1; x}
+    }
+
+    public fun test32(): u64 {
+        let x = 1;
+        {x = x + 1; x} + x + {x = x + 1; x}
+    }
+
+    public fun test33(): u64 {
+        let x = 1;
+        x + {x = x + 1; x} + {x = x + 1; x}
+    }
+
+    #[allow(dead_code)]
+    public fun test34(): u64 {
+        let x = 1;
+        {return x} + {x = x + 1; x} + {x = x + 1; x}
+    }
+
+    public fun test35(): u64 {
+        let x = 1;
+        add3(x, { x = x + 1; x }, { x = x + 1; x })
+    }
+
+    public fun test36(p: u64): u64 {
+        1 + (p + {p = p + 1; p})
+    }
+}
+
+// Run the tests separately so that we get all the results
+
+//# run
+module 0x42::test00 { public fun main() { assert!(0x42::m::test00() == 3, 0); } }
+
+//# run
+module 0x42::test01 { public fun main() { assert!(0x42::m::test01() == true, 1); } }
+
+//# run
+module 0x42::test02 { public fun main() { assert!(0x42::m::test02() == 31, 2); } }
+
+//# run
+module 0x42::test03 { public fun main() { assert!(0x42::m::test03() == 27, 3); } }
+
+//# run
+module 0x42::test04 { public fun main() { assert!(0x42::m::test04() == 27, 4); } }
+
+//# run
+module 0x42::test05 { public fun main() { assert!(0x42::m::test05() == 14, 5); } }
+
+//# run
+module 0x42::test06 { public fun main() { assert!(0x42::m::test06() == 37, 6); } }
+
+//# run
+module 0x42::test07 { public fun main() { assert!(0x42::m::test07() == 20, 7); } }
+
+//# run
+module 0x42::test08 { public fun main() { assert!(0x42::m::test08() == 962, 8); } }
+
+//# run
+module 0x42::test09 { public fun main() { assert!(0x42::m::test09() == 890, 9); } }
+
+//# run
+module 0x42::test10 { public fun main() { assert!(0x42::m::test10() == 746, 10); } }
+
+//# run
+module 0x42::test11 { public fun main() { assert!(0x42::m::test11() == 1, 11); } }
+
+//# run
+module 0x42::test12 { public fun main() { assert!(0x42::m::test12() == 4, 12); } }
+
+//# run
+module 0x42::test13 { public fun main() { assert!(0x42::m::test13() == 29, 13); } }
+
+//# run
+module 0x42::test14 { public fun main() { assert!(0x42::m::test14() == 15, 14); } }
+
+//# run
+module 0x42::test15 { public fun main() { assert!(0x42::m::test15() == 19, 15); } }
+
+//# run
+module 0x42::test16 { public fun main() { assert!(0x42::m::test16() == 20, 16); } }
+
+//# run
+module 0x42::test17 { public fun main() { assert!(0x42::m::test17(54) == 168, 17); } }
+
+//# run
+module 0x42::test18 { public fun main() { assert!(0x42::m::test18(true) == 6, 18); } }
+
+//# run
+module 0x42::test19 { public fun main() { assert!(0x42::m::test18(false) == 6, 18); } }
+
+//# run
+module 0x42::test20 { public fun main() { assert!(0x42::m::test19() == 28, 18); } }
+
+//# run
+module 0x42::test21 { public fun main() { assert!(0x42::m::test20(true) == true, 20); } }
+
+//# run
+module 0x42::test22 { public fun main() { assert!(0x42::m::test20(false) == false, 20); } }
+
+//# run
+module 0x42::test23 { public fun main() { assert!(0x42::m::test21() == true, 21); } }
+
+//# run
+module 0x42::test24 { public fun main() { assert!(0x42::m::test22(3) == vector[3,4,5], 22); } }
+
+//# run
+module 0x42::test25 { public fun main() { assert!(0x42::m::test23() == 6, 23); } }
+
+//# run
+module 0x42::test26 { public fun main() { assert!(0x42::m::test24() == 39, 24); } }
+
+//# run
+module 0x42::test27 { public fun main() { assert!(0x42::m::test25() == 99, 25); } }
+
+//# run
+module 0x42::test28 { public fun main() { assert!(0x42::m::test26() == 9, 26); } }
+
+//# run
+module 0x42::test29 { public fun main() { assert!(0x42::m::test27() == 6, 27); } }
+
+//# run
+module 0x42::test30 { public fun main() { assert!(0x42::m::test28() == 28, 28); } }
+
+//# run
+module 0x42::test31 { public fun main() { assert!(0x42::m::test29() == 11, 29); } }
+
+//# run
+module 0x42::test32 { public fun main() { assert!(0x42::m::test30() == 8, 30); } }
+
+//# run
+module 0x42::test33 { public fun main() { assert!(0x42::m::test31() == 6, 31); } }
+
+//# run
+module 0x42::test34 { public fun main() { assert!(0x42::m::test32() == 7, 32); } }
+
+//# run
+module 0x42::test35 { public fun main() { assert!(0x42::m::test33() == 6, 33); } }
+
+//# run
+module 0x42::test36 { public fun main() { assert!(0x42::m::test34() == 1, 34); } }
+
+//# run
+module 0x42::test37 { public fun main() { assert!(0x42::m::test35() == 6, 35); } }
+
+//# run
+module 0x42::test38 { public fun main() { assert!(0x42::m::test36(1) == 4, 36); } }
+

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/macro_calls.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/macro_calls.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/macro_calls.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/macro_calls.move
@@ -1,0 +1,75 @@
+//# init --edition 2024.alpha
+
+//# publish
+module 0x42::m {
+
+    public struct S has drop {
+        x: u64,
+        y: u64,
+        z: u64,
+    }
+
+    fun inc_x(self: &mut S, by: u64) {
+        self.x = self.x + by;
+    }
+
+    macro fun inc_xx($self: &mut S, $by: u64) {
+        let self = $self;
+        self.x = self.x + $by;
+    }
+
+    public fun test0(): u64 {
+        let mut s = S { x: 1, y: 2, z: 3 };
+        {inc_x(&mut s, 6); s.x} + {inc_x(&mut s, 47); s.x} + {inc_x(&mut s, 117); s.x}
+    }
+
+    public fun test1(): u64 {
+        let mut s = S { x: 1, y: 2, z: 3 };
+        {inc_xx!(&mut s, 6); s.x} + {inc_xx!(&mut s, 47); s.x} + {inc_xx!(&mut s, 117); s.x}
+    }
+
+    macro fun inc($x: &mut u64): u64 {
+        let x = $x;
+        *x = *x + 1;
+        *x
+    }
+
+    public fun test2(): u64 {
+        let mut x = 1;
+        x + inc!(&mut x) + inc!(&mut x)
+    }
+
+    macro fun inc_scope($x: u64): u64 {
+        let mut x = $x;
+        x = x + 1;
+        x
+    }
+
+    public fun test3(): u64 {
+        let x = 1;
+        x + inc_scope!(x) + inc_scope!(x)
+    }
+
+     macro fun call($f: || -> u64): u64 {
+        $f()
+    }
+
+    public fun test4(): u64 {
+        let mut x = 1;
+        x + call!(|| {x = x + 1; x}) + call!(|| {x = x + 7; x})
+    }
+}
+
+//# run
+module 0x42::main {
+    use 0x42::m;
+
+    public fun main() {
+        assert!(m::test0() == 232, 0);
+        assert!(m::test1() == 232, 1);
+        assert!(m::test2() == 6, 2);
+        assert!(m::test3() == 5, 3);
+        assert!(m::test4() == 12, 4);
+    }
+
+}

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/break_from_macro_arg.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/break_from_macro_arg.exp
@@ -6,5 +6,5 @@ Error: Function execution failed with VMError: {
     sub_status: Some(0),
     location: 0x2a::m,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 22)],
+    offsets: [(FunctionDefinitionIndex(0), 24)],
 }

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -132,6 +132,8 @@ pub(super) struct HLIRDebugFlags {
     pub(super) match_counterexample: bool,
     pub(super) match_work_queue: bool,
     pub(super) match_constant_conversion: bool,
+    pub(super) function_translation: bool,
+    pub(super) eval_order: bool,
 }
 
 pub(super) struct Context<'env> {
@@ -327,6 +329,8 @@ impl<'env> Context<'env> {
             match_counterexample: false,
             match_work_queue: false,
             match_constant_conversion: false,
+            function_translation: false,
+            eval_order: false,
         };
         Context {
             env,
@@ -657,7 +661,7 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
     assert!(macro_.is_none(), "ICE macros filtered above");
     context.env.add_warning_filter_scope(warning_filter.clone());
     let signature = function_signature(context, signature);
-    let body = function_body(context, &signature, body);
+    let body = function_body(context, &signature, _name, body);
     context.env.pop_warning_filter_scope();
     H::Function {
         warning_filter,
@@ -693,6 +697,7 @@ fn function_signature(context: &mut Context, sig: N::FunctionSignature) -> H::Fu
 fn function_body(
     context: &mut Context,
     sig: &H::FunctionSignature,
+    _name: FunctionName,
     sp!(loc, tb_): T::FunctionBody,
 ) -> H::FunctionBody {
     use H::FunctionBody_ as HB;
@@ -703,7 +708,13 @@ fn function_body(
             HB::Native
         }
         TB::Defined((_, seq)) => {
+            debug_print!(context.debug.function_translation,
+                         (msg format!("-- {} ----------------", _name)),
+                         (lines "body" => &seq));
             let (locals, body) = function_body_defined(context, sig, loc, seq);
+            debug_print!(context.debug.function_translation,
+                         (msg "--------"),
+                         (lines "body" => &body));
             HB::Defined { locals, body }
         }
         TB::Macro => unreachable!("ICE macros filtered above"),
@@ -2699,6 +2710,7 @@ fn value_evaluation_order(
     let mut values = vec![];
     for (exp, expected_type) in input_exps.into_iter().rev() {
         let mut new_stmts = make_block!();
+        debug_print!(context.debug.eval_order, ("has new statements" => !new_stmts.is_empty(); fmt));
         let exp = value(context, &mut new_stmts, expected_type.as_ref(), exp);
         let exp = if needs_binding {
             bind_exp(context, &mut new_stmts, exp)
@@ -2935,8 +2947,11 @@ fn process_binops(
                     }
                 }
                 op => {
-                    let (mut lhs_block, lhs_exp) = value_stack.pop().expect("ICE binop hlir issue");
+                    let (mut lhs_block, mut lhs_exp) = value_stack.pop().expect("ICE binop hlir issue");
                     let (mut rhs_block, rhs_exp) = value_stack.pop().expect("ICE binop hlir issue");
+                    if !rhs_block.is_empty() {
+                        lhs_exp = bind_exp(context, &mut lhs_block, lhs_exp);
+                    }
                     lhs_block.append(&mut rhs_block);
                     // NB: here we could check if the LHS and RHS are "large" terms and let-bind
                     // them if they are getting too big.

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -100,6 +100,11 @@ macro_rules! debug_print_internal {
         crate::shared::string_utils::debug_print_format!($val $(; $fmt)*);
         }
     };
+    ((msg $val:expr)) => {
+        {
+            println!("{}", $val);
+        }
+    };
     ((opt $name:expr => $val:expr $(; $fmt:ident)?)) => {
         {
         print!("{}: ", $name);


### PR DESCRIPTION
## Description 

Fixes an issue in how binops evaluated their arguments, ensuring the LHS value is stored if the RHS has effect operations.

## Test plan 

Tests thanks to Aptos: https://github.com/aptos-labs/aptos-core/pull/12936 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
