### PR TITLE
[ci] Add GitHub new issues workflow for Slack

### DIFF
--- a/.github/workflows/github-issues-monitor.yml
+++ b/.github/workflows/github-issues-monitor.yml
@@ -23,7 +23,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "New Issue *${{ github.event.issue.number }}* opened by *${{ github.event.issue.user.login }}* \n Please assign the right team member to this issue and mark this Slack message with :white_check_mark: once done."
+                  "text": "New GitHub issue <https://github.com/MystenLabs/sui/issues/${{ github.event.issue.number }}|${{ github.event.issue.number }}> opened by <https://github.com/${{ github.event.issue.user.login }}|${{ github.event.issue.user.login }}. \n Please assign this issue to a team member on GitHub and mark this Slack message with :white_check_mark: once done."
                 }
               }
             ]


### PR DESCRIPTION
## Description 

Adds a workflow that is triggered when a new GitHub issue is opened and sends a message on the Slack channel.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
