### PR TITLE
[replay] Add bcs format support for sandbox file during replay

### DIFF
--- a/crates/sui-replay/src/batch_replay.rs
+++ b/crates/sui-replay/src/batch_replay.rs
@@ -3,6 +3,7 @@
 
 use crate::replay::{ExecutionSandboxState, LocalExec};
 use crate::types::ReplayEngineError;
+use crate::SandboxFileFormat;
 use futures::future::join_all;
 use futures::FutureExt;
 use parking_lot::Mutex;
@@ -26,6 +27,7 @@ pub async fn batch_replay(
     use_authority: bool,
     terminate_early: bool,
     persist_path: Option<PathBuf>,
+    sandbox_format: SandboxFileFormat,
 ) {
     let provider = Arc::new(TransactionDigestProvider::new(tx_digests));
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -45,6 +47,7 @@ pub async fn batch_replay(
             terminate_early,
             cancel,
             persist_path_ref,
+            sandbox_format,
         ));
     }
     let all_failed_transactions: Vec<_> = join_all(tasks).await.into_iter().flatten().collect();
@@ -106,6 +109,7 @@ async fn run_task(
     terminate_early: bool,
     cancel: tokio_util::sync::CancellationToken,
     persist_path: Option<&PathBuf>,
+    sandbox_format: SandboxFileFormat,
 ) -> Vec<ReplayEngineError> {
     let total_count = tx_digest_provider.get_total_count();
     let mut failed_transactions = vec![];
@@ -118,7 +122,16 @@ async fn run_task(
             "[{}/{}] Replaying transaction {:?}...",
             index, total_count, digest
         );
-        let sandbox_persist_path = persist_path.map(|path| path.join(format!("{}.json", digest)));
+        let sandbox_persist_path = persist_path.map(|path| {
+            path.join(format!(
+                "{}.{}",
+                digest,
+                match sandbox_format {
+                    SandboxFileFormat::Bcs => "bcs",
+                    SandboxFileFormat::Json => "json",
+                }
+            ))
+        });
         if let Some(p) = sandbox_persist_path.as_ref() {
             if p.exists() {
                 info!(
@@ -153,8 +166,16 @@ async fn run_task(
             Ok(sandbox_state) => {
                 info!("Replaying transaction {:?} succeeded", digest);
                 if let Some(p) = sandbox_persist_path {
-                    let out = serde_json::to_string(&sandbox_state).unwrap();
-                    std::fs::write(p, out).unwrap();
+                    match sandbox_format {
+                        SandboxFileFormat::Bcs => {
+                            let out = bcs::to_bytes(&sandbox_state).unwrap();
+                            std::fs::write(p, out).unwrap();
+                        }
+                        SandboxFileFormat::Json => {
+                            let out = serde_json::to_string(&sandbox_state).unwrap();
+                            std::fs::write(p, out).unwrap();
+                        }
+                    }
                 }
             }
         }

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_recursion::async_recursion;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use config::ReplayableNetworkConfigSet;
 use fuzz::ReplayFuzzer;
 use fuzz::ReplayFuzzerConfig;
@@ -120,6 +120,14 @@ pub enum ReplayToolCommand {
             This will allow faster replay next time."
         )]
         persist_path: Option<PathBuf>,
+        #[arg(
+            long,
+            value_enum,
+            ignore_case = true,
+            help = "Format of the sandbox files",
+            default_value = "json"
+        )]
+        sandbox_format: SandboxFileFormat,
     },
 
     /// Replay a transaction from a node state dump
@@ -146,6 +154,14 @@ pub enum ReplayToolCommand {
             help = "Number of tasks to run in parallel"
         )]
         num_tasks: usize,
+        #[arg(
+            long,
+            value_enum,
+            ignore_case = true,
+            help = "Format of the sandbox files",
+            default_value = "json"
+        )]
+        sandbox_format: SandboxFileFormat,
     },
 
     /// Replay all transactions in a range of checkpoints
