### PR TITLE
Fixes to stabilize tests

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -20,6 +20,7 @@ mod test {
         LocalValidatorAggregatorProxy, ValidatorProxy,
     };
     use sui_config::genesis::Genesis;
+    use sui_config::node::AuthorityOverloadConfig;
     use sui_config::{AUTHORITIES_DB_NAME, SUI_KEYSTORE_FILENAME};
     use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
     use sui_core::authority::framework_injection;
@@ -610,6 +611,12 @@ mod test {
         default_epoch_duration_ms: u64,
     ) -> TestCluster {
         init_test_cluster_builder(default_num_validators, default_epoch_duration_ms)
+            .with_authority_overload_config(AuthorityOverloadConfig {
+                check_system_overload_at_execution: false,
+                check_system_overload_at_signing: false,
+                ..Default::default()
+            })
+            .with_submit_delay_step_override_millis(3000)
             .build()
             .await
     }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -612,6 +612,9 @@ mod test {
     ) -> TestCluster {
         init_test_cluster_builder(default_num_validators, default_epoch_duration_ms)
             .with_authority_overload_config(AuthorityOverloadConfig {
+                // Disable system overload checks for the test - during tests with crashes,
+                // it is is possible for overload protection to trigger due to validators
+                // having queued certs which are missing dependencies.
                 check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -102,7 +102,7 @@ fn get_scheduling_timeout() -> CheckpointTimeoutConfig {
             std::env::var("NEW_CHECKPOINT_TIMEOUT_MS")
                 .ok()
                 .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(if panic_on_timeout { 20000 } else { 2000 }),
+                .unwrap_or(if panic_on_timeout { 30000 } else { 2000 }),
         );
 
         CheckpointTimeoutConfig {

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -65,6 +65,8 @@ pub struct ConfigBuilder<R = OsRng> {
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
     firewall_config: Option<RemoteFirewallConfig>,
+    max_submit_position: Option<usize>,
+    submit_delay_step_override_millis: Option<u64>,
 }
 
 impl ConfigBuilder {
@@ -83,6 +85,8 @@ impl ConfigBuilder {
             data_ingestion_dir: None,
             policy_config: None,
             firewall_config: None,
+            max_submit_position: None,
+            submit_delay_step_override_millis: None,
         }
     }
 
@@ -215,6 +219,19 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_max_submit_position(mut self, max_submit_position: usize) -> Self {
+        self.max_submit_position = Some(max_submit_position);
+        self
+    }
+
+    pub fn with_submit_delay_step_override_millis(
+        mut self,
+        submit_delay_step_override_millis: u64,
+    ) -> Self {
+        self.submit_delay_step_override_millis = Some(submit_delay_step_override_millis);
+        self
+    }
+
     pub fn rng<N: rand::RngCore + rand::CryptoRng>(self, rng: N) -> ConfigBuilder<N> {
         ConfigBuilder {
             rng: Some(rng),
@@ -230,6 +247,8 @@ impl<R> ConfigBuilder<R> {
             data_ingestion_dir: self.data_ingestion_dir,
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
+            max_submit_position: self.max_submit_position,
+            submit_delay_step_override_millis: self.submit_delay_step_override_millis,
         }
     }
 
@@ -373,6 +392,17 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     .with_config_directory(self.config_directory.clone())
                     .with_policy_config(self.policy_config.clone())
                     .with_firewall_config(self.firewall_config.clone());
+
+                if let Some(max_submit_position) = self.max_submit_position {
+                    builder = builder.with_max_submit_position(max_submit_position);
+                }
+
+                if let Some(submit_delay_step_override_millis) =
+                    self.submit_delay_step_override_millis
+                {
+                    builder = builder
+                        .with_submit_delay_step_override_millis(submit_delay_step_override_millis);
+                }
 
                 if let Some(jwk_fetch_interval) = self.jwk_fetch_interval {
                     builder = builder.with_jwk_fetch_interval(jwk_fetch_interval);

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -38,6 +38,8 @@ pub struct ValidatorConfigBuilder {
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
     firewall_config: Option<RemoteFirewallConfig>,
+    max_submit_position: Option<usize>,
+    submit_delay_step_override_millis: Option<u64>,
 }
 
 impl ValidatorConfigBuilder {
@@ -90,6 +92,19 @@ impl ValidatorConfigBuilder {
         self
     }
 
+    pub fn with_max_submit_position(mut self, max_submit_position: usize) -> Self {
+        self.max_submit_position = Some(max_submit_position);
+        self
+    }
+
+    pub fn with_submit_delay_step_override_millis(
+        mut self,
+        submit_delay_step_override_millis: u64,
+    ) -> Self {
+        self.submit_delay_step_override_millis = Some(submit_delay_step_override_millis);
+        self
+    }
+
     pub fn build(
         self,
         validator: ValidatorGenesisConfig,
@@ -113,8 +128,8 @@ impl ValidatorConfigBuilder {
             db_path: consensus_db_path,
             internal_worker_address,
             max_pending_transactions: None,
-            max_submit_position: None,
-            submit_delay_step_override_millis: None,
+            max_submit_position: self.max_submit_position,
+            submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             protocol: ConsensusProtocol::Narwhal,
             narwhal_config: narwhal_config::Parameters {
                 network_admin_server: NetworkAdminServerParameters {

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -53,6 +53,8 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_run_with_range: Option<RunWithRange>,
     fullnode_policy_config: Option<PolicyConfig>,
     fullnode_fw_config: Option<RemoteFirewallConfig>,
+    max_submit_position: Option<usize>,
+    submit_delay_step_override_millis: Option<u64>,
 }
 
 impl SwarmBuilder {
@@ -78,6 +80,8 @@ impl SwarmBuilder {
             fullnode_run_with_range: None,
             fullnode_policy_config: None,
             fullnode_fw_config: None,
+            max_submit_position: None,
+            submit_delay_step_override_millis: None,
         }
     }
 }
@@ -105,6 +109,8 @@ impl<R> SwarmBuilder<R> {
             fullnode_run_with_range: self.fullnode_run_with_range,
             fullnode_policy_config: self.fullnode_policy_config,
             fullnode_fw_config: self.fullnode_fw_config,
+            max_submit_position: self.max_submit_position,
+            submit_delay_step_override_millis: self.submit_delay_step_override_millis,
         }
     }
 
@@ -264,6 +270,19 @@ impl<R> SwarmBuilder<R> {
         }
         self.genesis_config.as_mut().unwrap()
     }
+
+    pub fn with_max_submit_position(mut self, max_submit_position: usize) -> Self {
+        self.max_submit_position = Some(max_submit_position);
+        self
+    }
+
+    pub fn with_submit_delay_step_override_millis(
+        mut self,
+        submit_delay_step_override_millis: u64,
+    ) -> Self {
+        self.submit_delay_step_override_millis = Some(submit_delay_step_override_millis);
+        self
+    }
 }
 
 impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
@@ -298,6 +317,16 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
             if let Some(path) = self.data_ingestion_dir {
                 config_builder = config_builder.with_data_ingestion_dir(path);
+            }
+
+            if let Some(max_submit_position) = self.max_submit_position {
+                config_builder = config_builder.with_max_submit_position(max_submit_position);
+            }
+
+            if let Some(submit_delay_step_override_millis) = self.submit_delay_step_override_millis
+            {
+                config_builder = config_builder
+                    .with_submit_delay_step_override_millis(submit_delay_step_override_millis);
             }
 
             config_builder

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -770,6 +770,9 @@ pub struct TestClusterBuilder {
     fullnode_run_with_range: Option<RunWithRange>,
     fullnode_policy_config: Option<PolicyConfig>,
     fullnode_fw_config: Option<RemoteFirewallConfig>,
+
+    max_submit_position: Option<usize>,
+    submit_delay_step_override_millis: Option<u64>,
 }
 
 impl TestClusterBuilder {
@@ -794,6 +797,8 @@ impl TestClusterBuilder {
             fullnode_run_with_range: None,
             fullnode_policy_config: None,
             fullnode_fw_config: None,
+            max_submit_position: None,
+            submit_delay_step_override_millis: None,
         }
     }
 
@@ -960,6 +965,19 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_max_submit_position(mut self, max_submit_position: usize) -> Self {
+        self.max_submit_position = Some(max_submit_position);
+        self
+    }
+
+    pub fn with_submit_delay_step_override_millis(
+        mut self,
+        submit_delay_step_override_millis: u64,
+    ) -> Self {
+        self.submit_delay_step_override_millis = Some(submit_delay_step_override_millis);
+        self
+    }
+
     pub async fn build(mut self) -> TestCluster {
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to supply
@@ -1074,6 +1092,15 @@ impl TestClusterBuilder {
 
         if let Some(data_ingestion_dir) = self.data_ingestion_dir.take() {
             builder = builder.with_data_ingestion_dir(data_ingestion_dir);
+        }
+
+        if let Some(max_submit_position) = self.max_submit_position {
+            builder = builder.with_max_submit_position(max_submit_position);
+        }
+
+        if let Some(submit_delay_step_override_millis) = self.submit_delay_step_override_millis {
+            builder =
+                builder.with_submit_delay_step_override_millis(submit_delay_step_override_millis);
         }
 
         let mut swarm = builder.build();


### PR DESCRIPTION
- Do not stack timeouts in state sync
- Disable overload protection and make consensus submission very aggressive in tests
- Increase no-checkpoint timeout to 30s in simtests

After these changes, `test_simulated_load_reconfig_with_crashes_and_delays` can run for 400 seeds without failures.
