### PR TITLE
[consensus] Storage changes in preparation for LeaderSchedule/Scoring

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -322,7 +322,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // Compute an exclusive end index and bound the maximum number of commits scanned.
         let exclusive_end =
             (end + 1).min(start + self.context.parameters.commit_sync_batch_size as CommitIndex);
-        let mut commits = self.store.scan_commits(start..exclusive_end)?;
+        let mut commits = self.store.scan_commits((start..exclusive_end).into())?;
         let mut certifier_block_refs = vec![];
         'commit: while let Some(c) = commits.last() {
             let index = c.index();

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
@@ -107,7 +106,7 @@ impl CommitObserver {
         // We should not send the last processed commit again, so last_processed_commit_index+1
         let unsent_commits = self
             .store
-            .scan_commits((last_processed_commit_index + 1)..CommitIndex::MAX)
+            .scan_commits(((last_processed_commit_index + 1)..CommitIndex::MAX).into())
             .expect("Scanning commits should not fail");
 
         // Resend all the committed subdags to the consensus output channel
@@ -271,7 +270,9 @@ mod tests {
         // Check commits have been persisted to storage
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
         assert_eq!(last_commit.index(), commits.last().unwrap().commit_index);
-        let all_stored_commits = mem_store.scan_commits(0..CommitIndex::MAX).unwrap();
+        let all_stored_commits = mem_store
+            .scan_commits((0..CommitIndex::MAX).into())
+            .unwrap();
         assert_eq!(all_stored_commits.len(), leaders.len());
         let blocks_existence = mem_store.contains_blocks(&expected_stored_refs).unwrap();
         assert!(blocks_existence.iter().all(|exists| *exists));

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -762,7 +762,7 @@ mod test {
         // as soon as the new block for round 5 is proposed.
         assert_eq!(last_commit.index(), 2);
         assert_eq!(dag_state.read().last_commit_index(), 2);
-        let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
+        let all_stored_commits = store.scan_commits((0..CommitIndex::MAX).into()).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
     }
 
@@ -880,7 +880,7 @@ mod test {
         // as the new block for round 4 is proposed.
         assert_eq!(last_commit.index(), 2);
         assert_eq!(dag_state.read().last_commit_index(), 2);
-        let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
+        let all_stored_commits = store.scan_commits((0..CommitIndex::MAX).into()).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
     }
 
@@ -1139,7 +1139,7 @@ mod test {
             // There are 1 leader rounds with rounds completed up to and including
             // round 4
             assert_eq!(last_commit.index(), 1);
-            let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
+            let all_stored_commits = store.scan_commits((0..CommitIndex::MAX).into()).unwrap();
             assert_eq!(all_stored_commits.len(), 1);
         }
     }
@@ -1213,7 +1213,7 @@ mod test {
             // round 9. Round 10 blocks will only include their own blocks, so the
             // 8th leader will not be committed.
             assert_eq!(last_commit.index(), 7);
-            let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
+            let all_stored_commits = store.scan_commits((0..CommitIndex::MAX).into()).unwrap();
             assert_eq!(all_stored_commits.len(), 7);
         }
     }
