### PR TITLE
[feat]add length and is_empty funtion in priority_queue.move

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/priority_queue.move
+++ b/crates/sui-framework/packages/sui-framework/sources/priority_queue.move
@@ -75,7 +75,7 @@ module sui::priority_queue {
     }
     // Return `true` if the entries has no elements and `false` otherwise.
     public fun is_empty<T: drop>(pq: &PriorityQueue<T>): bool {
-        pq.entries.length() > 0
+        pq.entries.length() == 0
     } 
     // TODO: implement iterative version too and see performance difference.
     fun restore_heap_recursive<T: drop>(v: &mut vector<Entry<T>>, i: u64) {

--- a/crates/sui-framework/packages/sui-framework/sources/priority_queue.move
+++ b/crates/sui-framework/packages/sui-framework/sources/priority_queue.move
@@ -69,7 +69,14 @@ module sui::priority_queue {
         };
         res
     }
-
+    //Return the length of queue
+    public fun length<T: drop>(pq: &PriorityQueue<T>): u64 {
+        pq.entries.length()
+    }
+    // Return `true` if the entries has no elements and `false` otherwise.
+    public fun is_empty<T: drop>(pq: &PriorityQueue<T>): bool {
+        pq.entries.length() > 0
+    } 
     // TODO: implement iterative version too and see performance difference.
     fun restore_heap_recursive<T: drop>(v: &mut vector<Entry<T>>, i: u64) {
         if (i == 0) {


### PR DESCRIPTION
## Description 
To avoid errors, it is recommended to check if the queue is empty before each pop_max
If necessary, the queue length can also be obtained
## Test plan 

[](https://github.com/Crazyjs123/crazyjs123.github.io/blob/main/pic/pr.png?raw=true)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
