### PR TITLE
[sui-sdk] Add basic auth support when building an http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13591,6 +13591,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
+ "base64 0.21.2",
  "bcs",
  "clap",
  "colored",

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 clap.workspace = true
 colored.workspace = true
 jsonrpsee.workspace = true


### PR DESCRIPTION
## Description 

Allows us to add basic auth to the connection to a proxy FN.

## Test plan 

yolo

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
