### PR TITLE
[cherry-pick][GraphQL] Cherry pick fix graphiql into v2024.1.4

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -236,18 +236,7 @@ impl ServerBuilder {
 
     pub fn route(mut self, path: &str, method_handler: MethodRouter) -> Self {
         self.init_router();
-        self.router = self.router.map(|router| {
-            router
-                .route(path, method_handler)
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    set_version_middleware,
-                ))
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    check_version_middleware,
-                ))
-        });
+        self.router = self.router.map(|router| router.route(path, method_handler));
         self
     }
 
@@ -315,6 +304,14 @@ impl ServerBuilder {
         );
 
         let app = router
+            .route_layer(middleware::from_fn_with_state(
+                state.version,
+                set_version_middleware,
+            ))
+            .route_layer(middleware::from_fn_with_state(
+                state.version,
+                check_version_middleware,
+            ))
             .layer(axum::extract::Extension(schema))
             .layer(axum::extract::Extension(watermark_task.lock()))
             .layer(Self::cors()?);

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -227,14 +227,6 @@ impl ServerBuilder {
                 .route("/graphql", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
                 .with_state(self.state.clone())
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    set_version_middleware,
-                ))
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    check_version_middleware,
-                ))
                 .route_layer(CallbackLayer::new(MetricsMakeCallbackHandler {
                     metrics: self.state.metrics.clone(),
                 }));
@@ -244,7 +236,18 @@ impl ServerBuilder {
 
     pub fn route(mut self, path: &str, method_handler: MethodRouter) -> Self {
         self.init_router();
-        self.router = self.router.map(|router| router.route(path, method_handler));
+        self.router = self.router.map(|router| {
+            router
+                .route(path, method_handler)
+                .route_layer(middleware::from_fn_with_state(
+                    self.state.version,
+                    set_version_middleware,
+                ))
+                .route_layer(middleware::from_fn_with_state(
+                    self.state.version,
+                    check_version_middleware,
+                ))
+        });
         self
     }
 

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::extract::Path;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -8,8 +9,16 @@ use crate::config::{ServerConfig, Version};
 use crate::error::Error;
 use crate::server::builder::ServerBuilder;
 
-async fn graphiql(ide_title: axum::Extension<Option<String>>) -> impl axum::response::IntoResponse {
-    let gq = async_graphql::http::GraphiQLSource::build().endpoint("/");
+async fn graphiql(
+    ide_title: axum::Extension<Option<String>>,
+    path: Option<Path<String>>,
+) -> impl axum::response::IntoResponse {
+    let endpoint = if let Some(Path(path)) = path {
+        format!("/graphql/{}", path)
+    } else {
+        "/graphql".to_string()
+    };
+    let gq = async_graphql::http::GraphiQLSource::build().endpoint(&endpoint);
     if let axum::Extension(Some(title)) = ide_title {
         axum::response::Html(gq.title(&title).finish())
     } else {

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -40,7 +40,9 @@ async fn start_graphiql_server_impl(
     // Add GraphiQL IDE handler on GET request to `/`` endpoint
     let server = server_builder
         .route("/", axum::routing::get(graphiql))
+        .route("/:version", axum::routing::get(graphiql))
         .route("/graphql", axum::routing::get(graphiql))
+        .route("/graphql/:version", axum::routing::get(graphiql))
         .layer(axum::extract::Extension(Some(ide_title)))
         .build()?;
 


### PR DESCRIPTION
## Description 

Fix GraphiQL not loading on the new routes: `/:version` & `graphql/:version`

## Test plan 

Existing tests & manual tests in the browser:
```bash
http://127.0.0.1:8000/graphql/beta
http://127.0.0.1:8000/graphql/stable
http://127.0.0.1:8000/graphql/legacy
http://127.0.0.1:8000/graphql/2024.7
http://127.0.0.1:8000/beta
http://127.0.0.1:8000/stable
http://127.0.0.1:8000/legacy
http://127.0.0.1:8000/2024.7
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
