### PR TITLE
[Consensus 2.0] use DagBuilder

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -169,6 +169,7 @@ mod tests {
     use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
     use super::*;
+    use crate::test_dag_builder::DagBuilder;
     use crate::{
         block::{BlockRef, Round},
         commit::DEFAULT_WAVE_LENGTH,
@@ -176,7 +177,7 @@ mod tests {
         dag_state::DagState,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,
-        test_dag::{build_dag, get_all_uncommitted_leader_blocks},
+        test_dag::get_all_uncommitted_leader_blocks,
     };
 
     #[test]
@@ -207,7 +208,12 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
-        build_dag(context.clone(), dag_state.clone(), None, num_rounds);
+        let mut builder = DagBuilder::new(context.clone());
+        builder
+            .layers(1..=num_rounds)
+            .build()
+            .persist_layers(dag_state.clone());
+
         let leaders = get_all_uncommitted_leader_blocks(
             dag_state.clone(),
             leader_schedule,
@@ -306,7 +312,11 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
-        build_dag(context.clone(), dag_state.clone(), None, num_rounds);
+        let mut builder = DagBuilder::new(context.clone());
+        builder
+            .layers(1..=num_rounds)
+            .build()
+            .persist_layers(dag_state.clone());
         let leaders = get_all_uncommitted_leader_blocks(
             dag_state.clone(),
             leader_schedule,
@@ -443,7 +453,11 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
-        build_dag(context.clone(), dag_state.clone(), None, num_rounds);
+        let mut builder = DagBuilder::new(context.clone());
+        builder
+            .layers(1..=num_rounds)
+            .build()
+            .persist_layers(dag_state.clone());
         let leaders = get_all_uncommitted_leader_blocks(
             dag_state.clone(),
             leader_schedule,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -302,6 +302,7 @@ impl Core {
             if !self.leaders_exist(quorum_round) {
                 return None;
             }
+
             if Duration::from_millis(
                 self.context
                     .clock

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -246,7 +246,7 @@ mod tests {
 
         // Now take all the blocks from round `leader_round_wave_1` up to round `leader_round_wave_2-1`
         let mut blocks = dag_builder.blocks(leader_round_wave_1..=leader_round_wave_2 - 1);
-        // Filter out leader block or round `leader_round_wave_1`
+        // Filter out leader block of round `leader_round_wave_1`
         blocks.retain(|block| {
             !(block.round() == leader_round_wave_1
                 && block.author() == leader_schedule.elect_leader(leader_round_wave_1, 0))

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -7,10 +7,9 @@ use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
 use crate::{
-    block::{genesis_blocks, BlockRef, BlockTimestampMs, Round, Slot, TestBlock, VerifiedBlock},
+    block::{genesis_blocks, BlockRef, BlockTimestampMs, Round, TestBlock, VerifiedBlock},
     context::Context,
     dag_state::DagState,
-    leader_schedule::LeaderSchedule,
 };
 
 // todo: remove this once tests have been refactored to use DagBuilder/DagParser
@@ -88,29 +87,4 @@ pub(crate) fn build_dag_layer(
         dag_state.write().accept_block(block);
     }
     references
-}
-
-// Leader blocks start from round 1 as we do not consider any blocks from genesis
-// round as a leader block.
-// TODO: confirm pipelined & multi-leader cases work properly and interaction with
-// DagState flush
-pub(crate) fn get_all_uncommitted_leader_blocks(
-    dag_state: Arc<RwLock<DagState>>,
-    leader_schedule: LeaderSchedule,
-    num_rounds: u32,
-    wave_length: u32,
-    pipelined: bool,
-    num_leaders: u32,
-) -> Vec<VerifiedBlock> {
-    let mut blocks = Vec::new();
-    for round in 1..=num_rounds {
-        for leader_offset in 0..num_leaders {
-            if pipelined || round % wave_length == 0 {
-                let slot = Slot::new(round, leader_schedule.elect_leader(round, leader_offset));
-                let uncommitted_blocks = dag_state.read().get_uncommitted_blocks_at_slot(slot);
-                blocks.extend(uncommitted_blocks);
-            }
-        }
-    }
-    blocks
 }

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -392,6 +392,7 @@ impl<'a> LayerBuilder<'a> {
     }
 
     pub fn persist_layers(&self, dag_state: Arc<RwLock<DagState>>) {
+        assert!(!self.blocks.is_empty(), "Called to persist layers although no blocks have been created. Make sure you have called build before.");
         dag_state.write().accept_blocks(self.blocks.clone());
     }
 

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -107,6 +107,32 @@ impl DagBuilder {
         }
     }
 
+    pub(crate) fn blocks(&self, rounds: RangeInclusive<Round>) -> Vec<VerifiedBlock> {
+        assert!(
+            !self.blocks.is_empty(),
+            "No blocks have been created, please make sure that you have called build method"
+        );
+        self.blocks
+            .iter()
+            .filter_map(|(block_ref, block)| rounds.contains(&block_ref.round).then_some(block))
+            .cloned()
+            .collect::<Vec<VerifiedBlock>>()
+    }
+
+    pub(crate) fn leader_block(&self, round: Round) -> Option<VerifiedBlock> {
+        assert!(
+            !self.blocks.is_empty(),
+            "No blocks have been created, please make sure that you have called build method"
+        );
+        self.blocks
+            .iter()
+            .find(|(block_ref, block)| {
+                block_ref.round == round
+                    && block_ref.author == self.leader_schedule.elect_leader(round, 0)
+            })
+            .map(|(_block_ref, block)| block.clone())
+    }
+
     pub(crate) fn with_wave_length(mut self, wave_length: Round) -> Self {
         self.wave_length = wave_length;
         self

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -119,6 +119,20 @@ impl DagBuilder {
             .collect::<Vec<VerifiedBlock>>()
     }
 
+    pub(crate) fn leader_blocks(
+        &self,
+        rounds: RangeInclusive<Round>,
+    ) -> Vec<Option<VerifiedBlock>> {
+        assert!(
+            !self.blocks.is_empty(),
+            "No blocks have been created, please make sure that you have called build method"
+        );
+        rounds
+            .into_iter()
+            .map(|round| self.leader_block(round))
+            .collect()
+    }
+
     pub(crate) fn leader_block(&self, round: Round) -> Option<VerifiedBlock> {
         assert!(
             !self.blocks.is_empty(),


### PR DESCRIPTION
## Description 

This PR swaps the use of the `build_dag` method with the `DagBuilder`  in the `linearizer, commit_observer and dag_state`

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