@@ -1286,7 +1286,7 @@ mod test {
         // round 10. However because there were no blocks produced for authority 3
         // 2 leader rounds will be skipped.
         assert_eq!(last_commit.index(), 6);
-        let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
+        let all_stored_commits = store.scan_commits((0..CommitIndex::MAX).into()).unwrap();
         assert_eq!(all_stored_commits.len(), 6);
     }
 

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -636,12 +636,8 @@ impl DagState {
         let last_commit_info = if commits.is_empty() {
             None
         } else {
-            let last_commit_ref = self
-                .last_commit
-                .as_ref()
-                .expect("Last commit should be set if we have commits to write to store.")
-                .reference();
-            // TODO: Replace this with calculated repuation scores
+            let last_commit_ref = commits.last().as_ref().unwrap().reference();
+            // TODO: Replace this with calculated reputation scores
             let commit_info = CommitInfo::new(
                 self.last_committed_rounds.clone(),
                 ReputationScores::default(),

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -18,10 +18,11 @@ use crate::{
         genesis_blocks, BlockAPI, BlockDigest, BlockRef, BlockTimestampMs, Round, Slot,
         VerifiedBlock, GENESIS_ROUND,
     },
-    commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitVote, TrustedCommit},
+    commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitVote, TrustedCommit},
     context::Context,
+    leader_scoring::ReputationScores,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    storage::{CommitInfo, Store, WriteBatch},
+    storage::{Store, WriteBatch},
 };
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
@@ -635,7 +636,17 @@ impl DagState {
         let last_commit_info = if commits.is_empty() {
             None
         } else {
-            Some(CommitInfo::new(self.last_committed_rounds.clone()))
+            let last_commit_ref = self
+                .last_commit
+                .as_ref()
+                .expect("Last commit should be set if we have commits to write to store.")
+                .reference();
+            // TODO: Replace this with calculated repuation scores
+            let commit_info = CommitInfo::new(
+                self.last_committed_rounds.clone(),
+                ReputationScores::default(),
+            );
+            Some((last_commit_ref, commit_info))
         };
         self.store
             .write(WriteBatch::new(

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -4,10 +4,11 @@
 use std::{cmp::Ordering, fmt::Debug, sync::Arc};
 
 use consensus_config::AuthorityIndex;
+use serde::{Deserialize, Serialize};
 
 use crate::{commit::CommitRange, context::Context};
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ReputationScores {
     /// Score per authority. Vec index is the `AuthorityIndex`.
     pub(crate) scores_per_authority: Vec<u64>,

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -7,14 +7,11 @@ pub(crate) mod rocksdb_store;
 #[cfg(test)]
 mod store_tests;
 
-use std::ops::Range;
-
 use consensus_config::AuthorityIndex;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     block::{BlockRef, Round, Slot, VerifiedBlock},
-    commit::{CommitIndex, CommitRef, TrustedCommit},
+    commit::{CommitIndex, CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
 };
 
@@ -53,7 +50,7 @@ pub(crate) trait Store: Send + Sync {
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>>;
 
     /// Reads all commits from start (inclusive) until end (exclusive).
-    fn scan_commits(&self, range: Range<CommitIndex>) -> ConsensusResult<Vec<TrustedCommit>>;
+    fn scan_commits(&self, range: CommitRange) -> ConsensusResult<Vec<TrustedCommit>>;
 
     /// Reads all blocks voting on a particular commit.
     fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>>;
@@ -67,14 +64,14 @@ pub(crate) trait Store: Send + Sync {
 pub(crate) struct WriteBatch {
     pub(crate) blocks: Vec<VerifiedBlock>,
     pub(crate) commits: Vec<TrustedCommit>,
-    pub(crate) last_commit_info: Option<CommitInfo>,
+    pub(crate) last_commit_info: Option<(CommitRef, CommitInfo)>,
 }
 
 impl WriteBatch {
     pub(crate) fn new(
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
-        last_commit_info: Option<CommitInfo>,
+        last_commit_info: Option<(CommitRef, CommitInfo)>,
     ) -> Self {
         WriteBatch {
             blocks,
@@ -95,22 +92,5 @@ impl WriteBatch {
     pub(crate) fn commits(mut self, commits: Vec<TrustedCommit>) -> Self {
         self.commits = commits;
         self
-    }
-}
-
-/// Per-commit properties that can be regenerated from past values, and do not need to be part of
-/// the Commit struct.
-/// Only the latest version is needed for recovery, but more versions are stored for debugging,
-/// and potentially restoring from an earlier state.
-// TODO: version this struct.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct CommitInfo {
-    pub(crate) committed_rounds: Vec<Round>,
-}
-
-impl CommitInfo {
-    // Returns a new CommitInfo.
-    pub(crate) fn new(committed_rounds: Vec<Round>) -> Self {
-        CommitInfo { committed_rounds }
     }
 }

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
-use std::ops::Range;
 use std::{
+    collections::VecDeque,
     ops::Bound::{Excluded, Included},
     time::Duration,
 };
@@ -19,11 +18,9 @@ use typed_store::{
 };
 
 use super::{CommitInfo, Store, WriteBatch};
-use crate::block::Slot;
-use crate::commit::{CommitAPI as _, CommitDigest, CommitRef, TrustedCommit};
 use crate::{
-    block::{BlockAPI as _, BlockDigest, BlockRef, Round, SignedBlock, VerifiedBlock},
-    commit::CommitIndex,
+    block::{BlockAPI as _, BlockDigest, BlockRef, Round, SignedBlock, Slot, VerifiedBlock},
+    commit::{CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
 
@@ -34,12 +31,14 @@ pub(crate) struct RocksDBStore {
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockDigest), ()>,
     /// Maps commit index to Commit.
-    commits: DBMap<(CommitIndex, CommitDigest), Bytes>,
+    commits: DBMap<CommitRef, Bytes>,
     /// Collects votes on commits.
     /// TODO: batch multiple votes into a single row.
     commit_votes: DBMap<(CommitIndex, CommitDigest, BlockRef), ()>,
-    /// Stores info related to Commit that helps recovery.
-    commit_info: DBMap<(CommitIndex, CommitDigest), CommitInfo>,
+    /// Stores the latest values of a few properties. CommitInfo contains aggregated
+    /// CommitInfo across all previous commits. This info is keyed off the last commit
+    /// that is included in the range of these commits.
+    commit_info: DBMap<CommitRef, CommitInfo>,
 }
 
 impl RocksDBStore {
@@ -83,9 +82,9 @@ impl RocksDBStore {
         let (blocks, digests_by_authorities, commits, commit_votes, commit_info) = reopen!(&rocksdb,
             Self::BLOCKS_CF;<(Round, AuthorityIndex, BlockDigest), bytes::Bytes>,
             Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockDigest), ()>,
-            Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
+            Self::COMMITS_CF;<CommitRef, Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
-            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>
+            Self::COMMIT_INFO_CF;<CommitRef, CommitInfo>
         );
 
         Self {
@@ -129,28 +128,20 @@ impl Store for RocksDBStore {
                     .map_err(ConsensusError::RocksDBFailure)?;
             }
         }
-        if let Some(last_commit) = write_batch.commits.last().cloned() {
-            for commit in write_batch.commits {
-                batch
-                    .insert_batch(
-                        &self.commits,
-                        [((commit.index(), commit.digest()), commit.serialized())],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-            }
-            // CommitInfo can be unavailable in tests, or when we decide to skip writing it.
-            if let Some(last_commit_info) = write_batch.last_commit_info {
-                batch
-                    .insert_batch(
-                        &self.commit_info,
-                        [(
-                            (last_commit.index(), last_commit.digest()),
-                            last_commit_info,
-                        )],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-            }
+
+        for commit in write_batch.commits {
+            batch
+                .insert_batch(&self.commits, [(commit.reference(), commit.serialized())])
+                .map_err(ConsensusError::RocksDBFailure)?;
         }
+
+        // CommitInfo can be unavailable in tests, or when we decide to skip writing it.
+        if let Some((commit_ref, last_commit_info)) = write_batch.last_commit_info {
+            batch
+                .insert_batch(&self.commit_info, [(commit_ref, last_commit_info)])
+                .map_err(ConsensusError::RocksDBFailure)?;
+        }
+
         batch.write()?;
         fail_point!("consensus-store-after-write");
         Ok(())
@@ -261,27 +252,27 @@ impl Store for RocksDBStore {
         let Some(result) = self.commits.safe_iter().skip_to_last().next() else {
             return Ok(None);
         };
-        let ((_index, digest), serialized) = result?;
+        let (commit_ref, serialized) = result?;
         let commit = TrustedCommit::new_trusted(
             bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedCommit)?,
             serialized,
         );
-        assert_eq!(commit.digest(), digest);
+        assert_eq!(commit.digest(), commit_ref.digest);
         Ok(Some(commit))
     }
 
-    fn scan_commits(&self, range: Range<CommitIndex>) -> ConsensusResult<Vec<TrustedCommit>> {
+    fn scan_commits(&self, range: CommitRange) -> ConsensusResult<Vec<TrustedCommit>> {
         let mut commits = vec![];
         for result in self.commits.safe_range_iter((
-            Included((range.start, CommitDigest::MIN)),
-            Excluded((range.end, CommitDigest::MIN)),
+            Included(CommitRef::new(range.start(), CommitDigest::MIN)),
+            Excluded(CommitRef::new(range.end(), CommitDigest::MIN)),
         )) {
-            let ((_index, digest), serialized) = result?;
+            let (commit_ref, serialized) = result?;
             let commit = TrustedCommit::new_trusted(
                 bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedCommit)?,
                 serialized,
             );
-            assert_eq!(commit.digest(), digest);
+            assert_eq!(commit.digest(), commit_ref.digest);
             commits.push(commit);
         }
         Ok(commits)
@@ -303,7 +294,7 @@ impl Store for RocksDBStore {
         let Some(result) = self.commit_info.safe_iter().skip_to_last().next() else {
             return Ok(None);
         };
-        let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;
-        Ok(Some((CommitRef::new(key.0, key.1), commit_info)))
+        let (commit_ref, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;
+        Ok(Some((commit_ref, commit_info)))
     }
 }

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -262,14 +262,14 @@ async fn read_and_scan_commits(
 
     {
         let scanned_commits = store
-            .scan_commits(20..25)
+            .scan_commits((20..25).into())
             .expect("Scan commits should not fail");
         assert!(scanned_commits.is_empty(), "{:?}", scanned_commits);
     }
 
     {
         let scanned_commits = store
-            .scan_commits(3..5)
+            .scan_commits((3..5).into())
             .expect("Scan commits should not fail");
         assert_eq!(scanned_commits.len(), 2, "{:?}", scanned_commits);
         assert_eq!(
@@ -280,7 +280,7 @@ async fn read_and_scan_commits(
 
     {
         let scanned_commits = store
-            .scan_commits(0..3)
+            .scan_commits((0..3).into())
             .expect("Scan commits should not fail");
         assert_eq!(scanned_commits.len(), 2, "{:?}", scanned_commits);
         assert_eq!(
@@ -291,7 +291,7 @@ async fn read_and_scan_commits(
 
     {
         let scanned_commits = store
-            .scan_commits(0..5)
+            .scan_commits((0..5).into())
             .expect("Scan commits should not fail");
         assert_eq!(scanned_commits.len(), 4, "{:?}", scanned_commits);
         assert_eq!(scanned_commits, written_commits,);


### PR DESCRIPTION
PR#17040 has all of the changes required to store/recover leader schedule/scoring related items. Making the storage changes separately early before we go to testnet. 

Also started swapping over to using CommitRange but all of the changes will be done in PR#17040 to keep this PR small.