### PR TITLE
[replay] Skip persisting unsupported transactions

### DIFF
--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -132,8 +132,15 @@ pub enum ReplayEngineError {
         local: Box<SuiTransactionBlockEffects>,
     },
 
-    #[error("Genesis replay not supported digest {:#?}", digest)]
-    GenesisReplayNotSupported { digest: TransactionDigest },
+    #[error(
+        "Transaction {:#?} not supported by replay. Reason: {:?}",
+        digest,
+        reason
+    )]
+    TransactionNotSupported {
+        digest: TransactionDigest,
+        reason: String,
+    },
 
     #[error(
         "Fatal! No framework versions for protocol version {protocol_version}. Make sure version tables are populated"
@@ -169,9 +176,6 @@ pub enum ReplayEngineError {
 
     #[error("Error getting dynamic fields loaded objects: {}", rpc_err)]
     UnableToGetDynamicFieldLoadedObjects { rpc_err: String },
-
-    #[error("Unsupported epoch in replay engine: {epoch}")]
-    EpochNotSupported { epoch: u64 },
 
     #[error("Unable to open yaml cfg file at {}: {}", path, err)]
     UnableToOpenYamlFile { path: String, err: String },


### PR DESCRIPTION
## Description 

There are two types of transactions that are currently not supported today:
- System transactions (we should fix this)
- Transactions with protocol version < 16. This is due to the dependency to wrapped tombstones, which we have no way of fetching.
When we see unsupported transactions, we should return error instead of Ok. And in that case we skip persisting them.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
