### PR TITLE
[move-ide] Added support for displaying function types

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -253,7 +253,7 @@ fn context_specific_no_trigger(
             let Some(def_info) = symbols.def_info(&def_loc) else {
                 break;
             };
-            let DefInfo::Function(mod_ident, v, _, _, _, _, _) = def_info else {
+            let DefInfo::Function(mod_ident, v, _, _, _, _, _, _) = def_info else {
                 // not a function
                 break;
             };

--- a/external-crates/move/crates/move-analyzer/tests/macros/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/macros/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Macror"
+version = "0.0.1"
+edition = "2024.alpha"
+
+[addresses]
+Macros = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/macros/sources/fun_type.move
+++ b/external-crates/move/crates/move-analyzer/tests/macros/sources/fun_type.move
@@ -1,0 +1,14 @@
+module Macros::fun_type {
+
+    entry fun entry_fun() {
+    }
+
+    macro fun macro_fun() {
+    }
+
+    public fun foo() {
+        entry_fun();
+        macro_fun!();
+    }
+
+}

--- a/external-crates/move/crates/move-analyzer/tests/move-2024/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/move-2024/Move.toml
@@ -8,4 +8,3 @@ MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
 
 [addresses]
 Move2024 = "0xCAFE"
-Sui = "0x2"


### PR DESCRIPTION
## Description 

This PR adds support for on-hover displaying function types (`entry` and `macro`)

## Test plan 

A test has been added.
