### PR TITLE
[GraphQL] Fix GraphiQL not loading on the new routes

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -245,7 +245,18 @@ impl ServerBuilder {
 
     pub fn route(mut self, path: &str, method_handler: MethodRouter) -> Self {
         self.init_router();
-        self.router = self.router.map(|router| router.route(path, method_handler));
+        self.router = self.router.map(|router| {
+            router
+                .route(path, method_handler)
+                .route_layer(middleware::from_fn_with_state(
+                    self.state.version,
+                    set_version_middleware,
+                ))
+                .route_layer(middleware::from_fn_with_state(
+                    self.state.version,
+                    check_version_middleware,
+                ))
+        });
         self
     }
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -228,14 +228,6 @@ impl ServerBuilder {
                 .route("/graphql/:version", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
                 .with_state(self.state.clone())
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    set_version_middleware,
-                ))
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    check_version_middleware,
-                ))
                 .route_layer(CallbackLayer::new(MetricsMakeCallbackHandler {
                     metrics: self.state.metrics.clone(),
                 }));

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -40,7 +40,9 @@ async fn start_graphiql_server_impl(
     // Add GraphiQL IDE handler on GET request to `/`` endpoint
     let server = server_builder
         .route("/", axum::routing::get(graphiql))
+        .route("/:version", axum::routing::get(graphiql))
         .route("/graphql", axum::routing::get(graphiql))
+        .route("/graphql/:version", axum::routing::get(graphiql))
         .layer(axum::extract::Extension(Some(ide_title)))
         .build()?;
 


### PR DESCRIPTION
## Description 

 Fix GraphiQL not loading on the new routes: `/:version` & `graphql/:version`

## Test plan 

Existing tests & manual tests in the browser:
```bash
http://127.0.0.1:8000/graphql/beta
http://127.0.0.1:8000/graphql/stable
http://127.0.0.1:8000/graphql/legacy
http://127.0.0.1:8000/graphql/2024.7
http://127.0.0.1:8000/beta
http://127.0.0.1:8000/stable
http://127.0.0.1:8000/legacy
http://127.0.0.1:8000/2024.7
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
