### PR TITLE
[cherry-pick][graphql] Cherry pick version path

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -223,6 +223,7 @@ impl ServerBuilder {
         if self.router.is_none() {
             let router: Router = Router::new()
                 .route("/", post(graphql_handler))
+                .route("/:version", post(graphql_handler))
                 .route("/graphql", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
                 .with_state(self.state.clone())

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{
-    extract::State,
+    extract::{Path, State},
     headers,
     http::{HeaderName, HeaderValue, Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
-    TypedHeader,
 };
 
 use crate::{
@@ -18,6 +17,7 @@ use crate::{
 pub(crate) static VERSION_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-version");
 
 pub(crate) struct SuiRpcVersion(Vec<u8>, Vec<Vec<u8>>);
+const NAMED_VERSIONS: [&str; 3] = ["beta", "legacy", "stable"];
 
 impl headers::Header for SuiRpcVersion {
     fn name() -> &'static HeaderName {
@@ -50,60 +50,42 @@ impl headers::Header for SuiRpcVersion {
 /// one version of the RPC software, and it is the responsibility of the load balancer to make sure
 /// version constraints are met.
 pub(crate) async fn check_version_middleware<B>(
-    user_version: Option<TypedHeader<SuiRpcVersion>>,
-    State(version): State<Version>,
+    version: Option<Path<String>>,
+    State(service_version): State<Version>,
     request: Request<B>,
     next: Next<B>,
 ) -> Response {
-    if let Some(TypedHeader(SuiRpcVersion(req_version, rest))) = user_version {
-        if !rest.is_empty() {
-            return (
-                StatusCode::BAD_REQUEST,
-                graphql_error_response(
-                    code::BAD_REQUEST,
-                    format!("Failed to parse {VERSION_HEADER}: Multiple possible versions found."),
-                ),
-            )
-                .into_response();
-        }
+    let Some(Path(version)) = version else {
+        return next.run(request).await;
+    };
 
-        let Ok(req_version) = std::str::from_utf8(&req_version) else {
-            return (
-                StatusCode::BAD_REQUEST,
-                graphql_error_response(
-                    code::BAD_REQUEST,
-                    format!("Failed to parse {VERSION_HEADER}: Not a UTF8 string."),
-                ),
-            )
-                .into_response();
-        };
-
-        let Some((year, month)) = parse_version(req_version) else {
-            return (
+    if NAMED_VERSIONS.contains(&version.as_str()) || version.is_empty() {
+        return next.run(request).await;
+    }
+    let Some((year, month)) = parse_version(&version) else {
+        return (
                 StatusCode::BAD_REQUEST,
                 graphql_error_response(
                     code::BAD_REQUEST,
                     format!(
-                        "Failed to parse {VERSION_HEADER}: '{req_version}' not a valid \
-                         <YEAR>.<MONTH> version.",
+                        "Failed to parse version path: {version}. Expected either a `beta | legacy | stable` \
+                    version or <YEAR>.<MONTH> version.",
                     ),
                 ),
             )
                 .into_response();
-        };
-
-        if year != version.year || month != version.month {
-            return (
-                StatusCode::MISDIRECTED_REQUEST,
-                graphql_error_response(
-                    code::INTERNAL_SERVER_ERROR,
-                    format!("Version '{req_version}' not supported."),
-                ),
-            )
-                .into_response();
-        }
     };
 
+    if year != service_version.year || month != service_version.month {
+        return (
+            StatusCode::MISDIRECTED_REQUEST,
+            graphql_error_response(
+                code::INTERNAL_SERVER_ERROR,
+                format!("Version '{version}' not supported."),
+            ),
+        )
+            .into_response();
+    }
     next.run(request).await
 }
 
@@ -131,6 +113,10 @@ fn parse_version(version: &str) -> Option<(&str, &str)> {
     let mut parts = version.split('.');
     let year = parts.next()?;
     let month = parts.next()?;
+
+    if year.is_empty() || month.is_empty() {
+        return None;
+    }
 
     (parts.next().is_none()
         && year.chars().all(|c| c.is_ascii_digit())
@@ -175,6 +161,9 @@ mod tests {
 
         Router::new()
             .route("/", get(|| async { "Hello, Versioning!" }))
+            .route("/:version", get(|| async { "Hello, Versioning!" }))
+            .route("/graphql", get(|| async { "Hello, Versioning!" }))
+            .route("/graphql/:version", get(|| async { "Hello, Versioning!" }))
             .layer(middleware::from_fn_with_state(
                 state.version,
                 check_version_middleware,
@@ -185,17 +174,25 @@ mod tests {
             ))
     }
 
+    fn graphql_request() -> Request<Body> {
+        Request::builder()
+            .uri("/graphql")
+            .body(Body::empty())
+            .unwrap()
+    }
+
     fn plain_request() -> Request<Body> {
         Request::builder().uri("/").body(Body::empty()).unwrap()
     }
 
-    fn header_request(kvps: &[(&HeaderName, &[u8])]) -> Request<Body> {
-        let mut request = plain_request();
-        let headers = request.headers_mut();
-        for (name, value) in kvps {
-            headers.append(*name, HeaderValue::from_bytes(value).unwrap());
+    fn version_request(version: &str) -> Request<Body> {
+        if version.is_empty() {
+            return plain_request();
         }
-        request
+        Request::builder()
+            .uri(format!("/graphql/{}", version))
+            .body(Body::empty())
+            .unwrap()
     }
 
     async fn response_body(response: Response) -> String {
@@ -210,10 +207,7 @@ mod tests {
         let major_version = format!("{}.{}", version.year, version.month);
         let service = service();
         let response = service
-            .oneshot(header_request(&[(
-                &VERSION_HEADER,
-                major_version.as_bytes(),
-            )]))
+            .oneshot(version_request(&major_version))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
@@ -224,23 +218,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn case_insensitive() {
+    async fn default_graphql_route() {
         let version = Version::for_testing();
-        let major_version = format!("{}.{}", version.year, version.month);
         let service = service();
-        let response = service
-            .oneshot(header_request(&[(
-                &HeaderName::try_from("x-sUi-RpC-vERSION").unwrap(),
-                major_version.as_bytes(),
-            )]))
-            .await
-            .unwrap();
-
+        let response = service.oneshot(graphql_request()).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get(&VERSION_HEADER),
             Some(&HeaderValue::from_static(version.full))
         );
+    }
+
+    #[tokio::test]
+    async fn named_version() {
+        let version = Version::for_testing();
+        let service = service();
+        for named_version in NAMED_VERSIONS {
+            let response = service
+                .clone()
+                .oneshot(version_request(named_version))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                response.headers().get(&VERSION_HEADER),
+                Some(&HeaderValue::from_static(version.full))
+            );
+        }
     }
 
     #[tokio::test]
@@ -248,7 +252,18 @@ mod tests {
         let version = Version::for_testing();
         let service = service();
         let response = service.oneshot(plain_request()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(&VERSION_HEADER),
+            Some(&HeaderValue::from_static(version.full))
+        );
+    }
 
+    #[tokio::test]
+    async fn wrong_path() {
+        let version = Version::for_testing();
+        let service = service();
+        let response = service.oneshot(version_request("")).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get(&VERSION_HEADER),
@@ -260,10 +275,7 @@ mod tests {
     async fn incompatible_version() {
         let version = Version::for_testing();
         let service = service();
-        let response = service
-            .oneshot(header_request(&[(&VERSION_HEADER, "0.0".as_bytes())]))
-            .await
-            .unwrap();
+        let response = service.oneshot(version_request("0.0")).await.unwrap();
 
         assert_eq!(response.status(), StatusCode::MISDIRECTED_REQUEST);
         assert_eq!(
@@ -287,47 +299,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multiple_versions() {
-        let version = Version::for_testing();
-        let service = service();
-        let response = service
-            .oneshot(header_request(&[
-                (&VERSION_HEADER, "0.0".as_bytes()),
-                (&VERSION_HEADER, "1.0".as_bytes()),
-            ]))
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(
-            response.headers().get(&VERSION_HEADER),
-            Some(&HeaderValue::from_static(version.full))
-        );
-
-        let expect = expect![[r#"
-            {
-              "data": null,
-              "errors": [
-                {
-                  "message": "Failed to parse x-sui-rpc-version: Multiple possible versions found.",
-                  "extensions": {
-                    "code": "BAD_REQUEST"
-                  }
-                }
-              ]
-            }"#]];
-        expect.assert_eq(&response_body(response).await);
-    }
-
-    #[tokio::test]
     async fn not_a_version() {
         let version = Version::for_testing();
         let service = service();
         let response = service
-            .oneshot(header_request(&[(&VERSION_HEADER, b"not-a-version")]))
+            .oneshot(version_request("not-a-version"))
             .await
             .unwrap();
-
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
             response.headers().get(&VERSION_HEADER),
@@ -339,40 +317,7 @@ mod tests {
               "data": null,
               "errors": [
                 {
-                  "message": "Failed to parse x-sui-rpc-version: 'not-a-version' not a valid <YEAR>.<MONTH> version.",
-                  "extensions": {
-                    "code": "BAD_REQUEST"
-                  }
-                }
-              ]
-            }"#]];
-        expect.assert_eq(&response_body(response).await);
-    }
-
-    #[tokio::test]
-    async fn not_a_string() {
-        let version = Version::for_testing();
-        let service = service();
-        let response = service
-            .oneshot(header_request(&[(
-                &VERSION_HEADER,
-                &[0xf1, 0xf2, 0xf3, 0xf4],
-            )]))
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(
-            response.headers().get(&VERSION_HEADER),
-            Some(&HeaderValue::from_static(version.full))
-        );
-
-        let expect = expect![[r#"
-            {
-              "data": null,
-              "errors": [
-                {
-                  "message": "Failed to parse x-sui-rpc-version: Not a UTF8 string.",
+                  "message": "Failed to parse version path: not-a-version. Expected either a `beta | legacy | stable` version or <YEAR>.<MONTH> version.",
                   "extensions": {
                     "code": "BAD_REQUEST"
                   }


### PR DESCRIPTION
## Description 

Cherry pick the version path into the GraphQL legacy release version (v2024.1.4).

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
