### PR TITLE
[TrafficControl] Support param injection on map params; add fallback

### DIFF
--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -302,12 +302,15 @@ impl WriteApiServer for TransactionExecutionApi {
     #[instrument(skip(self))]
     async fn execute_transaction_block(
         &self,
-        _tx_bytes: Base64,
-        _signatures: Vec<Base64>,
-        _opts: Option<SuiTransactionBlockResponseOptions>,
-        _request_type: Option<ExecuteTransactionRequestType>,
+        tx_bytes: Base64,
+        signatures: Vec<Base64>,
+        opts: Option<SuiTransactionBlockResponseOptions>,
+        request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionBlockResponse> {
-        unimplemented!("Use monitored_execute_transaction_block instead")
+        with_tracing!(Duration::from_secs(10), async move {
+            self.execute_transaction_block(tx_bytes, signatures, opts, request_type, None)
+                .await
+        })
     }
 
     #[instrument(skip(self))]


### PR DESCRIPTION
## Description 

Before, map based params to `executeTransactionBlock` worked fine, in addition to array based. Now we fail due to the introduced panic. So:
* Support map based params
* Allow for deserialization errors on user input to fallback to injecting no client addr (in this case, we route to `execute_transaction_block` rather than `monitored_execute_transaction_block`)

## Test plan 

Ran from local build, and ran the curl request, and it looks to be getting past this point and instead failing due to the transaction missing a dependency that I don't have since I'm running from genesis

```
λ curl '127.0.0.1:9000' -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "id": 1, "method": "sui_executeTransactionBlock", "params": {"tx_bytes": "AAADAQA2D2S7yQT7LGUkRTntLEVU+d2nLEun34wEbhYGcszPqwEAAAAAAAAAILhTnZTKxFvh/BJd284+2YsF0SEAu+zF2d5zjikDLtrHAAhAQg8AAAAAAAAg0TZIq0+e7KwdrsC2pjFjICNxAjYqVZWDi7rJQJyYS/0CAgEAAAEBAQABAQIAAAECAAP8zwZA0RP5j6fUYJYE1B89/Ev+zbpKqmIzG8VNbA8hASa8yDMqll3ot4uShIB/wkWJ87YankMG9pKQzn/laqTKAQAAAAAAAAAgBPlJ4ZaagwpAVp3HJuLmI54sefVII4jWwdap7zzm3AkD/M8GQNET+Y+n1GCWBNQfPfxL/s26SqpiMxvFTWwPIegDAAAAAAAA+KI8AAAAAAAA", "signatures": ["ACN6a588MaLdp84iR7H33V1Vr1O2t6GByy5JiwYKHehAuYre6HXxFvS2DczINvb0JmcsI07ZaOz3WSKUh+e5BgefdzF+hnUlNGP1soyIZzL14pQyrYNUvPXeFj5mLzI2gg=="], "options": {"showBalanceChanges": true, "showEffects": true, "showEvents": true, "showInput": true, "showObjectChanges": true, "showRawEffects": false, "showRawInput": true}, "request_type": "WaitForLocalExecution"}}'
{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction execution failed due to issues with transaction inputs, please review the errors and try again: Could not find the referenced object 0x360f64bbc904fb2c65244539ed2c4554f9dda72c4ba7df8c046e160672cccfab at version None.."},"id":1}% 
```

Also dropped some debug statements and confirmed that param injection works for map based params given by client, and fallback successfully calls `execute_transaction_block` with no `client_addr`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
