### PR TITLE
[bridge] remove unnecessary &mut

### DIFF
--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -19,7 +19,10 @@ use sui_types::{
     transaction::Transaction,
 };
 
-use crate::events::{TokenTransferAlreadyClaimed, TokenTransferClaimed};
+use crate::events::{
+    TokenTransferAlreadyApproved, TokenTransferAlreadyClaimed, TokenTransferApproved,
+    TokenTransferClaimed,
+};
 use crate::{
     client::bridge_authority_aggregator::BridgeAuthorityAggregator,
     error::BridgeError,
@@ -408,7 +411,12 @@ where
                     .data
                     .iter()
                     .any(|e| e.type_ == *TokenTransferAlreadyClaimed.get().unwrap()
-                        || e.type_ == *TokenTransferClaimed.get().unwrap()),);
+                        || e.type_ == *TokenTransferClaimed.get().unwrap()
+                        || e.type_ == *TokenTransferApproved.get().unwrap()
+                        || e.type_ == *TokenTransferAlreadyApproved.get().unwrap()),
+                    "Expected TokenTransferAlreadyClaimed, TokenTransferClaimed, TokenTransferApproved or TokenTransferAlreadyApproved event but got: {:?}",
+                    events,
+                    );
                 info!(?tx_digest, "Sui transaction executed successfully");
                 store
                     .remove_pending_actions(&[action.digest()])

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -463,7 +463,7 @@ async fn wait_for_transfer_action_status(
         }
         if now.elapsed().as_secs() > 30 {
             panic!(
-                "Timeout waiting for token transfer action to be {:?}",
+                "Timeout waiting for token transfer action to be {:?}. chain_id: {chain_id}, nonce: {nonce}",
                 status
             );
         }

--- a/crates/sui-framework/docs/bridge/bridge.md
+++ b/crates/sui-framework/docs/bridge/bridge.md
@@ -969,9 +969,8 @@ title: Module `0xb::bridge`
     bridge_seq_num: u64,
     ctx: &<b>mut</b> TxContext,
 ): Coin&lt;T&gt; {
-    <b>let</b> (maybe_token, owner) = <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(
+    <b>let</b> (maybe_token, owner) = <a href="bridge.md#0xb_bridge">bridge</a>.<a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(
         <a href="../sui-framework/clock.md#0x2_clock">clock</a>,
-        <a href="bridge.md#0xb_bridge">bridge</a>,
         source_chain,
         bridge_seq_num,
         ctx,
@@ -1009,7 +1008,7 @@ title: Module `0xb::bridge`
     bridge_seq_num: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> (token, owner) = <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>, <a href="bridge.md#0xb_bridge">bridge</a>, source_chain, bridge_seq_num, ctx);
+    <b>let</b> (token, owner) = <a href="bridge.md#0xb_bridge">bridge</a>.<a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>, source_chain, bridge_seq_num, ctx);
     <b>if</b> (token.is_some()) {
         <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(token.destroy_some(), owner)
     } <b>else</b> {
@@ -1089,7 +1088,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, <b>address</b>)
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, <b>address</b>)
 </code></pre>
 
 
@@ -1099,8 +1098,8 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(
-    <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &Clock,
     <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &Clock,
     source_chain: u8,
     bridge_seq_num: u64,
     ctx: &<b>mut</b> TxContext,
@@ -1409,7 +1408,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): u8
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): u8
 </code></pre>
 
 
@@ -1419,11 +1418,11 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(
-    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     source_chain: u8,
     bridge_seq_num: u64,
 ): u8 {
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner">load_inner</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(
         source_chain,
         <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),
@@ -1457,7 +1456,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_signatures">get_token_transfer_action_signatures</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;&gt;
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_signatures">get_token_transfer_action_signatures</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;&gt;
 </code></pre>
 
 
@@ -1467,11 +1466,11 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_signatures">get_token_transfer_action_signatures</a>(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     source_chain: u8,
     bridge_seq_num: u64,
 ): Option&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;&gt; {
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner">load_inner</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(
         source_chain,
         <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),

