### PR TITLE
[Docs] Update Clock docs to use Move 2024 syntax

### DIFF
--- a/docs/content/guides/developer/sui-101/access-time.mdx
+++ b/docs/content/guides/developer/sui-101/access-time.mdx
@@ -20,18 +20,15 @@ module sui::clock {
 The example below demonstrates an entry function that emits an event containing a timestamp from the `Clock`:
 
 ```move
-module example::clock {
-    use sui::clock::{Self, Clock};
-    use sui::event;
+module basics::clock {
+    use sui::{clock::Clock, event};
 
-    struct TimeEvent has copy, drop, store {
-        timestamp_ms: u64
+    public struct TimeEvent has copy, drop, store {
+        timestamp_ms: u64,
     }
 
     entry fun access(clock: &Clock) {
-        event::emit(TimeEvent {
-            timestamp_ms: clock::timestamp_ms(clock),
-        });
+        event::emit(TimeEvent { timestamp_ms: clock.timestamp_ms() });
     }
 }
 ```
@@ -83,13 +80,13 @@ module example::clock_tests {
         let ctx = tx_context::dummy();
         let clock = clock::create_for_testing(&mut ctx);
 
-        clock::increment_for_testing(&mut clock, 42);
-        assert!(clock::timestamp_ms(&clock) == 42, 1);
+        clock.increment_for_testing(42);
+        assert!(clock.timestamp_ms() == 42, 1);
 
-        clock::set_for_testing(&mut clock, 50);
-        assert!(clock::timestamp_ms(&clock) == 50, 1);
+        clock.set_for_testing(50);
+        assert!(clock.timestamp_ms() == 50, 1);
 
-        clock::destroy_for_testing(clock);
+        clock.destroy_for_testing();
     }
 }
 ```

--- a/sui_programmability/examples/basics/sources/clock.move
+++ b/sui_programmability/examples/basics/sources/clock.move
@@ -4,15 +4,14 @@
 /// This example demonstrates reading a clock object.
 /// Current time is emitted as an event in the get_time transaction
 module basics::clock {
-    use sui::clock::{Self, Clock};
-    use sui::event;
+    use sui::{clock::Clock, event};
 
     public struct TimeEvent has copy, drop {
         timestamp_ms: u64,
     }
 
     /// Emit event with current time.
-    public entry fun get_time(clock: &Clock, _ctx: &mut TxContext) {
-        event::emit(TimeEvent { timestamp_ms: clock::timestamp_ms(clock) });
+    entry fun access(clock: &Clock) {
+        event::emit(TimeEvent { timestamp_ms: clock.timestamp_ms() });
     }
 }


### PR DESCRIPTION
## Description

...and make its corresponding module in `sui_programmability/examples/basics` line up.

## Test plan

```
sui$ cargo nextest run -p sui-framework-tests
```

+ :eyes: for docs