### PR TITLE
[bug fix][move] Removed compiler unwrap

### DIFF
--- a/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
@@ -155,7 +155,7 @@ impl<'a> SimpleAbsInt for IDLeakVerifierAI<'a> {
         let E::Pack(s, _tys, fields) = e__ else {
             return None;
         };
-        let abilities = self.declared_abilities.get(s).unwrap();
+        let abilities = self.declared_abilities.get(s)?;
         if !abilities.has_ability_(Ability_::Key) {
             return None;
         }

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/id_leak/private_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/id_leak/private_pack.exp
@@ -1,0 +1,7 @@
+error[E04001]: restricted visibility
+   ┌─ tests/sui_mode/id_leak/private_pack.move:19:9
+   │
+19 │         A { id }
+   │         ^^^^^^^^ Invalid instantiation of 'a::a::A'.
+All structs can only be constructed in the module in which they are declared
+

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/id_leak/private_pack.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/id_leak/private_pack.move
@@ -1,0 +1,27 @@
+// not allowed since C is not packed with a fresh UID
+module a::a {
+    use sui::object::UID;
+
+    struct A has key {
+        id: UID
+    }
+}
+
+module b::b {
+    use sui::object::UID;
+    use a::a::A;
+
+    struct B has key {
+        id: UID
+    }
+    public fun no(b: B): A {
+        let B { id } = b;
+        A { id }
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}


### PR DESCRIPTION
## Description 

- Fixes #17426
- The id-leak assumed pack visibility was a blocking error 

## Test plan 

- Added a test 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Fixed a bug where the Move compiler could panic when instantiating an object outside of its defining module. 
- [ ] Rust SDK: 

