### PR TITLE
[TrafficControl] Add sampling

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -696,7 +696,7 @@ impl ValidatorService {
             traffic_controller.tally(TrafficTally {
                 connection_ip: connection_ip.map(|ip| ip.ip()),
                 proxy_ip: proxy_ip.map(|ip| ip.ip()),
-                weight: error.map(normalize).unwrap_or(Weight::zero()),
+                error_weight: error.map(normalize).unwrap_or(Weight::zero()),
                 timestamp: SystemTime::now(),
             })
         }

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -269,7 +269,7 @@ async fn handle_error_tally(
     metrics: Arc<TrafficControllerMetrics>,
     mem_drainfile_present: bool,
 ) -> Result<(), reqwest::Error> {
-    if tally.weight == Weight::zero() {
+    if !tally.error_weight.is_sampled().await {
         return Ok(());
     }
     let resp = policy.handle_tally(tally.clone());
@@ -302,6 +302,9 @@ async fn handle_spam_tally(
     metrics: Arc<TrafficControllerMetrics>,
     mem_drainfile_present: bool,
 ) -> Result<(), reqwest::Error> {
+    if !policy_config.spam_sample_rate.is_sampled().await {
+        return Ok(());
+    }
     let resp = policy.handle_tally(tally.clone());
     if let Some(fw_config) = fw_config {
         if fw_config.delegate_spam_blocking && !mem_drainfile_present {

--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -121,16 +121,20 @@ impl TrafficSketch {
 pub struct TrafficTally {
     pub connection_ip: Option<IpAddr>,
     pub proxy_ip: Option<IpAddr>,
-    pub weight: Weight,
+    pub error_weight: Weight,
     pub timestamp: SystemTime,
 }
 
 impl TrafficTally {
-    pub fn new(connection_ip: Option<IpAddr>, proxy_ip: Option<IpAddr>, weight: Weight) -> Self {
+    pub fn new(
+        connection_ip: Option<IpAddr>,
+        proxy_ip: Option<IpAddr>,
+        error_weight: Weight,
+    ) -> Self {
         Self {
             connection_ip,
             proxy_ip,
-            weight,
+            error_weight,
             timestamp: SystemTime::now(),
         }
     }
@@ -403,13 +407,13 @@ mod tests {
         let alice = TrafficTally {
             connection_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
             proxy_ip: None,
-            weight: Weight::zero(),
+            error_weight: Weight::zero(),
             timestamp: SystemTime::now(),
         };
         let bob = TrafficTally {
             connection_ip: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
             proxy_ip: None,
-            weight: Weight::zero(),
+            error_weight: Weight::zero(),
             timestamp: SystemTime::now(),
         };
 

--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -191,7 +191,7 @@ fn handle_traffic_resp(
     traffic_controller.tally(TrafficTally {
         connection_ip: Some(client_ip.ip()),
         proxy_ip: None,
-        weight: error.map(normalize).unwrap_or(Weight::zero()),
+        error_weight: error.map(normalize).unwrap_or(Weight::zero()),
         timestamp: SystemTime::now(),
     });
 }


### PR DESCRIPTION
## Description 

* For error tallies, sample by `error_weight`, as defined by the originating server based on the error type. 
* For spam tallies, sample based on sampling weight, a new config parameter (by default, we will only tally 20% of "all traffic" for spam policy) 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
