### PR TITLE
Create consensus commit prologue transaction after finishing processing other transactions in a consensus commit batch

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2663,13 +2663,13 @@ impl AuthorityPerEpochStore {
                 roots.insert(processed_tx.key());
                 self.record_consensus_message_processed(
                     batch,
-                    SequencedConsensusTransactionKey::System(processed_tx.digest().clone()),
+                    SequencedConsensusTransactionKey::System(*processed_tx.digest()),
                 )?;
                 transactions.push_front(processed_tx);
                 Ok(())
             }
             ConsensusCertificateResult::IgnoredSystem => Ok(()),
-            _ => panic!(),
+            _ => unreachable!("process_consensus_system_transaction returned unexpected ConsensusCertificateResult."),
         }
     }
 
@@ -2738,13 +2738,18 @@ impl AuthorityPerEpochStore {
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ExecutionCacheRead,
         authority_metrics: &Arc<AuthorityMetrics>,
+        skip_consensus_commit_prologue_in_test: bool,
     ) -> SuiResult<Vec<VerifiedExecutableTransaction>> {
         self.process_consensus_transactions_and_commit_boundary(
             transactions,
             &ExecutionIndicesWithStats::default(),
             checkpoint_service,
             cache_reader,
-            &ConsensusCommitInfo::new_for_test(self.get_highest_pending_checkpoint_height() + 1, 0),
+            &ConsensusCommitInfo::new_for_test(
+                self.get_highest_pending_checkpoint_height() + 1,
+                0,
+                skip_consensus_commit_prologue_in_test,
+            ),
             authority_metrics,
         )
         .await

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2664,16 +2664,17 @@ impl AuthorityPerEpochStore {
         match self.process_consensus_system_transaction(&transaction) {
             ConsensusCertificateResult::SuiTransaction(processed_tx) => {
                 roots.insert(processed_tx.key());
-                self.record_consensus_message_processed(
-                    batch,
-                    SequencedConsensusTransactionKey::System(*processed_tx.digest()),
-                )?;
                 transactions.push_front(processed_tx);
-                Ok(())
             }
-            ConsensusCertificateResult::IgnoredSystem => Ok(()),
+            ConsensusCertificateResult::IgnoredSystem => (),
             _ => unreachable!("process_consensus_system_transaction returned unexpected ConsensusCertificateResult."),
-        }
+        };
+
+        self.record_consensus_message_processed(
+            batch,
+            SequencedConsensusTransactionKey::System(*transaction.digest()),
+        )?;
+        Ok(())
     }
 
     // Assigns shared object versions to transactions and updates the shared object version state.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -67,7 +67,7 @@ use crate::consensus_handler::{
     SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
 };
 use crate::epoch::epoch_metrics::EpochMetrics;
-use crate::epoch::randomness::{self, DkgStatus, RandomnessManager, RandomnessReporter};
+use crate::epoch::randomness::{DkgStatus, RandomnessManager, RandomnessReporter};
 use crate::epoch::reconfiguration::ReconfigState;
 use crate::execution_cache::{ExecutionCache, ExecutionCacheRead};
 use crate::module_cache_metrics::ResolverMetrics;