--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -300,9 +300,8 @@ module bridge::bridge {
         bridge_seq_num: u64,
         ctx: &mut TxContext,
     ): Coin<T> {
-        let (maybe_token, owner) = claim_token_internal<T>(
+        let (maybe_token, owner) = bridge.claim_token_internal<T>(
             clock,
-            bridge,
             source_chain,
             bridge_seq_num,
             ctx,
@@ -322,7 +321,7 @@ module bridge::bridge {
         bridge_seq_num: u64,
         ctx: &mut TxContext,
     ) {
-        let (token, owner) = claim_token_internal<T>(clock, bridge, source_chain, bridge_seq_num, ctx);
+        let (token, owner) = bridge.claim_token_internal<T>(clock, source_chain, bridge_seq_num, ctx);
         if (token.is_some()) {
             transfer::public_transfer(token.destroy_some(), owner)
         } else {
@@ -339,7 +338,6 @@ module bridge::bridge {
         inner
     }
 
-    #[allow(unused_function)] // TODO: remove annotation after implementing user-facing API
     fun load_inner(
         bridge: &Bridge,
     ): &BridgeInner {
@@ -355,8 +353,8 @@ module bridge::bridge {
     // Claim token from approved bridge message
     // Returns Some(Coin) if coin can be claimed. If already claimed, return None
     fun claim_token_internal<T>(
-        clock: &Clock,
         bridge: &mut Bridge,
+        clock: &Clock,
         source_chain: u8,
         bridge_seq_num: u64,
         ctx: &mut TxContext,
@@ -537,11 +535,11 @@ module bridge::bridge {
     }
 
     public fun get_token_transfer_action_status(
-        bridge: &mut Bridge,
+        bridge: &Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
     ): u8 {
-        let inner = load_inner_mut(bridge);
+        let inner = load_inner(bridge);
         let key = message::create_key(
             source_chain,
             message_types::token(),
@@ -566,11 +564,11 @@ module bridge::bridge {
 
     #[allow(unused_function)]
     fun get_token_transfer_action_signatures(
-        self: &mut Bridge,
+        bridge: &Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
     ): Option<vector<vector<u8>>> {
-        let inner = load_inner_mut(self);
+        let inner = load_inner(bridge);
         let key = message::create_key(
             source_chain,
             message_types::token(),

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x906fb78605af053487ebdff491e6157b2d5e358505a179e381c32555651ecf6c"
+            id: "0x301001a2da5a8b89d39bbfb0db52e0750645b40280421ab360d886ea7a10a67c"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x50314f123a7359d1c661b29733f311af838bc615da580e182656be476cdcf5f1"
+      operation_cap_id: "0xcea25dc4c27a4b98a32c49d6c5f3e40eb050247d51430c41813c7ab12fe7e6f6"
       gas_price: 1000
       staking_pool:
-        id: "0x02e5932a034e37bcaaf0fc2fa4a37755dbf7285cb8d9887e2fbe34a0e086f40f"
+        id: "0x91b44d5ed7c735997db131170400d11fe8ad85de99c28ebcda96892b513b5b93"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x6f0e4ff0c7332c00662c634751e1370386ad6307ae7dafe47c8eccbd22d7ae6f"
+          id: "0x2996d8dc358db9faa46cbf628ebf48a07f4b30c950d0c7cee9138c4a68fcf2ba"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xb8fe98011e066de8495d982b51429d93c310812652000173427ab7de4fea3ea1"
+            id: "0xbbc95c8d45a2bd951bfc5d3bed4aaab7ceae5930af943acdd61056ebe58fc246"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x08f050953b32ac085cceac2be5aa7b24a02335c8528ce1a5207299e8c50938a6"
+          id: "0xa88affe32e7e3443bc29ddbcfaa9c116970b4b8092115192c90e1e9f5a6391ed"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xb8df133631d18fad3a5d2b226ba0146f97a5486101200ea71858897131f82b38"
+      id: "0x369e2df71f9dd4f249ceef645df2cb61197b8d90f688b35324db31b00d30f4a7"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x27bbfdb08d62fb71182f626294b27844185cc3354c7737070f5df4ec62f7b07b"
+    id: "0x3bd68479772cbbab79cb8294595fd43cf82bfd070e0a76012806edffda4b0492"
     size: 1
   inactive_validators:
-    id: "0xf232aea72060c23ac0ebeca5f21097e583571c70166867be0d30b5234728f887"
+    id: "0xd7df14722d8e94e6d497180a1b4ee8a938926674225443b3bbf9c87f92c7d456"
     size: 0
   validator_candidates:
-    id: "0x6b12194a3025c466f46968cfb831c5ff76d271a22d013b787634cdd6a16d79ac"
+    id: "0xa401245a4acbebf49b117fd42b880f780330bf6ba332f5d0e91cebca82fe2ed5"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x82e670d7c277a1098d7b4e98710c6d324354a0058d49695d539cc14bd49c2eda"
+      id: "0xbe9434e5941668f2b562e24515159284ac8439326374459fc4c455fce4fda11a"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xd5c2760d541db3680a0811fe08c8a9908baec32c2a8daa644a75e7803290c53d"
+      id: "0x6759fedf0a67590481121e9e196d1038615d9fd97a057df996a935798cf5945b"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x5bb9883d0d249399d8074b5cc71e57a964161943904d08a3d5c7b2692f96a582"
+      id: "0x955f9c3533be3df6a61471c23bc12ed334d5a928344fadd16b3f573c92a5d21f"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x3ed5c1f16fa3d0e0321a76cb430d97db3f60e476c8eaf7ac6beaef8b35ad8c14"
+    id: "0x57a5ee6193393884e9e3f24584867ab7c1d93988c69cbab511c1f10e07e15d65"
   size: 0
 


### PR DESCRIPTION
## Description 

1. `get_token_transfer_action_signatures` and `get_token_transfer_action_status` does not need mutable Bridge ref
2. switch the order of Bridge and clock in `claim_token_internal` so we can use the receiver syntax


## Test plan 

existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
