### PR TITLE
[core] Use read_objects_for_signing for dry run and devinspect

### DIFF
--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -120,8 +120,10 @@ pub trait SimulatorStore:
 
     fn backing_store(&self) -> &dyn BackingStore;
 
-    // TODO: After we abstract object storage into the ExecutionCache trait, we can replace this with
-    // sui_core::TransactionInputLoad using an appropriate cache implementation.
+    // TODO: This function is now out-of-sync with read_objects_for_execution from transaction_input_loader.rs.
+    // For instance, it does not support the use of deleted shared objects.
+    // We will need to make SimulatorStore implement ExecutionCacheRead, and keep track of deleted shared objects
+    // in a marker table in order to merge this function.
     fn read_objects_for_synchronous_execution(
         &self,
         _tx_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1142,7 +1142,9 @@ impl AuthorityState {
         debug!("execute_certificate_internal");
 
         let tx_digest = certificate.digest();
-        let input_objects = self.read_objects(certificate, epoch_store).await?;
+        let input_objects = self
+            .read_objects_for_execution(certificate, epoch_store)
+            .await?;
 
         // This acquires a lock on the tx digest to prevent multiple concurrent executions of the
         // same tx. While we don't need this for safety (tx sequencing is ultimately atomic), it is
@@ -1161,7 +1163,7 @@ impl AuthorityState {
         .tap_err(|e| info!(?tx_digest, "process_certificate failed: {e}"))
     }
 
-    async fn read_objects(
+    pub async fn read_objects_for_execution(
         &self,
         certificate: &VerifiedExecutableTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -1172,28 +1174,14 @@ impl AuthorityState {
             .execution_load_input_objects_latency
             .start_timer();
         let input_objects = &certificate.data().transaction_data().input_objects()?;
-        if certificate.data().transaction_data().is_end_of_epoch_tx() {
-            self.input_loader
-                .read_objects_for_synchronous_execution(input_objects)
-                .await
-        } else {
-            self.input_loader
-                .read_objects_for_execution(
-                    epoch_store.as_ref(),
-                    &certificate.key(),
-                    input_objects,
-                    epoch_store.epoch(),
-                )
-                .await
-        }
-    }
-
-    pub async fn read_objects_for_benchmarking(
-        &self,
-        certificate: &VerifiedExecutableTransaction,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<InputObjects> {
-        self.read_objects(certificate, epoch_store).await
+        self.input_loader
+            .read_objects_for_execution(
+                epoch_store.as_ref(),
+                &certificate.key(),
+                input_objects,
+                epoch_store.epoch(),
+            )
+            .await
     }
 
     /// Test only wrapper for `try_execute_immediately()` above, useful for checking errors if the
@@ -4549,15 +4537,17 @@ impl AuthorityState {
             .execution_lock_for_executable_transaction(&executable_tx)
             .await?;
 
-        let input_objects = self
-            .input_loader
-            .read_objects_for_synchronous_execution(
-                &executable_tx
-                    .data()
-                    .intent_message()
-                    .value
-                    .input_objects()?,
+        // We must manually assign the shared object versions to the transaction before executing it.
+        // This is because we do not sequence end-of-epoch transactions through consensus.
+        epoch_store
+            .assign_shared_object_versions_idempotent(
+                self.get_cache_reader().as_ref(),
+                &[executable_tx.clone()],
             )
+            .await?;
+
+        let input_objects = self
+            .read_objects_for_execution(&executable_tx, epoch_store)
             .await?;
 
         let (temporary_store, effects, _execution_error_opt) =

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -6,7 +6,6 @@ use itertools::izip;
 use once_cell::unsync::OnceCell;
 use std::collections::HashMap;
 use std::sync::Arc;
-use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, TransactionDigest},
     error::{SuiError, SuiResult, UserInputError},
@@ -37,7 +36,7 @@ impl TransactionInputLoader {
     #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_signing(
         &self,
-        _tx_digest: &TransactionDigest,
+        _tx_digest_for_caching: Option<&TransactionDigest>,
         input_object_kinds: &[InputObjectKind],
         receiving_objects: &[ObjectRef],
         epoch_id: EpochId,
@@ -95,7 +94,8 @@ impl TransactionInputLoader {
             });
         }
 
-        let receiving_results = self.read_receiving_objects(receiving_objects, epoch_id)?;
+        let receiving_results =
+            self.read_receiving_objects_for_signing(receiving_objects, epoch_id)?;
 
         Ok((
             input_results
@@ -107,59 +107,34 @@ impl TransactionInputLoader {
         ))
     }
 
+    // TODO: We should find a way to merge this with the above function.
     /// Reads input objects assuming a synchronous context such as the end of epoch transaction.
     /// By "synchronous" we mean that it is safe to read the latest version of all shared objects,
     /// as opposed to relying on the shared input version assignment.
     #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_synchronous_execution(
         &self,
-        tx_digest: &TransactionDigest,
         input_object_kinds: &[InputObjectKind],
-        protocol_config: &ProtocolConfig,
     ) -> SuiResult<InputObjects> {
-        self.read_objects_for_synchronous_execution_impl(
-            Some(tx_digest),
-            input_object_kinds,
-            &[],
-            protocol_config,
-        )
-        .await
-        .map(|r| r.0)
-    }
+        let mut results = Vec::with_capacity(input_object_kinds.len());
+        // Length of input_object_kinds have been checked via validity_check() for ProgrammableTransaction.
+        for kind in input_object_kinds {
+            let obj = match kind {
+                InputObjectKind::MovePackage(id) => self
+                    .cache
+                    .get_package_object(id)?
+                    .map(|o| o.object().clone()),
 
-    /// Read input objects for a dry run execution.
-    #[instrument(level = "trace", skip_all)]
-    pub async fn read_objects_for_dry_run_exec(
-        &self,
-        tx_digest: &TransactionDigest,
-        input_object_kinds: &[InputObjectKind],
-        receiving_objects: &[ObjectRef],
-        protocol_config: &ProtocolConfig,
-    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
-        self.read_objects_for_synchronous_execution_impl(
-            Some(tx_digest),
-            input_object_kinds,
-            receiving_objects,
-            protocol_config,
-        )
-        .await
-    }
+                InputObjectKind::SharedMoveObject { id, .. } => self.cache.get_object(id)?,
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
+                    self.cache.get_object_by_key(&objref.0, objref.1)?
+                }
+            }
+            .ok_or_else(|| SuiError::from(kind.object_not_found_error()))?;
+            results.push(ObjectReadResult::new(*kind, obj.into()));
+        }
 
-    /// Read input objects for dev inspect
-    #[instrument(level = "trace", skip_all)]
-    pub async fn read_objects_for_dev_inspect(
-        &self,
-        input_object_kinds: &[InputObjectKind],
-        receiving_objects: &[ObjectRef],
-        protocol_config: &ProtocolConfig,
-    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
-        self.read_objects_for_synchronous_execution_impl(
-            None,
-            input_object_kinds,
-            receiving_objects,
-            protocol_config,
-        )
-        .await
+        Ok(results.into())
     }
 
     /// Read the inputs for a transaction that is ready to be executed.
@@ -268,37 +243,7 @@ impl TransactionInputLoader {
 
 // private methods
 impl TransactionInputLoader {
-    async fn read_objects_for_synchronous_execution_impl(
-        &self,
-        _tx_digest: Option<&TransactionDigest>,
-        input_object_kinds: &[InputObjectKind],
-        receiving_objects: &[ObjectRef],
-        _protocol_config: &ProtocolConfig,
-    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
-        let mut results = Vec::with_capacity(input_object_kinds.len());
-        // Length of input_object_kinds have been checked via validity_check() for ProgrammableTransaction.
-        for kind in input_object_kinds {
-            let obj = match kind {
-                InputObjectKind::MovePackage(id) => self
-                    .cache
-                    .get_package_object(id)?
-                    .map(|o| o.object().clone()),
-
-                InputObjectKind::SharedMoveObject { id, .. } => self.cache.get_object(id)?,
-                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    self.cache.get_object_by_key(&objref.0, objref.1)?
-                }
-            }
-            .ok_or_else(|| SuiError::from(kind.object_not_found_error()))?;
-            results.push(ObjectReadResult::new(*kind, obj.into()));
-        }
-
-        let receiving_results = self.read_receiving_objects(receiving_objects, 0)?;
-
-        Ok((results.into(), receiving_results))
-    }
-
-    fn read_receiving_objects(
+    fn read_receiving_objects_for_signing(
         &self,
         receiving_objects: &[ObjectRef],
         epoch_id: EpochId,

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -39,8 +39,9 @@ impl InMemoryObjectStore {
         self.num_object_reads.get()
     }
 
-    // TODO: remove this when TransactionInputLoader is able to use the ExecutionCache trait
-    // note: does not support shared object deletion.
+    // TODO: This function is out-of-sync with read_objects_for_execution from transaction_input_loader.rs.
+    // For instance, it does not support the use of deleted shared objects.
+    // We will need a trait to unify the these functions. (similarly the one in simulacrum)
     pub(crate) fn read_objects_for_execution(
         &self,
         shared_locks: &dyn GetSharedLocks,

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -8,7 +8,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::authority_store_tables::LiveObject;
-use sui_core::authority::shared_object_version_manager::SharedObjVerManager;
 use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
 use sui_core::authority::AuthorityState;
 use sui_core::authority_server::{ValidatorService, ValidatorServiceMetrics};
@@ -310,17 +309,13 @@ impl SingleValidator {
                 )
             })
             .collect();
-        let versions = SharedObjVerManager::assign_versions_from_consensus(
-            self.epoch_store.as_ref(),
-            self.get_validator().get_cache_reader().as_ref(),
-            &transactions,
-            None,
-        )
-        .await
-        .unwrap();
         self.epoch_store
-            .set_assigned_shared_object_versions_for_benchmark(versions.assigned_versions)
-            .await;
+            .assign_shared_object_versions_idempotent(
+                self.get_validator().get_cache_reader().as_ref(),
+                &transactions,
+            )
+            .await
+            .unwrap();
     }
 }
 

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -141,7 +141,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
 
         let epoch_store = self.validator.load_epoch_store_one_call_per_task().clone();
         self.validator
-            .read_objects_for_benchmarking(&tx, &epoch_store)
+            .read_objects_for_execution(&tx, &epoch_store)
             .await
     }
 


### PR DESCRIPTION
## Description 

Previously we share the same code path between dryrun/devinspect and `read_objects_for_synchronous_execution`  when loading input objects. This is error prone. For instance, we check receiving objects in that path. But we should not check receiving objects when loading input for execution. This makes the end of epoch transaction vulnerable to any potential issue that code might lead to. In general, the mix of these two entirely separate concepts (one for builders, one for end-of-epoch transaction) is very dangerous.
This PR changes it such that the dryrun/devinpect uses the signing path, which is much less prone to mistakes, and probably is more aligned with the intention of dryrun/devinspect.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
