### PR TITLE
[Consensus 2.0] convert use of std::time::Instant to tokio::time::Instant

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -640,8 +640,6 @@ mod tests {
         authorities.remove(index.value()).stop().await;
         sleep(Duration::from_secs(15)).await;
 
-        println!("Restarting now authority 1");
-
         // Restart authority 1 and let it run.
         let (authority, receiver) = make_authority(index).await;
         output_receivers[index] = receiver;

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -9,7 +9,6 @@ use prometheus::Registry;
 use sui_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use tracing::info;
 
-use crate::context::Clock;
 use crate::{
     authority_service::AuthorityService,
     block_manager::BlockManager,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -9,6 +9,7 @@ use prometheus::Registry;
 use sui_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use tracing::info;
 
+use crate::context::Clock;
 use crate::{
     authority_service::AuthorityService,
     block_manager::BlockManager,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -542,7 +542,7 @@ mod tests {
 
     // TODO: build AuthorityFixture.
     #[rstest]
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_authority_committee(
         #[values(ConsensusNetwork::Anemo, ConsensusNetwork::Tonic)] network_type: ConsensusNetwork,
     ) {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -630,8 +630,8 @@ mod tests {
         error::ConsensusError,
     };
 
-    #[test]
-    fn test_sign_and_verify() {
+    #[tokio::test]
+    async fn test_sign_and_verify() {
         let (context, key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -382,8 +382,8 @@ mod tests {
         storage::mem_store::MemStore,
     };
 
-    #[test]
-    fn suspend_blocks_with_missing_ancestors() {
+    #[tokio::test]
+    async fn suspend_blocks_with_missing_ancestors() {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
@@ -436,8 +436,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn try_accept_block_returns_missing_blocks() {
+    #[tokio::test]
+    async fn try_accept_block_returns_missing_blocks() {
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -476,8 +476,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn accept_blocks_with_complete_causal_history() {
+    #[tokio::test]
+    async fn accept_blocks_with_complete_causal_history() {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
@@ -514,8 +514,8 @@ mod tests {
         assert!(accepted_blocks.is_empty());
     }
 
-    #[test]
-    fn accept_blocks_unsuspend_children_blocks() {
+    #[tokio::test]
+    async fn accept_blocks_unsuspend_children_blocks() {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
@@ -589,8 +589,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn reject_blocks_failing_verifications() {
+    #[tokio::test]
+    async fn reject_blocks_failing_verifications() {
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
 

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -219,8 +219,8 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_verify_block() {
+    #[tokio::test]
+    async fn test_verify_block() {
         let (context, keypairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let authority_2_protocol_keypair = &keypairs[2].1;
@@ -447,8 +447,8 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_check_ancestors() {
+    #[tokio::test]
+    async fn test_check_ancestors() {
         let num_authorities = 4;
         let (context, _keypairs) = Context::new_for_test(num_authorities);
         let context = Arc::new(context);

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -633,7 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    fn test_commit_range() {
+    async fn test_commit_range() {
         let range1 = CommitRange::new(1..6);
         let range2 = CommitRange::new(2..6);
         let range3 = CommitRange::new(5..10);

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -559,8 +559,8 @@ mod tests {
         storage::{mem_store::MemStore, WriteBatch},
     };
 
-    #[test]
-    fn test_new_subdag_from_commit() {
+    #[tokio::test]
+    async fn test_new_subdag_from_commit() {
         let store = Arc::new(MemStore::new());
         let context = Arc::new(Context::new_for_test(4).0);
         let wave_length = DEFAULT_WAVE_LENGTH;
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(subdag.commit_index, commit_index);
     }
 
-    #[test]
+    #[tokio::test]
     fn test_commit_range() {
         let range1 = CommitRange::new(1..6);
         let range2 = CommitRange::new(2..6);

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -178,8 +178,8 @@ mod tests {
         storage::mem_store::MemStore,
     };
 
-    #[test]
-    fn test_handle_commit() {
+    #[tokio::test]
+    async fn test_handle_commit() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
@@ -272,8 +272,8 @@ mod tests {
         assert!(blocks_existence.iter().all(|exists| *exists));
     }
 
-    #[test]
-    fn test_recover_and_send_commits() {
+    #[tokio::test]
+    async fn test_recover_and_send_commits() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
@@ -410,8 +410,8 @@ mod tests {
         verify_channel_empty(&mut receiver);
     }
 
-    #[test]
-    fn test_send_no_missing_commits() {
+    #[tokio::test]
+    async fn test_send_no_missing_commits() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -671,8 +671,8 @@ mod test {
         context::Context,
     };
 
-    #[test]
-    fn test_commit_vote_monitor() {
+    #[tokio::test]
+    async fn test_commit_vote_monitor() {
         let context = Arc::new(Context::new_for_test(4).0);
         let monitor = CommitVoteMonitor::new(context.clone());
 

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
-use crate::block::BlockTimestampMs;
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 #[cfg(test)]
 use consensus_config::{NetworkKeyPair, ProtocolKeyPair};
 use sui_protocol_config::ProtocolConfig;
 #[cfg(test)]
 use tempfile::TempDir;
+use tokio::time::Instant;
 
 use crate::block::BlockTimestampMs;
 #[cfg(test)]

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
+use crate::block::BlockTimestampMs;
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 #[cfg(test)]
 use consensus_config::{NetworkKeyPair, ProtocolKeyPair};

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -158,6 +158,10 @@ impl Core {
                 "Waiting for {} ms while recovering ancestors from storage",
                 wait_ms
             );
+            println!(
+                "Waiting for {} ms while recovering ancestors from storage",
+                wait_ms
+            );
             std::thread::sleep(Duration::from_millis(wait_ms));
         }
         // Recover the last available quorum to correctly advance the threshold clock.

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1083,6 +1083,25 @@ mod test {
     async fn test_core_try_new_block_leader_timeout() {
         telemetry_subscribers::init_for_testing();
 
+        // Since we run the test with started_paused = true, any time-dependent operations using Tokio's time
+        // facilities, such as tokio::time::sleep or tokio::time::Instant, will not advance. So practically each
+        // Core's clock will have initialised potentially with different values but it never advances.
+        // To ensure that blocks won't get rejected by cores we'll need to manually wait for the time
+        // diff before processing them. By calling the `tokio::time::sleep` we implicitly also advance the
+        // tokio clock.
+        async fn wait_blocks(blocks: &[VerifiedBlock], context: &Context) {
+            // Simulate the time wait before processing a block to ensure that block.timestamp <= now
+            let now = context.clock.timestamp_utc_ms();
+            let max_timestamp = blocks
+                .iter()
+                .max_by_key(|block| block.timestamp_ms() as BlockTimestampMs)
+                .map(|block| block.timestamp_ms())
+                .unwrap_or(0);
+
+            let wait_time = Duration::from_millis(max_timestamp.saturating_sub(now));
+            sleep(wait_time).await;
+        }
+
         // Create the cores for all authorities
         let mut all_cores = create_cores(vec![1, 1, 1, 1]);
 
@@ -1098,6 +1117,8 @@ mod test {
             let mut this_round_blocks = Vec::new();
 
             for (core, _signal_receivers, _, _, _) in cores.iter_mut() {
+                wait_blocks(&last_round_blocks, &core.context).await;
+
                 core.add_blocks(last_round_blocks.clone()).unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -1122,6 +1143,8 @@ mod test {
         // Try to create the blocks for round 4 by calling the try_propose() method. No block should be created as the
         // leader - authority 3 - hasn't proposed any block.
         for (core, _, _, _, _) in cores.iter_mut() {
+            wait_blocks(&last_round_blocks, &core.context).await;
+
             core.add_blocks(last_round_blocks.clone()).unwrap();
             assert!(core.try_propose(false).unwrap().is_none());
         }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -752,8 +752,8 @@ mod test {
         storage::{mem_store::MemStore, WriteBatch},
     };
 
-    #[test]
-    fn test_get_blocks() {
+    #[tokio::test]
+    async fn test_get_blocks() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -858,8 +858,8 @@ mod test {
             .is_empty());
     }
 
-    #[test]
-    fn test_ancestors_at_uncommitted_round() {
+    #[tokio::test]
+    async fn test_ancestors_at_uncommitted_round() {
         // Initialize DagState.
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
@@ -1015,8 +1015,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_contains_blocks_in_cache_or_store() {
+    #[tokio::test]
+    async fn test_contains_blocks_in_cache_or_store() {
         /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
 
@@ -1074,8 +1074,8 @@ mod test {
         assert_eq!(result, expected.clone());
     }
 
-    #[test]
-    fn test_contains_cached_block_at_slot() {
+    #[tokio::test]
+    async fn test_contains_cached_block_at_slot() {
         /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
 
@@ -1138,9 +1138,9 @@ mod test {
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic(expected = "Attempted to check for slot A8 that is <= the last evicted round 8")]
-    fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
+    async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
         /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
 
@@ -1179,8 +1179,8 @@ mod test {
             dag_state.contains_cached_block_at_slot(Slot::new(8, AuthorityIndex::new_for_test(0)));
     }
 
-    #[test]
-    fn test_get_blocks_in_cache_or_store() {
+    #[tokio::test]
+    async fn test_get_blocks_in_cache_or_store() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -1237,8 +1237,8 @@ mod test {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_flush_and_recovery() {
+    #[tokio::test]
+    async fn test_flush_and_recovery() {
         let num_authorities: u32 = 4;
         let (context, _) = Context::new_for_test(num_authorities as usize);
         let context = Arc::new(context);
@@ -1335,8 +1335,8 @@ mod test {
         assert_eq!(dag_state.last_commit_index(), 5);
     }
 
-    #[test]
-    fn test_get_cached_blocks() {
+    #[tokio::test]
+    async fn test_get_cached_blocks() {
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = 5;
 
@@ -1390,8 +1390,8 @@ mod test {
         assert_eq!(cached_blocks[0].round(), 12);
     }
 
-    #[test]
-    fn test_get_cached_last_block_per_authority() {
+    #[tokio::test]
+    async fn test_get_cached_last_block_per_authority() {
         // GIVEN
         const CACHED_ROUNDS: Round = 2;
         let (mut context, _) = Context::new_for_test(4);
@@ -1439,11 +1439,11 @@ mod test {
         assert_eq!(last_blocks[3].round(), 2);
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic(
         expected = "Attempted to request for blocks of rounds < 2, when the last evicted round is 1 for authority C"
     )]
-    fn test_get_cached_last_block_per_authority_requesting_out_of_round_range() {
+    async fn test_get_cached_last_block_per_authority_requesting_out_of_round_range() {
         // GIVEN
         const CACHED_ROUNDS: Round = 1;
         let (mut context, _) = Context::new_for_test(4);
@@ -1486,8 +1486,8 @@ mod test {
         dag_state.get_last_cached_block_per_authority(end_round);
     }
 
-    #[test]
-    fn test_last_quorum() {
+    #[tokio::test]
+    async fn test_last_quorum() {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
@@ -1538,8 +1538,8 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_last_block_for_authority() {
+    #[tokio::test]
+    async fn test_last_block_for_authority() {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -302,8 +302,8 @@ mod tests {
     use super::*;
     use crate::commit::CommitRange;
 
-    #[test]
-    fn test_elect_leader() {
+    #[tokio::test]
+    async fn test_elect_leader() {
         let context = Arc::new(Context::new_for_test(4).0);
         let leader_schedule = LeaderSchedule::new(context, LeaderSwapTable::default());
 
@@ -326,8 +326,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_elect_leader_stake_based() {
+    #[tokio::test]
+    async fn test_elect_leader_stake_based() {
         let context = Arc::new(Context::new_for_test(4).0);
         let leader_schedule = LeaderSchedule::new(context, LeaderSwapTable::default());
 
@@ -350,8 +350,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_leader_swap_table() {
+    #[tokio::test]
+    async fn test_leader_swap_table() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 
@@ -374,8 +374,8 @@ mod tests {
             .contains_key(&AuthorityIndex::new_for_test(0)));
     }
 
-    #[test]
-    fn test_leader_swap_table_swap() {
+    #[tokio::test]
+    async fn test_leader_swap_table_swap() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 
@@ -402,8 +402,8 @@ mod tests {
         assert_eq!(swapped_leader, None);
     }
 
-    #[test]
-    fn test_leader_swap_table_retrieve_first_nodes() {
+    #[tokio::test]
+    async fn test_leader_swap_table_retrieve_first_nodes() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 
@@ -440,11 +440,11 @@ mod tests {
         )));
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic(
         expected = "The swap_stake_threshold (34) should be in range [0 - 33], out of bounds parameter detected"
     )]
-    fn test_leader_swap_table_swap_stake_threshold_out_of_bounds() {
+    async fn test_leader_swap_table_swap_stake_threshold_out_of_bounds() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 
@@ -456,8 +456,8 @@ mod tests {
         LeaderSwapTable::new(context, reputation_scores, swap_stake_threshold);
     }
 
-    #[test]
-    fn test_update_leader_swap_table() {
+    #[tokio::test]
+    async fn test_update_leader_swap_table() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 
@@ -485,11 +485,11 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic(
         expected = "The new LeaderSwapTable has an invalid CommitRange. Old LeaderSwapTable CommitRange(11..21) vs new LeaderSwapTable CommitRange(21..26)"
     )]
-    fn test_update_bad_leader_swap_table() {
+    async fn test_update_bad_leader_swap_table() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -385,8 +385,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_reputation_scores_update_metrics() {
+    #[tokio::test]
+    async fn test_reputation_scores_update_metrics() {
         let context = Arc::new(Context::new_for_test(4).0);
         let scores = ReputationScores::new(CommitRange::new(1..300), vec![1, 2, 4, 3]);
         scores.update_metrics(context.clone());

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -421,8 +421,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_reputation_score_calculator() {
+    #[tokio::test]
+    async fn test_reputation_score_calculator() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
         let leader_schedule = Arc::new(LeaderSchedule::new(
@@ -504,9 +504,9 @@ mod tests {
         assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic(expected = "Attempted to calculate scores with no unscored subdags")]
-    fn test_reputation_score_calculator_no_subdags() {
+    async fn test_reputation_score_calculator_no_subdags() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
         let leader_schedule = Arc::new(LeaderSchedule::new(
@@ -535,9 +535,9 @@ mod tests {
         calculator.calculate();
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic(expected = "Attempted to create UnscoredSubdag with no blocks")]
-    fn test_reputation_score_calculator_no_subdag_blocks() {
+    async fn test_reputation_score_calculator_no_subdag_blocks() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
         let leader_schedule = Arc::new(LeaderSchedule::new(
@@ -572,8 +572,8 @@ mod tests {
         calculator.calculate();
     }
 
-    #[test]
-    fn test_scoring_with_missing_block_in_subdag() {
+    #[tokio::test]
+    async fn test_scoring_with_missing_block_in_subdag() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
         let leader_schedule = Arc::new(LeaderSchedule::new(

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -369,8 +369,8 @@ mod tests {
         universal_committer::universal_committer_builder::UniversalCommitterBuilder,
     };
 
-    #[test]
-    fn test_reputation_scores_authorities_by_score_desc() {
+    #[tokio::test]
+    async fn test_reputation_scores_authorities_by_score_desc() {
         let context = Arc::new(Context::new_for_test(4).0);
         let scores = ReputationScores::new(CommitRange::new(1..300), vec![4, 1, 1, 3]);
         let authorities = scores.authorities_by_score_desc(context);

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -317,8 +317,8 @@ mod tests {
         CommittedSubDag,
     };
 
-    #[test]
-    fn test_certificate_scoring_strategy() {
+    #[tokio::test]
+    async fn test_certificate_scoring_strategy() {
         let (context, committer, unscored_subdags) = basic_setup();
 
         let mut calculator = ReputationScoreCalculator::new(
@@ -332,8 +332,8 @@ mod tests {
         assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
-    #[test]
-    fn test_vote_scoring_strategy() {
+    #[tokio::test]
+    async fn test_vote_scoring_strategy() {
         let (context, committer, unscored_subdags) = basic_setup();
 
         let mut calculator = ReputationScoreCalculator::new(
@@ -347,8 +347,8 @@ mod tests {
         assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
-    #[test]
-    fn test_certified_vote_scoring_strategy_v1() {
+    #[tokio::test]
+    async fn test_certified_vote_scoring_strategy_v1() {
         let (context, committer, unscored_subdags) = basic_setup();
 
         let mut calculator = ReputationScoreCalculator::new(
@@ -362,8 +362,8 @@ mod tests {
         assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
-    #[test]
-    fn test_certified_vote_scoring_strategy_v2() {
+    #[tokio::test]
+    async fn test_certified_vote_scoring_strategy_v2() {
         let (context, committer, unscored_subdags) = basic_setup();
 
         let mut calculator = ReputationScoreCalculator::new(

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -155,8 +155,8 @@ mod tests {
         storage::mem_store::MemStore,
     };
 
-    #[test]
-    fn test_handle_commit() {
+    #[tokio::test]
+    async fn test_handle_commit() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
@@ -200,8 +200,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_handle_already_committed() {
+    #[tokio::test]
+    async fn test_handle_already_committed() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);

--- a/consensus/core/src/test_dag_parser.rs
+++ b/consensus/core/src/test_dag_parser.rs
@@ -282,8 +282,8 @@ mod tests {
     use super::*;
     use crate::block::BlockAPI;
 
-    #[test]
-    fn test_dag_parsing() {
+    #[tokio::test]
+    async fn test_dag_parsing() {
         telemetry_subscribers::init_for_testing();
         let dag_str = "DAG { 
             Round 0 : { 4 },
@@ -374,8 +374,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_genesis_round_parsing() {
+    #[tokio::test]
+    async fn test_genesis_round_parsing() {
         let dag_str = "Round 0 : { 4 }";
         let result = parse_genesis(dag_str);
         assert!(result.is_ok());
@@ -384,8 +384,8 @@ mod tests {
         assert_eq!(num_authorities, 4);
     }
 
-    #[test]
-    fn test_slot_parsing() {
+    #[tokio::test]
+    async fn test_slot_parsing() {
         let dag_str = "A0";
         let result = parse_slot(dag_str);
         assert!(result.is_ok());
@@ -395,8 +395,8 @@ mod tests {
         assert_eq!(slot.round, 0);
     }
 
-    #[test]
-    fn test_all_round_parsing() {
+    #[tokio::test]
+    async fn test_all_round_parsing() {
         let dag_str = "Round 1 : { * }";
         let context = Arc::new(Context::new_for_test(4).0);
         let dag_builder = DagBuilder::new(context);
@@ -411,8 +411,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_specific_round_parsing() {
+    #[tokio::test]
+    async fn test_specific_round_parsing() {
         let dag_str = "Round 1 : {
             A -> [A0, B0, C0, D0],
             B -> [*, A0],
@@ -444,8 +444,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_parse_author_and_connections() {
+    #[tokio::test]
+    async fn test_parse_author_and_connections() {
         let expected_authority = str_to_authority_index("A").unwrap();
 
         // case 1: all authorities
@@ -483,8 +483,8 @@ mod tests {
         // TODO: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
     }
 
-    #[test]
-    fn test_str_to_authority_index() {
+    #[tokio::test]
+    async fn test_str_to_authority_index() {
         assert_eq!(
             str_to_authority_index("A"),
             Some(AuthorityIndex::new_for_test(0))

--- a/consensus/core/src/tests/base_committer_tests.rs
+++ b/consensus/core/src/tests/base_committer_tests.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 
 /// Commit one leader.  
-#[test]
-fn try_direct_commit() {
+#[tokio::test]
+async fn try_direct_commit() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -73,8 +73,8 @@ fn try_direct_commit() {
 }
 
 /// Ensure idempotent replies.
-#[test]
-fn idempotence() {
+#[tokio::test]
+async fn idempotence() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -117,8 +117,8 @@ fn idempotence() {
 }
 
 /// Commit one by one each leader as the dag progresses in ideal conditions.
-#[test]
-fn multiple_direct_commit() {
+#[tokio::test]
+async fn multiple_direct_commit() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -158,8 +158,8 @@ fn multiple_direct_commit() {
 }
 
 /// We directly skip the leader if it has enough blame.
-#[test]
-fn direct_skip() {
+#[tokio::test]
+async fn direct_skip() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -210,8 +210,8 @@ fn direct_skip() {
 }
 
 /// Indirect-commit the first leader.
-#[test]
-fn indirect_commit() {
+#[tokio::test]
+async fn indirect_commit() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -352,8 +352,8 @@ fn indirect_commit() {
 }
 
 /// Commit the first leader, indirectly skip the 2nd, and commit the 3rd leader.
-#[test]
-fn indirect_skip() {
+#[tokio::test]
+async fn indirect_skip() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -482,8 +482,8 @@ fn indirect_skip() {
 }
 
 /// If there is no leader with enough support nor blame, we commit nothing.
-#[test]
-fn undecided() {
+#[tokio::test]
+async fn undecided() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);
@@ -570,8 +570,8 @@ fn undecided() {
 // This test scenario has one authority that is acting in a byzantine manner. It
 // will be sending multiple different blocks to different validators for a round.
 // The commit rule should handle this and correctly commit the expected blocks.
-#[test]
-fn test_byzantine_direct_commit() {
+#[tokio::test]
+async fn test_byzantine_direct_commit() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
     let context = Arc::new(Context::new_for_test(4).0);

--- a/consensus/core/src/tests/pipelined_committer_tests.rs
+++ b/consensus/core/src/tests/pipelined_committer_tests.rs
@@ -18,8 +18,8 @@ use crate::{
 };
 
 /// Commit one leader.
-#[test]
-fn direct_commit() {
+#[tokio::test]
+async fn direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // note: pipelines, waves & rounds are zero-indexed.
@@ -44,8 +44,8 @@ fn direct_commit() {
 }
 
 /// Ensure idempotent replies.
-#[test]
-fn idempotence() {
+#[tokio::test]
+async fn idempotence() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach decision round of pipeline 1 wave 0 which is round 4.
@@ -97,8 +97,8 @@ fn idempotence() {
 }
 
 /// Commit one by one each leader as the dag progresses in ideal conditions.
-#[test]
-fn multiple_direct_commit() {
+#[tokio::test]
+async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = DEFAULT_WAVE_LENGTH;
 
@@ -143,8 +143,8 @@ fn multiple_direct_commit() {
 }
 
 /// Commit 10 leaders in a row (calling the committer after adding them).
-#[test]
-fn direct_commit_late_call() {
+#[tokio::test]
+async fn direct_commit_late_call() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = DEFAULT_WAVE_LENGTH;
 
@@ -174,8 +174,8 @@ fn direct_commit_late_call() {
 }
 
 /// Do not commit anything if we are still in the first wave.
-#[test]
-fn no_genesis_commit() {
+#[tokio::test]
+async fn no_genesis_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Pipeline 0 wave 0 will not have a commit because its leader round is the
@@ -194,8 +194,8 @@ fn no_genesis_commit() {
 }
 
 /// We do not commit anything if we miss the first leader.
-#[test]
-fn direct_skip_no_leader() {
+#[tokio::test]
+async fn direct_skip_no_leader() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach the decision round of the leader of wave 0 for
@@ -245,8 +245,8 @@ fn direct_skip_no_leader() {
 }
 
 /// We directly skip the leader if it has enough blame.
-#[test]
-fn direct_skip_enough_blame() {
+#[tokio::test]
+async fn direct_skip_enough_blame() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach the wave 0 leader for pipeline 1.
@@ -318,8 +318,8 @@ fn direct_skip_enough_blame() {
 }
 
 /// Indirect-commit the first leader.
-#[test]
-fn indirect_commit() {
+#[tokio::test]
+async fn indirect_commit() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = DEFAULT_WAVE_LENGTH;
 
@@ -435,8 +435,8 @@ fn indirect_commit() {
 }
 
 /// Commit the first 3 leaders, skip the 4th, and commit the next 3 leaders.
-#[test]
-fn indirect_skip() {
+#[tokio::test]
+async fn indirect_skip() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = DEFAULT_WAVE_LENGTH;
 
@@ -528,8 +528,8 @@ fn indirect_skip() {
 }
 
 /// If there is no leader with enough support nor blame, we commit nothing.
-#[test]
-fn undecided() {
+#[tokio::test]
+async fn undecided() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach the first leader.
@@ -579,8 +579,8 @@ fn undecided() {
 // However when extra dag layers are added and the byzantine node is meant to be
 // a leader, its block is skipped as there is not enough votes to directly
 // decide it and not any certified links to indirectly commit it.
-#[test]
-fn test_byzantine_validator() {
+#[tokio::test]
+async fn test_byzantine_validator() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach leader A12

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -20,8 +20,8 @@ use crate::{
 };
 
 /// Commit one leader.
-#[test]
-fn direct_commit() {
+#[tokio::test]
+async fn direct_commit() {
     let mut test_setup = basic_dag_builder_test_setup();
 
     // Build fully connected dag with empty blocks adding up to voting round of
@@ -58,8 +58,8 @@ fn direct_commit() {
 }
 
 /// Ensure idempotent replies.
-#[test]
-fn idempotence() {
+#[tokio::test]
+async fn idempotence() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // note: waves & rounds are zero-indexed.
@@ -135,8 +135,8 @@ fn idempotence() {
 }
 
 /// Commit one by one each leader as the dag progresses in ideal conditions.
-#[test]
-fn multiple_direct_commit() {
+#[tokio::test]
+async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     let mut ancestors = None;
@@ -173,8 +173,8 @@ fn multiple_direct_commit() {
 }
 
 /// Commit 10 leaders in a row (calling the committer after adding them).
-#[test]
-fn direct_commit_late_call() {
+#[tokio::test]
+async fn direct_commit_late_call() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // note: waves & rounds are zero-indexed.
@@ -206,8 +206,8 @@ fn direct_commit_late_call() {
 }
 
 /// Do not commit anything if we are still in the first wave.
-#[test]
-fn no_genesis_commit() {
+#[tokio::test]
+async fn no_genesis_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // note: waves & rounds are zero-indexed.
@@ -224,8 +224,8 @@ fn no_genesis_commit() {
 }
 
 /// We directly skip the leader if there are enough non-votes (blames).
-#[test]
-fn direct_skip_no_leader_votes() {
+#[tokio::test]
+async fn direct_skip_no_leader_votes() {
     let mut test_setup = basic_dag_builder_test_setup();
 
     // Add enough blocks to reach the leader round of wave 1.
@@ -272,8 +272,8 @@ fn direct_skip_no_leader_votes() {
 }
 
 /// We directly skip the leader if it is missing.
-#[test]
-fn direct_skip_missing_leader_block() {
+#[tokio::test]
+async fn direct_skip_missing_leader_block() {
     let mut test_setup = basic_dag_builder_test_setup();
 
     // Add enough blocks to reach the decision round of wave 0
@@ -323,8 +323,8 @@ fn direct_skip_missing_leader_block() {
 }
 
 /// Indirect-commit the first leader.
-#[test]
-fn indirect_commit() {
+#[tokio::test]
+async fn indirect_commit() {
     telemetry_subscribers::init_for_testing();
     // Dag Notes:
     // - Fully connected up to the leader round of wave 1.
@@ -398,8 +398,8 @@ fn indirect_commit() {
 }
 
 /// Commit the first leader, skip the 2nd, and commit the 3rd leader.
-#[test]
-fn indirect_skip() {
+#[tokio::test]
+async fn indirect_skip() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach the leader of wave 2
@@ -498,8 +498,8 @@ fn indirect_skip() {
 }
 
 /// If there is no leader with enough support nor blame, we commit nothing.
-#[test]
-fn undecided() {
+#[tokio::test]
+async fn undecided() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach the leader of wave 1.
@@ -557,8 +557,8 @@ fn undecided() {
 // This test scenario has one authority that is acting in a byzantine manner. It
 // will be sending multiple different blocks to different validators for a round.
 // The commit rule should handle this and correctly commit the expected blocks.
-#[test]
-fn test_byzantine_direct_commit() {
+#[tokio::test]
+async fn test_byzantine_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     // Add enough blocks to reach leader round of wave 4


### PR DESCRIPTION
## Description 

This is an attempt to re-merge the changes of an earlier PR that reverted here https://github.com/MystenLabs/sui/pull/17467.

## Test plan 

CI/locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
