### PR TITLE
Update the usage of update_index_and_hash

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -960,6 +960,31 @@ mod tests {
     }
 
     #[test]
+    pub fn test_update_index_and_hash() {
+        let index0 = ExecutionIndices {
+            sub_dag_index: 0,
+            transaction_index: 5,
+            last_committed_round: 0,
+        };
+        let index1 = ExecutionIndices {
+            sub_dag_index: 1,
+            transaction_index: 2,
+            last_committed_round: 3,
+        };
+
+        let mut last_seen = ExecutionIndicesWithStats {
+            index: index0,
+            hash: 1000,
+            stats: ConsensusStats::default(),
+        };
+
+        let tx = &[0];
+        update_index_and_hash(&mut last_seen, index1, tx);
+        assert_eq!(last_seen.index, index1);
+        assert_ne!(last_seen.hash, 1000);
+    }
+
+    #[test]
     fn test_order_by_gas_price() {
         let mut v = vec![cap_txn(10), user_txn(42), user_txn(100), cap_txn(1)];
         PostConsensusTxReorder::reorder(&mut v, ConsensusTransactionOrdering::ByGasPrice);

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -179,6 +179,7 @@ fn update_index_and_hash(
     v: &[u8],
 ) -> bool {
     if last_consensus_stats.index >= index {
+        panic!("Consensus handler update index and hash returned false, which is unexpected");
         return false;
     }
 
@@ -408,7 +409,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 let index_with_stats = if self.update_index_and_hash(index, serialized) {
                     self.last_consensus_stats.clone()
                 } else {
-                    debug!(
+                    panic!(
                         "Ignore consensus transaction at index {:?} as it appear to be already processed",
                         index
                     );
@@ -970,6 +971,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[test]
     pub fn test_update_index_and_hash() {
         let index0 = ExecutionIndices {


### PR DESCRIPTION
## Description 

`update_index_and_hash` was originally created to both checking whether a transaction is processed and updating consensus handler's `last_consensus_stats`. Overtime, consensus handler semantic has changed and the call site of update_index_and_hash is no longer able to receive already processed transactions (see checks [here](https://github.com/MystenLabs/sui/blob/bcbd84900e0da8aae9c41bf326def383ad9102ec/crates/sui-core/src/consensus_handler.rs#L239)). This PR clean up the usage of update_index_and_hash to only update the index and hash.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
