### PR TITLE
[Docs] Deprecate sui_programmability examples

### DIFF
--- a/sui_programmability/examples/README.md
+++ b/sui_programmability/examples/README.md
@@ -1,3 +1,6 @@
+>[!IMPORTANT]
+> These examples are out-of-date and have been retained as an archive, please **find the latest examples in the [examples](../../examples) directory** which contains up-to-date [Move](../../examples/move) examples as well as end-to-end examples!
+
 Lots of Move code examples, partitioned by category:
 
 * basics: The very simplest examples of Sui programming.

--- a/sui_programmability/examples/README.md
+++ b/sui_programmability/examples/README.md
@@ -1,5 +1,5 @@
 >[!IMPORTANT]
-> These examples are out-of-date and have been retained as an archive, please **find the latest examples in the [examples](../../examples) directory** which contains up-to-date [Move](../../examples/move) examples as well as end-to-end examples!
+> These examples are out-of-date and have been retained as an archive, please **find the latest versions in the [examples](../../examples) directory** which contains up-to-date [Move](../../examples/move) and end-to-end examples!
 
 Lots of Move code examples, partitioned by category:
 


### PR DESCRIPTION
## Description

Add a message to indicate that these examples are out-of-date and that people should go to the `examples` directory instead.

## Test plan

:eyes:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
