### PR TITLE
add caching for zklogin verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14135,6 +14135,7 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.10.5",
  "jsonrpsee",
+ "lru 0.10.0",
  "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -175,7 +175,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
         let transaction =
-            transaction.try_into_verified(self.epoch_state.epoch(), &VerifyParams::default())?;
+            transaction.try_into_verified_for_testing(self.epoch_state.epoch(), &VerifyParams::default())?;
 
         let (inner_temporary_store, _, effects, execution_error_opt) = self
             .epoch_state

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -174,8 +174,8 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         &mut self,
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
-        let transaction =
-            transaction.try_into_verified_for_testing(self.epoch_state.epoch(), &VerifyParams::default())?;
+        let transaction = transaction
+            .try_into_verified_for_testing(self.epoch_state.epoch(), &VerifyParams::default())?;
 
         let (inner_temporary_store, _, effects, execution_error_opt) = self
             .epoch_state

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -16,7 +16,7 @@ use sui_types::transaction::CertifiedTransaction;
 
 use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
 use sui_core::signature_verifier::*;
-
+use sui_types::signature_verification::VerifiedDigestCache;
 fn gen_certs(
     committee: &Committee,
     key_pairs: &[AuthorityKeyPair],
@@ -133,7 +133,11 @@ fn batch_verification_bench(c: &mut Criterion) {
                     assert_eq!(certs.len() as u64, *batch_size);
                     b.iter(|| {
                         certs.shuffle(&mut thread_rng());
-                        batch_verify_certificates(&committee, &certs, None);
+                        batch_verify_certificates(
+                            &committee,
+                            &certs,
+                            Arc::new(VerifiedDigestCache::new_for_testing()),
+                        );
                     })
                 },
             );

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -133,7 +133,7 @@ fn batch_verification_bench(c: &mut Criterion) {
                     assert_eq!(certs.len() as u64, *batch_size);
                     b.iter(|| {
                         certs.shuffle(&mut thread_rng());
-                        batch_verify_certificates(&committee, &certs);
+                        batch_verify_certificates(&committee, &certs, None);
                     })
                 },
             );

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -136,7 +136,7 @@ fn batch_verification_bench(c: &mut Criterion) {
                         batch_verify_certificates(
                             &committee,
                             &certs,
-                            Arc::new(VerifiedDigestCache::new_for_testing()),
+                            Arc::new(VerifiedDigestCache::new_empty()),
                         );
                     })
                 },

--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -4,8 +4,9 @@
 use criterion::*;
 
 use criterion::Criterion;
-use sui_core::signature_verifier::{SignatureVerifierMetrics, VerifiedDigestCache};
+use sui_core::signature_verifier::SignatureVerifierMetrics;
 use sui_types::digests::CertificateDigest;
+use sui_types::signature_verification::VerifiedDigestCache;
 
 fn verified_cert_cache_bench(c: &mut Criterion) {
     let mut digests: Vec<_> = (0..(1 << 18))

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -65,7 +65,7 @@ pub async fn certify_transaction(
     let committee = authority.clone_committee_for_testing();
     let certificate = CertifiedTransaction::new(transaction.into_message(), vec![vote], &committee)
         .unwrap()
-        .try_into_verified(&committee, &Default::default())
+        .try_into_verified_for_testing(&committee, &Default::default())
         .unwrap();
     Ok(certificate)
 }
@@ -305,7 +305,7 @@ pub fn init_certified_transaction(
         epoch_store.committee(),
     )
     .unwrap()
-    .try_into_verified(epoch_store.committee(), &Default::default())
+    .try_into_verified_for_testing(epoch_store.committee(), &Default::default())
     .unwrap()
 }
 
