### PR TITLE
[std] Better ASCII methods + minor cleanup in std

### DIFF
--- a/crates/sui-cost/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/sui-cost/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -3,10 +3,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use sui::coin::{Self, TreasuryCap};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -16,14 +16,17 @@ that characters are valid ASCII, and that strings consist of only valid ASCII ch
 -  [Function `push_char`](#0x1_ascii_push_char)
 -  [Function `pop_char`](#0x1_ascii_pop_char)
 -  [Function `length`](#0x1_ascii_length)
+-  [Function `append`](#0x1_ascii_append)
 -  [Function `as_bytes`](#0x1_ascii_as_bytes)
 -  [Function `into_bytes`](#0x1_ascii_into_bytes)
 -  [Function `byte`](#0x1_ascii_byte)
 -  [Function `is_valid_char`](#0x1_ascii_is_valid_char)
 -  [Function `is_printable_char`](#0x1_ascii_is_printable_char)
+-  [Function `is_alphanumeric`](#0x1_ascii_is_alphanumeric)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../move-stdlib/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -228,6 +231,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 ## Function `push_char`
 
+Push a <code><a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> to the end of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_push_char">push_char</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, char: <a href="../move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>)
@@ -252,6 +256,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 ## Function `pop_char`
 
+Pop a <code><a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> from the end of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_pop_char">pop_char</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>
@@ -276,6 +281,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 ## Function `length`
 
+Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> in bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): u64
@@ -289,6 +295,31 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): u64 {
     <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_as_bytes">as_bytes</a>().<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_append"></a>
+
+## Function `append`
+
+Append the <code>other</code> string to the end of <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, other: <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, other: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
+    <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(other.bytes)
 }
 </code></pre>
 
@@ -377,7 +408,8 @@ Unpack the <code>char</code> into its underlying byte.
 
 ## Function `is_valid_char`
 
-Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
+Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character.
+Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool
@@ -402,7 +434,8 @@ Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. R
 
 ## Function `is_printable_char`
 
-Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
+Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character.
+Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool
@@ -417,6 +450,43 @@ Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII char
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool {
    byte &gt;= 0x20 && // Disallow metacharacters
    <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7E // Don't allow DEL metacharacter
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_is_alphanumeric"></a>
+
+## Function `is_alphanumeric`
+
+Returns <code><b>true</b></code> if <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> is an alphanumeric ASCII string.
+Returns <code><b>false</b></code> otherwise.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_alphanumeric">is_alphanumeric</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_alphanumeric">is_alphanumeric</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): bool {
+    <b>let</b> (<b>mut</b> i, len) = (0, <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>());
+    <b>while</b> (i &lt; len) {
+        <b>let</b> byte = <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i];
+        <b>let</b> is_alphanumeric =
+            (byte &gt;= 0x41 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x5A) || // A-Z
+            (byte &gt;= 0x61 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7A) || // a-z
+            (byte &gt;= 0x30 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x39); // 0-9
+        <b>if</b> (!is_alphanumeric) <b>return</b> <b>false</b>;
+        i = i + 1;
+    };
+
+    <b>true</b>
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -645,7 +645,7 @@ Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">st
         <b>if</b> (<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i] == substr.bytes[j]) {
             j = j + 1;
             <b>if</b> (j == m) {
-                <b>return</b> i - m + 1;
+                <b>return</b> i - m + 1
             }
         } <b>else</b> {
             j = 0;

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -18,14 +18,18 @@ that characters are valid ASCII, and that strings consist of only valid ASCII ch
 -  [Function `length`](#0x1_ascii_length)
 -  [Function `append`](#0x1_ascii_append)
 -  [Function `insert`](#0x1_ascii_insert)
--  [Function `sub_string`](#0x1_ascii_sub_string)
+-  [Function `substring`](#0x1_ascii_substring)
 -  [Function `as_bytes`](#0x1_ascii_as_bytes)
 -  [Function `into_bytes`](#0x1_ascii_into_bytes)
 -  [Function `byte`](#0x1_ascii_byte)
 -  [Function `is_valid_char`](#0x1_ascii_is_valid_char)
 -  [Function `is_printable_char`](#0x1_ascii_is_printable_char)
 -  [Function `is_empty`](#0x1_ascii_is_empty)
--  [Function `is_alphanumeric`](#0x1_ascii_is_alphanumeric)
+-  [Function `to_uppercase`](#0x1_ascii_to_uppercase)
+-  [Function `to_lowercase`](#0x1_ascii_to_lowercase)
+-  [Function `index_of`](#0x1_ascii_index_of)
+-  [Function `char_to_uppercase`](#0x1_ascii_char_to_uppercase)
+-  [Function `char_to_lowercase`](#0x1_ascii_char_to_lowercase)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
@@ -359,8 +363,8 @@ Insert the <code>other</code> string at the <code>at</code> index of <code><a hr
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, at: u64, o: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
     <b>assert</b>!(at &lt;= s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
     <b>let</b> l = s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>();
-    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(0, at);
-    <b>let</b> end = s.<a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(at, l);
+    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(0, at);
+    <b>let</b> end = s.<a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(at, l);
     front.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(o);
     front.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(end);
     *s = front;
@@ -371,14 +375,14 @@ Insert the <code>other</code> string at the <code>at</code> index of <code><a hr
 
 </details>
 
-<a name="0x1_ascii_sub_string"></a>
+<a name="0x1_ascii_substring"></a>
 
-## Function `sub_string`
+## Function `substring`
 
 Copy the slice of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> from <code>i</code> to <code>j</code> into a new <code><a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
 </code></pre>
 
 
@@ -387,7 +391,7 @@ Copy the slice of the <code><a href="../move-stdlib/string.md#0x1_string">string
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, <b>mut</b> i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, <b>mut</b> i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
     <b>assert</b>!(i &lt;= j && j &lt;= <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
     <b>let</b> <b>mut</b> bytes = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
     <b>while</b> (i &lt; j) {
@@ -557,15 +561,14 @@ Returns <code><b>true</b></code> if <code><a href="../move-stdlib/string.md#0x1_
 
 </details>
 
-<a name="0x1_ascii_is_alphanumeric"></a>
+<a name="0x1_ascii_to_uppercase"></a>
 
-## Function `is_alphanumeric`
+## Function `to_uppercase`
 
-Returns <code><b>true</b></code> if <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> is an alphanumeric ASCII string.
-Returns <code><b>false</b></code> otherwise.
+Convert a <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> to its uppercase equivalent.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_alphanumeric">is_alphanumeric</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_uppercase">to_uppercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
 </code></pre>
 
 
@@ -574,19 +577,140 @@ Returns <code><b>false</b></code> otherwise.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_alphanumeric">is_alphanumeric</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): bool {
-    <b>let</b> (<b>mut</b> i, len) = (0, <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>());
-    <b>while</b> (i &lt; len) {
-        <b>let</b> byte = <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i];
-        <b>let</b> is_alphanumeric =
-            (0x41 &lt;= byte && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x5A) || // A-Z
-            (0x61 &lt;= byte && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7A) || // a-z
-            (0x30 &lt;= byte && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x39); // 0-9
-        <b>if</b> (!is_alphanumeric) <b>return</b> <b>false</b>;
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_uppercase">to_uppercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+    <b>let</b> (<b>mut</b> i, <b>mut</b> bytes) = (0, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[]);
+    <b>while</b> (i &lt; <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>()) {
+        bytes.push_back(<a href="../move-stdlib/ascii.md#0x1_ascii_char_to_uppercase">char_to_uppercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i]));
         i = i + 1;
     };
+    <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> { bytes }
+}
+</code></pre>
 
-    <b>true</b>
+
+
+</details>
+
+<a name="0x1_ascii_to_lowercase"></a>
+
+## Function `to_lowercase`
+
+Convert a <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> to its lowercase equivalent.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_lowercase">to_lowercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_lowercase">to_lowercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+    <b>let</b> (<b>mut</b> i, <b>mut</b> bytes) = (0, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[]);
+    <b>while</b> (i &lt; <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>()) {
+        bytes.push_back(<a href="../move-stdlib/ascii.md#0x1_ascii_char_to_lowercase">char_to_lowercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i]));
+        i = i + 1;
+    };
+    <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_index_of"></a>
+
+## Function `index_of`
+
+Computes the index of the first occurrence of the <code>substr</code> in the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
+Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> if the <code>substr</code> is not found.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_index_of">index_of</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, substr: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_index_of">index_of</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, substr: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): u64 {
+    <b>let</b> (<b>mut</b> i, <b>mut</b> j) = (0, 0);
+    <b>let</b> (n, m) = (<a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), substr.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>());
+    <b>while</b> (i &lt; n) {
+        <b>if</b> (<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i] == substr.bytes[j]) {
+            j = j + 1;
+            <b>if</b> (j == m) {
+                <b>return</b> i - m + 1;
+            }
+        } <b>else</b> {
+            j = 0;
+        };
+        i = i + 1;
+    };
+    n
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_char_to_uppercase"></a>
+
+## Function `char_to_uppercase`
+
+Convert a <code>char</code> to its lowercase equivalent.
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_uppercase">char_to_uppercase</a>(byte: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_uppercase">char_to_uppercase</a>(byte: u8): u8 {
+    <b>if</b> (byte &gt;= 0x61 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7A) {
+        byte - 0x20
+    } <b>else</b> {
+        byte
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_char_to_lowercase"></a>
+
+## Function `char_to_lowercase`
+
+Convert a <code>char</code> to its lowercase equivalent.
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_lowercase">char_to_lowercase</a>(byte: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_lowercase">char_to_lowercase</a>(byte: u8): u8 {
+    <b>if</b> (byte &gt;= 0x41 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x5A) {
+        byte + 0x20
+    } <b>else</b> {
+        byte
+    }
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -17,11 +17,14 @@ that characters are valid ASCII, and that strings consist of only valid ASCII ch
 -  [Function `pop_char`](#0x1_ascii_pop_char)
 -  [Function `length`](#0x1_ascii_length)
 -  [Function `append`](#0x1_ascii_append)
+-  [Function `insert`](#0x1_ascii_insert)
+-  [Function `sub_string`](#0x1_ascii_sub_string)
 -  [Function `as_bytes`](#0x1_ascii_as_bytes)
 -  [Function `into_bytes`](#0x1_ascii_into_bytes)
 -  [Function `byte`](#0x1_ascii_byte)
 -  [Function `is_valid_char`](#0x1_ascii_is_valid_char)
 -  [Function `is_printable_char`](#0x1_ascii_is_printable_char)
+-  [Function `is_empty`](#0x1_ascii_is_empty)
 -  [Function `is_alphanumeric`](#0x1_ascii_is_alphanumeric)
 
 
@@ -96,12 +99,22 @@ An ASCII character.
 ## Constants
 
 
-<a name="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
+<a name="0x1_ascii_EInvalidASCIICharacter"></a>
 
 An invalid ASCII character was encountered when creating an ASCII string.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>: u64 = 65536;
+<pre><code><b>const</b> <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidASCIICharacter">EInvalidASCIICharacter</a>: u64 = 65536;
+</code></pre>
+
+
+
+<a name="0x1_ascii_EInvalidIndex"></a>
+
+An invalid index was encountered when creating a substring.
+
+
+<pre><code><b>const</b> <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>: u64 = 65537;
 </code></pre>
 
 
@@ -123,7 +136,7 @@ Convert a <code>byte</code> into a <code><a href="../move-stdlib/ascii.md#0x1_as
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a> {
-    <b>assert</b>!(<a href="../move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(byte), <a href="../move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>);
+    <b>assert</b>!(<a href="../move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(byte), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidASCIICharacter">EInvalidASCIICharacter</a>);
     <a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a> { byte }
 }
 </code></pre>
@@ -151,7 +164,7 @@ Convert a vector of bytes <code>bytes</code> into an <code><a href="../move-stdl
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string">string</a>(bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
    <b>let</b> x = <a href="../move-stdlib/ascii.md#0x1_ascii_try_string">try_string</a>(bytes);
-   <b>assert</b>!(x.is_some(), <a href="../move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>);
+   <b>assert</b>!(x.is_some(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidASCIICharacter">EInvalidASCIICharacter</a>);
    x.destroy_some()
 }
 </code></pre>
@@ -327,6 +340,68 @@ Append the <code>other</code> string to the end of <code><a href="../move-stdlib
 
 </details>
 
+<a name="0x1_ascii_insert"></a>
+
+## Function `insert`
+
+Insert the <code>other</code> string at the <code>at</code> index of <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, at: u64, o: <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, at: u64, o: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
+    <b>assert</b>!(at &lt;= s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
+    <b>let</b> l = s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>();
+    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(0, at);
+    <b>let</b> end = s.<a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(at, l);
+    front.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(o);
+    front.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(end);
+    *s = front;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_sub_string"></a>
+
+## Function `sub_string`
+
+Copy the slice of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> from <code>i</code> to <code>j</code> into a new <code><a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_sub_string">sub_string</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, <b>mut</b> i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+    <b>assert</b>!(i &lt;= j && j &lt;= <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
+    <b>let</b> <b>mut</b> bytes = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
+    <b>while</b> (i &lt; j) {
+        bytes.push_back(<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i]);
+        i = i + 1;
+    };
+    <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_ascii_as_bytes"></a>
 
 ## Function `as_bytes`
@@ -382,7 +457,7 @@ Unpack the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>
 
 ## Function `byte`
 
-Unpack the <code>char</code> into its underlying byte.
+Unpack the <code>char</code> into its underlying bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a>(char: <a href="../move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>): u8
@@ -457,6 +532,31 @@ Returns <code><b>false</b></code> otherwise.
 
 </details>
 
+<a name="0x1_ascii_is_empty"></a>
+
+## Function `is_empty`
+
+Returns <code><b>true</b></code> if <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): bool {
+    <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>()
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_ascii_is_alphanumeric"></a>
 
 ## Function `is_alphanumeric`
@@ -479,9 +579,9 @@ Returns <code><b>false</b></code> otherwise.
     <b>while</b> (i &lt; len) {
         <b>let</b> byte = <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i];
         <b>let</b> is_alphanumeric =
-            (byte &gt;= 0x41 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x5A) || // A-Z
-            (byte &gt;= 0x61 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7A) || // a-z
-            (byte &gt;= 0x30 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x39); // 0-9
+            (0x41 &lt;= byte && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x5A) || // A-Z
+            (0x61 &lt;= byte && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7A) || // a-z
+            (0x30 &lt;= byte && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x39); // 0-9
         <b>if</b> (!is_alphanumeric) <b>return</b> <b>false</b>;
         i = i + 1;
     };

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -625,6 +625,7 @@ Convert a <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> 
 
 Computes the index of the first occurrence of the <code>substr</code> in the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
 Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> if the <code>substr</code> is not found.
+Returns 0 if the <code>substr</code> is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_index_of">index_of</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, substr: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): u64
@@ -637,17 +638,13 @@ Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">st
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_index_of">index_of</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, substr: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): u64 {
-    <b>let</b> (<b>mut</b> i, <b>mut</b> j) = (0, 0);
+    <b>let</b> <b>mut</b> i = 0;
     <b>let</b> (n, m) = (<a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), substr.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>());
-    <b>while</b> (i &lt; n) {
-        <b>if</b> (<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i] == substr.bytes[j]) {
-            j = j + 1;
-            <b>if</b> (j == m) {
-                <b>return</b> (i + 1) - m
-            }
-        } <b>else</b> {
-            j = 0;
-        };
+    <b>if</b> (n &lt; m) <b>return</b> n;
+    <b>while</b> (i &lt;= n - m) {
+        <b>let</b> <b>mut</b> j = 0;
+        <b>while</b> (j &lt; m && <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i + j] == substr.bytes[j]) j = j + 1;
+        <b>if</b> (j == m) <b>return</b> i;
         i = i + 1;
     };
     n

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -336,7 +336,7 @@ Append the <code>other</code> string to the end of <code><a href="../move-stdlib
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, other: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
-    <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(other.bytes)
+    <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(other.<a href="../move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>())
 }
 </code></pre>
 
@@ -362,12 +362,10 @@ Insert the <code>other</code> string at the <code>at</code> index of <code><a hr
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, at: u64, o: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
     <b>assert</b>!(at &lt;= s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
-    <b>let</b> l = s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>();
-    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(0, at);
-    <b>let</b> end = s.<a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(at, l);
-    front.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(o);
-    front.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(end);
-    *s = front;
+    <b>let</b> <b>mut</b> bytes = o.<a href="../move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>();
+    <b>while</b> (!bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>()) {
+        s.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(bytes.pop_back(), at);
+    };
 }
 </code></pre>
 
@@ -645,7 +643,7 @@ Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">st
         <b>if</b> (<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i] == substr.bytes[j]) {
             j = j + 1;
             <b>if</b> (j == m) {
-                <b>return</b> i - m + 1
+                <b>return</b> (i + 1) - m
             }
         } <b>else</b> {
             j = 0;

--- a/crates/sui-framework/docs/move-stdlib/option.md
+++ b/crates/sui-framework/docs/move-stdlib/option.md
@@ -65,24 +65,24 @@ zero or one because Move bytecode does not have ADTs.
 ## Constants
 
 
-<a name="0x1_option_EOPTION_IS_SET"></a>
+<a name="0x1_option_EOptionIsSet"></a>
 
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>Some</code> while it should be <code>None</code>.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>: u64 = 262144;
+<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOptionIsSet">EOptionIsSet</a>: u64 = 262144;
 </code></pre>
 
 
 
-<a name="0x1_option_EOPTION_NOT_SET"></a>
+<a name="0x1_option_EOptionNotSet"></a>
 
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>None</code> while it should be <code>Some</code>.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>: u64 = 262145;
+<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>: u64 = 262145;
 </code></pre>
 
 
@@ -231,7 +231,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     &t.vec[0]
 }
 </code></pre>
@@ -319,7 +319,7 @@ Aborts if <code>t</code> already holds a value
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element) {
     <b>let</b> vec_ref = &<b>mut</b> t.vec;
     <b>if</b> (vec_ref.is_empty()) vec_ref.push_back(e)
-    <b>else</b> <b>abort</b> <a href="../move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>
+    <b>else</b> <b>abort</b> <a href="../move-stdlib/option.md#0x1_option_EOptionIsSet">EOptionIsSet</a>
 }
 </code></pre>
 
@@ -345,7 +345,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     t.vec.pop_back()
 }
 </code></pre>
@@ -372,7 +372,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &<b>mut</b> Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     &<b>mut</b> t.vec[0]
 }
 </code></pre>
@@ -399,7 +399,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     <b>let</b> vec_ref = &<b>mut</b> t.vec;
     <b>let</b> old_value = vec_ref.pop_back();
     vec_ref.push_back(e);
@@ -487,7 +487,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     <b>let</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a> { <b>mut</b> vec } = t;
     <b>let</b> elem = vec.pop_back();
     vec.destroy_empty();
@@ -517,7 +517,7 @@ Aborts if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;) {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_none">is_none</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_none">is_none</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionIsSet">EOptionIsSet</a>);
     <b>let</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a> { vec } = t;
     vec.destroy_empty()
 }

--- a/crates/sui-framework/docs/move-stdlib/string.md
+++ b/crates/sui-framework/docs/move-stdlib/string.md
@@ -371,8 +371,8 @@ must be at a valid utf8 char boundary.
         <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>
     );
     <b>let</b> l = s.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
-    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(0, at);
-    <b>let</b> end = s.<a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(at, l);
+    <b>let</b> <b>mut</b> front = s.substring(0, at);
+    <b>let</b> end = s.substring(at, l);
     front.<a href="../move-stdlib/string.md#0x1_string_append">append</a>(o);
     front.<a href="../move-stdlib/string.md#0x1_string_append">append</a>(end);
     *s = front;

--- a/crates/sui-framework/docs/move-stdlib/string.md
+++ b/crates/sui-framework/docs/move-stdlib/string.md
@@ -12,19 +12,21 @@ strings.
 -  [Function `from_ascii`](#0x1_string_from_ascii)
 -  [Function `to_ascii`](#0x1_string_to_ascii)
 -  [Function `try_utf8`](#0x1_string_try_utf8)
--  [Function `bytes`](#0x1_string_bytes)
+-  [Function `as_bytes`](#0x1_string_as_bytes)
 -  [Function `into_bytes`](#0x1_string_into_bytes)
 -  [Function `is_empty`](#0x1_string_is_empty)
 -  [Function `length`](#0x1_string_length)
 -  [Function `append`](#0x1_string_append)
 -  [Function `append_utf8`](#0x1_string_append_utf8)
 -  [Function `insert`](#0x1_string_insert)
--  [Function `sub_string`](#0x1_string_sub_string)
+-  [Function `substring`](#0x1_string_substring)
 -  [Function `index_of`](#0x1_string_index_of)
 -  [Function `internal_check_utf8`](#0x1_string_internal_check_utf8)
 -  [Function `internal_is_char_boundary`](#0x1_string_internal_is_char_boundary)
 -  [Function `internal_sub_string`](#0x1_string_internal_sub_string)
 -  [Function `internal_index_of`](#0x1_string_internal_index_of)
+-  [Function `bytes`](#0x1_string_bytes)
+-  [Function `sub_string`](#0x1_string_sub_string)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/ascii.md#0x1_ascii">0x1::ascii</a>;
@@ -196,14 +198,14 @@ Tries to create a new string from a sequence of bytes.
 
 </details>
 
-<a name="0x1_string_bytes"></a>
+<a name="0x1_string_as_bytes"></a>
 
-## Function `bytes`
+## Function `as_bytes`
 
 Returns a reference to the underlying byte vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_as_bytes">as_bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -212,7 +214,7 @@ Returns a reference to the underlying byte vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_as_bytes">as_bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     &s.bytes
 }
 </code></pre>
@@ -371,8 +373,8 @@ must be at a valid utf8 char boundary.
         <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>
     );
     <b>let</b> l = s.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
-    <b>let</b> <b>mut</b> front = s.substring(0, at);
-    <b>let</b> end = s.substring(at, l);
+    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(0, at);
+    <b>let</b> end = s.<a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(at, l);
     front.<a href="../move-stdlib/string.md#0x1_string_append">append</a>(o);
     front.<a href="../move-stdlib/string.md#0x1_string_append">append</a>(end);
     *s = front;
@@ -383,9 +385,9 @@ must be at a valid utf8 char boundary.
 
 </details>
 
-<a name="0x1_string_sub_string"></a>
+<a name="0x1_string_substring"></a>
 
-## Function `sub_string`
+## Function `substring`
 
 Returns a sub-string using the given byte indices, where <code>i</code> is the first
 byte position and <code>j</code> is the start of the first byte not included (or the
@@ -393,7 +395,7 @@ length of the string). The indices must be at valid utf8 char boundaries,
 guaranteeing that the result is valid utf8.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
@@ -402,7 +404,7 @@ guaranteeing that the result is valid utf8.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
     <b>let</b> bytes = &s.bytes;
     <b>let</b> l = bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
     <b>assert</b>!(
@@ -528,6 +530,56 @@ if no occurrence found.
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_internal_index_of">internal_index_of</a>(v: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, r: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_bytes"></a>
+
+## Function `bytes`
+
+[DEPRECATED]
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    s.<a href="../move-stdlib/string.md#0x1_string_as_bytes">as_bytes</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_sub_string"></a>
+
+## Function `sub_string`
+
+[DEPRECATED]
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
+    s.<a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(i, j)
+}
 </code></pre>
 
 

--- a/crates/sui-framework/docs/move-stdlib/string.md
+++ b/crates/sui-framework/docs/move-stdlib/string.md
@@ -2,7 +2,8 @@
 title: Module `0x1::string`
 ---
 
-The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
+The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded
+strings.
 
 
 -  [Struct `String`](#0x1_string_String)
@@ -12,6 +13,7 @@ The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module
 -  [Function `to_ascii`](#0x1_string_to_ascii)
 -  [Function `try_utf8`](#0x1_string_try_utf8)
 -  [Function `bytes`](#0x1_string_bytes)
+-  [Function `into_bytes`](#0x1_string_into_bytes)
 -  [Function `is_empty`](#0x1_string_is_empty)
 -  [Function `length`](#0x1_string_length)
 -  [Function `append`](#0x1_string_append)
@@ -36,7 +38,8 @@ The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module
 
 ## Struct `String`
 
-A <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
+A <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8
+format.
 
 
 <pre><code><b>struct</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -65,22 +68,22 @@ A <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> h
 ## Constants
 
 
-<a name="0x1_string_EINVALID_INDEX"></a>
+<a name="0x1_string_EInvalidIndex"></a>
 
 Index out of range.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>: u64 = 2;
+<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>: u64 = 2;
 </code></pre>
 
 
 
-<a name="0x1_string_EINVALID_UTF8"></a>
+<a name="0x1_string_EInvalidUTF8"></a>
 
 An invalid UTF8 encoding.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>: u64 = 1;
+<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EInvalidUTF8">EInvalidUTF8</a>: u64 = 1;
 </code></pre>
 
 
@@ -89,7 +92,8 @@ An invalid UTF8 encoding.
 
 ## Function `utf8`
 
-Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
+Creates a new string from a sequence of bytes. Aborts if the bytes do
+not represent valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -102,7 +106,7 @@ Creates a new string from a sequence of bytes. Aborts if the bytes do not repres
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
-    <b>assert</b>!(<a href="../move-stdlib/string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(&bytes), <a href="../move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>);
+    <b>assert</b>!(<a href="../move-stdlib/string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(&bytes), <a href="../move-stdlib/string.md#0x1_string_EInvalidUTF8">EInvalidUTF8</a>);
     <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes }
 }
 </code></pre>
@@ -128,7 +132,7 @@ Convert an ASCII string to a UTF8 string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_from_ascii">from_ascii</a>(s: <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
-    <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes: <a href="../move-stdlib/ascii.md#0x1_ascii_into_bytes">ascii::into_bytes</a>(s) }
+    <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes: s.<a href="../move-stdlib/string.md#0x1_string_into_bytes">into_bytes</a>() }
 }
 </code></pre>
 
@@ -155,7 +159,7 @@ Aborts if <code>s</code> is not valid ASCII
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_to_ascii">to_ascii</a>(s: <a href="../move-stdlib/string.md#0x1_string_String">String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a> {
     <b>let</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes } = s;
-    <a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(bytes)
+    bytes.to_ascii_string()
 }
 </code></pre>
 
@@ -210,6 +214,32 @@ Returns a reference to the underlying byte vector.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     &s.bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_into_bytes"></a>
+
+## Function `into_bytes`
+
+Unpack the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> to get its underlying bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_into_bytes">into_bytes</a>(s: <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_into_bytes">into_bytes</a>(s: <a href="../move-stdlib/string.md#0x1_string_String">String</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes } = s;
+    bytes
 }
 </code></pre>
 
@@ -321,8 +351,8 @@ Appends bytes which must be in valid utf8 format.
 
 ## Function `insert`
 
-Insert the other string at the byte index in given string. The index must be at a valid utf8 char
-boundary.
+Insert the other string at the byte index in given string. The index
+must be at a valid utf8 char boundary.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -336,7 +366,10 @@ boundary.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a>, at: u64, o: <a href="../move-stdlib/string.md#0x1_string_String">String</a>) {
     <b>let</b> bytes = &s.bytes;
-    <b>assert</b>!(at &lt;= bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>() && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, at), <a href="../move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>);
+    <b>assert</b>!(
+        at &lt;= bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>() && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, at),
+        <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>
+    );
     <b>let</b> l = s.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
     <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(0, at);
     <b>let</b> end = s.<a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(at, l);
@@ -354,8 +387,9 @@ boundary.
 
 ## Function `sub_string`
 
-Returns a sub-string using the given byte indices, where <code>i</code> is the first byte position and <code>j</code> is the start
-of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+Returns a sub-string using the given byte indices, where <code>i</code> is the first
+byte position and <code>j</code> is the start of the first byte not included (or the
+length of the string). The indices must be at valid utf8 char boundaries,
 guaranteeing that the result is valid utf8.
 
 
@@ -372,10 +406,13 @@ guaranteeing that the result is valid utf8.
     <b>let</b> bytes = &s.bytes;
     <b>let</b> l = bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
     <b>assert</b>!(
-        j &lt;= l && i &lt;= j && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, i) && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, j),
-        <a href="../move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>
+        j &lt;= l &&
+        i &lt;= j &&
+        <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, i) &&
+        <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, j),
+        <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>
     );
-    <a href="../move-stdlib/string.md#0x1_string_String">String</a>{bytes: <a href="../move-stdlib/string.md#0x1_string_internal_sub_string">internal_sub_string</a>(bytes, i, j)}
+    <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes: <a href="../move-stdlib/string.md#0x1_string_internal_sub_string">internal_sub_string</a>(bytes, i, j) }
 }
 </code></pre>
 
@@ -387,7 +424,8 @@ guaranteeing that the result is valid utf8.
 
 ## Function `index_of`
 
-Computes the index of the first occurrence of a string. Returns <code><a href="../move-stdlib/string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
+Computes the index of the first occurrence of a string. Returns <code>s.<a href="../move-stdlib/string.md#0x1_string_length">length</a>()</code>
+if no occurrence found.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_index_of">index_of</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, r: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): u64

--- a/crates/sui-framework/docs/move-stdlib/type_name.md
+++ b/crates/sui-framework/docs/move-stdlib/type_name.md
@@ -282,7 +282,7 @@ Aborts if given a primitive type.
 
     // Base16 (<a href="../move-stdlib/string.md#0x1_string">string</a>) representation of an <b>address</b> <b>has</b> 2 symbols per byte.
     <b>let</b> len = <a href="../move-stdlib/address.md#0x1_address_length">address::length</a>() * 2;
-    self.name.sub_string(0, len)
+    self.name.substring(0, len)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/move-stdlib/type_name.md
+++ b/crates/sui-framework/docs/move-stdlib/type_name.md
@@ -282,17 +282,7 @@ Aborts if given a primitive type.
 
     // Base16 (<a href="../move-stdlib/string.md#0x1_string">string</a>) representation of an <b>address</b> <b>has</b> 2 symbols per byte.
     <b>let</b> len = <a href="../move-stdlib/address.md#0x1_address_length">address::length</a>() * 2;
-    <b>let</b> str_bytes = self.name.as_bytes();
-    <b>let</b> <b>mut</b> addr_bytes = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> <b>mut</b> i = 0;
-
-    // Read `len` bytes from the type name and push them <b>to</b> addr_bytes.
-    <b>while</b> (i &lt; len) {
-        addr_bytes.push_back(str_bytes[i]);
-        i = i + 1;
-    };
-
-    <a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(addr_bytes)
+    self.name.sub_string(0, len)
 }
 </code></pre>
 
@@ -335,7 +325,7 @@ Aborts if given a primitive type.
         }
     };
 
-    <a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(module_name)
+    module_name.to_ascii_string()
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/move-stdlib/vector.md
+++ b/crates/sui-framework/docs/move-stdlib/vector.md
@@ -35,12 +35,12 @@ vectors are growable. This module has many native functions.
 ## Constants
 
 
-<a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
+<a name="0x1_vector_EIndexOutOfBounds"></a>
 
 The index into the vector is out of bounds
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
+<pre><code><b>const</b> <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 131072;
 </code></pre>
 
 
@@ -432,7 +432,7 @@ Aborts if <code>i</code> is out of bounds.
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, <b>mut</b> i: u64): Element {
     <b>let</b> <b>mut</b> len = v.<a href="../move-stdlib/vector.md#0x1_vector_length">length</a>();
     // i out of bounds; <b>abort</b>
-    <b>if</b> (i &gt;= len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
+    <b>if</b> (i &gt;= len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>;
 
     len = len - 1;
     <b>while</b> (i &lt; len) v.<a href="../move-stdlib/vector.md#0x1_vector_swap">swap</a>(i, { i = i + 1; i });
@@ -467,7 +467,7 @@ Aborts if <code>i &gt; v.<a href="../move-stdlib/vector.md#0x1_vector_length">le
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, <b>mut</b> i: u64) {
     <b>let</b> len = v.<a href="../move-stdlib/vector.md#0x1_vector_length">length</a>();
     // i too big <b>abort</b>
-    <b>if</b> (i &gt; len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
+    <b>if</b> (i &gt; len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>;
 
     v.<a href="../move-stdlib/vector.md#0x1_vector_push_back">push_back</a>(e);
     <b>while</b> (i &lt; len) {
@@ -500,7 +500,7 @@ Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
-    <b>assert</b>!(!v.<a href="../move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>(), <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+    <b>assert</b>!(!v.<a href="../move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>(), <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>);
     <b>let</b> last_idx = v.<a href="../move-stdlib/vector.md#0x1_vector_length">length</a>() - 1;
     v.<a href="../move-stdlib/vector.md#0x1_vector_swap">swap</a>(i, last_idx);
     v.<a href="../move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>()

--- a/crates/sui-framework/docs/sui-framework/vec_map.md
+++ b/crates/sui-framework/docs/sui-framework/vec_map.md
@@ -105,6 +105,16 @@ An entry in the map
 ## Constants
 
 
+<a name="0x2_vec_map_EIndexOutOfBounds"></a>
+
+Trying to access an element of the map at an invalid index
+
+
+<pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 3;
+</code></pre>
+
+
+
 <a name="0x2_vec_map_EKeyAlreadyExists"></a>
 
 This key already exists in the map
@@ -121,16 +131,6 @@ This key does not exist in the map
 
 
 <pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x2_vec_map_EIndexOutOfBounds"></a>
-
-Trying to access an element of the map at an invalid index
-
-
-<pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 3;
 </code></pre>
 
 

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -4,8 +4,6 @@
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module std::ascii {
-    use std::option::{Self, Option};
-
     // Allows calling `.to_string()` to convert an `ascii::String` into as `string::String`
     public use fun std::string::from_ascii as String.to_string;
 
@@ -67,16 +65,24 @@ module std::ascii {
         true
     }
 
+    /// Push a `Char` to the end of the `string`.
     public fun push_char(string: &mut String, char: Char) {
         string.bytes.push_back(char.byte);
     }
 
+    /// Pop a `Char` from the end of the `string`.
     public fun pop_char(string: &mut String): Char {
         Char { byte: string.bytes.pop_back() }
     }
 
+    /// Returns the length of the `string` in bytes.
     public fun length(string: &String): u64 {
         string.as_bytes().length()
+    }
+
+    /// Append the `other` string to the end of `string`.
+    public fun append(string: &mut String, other: String) {
+        string.bytes.append(other.bytes)
     }
 
     /// Get the inner bytes of the `string` as a reference
@@ -96,14 +102,33 @@ module std::ascii {
        byte
     }
 
-    /// Returns `true` if `b` is a valid ASCII character. Returns `false` otherwise.
+    /// Returns `true` if `b` is a valid ASCII character.
+    /// Returns `false` otherwise.
     public fun is_valid_char(b: u8): bool {
        b <= 0x7F
     }
 
-    /// Returns `true` if `byte` is an printable ASCII character. Returns `false` otherwise.
+    /// Returns `true` if `byte` is an printable ASCII character.
+    /// Returns `false` otherwise.
     public fun is_printable_char(byte: u8): bool {
        byte >= 0x20 && // Disallow metacharacters
        byte <= 0x7E // Don't allow DEL metacharacter
+    }
+
+    /// Returns `true` if `string` is an alphanumeric ASCII string.
+    /// Returns `false` otherwise.
+    public fun is_alphanumeric(string: &String): bool {
+        let (mut i, len) = (0, string.length());
+        while (i < len) {
+            let byte = string.bytes[i];
+            let is_alphanumeric =
+                (byte >= 0x41 && byte <= 0x5A) || // A-Z
+                (byte >= 0x61 && byte <= 0x7A) || // a-z
+                (byte >= 0x30 && byte <= 0x39); // 0-9
+            if (!is_alphanumeric) return false;
+            i = i + 1;
+        };
+
+        true
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -91,15 +91,15 @@ module std::ascii {
     public fun insert(s: &mut String, at: u64, o: String) {
         assert!(at <= s.length(), EInvalidIndex);
         let l = s.length();
-        let mut front = s.sub_string(0, at);
-        let end = s.sub_string(at, l);
+        let mut front = s.substring(0, at);
+        let end = s.substring(at, l);
         front.append(o);
         front.append(end);
         *s = front;
     }
 
     /// Copy the slice of the `string` from `i` to `j` into a new `String`.
-    public fun sub_string(string: &String, mut i: u64, j: u64): String {
+    public fun substring(string: &String, mut i: u64, j: u64): String {
         assert!(i <= j && j <= string.length(), EInvalidIndex);
         let mut bytes = vector[];
         while (i < j) {
@@ -144,20 +144,60 @@ module std::ascii {
         string.bytes.is_empty()
     }
 
-    /// Returns `true` if `string` is an alphanumeric ASCII string.
-    /// Returns `false` otherwise.
-    public fun is_alphanumeric(string: &String): bool {
-        let (mut i, len) = (0, string.length());
-        while (i < len) {
-            let byte = string.bytes[i];
-            let is_alphanumeric =
-                (0x41 <= byte && byte <= 0x5A) || // A-Z
-                (0x61 <= byte && byte <= 0x7A) || // a-z
-                (0x30 <= byte && byte <= 0x39); // 0-9
-            if (!is_alphanumeric) return false;
+    /// Convert a `string` to its uppercase equivalent.
+    public fun to_uppercase(string: &String): String {
+        let (mut i, mut bytes) = (0, vector[]);
+        while (i < string.length()) {
+            bytes.push_back(char_to_uppercase(string.bytes[i]));
             i = i + 1;
         };
+        String { bytes }
+    }
 
-        true
+    /// Convert a `string` to its lowercase equivalent.
+    public fun to_lowercase(string: &String): String {
+        let (mut i, mut bytes) = (0, vector[]);
+        while (i < string.length()) {
+            bytes.push_back(char_to_lowercase(string.bytes[i]));
+            i = i + 1;
+        };
+        String { bytes }
+    }
+
+    /// Computes the index of the first occurrence of the `substr` in the `string`.
+    /// Returns the length of the `string` if the `substr` is not found.
+    public fun index_of(string: &String, substr: &String): u64 {
+        let (mut i, mut j) = (0, 0);
+        let (n, m) = (string.length(), substr.length());
+        while (i < n) {
+            if (string.bytes[i] == substr.bytes[j]) {
+                j = j + 1;
+                if (j == m) {
+                    return i - m + 1
+                }
+            } else {
+                j = 0;
+            };
+            i = i + 1;
+        };
+        n
+    }
+
+    /// Convert a `char` to its lowercase equivalent.
+    fun char_to_uppercase(byte: u8): u8 {
+        if (byte >= 0x61 && byte <= 0x7A) {
+            byte - 0x20
+        } else {
+            byte
+        }
+    }
+
+    /// Convert a `char` to its lowercase equivalent.
+    fun char_to_lowercase(byte: u8): u8 {
+        if (byte >= 0x41 && byte <= 0x5A) {
+            byte + 0x20
+        } else {
+            byte
+        }
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -166,19 +166,13 @@ module std::ascii {
     /// Returns the length of the `string` if the `substr` is not found.
     /// Returns 0 if the `substr` is empty.
     public fun index_of(string: &String, substr: &String): u64 {
-        let (mut i, mut j) = (0, 0);
+        let mut i = 0;
         let (n, m) = (string.length(), substr.length());
-        if (m == 0) return 0;
-        while (i < n) {
-            if (string.bytes[i] == substr.bytes[j]) {
-                j = j + 1;
-                if (j == m) {
-                    return (i + 1) - m
-                }
-            } else {
-                i = i - j;
-                j = 0;
-            };
+        if (n < m) return n;
+        while (i <= n - m) {
+            let mut j = 0;
+            while (j < m && string.bytes[i + j] == substr.bytes[j]) j = j + 1;
+            if (j == m) return i;
             i = i + 1;
         };
         n

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -84,18 +84,20 @@ module std::ascii {
 
     /// Append the `other` string to the end of `string`.
     public fun append(string: &mut String, other: String) {
-        string.bytes.append(other.bytes)
+        string.bytes.append(other.into_bytes())
     }
 
     /// Insert the `other` string at the `at` index of `string`.
     public fun insert(s: &mut String, at: u64, o: String) {
         assert!(at <= s.length(), EInvalidIndex);
-        let l = s.length();
-        let mut front = s.substring(0, at);
-        let end = s.substring(at, l);
-        front.append(o);
-        front.append(end);
-        *s = front;
+        let mut tail = vector[];
+        while (s.length() > at) {
+            tail.push_back(s.bytes.pop_back());
+        };
+        s.append(o);
+        while (!tail.is_empty()) {
+            s.bytes.push_back(tail.pop_back());
+        };
     }
 
     /// Copy the slice of the `string` from `i` to `j` into a new `String`.

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -87,6 +87,17 @@ module std::ascii {
         string.bytes.append(other.bytes)
     }
 
+    /// Insert the `other` string at the `at` index of `string`.
+    public fun insert(s: &mut String, at: u64, o: String) {
+        assert!(at <= s.length(), EInvalidIndex);
+        let l = s.length();
+        let mut front = s.sub_string(0, at);
+        let end = s.sub_string(at, l);
+        front.append(o);
+        front.append(end);
+        *s = front;
+    }
+
     /// Copy the slice of the `string` from `i` to `j` into a new `String`.
     public fun sub_string(string: &String, mut i: u64, j: u64): String {
         assert!(i <= j && j <= string.length(), EInvalidIndex);
@@ -109,7 +120,7 @@ module std::ascii {
        bytes
     }
 
-    /// Unpack the `char` into its underlying byte.
+    /// Unpack the `char` into its underlying bytes.
     public fun byte(char: Char): u8 {
        let Char { byte } = char;
        byte

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -173,7 +173,7 @@ module std::ascii {
             if (string.bytes[i] == substr.bytes[j]) {
                 j = j + 1;
                 if (j == m) {
-                    return i - m + 1
+                    return (i + 1) - m
                 }
             } else {
                 j = 0;

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -89,7 +89,7 @@ module std::ascii {
 
     /// Copy the slice of the `string` from `i` to `j` into a new `String`.
     public fun sub_string(string: &String, mut i: u64, j: u64): String {
-        assert!(i <= string.length() && j <= string.length() && i <= j, EInvalidIndex);
+        assert!(i <= j && j <= string.length(), EInvalidIndex);
         let mut bytes = vector[];
         while (i < j) {
             bytes.push_back(string.bytes[i]);

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -90,13 +90,9 @@ module std::ascii {
     /// Insert the `other` string at the `at` index of `string`.
     public fun insert(s: &mut String, at: u64, o: String) {
         assert!(at <= s.length(), EInvalidIndex);
-        let mut tail = vector[];
-        while (s.length() > at) {
-            tail.push_back(s.bytes.pop_back());
-        };
-        s.append(o);
-        while (!tail.is_empty()) {
-            s.bytes.push_back(tail.pop_back());
+        let mut bytes = o.into_bytes();
+        while (!bytes.is_empty()) {
+            s.bytes.insert(bytes.pop_back(), at);
         };
     }
 

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -140,9 +140,9 @@ module std::ascii {
         while (i < len) {
             let byte = string.bytes[i];
             let is_alphanumeric =
-                (byte >= 0x41 && byte <= 0x5A) || // A-Z
-                (byte >= 0x61 && byte <= 0x7A) || // a-z
-                (byte >= 0x30 && byte <= 0x39); // 0-9
+                (0x41 <= byte && byte <= 0x5A) || // A-Z
+                (0x61 <= byte && byte <= 0x7A) || // a-z
+                (0x30 <= byte && byte <= 0x39); // 0-9
             if (!is_alphanumeric) return false;
             i = i + 1;
         };

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -164,9 +164,11 @@ module std::ascii {
 
     /// Computes the index of the first occurrence of the `substr` in the `string`.
     /// Returns the length of the `string` if the `substr` is not found.
+    /// Returns 0 if the `substr` is empty.
     public fun index_of(string: &String, substr: &String): u64 {
         let (mut i, mut j) = (0, 0);
         let (n, m) = (string.length(), substr.length());
+        if (m == 0) return 0;
         while (i < n) {
             if (string.bytes[i] == substr.bytes[j]) {
                 j = j + 1;
@@ -174,6 +176,7 @@ module std::ascii {
                     return (i + 1) - m
                 }
             } else {
+                i = i - j;
                 j = 0;
             };
             i = i + 1;

--- a/crates/sui-framework/packages/move-stdlib/sources/bit_vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/bit_vector.move
@@ -3,9 +3,9 @@
 
 module std::bit_vector {
     /// The provided index is out of bounds
-    const EINDEX: u64 = 0x20000;
+    const EIndexOutOfBounds: u64 = 0x20000;
     /// An invalid length of bitvector was given
-    const ELENGTH: u64 = 0x20001;
+    const EInvalidLength: u64 = 0x20001;
 
     #[allow(unused_const)]
     const WORD_SIZE: u64 = 1;
@@ -18,8 +18,8 @@ module std::bit_vector {
     }
 
     public fun new(length: u64): BitVector {
-        assert!(length > 0, ELENGTH);
-        assert!(length < MAX_SIZE, ELENGTH);
+        assert!(length > 0, EInvalidLength);
+        assert!(length < MAX_SIZE, EInvalidLength);
         let mut counter = 0;
         let mut bit_field = vector::empty();
         while (counter < length) {
@@ -35,14 +35,14 @@ module std::bit_vector {
 
     /// Set the bit at `bit_index` in the `bitvector` regardless of its previous state.
     public fun set(bitvector: &mut BitVector, bit_index: u64) {
-        assert!(bit_index < bitvector.bit_field.length(), EINDEX);
+        assert!(bit_index < bitvector.bit_field.length(), EIndexOutOfBounds);
         let x = &mut bitvector.bit_field[bit_index];
         *x = true;
     }
 
     /// Unset the bit at `bit_index` in the `bitvector` regardless of its previous state.
     public fun unset(bitvector: &mut BitVector, bit_index: u64) {
-        assert!(bit_index < bitvector.bit_field.length(), EINDEX);
+        assert!(bit_index < bitvector.bit_field.length(), EIndexOutOfBounds);
         let x = &mut bitvector.bit_field[bit_index];
         *x = false;
     }
@@ -79,7 +79,7 @@ module std::bit_vector {
     /// Return the value of the bit at `bit_index` in the `bitvector`. `true`
     /// represents "1" and `false` represents a 0
     public fun is_index_set(bitvector: &BitVector, bit_index: u64): bool {
-        assert!(bit_index < bitvector.bit_field.length(), EINDEX);
+        assert!(bit_index < bitvector.bit_field.length(), EIndexOutOfBounds);
         bitvector.bit_field[bit_index]
     }
 
@@ -92,7 +92,7 @@ module std::bit_vector {
     /// including) `start_index` in the `bitvector`. If there is no such
     /// sequence, then `0` is returned.
     public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
-        assert!(start_index < bitvector.length, EINDEX);
+        assert!(start_index < bitvector.length, EIndexOutOfBounds);
         let mut index = start_index;
 
         // Find the greatest index in the vector such that all indices less than it are set.

--- a/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
@@ -21,15 +21,15 @@ module std::fixed_point32 {
     const MAX_U64: u128 = 18446744073709551615;
 
     /// The denominator provided was zero
-    const EDENOMINATOR: u64 = 0x10001;
+    const EDenominatorIsZero: u64 = 0x10001;
     /// The quotient value would be too large to be held in a `u64`
-    const EDIVISION: u64 = 0x20002;
+    const EDivValueTooLarge: u64 = 0x20002;
     /// The multiplied value would be too large to be held in a `u64`
-    const EMULTIPLICATION: u64 = 0x20003;
+    const EMulValueTooLarge: u64 = 0x20003;
     /// A division by zero was encountered
-    const EDIVISION_BY_ZERO: u64 = 0x10004;
+    const EDivisionByZero: u64 = 0x10004;
     /// The computed ratio when converting to a `FixedPoint32` would be unrepresentable
-    const ERATIO_OUT_OF_RANGE: u64 = 0x20005;
+    const ERatioOutOfRange: u64 = 0x20005;
 
     /// Multiply a u64 integer by a fixed-point number, truncating any
     /// fractional part of the product. This will abort if the product
@@ -43,7 +43,7 @@ module std::fixed_point32 {
         // so rescale it by shifting away the low bits.
         let product = unscaled_product >> 32;
         // Check whether the value is too large.
-        assert!(product <= MAX_U64, EMULTIPLICATION);
+        assert!(product <= MAX_U64, EMulValueTooLarge);
         product as u64
     }
 
@@ -52,13 +52,13 @@ module std::fixed_point32 {
     /// is zero or if the quotient overflows.
     public fun divide_u64(val: u64, divisor: FixedPoint32): u64 {
         // Check for division by zero.
-        assert!(divisor.value != 0, EDIVISION_BY_ZERO);
+        assert!(divisor.value != 0, EDivisionByZero);
         // First convert to 128 bits and then shift left to
         // add 32 fractional zero bits to the dividend.
         let scaled_value = val as u128 << 32;
         let quotient = scaled_value / (divisor.value as u128);
         // Check whether the value is too large.
-        assert!(quotient <= MAX_U64, EDIVISION);
+        assert!(quotient <= MAX_U64, EDivValueTooLarge);
         // the value may be too large, which will cause the cast to fail
         // with an arithmetic error.
         quotient as u64
@@ -81,12 +81,12 @@ module std::fixed_point32 {
         // fractional bits.
         let scaled_numerator = numerator as u128 << 64;
         let scaled_denominator = denominator as u128 << 32;
-        assert!(scaled_denominator != 0, EDENOMINATOR);
+        assert!(scaled_denominator != 0, EDenominatorIsZero);
         let quotient = scaled_numerator / scaled_denominator;
-        assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
+        assert!(quotient != 0 || numerator == 0, ERatioOutOfRange);
         // Return the quotient as a fixed-point number. We first need to check whether the cast
         // can succeed.
-        assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        assert!(quotient <= MAX_U64, ERatioOutOfRange);
         FixedPoint32 { value: quotient as u64 }
     }
 

--- a/crates/sui-framework/packages/move-stdlib/sources/option.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/option.move
@@ -11,10 +11,10 @@ module std::option {
 
     /// The `Option` is in an invalid state for the operation attempted.
     /// The `Option` is `Some` while it should be `None`.
-    const EOPTION_IS_SET: u64 = 0x40000;
+    const EOptionIsSet: u64 = 0x40000;
     /// The `Option` is in an invalid state for the operation attempted.
     /// The `Option` is `None` while it should be `Some`.
-    const EOPTION_NOT_SET: u64 = 0x40001;
+    const EOptionNotSet: u64 = 0x40001;
 
     /// Return an empty `Option`
     public fun none<Element>(): Option<Element> {
@@ -45,7 +45,7 @@ module std::option {
     /// Return an immutable reference to the value inside `t`
     /// Aborts if `t` does not hold a value
     public fun borrow<Element>(t: &Option<Element>): &Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         &t.vec[0]
     }
 
@@ -73,27 +73,27 @@ module std::option {
     public fun fill<Element>(t: &mut Option<Element>, e: Element) {
         let vec_ref = &mut t.vec;
         if (vec_ref.is_empty()) vec_ref.push_back(e)
-        else abort EOPTION_IS_SET
+        else abort EOptionIsSet
     }
 
     /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
     /// Aborts if `t` does not hold a value
     public fun extract<Element>(t: &mut Option<Element>): Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         t.vec.pop_back()
     }
 
     /// Return a mutable reference to the value inside `t`
     /// Aborts if `t` does not hold a value
     public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         &mut t.vec[0]
     }
 
     /// Swap the old value inside `t` with `e` and return the old value
     /// Aborts if `t` does not hold a value
     public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         let vec_ref = &mut t.vec;
         let old_value = vec_ref.pop_back();
         vec_ref.push_back(e);
@@ -121,7 +121,7 @@ module std::option {
     /// Unpack `t` and return its contents
     /// Aborts if `t` does not hold a value
     public fun destroy_some<Element>(t: Option<Element>): Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         let Option { mut vec } = t;
         let elem = vec.pop_back();
         vec.destroy_empty();
@@ -131,7 +131,7 @@ module std::option {
     /// Unpack `t`
     /// Aborts if `t` holds a value
     public fun destroy_none<Element>(t: Option<Element>) {
-        assert!(t.is_none(), EOPTION_IS_SET);
+        assert!(t.is_none(), EOptionIsSet);
         let Option { vec } = t;
         vec.destroy_empty()
     }

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -4,7 +4,6 @@
 /// The `string` module defines the `String` type which represents UTF8 encoded strings.
 module std::string {
     use std::ascii;
-    use std::option::{Self, Option};
 
     /// An invalid UTF8 encoding.
     const EINVALID_UTF8: u64 = 1;

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -6,10 +6,10 @@ module std::string {
     use std::ascii;
 
     /// An invalid UTF8 encoding.
-    const EINVALID_UTF8: u64 = 1;
+    const EInvalidUTF8: u64 = 1;
 
     /// Index out of range.
-    const EINVALID_INDEX: u64 = 2;
+    const EInvalidIndex: u64 = 2;
 
     /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
     public struct String has copy, drop, store {
@@ -18,7 +18,7 @@ module std::string {
 
     /// Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
     public fun utf8(bytes: vector<u8>): String {
-        assert!(internal_check_utf8(&bytes), EINVALID_UTF8);
+        assert!(internal_check_utf8(&bytes), EInvalidUTF8);
         String { bytes }
     }
 
@@ -72,7 +72,7 @@ module std::string {
     /// boundary.
     public fun insert(s: &mut String, at: u64, o: String) {
         let bytes = &s.bytes;
-        assert!(at <= bytes.length() && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
+        assert!(at <= bytes.length() && internal_is_char_boundary(bytes, at), EInvalidIndex);
         let l = s.length();
         let mut front = s.sub_string(0, at);
         let end = s.sub_string(at, l);
@@ -89,7 +89,7 @@ module std::string {
         let l = bytes.length();
         assert!(
             j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
-            EINVALID_INDEX
+            EInvalidIndex
         );
         String{bytes: internal_sub_string(bytes, i, j)}
     }

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -46,11 +46,8 @@ module std::string {
         }
     }
 
-    /// Alias to align the API with `ASCII`.
-    public use fun bytes as String.as_bytes;
-
     /// Returns a reference to the underlying byte vector.
-    public fun bytes(s: &String): &vector<u8> {
+    public fun as_bytes(s: &String): &vector<u8> {
         &s.bytes
     }
 
@@ -96,14 +93,11 @@ module std::string {
         *s = front;
     }
 
-    /// Alias to align the API with `ASCII` and standardize naming.
-    public use fun sub_string as String.substring;
-
     /// Returns a sub-string using the given byte indices, where `i` is the first
     /// byte position and `j` is the start of the first byte not included (or the
     /// length of the string). The indices must be at valid utf8 char boundaries,
     /// guaranteeing that the result is valid utf8.
-    public fun sub_string(s: &String, i: u64, j: u64): String {
+    public fun substring(s: &String, i: u64, j: u64): String {
         let bytes = &s.bytes;
         let l = bytes.length();
         assert!(
@@ -128,4 +122,16 @@ module std::string {
     native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;
     native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
     native fun internal_index_of(v: &vector<u8>, r: &vector<u8>): u64;
+
+    // === Deprecated ===
+
+    /// [DEPRECATED]
+    public fun bytes(s: &String): &vector<u8> {
+        s.as_bytes()
+    }
+
+    /// [DEPRECATED]
+    public fun sub_string(s: &String, i: u64, j: u64): String {
+        s.substring(i, j)
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -89,8 +89,8 @@ module std::string {
             EInvalidIndex
         );
         let l = s.length();
-        let mut front = s.sub_string(0, at);
-        let end = s.sub_string(at, l);
+        let mut front = s.substring(0, at);
+        let end = s.substring(at, l);
         front.append(o);
         front.append(end);
         *s = front;

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -46,6 +46,9 @@ module std::string {
         }
     }
 
+    /// Alias to align the API with `ASCII`.
+    public use fun bytes as String.as_bytes;
+
     /// Returns a reference to the underlying byte vector.
     public fun bytes(s: &String): &vector<u8> {
         &s.bytes
@@ -92,6 +95,9 @@ module std::string {
         front.append(end);
         *s = front;
     }
+
+    /// Alias to align the API with `ASCII` and standardize naming.
+    public use fun sub_string as String.substring;
 
     /// Returns a sub-string using the given byte indices, where `i` is the first
     /// byte position and `j` is the start of the first byte not included (or the

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// The `string` module defines the `String` type which represents UTF8 encoded strings.
+/// The `string` module defines the `String` type which represents UTF8 encoded
+/// strings.
 module std::string {
     use std::ascii;
 
@@ -11,12 +12,14 @@ module std::string {
     /// Index out of range.
     const EInvalidIndex: u64 = 2;
 
-    /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
+    /// A `String` holds a sequence of bytes which is guaranteed to be in utf8
+    /// format.
     public struct String has copy, drop, store {
         bytes: vector<u8>,
     }
 
-    /// Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
+    /// Creates a new string from a sequence of bytes. Aborts if the bytes do
+    /// not represent valid utf8.
     public fun utf8(bytes: vector<u8>): String {
         assert!(internal_check_utf8(&bytes), EInvalidUTF8);
         String { bytes }
@@ -24,14 +27,14 @@ module std::string {
 
     /// Convert an ASCII string to a UTF8 string
     public fun from_ascii(s: ascii::String): String {
-        String { bytes: ascii::into_bytes(s) }
+        String { bytes: s.into_bytes() }
     }
 
     /// Convert an UTF8 string to an ASCII string.
     /// Aborts if `s` is not valid ASCII
     public fun to_ascii(s: String): ascii::String {
         let String { bytes } = s;
-        ascii::string(bytes)
+        bytes.to_ascii_string()
     }
 
     /// Tries to create a new string from a sequence of bytes.
@@ -46,6 +49,12 @@ module std::string {
     /// Returns a reference to the underlying byte vector.
     public fun bytes(s: &String): &vector<u8> {
         &s.bytes
+    }
+
+    /// Unpack the `string` to get its underlying bytes.
+    public fun into_bytes(s: String): vector<u8> {
+        let String { bytes } = s;
+        bytes
     }
 
     /// Checks whether this string is empty.
@@ -68,11 +77,14 @@ module std::string {
         s.append(utf8(bytes))
     }
 
-    /// Insert the other string at the byte index in given string. The index must be at a valid utf8 char
-    /// boundary.
+    /// Insert the other string at the byte index in given string. The index
+    /// must be at a valid utf8 char boundary.
     public fun insert(s: &mut String, at: u64, o: String) {
         let bytes = &s.bytes;
-        assert!(at <= bytes.length() && internal_is_char_boundary(bytes, at), EInvalidIndex);
+        assert!(
+            at <= bytes.length() && internal_is_char_boundary(bytes, at),
+            EInvalidIndex
+        );
         let l = s.length();
         let mut front = s.sub_string(0, at);
         let end = s.sub_string(at, l);
@@ -81,20 +93,25 @@ module std::string {
         *s = front;
     }
 
-    /// Returns a sub-string using the given byte indices, where `i` is the first byte position and `j` is the start
-    /// of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+    /// Returns a sub-string using the given byte indices, where `i` is the first
+    /// byte position and `j` is the start of the first byte not included (or the
+    /// length of the string). The indices must be at valid utf8 char boundaries,
     /// guaranteeing that the result is valid utf8.
     public fun sub_string(s: &String, i: u64, j: u64): String {
         let bytes = &s.bytes;
         let l = bytes.length();
         assert!(
-            j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
+            j <= l &&
+            i <= j &&
+            internal_is_char_boundary(bytes, i) &&
+            internal_is_char_boundary(bytes, j),
             EInvalidIndex
         );
-        String{bytes: internal_sub_string(bytes, i, j)}
+        String { bytes: internal_sub_string(bytes, i, j) }
     }
 
-    /// Computes the index of the first occurrence of a string. Returns `length(s)` if no occurrence found.
+    /// Computes the index of the first occurrence of a string. Returns `s.length()`
+    /// if no occurrence found.
     public fun index_of(s: &String, r: &String): u64 {
         internal_index_of(&s.bytes, &r.bytes)
     }

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -84,17 +84,7 @@ module std::type_name {
 
         // Base16 (string) representation of an address has 2 symbols per byte.
         let len = address::length() * 2;
-        let str_bytes = self.name.as_bytes();
-        let mut addr_bytes = vector[];
-        let mut i = 0;
-
-        // Read `len` bytes from the type name and push them to addr_bytes.
-        while (i < len) {
-            addr_bytes.push_back(str_bytes[i]);
-            i = i + 1;
-        };
-
-        addr_bytes.to_ascii_string()
+        self.name.sub_string(0, len)
     }
 
     /// Get name of the module.

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -4,7 +4,7 @@
 #[allow(implicit_const_copy)]
 /// Functionality for converting Move types into values. Use with care!
 module std::type_name {
-    use std::ascii::{Self, String};
+    use std::ascii::String;
     use std::address;
 
     /// ASCII Character code for the `:` (colon) symbol.
@@ -94,7 +94,7 @@ module std::type_name {
             i = i + 1;
         };
 
-        ascii::string(addr_bytes)
+        addr_bytes.to_ascii_string()
     }
 
     /// Get name of the module.
@@ -117,7 +117,7 @@ module std::type_name {
             }
         };
 
-        ascii::string(module_name)
+        module_name.to_ascii_string()
     }
 
     /// Convert `self` into its inner String

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -84,7 +84,7 @@ module std::type_name {
 
         // Base16 (string) representation of an address has 2 symbols per byte.
         let len = address::length() * 2;
-        self.name.sub_string(0, len)
+        self.name.substring(0, len)
     }
 
     /// Get name of the module.

--- a/crates/sui-framework/packages/move-stdlib/sources/vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/vector.move
@@ -21,7 +21,7 @@ module std::vector {
     public use fun std::ascii::try_string as vector.try_to_ascii_string;
 
     /// The index into the vector is out of bounds
-    const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
+    const EIndexOutOfBounds: u64 = 0x20000;
 
     #[bytecode_instruction]
     /// Create an empty vector.
@@ -125,7 +125,7 @@ module std::vector {
     public fun remove<Element>(v: &mut vector<Element>, mut i: u64): Element {
         let mut len = v.length();
         // i out of bounds; abort
-        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+        if (i >= len) abort EIndexOutOfBounds;
 
         len = len - 1;
         while (i < len) v.swap(i, { i = i + 1; i });
@@ -140,7 +140,7 @@ module std::vector {
     public fun insert<Element>(v: &mut vector<Element>, e: Element, mut i: u64) {
         let len = v.length();
         // i too big abort
-        if (i > len) abort EINDEX_OUT_OF_BOUNDS;
+        if (i > len) abort EIndexOutOfBounds;
 
         v.push_back(e);
         while (i < len) {
@@ -153,7 +153,7 @@ module std::vector {
     /// This is O(1), but does not preserve ordering of elements in the vector.
     /// Aborts if `i` is out of bounds.
     public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
-        assert!(!v.is_empty(), EINDEX_OUT_OF_BOUNDS);
+        assert!(!v.is_empty(), EIndexOutOfBounds);
         let last_idx = v.length() - 1;
         v.swap(i, last_idx);
         v.pop_back()

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -120,4 +120,21 @@ module std::ascii_tests {
             i = i + 1;
         };
     }
+
+    #[test]
+    fun test_append() {
+        let mut str = b"hello".to_ascii_string();
+        str.append(b" world".to_ascii_string());
+
+        assert!(str == b"hello world".to_ascii_string(), 0);
+    }
+
+    #[test]
+    fun test_is_alphanumeric() {
+        assert!(b"ahelloz".to_ascii_string().is_alphanumeric(), 0);
+        assert!(b"AHELLOZ".to_ascii_string().is_alphanumeric(), 3);
+        assert!(b"0123".to_ascii_string().is_alphanumeric(), 4);
+        assert!(!b"!".to_ascii_string().is_alphanumeric(), 2);
+        assert!(!b" ".to_ascii_string().is_alphanumeric(), 1);
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -137,4 +137,42 @@ module std::ascii_tests {
         assert!(!b"!".to_ascii_string().is_alphanumeric(), 2);
         assert!(!b" ".to_ascii_string().is_alphanumeric(), 1);
     }
+
+    #[test]
+    fun test_sub_string() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.sub_string(0, 5) == b"hello".to_ascii_string(), 0);
+        assert!(str.sub_string(6, 11) == b"world".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_sub_string_len_one() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.sub_string(0, 1) == b"h".to_ascii_string(), 0);
+        assert!(str.sub_string(6, 7) == b"w".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_sub_string_len_zero() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.sub_string(0, 0).is_empty(), 0);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_sub_string_i_out_of_bounds_fail() {
+        let str = b"hello world".to_ascii_string();
+        str.sub_string(12, 13);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_sub_string_j_lt_i_fail() {
+        let str = b"hello world".to_ascii_string();
+        str.sub_string(9, 8);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_sub_string_j_out_of_bounds_fail() {
+        let str = b"hello world".to_ascii_string();
+        str.sub_string(9, 13);
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -130,50 +130,53 @@ module std::ascii_tests {
     }
 
     #[test]
-    fun test_is_alphanumeric() {
-        assert!(b"ahelloz".to_ascii_string().is_alphanumeric(), 0);
-        assert!(b"AHELLOZ".to_ascii_string().is_alphanumeric(), 3);
-        assert!(b"0123".to_ascii_string().is_alphanumeric(), 4);
-        assert!(!b"!".to_ascii_string().is_alphanumeric(), 2);
-        assert!(!b" ".to_ascii_string().is_alphanumeric(), 1);
+    fun test_to_uppercase() {
+        let str = b"hello_world_!".to_ascii_string();
+        assert!(str.to_uppercase() == b"HELLO_WORLD_!".to_ascii_string(), 0);
     }
 
     #[test]
-    fun test_sub_string() {
-        let str = b"hello world".to_ascii_string();
-        assert!(str.sub_string(0, 5) == b"hello".to_ascii_string(), 0);
-        assert!(str.sub_string(6, 11) == b"world".to_ascii_string(), 1);
+    fun test_to_lowercase() {
+        let str = b"HELLO_WORLD_!".to_ascii_string();
+        assert!(str.to_lowercase() == b"hello_world_!".to_ascii_string(), 0);
     }
 
     #[test]
-    fun test_sub_string_len_one() {
+    fun test_substring() {
         let str = b"hello world".to_ascii_string();
-        assert!(str.sub_string(0, 1) == b"h".to_ascii_string(), 0);
-        assert!(str.sub_string(6, 7) == b"w".to_ascii_string(), 1);
+        assert!(str.substring(0, 5) == b"hello".to_ascii_string(), 0);
+        assert!(str.substring(6, 11) == b"world".to_ascii_string(), 1);
     }
 
     #[test]
-    fun test_sub_string_len_zero() {
+    fun test_substring_len_one() {
         let str = b"hello world".to_ascii_string();
-        assert!(str.sub_string(0, 0).is_empty(), 0);
+        assert!(str.substring(0, 1) == b"h".to_ascii_string(), 0);
+        assert!(str.substring(6, 7) == b"w".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_substring_len_zero() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.substring(0, 0).is_empty(), 0);
     }
 
     #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
-    fun test_sub_string_i_out_of_bounds_fail() {
+    fun test_substring_i_out_of_bounds_fail() {
         let str = b"hello world".to_ascii_string();
-        str.sub_string(12, 13);
+        str.substring(12, 13);
     }
 
     #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
-    fun test_sub_string_j_lt_i_fail() {
+    fun test_substring_j_lt_i_fail() {
         let str = b"hello world".to_ascii_string();
-        str.sub_string(9, 8);
+        str.substring(9, 8);
     }
 
     #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
-    fun test_sub_string_j_out_of_bounds_fail() {
+    fun test_substring_j_out_of_bounds_fail() {
         let str = b"hello world".to_ascii_string();
-        str.sub_string(9, 13);
+        str.substring(9, 13);
     }
 
     #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -131,14 +131,14 @@ module std::ascii_tests {
 
     #[test]
     fun test_to_uppercase() {
-        let str = b"hello_world_!".to_ascii_string();
-        assert!(str.to_uppercase() == b"HELLO_WORLD_!".to_ascii_string(), 0);
+        let str = b"azhello_world_!".to_ascii_string();
+        assert!(str.to_uppercase() == b"AZHELLO_WORLD_!".to_ascii_string(), 0);
     }
 
     #[test]
     fun test_to_lowercase() {
-        let str = b"HELLO_WORLD_!".to_ascii_string();
-        assert!(str.to_lowercase() == b"hello_world_!".to_ascii_string(), 0);
+        let str = b"AZHELLO_WORLD_!".to_ascii_string();
+        assert!(str.to_lowercase() == b"azhello_world_!".to_ascii_string(), 0);
     }
 
     #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -161,6 +161,17 @@ module std::ascii_tests {
         assert!(str.substring(0, 0).is_empty(), 0);
     }
 
+    #[test]
+    fun test_index_of() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.index_of(&b"hello".to_ascii_string()) == 0, 0);
+        assert!(str.index_of(&b"world".to_ascii_string()) == 6, 1);
+        assert!(str.index_of(&b"o".to_ascii_string()) == 4, 2);
+        assert!(str.index_of(&b"z".to_ascii_string()) == str.length(), 3);
+        assert!(str.index_of(&b"o ".to_ascii_string()) == 4, 4);
+        assert!(str.index_of(&b"or".to_ascii_string()) == 7, 4);
+    }
+
     #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
     fun test_substring_i_out_of_bounds_fail() {
         let str = b"hello world".to_ascii_string();

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -175,4 +175,27 @@ module std::ascii_tests {
         let str = b"hello world".to_ascii_string();
         str.sub_string(9, 13);
     }
+
+    #[test]
+    fun test_insert() {
+        let mut str = b"hello".to_ascii_string();
+        str.insert(5, b" world".to_ascii_string());
+        assert!(str == b"hello world".to_ascii_string(), 0);
+
+        str.insert(5, b" cruel".to_ascii_string());
+        assert!(str == b"hello cruel world".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_insert_empty() {
+        let mut str = b"hello".to_ascii_string();
+        str.insert(5, b"".to_ascii_string());
+        assert!(str == b"hello".to_ascii_string(), 0);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_insert_out_of_bounds_fail() {
+        let mut str = b"hello".to_ascii_string();
+        str.insert(6, b" world".to_ascii_string());
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -163,13 +163,21 @@ module std::ascii_tests {
 
     #[test]
     fun test_index_of() {
-        let str = b"hello world".to_ascii_string();
+        let str = b"hello world orwell".to_ascii_string();
         assert!(str.index_of(&b"hello".to_ascii_string()) == 0, 0);
         assert!(str.index_of(&b"world".to_ascii_string()) == 6, 1);
         assert!(str.index_of(&b"o".to_ascii_string()) == 4, 2);
         assert!(str.index_of(&b"z".to_ascii_string()) == str.length(), 3);
         assert!(str.index_of(&b"o ".to_ascii_string()) == 4, 4);
         assert!(str.index_of(&b"or".to_ascii_string()) == 7, 4);
+        assert!(str.index_of(&b"".to_ascii_string()) == 0, 4);
+        assert!(str.index_of(&b"orwell".to_ascii_string()) == 12, 4);
+        assert!(
+            b"ororwell"
+                .to_ascii_string()
+                .index_of(&b"orwell".to_ascii_string()) == 2,
+            0
+        );
     }
 
     #[test, expected_failure(abort_code = ascii::EInvalidIndex)]

--- a/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
@@ -37,21 +37,21 @@ module std::bit_vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    #[expected_failure(abort_code = bit_vector::EIndexOutOfBounds)]
     fun set_bit_out_of_bounds() {
         let mut bitvector = bit_vector::new(bit_vector::word_size());
         bitvector.set(bit_vector::word_size());
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    #[expected_failure(abort_code = bit_vector::EIndexOutOfBounds)]
     fun unset_bit_out_of_bounds() {
         let mut bitvector = bit_vector::new(bit_vector::word_size());
         bitvector.unset(bit_vector::word_size());
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    #[expected_failure(abort_code = bit_vector::EIndexOutOfBounds)]
     fun index_bit_out_of_bounds() {
         let bitvector = bit_vector::new(bit_vector::word_size());
         bitvector.is_index_set(bit_vector::word_size());
@@ -215,7 +215,7 @@ module std::bit_vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::ELENGTH)]
+    #[expected_failure(abort_code = bit_vector::EInvalidLength)]
     fun empty_bitvector() {
         bit_vector::new(0);
     }

--- a/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
@@ -8,14 +8,14 @@ module std::fixed_point32_tests {
     use std::fixed_point32;
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDENOMINATOR)]
+    #[expected_failure(abort_code = fixed_point32::EDenominatorIsZero)]
     fun create_div_zero() {
         // A denominator of zero should cause an arithmetic error.
         fixed_point32::create_from_rational(2, 0);
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::ERATIO_OUT_OF_RANGE)]
+    #[expected_failure(abort_code = fixed_point32::ERatioOutOfRange)]
     fun create_overflow() {
         // The maximum value is 2^32 - 1. Check that anything larger aborts
         // with an overflow.
@@ -23,7 +23,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::ERATIO_OUT_OF_RANGE)]
+    #[expected_failure(abort_code = fixed_point32::ERatioOutOfRange)]
     fun create_underflow() {
         // The minimum non-zero value is 2^-32. Check that anything smaller
         // aborts.
@@ -37,7 +37,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDIVISION_BY_ZERO)]
+    #[expected_failure(abort_code = fixed_point32::EDivisionByZero)]
     fun divide_by_zero() {
         // Dividing by zero should cause an arithmetic error.
         let f = fixed_point32::create_from_raw_value(0);
@@ -45,7 +45,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDIVISION)]
+    #[expected_failure(abort_code = fixed_point32::EDivValueTooLarge)]
     fun divide_overflow_small_divisore() {
         let f = fixed_point32::create_from_raw_value(1); // 0x0.00000001
         // Divide 2^32 by the minimum fractional value. This should overflow.
@@ -53,7 +53,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDIVISION)]
+    #[expected_failure(abort_code = fixed_point32::EDivValueTooLarge)]
     fun divide_overflow_large_numerator() {
         let f = fixed_point32::create_from_rational(1, 2); // 0.5
         // Divide the maximum u64 value by 0.5. This should overflow.
@@ -61,7 +61,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EMULTIPLICATION)]
+    #[expected_failure(abort_code = fixed_point32::EMulValueTooLarge)]
     fun multiply_overflow_small_multiplier() {
         let f = fixed_point32::create_from_rational(3, 2); // 1.5
         // Multiply the maximum u64 value by 1.5. This should overflow.
@@ -69,7 +69,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EMULTIPLICATION)]
+    #[expected_failure(abort_code = fixed_point32::EMulValueTooLarge)]
     fun multiply_overflow_large_multiplier() {
         let f = fixed_point32::create_from_raw_value(18446744073709551615);
         // Multiply 2^33 by the maximum fixed-point value. This should overflow.

--- a/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
@@ -5,8 +5,6 @@
 
 #[test_only]
 module std::option_tests {
-    use std::option;
-
     #[test]
     fun option_none_is_none() {
         let none = option::none<u64>();
@@ -41,7 +39,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun option_borrow_none() {
         option::none<u64>().borrow();
     }
@@ -55,7 +53,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun borrow_mut_none() {
         option::none<u64>().borrow_mut();
     }
@@ -84,7 +82,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun extract_none() {
         option::none<u64>().extract();
     }
@@ -111,7 +109,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun swap_none() {
         option::none<u64>().swap(1);
     }
@@ -125,7 +123,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_IS_SET)]
+    #[expected_failure(abort_code = option::EOptionIsSet)]
     fun fill_some() {
         option::some(3).fill(0);
     }
@@ -142,7 +140,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun destroy_some_none() {
         option::none<u64>().destroy_some();
     }
@@ -153,7 +151,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_IS_SET)]
+    #[expected_failure(abort_code = option::EOptionIsSet)]
     fun destroy_none_some() {
         option::some<u64>(0).destroy_none();
     }

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -15,7 +15,7 @@ module std::string_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = string::EINVALID_UTF8)]
+    #[expected_failure(abort_code = string::EInvalidUTF8)]
     fun test_invalid_utf8() {
         let no_sparkle_heart = vector[0, 159, 146, 150];
         let s = no_sparkle_heart.to_string();
@@ -30,7 +30,7 @@ module std::string_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = string::EINVALID_INDEX)]
+    #[expected_failure(abort_code = string::EInvalidIndex)]
     fun test_sub_string_invalid_boundary() {
         let sparkle_heart = vector[240, 159, 146, 150];
         let s = sparkle_heart.to_string();
@@ -38,7 +38,7 @@ module std::string_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = string::EINVALID_INDEX)]
+    #[expected_failure(abort_code = string::EInvalidIndex)]
     fun test_sub_string_invalid_index() {
         let s = b"abcd".to_string();
         let _sub = s.sub_string(4, 5);

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -23,31 +23,31 @@ module std::string_tests {
     }
 
     #[test]
-    fun test_sub_string() {
+    fun test_substring() {
         let s = b"abcd".to_string();
-        let sub = s.sub_string(2, 4);
+        let sub = s.substring(2, 4);
         assert!(sub == b"cd".to_string(), 22)
     }
 
     #[test]
     #[expected_failure(abort_code = string::EInvalidIndex)]
-    fun test_sub_string_invalid_boundary() {
+    fun test_substring_invalid_boundary() {
         let sparkle_heart = vector[240, 159, 146, 150];
         let s = sparkle_heart.to_string();
-        let _sub = s.sub_string(1, 4);
+        let _sub = s.substring(1, 4);
     }
 
     #[test]
     #[expected_failure(abort_code = string::EInvalidIndex)]
-    fun test_sub_string_invalid_index() {
+    fun test_substring_invalid_index() {
         let s = b"abcd".to_string();
-        let _sub = s.sub_string(4, 5);
+        let _sub = s.substring(4, 5);
     }
 
     #[test]
-    fun test_sub_string_empty() {
+    fun test_substring_empty() {
         let s = b"abcd".to_string();
-        let sub = s.sub_string(4, 4);
+        let sub = s.substring(4, 4);
         assert!(sub.is_empty(), 22)
     }
 

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -80,4 +80,9 @@ module std::string_tests {
         s.insert(1, b"xy".to_string());
         assert!(s == b"axybcd".to_string(), 22)
     }
+
+    #[test]
+    fun test_into_bytes() {
+        assert!(b"abcd" == b"abcd".to_string().into_bytes(), 0)
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
@@ -5,8 +5,6 @@
 
 #[test_only]
 module std::vector_tests {
-    use std::vector;
-
     public struct R has store { }
     public struct Droppable has drop {}
     public struct NotDroppable {}
@@ -235,14 +233,14 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = vector::EIndexOutOfBounds)]
     fun remove_empty_vector() {
         let mut v = vector<u64>[];
         v.remove(0);
     }
 
     #[test]
-    #[expected_failure(abort_code = vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = vector::EIndexOutOfBounds)]
     fun remove_out_of_bound_index() {
         let mut v = vector<u64>[];
         v.push_back(0);
@@ -326,7 +324,7 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = std::vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = std::vector::EIndexOutOfBounds)]
     fun swap_remove_empty() {
         let mut v = vector<u64>[];
         v.swap_remove(0);
@@ -541,7 +539,7 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = std::vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = std::vector::EIndexOutOfBounds)]
     fun insert_out_of_range() {
         let mut v = vector[7];
         v.insert(6, 2);

--- a/crates/sui-framework/published_api.txt
+++ b/crates/sui-framework/published_api.txt
@@ -3718,6 +3718,9 @@ pop_char
 length
 	public fun
 	0x1::ascii
+append
+	public fun
+	0x1::ascii
 as_bytes
 	public fun
 	0x1::ascii
@@ -3731,6 +3734,9 @@ is_valid_char
 	public fun
 	0x1::ascii
 is_printable_char
+	public fun
+	0x1::ascii
+is_alphanumeric
 	public fun
 	0x1::ascii
 BitVector

--- a/crates/sui-framework/published_api.txt
+++ b/crates/sui-framework/published_api.txt
@@ -3799,7 +3799,7 @@ to_ascii
 try_utf8
 	public fun
 	0x1::string
-bytes
+as_bytes
 	public fun
 	0x1::string
 into_bytes
@@ -3820,7 +3820,7 @@ append_utf8
 insert
 	public fun
 	0x1::string
-sub_string
+substring
 	public fun
 	0x1::string
 index_of
@@ -3837,6 +3837,12 @@ internal_sub_string
 	0x1::string
 internal_index_of
 	fun
+	0x1::string
+bytes
+	public fun
+	0x1::string
+sub_string
+	public fun
 	0x1::string
 length
 	public fun

--- a/crates/sui-framework/published_api.txt
+++ b/crates/sui-framework/published_api.txt
@@ -3724,7 +3724,7 @@ append
 insert
 	public fun
 	0x1::ascii
-sub_string
+substring
 	public fun
 	0x1::ascii
 as_bytes
@@ -3745,8 +3745,20 @@ is_printable_char
 is_empty
 	public fun
 	0x1::ascii
-is_alphanumeric
+to_uppercase
 	public fun
+	0x1::ascii
+to_lowercase
+	public fun
+	0x1::ascii
+index_of
+	public fun
+	0x1::ascii
+char_to_uppercase
+	fun
+	0x1::ascii
+char_to_lowercase
+	fun
 	0x1::ascii
 BitVector
 	public struct

--- a/crates/sui-framework/published_api.txt
+++ b/crates/sui-framework/published_api.txt
@@ -3721,6 +3721,12 @@ length
 append
 	public fun
 	0x1::ascii
+insert
+	public fun
+	0x1::ascii
+sub_string
+	public fun
+	0x1::ascii
 as_bytes
 	public fun
 	0x1::ascii
@@ -3734,6 +3740,9 @@ is_valid_char
 	public fun
 	0x1::ascii
 is_printable_char
+	public fun
+	0x1::ascii
+is_empty
 	public fun
 	0x1::ascii
 is_alphanumeric
@@ -3779,6 +3788,9 @@ try_utf8
 	public fun
 	0x1::string
 bytes
+	public fun
+	0x1::string
+into_bytes
 	public fun
 	0x1::string
 is_empty

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x93d24898fb529aef7433a35b7a4de05036b087aac96f33aa6ebea11bca918873"
+            id: "0xbd5b05eb8754c5dd24b4bdf6007361b3cb01058a764f22ec1b29b45e14d22bfd"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xad75a4f0dafa36f6c37a08501501279213d930189bdbdedf0f9c98ff5f718322"
+      operation_cap_id: "0xf2619e387eb3428cce5b2f5901f75fdaa22694a10d86943d792b129c02cb5800"
       gas_price: 1000
       staking_pool:
-        id: "0xb580917d26a325db5527c08cab34dbdb767e56b5840e2e4fa599222f86977d2b"
+        id: "0x3c0f6a5096408b117b362f341db333e84762c3037babbaafd7305c60c1989d90"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xee81da2200b48ee373e8d9d14340461459c713aaf7c4eae88f916420ceeb1236"
+          id: "0xe303ce7ed59c01afa364ac5c0ee49f887ba41c9d88a0b93de3a4233ea7fb5c5e"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x5b3cbb226c5ab748b3e62cec6b7446f85768214806256c5eb605bddd2287a374"
+            id: "0xb4f540d07358463dfa4769ec05754259db8ddb94daf2020ecd3a1cc4fef19706"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x74ae2314dbd1cd1ddc0497d9616b58d117253754175fb99136b4d7c70a1e17b1"
+          id: "0x4eba34dd982187ff77cbb4876c65d82b82c27e92fa3d0ed3993f1885dfad3355"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xbdacc1af1f90dc7c36e5c5ec67a115caf5f366761279fd4647ff6417c7efb791"
+      id: "0x55080c7fdc763f8814fb080c38303e52cf00fcbc150965961b21b884b4236d2e"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x47040d1659ed168e3ead94614b16680604d7983d17b25ab1351de356a30c7488"
+    id: "0x18f7dea48a0ca773fb2692ae6c78c09ca2562d23c315add943d1720cc09ede70"
     size: 1
   inactive_validators:
-    id: "0x3f371596e9faed0adfa565d83749e12dbd3d6bb97f97e3863dd2dfdb24ee7cf3"
+    id: "0x9bb4862109e76415e6b8c70a4282e3e3ec631bf04c790b739d19b6708d2719a6"
     size: 0
   validator_candidates:
-    id: "0xf07d7fd23b6ab04c1634b2bfc89cd15f11771e7bfc4675a0cee9f5cd1f36fd04"
+    id: "0x889234221a8d84cf22dd47ebe9cdfaf366bfea746ce47e5bed941d7aaa575c5f"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x9788679b8a4eb68ebe565041337b029d1192b2ae3883c531b665dd53b54dedcf"
+      id: "0xeccfc0df9ed9ee6f34bd38e8c66ff507045dd93411c469a8398e5283b284e426"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x0e39e3baeb1a652db096a6510bcd8b3eeac0ea729729251692c1d545d158443e"
+      id: "0xa2071291cabfe7849c4f55a0da0b50998c0625a680af15f6448b40d575c12476"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x1a73c2836d39587c63685aeac9dd86e618bd4651055c17a03f986020110df0d9"
+      id: "0xe5c08472edccfc45049b9806f4913a479a810c79387c495ee8863575a05276f4"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x589a4beca826b64ddfaaa96b69b0e0eb009259b31a825f4d2a9b47d57211a5f4"
+    id: "0x929a0d902ac014369cfd9509abfd93fb317c0f065860e6608bd106efe58f9271"
   size: 0
-

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xbd5b05eb8754c5dd24b4bdf6007361b3cb01058a764f22ec1b29b45e14d22bfd"
+            id: "0x4e29317b70d9929927e583268d4d743cda31569b7684378c0cf2aca86f5dc246"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xf2619e387eb3428cce5b2f5901f75fdaa22694a10d86943d792b129c02cb5800"
+      operation_cap_id: "0xcc09b4fbd2c34e1e6a960c1b9ba29039e8dc180a4861de617e0c04c16cf46b06"
       gas_price: 1000
       staking_pool:
-        id: "0x3c0f6a5096408b117b362f341db333e84762c3037babbaafd7305c60c1989d90"
+        id: "0x294884129352d4b422eea48d8c5157f6035fd4b2296bf17931b8c93d5fdee887"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xe303ce7ed59c01afa364ac5c0ee49f887ba41c9d88a0b93de3a4233ea7fb5c5e"
+          id: "0x7504d75fd84077c8ee2d9beffcdb05f23ef0326df0de10e1d3cf03f00ac535d6"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xb4f540d07358463dfa4769ec05754259db8ddb94daf2020ecd3a1cc4fef19706"
+            id: "0xa2f42a4b7f4a4154cf5ee201d9a9794b1131670ccfd1f9e77874c01a95d5c24f"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x4eba34dd982187ff77cbb4876c65d82b82c27e92fa3d0ed3993f1885dfad3355"
+          id: "0xc93803db63c8d1e370250f4de7bab8f96c50f15972e9fc6e44c0400bbbc569e6"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x55080c7fdc763f8814fb080c38303e52cf00fcbc150965961b21b884b4236d2e"
+      id: "0x7fc831301a2446c9d5558c50be38bbec738f36601e961d2b8f5d85c6d1bd56cb"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x18f7dea48a0ca773fb2692ae6c78c09ca2562d23c315add943d1720cc09ede70"
+    id: "0x4a51b4e7708c6058eaf1053322d2dca2cb09c75bd050f053017fd238306b0595"
     size: 1
   inactive_validators:
-    id: "0x9bb4862109e76415e6b8c70a4282e3e3ec631bf04c790b739d19b6708d2719a6"
+    id: "0x4cfc8b7edbfd2b5a5324f66f4f92da79990ca51825d37d99d1baa04c9640e87a"
     size: 0
   validator_candidates:
-    id: "0x889234221a8d84cf22dd47ebe9cdfaf366bfea746ce47e5bed941d7aaa575c5f"
+    id: "0xc6f4489f0dde444d4de88ef7dba37ff313cb06b882533ee1c1a3d6778339f6e8"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xeccfc0df9ed9ee6f34bd38e8c66ff507045dd93411c469a8398e5283b284e426"
+      id: "0x7df36a659fc160ae9d8cae8e1c9b3ce3a374cc02faf12f66bdb16e7a5e62cd1d"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xa2071291cabfe7849c4f55a0da0b50998c0625a680af15f6448b40d575c12476"
+      id: "0x2aa64e60c40bd842649f0927386d243b1a53a6f8da48ae6edc01fd25482301b2"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xe5c08472edccfc45049b9806f4913a479a810c79387c495ee8863575a05276f4"
+      id: "0x196ccbcc92f154c22d5636ccd98ef9e9d5e215ab9f805afe65d780aa575741fd"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x929a0d902ac014369cfd9509abfd93fb317c0f065860e6608bd106efe58f9271"
+    id: "0x15bfe4fc8d542d9dfe2b575ce103eab3b0f1306630eb18b52c00c7807db2e90d"
   size: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x4e29317b70d9929927e583268d4d743cda31569b7684378c0cf2aca86f5dc246"
+            id: "0xb01eb86a5cac210f74a4a55f5f042cdfe3f9b59b9c01bc79cc72eab6698f448f"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xcc09b4fbd2c34e1e6a960c1b9ba29039e8dc180a4861de617e0c04c16cf46b06"
+      operation_cap_id: "0x923b26f1675d60056241a1e3af770681de848910341c784aa75f6705cec3d98c"
       gas_price: 1000
       staking_pool:
-        id: "0x294884129352d4b422eea48d8c5157f6035fd4b2296bf17931b8c93d5fdee887"
+        id: "0x09d6c710d23417838177d46a30d80da66644196d019c18d5c29b0c07582ce3db"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x7504d75fd84077c8ee2d9beffcdb05f23ef0326df0de10e1d3cf03f00ac535d6"
+          id: "0xeab71d30266ef947577cb9aafbc4266ca7e1a221cc56d25c9ded01f6deebd045"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xa2f42a4b7f4a4154cf5ee201d9a9794b1131670ccfd1f9e77874c01a95d5c24f"
+            id: "0x7891aa028ed646e0d6dfcbff4fdd2f138b903bf22f6ab022c58c82d176507cb0"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xc93803db63c8d1e370250f4de7bab8f96c50f15972e9fc6e44c0400bbbc569e6"
+          id: "0x333f63faa5c0d640ea8206cb99cc834fad35c7932cb2afaf54ed9af0c2ed1d98"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x7fc831301a2446c9d5558c50be38bbec738f36601e961d2b8f5d85c6d1bd56cb"
+      id: "0xe1cdd4410b9f6e02e265ab4e1408c0b3a80216a2c009608b5e5e4adcfdd161ed"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x4a51b4e7708c6058eaf1053322d2dca2cb09c75bd050f053017fd238306b0595"
+    id: "0xc3a9f606ca519330d1ada296f1340762ca72042aa4bb004479bcf21eda663921"
     size: 1
   inactive_validators:
-    id: "0x4cfc8b7edbfd2b5a5324f66f4f92da79990ca51825d37d99d1baa04c9640e87a"
+    id: "0x90bdf399fd0cf9b66001bb3d084018ef42030aaf768eeb161109da6d73ce5b5a"
     size: 0
   validator_candidates:
-    id: "0xc6f4489f0dde444d4de88ef7dba37ff313cb06b882533ee1c1a3d6778339f6e8"
+    id: "0x18777943bfeaa3489d9a68a915bbbdd7e3a4b69b35ad676453911f945eef93c5"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x7df36a659fc160ae9d8cae8e1c9b3ce3a374cc02faf12f66bdb16e7a5e62cd1d"
+      id: "0x2eae42de81d504c2cbfcb6721e42a804cf79606d26d6ed12641d0cc8ec0bd0e6"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x2aa64e60c40bd842649f0927386d243b1a53a6f8da48ae6edc01fd25482301b2"
+      id: "0xa8c62ae5ac279a5f539394b03d87108b0435a73c3f98b757aaeb08535b67fc4d"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x196ccbcc92f154c22d5636ccd98ef9e9d5e215ab9f805afe65d780aa575741fd"
+      id: "0xea547508f5931302b52543e7432867e09be225197c8aa41ff1a26835ce3f7597"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x15bfe4fc8d542d9dfe2b575ce103eab3b0f1306630eb18b52c00c7807db2e90d"
+    id: "0x0f660aaad3b4b781f6ca9bbfaf428fdaa92a8973a8706f692aa3747ee7372918"
   size: 0

--- a/crates/sui/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/sui/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -3,10 +3,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use sui::coin::{Self, TreasuryCap};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}


### PR DESCRIPTION
## Description 

Adds new methods to `std::ascii`:
- `ascii::append(&mut String, String)`
- `ascii::is_empty(): bool`
- `ascii::substring(&String, i, j): String`
- `ascii::index_of(&String, &String): u64`
- `ascii::to_uppercase(&String): String`
- `ascii::to_lowercase(&String): String`

_So ASCII interface is similar to the one in UTF8_

Renames:
- `string::bytes() -> string::as_bytes()`
- `string::sub_string() -> string::substring()`

Additionally:
- updates `std::type_name` to use `std::substring`
- removes use statements for implicit imports
- renames constants from `E_INDEX` to conventional `EIndexOutOfBounds`

## Test plan 

Features tests

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
