### PR TITLE
Tweaks for random beacon from code walkthrough

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2561,10 +2561,10 @@ impl AuthorityPerEpochStore {
                     + previously_deferred_tx_digests.len(),
             );
 
-        let mut randomness_manager = match self.randomness_manager.get() {
-            Some(rm) => Some(rm.lock().await),
-            None => None,
-        };
+        let mut randomness_manager = self.randomness_manager.get().map(|rm| {
+            rm.try_lock()
+                .expect("should only ever be called from the commit handler thread")
+        });
         let mut dkg_failed = false;
         let randomness_round = if self.randomness_state_enabled() {
             let randomness_manager = randomness_manager

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -89,11 +89,8 @@ impl SharedObjectCongestionTracker {
                     previous_key.deferred_from_round(),
                 )
             } else {
-                // There are two cases where we can end up here:
-                // 1. This transaction has not been deferred before.
-                // 2. This transaction has been deferred due to randomness.
-                // In both case, we use the current commit round as the deferred_from_round.
-                // TODO: preserve deferred_from_round if tx was previously deferred due to randomness.
+                // This transaction has not been deferred before. Use the current commit round
+                // as the deferred_from_round.
                 DeferralKey::new_for_consensus_round(commit_round + 1, commit_round)
             };
         Some((deferral_key, congested_objects))
@@ -329,7 +326,7 @@ mod object_cost_tests {
         previously_deferred_tx_digests.insert(
             *tx.digest(),
             DeferralKey::Randomness {
-                deferred_from_round: 5,
+                deferred_from_round: 4,
             },
         );
 
@@ -347,7 +344,7 @@ mod object_cost_tests {
             10,
         ) {
             assert_eq!(future_round, 11);
-            assert_eq!(deferred_from_round, 5);
+            assert_eq!(deferred_from_round, 4);
         } else {
             panic!("should defer");
         }

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -339,7 +339,7 @@ mod object_cost_tests {
             },
         );
 
-        // New deferral key should have deferred_from_round equal to the current round.
+        // New deferral key should have deferred_from_round equal to the deferred randomness round.
         if let Some((
             DeferralKey::ConsensusRound {
                 future_round,
@@ -353,7 +353,7 @@ mod object_cost_tests {
             10,
         ) {
             assert_eq!(future_round, 11);
-            assert_eq!(deferred_from_round, 10);
+            assert_eq!(deferred_from_round, 5);
         } else {
             panic!("should defer");
         }

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -84,16 +84,10 @@ impl SharedObjectCongestionTracker {
         let deferral_key =
             if let Some(previous_key) = previously_deferred_tx_digests.get(cert.digest()) {
                 // This transaction has been deferred in previous consensus commit. Use its previous deferred_from_round.
-                let deferred_from_round = match previous_key {
-                    DeferralKey::ConsensusRound {
-                        future_round: _,
-                        deferred_from_round,
-                    } => deferred_from_round,
-                    DeferralKey::Randomness {
-                        deferred_from_round,
-                    } => deferred_from_round,
-                };
-                DeferralKey::new_for_consensus_round(commit_round + 1, *deferred_from_round)
+                DeferralKey::new_for_consensus_round(
+                    commit_round + 1,
+                    previous_key.deferred_from_round(),
+                )
             } else {
                 // There are two cases where we can end up here:
                 // 1. This transaction has not been deferred before.

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -436,7 +436,7 @@ impl RandomnessManager {
                     epoch_store
                         .metrics
                         .epoch_random_beacon_dkg_num_shares
-                        .set(output.shares.as_ref().map_or(0, |shares| shares.len()) as i64);
+                        .set(num_shares as i64);
                     epoch_store
                         .metrics
                         .epoch_random_beacon_dkg_epoch_start_completion_time_ms

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1964,7 +1964,7 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.random_beacon = true;
                         cfg.random_beacon_reduction_lower_bound = Some(1600);
-                        cfg.random_beacon_dkg_timeout_round = Some(200);
+                        cfg.random_beacon_dkg_timeout_round = Some(3000);
                         cfg.random_beacon_min_round_interval_ms = Some(150);
                     }
                     // Only enable consensus digest in consensus commit prologue in devnet.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_32.snap
@@ -211,6 +211,6 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_33.snap
@@ -213,6 +213,6 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_34.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_34.snap
@@ -213,6 +213,6 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_35.snap
@@ -217,6 +217,6 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
@@ -249,7 +249,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_37.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_37.snap
@@ -250,7 +250,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_38.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_38.snap
@@ -265,7 +265,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_39.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_39.snap
@@ -265,7 +265,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_40.snap
@@ -265,7 +265,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_41.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_41.snap
@@ -265,7 +265,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
@@ -265,7 +265,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_43.snap
@@ -267,7 +267,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_44.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_44.snap
@@ -268,7 +268,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_45.snap
@@ -269,7 +269,7 @@ max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 random_beacon_reduction_lower_bound: 1600
-random_beacon_dkg_timeout_round: 200
+random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 150
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456


### PR DESCRIPTION
Most substantive:
- Longer delay until DKG failure.
- Preserve original deferral round when randomness-deferred tx becomes congestion-deferred tx and vice versa.