### PR TITLE
[GraphQL] Fix endpoint for GraphiQL IDE

### DIFF
--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::extract::Path;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -8,8 +9,16 @@ use crate::config::{ServerConfig, Version};
 use crate::error::Error;
 use crate::server::builder::ServerBuilder;
 
-async fn graphiql(ide_title: axum::Extension<Option<String>>) -> impl axum::response::IntoResponse {
-    let gq = async_graphql::http::GraphiQLSource::build().endpoint("/");
+async fn graphiql(
+    ide_title: axum::Extension<Option<String>>,
+    path: Option<Path<String>>,
+) -> impl axum::response::IntoResponse {
+    let endpoint = if let Some(Path(path)) = path {
+        format!("/graphql/{}", path)
+    } else {
+        "/graphql".to_string()
+    };
+    let gq = async_graphql::http::GraphiQLSource::build().endpoint(&endpoint);
     if let axum::Extension(Some(title)) = ide_title {
         axum::response::Html(gq.title(&title).finish())
     } else {


### PR DESCRIPTION
## Description 

Fixes the endpoint for the GraphiQL service to always be `/graphql` + version if it is specified, regardless if the request is to `[...]/` or to `[...]/graphql`.  

## Test plan 

Visually in the browser. Checked: 
* bad version `/graphql/test` is caught: ✅ 
* good version works `/graphql` or `/` or `/stable` or `/legacy`: ✅ 
* if the routing actually goes where it needs

![image](https://github.com/MystenLabs/sui/assets/135084671/61bdb5fd-3d47-4f2b-bc1d-5874c403ec0c)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
