### PR TITLE
[GraphQL] Move the version middleware route layer to build function

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -237,18 +237,7 @@ impl ServerBuilder {
 
     pub fn route(mut self, path: &str, method_handler: MethodRouter) -> Self {
         self.init_router();
-        self.router = self.router.map(|router| {
-            router
-                .route(path, method_handler)
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    set_version_middleware,
-                ))
-                .route_layer(middleware::from_fn_with_state(
-                    self.state.version,
-                    check_version_middleware,
-                ))
-        });
+        self.router = self.router.map(|router| router.route(path, method_handler));
         self
     }
 
@@ -316,6 +305,14 @@ impl ServerBuilder {
         );
 
         let app = router
+            .route_layer(middleware::from_fn_with_state(
+                state.version,
+                set_version_middleware,
+            ))
+            .route_layer(middleware::from_fn_with_state(
+                state.version,
+                check_version_middleware,
+            ))
             .layer(axum::extract::Extension(schema))
             .layer(axum::extract::Extension(watermark_task.lock()))
             .layer(Self::cors()?);


### PR DESCRIPTION
## Description 

Move the middleware to the `build` function to avoid adding it multiple times due to multiple `route` calls in the `start_graphiql_server`, which was introduced in #17456.

## Test plan 

http://127.0.0.1:8000/graphql/beta
http://127.0.0.1:8000/graphql/stable
http://127.0.0.1:8000/graphql/legacy
http://127.0.0.1:8000/graphql/2024.7
http://127.0.0.1:8000/beta
http://127.0.0.1:8000/stable
http://127.0.0.1:8000/legacy
http://127.0.0.1:8000/2024.7

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
