### PR TITLE
[move] Split bytecode's absint into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,6 +6575,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-abstract-interpreter-v2"
+version = "0.1.0"
+dependencies = [
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
+]
+
+[[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
 
@@ -6647,7 +6655,7 @@ dependencies = [
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
 dependencies = [
- "move-abstract-interpreter",
+ "move-abstract-interpreter-v2",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -6661,7 +6669,7 @@ dependencies = [
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
 dependencies = [
- "move-abstract-interpreter",
+ "move-abstract-interpreter-v2",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -6675,7 +6683,7 @@ dependencies = [
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
 dependencies = [
- "move-abstract-interpreter",
+ "move-abstract-interpreter-v2",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -12470,6 +12478,8 @@ name = "sui-execution"
 version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.15.4",
+ "move-abstract-interpreter",
+ "move-abstract-interpreter-v2",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6567,6 +6567,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "move-abstract-interpreter"
+version = "0.1.0"
+dependencies = [
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
+]
+
+[[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
 
@@ -6616,6 +6624,7 @@ dependencies = [
 name = "move-bytecode-verifier"
 version = "0.1.0"
 dependencies = [
+ "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -6638,6 +6647,7 @@ dependencies = [
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
 dependencies = [
+ "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -6651,6 +6661,7 @@ dependencies = [
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
 dependencies = [
+ "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -6664,6 +6675,7 @@ dependencies = [
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
 dependencies = [
+ "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -6806,6 +6818,7 @@ dependencies = [
  "clap",
  "codespan",
  "colored",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -6824,6 +6837,7 @@ dependencies = [
  "clap",
  "colored",
  "hex",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -6868,6 +6882,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -14193,6 +14208,7 @@ dependencies = [
 name = "sui-verifier-latest"
 version = "0.1.0"
 dependencies = [
+ "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
   "external-crates/move/crates/invalid-mutations",
   "external-crates/move/crates/language-benchmarks",
   "external-crates/move/crates/module-generation",
+  "external-crates/move/crates/move-abstract-interpreter",
   "external-crates/move/crates/move-abstract-stack",
   "external-crates/move/crates/move-analyzer",
   "external-crates/move/crates/move-binary-format",
@@ -556,6 +557,7 @@ move-ir-types = { path = "external-crates/move/crates/move-ir-types" }
 move-prover = { path = "external-crates/move/crates/move-prover" }
 move-stackless-bytecode = { path = "external-crates/move/crates/move-stackless-bytecode" }
 move-symbol-pool = { path = "external-crates/move/crates/move-symbol-pool" }
+move-abstract-interpreter = { path = "external-crates/move/crates/move-abstract-interpreter" }
 move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "878492bd2541dce1491791bcadf3cc855ddcdc05" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ exclude = [
   "external-crates/move/move-execution/v1/crates/move-bytecode-verifier",
   "external-crates/move/move-execution/v1/crates/move-stdlib-natives",
   "external-crates/move/move-execution/v1/crates/move-vm-runtime",
+  "external-crates/move/move-execution/v2/crates/move-abstract-interpreter",
   "external-crates/move/move-execution/v2/crates/move-bytecode-verifier",
   "external-crates/move/move-execution/v2/crates/move-stdlib-natives",
   "external-crates/move/move-execution/v2/crates/move-vm-runtime",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -335,6 +335,7 @@ version = "0.1.0"
 dependencies = [
  "fail",
  "hex",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
@@ -349,6 +350,7 @@ version = "0.1.0"
 dependencies = [
  "fail",
  "hex",
+ "move-abstract-interpreter-v2",
  "move-binary-format",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
@@ -363,6 +365,7 @@ version = "0.1.0"
 dependencies = [
  "fail",
  "hex",
+ "move-abstract-interpreter-v2",
  "move-binary-format",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v1",
@@ -377,6 +380,7 @@ version = "0.1.0"
 dependencies = [
  "fail",
  "hex",
+ "move-abstract-interpreter-v2",
  "move-binary-format",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v2",
@@ -1553,6 +1557,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-abstract-interpreter"
+version = "0.1.0"
+dependencies = [
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
+]
+
+[[package]]
+name = "move-abstract-interpreter-v2"
+version = "0.1.0"
+dependencies = [
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
+]
+
+[[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
 
@@ -1633,6 +1653,7 @@ name = "move-bytecode-verifier"
 version = "0.1.0"
 dependencies = [
  "hex-literal",
+ "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -1656,6 +1677,7 @@ name = "move-bytecode-verifier-v0"
 version = "0.1.0"
 dependencies = [
  "hex-literal",
+ "move-abstract-interpreter-v2",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -1670,6 +1692,7 @@ name = "move-bytecode-verifier-v1"
 version = "0.1.0"
 dependencies = [
  "hex-literal",
+ "move-abstract-interpreter-v2",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -1684,6 +1707,7 @@ name = "move-bytecode-verifier-v2"
 version = "0.1.0"
 dependencies = [
  "hex-literal",
+ "move-abstract-interpreter-v2",
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
@@ -1840,6 +1864,7 @@ dependencies = [
  "clap 4.4.1",
  "codespan",
  "colored",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -1858,6 +1883,7 @@ dependencies = [
  "clap 4.4.1",
  "colored",
  "hex",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -1919,6 +1945,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap 4.4.1",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -132,6 +132,7 @@ bytecode-interpreter-crypto = { path = "crates/bytecode-interpreter-crypto" }
 enum-compat-util = { path = "crates/enum-compat-util"}
 invalid-mutations = { path = "crates/invalid-mutations" }
 module-generation = { path = "crates/module-generation" }
+move-abstract-interpreter = { path = "crates/move-abstract-interpreter" }
 move-abstract-stack = { path = "crates/move-abstract-stack" }
 move-binary-format = { path = "crates/move-binary-format" }
 move-borrow-graph = { path = "crates/move-borrow-graph" }

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "move-execution/v1/crates/move-stdlib-natives",
     "move-execution/v2/crates/move-stdlib-natives",
     # "move-execution/$CUT/crates/move-stdlib-natives",
+    "move-execution/v2/crates/move-abstract-interpreter",
+    # "move-execution/$CUT/crates/move-abstract-interpreter",
 ]
 
 # Dependencies that should be kept in sync through the whole workspace

--- a/external-crates/move/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,6 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier" }
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
+move-abstract-interpreter.workspace = true
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{control_flow_graph::VMControlFlowGraph, file_format::Bytecode};
+use move_abstract_interpreter::control_flow_graph::VMControlFlowGraph;
+use move_binary_format::file_format::Bytecode;
 use move_bytecode_verifier::loop_summary::{LoopPartition, LoopSummary};
 
 macro_rules! assert_node {

--- a/external-crates/move/crates/move-abstract-interpreter/Cargo.toml
+++ b/external-crates/move/crates/move-abstract-interpreter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "move-abstract-interpreter"
+version = "0.1.0"
+authors = ["The Move Contributors"]
+description = "Move abstract interpreter"
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+move-binary-format.workspace = true
+move-bytecode-verifier-meter.workspace = true
+
+[features]
+default = []

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -2,8 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
     errors::PartialVMResult,
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the control-flow graph uses for bytecode verification.
-use crate::file_format::{Bytecode, CodeOffset};
+use move_binary_format::file_format::{Bytecode, CodeOffset};
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 // BTree/Hash agnostic type wrappers

--- a/external-crates/move/crates/move-abstract-interpreter/src/lib.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod absint;
+pub mod control_flow_graph;
+
+#[cfg(test)]
+mod unit_tests;

--- a/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/control_flow_graph_tests.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/control_flow_graph_tests.rs
@@ -1,10 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
-    file_format::Bytecode,
-};
+use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_binary_format::file_format::Bytecode;
 
 #[test]
 fn traversal_no_loops() {

--- a/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod control_flow_graph_tests;

--- a/external-crates/move/crates/move-binary-format/src/lib.rs
+++ b/external-crates/move/crates/move-binary-format/src/lib.rs
@@ -12,7 +12,6 @@ pub mod compatibility;
 #[macro_use]
 pub mod errors;
 pub mod constant;
-pub mod control_flow_graph;
 pub mod deserializer;
 pub mod file_format;
 pub mod file_format_common;

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/mod.rs
@@ -5,7 +5,6 @@
 mod binary_limits_tests;
 mod binary_tests;
 mod compatibility_tests;
-mod control_flow_graph_tests;
 mod deserializer_tests;
 mod number_tests;
 mod signature_token_tests;

--- a/external-crates/move/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/crates/move-bytecode-verifier/Cargo.toml
@@ -18,6 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
+move-abstract-interpreter.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -6,11 +6,11 @@
 //! The overall verification is split between stack_usage_verifier.rs and
 //! abstract_interpreter.rs. CodeUnitVerifier simply orchestrates calls into these two files.
 use crate::{
-    absint::FunctionContext, acquires_list_verifier::AcquiresVerifier, control_flow, locals_safety,
-    reference_safety, stack_usage_verifier::StackUsageVerifier, type_safety,
+    acquires_list_verifier::AcquiresVerifier, control_flow, locals_safety, reference_safety,
+    stack_usage_verifier::StackUsageVerifier, type_safety,
 };
+use move_abstract_interpreter::{absint::FunctionContext, control_flow_graph::ControlFlowGraph};
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
         CompiledModule, FunctionDefinition, FunctionDefinitionIndex, IdentifierIndex, TableIndex,

--- a/external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs
@@ -13,10 +13,10 @@
 //!
 //! For bytecode versions 5 and below, delegates to `control_flow_v5`.
 use crate::{
-    absint::FunctionContext,
     control_flow_v5,
     loop_summary::{LoopPartition, LoopSummary},
 };
+use move_abstract_interpreter::absint::FunctionContext;
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{CodeOffset, CodeUnit, FunctionDefinition, FunctionDefinitionIndex},

--- a/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
@@ -8,7 +8,6 @@
 
 // Bounds checks are implemented in the `vm` crate.
 pub mod ability_field_requirements;
-pub mod absint;
 pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod constants;

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/abstract_state.rs
@@ -4,7 +4,7 @@
 
 //! This module defines the abstract state for the local safety analysis.
 
-use crate::absint::{AbstractDomain, FunctionContext, JoinResult};
+use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex},

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -8,11 +8,9 @@
 
 mod abstract_state;
 
-use crate::{
-    absint::{AbstractInterpreter, FunctionContext, TransferFunctions},
-    locals_safety::abstract_state::{RET_PER_LOCAL_COST, STEP_BASE_COST},
-};
+use crate::locals_safety::abstract_state::{RET_PER_LOCAL_COST, STEP_BASE_COST};
 use abstract_state::{AbstractState, LocalState};
+use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeOffset},

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 /// Dense index into nodes in the same `LoopSummary`

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the abstract state for the type and memory safety analysis.
-use crate::absint::{AbstractDomain, FunctionContext, JoinResult};
+use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -10,13 +10,11 @@
 
 mod abstract_state;
 
-use crate::{
-    absint::{AbstractInterpreter, FunctionContext, TransferFunctions},
-    reference_safety::abstract_state::{
-        STEP_BASE_COST, STEP_PER_GRAPH_ITEM_COST, STEP_PER_LOCAL_COST,
-    },
+use crate::reference_safety::abstract_state::{
+    STEP_BASE_COST, STEP_PER_GRAPH_ITEM_COST, STEP_PER_LOCAL_COST,
 };
 use abstract_state::{AbstractState, AbstractValue};
+use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},

--- a/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -9,9 +9,11 @@
 //! the stack height by the number of values returned by the function as indicated in its
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
-use crate::absint::FunctionContext;
-use move_binary_format::{
+use move_abstract_interpreter::{
+    absint::FunctionContext,
     control_flow_graph::{BlockId, ControlFlowGraph},
+};
+use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
     CompiledModule,

--- a/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
@@ -7,10 +7,9 @@
 
 use std::num::NonZeroU64;
 
-use crate::absint::FunctionContext;
+use move_abstract_interpreter::{absint::FunctionContext, control_flow_graph::ControlFlowGraph};
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{PartialVMError, PartialVMResult},
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CompiledModule, FieldHandleIndex,

--- a/external-crates/move/crates/move-coverage/Cargo.toml
+++ b/external-crates/move/crates/move-coverage/Cargo.toml
@@ -24,6 +24,7 @@ move-core-types.workspace = true
 move-ir-types.workspace = true
 move-binary-format.workspace = true
 move-bytecode-source-map.workspace = true
+move-abstract-interpreter.workspace = true
 
 [features]
 default = []

--- a/external-crates/move/crates/move-coverage/src/summary.rs
+++ b/external-crates/move/crates/move-coverage/src/summary.rs
@@ -7,8 +7,10 @@
 use crate::coverage_map::{
     ExecCoverageMap, ExecCoverageMapWithModules, ModuleCoverageMap, TraceMap,
 };
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
     file_format::{Bytecode, CodeOffset},
     CompiledModule,
 };

--- a/external-crates/move/crates/move-disassembler/Cargo.toml
+++ b/external-crates/move/crates/move-disassembler/Cargo.toml
@@ -18,6 +18,7 @@ move-ir-types.workspace = true
 move-binary-format.workspace = true
 move-coverage.workspace = true
 move-compiler.workspace = true
+move-abstract-interpreter.workspace = true
 
 bcs.workspace = true
 clap.workspace = true

--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use anyhow::{bail, format_err, Result};
 use clap::Parser;
 use colored::*;
+use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
 use move_binary_format::{
-    control_flow_graph::{ControlFlowGraph, VMControlFlowGraph},
     file_format::{
         Ability, AbilitySet, Bytecode, CodeUnit, Constant, FieldHandleIndex, FunctionDefinition,
         FunctionDefinitionIndex, FunctionHandle, ModuleHandle, Signature, SignatureIndex,

--- a/external-crates/move/crates/move-ir-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-ir-compiler/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+move-abstract-interpreter.workspace = true
 move-bytecode-verifier.workspace = true
 move-command-line-common.workspace = true
 move-ir-to-bytecode.workspace = true

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::unit_tests::testutils::compile_module_string;
-use move_binary_format::{
-    control_flow_graph::{ControlFlowGraph, VMControlFlowGraph},
-    file_format::Bytecode,
-};
+use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
+use move_binary_format::file_format::Bytecode;
 
 #[test]
 fn cfg_compile_script_ret() {

--- a/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,6 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier", package = "move-b
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
+move-abstract-interpreter.workspace = true
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,7 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier", package = "move-b
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
-move-abstract-interpreter.workspace = true
+move-abstract-interpreter = { path = "../../../v2/crates/move-abstract-interpreter", package = "move-abstract-interpreter-v2" }
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
+++ b/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{control_flow_graph::VMControlFlowGraph, file_format::Bytecode};
+use move_abstract_interpreter::control_flow_graph::VMControlFlowGraph;
+use move_binary_format::file_format::Bytecode;
 use move_bytecode_verifier::loop_summary::{LoopPartition, LoopSummary};
 
 macro_rules! assert_node {

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/Cargo.toml
@@ -18,7 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
-move-abstract-interpreter.workspace = true
+move-abstract-interpreter = { path = "../../../v2/crates/move-abstract-interpreter", package = "move-abstract-interpreter-v2" }
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/Cargo.toml
@@ -18,6 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
+move-abstract-interpreter.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/absint.rs
@@ -2,8 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
     errors::PartialVMResult,
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -9,8 +9,8 @@ use crate::{
     absint::FunctionContext, acquires_list_verifier::AcquiresVerifier, control_flow, locals_safety,
     reference_safety, stack_usage_verifier::StackUsageVerifier, type_safety,
 };
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
         CompiledModule, FunctionDefinition, FunctionDefinitionIndex, IdentifierIndex, TableIndex,

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 /// Dense index into nodes in the same `LoopSummary`

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -10,8 +10,8 @@
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
 use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::{BlockId, ControlFlowGraph};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph},
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
     CompiledModule,

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/type_safety.rs
@@ -8,9 +8,9 @@
 use std::num::NonZeroU64;
 
 use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{PartialVMError, PartialVMResult},
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CompiledModule, FieldHandleIndex,

--- a/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,6 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier", package = "move-b
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
+move-abstract-interpreter.workspace = true
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,7 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier", package = "move-b
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
-move-abstract-interpreter.workspace = true
+move-abstract-interpreter = { path = "../../../v2/crates/move-abstract-interpreter", package = "move-abstract-interpreter-v2" }
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
+++ b/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{control_flow_graph::VMControlFlowGraph, file_format::Bytecode};
+use move_abstract_interpreter::control_flow_graph::VMControlFlowGraph;
+use move_binary_format::file_format::Bytecode;
 use move_bytecode_verifier::loop_summary::{LoopPartition, LoopSummary};
 
 macro_rules! assert_node {

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/Cargo.toml
@@ -18,7 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
-move-abstract-interpreter.workspace = true
+move-abstract-interpreter = { path = "../../../v2/crates/move-abstract-interpreter", package = "move-abstract-interpreter-v2" }
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/Cargo.toml
@@ -18,6 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
+move-abstract-interpreter.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/absint.rs
@@ -2,8 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
     errors::PartialVMResult,
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -9,8 +9,8 @@ use crate::{
     absint::FunctionContext, acquires_list_verifier::AcquiresVerifier, control_flow, locals_safety,
     reference_safety, stack_usage_verifier::StackUsageVerifier, type_safety,
 };
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
         CompiledModule, FunctionDefinition, FunctionDefinitionIndex, IdentifierIndex, TableIndex,

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 /// Dense index into nodes in the same `LoopSummary`

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -10,8 +10,8 @@
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
 use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::{BlockId, ControlFlowGraph};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph},
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
     CompiledModule,

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/type_safety.rs
@@ -8,9 +8,9 @@
 use std::num::NonZeroU64;
 
 use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{PartialVMError, PartialVMResult},
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CompiledModule, FieldHandleIndex,

--- a/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,6 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier", package = "move-b
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
+move-abstract-interpreter.workspace = true
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/Cargo.toml
@@ -20,7 +20,7 @@ move-bytecode-verifier = { path = "../move-bytecode-verifier", package = "move-b
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
-move-abstract-interpreter.workspace = true
+move-abstract-interpreter = { path = "../../../v2/crates/move-abstract-interpreter", package = "move-abstract-interpreter-v2" }
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
+++ b/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/src/unit_tests/loop_summary_tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{control_flow_graph::VMControlFlowGraph, file_format::Bytecode};
+use move_abstract_interpreter::control_flow_graph::VMControlFlowGraph;
+use move_binary_format::file_format::Bytecode;
 use move_bytecode_verifier::loop_summary::{LoopPartition, LoopSummary};
 
 macro_rules! assert_node {

--- a/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/Cargo.toml
+++ b/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "move-abstract-interpreter-v2"
+version = "0.1.0"
+authors = ["The Move Contributors"]
+description = "Move abstract interpreter"
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+move-binary-format.workspace = true
+move-bytecode-verifier-meter.workspace = true
+
+[features]
+default = []

--- a/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -1,0 +1,337 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines the control-flow graph uses for bytecode verification.
+use move_binary_format::file_format::{Bytecode, CodeOffset};
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+
+// BTree/Hash agnostic type wrappers
+type Map<K, V> = BTreeMap<K, V>;
+type Set<V> = BTreeSet<V>;
+
+pub type BlockId = CodeOffset;
+
+/// A trait that specifies the basic requirements for a CFG
+pub trait ControlFlowGraph {
+    /// Start index of the block ID in the bytecode vector
+    fn block_start(&self, block_id: BlockId) -> CodeOffset;
+
+    /// End index of the block ID in the bytecode vector
+    fn block_end(&self, block_id: BlockId) -> CodeOffset;
+
+    /// Successors of the block ID in the bytecode vector
+    fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
+
+    /// Return the next block in traversal order
+    fn next_block(&self, block_id: BlockId) -> Option<BlockId>;
+
+    /// Iterator over the indexes of instructions in this block
+    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;
+
+    /// Return an iterator over the blocks of the CFG
+    fn blocks(&self) -> Vec<BlockId>;
+
+    /// Return the number of blocks (vertices) in the control flow graph
+    fn num_blocks(&self) -> u16;
+
+    /// Return the id of the entry block for this control-flow graph
+    /// Note: even a CFG with no instructions has an (empty) entry block.
+    fn entry_block_id(&self) -> BlockId;
+
+    /// Checks if the block ID is a loop head
+    fn is_loop_head(&self, block_id: BlockId) -> bool;
+
+    /// Checks if the the edge from cur->next is a back edge
+    /// returns false if the edge is not in the cfg
+    fn is_back_edge(&self, cur: BlockId, next: BlockId) -> bool;
+
+    /// Return the number of back edges in the cfg
+    fn num_back_edges(&self) -> usize;
+}
+
+struct BasicBlock {
+    exit: CodeOffset,
+    successors: Vec<BlockId>,
+}
+
+/// The control flow graph that we build from the bytecode.
+pub struct VMControlFlowGraph {
+    /// The basic blocks
+    blocks: Map<BlockId, BasicBlock>,
+    /// Basic block ordering for traversal
+    traversal_successors: Map<BlockId, BlockId>,
+    /// Map of loop heads with all of their back edges
+    loop_heads: Map<BlockId, /* back edges */ Set<BlockId>>,
+}
+
+impl BasicBlock {
+    pub fn display(&self, entry: BlockId) {
+        println!("+=======================+");
+        println!("| Enter:  {}            |", entry);
+        println!("+-----------------------+");
+        println!("==> Children: {:?}", self.successors);
+        println!("+-----------------------+");
+        println!("| Exit:   {}            |", self.exit);
+        println!("+=======================+");
+    }
+}
+
+const ENTRY_BLOCK_ID: BlockId = 0;
+
+impl VMControlFlowGraph {
+    pub fn new(code: &[Bytecode]) -> Self {
+        let code_len = code.len() as CodeOffset;
+        // First go through and collect block ids, i.e., offsets that begin basic blocks.
+        // Need to do this first in order to handle backwards edges.
+        let mut block_ids = Set::new();
+        block_ids.insert(ENTRY_BLOCK_ID);
+        for pc in 0..code.len() {
+            VMControlFlowGraph::record_block_ids(pc as CodeOffset, code, &mut block_ids);
+        }
+
+        // Create basic blocks
+        let mut blocks = Map::new();
+        let mut entry = 0;
+        let mut exit_to_entry = Map::new();
+        for pc in 0..code.len() {
+            let co_pc = pc as CodeOffset;
+
+            // Create a basic block
+            if Self::is_end_of_block(co_pc, code, &block_ids) {
+                let exit = co_pc;
+                exit_to_entry.insert(exit, entry);
+                let successors = Bytecode::get_successors(co_pc, code);
+                let bb = BasicBlock { exit, successors };
+                blocks.insert(entry, bb);
+                entry = co_pc + 1;
+            }
+        }
+        let blocks = blocks;
+        assert_eq!(entry, code_len);
+
+        // # Loop analysis
+        //
+        // This section identifies loops in the control-flow graph, picks a back edge and loop head
+        // (the basic block the back edge returns to), and decides the order that blocks are
+        // traversed during abstract interpretation (reverse post-order).
+        //
+        // The implementation is based on the algorithm for finding widening points in Section 4.1,
+        // "Depth-first numbering" of Bourdoncle [1993], "Efficient chaotic iteration strategies
+        // with widenings."
+        //
+        // NB. The comments below refer to a block's sub-graph -- the reflexive transitive closure
+        // of its successor edges, modulo cycles.
+
+        #[derive(Copy, Clone)]
+        enum Exploration {
+            InProgress,
+            Done,
+        }
+
+        let mut exploration: Map<BlockId, Exploration> = Map::new();
+        let mut stack = vec![ENTRY_BLOCK_ID];
+
+        // For every loop in the CFG that is reachable from the entry block, there is an entry in
+        // `loop_heads` mapping to all the back edges pointing to it, and vice versa.
+        //
+        // Entry in `loop_heads` implies loop in the CFG is justified by the comments in the loop
+        // below.  Loop in the CFG implies entry in `loop_heads` is justified by considering the
+        // point at which the first node in that loop, `F` is added to the `exploration` map:
+        //
+        // - By definition `F` is part of a loop, meaning there is a block `L` such that:
+        //
+        //     F - ... -> L -> F
+        //
+        // - `F` will not transition to `Done` until all the nodes reachable from it (including `L`)
+        //   have been visited.
+        // - Because `F` is the first node seen in the loop, all the other nodes in the loop
+        //   (including `L`) will be visited while `F` is `InProgress`.
+        // - Therefore, we will process the `L -> F` edge while `F` is `InProgress`.
+        // - Therefore, we will record a back edge to it.
+        let mut loop_heads: Map<BlockId, Set<BlockId>> = Map::new();
+
+        // Blocks appear in `post_order` after all the blocks in their (non-reflexive) sub-graph.
+        let mut post_order = Vec::with_capacity(blocks.len());
+
+        while let Some(block) = stack.pop() {
+            match exploration.entry(block) {
+                Entry::Vacant(entry) => {
+                    // Record the fact that exploration of this block and its sub-graph has started.
+                    entry.insert(Exploration::InProgress);
+
+                    // Push the block back on the stack to finish processing it, and mark it as done
+                    // once its sub-graph has been traversed.
+                    stack.push(block);
+
+                    for succ in &blocks[&block].successors {
+                        match exploration.get(succ) {
+                            // This successor has never been visited before, add it to the stack to
+                            // be explored before `block` gets marked `Done`.
+                            None => stack.push(*succ),
+
+                            // This block's sub-graph was being explored, meaning it is a (reflexive
+                            // transitive) predecessor of `block` as well as being a successor,
+                            // implying a loop has been detected -- greedily choose the successor
+                            // block as the loop head.
+                            Some(Exploration::InProgress) => {
+                                loop_heads.entry(*succ).or_default().insert(block);
+                            }
+
+                            // Cross-edge detected, this block and its entire sub-graph (modulo
+                            // cycles) has already been explored via a different path, and is
+                            // already present in `post_order`.
+                            Some(Exploration::Done) => { /* skip */ }
+                        };
+                    }
+                }
+
+                Entry::Occupied(mut entry) => match entry.get() {
+                    // Already traversed the sub-graph reachable from this block, so skip it.
+                    Exploration::Done => continue,
+
+                    // Finish up the traversal by adding this block to the post-order traversal
+                    // after its sub-graph (modulo cycles).
+                    Exploration::InProgress => {
+                        post_order.push(block);
+                        entry.insert(Exploration::Done);
+                    }
+                },
+            }
+        }
+
+        let traversal_order = {
+            // This reverse post order is akin to a topological sort (ignoring cycles) and is
+            // different from a pre-order in the presence of diamond patterns in the graph.
+            post_order.reverse();
+            post_order
+        };
+
+        // build a mapping from a block id to the next block id in the traversal order
+        let traversal_successors = traversal_order
+            .windows(2)
+            .map(|window| {
+                debug_assert!(window.len() == 2);
+                (window[0], window[1])
+            })
+            .collect();
+
+        VMControlFlowGraph {
+            blocks,
+            traversal_successors,
+            loop_heads,
+        }
+    }
+
+    pub fn display(&self) {
+        for (entry, block) in &self.blocks {
+            block.display(*entry);
+        }
+        println!("Traversal: {:#?}", self.traversal_successors);
+    }
+
+    fn is_end_of_block(pc: CodeOffset, code: &[Bytecode], block_ids: &Set<BlockId>) -> bool {
+        pc + 1 == (code.len() as CodeOffset) || block_ids.contains(&(pc + 1))
+    }
+
+    fn record_block_ids(pc: CodeOffset, code: &[Bytecode], block_ids: &mut Set<BlockId>) {
+        let bytecode = &code[pc as usize];
+
+        if let Some(offset) = bytecode.offset() {
+            block_ids.insert(*offset);
+        }
+
+        if bytecode.is_branch() && pc + 1 < (code.len() as CodeOffset) {
+            block_ids.insert(pc + 1);
+        }
+    }
+
+    /// A utility function that implements BFS-reachability from block_id with
+    /// respect to get_targets function
+    fn traverse_by(&self, block_id: BlockId) -> Vec<BlockId> {
+        let mut ret = Vec::new();
+        // We use this index to keep track of our frontier.
+        let mut index = 0;
+        // Guard against cycles
+        let mut seen = Set::new();
+
+        ret.push(block_id);
+        seen.insert(&block_id);
+
+        while index < ret.len() {
+            let block_id = ret[index];
+            index += 1;
+            let successors = self.successors(block_id);
+            for block_id in successors.iter() {
+                if !seen.contains(&block_id) {
+                    ret.push(*block_id);
+                    seen.insert(block_id);
+                }
+            }
+        }
+
+        ret
+    }
+
+    pub fn reachable_from(&self, block_id: BlockId) -> Vec<BlockId> {
+        self.traverse_by(block_id)
+    }
+}
+
+impl ControlFlowGraph for VMControlFlowGraph {
+    // Note: in the following procedures, it's safe not to check bounds because:
+    // - Every CFG (even one with no instructions) has a block at ENTRY_BLOCK_ID
+    // - The only way to acquire new BlockId's is via block_successors()
+    // - block_successors only() returns valid BlockId's
+    // Note: it is still possible to get a BlockId from one CFG and use it in another CFG where it
+    // is not valid. The design does not attempt to prevent this abuse of the API.
+
+    fn block_start(&self, block_id: BlockId) -> CodeOffset {
+        block_id
+    }
+
+    fn block_end(&self, block_id: BlockId) -> CodeOffset {
+        self.blocks[&block_id].exit
+    }
+
+    fn successors(&self, block_id: BlockId) -> &Vec<BlockId> {
+        &self.blocks[&block_id].successors
+    }
+
+    fn next_block(&self, block_id: BlockId) -> Option<CodeOffset> {
+        debug_assert!(self.blocks.contains_key(&block_id));
+        self.traversal_successors.get(&block_id).copied()
+    }
+
+    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
+        Box::new(self.block_start(block_id)..=self.block_end(block_id))
+    }
+
+    fn blocks(&self) -> Vec<BlockId> {
+        self.blocks.keys().cloned().collect()
+    }
+
+    fn num_blocks(&self) -> u16 {
+        self.blocks.len() as u16
+    }
+
+    fn entry_block_id(&self) -> BlockId {
+        ENTRY_BLOCK_ID
+    }
+
+    fn is_loop_head(&self, block_id: BlockId) -> bool {
+        self.loop_heads.contains_key(&block_id)
+    }
+
+    fn is_back_edge(&self, cur: BlockId, next: BlockId) -> bool {
+        self.loop_heads
+            .get(&next)
+            .map_or(false, |back_edges| back_edges.contains(&cur))
+    }
+
+    fn num_back_edges(&self) -> usize {
+        self.loop_heads
+            .iter()
+            .fold(0, |acc, (_, edges)| acc + edges.len())
+    }
+}

--- a/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/lib.rs
+++ b/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod control_flow_graph;
+
+#[cfg(test)]
+mod unit_tests;

--- a/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/unit_tests/control_flow_graph_tests.rs
+++ b/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/unit_tests/control_flow_graph_tests.rs
@@ -1,0 +1,72 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_binary_format::file_format::Bytecode;
+
+#[test]
+fn traversal_no_loops() {
+    let cfg = {
+        use Bytecode::*;
+        VMControlFlowGraph::new(&[
+            /* L0 */ LdTrue,
+            /*    */ BrTrue(3),
+            /* L2 */ Branch(3),
+            /* L3 */ Ret,
+        ])
+    };
+
+    cfg.display();
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(traversal(&cfg), vec![0, 2, 3]);
+}
+
+#[test]
+fn traversal_loops() {
+    let cfg = {
+        use Bytecode::*;
+        VMControlFlowGraph::new(&[
+            /* L0: Outer head     */ LdTrue,
+            /*     Outer break    */ BrTrue(6),
+            /* L2: Inner head     */ LdTrue,
+            /*     Inner break    */ BrTrue(5),
+            /* L4: Inner continue */ Branch(2),
+            /*     Outer continue */ Branch(0),
+            /* L6:                */ Ret,
+        ])
+    };
+
+    cfg.display();
+    assert_eq!(cfg.num_blocks(), 5);
+    assert_eq!(traversal(&cfg), vec![0, 2, 4, 5, 6]);
+}
+
+#[test]
+fn traversal_non_loop_back_branch() {
+    let cfg = {
+        use Bytecode::*;
+        VMControlFlowGraph::new(&[
+            /* L0 */ Branch(2),
+            /* L1 */ Ret,
+            /* L2 */ Branch(1),
+        ])
+    };
+
+    cfg.display();
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(traversal(&cfg), vec![0, 2, 1]);
+}
+
+/// Return a vector containing the `BlockId`s from `cfg` in the order suggested by successively
+/// calling `ControlFlowGraph::next_block` starting from the entry block.
+fn traversal(cfg: &dyn ControlFlowGraph) -> Vec<BlockId> {
+    let mut order = Vec::with_capacity(cfg.num_blocks() as usize);
+    let mut next = Some(cfg.entry_block_id());
+
+    while let Some(block) = next {
+        order.push(block);
+        next = cfg.next_block(block);
+    }
+
+    order
+}

--- a/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v2/crates/move-abstract-interpreter/src/unit_tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod control_flow_graph_tests;

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/Cargo.toml
@@ -18,7 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
-move-abstract-interpreter.workspace = true
+move-abstract-interpreter = { path = "../../../v2/crates/move-abstract-interpreter", package = "move-abstract-interpreter-v2" }
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/Cargo.toml
@@ -18,6 +18,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
+move-abstract-interpreter.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/absint.rs
@@ -2,8 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
     errors::PartialVMResult,
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -9,8 +9,8 @@ use crate::{
     absint::FunctionContext, acquires_list_verifier::AcquiresVerifier, control_flow, locals_safety,
     reference_safety, stack_usage_verifier::StackUsageVerifier, type_safety,
 };
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
         CompiledModule, FunctionDefinition, FunctionDefinitionIndex, IdentifierIndex, TableIndex,

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::{
+    BlockId, ControlFlowGraph, VMControlFlowGraph,
+};
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 /// Dense index into nodes in the same `LoopSummary`

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -10,8 +10,8 @@
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
 use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::{BlockId, ControlFlowGraph};
 use move_binary_format::{
-    control_flow_graph::{BlockId, ControlFlowGraph},
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
     CompiledModule,

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/type_safety.rs
@@ -8,9 +8,9 @@
 use std::num::NonZeroU64;
 
 use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
-    control_flow_graph::ControlFlowGraph,
     errors::{PartialVMError, PartialVMResult},
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CompiledModule, FieldHandleIndex,

--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -358,6 +358,7 @@ def cut_command(f):
         *["-p", "sui-adapter-latest"],
         *["-p", "sui-move-natives-latest"],
         *["-p", "sui-verifier-latest"],
+        *["-p", "move-abstract-interpreter"],
         *["-p", "move-bytecode-verifier"],
         *["-p", "move-stdlib-natives"],
         *["-p", "move-vm-runtime"],
@@ -379,6 +380,7 @@ def cut_directories(f):
     if f == "latest":
         crates.extend(
             [
+                external / "move" / "crates" / "move-abstract-interpreter",
                 external / "move" / "crates" / "move-bytecode-verifier",
                 external / "move" / "crates" / "move-stdlib-natives",
                 external / "move" / "crates" / "move-vm-runtime",
@@ -388,6 +390,7 @@ def cut_directories(f):
     else:
         crates.extend(
             [
+                external / "move" / "move-execution" / f / "crates" / "move-abstract-interpreter",
                 external / "move" / "move-execution" / f / "crates" / "move-bytecode-verifier",
                 external / "move" / "move-execution" / f / "crates" / "move-stdlib-natives",
                 external / "move" / "move-execution" / f / "crates" / "move-vm-runtime",

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -33,6 +33,7 @@ sui-verifier-v2 = { path = "v2/sui-verifier" }
 
 move-abstract-interpreter-latest = { path = "../external-crates/move/crates/move-abstract-interpreter", package = "move-abstract-interpreter" }
 move-abstract-interpreter-v2 = { path = "../external-crates/move/move-execution/v2/crates/move-abstract-interpreter" }
+# move-abstract-interpreter-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-abstract-interpreter" }
 move-bytecode-verifier-latest = { path = "../external-crates/move/crates/move-bytecode-verifier", package = "move-bytecode-verifier" }
 move-bytecode-verifier-v0 = { path = "../external-crates/move/move-execution/v0/crates/move-bytecode-verifier" }
 move-bytecode-verifier-v1 = { path = "../external-crates/move/move-execution/v1/crates/move-bytecode-verifier" }

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -31,6 +31,8 @@ sui-verifier-v1 = { path = "v1/sui-verifier" }
 sui-verifier-v2 = { path = "v2/sui-verifier" }
 # sui-verifier-$CUT = { path = "$CUT/sui-verifier" }
 
+move-abstract-interpreter-latest = { path = "../external-crates/move/crates/move-abstract-interpreter", package = "move-abstract-interpreter" }
+move-abstract-interpreter-v2 = { path = "../external-crates/move/move-execution/v2/crates/move-abstract-interpreter" }
 move-bytecode-verifier-latest = { path = "../external-crates/move/crates/move-bytecode-verifier", package = "move-bytecode-verifier" }
 move-bytecode-verifier-v0 = { path = "../external-crates/move/move-execution/v0/crates/move-bytecode-verifier" }
 move-bytecode-verifier-v1 = { path = "../external-crates/move/move-execution/v1/crates/move-bytecode-verifier" }

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -14,6 +14,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
+move-abstract-interpreter.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }
 

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -14,8 +14,8 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
-move-abstract-interpreter.workspace = true
 
+move-abstract-interpreter = { path = "../../../external-crates/move/crates/move-abstract-interpreter" }
 move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }
 
 sui-types.workspace = true

--- a/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
@@ -12,6 +12,9 @@
 //! 2. Written into a mutable reference
 //! 3. Added to a vector
 //! 4. Passed to a function cal::;
+use move_abstract_interpreter::absint::{
+    AbstractDomain, AbstractInterpreter, FunctionContext, JoinResult, TransferFunctions,
+};
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     errors::PartialVMError,
@@ -19,9 +22,6 @@ use move_binary_format::{
         Bytecode, CodeOffset, CompiledModule, FunctionDefinitionIndex, FunctionHandle, LocalIndex,
         StructDefinition, StructFieldInformation,
     },
-};
-use move_bytecode_verifier::absint::{
-    AbstractDomain, AbstractInterpreter, FunctionContext, JoinResult, TransferFunctions,
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::{


### PR DESCRIPTION
## Description 

- Moved the absint and control_flow_graph modules into their own crate, `move-abstract-interpreter`
- Added the crate to the execution cut. The `absint` module was in the bytecode verifier, so this was already versioned for the existing cuts. However `control_flow_graph` was in the binary format, so this version cut is new. As a result, I have just made one cut for v2 and used it for v0 and v1. I think this is a bit un-orthodox, but preserves the existing behavior just fine (which is the intention of the execution cuts) 

## Test plan 

- Ran the execution cut script

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
