### PR TITLE
[core] More cleanup on transaction validity check

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -844,10 +844,6 @@ impl AuthorityState {
         let tx_digest = transaction.digest();
         let tx_data = transaction.data().transaction_data();
 
-        // Cheap validity checks for a transaction, including input size limits.
-        tx_data.check_version_supported(epoch_store.protocol_config())?;
-        tx_data.validity_check(epoch_store.protocol_config())?;
-
         let input_object_kinds = tx_data.input_objects()?;
         let receiving_objects_refs = tx_data.receiving_objects();
 
@@ -882,9 +878,7 @@ impl AuthorityState {
             &self.metrics.bytecode_verifier_metrics,
         )?;
 
-        if epoch_store.coin_deny_list_state_enabled() {
-            self.check_coin_deny(tx_data.sender(), &checked_input_objects, &receiving_objects)?;
-        }
+        self.check_coin_deny(tx_data.sender(), &checked_input_objects, &receiving_objects)?;
 
         let owned_objects = checked_input_objects.inner().filter_owned_objects();
 
@@ -913,17 +907,10 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
     ) -> SuiResult<HandleTransactionResponse> {
-        // CRITICAL! Validators should never sign an external system transaction.
-        fp_ensure!(
-            !transaction.is_system_tx(),
-            SuiError::InvalidSystemTransaction
-        );
-
         let tx_digest = *transaction.digest();
         debug!("handle_transaction");
 
-        // Ensure an idempotent answer. This is checked before the system_tx check so that
-        // a validator is able to return the signed system tx if it was already signed locally.
+        // Ensure an idempotent answer.
         if let Some((_, status)) = self.get_transaction_status(&tx_digest, epoch_store)? {
             return Ok(HandleTransactionResponse { status });
         }
@@ -942,14 +929,6 @@ impl AuthorityState {
             .should_accept_user_certs()
         {
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
-        }
-
-        // Checks to see if the transaction has expired
-        if match &transaction.inner().data().transaction_data().expiration() {
-            TransactionExpiration::None => false,
-            TransactionExpiration::Epoch(epoch) => *epoch < epoch_store.epoch(),
-        } {
-            return Err(SuiError::TransactionExpired);
         }
 
         let signed = self.handle_transaction_impl(transaction, epoch_store).await;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -878,7 +878,9 @@ impl AuthorityState {
             &self.metrics.bytecode_verifier_metrics,
         )?;
 
-        self.check_coin_deny(tx_data.sender(), &checked_input_objects, &receiving_objects)?;
+        if epoch_store.coin_deny_list_state_enabled() {
+            self.check_coin_deny(tx_data.sender(), &checked_input_objects, &receiving_objects)?;
+        }
 
         let owned_objects = checked_input_objects.inner().filter_owned_objects();
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1740,7 +1740,7 @@ impl AuthorityPerEpochStore {
         if !dkg_failed
             && !generating_randomness
             && self.randomness_state_enabled()
-            && cert.is_randomness_reader()
+            && cert.uses_randomness()
         {
             return Some((
                 DeferralKey::new_for_randomness(commit_round),
@@ -3203,10 +3203,7 @@ impl AuthorityPerEpochStore {
                     return Ok(ConsensusCertificateResult::Deferred(deferral_key));
                 }
 
-                if dkg_failed
-                    && self.randomness_state_enabled()
-                    && certificate.is_randomness_reader()
-                {
+                if dkg_failed && self.randomness_state_enabled() && certificate.uses_randomness() {
                     // TODO: Cancel these immediately instead of waiting until end of epoch.
                     debug!(
                         "Ignoring randomness-using certificate for transaction {:?} because DKG failed",

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -576,7 +576,7 @@ impl ValidatorService {
         // Being double cautious to also check this for certificates even though we have
         // already checked when signing transactions.
         Self::transaction_validity_check(&epoch_store, certificate.data()).tap_err(|err| {
-            // TODO: This is an invariant violation.
+            // TODO: Send invariant violation metric in release mode; panic in debug mode.
             error!(
                 "INVARIANT VIOLATION: Transaction validity check failed for certificate: {:?}",
                 err
@@ -610,7 +610,7 @@ impl ValidatorService {
         // Being double cautious to also check this for certificates even though we have
         // already checked when signing transactions.
         Self::transaction_validity_check(&epoch_store, certificate.data()).tap_err(|err| {
-            // TODO: This is an invariant violation.
+            // TODO: Send invariant violation metric in release mode; panic in debug mode.
             error!(
                 "INVARIANT VIOLATION: Transaction validity check failed for certificate: {:?}",
                 err

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -766,7 +766,7 @@ impl SequencedConsensusTransaction {
         else {
             return false;
         };
-        certificate.is_randomness_reader()
+        certificate.uses_randomness()
     }
 
     pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -34,14 +34,12 @@ use sui_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
     SupportedProtocolVersions,
 };
-use sui_types::digests::ConsensusCommitDigest;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::effects::TransactionEffects;
 use sui_types::epoch_data::EpochData;
 use sui_types::error::UserInputError;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
-use sui_types::messages_consensus::{ConsensusCommitPrologue, ConsensusCommitPrologueV2};
 use sui_types::object::Data;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
@@ -2976,79 +2974,6 @@ async fn test_idempotent_reversed_confirmation() {
             .into_effects_for_testing()
             .into_data()
     );
-}
-
-#[tokio::test]
-async fn test_refusal_to_sign_consensus_commit_prologue() {
-    // The system should refuse to handle sender-signed system transactions
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    let authority_state = init_state_with_objects(vec![gas_object.clone()]).await;
-    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-
-    let gas_ref = gas_object.compute_object_reference();
-    let tx_data = TransactionData::new(
-        TransactionKind::ConsensusCommitPrologue(ConsensusCommitPrologue {
-            epoch: 0,
-            round: 0,
-            commit_timestamp_ms: 42,
-        }),
-        sender,
-        gas_ref,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC * rgp,
-        rgp,
-    );
-
-    // Sender is able to sign it.
-    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = epoch_store.verify_transaction(transaction).unwrap();
-
-    // But the authority should refuse to handle it.
-    assert!(matches!(
-        authority_state
-            .handle_transaction(&epoch_store, transaction)
-            .await,
-        Err(SuiError::InvalidSystemTransaction),
-    ));
-}
-
-#[tokio::test]
-async fn test_refusal_to_sign_consensus_commit_prologue_v2() {
-    // The system should refuse to handle sender-signed system transactions
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    let authority_state = init_state_with_objects(vec![gas_object.clone()]).await;
-    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-
-    let gas_ref = gas_object.compute_object_reference();
-    let tx_data = TransactionData::new(
-        TransactionKind::ConsensusCommitPrologueV2(ConsensusCommitPrologueV2 {
-            epoch: 0,
-            round: 0,
-            commit_timestamp_ms: 42,
-            consensus_commit_digest: ConsensusCommitDigest::default(),
-        }),
-        sender,
-        gas_ref,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC * rgp,
-        rgp,
-    );
-
-    // Sender is able to sign it.
-    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = epoch_store.verify_transaction(transaction).unwrap();
-
-    // But the authority should refuse to handle it.
-    assert!(matches!(
-        authority_state
-            .handle_transaction(&epoch_store, transaction)
-            .await,
-        Err(SuiError::InvalidSystemTransaction),
-    ));
 }
 
 #[tokio::test]

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -96,29 +96,21 @@ async fn test_transaction_expiration() {
     let mut expired_data = data.clone();
     *expired_data.expiration_mut_for_testing() = TransactionExpiration::Epoch(0);
     let expired_transaction = test_cluster.wallet.sign_transaction(&expired_data);
-    let authority = test_cluster.swarm.validator_node_handles().pop().unwrap();
-    let result = authority
-        .with_async(|node| async {
-            let epoch_store = node.state().epoch_store_for_testing();
-            let state = node.state();
-            let expired_transaction = epoch_store.verify_transaction(expired_transaction).unwrap();
-            state
-                .handle_transaction(&epoch_store, expired_transaction)
-                .await
-        })
+    let result = test_cluster
+        .wallet
+        .execute_transaction_may_fail(expired_transaction)
         .await;
-    assert!(matches!(result.unwrap_err(), SuiError::TransactionExpired));
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains(&SuiError::TransactionExpired.to_string()));
 
     // Non expired transaction signed without issue
     *data.expiration_mut_for_testing() = TransactionExpiration::Epoch(10);
     let transaction = test_cluster.wallet.sign_transaction(&data);
-    authority
-        .with_async(|node| async {
-            let epoch_store = node.state().epoch_store_for_testing();
-            let state = node.state();
-            let transaction = epoch_store.verify_transaction(transaction).unwrap();
-            state.handle_transaction(&epoch_store, transaction).await
-        })
+    test_cluster
+        .wallet
+        .execute_transaction_may_fail(transaction)
         .await
         .unwrap();
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -393,8 +393,6 @@ pub enum SuiError {
     },
     #[error("Transaction is already finalized but with different user signatures")]
     TxAlreadyFinalizedWithDifferentUserSigs,
-    #[error("System Transaction not accepted")]
-    InvalidSystemTransaction,
 
     // Account access
     #[error("Invalid authenticator")]


### PR DESCRIPTION
## Description 

1. We only call validity_check once on a transaction.
2. Make the validity_check path identical for all cases.
3. Remove some out-of-dated comments
4. Also check transaction expiration during validity check.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
