### PR TITLE
[replay] Fix execution from sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13471,6 +13471,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-storage",
+ "sui-transaction-checks",
  "sui-types",
  "tabled",
  "tempfile",

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -48,4 +48,5 @@ sui-json-rpc-types.workspace = true
 sui-protocol-config.workspace = true
 sui-sdk.workspace = true
 sui-storage.workspace = true
+sui-transaction-checks.workspace = true
 sui-types.workspace = true

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -32,8 +32,6 @@ pub(crate) const MAX_CONCURRENT_REQUESTS: usize = 1_000;
 pub(crate) const EPOCH_CHANGE_STRUCT_TAG: &str =
     "0x3::sui_system_state_inner::SystemEpochInfoEvent";
 
-pub(crate) const ONE_DAY_MS: u64 = 24 * 60 * 60 * 1000;
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OnChainTransactionInfo {
     pub tx_digest: TransactionDigest,

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -527,3 +527,34 @@ pub trait GetSharedLocks: Send + Sync {
         key: &TransactionKey,
     ) -> Result<Vec<(ObjectID, SequenceNumber)>, SuiError>;
 }
+
+#[derive(Default)]
+pub struct InMemorySharedLocks {
+    shared_version_map: BTreeMap<TransactionKey, Vec<(ObjectID, SequenceNumber)>>,
+}
+
+impl InMemorySharedLocks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_shared_locks(
+        &mut self,
+        tx_key: TransactionKey,
+        locks: Vec<(ObjectID, SequenceNumber)>,
+    ) {
+        self.shared_version_map.insert(tx_key, locks);
+    }
+}
+
+impl GetSharedLocks for InMemorySharedLocks {
+    fn get_shared_locks(
+        &self,
+        key: &TransactionKey,
+    ) -> Result<Vec<(ObjectID, SequenceNumber)>, SuiError> {
+        self.shared_version_map
+            .get(key)
+            .cloned()
+            .ok_or_else(|| SuiError::Unknown(format!("No shared locks found for {:?}", key)))
+    }
+}


### PR DESCRIPTION
## Description 

This PR fixes a few things when replaying from sandbox:
1. Instead of using a random chain ID, this PR now uses the actual chain ID of the sandbox.
2. To avoid a few other issues that's introduced when creating the authority and epoch store in-place and manually setting the epoch, this PR removes that and uses execution directly. While this makes the replay execution more stable, it does introduce a potential problem where things may go out of sync.

As follow up we should look into unifying the execution process and make it called from all places that require execution (simcrum, single node benchmark, sync and async execution and etc.)

## Test plan 

CI and replay locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