@@ -185,6 +201,12 @@ pub enum ReplayToolCommand {
 
     #[command(name = "report")]
     Report,
+}
+
+#[derive(Parser, Copy, Clone, ValueEnum)]
+pub enum SandboxFileFormat {
+    Json,
+    Bcs,
 }
 
 #[async_recursion]
@@ -288,6 +310,7 @@ pub async fn execute_replay_command(
             terminate_early,
             num_tasks,
             persist_path,
+            sandbox_format,
         } => {
             let file = std::fs::File::open(path).unwrap();
             let buf_reader = std::io::BufReader::new(file);
@@ -305,13 +328,18 @@ pub async fn execute_replay_command(
                 use_authority,
                 terminate_early,
                 persist_path,
+                sandbox_format,
             )
             .await;
 
             // TODO: clean this up
             Some((0u64, 0u64))
         }
-        ReplayToolCommand::BatchReplayFromSandbox { path, num_tasks } => {
+        ReplayToolCommand::BatchReplayFromSandbox {
+            path,
+            num_tasks,
+            sandbox_format,
+        } => {
             let files: Vec<_> = std::fs::read_dir(path)?
                 .filter_map(|entry| {
                     let path = entry.ok()?.path();
@@ -327,9 +355,16 @@ pub async fn execute_replay_command(
             let tasks = chunks.into_iter().map(|chunk| async move {
                 for file in chunk {
                     info!("Replaying from state dump file {}", file);
-                    let contents = std::fs::read_to_string(file).unwrap();
-                    let sandbox_state: ExecutionSandboxState =
-                        serde_json::from_str(&contents).unwrap();
+                    let sandbox_state: ExecutionSandboxState = match sandbox_format {
+                        SandboxFileFormat::Json => {
+                            let contents = std::fs::read_to_string(file).unwrap();
+                            serde_json::from_str(&contents).unwrap()
+                        }
+                        SandboxFileFormat::Bcs => {
+                            let contents = std::fs::read(file).unwrap();
+                            bcs::from_bytes(&contents).unwrap()
+                        }
+                    };
                     let sandbox_state = LocalExec::certificate_execute_with_sandbox_state(
                         &sandbox_state,
                         &sandbox_state.pre_exec_diag,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -37,6 +37,7 @@ use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsA
 use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::in_memory_storage::InMemoryStorage;
+use sui_types::message_envelope::Message;
 use sui_types::storage::{get_module, PackageObject};
 use sui_types::transaction::TransactionKind::ProgrammableTransaction;
 use sui_types::{
@@ -709,45 +710,18 @@ impl LocalExec {
             unreachable!("Transaction was valid so gas status must be valid");
         };
 
-        trace!(target: "replay_gas_info", "{}", Pretty(&gas_status));
-
-        let skip_checks = true;
-        if let ProgrammableTransaction(ref pt) = transaction_kind {
-            let full_ptb = FullPTB {
-                ptb: pt.clone(),
-                results: transform_command_results_to_annotated(
-                    &executor,
-                    &self.clone(),
-                    executor
-                        .dev_inspect_transaction(
-                            &self,
-                            protocol_config,
-                            metrics,
-                            expensive_checks,
-                            &certificate_deny_set,
-                            &tx_info.executed_epoch,
-                            tx_info.epoch_start_timestamp,
-                            CheckedInputObjects::new_for_replay(input_objects),
-                            tx_info.gas.clone(),
-                            SuiGasStatus::new(
-                                tx_info.gas_budget,
-                                tx_info.gas_price,
-                                tx_info.reference_gas_price,
-                                protocol_config,
-                            )?,
-                            transaction_kind.clone(),
-                            tx_info.sender,
-                            *tx_digest,
-                            skip_checks,
-                        )
-                        .3
-                        .unwrap_or_else(|e| {
-                            panic!("Error executing this transaction in dev-inspect mode, {e}")
-                        }),
-                )?,
-            };
-            trace!(target: "replay_ptb_info", "{}", Pretty(&full_ptb))
-        };
+        if let Err(err) = self.pretty_print_for_tracing(
+            &gas_status,
+            &executor,
+            tx_info,
+            &transaction_kind,
+            protocol_config,
+            metrics,
+            expensive_checks,
+            input_objects.clone(),
+        ) {
+            error!("Failed to pretty print for tracing: {:?}", err);
+        }
 
         let all_required_objects = self.storage.all_objects();
 
@@ -762,6 +736,58 @@ impl LocalExec {
             local_exec_status: Some(result),
             pre_exec_diag: self.diag.clone(),
         })
+    }
+
+    fn pretty_print_for_tracing(
+        &self,
+        gas_status: &SuiGasStatus,
+        executor: &Arc<dyn Executor + Send + Sync>,
+        tx_info: &OnChainTransactionInfo,
+        transaction_kind: &TransactionKind,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        expensive_checks: bool,
+        input_objects: InputObjects,
+    ) -> anyhow::Result<()> {
+        trace!(target: "replay_gas_info", "{}", Pretty(gas_status));
+
+        let skip_checks = true;
+        if let ProgrammableTransaction(pt) = transaction_kind {
+            trace!(
+                target: "replay_ptb_info",
+                "{}",
+                Pretty(&FullPTB {
+                    ptb: pt.clone(),
+                    results: transform_command_results_to_annotated(
+                        executor,
+                        &self.clone(),
+                        executor.dev_inspect_transaction(
+                            &self,
+                            protocol_config,
+                            metrics,
+                            expensive_checks,
+                            &HashSet::new(),
+                            &tx_info.executed_epoch,
+                            tx_info.epoch_start_timestamp,
+                            CheckedInputObjects::new_for_replay(input_objects),
+                            tx_info.gas.clone(),
+                            SuiGasStatus::new(
+                                tx_info.gas_budget,
+                                tx_info.gas_price,
+                                tx_info.reference_gas_price,
+                                protocol_config,
+                            )?,
+                            transaction_kind.clone(),
+                            tx_info.sender,
+                            tx_info.sender_signed_data.digest(),
+                            skip_checks,
+                        )
+                        .3
+                        .unwrap_or_default(),
+                    )?,
+            }));
+        }
+        Ok(())
     }
 
     /// Must be called after `init_for_execution`

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -32,6 +32,8 @@ pub(crate) const MAX_CONCURRENT_REQUESTS: usize = 1_000;
 pub(crate) const EPOCH_CHANGE_STRUCT_TAG: &str =
     "0x3::sui_system_state_inner::SystemEpochInfoEvent";
 
+// TODO: A lot of the information in OnChainTransactionInfo is redundant from what's already in
+// SenderSignedData. We should consider removing them.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OnChainTransactionInfo {
     pub tx_digest: TransactionDigest,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -48,7 +48,7 @@ use sui_move_build::{
     gather_published_ids, BuildConfig, CompiledPackage, PackageDependencies, PublishedAtError,
 };
 use sui_package_management::LockCommand;
-use sui_replay::ReplayToolCommand;
+use sui_replay::{ReplayToolCommand, SandboxFileFormat};
 use sui_sdk::{
     apis::ReadApi,
     sui_client_config::{SuiClientConfig, SuiEnv},
@@ -755,6 +755,7 @@ impl SuiClientCommands {
                     terminate_early,
                     num_tasks: 16,
                     persist_path: None,
+                    sandbox_format: SandboxFileFormat::Json,
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =


### PR DESCRIPTION
## Description 

This PR adds sandbox file format option (json or bcs) to batch replay.
Only batch replay needs this because otherwise we prefer json as we don't care about the size of the files.
This cuts the size of a sandbox file by 70%.

Also fixing a bug in the dev inspect tracing execution: it's not always guaranteed that the transaction execution would succeed.

## Test plan 

Run locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
