### PR TITLE
[fix] make wait_interval_when_no_peer_to_sync_content configurable for simtests

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -107,7 +107,7 @@ mod test {
             .with_kill_interval_secs(5, 15)
             .with_restart_delay_secs(1, 10);
         node_restarter.run();
-        test_simulated_load(TestInitData::new(&test_cluster).await, 140).await;
+        test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }
 
     #[ignore("Disabled due to flakiness - re-enable when failure is fixed")]
@@ -348,7 +348,7 @@ mod test {
 
         register_fail_point_async("writeback-cache-commit", || delay_failpoint(10..20, 0.001));
 
-        test_simulated_load(TestInitData::new(&test_cluster).await, 140).await;
+        test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }
 
     #[sim_test(config = "test_config()")]
@@ -367,7 +367,7 @@ mod test {
                 1.0,
             );
         });
-        test_simulated_load(TestInitData::new(&test_cluster).await, 140).await;
+        test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }
 
     #[sim_test(config = "test_config()")]

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -107,7 +107,7 @@ mod test {
             .with_kill_interval_secs(5, 15)
             .with_restart_delay_secs(1, 10);
         node_restarter.run();
-        test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
+        test_simulated_load(TestInitData::new(&test_cluster).await, 140).await;
     }
 
     #[ignore("Disabled due to flakiness - re-enable when failure is fixed")]
@@ -348,7 +348,7 @@ mod test {
 
         register_fail_point_async("writeback-cache-commit", || delay_failpoint(10..20, 0.001));
 
-        test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
+        test_simulated_load(TestInitData::new(&test_cluster).await, 140).await;
     }
 
     #[sim_test(config = "test_config()")]
@@ -367,7 +367,7 @@ mod test {
                 1.0,
             );
         });
-        test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
+        test_simulated_load(TestInitData::new(&test_cluster).await, 140).await;
     }
 
     #[sim_test(config = "test_config()")]

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -182,6 +182,11 @@ pub struct StateSyncConfig {
     /// If unspecified, this will default to no limit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub get_checkpoint_contents_per_checkpoint_limit: Option<usize>,
+
+    /// The amount of time to wait before retry if there are no peers to sync content from.
+    /// If unspecified, this will set to default value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wait_interval_when_no_peer_to_sync_content_ms: Option<u64>,
 }
 
 impl StateSyncConfig {
@@ -239,6 +244,20 @@ impl StateSyncConfig {
         self.checkpoint_content_timeout_ms
             .map(Duration::from_millis)
             .unwrap_or(DEFAULT_TIMEOUT)
+    }
+
+    pub fn wait_interval_when_no_peer_to_sync_content(&self) -> Duration {
+        self.wait_interval_when_no_peer_to_sync_content_ms
+            .map(Duration::from_millis)
+            .unwrap_or(self.default_wait_interval_when_no_peer_to_sync_content())
+    }
+
+    fn default_wait_interval_when_no_peer_to_sync_content(&self) -> Duration {
+        if cfg!(msim) {
+            Duration::from_secs(5)
+        } else {
+            Duration::from_secs(10)
+        }
     }
 }
 

--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -6,7 +6,6 @@ use anemo_tower::{inflight_limit, rate_limit};
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
-    time::Duration,
 };
 use sui_archival::reader::ArchiveReaderBalancer;
 use sui_config::p2p::StateSyncConfig;
@@ -145,7 +144,8 @@ where
             peers: HashMap::new(),
             unprocessed_checkpoints: HashMap::new(),
             sequence_number_to_digest: HashMap::new(),
-            wait_interval_when_no_peer_to_sync_content: Duration::from_secs(10),
+            wait_interval_when_no_peer_to_sync_content: config
+                .wait_interval_when_no_peer_to_sync_content(),
         }
         .pipe(RwLock::new)
         .pipe(Arc::new);


### PR DESCRIPTION
## Description 

Making the `wait_interval_when_no_peer_to_sync_content`  property configurable so we can run in simtests with lower wait as with the current setting `10s` some tests seem to fail due to early timeout without giving the opportunity to nodes to retry.

## Test plan 

CI/simtests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