@@ -2649,6 +2649,13 @@ impl AuthorityPerEpochStore {
         consensus_commit_info: &ConsensusCommitInfo,
         roots: &mut BTreeSet<TransactionKey>,
     ) -> SuiResult {
+        #[cfg(any(test, feature = "test-utils"))]
+        {
+            if consensus_commit_info.skip_consensus_commit_prologue_in_test() {
+                return Ok(());
+            }
+        }
+
         let transaction = consensus_commit_info
             .create_consensus_commit_prologue_transaction(self.epoch(), self.protocol_config());
         match self.process_consensus_system_transaction(&transaction) {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2884,7 +2884,7 @@ impl AuthorityPerEpochStore {
                 ConsensusCertificateResult::Cancelled((cert, reason)) => {
                     notifications.push(key.clone());
                     assert!(cancelled_txns.insert(*cert.digest(), reason).is_none());
-                    verified_certificates.push(cert);
+                    verified_certificates.push_back(cert);
                 }
                 ConsensusCertificateResult::RandomnessConsensusMessage => {
                     randomness_state_updated = true;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -78,7 +78,7 @@ use move_bytecode_utils::module_cache::SyncModuleCache;
 use mysten_common::sync::notify_once::NotifyOnce;
 use mysten_common::sync::notify_read::NotifyRead;
 use mysten_metrics::monitored_scope;
-use narwhal_types::Round;
+use narwhal_types::{Round, TimestampMs};
 use prometheus::IntCounter;
 use std::str::FromStr;
 use sui_execution::{self, Executor};
@@ -2453,7 +2453,8 @@ impl AuthorityPerEpochStore {
                         .get_reconfig_state_read_lock_guard()
                         .should_accept_tx()
                     {
-                        randomness_manager.reserve_next_randomness(commit_timestamp, &mut batch)?
+                        randomness_manager
+                            .reserve_next_randomness(consensus_commit_info.timestamp, &mut batch)?
                     } else {
                         None
                     }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2642,6 +2642,8 @@ impl AuthorityPerEpochStore {
         Ok(transactions_to_schedule)
     }
 
+    // Adds the consensus commit prologue transaction to the beginning of input `transactions` to update
+    // the system clock used in all transactions in the current consensus commit.
     fn add_consensus_commit_prologue_transaction(
         &self,
         batch: &mut DBBatch,
@@ -2869,6 +2871,7 @@ impl AuthorityPerEpochStore {
                             .executable_transaction_digest()
                             .map(TransactionKey::Digest)
                     {
+                        // Filter out roots of any deferred tx.
                         roots.remove(&txn_key);
                         randomness_roots.remove(&txn_key);
 
@@ -2914,6 +2917,9 @@ impl AuthorityPerEpochStore {
             }
         }
 
+        // TODO: once transaction cancellation is implemented, we need to add cancelled transaction info to
+        //       the created consensus commit prologue transactions.
+        // Add the consensus commit prologue transaction to the beginning of `verified_certificates`.
         self.add_consensus_commit_prologue_transaction(
             batch,
             &mut verified_certificates,

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -375,6 +375,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_cache_reader().as_ref(),
             &authority.metrics,
+            true,
         )
         .await
         .unwrap();
@@ -398,6 +399,7 @@ pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &Veri
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_cache_reader().as_ref(),
             &authority.metrics,
+            true,
         )
         .await
         .unwrap();
@@ -406,6 +408,7 @@ pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &Veri
 pub async fn send_batch_consensus_no_execution(
     authority: &AuthorityState,
     certificates: &[VerifiedCertificate],
+    skip_consensus_commit_prologue_in_test: bool,
 ) -> Vec<VerifiedExecutableTransaction> {
     let transactions = certificates
         .iter()
@@ -426,6 +429,7 @@ pub async fn send_batch_consensus_no_execution(
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_cache_reader().as_ref(),
             &authority.metrics,
+            skip_consensus_commit_prologue_in_test,
         )
         .await
         .unwrap()

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -774,12 +774,16 @@ impl ConsensusCommitInfo {
         }
     }
 
-    pub fn new_for_test(commit_round: u64, commit_timestamp: u64) -> Self {
+    pub fn new_for_test(
+        commit_round: u64,
+        commit_timestamp: u64,
+        skip_consensus_commit_prologue_in_test: bool,
+    ) -> Self {
         Self {
             round: commit_round,
             timestamp: commit_timestamp,
             consensus_commit_digest: ConsensusCommitDigest::default(),
-            skip_consensus_commit_prologue_in_test: true,
+            skip_consensus_commit_prologue_in_test,
         }
     }
 
@@ -950,7 +954,7 @@ mod tests {
         let num_transactions = transactions.len();
         let last_consensus_stats_1 = consensus_handler.last_consensus_stats.clone();
         assert_eq!(
-            last_consensus_stats_1.index.transaction_index,
+            last_consensus_stats_1.index.transaction_index + 1,
             num_transactions as u64
         );
         assert_eq!(last_consensus_stats_1.index.sub_dag_index, 10_u64);

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -278,7 +278,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             ExecutionIndices {
                 last_committed_round: round,
                 sub_dag_index: commit_sub_dag_index,
-                transaction_index: 0 as u64,
+                transaction_index: 0_u64,
             },
             &empty_bytes,
         );
@@ -777,6 +777,7 @@ pub struct ConsensusCommitInfo {
     pub timestamp: u64,
     pub consensus_commit_digest: ConsensusCommitDigest,
 
+    #[cfg(any(test, feature = "test-utils"))]
     skip_consensus_commit_prologue_in_test: bool,
 }
 
@@ -786,10 +787,13 @@ impl ConsensusCommitInfo {
             round: consensus_output.leader_round(),
             timestamp: consensus_output.commit_timestamp_ms(),
             consensus_commit_digest: consensus_output.consensus_digest(),
+
+            #[cfg(any(test, feature = "test-utils"))]
             skip_consensus_commit_prologue_in_test: false,
         }
     }
 
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn new_for_test(
         commit_round: u64,
         commit_timestamp: u64,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4746,8 +4746,8 @@ async fn test_consensus_commit_prologue_generation() {
         make_test_transaction(
             &sender,
             &sender_key,
-            shared_object_id,
-            initial_shared_version,
+            &[],
+            &[(shared_object_id, initial_shared_version, true)],
             &gas_objects[1].compute_object_reference(),
             &[&authority_state],
             0,
@@ -6022,19 +6022,19 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     certificates.shuffle(&mut rand::thread_rng());
 
     // Sends all transactions to consensus. Expect first 2 rounds with 1 transaction per round going through.
-    let scheduled_txns = send_batch_consensus_no_execution(&authority, &certificates).await;
+    let scheduled_txns = send_batch_consensus_no_execution(&authority, &certificates, true).await;
     assert_eq!(scheduled_txns.len(), 1);
     for cert in scheduled_txns.iter() {
         assert!(cert.data().transaction_data().gas_price() == 2000);
     }
-    let scheduled_txns = send_batch_consensus_no_execution(&authority, &[]).await;
+    let scheduled_txns = send_batch_consensus_no_execution(&authority, &[], true).await;
     assert_eq!(scheduled_txns.len(), 1);
     for cert in scheduled_txns.iter() {
         assert!(cert.data().transaction_data().gas_price() == 2000);
     }
 
     // Run consensus round 3. 2 transactions will come out with 1 transaction being cancelled.
-    let scheduled_txns = send_batch_consensus_no_execution(&authority, &[]).await;
+    let scheduled_txns = send_batch_consensus_no_execution(&authority, &[], true).await;
     assert_eq!(scheduled_txns.len(), 2);
     assert!(authority
         .epoch_store_for_testing()

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -137,6 +137,7 @@ async fn submit_transaction_to_consensus_adapter() {
                     &Arc::new(CheckpointServiceNoop {}),
                     self.0.get_cache_reader().as_ref(),
                     &self.0.metrics,
+                    true,
                 )
                 .await?;
             Ok(())

--- a/crates/sui-single-node-benchmark/src/mock_consensus.rs
+++ b/crates/sui-single-node-benchmark/src/mock_consensus.rs
@@ -62,6 +62,7 @@ impl MockConsensusClient {
                             &checkpoint_service,
                             validator.get_cache_reader().as_ref(),
                             &authority_metrics,
+                            true,
                         )
                         .await
                         .unwrap();


### PR DESCRIPTION
## Description 

Move consensus commit prologue transaction creation after all the transitions in a consensus commit
is processed, and before shared object versions are assigned.

This is to prepare for adding cancelled transaction info into the consensus commit prologue message later.

## Test plan 

Unit test added.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