@@ -325,7 +325,7 @@ pub async fn certify_shared_obj_transaction_no_execution(
     let certificate =
         CertifiedTransaction::new(transaction.into_message(), vec![vote.clone()], &committee)
             .unwrap()
-            .try_into_verified(&committee, &Default::default())
+            .try_into_verified_for_testing(&committee, &Default::default())
             .unwrap();
 
     send_consensus_no_execution(authority, &certificate).await;

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -302,7 +302,7 @@ impl SignatureVerifier {
         let zklogin_inputs_cache = self.zklogin_inputs_cache.clone();
         Handle::current()
             .spawn_blocking(move || {
-                Self::process_queue_sync(committee, metrics, buffer, Some(zklogin_inputs_cache))
+                Self::process_queue_sync(committee, metrics, buffer, zklogin_inputs_cache)
             })
             .await
             .expect("Spawn blocking should not fail");
@@ -312,7 +312,7 @@ impl SignatureVerifier {
         committee: Arc<Committee>,
         metrics: Arc<SignatureVerifierMetrics>,
         buffer: CertBuffer,
-        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+        zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) {
         let _scope = monitored_scope("BatchCertificateVerifier::process_queue");
 
@@ -378,7 +378,7 @@ impl SignatureVerifier {
                     signed_tx,
                     self.committee.epoch(),
                     &verify_params,
-                    Some(self.zklogin_inputs_cache.clone()),
+                    self.zklogin_inputs_cache.clone(),
                 )
             },
             || Ok(()),
@@ -519,7 +519,7 @@ pub fn batch_verify_all_certificates_and_checkpoints(
 pub fn batch_verify_certificates(
     committee: &Committee,
     certs: &[CertifiedTransaction],
-    zk_login_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+    zk_login_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
 ) -> Vec<SuiResult> {
     // certs.data() is assumed to be verified already by the caller.
     let verify_params = VerifyParams::default();

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -8,16 +8,16 @@ use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
 use futures::pin_mut;
 use im::hashmap::HashMap as ImHashMap;
 use itertools::izip;
-use lru::LruCache;
 use mysten_metrics::monitored_scope;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
 use shared_crypto::intent::Intent;
-use std::hash::Hash;
 use std::sync::Arc;
 use sui_types::digests::SenderSignedDataDigest;
 use sui_types::digests::ZKLoginInputsDigest;
-use sui_types::signature_verification::verify_sender_signed_data_message_signatures;
+use sui_types::signature_verification::{
+    verify_sender_signed_data_message_signatures, VerifiedDigestCache,
+};
 use sui_types::transaction::SenderSignedData;
 use sui_types::{
     committee::Committee,
@@ -94,7 +94,7 @@ pub struct SignatureVerifier {
     committee: Arc<Committee>,
     certificate_cache: VerifiedDigestCache<CertificateDigest>,
     signed_data_cache: VerifiedDigestCache<SenderSignedDataDigest>,
-    zklogin_inputs_cache: VerifiedDigestCache<ZKLoginInputsDigest>,
+    zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
 
     /// Map from JwkId (iss, kid) to the fetched JWK for that key.
     /// We use an immutable data structure because verification of ZKLogins may be slow, so we
@@ -148,11 +148,11 @@ impl SignatureVerifier {
                 metrics.signed_data_cache_misses.clone(),
                 metrics.signed_data_cache_evictions.clone(),
             ),
-            zklogin_inputs_cache: VerifiedDigestCache::new(
+            zklogin_inputs_cache: Arc::new(VerifiedDigestCache::new(
                 metrics.zklogin_inputs_cache_hits.clone(),
                 metrics.zklogin_inputs_cache_misses.clone(),
                 metrics.zklogin_inputs_cache_evictions.clone(),
-            ),
+            )),
             jwks: Default::default(),
             queue: Mutex::new(CertBuffer::new(batch_size)),
             metrics,
@@ -299,8 +299,11 @@ impl SignatureVerifier {
     async fn process_queue(&self, buffer: CertBuffer) {
         let committee = self.committee.clone();
         let metrics = self.metrics.clone();
+        let zklogin_inputs_cache = self.zklogin_inputs_cache.clone();
         Handle::current()
-            .spawn_blocking(move || Self::process_queue_sync(committee, metrics, buffer))
+            .spawn_blocking(move || {
+                Self::process_queue_sync(committee, metrics, buffer, Some(zklogin_inputs_cache))
+            })
             .await
             .expect("Spawn blocking should not fail");
     }
@@ -309,10 +312,11 @@ impl SignatureVerifier {
         committee: Arc<Committee>,
         metrics: Arc<SignatureVerifierMetrics>,
         buffer: CertBuffer,
+        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
     ) {
         let _scope = monitored_scope("BatchCertificateVerifier::process_queue");
 
-        let results = batch_verify_certificates(&committee, &buffer.certs);
+        let results = batch_verify_certificates(&committee, &buffer.certs, zklogin_inputs_cache);
         izip!(
             results.into_iter(),
             buffer.certs.into_iter(),
@@ -374,6 +378,7 @@ impl SignatureVerifier {
                     signed_tx,
                     self.committee.epoch(),
                     &verify_params,
+                    Some(self.zklogin_inputs_cache.clone()),
                 )
             },
             || Ok(()),
@@ -514,16 +519,10 @@ pub fn batch_verify_all_certificates_and_checkpoints(
 pub fn batch_verify_certificates(
     committee: &Committee,
     certs: &[CertifiedTransaction],
+    zk_login_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
 ) -> Vec<SuiResult> {
     // certs.data() is assumed to be verified already by the caller.
-    let verify_params = VerifyParams::new(
-        Default::default(),
-        Vec::new(),
-        Default::default(),
-        true,
-        true,
-        Some(30),
-    );
+    let verify_params = VerifyParams::default();
     match batch_verify(committee, certs, &[]) {
         Ok(_) => vec![Ok(()); certs.len()],
 
@@ -532,7 +531,9 @@ pub fn batch_verify_certificates(
             .iter()
             // TODO: verify_signature currently checks the tx sig as well, which might be cached
             // already.
-            .map(|c| c.verify_signatures_authenticated(committee, &verify_params))
+            .map(|c| {
+                c.verify_signatures_authenticated(committee, &verify_params, zk_login_cache.clone())
+            })
             .collect(),
 
         Err(e) => vec![Err(e)],
@@ -559,84 +560,4 @@ fn batch_verify(
     }
 
     obligation.verify_all()
-}
-
-// Cache up to 20000 verified certs. We will need to tune this number in the future - a decent
-// guess to start with is that it should be 10-20 times larger than peak transactions per second,
-// on the assumption that we should see most certs twice within about 10-20 seconds at most: Once via RPC, once via consensus.
-const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
-
-pub struct VerifiedDigestCache<D> {
-    inner: RwLock<LruCache<D, ()>>,
-    cache_hits_counter: IntCounter,
-    cache_misses_counter: IntCounter,
-    cache_evictions_counter: IntCounter,
-}
-
-impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
-    pub fn new(
-        cache_hits_counter: IntCounter,
-        cache_misses_counter: IntCounter,
-        cache_evictions_counter: IntCounter,
-    ) -> Self {
-        Self {
-            inner: RwLock::new(LruCache::new(
-                std::num::NonZeroUsize::new(VERIFIED_CERTIFICATE_CACHE_SIZE).unwrap(),
-            )),
-            cache_hits_counter,
-            cache_misses_counter,
-            cache_evictions_counter,
-        }
-    }
-
-    pub fn is_cached(&self, digest: &D) -> bool {
-        let inner = self.inner.read();
-        if inner.contains(digest) {
-            self.cache_hits_counter.inc();
-            true
-        } else {
-            self.cache_misses_counter.inc();
-            false
-        }
-    }
-
-    pub fn cache_digest(&self, digest: D) {
-        let mut inner = self.inner.write();
-        if let Some(old) = inner.push(digest, ()) {
-            if old.0 != digest {
-                self.cache_evictions_counter.inc();
-            }
-        }
-    }
-
-    pub fn cache_digests(&self, digests: Vec<D>) {
-        let mut inner = self.inner.write();
-        digests.into_iter().for_each(|d| {
-            if let Some(old) = inner.push(d, ()) {
-                if old.0 != d {
-                    self.cache_evictions_counter.inc();
-                }
-            }
-        });
-    }
-
-    pub fn is_verified<F, G>(&self, digest: D, verify_callback: F, uncached_checks: G) -> SuiResult
-    where
-        F: FnOnce() -> SuiResult,
-        G: FnOnce() -> SuiResult,
-    {
-        if !self.is_cached(&digest) {
-            verify_callback()?;
-            self.cache_digest(digest);
-        } else {
-            // Checks that are required to be performed outside the cache.
-            uncached_checks()?;
-        }
-        Ok(())
-    }
-
-    pub fn clear(&self) {
-        let mut inner = self.inner.write();
-        inner.clear();
-    }
 }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -28,6 +28,7 @@ use sui_types::crypto::{
 use sui_types::crypto::{AuthorityKeyPair, Signer};
 use sui_types::effects::{SignedTransactionEffects, TestEffectsBuilder};
 use sui_types::error::SuiError;
+use sui_types::signature_verification::VerifiedDigestCache;
 use sui_types::transaction::ObjectArg;
 use sui_types::transaction::{
     CallArg, SignedTransaction, Transaction, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
@@ -71,7 +72,7 @@ pub async fn send_and_confirm_transaction(
     let certificate =
         CertifiedTransaction::new(transaction.into_message(), vec![vote.clone()], &committee)
             .unwrap()
-            .try_into_verified(&committee, &Default::default())
+            .try_into_verified_for_testing(&committee, &Default::default())
             .unwrap();
 
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
@@ -466,7 +467,11 @@ pub fn make_cert_with_large_committee(
         .collect();
 
     let cert = CertifiedTransaction::new(transaction.clone().into_data(), sigs, committee).unwrap();
-    cert.verify_signatures_authenticated(committee, &Default::default(), None)
-        .unwrap();
+    cert.verify_signatures_authenticated(
+        committee,
+        &Default::default(),
+        Arc::new(VerifiedDigestCache::new_for_testing()),
+    )
+    .unwrap();
     cert
 }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -466,7 +466,7 @@ pub fn make_cert_with_large_committee(
         .collect();
 
     let cert = CertifiedTransaction::new(transaction.clone().into_data(), sigs, committee).unwrap();
-    cert.verify_signatures_authenticated(committee, &Default::default())
+    cert.verify_signatures_authenticated(committee, &Default::default(), None)
         .unwrap();
     cert
 }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -470,7 +470,7 @@ pub fn make_cert_with_large_committee(
     cert.verify_signatures_authenticated(
         committee,
         &Default::default(),
-        Arc::new(VerifiedDigestCache::new_for_testing()),
+        Arc::new(VerifiedDigestCache::new_empty()),
     )
     .unwrap();
     cert

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4613,7 +4613,7 @@ async fn make_test_transaction(
             CertifiedTransaction::new(transaction.clone().into_message(), sigs.clone(), &committee)
         {
             return cert
-                .try_into_verified(&committee, &Default::default())
+                .try_into_verified_for_testing(&committee, &Default::default())
                 .unwrap();
         }
     }

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -15,6 +15,7 @@ use sui_types::gas::GasCostSummary;
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointSummary, SignedCheckpointSummary,
 };
+use sui_types::signature_verification::VerifiedDigestCache;
 use sui_types::transaction::CertifiedTransaction;
 
 // TODO consolidate with `gen_certs` in batch_verification_bench.rs
@@ -96,7 +97,11 @@ async fn test_batch_verify() {
         *certs[i].auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
         batch_verify_all_certificates_and_checkpoints(&committee, &certs, &ckpts).unwrap_err();
 
-        let results = batch_verify_certificates(&committee, &certs, None);
+        let results = batch_verify_certificates(
+            &committee,
+            &certs,
+            Arc::new(VerifiedDigestCache::new_for_testing()),
+        );
         results[i].as_ref().unwrap_err();
         for (_, r) in results.iter().enumerate().filter(|(j, _)| *j != i) {
             r.as_ref().unwrap();

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -96,7 +96,7 @@ async fn test_batch_verify() {
         *certs[i].auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
         batch_verify_all_certificates_and_checkpoints(&committee, &certs, &ckpts).unwrap_err();
 
-        let results = batch_verify_certificates(&committee, &certs);
+        let results = batch_verify_certificates(&committee, &certs, None);
         results[i].as_ref().unwrap_err();
         for (_, r) in results.iter().enumerate().filter(|(j, _)| *j != i) {
             r.as_ref().unwrap();

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -100,7 +100,7 @@ async fn test_batch_verify() {
         let results = batch_verify_certificates(
             &committee,
             &certs,
-            Arc::new(VerifiedDigestCache::new_for_testing()),
+            Arc::new(VerifiedDigestCache::new_empty()),
         );
         results[i].as_ref().unwrap_err();
         for (_, r) in results.iter().enumerate().filter(|(j, _)| *j != i) {

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -250,7 +250,7 @@ async fn execute_owned_on_first_three_authorities(
     do_transaction(&authority_clients[2], txn).await;
     let cert = extract_cert(authority_clients, committee, txn.digest())
         .await
-        .try_into_verified(committee, &Default::default())
+        .try_into_verified_for_testing(committee, &Default::default())
         .unwrap();
     do_cert(&authority_clients[0], &cert).await;
     do_cert(&authority_clients[1], &cert).await;
@@ -282,7 +282,7 @@ async fn execute_shared_on_first_three_authorities(
     do_transaction(&authority_clients[2], txn).await;
     let cert = extract_cert(authority_clients, committee, txn.digest())
         .await
-        .try_into_verified(committee, &Default::default())
+        .try_into_verified_for_testing(committee, &Default::default())
         .unwrap();
     do_cert_with_shared_objects(&authority_clients[0].authority_client().state, &cert).await;
     do_cert_with_shared_objects(&authority_clients[1].authority_client().state, &cert).await;
@@ -465,7 +465,7 @@ async fn try_sign_on_first_three_authorities(
     }
     extract_cert(authority_clients, committee, txn.digest())
         .await
-        .try_into_verified(committee, &Default::default())
+        .try_into_verified_for_testing(committee, &Default::default())
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -8,7 +8,8 @@ use rand::{rngs::StdRng, SeedableRng};
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Deref;
-use sui_types::base_types::random_object_ref;
+use sui_types::crypto::{PublicKey, SuiSignature, ToFromBytes, ZkLoginPublicIdentifier};
+use sui_types::utils::get_one_zklogin_inputs;
 use sui_types::{
     authenticator_state::ActiveJwk,
     base_types::dbg_addr,
@@ -26,7 +27,6 @@ use sui_types::{
 };
 
 use sui_macros::sim_test;
-
 macro_rules! assert_matches {
     ($expression:expr, $pattern:pat $(if $guard: expr)?) => {
         match $expression {
@@ -517,8 +517,18 @@ async fn test_zklogin_transfer_with_bad_ephemeral_sig() {
 #[sim_test]
 async fn test_zklogin_transfer_with_large_address_seed() {
     telemetry_subscribers::init_for_testing();
-    let (object_ids, gas_object_ids, authority_state, _epoch_store, _, _, _server, client) =
-        setup_zklogin_network(|_| {}).await;
+    let (
+        object_ids,
+        gas_object_ids,
+        authority_state,
+        _epoch_store,
+        _,
+        _,
+        _server,
+        client,
+        _senders,
+        _multisig_pk,
+    ) = setup_zklogin_network(|_| {}).await;
 
     let ephemeral_key = Ed25519KeyPair::generate(&mut StdRng::from_seed([3; 32]));
 
@@ -547,26 +557,28 @@ async fn test_zklogin_transfer_with_large_address_seed() {
 }
 
 #[sim_test]
-async fn zklogin_test_cached_proof_wrong_key() {
+async fn zklogin_test_caching_scenarios() {
     telemetry_subscribers::init_for_testing();
     let (
-        mut object_ids,
+        object_ids,
         gas_object_ids,
         authority_state,
-        _epoch_store,
+        epoch_store,
         transfer_transaction,
         metrics,
         _server,
         client,
+        senders,
+        multisig_pk,
     ) = setup_zklogin_network(|_| {}).await;
     let socket_addr = make_socket_addr();
 
+    // case 1: a valid zklogin txn verifies ok, cache misses bc its a fresh zklogin inputs.
     let res = client
         .handle_transaction(transfer_transaction, Some(socket_addr))
         .await;
     assert!(res.is_ok());
 
-    /*
     assert_eq!(
         epoch_store
             .signature_verifier
@@ -575,7 +587,6 @@ async fn zklogin_test_cached_proof_wrong_key() {
             .get(),
         1
     );
-    */
 
     let (skp, _eph_pk, zklogin) =
         &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1];
@@ -583,10 +594,12 @@ async fn zklogin_test_cached_proof_wrong_key() {
         SuiKeyPair::Ed25519(kp) => kp,
         _ => panic!(),
     };
-    let sender = SuiAddress::try_from_unpadded(zklogin).unwrap();
+    let sender = senders[0];
     let recipient = dbg_addr(2);
 
-    let mut transfer_transaction2 = init_zklogin_transfer(
+    // case 2: use a different ephemeral key for a valid ephemeral pk + sig, but pk does
+    // not match the zklogin inputs, cache misses and txn fails.
+    let mut txn = init_zklogin_transfer(
         &authority_state,
         object_ids[2],
         gas_object_ids[2],
@@ -598,28 +611,62 @@ async fn zklogin_test_cached_proof_wrong_key() {
     )
     .await;
 
-    let intent_message = transfer_transaction2.data().intent_message().clone();
-    match &mut transfer_transaction2
-        .data_mut_for_testing()
-        .tx_signatures_mut_for_testing()[0]
-    {
+    let intent_message = txn.clone().data().intent_message().clone();
+    match &mut txn.data_mut_for_testing().tx_signatures_mut_for_testing()[0] {
         GenericSignature::ZkLoginAuthenticator(zklogin) => {
             let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
-            // replace the signature with a bogus one
+            // replace the ephemeral signature with a bogus one
             *zklogin.user_signature_mut_for_testing() =
                 Signature::new_secure(&intent_message, &unknown_key);
         }
         _ => panic!(),
     }
 
-    // This tx should fail, but passes because we skip the ephemeral sig check when hitting the zklogin check!
-    assert!(client
-        .handle_transaction(transfer_transaction2, Some(socket_addr))
-        .await
-        .is_err());
+    assert!(matches!(
+        client
+            .handle_transaction(txn.clone(), Some(socket_addr))
+            .await
+            .unwrap_err(),
+        SuiError::InvalidSignature { .. }
+    ));
+    assert_eq!(metrics.signature_errors.get(), 1);
 
-    // TODO: re-enable when cache is re-enabled.
-    /*
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_misses
+            .get(),
+        2
+    );
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_hits
+            .get(),
+        0
+    );
+
+    // case 3: use the same proof and same ephemeral key for a different txn
+    // cache hits, also txn verifies.
+    let txn3 = init_zklogin_transfer(
+        &authority_state,
+        object_ids[3],
+        gas_object_ids[3],
+        recipient,
+        sender,
+        |_| {},
+        ephemeral_key,
+        zklogin,
+    )
+    .await;
+
+    assert!(client
+        .handle_transaction(txn3, Some(socket_addr))
+        .await
+        .is_ok());
+
     assert_eq!(
         epoch_store
             .signature_verifier
@@ -628,12 +675,197 @@ async fn zklogin_test_cached_proof_wrong_key() {
             .get(),
         1
     );
-    */
 
-    assert_eq!(metrics.signature_errors.get(), 1);
+    // case 4: create a multisig txn where the zklogin signature inside is already cached
+    // from the first call for the single zklogin txn. cache hits and txn verifies.
+    let sender_2 = senders[1];
+    let multisig_txn = sign_with_zklogin_inside_multisig(
+        &authority_state,
+        object_ids[11],
+        gas_object_ids[11],
+        recipient,
+        sender_2,
+        |_| {},
+        ephemeral_key,
+        zklogin,
+        2,
+        multisig_pk.clone(),
+    )
+    .await;
+    assert!(client
+        .handle_transaction(multisig_txn, Some(socket_addr))
+        .await
+        .is_ok());
 
-    object_ids.remove(0); // first object was successfully locked.
-    check_locks(authority_state, object_ids).await;
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_hits
+            .get(),
+        2
+    );
+    // case 5: use the same proof and modify ephemeral sig bytes but keep the ephemeral pk and flag as same,
+    // it fails earlier at the ephemeral sig verify check, txn fails, did not miss or hit cache.
+    let intent_message = txn.data().intent_message().clone();
+    match &mut txn.data_mut_for_testing().tx_signatures_mut_for_testing()[0] {
+        GenericSignature::ZkLoginAuthenticator(zklogin) => {
+            let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
+            let correct_sig = Signature::new_secure(&intent_message, ephemeral_key);
+            let unknown_sig = Signature::new_secure(&intent_message, &unknown_key);
+
+            // create a mutated sig with the correct flag and pk bytes, but wrong signature bytes
+            let mut mutated_bytes = vec![correct_sig.scheme().flag()];
+            mutated_bytes.extend_from_slice(unknown_sig.signature_bytes());
+            mutated_bytes.extend_from_slice(correct_sig.public_key_bytes());
+            let mutated_sig = Signature::from_bytes(&mutated_bytes).unwrap();
+            *zklogin.user_signature_mut_for_testing() = mutated_sig;
+        }
+        _ => panic!(),
+    }
+
+    assert!(matches!(
+        client
+            .handle_transaction(txn.clone(), Some(socket_addr))
+            .await
+            .unwrap_err(),
+        SuiError::InvalidSignature { .. }
+    ));
+    assert_eq!(metrics.signature_errors.get(), 2);
+
+    // cache hits unchanged
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_hits
+            .get(),
+        2
+    );
+
+    // cache misses unchanged
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_misses
+            .get(),
+        2
+    );
+
+    // case 6: use the same proof and modify max_epoch, cache misses and txn fails.
+    let mut transfer_transaction3 = init_zklogin_transfer(
+        &authority_state,
+        object_ids[4],
+        gas_object_ids[4],
+        recipient,
+        sender,
+        |_| {},
+        ephemeral_key,
+        zklogin,
+    )
+    .await;
+    match &mut transfer_transaction3
+        .data_mut_for_testing()
+        .tx_signatures_mut_for_testing()[0]
+    {
+        GenericSignature::ZkLoginAuthenticator(zklogin) => {
+            *zklogin.max_epoch_mut_for_testing() += 1; // modify max epoch
+        }
+        _ => panic!(),
+    }
+    assert!(matches!(
+        client
+            .handle_transaction(transfer_transaction3.clone(), Some(socket_addr))
+            .await
+            .unwrap_err(),
+        SuiError::InvalidSignature { .. }
+    ));
+    assert_eq!(metrics.signature_errors.get(), 3);
+
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_misses
+            .get(),
+        3
+    );
+
+    // case 7: create a multisig txn with zklogin inside where the max epoch is changed,
+    // cache misses and txn fails.
+    let multisig_txn = sign_with_zklogin_inside_multisig(
+        &authority_state,
+        object_ids[11],
+        gas_object_ids[11],
+        recipient,
+        sender_2,
+        |_| {},
+        ephemeral_key,
+        zklogin,
+        3, // modified from 2 to 3
+        multisig_pk.clone(),
+    )
+    .await;
+    assert!(matches!(
+        client
+            .handle_transaction(multisig_txn.clone(), Some(socket_addr))
+            .await
+            .unwrap_err(),
+        SuiError::InvalidSignature { .. }
+    ));
+
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_misses
+            .get(),
+        4
+    );
+
+    // case 8: use the same proof and modify zklogin_inputs.address_seed, cache misses and txn fails.
+    // use test_vectors[1] but with modified address_seed to create a bad zklogin inputs, and derive sender.
+    let zklogin_json_string =
+        &get_one_zklogin_inputs("../sui-types/src/unit_tests/zklogin_test_vectors.json");
+    let bad_zklogin_inputs = ZkLoginInputs::from_json(zklogin_json_string, "111").unwrap();
+    let sender = SuiAddress::try_from_unpadded(&bad_zklogin_inputs).unwrap();
+
+    let mut txn4 = init_zklogin_transfer(
+        &authority_state,
+        object_ids[5],
+        gas_object_ids[5],
+        recipient,
+        sender,
+        |_| {},
+        ephemeral_key,
+        zklogin,
+    )
+    .await;
+    match &mut txn4.data_mut_for_testing().tx_signatures_mut_for_testing()[0] {
+        GenericSignature::ZkLoginAuthenticator(zklogin) => {
+            *zklogin.zk_login_inputs_mut_for_testing() = bad_zklogin_inputs;
+        }
+        _ => panic!(),
+    }
+
+    assert!(matches!(
+        client
+            .handle_transaction(txn4.clone(), Some(socket_addr))
+            .await
+            .unwrap_err(),
+        SuiError::InvalidSignature { .. }
+    ));
+    assert_eq!(metrics.signature_errors.get(), 5);
+
+    assert_eq!(
+        epoch_store
+            .signature_verifier
+            .metrics
+            .zklogin_inputs_cache_misses
+            .get(),
+        5
+    );
 }
 
 async fn do_zklogin_transaction_test(
@@ -645,11 +877,13 @@ async fn do_zklogin_transaction_test(
         object_ids,
         _gas_object_id,
         authority_state,
-        _epoch_store,
+        epoch_store,
         mut transfer_transaction,
         metrics,
         _server,
         client,
+        _senders,
+        _multisig_pk,
     ) = setup_zklogin_network(pre_sign_mutations).await;
 
     post_sign_mutations(&mut transfer_transaction);
@@ -659,8 +893,6 @@ async fn do_zklogin_transaction_test(
         .await
         .is_err());
 
-    // TODO: re-enable when cache is re-enabled.
-    /*
     assert_eq!(
         epoch_store
             .signature_verifier
@@ -669,7 +901,6 @@ async fn do_zklogin_transaction_test(
             .get(),
         1
     );
-    */
 
     assert_eq!(metrics.signature_errors.get(), expected_sig_errors);
 
@@ -705,6 +936,8 @@ async fn setup_zklogin_network(
     Arc<crate::authority_server::ValidatorServiceMetrics>,
     AuthorityServerHandle,
     NetworkAuthorityClient,
+    Vec<SuiAddress>,
+    MultiSigPublicKey,
 ) {
     let (skp, _eph_pk, zklogin) =
         &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1];
@@ -712,11 +945,31 @@ async fn setup_zklogin_network(
         SuiKeyPair::Ed25519(kp) => kp,
         _ => panic!(),
     };
+
+    // a single zklogin address.
     let sender = SuiAddress::try_from_unpadded(zklogin).unwrap();
 
+    // a 1-out-2 multisig address.
+    let zklogin_pk = PublicKey::ZkLogin(
+        ZkLoginPublicIdentifier::new(zklogin.get_iss(), zklogin.get_address_seed()).unwrap(),
+    );
+    let regular_pk = skp.public();
+    let multisig_pk = MultiSigPublicKey::new(vec![zklogin_pk, regular_pk], vec![1, 1], 1).unwrap();
+    let sender_2 = SuiAddress::from(&multisig_pk);
+
     let recipient = dbg_addr(2);
-    let objects: Vec<_> = (0..10).map(|_| (sender, ObjectID::random())).collect();
-    let gas_objects: Vec<_> = (0..10).map(|_| (sender, ObjectID::random())).collect();
+    let objects: Vec<_> = (0..20)
+        .map(|i| match i < 10 {
+            true => (sender, ObjectID::random()),
+            false => (sender_2, ObjectID::random()),
+        })
+        .collect();
+    let gas_objects: Vec<_> = (0..20)
+        .map(|i| match i < 10 {
+            true => (sender, ObjectID::random()),
+            false => (sender_2, ObjectID::random()),
+        })
+        .collect();
     let object_ids: Vec<_> = objects.iter().map(|(_, id)| *id).collect();
     let gas_object_ids: Vec<_> = gas_objects.iter().map(|(_, id)| *id).collect();
 
@@ -776,6 +1029,8 @@ async fn setup_zklogin_network(
         metrics,
         server_handle,
         client,
+        vec![sender, sender_2],
+        multisig_pk,
     )
 }
 
@@ -824,6 +1079,59 @@ async fn init_zklogin_transfer(
         signature,
     ));
     tx.data_mut_for_testing().tx_signatures_mut_for_testing()[0] = authenticator;
+    tx
+}
+
+async fn sign_with_zklogin_inside_multisig(
+    authority_state: &Arc<AuthorityState>,
+    object_id: ObjectID,
+    gas_object_id: ObjectID,
+    recipient: SuiAddress,
+    sender: SuiAddress,
+    pre_sign_mutations: impl FnOnce(&mut TransactionData),
+    ephemeral_key: &Ed25519KeyPair,
+    zklogin: &ZkLoginInputs,
+    max_epoch: u64,
+    multisig_pk: MultiSigPublicKey,
+) -> sui_types::message_envelope::Envelope<SenderSignedData, sui_types::crypto::EmptySignInfo> {
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let gas_object = authority_state
+        .get_object(&gas_object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let object_ref = object.compute_object_reference();
+    let gas_object_ref = gas_object.compute_object_reference();
+    let gas_budget = rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER;
+    let mut data = TransactionData::new_transfer(
+        recipient,
+        object_ref,
+        sender,
+        gas_object_ref,
+        gas_budget,
+        rgp,
+    );
+    pre_sign_mutations(&mut data);
+    let mut tx = to_sender_signed_transaction(data, ephemeral_key);
+    let GenericSignature::Signature(signature) =
+        tx.data_mut_for_testing().tx_signatures_mut_for_testing()[0].clone()
+    else {
+        panic!();
+    };
+    let multisig = MultiSig::combine(
+        vec![GenericSignature::ZkLoginAuthenticator(
+            ZkLoginAuthenticator::new(zklogin.clone(), max_epoch, signature),
+        )],
+        multisig_pk,
+    )
+    .unwrap();
+    tx.data_mut_for_testing().tx_signatures_mut_for_testing()[0] =
+        GenericSignature::MultiSig(multisig);
     tx
 }
 
@@ -1239,7 +1547,6 @@ async fn test_handle_certificate_errors() {
         .handle_certificate_v2(ct.clone(), Some(socket_addr))
         .await
         .unwrap_err();
-
     assert_matches!(
         err,
         SuiError::WrongEpoch {

--- a/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
+++ b/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
@@ -130,7 +130,8 @@ pub(crate) async fn verify_zklogin_signature(
                 return Err(Error::Client("Tx sender mismatch author".to_string()));
             }
             let sig = GenericSignature::ZkLoginAuthenticator(zklogin_sig);
-            match sig.verify_authenticator(&intent_msg, tx_sender, curr_epoch, &verify_params) {
+            match sig.verify_authenticator(&intent_msg, tx_sender, curr_epoch, &verify_params, None)
+            {
                 Ok(_) => Ok(ZkLoginVerifyResult {
                     success: true,
                     errors: vec![],
@@ -153,7 +154,13 @@ pub(crate) async fn verify_zklogin_signature(
             );
 
             let sig = GenericSignature::ZkLoginAuthenticator(zklogin_sig);
-            match sig.verify_authenticator(&intent_msg, author.into(), curr_epoch, &verify_params) {
+            match sig.verify_authenticator(
+                &intent_msg,
+                author.into(),
+                curr_epoch,
+                &verify_params,
+                None,
+            ) {
                 Ok(_) => Ok(ZkLoginVerifyResult {
                     success: true,
                     errors: vec![],

--- a/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
+++ b/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
@@ -138,7 +138,7 @@ pub(crate) async fn verify_zklogin_signature(
                 tx_sender,
                 curr_epoch,
                 &verify_params,
-                Arc::new(VerifiedDigestCache::new_for_testing()),
+                Arc::new(VerifiedDigestCache::new_empty()),
             ) {
                 Ok(_) => Ok(ZkLoginVerifyResult {
                     success: true,
@@ -167,7 +167,7 @@ pub(crate) async fn verify_zklogin_signature(
                 author.into(),
                 curr_epoch,
                 &verify_params,
-                Arc::new(VerifiedDigestCache::new_for_testing()),
+                Arc::new(VerifiedDigestCache::new_empty()),
             ) {
                 Ok(_) => Ok(ZkLoginVerifyResult {
                     success: true,

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -119,6 +119,7 @@ pub async fn combine(
         &signed_tx,
         place_holder_epoch,
         &VerifyParams::default(),
+        None, // no need to optimize for caching in rosseta
     )?;
     let signed_tx_bytes = bcs::to_bytes(&signed_tx)?;
 

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use axum::extract::State;
 use axum::{Extension, Json};
 use axum_extra::extract::WithRejection;
@@ -18,7 +20,9 @@ use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{DefaultHash, SignatureScheme, ToFromBytes};
 use sui_types::error::SuiError;
 use sui_types::signature::{GenericSignature, VerifyParams};
-use sui_types::signature_verification::verify_sender_signed_data_message_signatures;
+use sui_types::signature_verification::{
+    verify_sender_signed_data_message_signatures, VerifiedDigestCache,
+};
 use sui_types::transaction::{Transaction, TransactionData, TransactionDataAPI};
 
 use crate::errors::Error;
@@ -119,7 +123,7 @@ pub async fn combine(
         &signed_tx,
         place_holder_epoch,
         &VerifyParams::default(),
-        None, // no need to optimize for caching in rosseta
+        Arc::new(VerifiedDigestCache::new_for_testing()), // no need to use cache in rosetta
     )?;
     let signed_tx_bytes = bcs::to_bytes(&signed_tx)?;
 

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -123,7 +123,7 @@ pub async fn combine(
         &signed_tx,
         place_holder_epoch,
         &VerifyParams::default(),
-        Arc::new(VerifiedDigestCache::new_for_testing()), // no need to use cache in rosetta
+        Arc::new(VerifiedDigestCache::new_empty()), // no need to use cache in rosetta
     )?;
     let signed_tx_bytes = bcs::to_bytes(&signed_tx)?;
 

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -70,6 +70,7 @@ derive_more.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
 better_any.workspace = true
+lru.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -96,7 +96,7 @@ impl AuthenticatorTrait for MultiSig {
         value: &IntentMessage<T>,
         multisig_address: SuiAddress,
         verify_params: &VerifyParams,
-        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+        zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) -> Result<(), SuiError>
     where
         T: Serialize,

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -3,8 +3,10 @@
 
 use crate::{
     crypto::{CompressedSignature, SignatureScheme},
+    digests::ZKLoginInputsDigest,
     multisig::{MultiSig, MultiSigPublicKey},
     signature::{AuthenticatorTrait, GenericSignature, VerifyParams},
+    signature_verification::VerifiedDigestCache,
     sui_serde::SuiBitmap,
 };
 pub use enum_dispatch::enum_dispatch;
@@ -19,7 +21,10 @@ use schemars::JsonSchema;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use shared_crypto::intent::IntentMessage;
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use crate::{
     base_types::{EpochId, SuiAddress},
@@ -105,6 +110,7 @@ impl AuthenticatorTrait for MultiSigLegacy {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
+        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
@@ -115,7 +121,7 @@ impl AuthenticatorTrait for MultiSigLegacy {
                 .map_err(|_| SuiError::InvalidSignature {
                     error: "Invalid legacy multisig".to_string(),
                 })?;
-        multisig.verify_claims(value, author, aux_verify_data)
+        multisig.verify_claims(value, author, aux_verify_data, zklogin_inputs_cache)
     }
 }
 

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -110,7 +110,7 @@ impl AuthenticatorTrait for MultiSigLegacy {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+        zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) -> Result<(), SuiError>
     where
         T: Serialize,

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -5,8 +5,10 @@ use crate::committee::EpochId;
 use crate::crypto::{
     CompressedSignature, PublicKey, SignatureScheme, SuiSignature, ZkLoginAuthenticatorAsBytes,
 };
+use crate::digests::ZKLoginInputsDigest;
 use crate::error::SuiError;
 use crate::multisig_legacy::MultiSigLegacy;
+use crate::signature_verification::VerifiedDigestCache;
 use crate::zk_login_authenticator::ZkLoginAuthenticator;
 use crate::{base_types::SuiAddress, crypto::Signature, error::SuiResult, multisig::MultiSig};
 pub use enum_dispatch::enum_dispatch;
@@ -24,6 +26,7 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use shared_crypto::intent::IntentMessage;
 use std::hash::Hash;
+use std::sync::Arc;
 #[derive(Default, Debug, Clone)]
 pub struct VerifyParams {
     // map from JwkId (iss, kid) => JWK
@@ -69,6 +72,7 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
+        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
     ) -> SuiResult
     where
         T: Serialize;
@@ -102,6 +106,7 @@ impl GenericSignature {
         author: SuiAddress,
         epoch: EpochId,
         verify_params: &VerifyParams,
+        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
     ) -> SuiResult
     where
         T: Serialize,
@@ -110,7 +115,7 @@ impl GenericSignature {
             epoch,
             verify_params.zklogin_max_epoch_upper_bound_delta,
         )?;
-        self.verify_claims(value, author, verify_params)
+        self.verify_claims(value, author, verify_params, zklogin_inputs_cache)
     }
 
     /// Parse [enum CompressedSignature] from trait SuiSignature `flag || sig || pk`.
@@ -286,6 +291,7 @@ impl AuthenticatorTrait for Signature {
         value: &IntentMessage<T>,
         author: SuiAddress,
         _aux_verify_data: &VerifyParams,
+        _zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
     ) -> SuiResult
     where
         T: Serialize,

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -72,7 +72,7 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+        zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) -> SuiResult
     where
         T: Serialize;
@@ -106,7 +106,7 @@ impl GenericSignature {
         author: SuiAddress,
         epoch: EpochId,
         verify_params: &VerifyParams,
-        zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+        zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) -> SuiResult
     where
         T: Serialize,
@@ -291,7 +291,7 @@ impl AuthenticatorTrait for Signature {
         value: &IntentMessage<T>,
         author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+        _zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
     ) -> SuiResult
     where
         T: Serialize,

--- a/crates/sui-types/src/signature_verification.rs
+++ b/crates/sui-types/src/signature_verification.rs
@@ -93,6 +93,15 @@ impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
         let mut inner = self.inner.write();
         inner.clear();
     }
+
+    // Initialize an empty cache when the cache is not needed (in testing scenarios, graphql and rosetta initialization). 
+    pub fn new_for_testing() -> Self {
+        Self::new(
+            IntCounter::new("test_cache_hits", "test cache hits").unwrap(),
+            IntCounter::new("test_cache_misses", "test cache misses").unwrap(),
+            IntCounter::new("test_cache_evictions", "test cache evictions").unwrap(),
+        )
+    }
 }
 
 /// Does crypto validation for a transaction which may be user-provided, or may be from a checkpoint.
@@ -100,7 +109,7 @@ pub fn verify_sender_signed_data_message_signatures(
     txn: &SenderSignedData,
     current_epoch: EpochId,
     verify_params: &VerifyParams,
-    zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
+    zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
 ) -> SuiResult {
     let intent_message = txn.intent_message();
     assert_eq!(intent_message.intent, Intent::sui_transaction());

--- a/crates/sui-types/src/signature_verification.rs
+++ b/crates/sui-types/src/signature_verification.rs
@@ -94,7 +94,7 @@ impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
         inner.clear();
     }
 
-    // Initialize an empty cache when the cache is not needed (in testing scenarios, graphql and rosetta initialization). 
+    // Initialize an empty cache when the cache is not needed (in testing scenarios, graphql and rosetta initialization).
     pub fn new_for_testing() -> Self {
         Self::new(
             IntCounter::new("test_cache_hits", "test cache hits").unwrap(),

--- a/crates/sui-types/src/signature_verification.rs
+++ b/crates/sui-types/src/signature_verification.rs
@@ -95,7 +95,7 @@ impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
     }
 
     // Initialize an empty cache when the cache is not needed (in testing scenarios, graphql and rosetta initialization).
-    pub fn new_for_testing() -> Self {
+    pub fn new_empty() -> Self {
         Self::new(
             IntCounter::new("test_cache_hits", "test cache hits").unwrap(),
             IntCounter::new("test_cache_misses", "test cache misses").unwrap(),

--- a/crates/sui-types/src/signature_verification.rs
+++ b/crates/sui-types/src/signature_verification.rs
@@ -5,15 +5,102 @@ use nonempty::NonEmpty;
 use shared_crypto::intent::Intent;
 
 use crate::committee::EpochId;
+use crate::digests::ZKLoginInputsDigest;
 use crate::error::{SuiError, SuiResult};
 use crate::signature::VerifyParams;
 use crate::transaction::{SenderSignedData, TransactionDataAPI};
+use lru::LruCache;
+use parking_lot::RwLock;
+use prometheus::IntCounter;
+use std::hash::Hash;
+use std::sync::Arc;
+
+// Cache up to 20000 verified certs. We will need to tune this number in the future - a decent
+// guess to start with is that it should be 10-20 times larger than peak transactions per second,
+// on the assumption that we should see most certs twice within about 10-20 seconds at most: Once via RPC, once via consensus.
+const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
+
+pub struct VerifiedDigestCache<D> {
+    inner: RwLock<LruCache<D, ()>>,
+    cache_hits_counter: IntCounter,
+    cache_misses_counter: IntCounter,
+    cache_evictions_counter: IntCounter,
+}
+
+impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
+    pub fn new(
+        cache_hits_counter: IntCounter,
+        cache_misses_counter: IntCounter,
+        cache_evictions_counter: IntCounter,
+    ) -> Self {
+        Self {
+            inner: RwLock::new(LruCache::new(
+                std::num::NonZeroUsize::new(VERIFIED_CERTIFICATE_CACHE_SIZE).unwrap(),
+            )),
+            cache_hits_counter,
+            cache_misses_counter,
+            cache_evictions_counter,
+        }
+    }
+
+    pub fn is_cached(&self, digest: &D) -> bool {
+        let inner = self.inner.read();
+        if inner.contains(digest) {
+            self.cache_hits_counter.inc();
+            true
+        } else {
+            self.cache_misses_counter.inc();
+            false
+        }
+    }
+
+    pub fn cache_digest(&self, digest: D) {
+        let mut inner = self.inner.write();
+        if let Some(old) = inner.push(digest, ()) {
+            if old.0 != digest {
+                self.cache_evictions_counter.inc();
+            }
+        }
+    }
+
+    pub fn cache_digests(&self, digests: Vec<D>) {
+        let mut inner = self.inner.write();
+        digests.into_iter().for_each(|d| {
+            if let Some(old) = inner.push(d, ()) {
+                if old.0 != d {
+                    self.cache_evictions_counter.inc();
+                }
+            }
+        });
+    }
+
+    pub fn is_verified<F, G>(&self, digest: D, verify_callback: F, uncached_checks: G) -> SuiResult
+    where
+        F: FnOnce() -> SuiResult,
+        G: FnOnce() -> SuiResult,
+    {
+        if !self.is_cached(&digest) {
+            verify_callback()?;
+            self.cache_digest(digest);
+        } else {
+            // Checks that are required to be performed outside the cache.
+            uncached_checks()?;
+        }
+        Ok(())
+    }
+
+    pub fn clear(&self) {
+        let mut inner = self.inner.write();
+        inner.clear();
+    }
+}
 
 /// Does crypto validation for a transaction which may be user-provided, or may be from a checkpoint.
 pub fn verify_sender_signed_data_message_signatures(
     txn: &SenderSignedData,
     current_epoch: EpochId,
     verify_params: &VerifyParams,
+    zklogin_inputs_cache: Option<Arc<VerifiedDigestCache<ZKLoginInputsDigest>>>,
 ) -> SuiResult {
     let intent_message = txn.intent_message();
     assert_eq!(intent_message.intent, Intent::sui_transaction());
@@ -47,7 +134,13 @@ pub fn verify_sender_signed_data_message_signatures(
 
     // 4. Every signature must be valid.
     for (signer, signature) in present_sigs {
-        signature.verify_authenticator(intent_message, signer, current_epoch, verify_params)?;
+        signature.verify_authenticator(
+            intent_message,
+            signer,
+            current_epoch,
+            verify_params,
+            zklogin_inputs_cache.clone(),
+        )?;
     }
     Ok(())
 }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2636,7 +2636,7 @@ impl Transaction {
             self.data(),
             current_epoch,
             verify_params,
-            Arc::new(VerifiedDigestCache::new_for_testing()),
+            Arc::new(VerifiedDigestCache::new_empty()),
         )
     }
 
@@ -2660,7 +2660,7 @@ impl SignedTransaction {
             self.data(),
             committee.epoch(),
             verify_params,
-            Arc::new(VerifiedDigestCache::new_for_testing()),
+            Arc::new(VerifiedDigestCache::new_empty()),
         )?;
 
         self.auth_sig().verify_secure(
@@ -2723,7 +2723,7 @@ impl CertifiedTransaction {
         self.verify_signatures_authenticated(
             committee,
             verify_params,
-            Arc::new(VerifiedDigestCache::new_for_testing()),
+            Arc::new(VerifiedDigestCache::new_empty()),
         )?;
         Ok(VerifiedCertificate::new_from_verified(self))
     }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2651,8 +2651,7 @@ impl Transaction {
 }
 
 impl SignedTransaction {
-    // used for testing only.
-    pub fn verify_signatures_authenticated(
+    pub fn verify_signatures_authenticated_for_testing(
         &self,
         committee: &Committee,
         verify_params: &VerifyParams,
@@ -2671,13 +2670,12 @@ impl SignedTransaction {
         )
     }
 
-    // used for testing only.
-    pub fn try_into_verified(
+    pub fn try_into_verified_for_testing(
         self,
         committee: &Committee,
         verify_params: &VerifyParams,
     ) -> SuiResult<VerifiedSignedTransaction> {
-        self.verify_signatures_authenticated(committee, verify_params)?;
+        self.verify_signatures_authenticated_for_testing(committee, verify_params)?;
         Ok(VerifiedSignedTransaction::new_from_verified(self))
     }
 }

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -82,7 +82,9 @@ fn test_authority_signature_intent() {
     );
     let tx = Transaction::from_data(data, vec![signature]);
     let tx1 = tx.clone();
-    assert!(tx.try_into_verified_for_testing(epoch, &Default::default()).is_ok());
+    assert!(tx
+        .try_into_verified_for_testing(epoch, &Default::default())
+        .is_ok());
 
     // Create an intent with signed data.
     let intent_bcs = bcs::to_bytes(tx1.intent_message()).unwrap();

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -82,7 +82,7 @@ fn test_authority_signature_intent() {
     );
     let tx = Transaction::from_data(data, vec![signature]);
     let tx1 = tx.clone();
-    assert!(tx.try_into_verified(epoch, &Default::default()).is_ok());
+    assert!(tx.try_into_verified_for_testing(epoch, &Default::default()).is_ok());
 
     // Create an intent with signed data.
     let intent_bcs = bcs::to_bytes(tx1.intent_message()).unwrap();

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -175,7 +175,7 @@ fn test_certificates() {
     let c =
         CertifiedTransaction::new(transaction.clone().into_message(), sigs, &committee).unwrap();
     assert!(c
-        .verify_signatures_authenticated(&committee, &Default::default())
+        .verify_signatures_authenticated(&committee, &Default::default(), None)
         .is_ok());
 
     let sigs = vec![v1.auth_sig().clone(), v3.auth_sig().clone()];
@@ -1306,7 +1306,7 @@ fn test_certificate_digest() {
 
         let cert = CertifiedTransaction::new(transaction.clone().into_message(), sigs, &committee)
             .unwrap();
-        cert.verify_signatures_authenticated(&committee, &Default::default())
+        cert.verify_signatures_authenticated(&committee, &Default::default(), None)
             .unwrap();
         cert
     };

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -180,7 +180,7 @@ fn test_certificates() {
         .verify_signatures_authenticated(
             &committee,
             &Default::default(),
-            Arc::new(VerifiedDigestCache::new_for_testing())
+            Arc::new(VerifiedDigestCache::new_empty())
         )
         .is_ok());
 
@@ -1315,7 +1315,7 @@ fn test_certificate_digest() {
         cert.verify_signatures_authenticated(
             &committee,
             &Default::default(),
-            Arc::new(VerifiedDigestCache::new_for_testing()),
+            Arc::new(VerifiedDigestCache::new_empty()),
         )
         .unwrap();
         cert

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -59,7 +59,7 @@ fn test_signed_values() {
         ),
         vec![&sender_sec],
     )
-    .try_into_verified(committee.epoch(), &Default::default())
+    .try_into_verified_testing(committee.epoch(), &Default::default())
     .unwrap();
 
     let bad_transaction = VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
@@ -80,7 +80,7 @@ fn test_signed_values() {
         &sec1,
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
-    assert!(v.try_into_verified(&committee, &Default::default()).is_ok());
+    assert!(v.try_into_verified_for_testing(&committee, &Default::default()).is_ok());
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -89,7 +89,7 @@ fn test_signed_values() {
         AuthorityPublicKeyBytes::from(sec2.public()),
     );
     assert!(v
-        .try_into_verified(&committee, &Default::default())
+        .try_into_verified_for_testing(&committee, &Default::default())
         .is_err());
 
     let v = SignedTransaction::new(
@@ -99,7 +99,7 @@ fn test_signed_values() {
         AuthorityPublicKeyBytes::from(sec3.public()),
     );
     assert!(v
-        .try_into_verified(&committee, &Default::default())
+        .try_into_verified_for_testing(&committee, &Default::default())
         .is_err());
 
     let v = SignedTransaction::new(
@@ -109,7 +109,7 @@ fn test_signed_values() {
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
     assert!(v
-        .try_into_verified(&committee, &Default::default())
+        .try_into_verified_for_testing(&committee, &Default::default())
         .is_err());
 }
 
@@ -175,7 +175,11 @@ fn test_certificates() {
     let c =
         CertifiedTransaction::new(transaction.clone().into_message(), sigs, &committee).unwrap();
     assert!(c
-        .verify_signatures_authenticated(&committee, &Default::default(), None)
+        .verify_signatures_authenticated(
+            &committee,
+            &Default::default(),
+            Arc::new(VerifiedDigestCache::new_for_testing())
+        )
         .is_ok());
 
     let sigs = vec![v1.auth_sig().clone(), v3.auth_sig().clone()];
@@ -919,7 +923,7 @@ fn verify_sender_signature_correctly_with_flag() {
     tx_data_3.gas_data_mut().owner = tx_data_3.sender();
 
     let transaction = Transaction::from_data_and_signer(tx_data, vec![&sender_kp])
-        .try_into_verified(committee.epoch(), &Default::default())
+        .try_into_verified_for_testing(committee.epoch(), &Default::default())
         .unwrap();
 
     // create tx also signed by authority
@@ -948,7 +952,7 @@ fn verify_sender_signature_correctly_with_flag() {
         .is_ok());
 
     let transaction_1 = Transaction::from_data_and_signer(tx_data_2, vec![&sender_kp_2])
-        .try_into_verified(committee.epoch(), &Default::default())
+        .try_into_verified_for_testing(committee.epoch(), &Default::default())
         .unwrap();
 
     let signed_tx_1 = SignedTransaction::new(
@@ -991,10 +995,10 @@ fn verify_sender_signature_correctly_with_flag() {
 
     // r1 signature tx verifies ok
     assert!(tx_3
-        .try_into_verified(committee.epoch(), &Default::default())
+        .try_into_verified_for_testing(committee.epoch(), &Default::default())
         .is_ok());
     let verified_tx_3 = tx_31
-        .try_into_verified(committee.epoch(), &Default::default())
+        .try_into_verified_for_testing(committee.epoch(), &Default::default())
         .unwrap();
     // r1 signature verified and accepted by authority
     let signed_tx_3 = SignedTransaction::new(
@@ -1281,7 +1285,7 @@ fn test_certificate_digest() {
             ),
             vec![&sender_sec],
         )
-        .try_into_verified(committee.epoch(), &Default::default())
+        .try_into_verified_for_testing(committee.epoch(), &Default::default())
         .unwrap()
     };
 
@@ -1306,8 +1310,12 @@ fn test_certificate_digest() {
 
         let cert = CertifiedTransaction::new(transaction.clone().into_message(), sigs, &committee)
             .unwrap();
-        cert.verify_signatures_authenticated(&committee, &Default::default(), None)
-            .unwrap();
+        cert.verify_signatures_authenticated(
+            &committee,
+            &Default::default(),
+            Arc::new(VerifiedDigestCache::new_for_testing()),
+        )
+        .unwrap();
         cert
     };
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -59,7 +59,7 @@ fn test_signed_values() {
         ),
         vec![&sender_sec],
     )
-    .try_into_verified_testing(committee.epoch(), &Default::default())
+    .try_into_verified_for_testing(committee.epoch(), &Default::default())
     .unwrap();
 
     let bad_transaction = VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
@@ -80,7 +80,9 @@ fn test_signed_values() {
         &sec1,
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
-    assert!(v.try_into_verified_for_testing(&committee, &Default::default()).is_ok());
+    assert!(v
+        .try_into_verified_for_testing(&committee, &Default::default())
+        .is_ok());
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -142,7 +144,7 @@ fn test_certificates() {
         ),
         vec![&sender_sec],
     )
-    .try_into_verified(committee.epoch(), &Default::default())
+    .try_into_verified_for_testing(committee.epoch(), &Default::default())
     .unwrap();
 
     let v1 = SignedTransaction::new(
@@ -482,7 +484,7 @@ fn test_digest_caching() {
         ),
         vec![&ssec2],
     )
-    .try_into_verified(committee.epoch(), &Default::default())
+    .try_into_verified_for_testing(committee.epoch(), &Default::default())
     .unwrap();
 
     let mut signed_tx = SignedTransaction::new(
@@ -492,7 +494,7 @@ fn test_digest_caching() {
         AuthorityPublicKeyBytes::from(sec1.public()),
     );
     assert!(signed_tx
-        .verify_signatures_authenticated(&committee, &Default::default())
+        .verify_signatures_authenticated_for_testing(&committee, &Default::default())
         .is_ok());
 
     let initial_digest = *signed_tx.digest();
@@ -606,7 +608,7 @@ fn test_user_signature_committed_in_signed_transactions() {
         gas_price,
     );
     let transaction_a = Transaction::from_data_and_signer(tx_data.clone(), vec![&sender_sec])
-        .try_into_verified(epoch, &Default::default())
+        .try_into_verified_for_testing(epoch, &Default::default())
         .unwrap();
     // transaction_b intentionally invalid (sender does not match signer).
     let transaction_b = VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
@@ -709,7 +711,7 @@ fn test_sponsored_transaction_message() {
         tx_data.clone(),
         vec![sender_sig.clone(), sponsor_sig.clone()],
     )
-    .try_into_verified(epoch, &Default::default())
+    .try_into_verified_for_testing(epoch, &Default::default())
     .unwrap();
 
     assert_eq!(
@@ -725,13 +727,13 @@ fn test_sponsored_transaction_message() {
         tx_data.clone(),
         vec![sponsor_sig.clone(), sender_sig.clone()],
     )
-    .try_into_verified(epoch, &Default::default())
+    .try_into_verified_for_testing(epoch, &Default::default())
     .unwrap();
 
     // Test incomplete signature lists (missing sponsor sig)
     assert!(matches!(
         Transaction::from_generic_sig_data(tx_data.clone(), vec![sender_sig.clone()],)
-            .try_into_verified(epoch, &Default::default())
+            .try_into_verified_for_testing(epoch, &Default::default())
             .unwrap_err(),
         SuiError::SignerSignatureNumberMismatch { .. }
     ));
@@ -739,7 +741,7 @@ fn test_sponsored_transaction_message() {
     // Test incomplete signature lists (missing sender sig)
     assert!(matches!(
         Transaction::from_generic_sig_data(tx_data.clone(), vec![sponsor_sig.clone()],)
-            .try_into_verified(epoch, &Default::default())
+            .try_into_verified_for_testing(epoch, &Default::default())
             .unwrap_err(),
         SuiError::SignerSignatureNumberMismatch { .. }
     ));
@@ -753,7 +755,7 @@ fn test_sponsored_transaction_message() {
             tx_data.clone(),
             vec![sender_sig, sponsor_sig.clone(), third_party_sig.clone()],
         )
-        .try_into_verified(epoch, &Default::default())
+        .try_into_verified_for_testing(epoch, &Default::default())
         .unwrap_err(),
         SuiError::SignerSignatureNumberMismatch { .. }
     ));
@@ -761,7 +763,7 @@ fn test_sponsored_transaction_message() {
     // Test irrelevant sigs
     assert!(matches!(
         Transaction::from_generic_sig_data(tx_data, vec![sponsor_sig, third_party_sig],)
-            .try_into_verified(epoch, &Default::default())
+            .try_into_verified_for_testing(epoch, &Default::default())
             .unwrap_err(),
         SuiError::SignerSignatureAbsent { .. }
     ));

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -11,6 +11,7 @@ use crate::{
     multisig::{as_indices, MultiSig, MAX_SIGNER_IN_MULTISIG},
     multisig_legacy::bitmap_to_u16,
     signature::{AuthenticatorTrait, GenericSignature, VerifyParams},
+    signature_verification::VerifiedDigestCache,
     utils::{
         keys, load_test_vectors, make_transaction_data, make_zklogin_tx, DEFAULT_ADDRESS_SEED,
         SHORT_ADDRESS_SEED,
@@ -31,7 +32,7 @@ use once_cell::sync::OnceCell;
 use rand::{rngs::StdRng, SeedableRng};
 use roaring::RoaringBitmap;
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 #[test]
 fn test_combine_sigs() {
     let kp1: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair().1);
@@ -418,7 +419,12 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         .collect();
 
     let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(30));
-    let res = multisig.verify_claims(intent_msg, multisig_address, &aux_verify_data, None);
+    let res = multisig.verify_claims(
+        intent_msg,
+        multisig_address,
+        &aux_verify_data,
+        Arc::new(VerifiedDigestCache::new_for_testing()),
+    );
     // since the zklogin inputs is crafted, it is expected that the proof verify failed, but all checks before passes.
     assert!(
         matches!(res, Err(crate::error::SuiError::InvalidSignature { error }) if error.contains("General cryptographic error: Groth16 proof verify failed"))
@@ -457,7 +463,7 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         intent_msg_padded,
         multisig_address_padded,
         &aux_verify_data,
-        None,
+        Arc::new(VerifiedDigestCache::new_for_testing()),
     );
     assert!(
         matches!(res, Err(crate::error::SuiError::InvalidSignature { error }) if error.contains("General cryptographic error: Groth16 proof verify failed"))

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -418,7 +418,7 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         .collect();
 
     let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(30));
-    let res = multisig.verify_claims(intent_msg, multisig_address, &aux_verify_data);
+    let res = multisig.verify_claims(intent_msg, multisig_address, &aux_verify_data, None);
     // since the zklogin inputs is crafted, it is expected that the proof verify failed, but all checks before passes.
     assert!(
         matches!(res, Err(crate::error::SuiError::InvalidSignature { error }) if error.contains("General cryptographic error: Groth16 proof verify failed"))
@@ -453,8 +453,12 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         multisig_pk_padded,
     );
 
-    let res =
-        multisig_padded.verify_claims(intent_msg_padded, multisig_address_padded, &aux_verify_data);
+    let res = multisig_padded.verify_claims(
+        intent_msg_padded,
+        multisig_address_padded,
+        &aux_verify_data,
+        None,
+    );
     assert!(
         matches!(res, Err(crate::error::SuiError::InvalidSignature { error }) if error.contains("General cryptographic error: Groth16 proof verify failed"))
     );

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -423,7 +423,7 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         intent_msg,
         multisig_address,
         &aux_verify_data,
-        Arc::new(VerifiedDigestCache::new_for_testing()),
+        Arc::new(VerifiedDigestCache::new_empty()),
     );
     // since the zklogin inputs is crafted, it is expected that the proof verify failed, but all checks before passes.
     assert!(
@@ -463,7 +463,7 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         intent_msg_padded,
         multisig_address_padded,
         &aux_verify_data,
-        Arc::new(VerifiedDigestCache::new_for_testing()),
+        Arc::new(VerifiedDigestCache::new_empty()),
     );
     assert!(
         matches!(res, Err(crate::error::SuiError::InvalidSignature { error }) if error.contains("General cryptographic error: Groth16 proof verify failed"))

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -186,6 +186,12 @@ mod zk_login {
         }
         res
     }
+    pub fn get_one_zklogin_inputs(path: &str) -> String {
+        let file = std::fs::File::open(path).expect("Unable to open file");
+
+        let test_data: Vec<TestData> = serde_json::from_reader(file).unwrap();
+        test_data[1].zklogin_inputs.clone()
+    }
 
     pub fn get_zklogin_user_address() -> SuiAddress {
         thread_local! {

--- a/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
+++ b/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
@@ -106,7 +106,7 @@ fn zklogin_sign_personal_message() {
         user_address,
         0,
         &aux_verify_data,
-        Arc::new(VerifiedDigestCache::new_for_testing()),
+        Arc::new(VerifiedDigestCache::new_empty()),
     );
     // Verify passes.
     assert!(res.is_ok());

--- a/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
+++ b/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
@@ -99,7 +99,8 @@ fn zklogin_sign_personal_message() {
 
     // Construct the required info to verify a zk login authenticator, jwks, supported providers list and env (prod/test).
     let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(30));
-    let res = authenticator.verify_authenticator(&intent_msg, user_address, 0, &aux_verify_data);
+    let res =
+        authenticator.verify_authenticator(&intent_msg, user_address, 0, &aux_verify_data, None);
     // Verify passes.
     assert!(res.is_ok());
 }

--- a/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
+++ b/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::crypto::{PublicKey, SignatureScheme, ZkLoginPublicIdentifier};
 
 use crate::signature::VerifyParams;
+use crate::signature_verification::VerifiedDigestCache;
 use crate::utils::{get_zklogin_user_address, make_zklogin_tx, sign_zklogin_personal_msg};
 use crate::utils::{load_test_vectors, SHORT_ADDRESS_SEED};
 use crate::{
@@ -99,8 +101,13 @@ fn zklogin_sign_personal_message() {
 
     // Construct the required info to verify a zk login authenticator, jwks, supported providers list and env (prod/test).
     let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(30));
-    let res =
-        authenticator.verify_authenticator(&intent_msg, user_address, 0, &aux_verify_data, None);
+    let res = authenticator.verify_authenticator(
+        &intent_msg,
+        user_address,
+        0,
+        &aux_verify_data,
+        Arc::new(VerifiedDigestCache::new_for_testing()),
+    );
     // Verify passes.
     assert!(res.is_ok());
 }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -539,6 +539,7 @@ impl KeyToolCommand {
                         address,
                         cur_epoch,
                         &VerifyParams::default(),
+                        None,
                     );
                     output.transaction_result = format!("{:?}", res);
                 };
@@ -565,6 +566,7 @@ impl KeyToolCommand {
                             tx_data.sender(),
                             cur_epoch,
                             &VerifyParams::default(),
+                            None,
                         );
                         CommandOutput::DecodeOrVerifyTx(DecodeOrVerifyTxOutput {
                             tx: tx_data,
@@ -1161,6 +1163,7 @@ impl KeyToolCommand {
                                     tx_data.execution_parts().1,
                                     cur_epoch.unwrap(),
                                     &verify_params,
+                                    None,
                                 );
                                 (serde_json::to_string(&tx_data)?, res)
                             }
@@ -1177,6 +1180,7 @@ impl KeyToolCommand {
                                     (&zk).try_into()?,
                                     cur_epoch.unwrap(),
                                     &verify_params,
+                                    None,
                                 );
                                 (serde_json::to_string(&data)?, res)
                             }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -32,6 +32,7 @@ use shared_crypto::intent::{Intent, IntentMessage, IntentScope, PersonalMessage}
 use std::fmt::{Debug, Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use sui_keys::key_derive::generate_new_key;
 use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, write_authority_keypair_to_file,
@@ -49,6 +50,7 @@ use sui_types::error::SuiResult;
 use sui_types::multisig::{MultiSig, MultiSigPublicKey, ThresholdUnit, WeightUnit};
 use sui_types::multisig_legacy::{MultiSigLegacy, MultiSigPublicKeyLegacy};
 use sui_types::signature::{GenericSignature, VerifyParams};
+use sui_types::signature_verification::VerifiedDigestCache;
 use sui_types::transaction::{TransactionData, TransactionDataAPI};
 use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use tabled::builder::Builder;
@@ -539,7 +541,7 @@ impl KeyToolCommand {
                         address,
                         cur_epoch,
                         &VerifyParams::default(),
-                        None,
+                        Arc::new(VerifiedDigestCache::new_for_testing()),
                     );
                     output.transaction_result = format!("{:?}", res);
                 };
@@ -566,7 +568,7 @@ impl KeyToolCommand {
                             tx_data.sender(),
                             cur_epoch,
                             &VerifyParams::default(),
-                            None,
+                            Arc::new(VerifiedDigestCache::new_for_testing()),
                         );
                         CommandOutput::DecodeOrVerifyTx(DecodeOrVerifyTxOutput {
                             tx: tx_data,
@@ -1163,7 +1165,7 @@ impl KeyToolCommand {
                                     tx_data.execution_parts().1,
                                     cur_epoch.unwrap(),
                                     &verify_params,
-                                    None,
+                                    Arc::new(VerifiedDigestCache::new_for_testing()),
                                 );
                                 (serde_json::to_string(&tx_data)?, res)
                             }
@@ -1180,7 +1182,7 @@ impl KeyToolCommand {
                                     (&zk).try_into()?,
                                     cur_epoch.unwrap(),
                                     &verify_params,
-                                    None,
+                                    Arc::new(VerifiedDigestCache::new_for_testing()),
                                 );
                                 (serde_json::to_string(&data)?, res)
                             }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -541,7 +541,7 @@ impl KeyToolCommand {
                         address,
                         cur_epoch,
                         &VerifyParams::default(),
-                        Arc::new(VerifiedDigestCache::new_for_testing()),
+                        Arc::new(VerifiedDigestCache::new_empty()),
                     );
                     output.transaction_result = format!("{:?}", res);
                 };
@@ -568,7 +568,7 @@ impl KeyToolCommand {
                             tx_data.sender(),
                             cur_epoch,
                             &VerifyParams::default(),
-                            Arc::new(VerifiedDigestCache::new_for_testing()),
+                            Arc::new(VerifiedDigestCache::new_empty()),
                         );
                         CommandOutput::DecodeOrVerifyTx(DecodeOrVerifyTxOutput {
                             tx: tx_data,
@@ -1165,7 +1165,7 @@ impl KeyToolCommand {
                                     tx_data.execution_parts().1,
                                     cur_epoch.unwrap(),
                                     &verify_params,
-                                    Arc::new(VerifiedDigestCache::new_for_testing()),
+                                    Arc::new(VerifiedDigestCache::new_empty()),
                                 );
                                 (serde_json::to_string(&tx_data)?, res)
                             }
@@ -1182,7 +1182,7 @@ impl KeyToolCommand {
                                     (&zk).try_into()?,
                                     cur_epoch.unwrap(),
                                     &verify_params,
-                                    Arc::new(VerifiedDigestCache::new_for_testing()),
+                                    Arc::new(VerifiedDigestCache::new_empty()),
                                 );
                                 (serde_json::to_string(&data)?, res)
                             }


### PR DESCRIPTION
## Description 

- moved the caching definition to sui-types
- pass down the zklogin cache to the authenticator trait themselves from verify_claims
- move the caching check logic inside zklogin authenticator: if hash_input is in cache, skip the verify_zklogin_inputs. otherwise, verify_zklogin_inputs, if its ok, cache it, else return error for txn and do not cache. 
- 
## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
