### PR TITLE
[move-ide] Fixed a problem related to handling package identity

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -81,7 +81,8 @@ Move source file (a file with a `.move` file extension) and:
   Toggle Line Comment*).
 - Place your cursor on a delimiter, such as `<`, `(`, or `{`, and its corresponding delimiter --
   `>`, `)`, or `}` -- will be highlighted.
-- As you type, Move keywords will appear as completion suggestions.
+- As you type, the editor will offer completion suggestions, in particular:
+  - code snippets to complete `init` function and object type definitions
 - If the opened Move source file is located within a buildable project (a `Move.toml` file can be
   found in one of its parent directories), the following advanced features will also be available:
   - compiler diagnostics

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
 	"publisher": "mysten",
 	"icon": "images/move.png",
 	"license": "Apache-2.0",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"preview": true,
 	"repository": {
 		"url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -216,8 +216,13 @@ fn main() {
                             },
                         }
                     },
-                    Err(error) =>
-                        eprintln!("symbolicator message error: {:?}", error),
+                    Err(error) => {
+                        eprintln!("symbolicator message error: {:?}", error);
+                        // if the analyzer crashes in a separate thread, this error will keep
+                        // getting generated for a while unless we explicitly end the process
+                        // obscuring the real logged reason for the crash
+                        std::process::exit(-1);
+                    }
                 }
             },
             recv(context.connection.receiver) -> message => {

--- a/external-crates/move/crates/move-analyzer/tests/pkg-naming-error/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/pkg-naming-error/Move.toml
@@ -1,0 +1,13 @@
+[package]
+name = "PkgNamingError"
+version = "0.0.1"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+Symbols = { local = "../symbols" }
+
+[addresses]
+PkgNamingError = "0xABBA"
+# the following is a different package name than specified in the dependency's source
+# which may crash the analyzer if not handled correctly
+SymbolsRenamed = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/pkg-naming-error/sources/M1.move
+++ b/external-crates/move/crates/move-analyzer/tests/pkg-naming-error/sources/M1.move
@@ -1,0 +1,7 @@
+module PkgNamingError::M1 {
+    use SymbolsRenamed::M9;
+
+    public fun foo() {
+        M9::pack();
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/pkg-naming-error/sources/M2.move
+++ b/external-crates/move/crates/move-analyzer/tests/pkg-naming-error/sources/M2.move
@@ -1,0 +1,7 @@
+module PkgNamingError::M2 {
+    use 0xCAFE::M9;
+
+    public fun foo() {
+        M9::pack();
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/pre-type-error/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/pre-type-error/Move.toml
@@ -2,8 +2,5 @@
 name = "PreTypeError"
 version = "0.0.1"
 
-[dependencies]
-MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
-
 [addresses]
 PreTypeError = "0xCAFE"


### PR DESCRIPTION
## Description 

This PR fixes a problem with move-analyzer crashing if a dependency defined one package name in the source but the main package overrode this name with a new one. The gist of the problem was that we used package name to represent its identity which is not reliable due to above-mentioned renamings. What we need to do instead is to rely on package addresses whenever they are available.

## Test plan 

Added a new test that was crashing the analyzer before this PR's fix.
