### PR TITLE
[move] macros and type holes to 2024.beta

### DIFF
--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -132,7 +132,7 @@ pub fn valid_editions_for_feature(feature: FeatureGate) -> Vec<Edition> {
 static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
     Lazy::new(|| BTreeMap::from_iter(Edition::ALL.iter().map(|e| (*e, e.features()))));
 
-const E2024_ALPHA_FEATURES: &[FeatureGate] = &[FeatureGate::MacroFuns, FeatureGate::TypeHoles];
+const E2024_ALPHA_FEATURES: &[FeatureGate] = &[];
 
 const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::NestedUse,
@@ -149,6 +149,8 @@ const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::SyntaxMethods,
     FeatureGate::AutoborrowEq,
     FeatureGate::NoParensCast,
+    FeatureGate::MacroFuns,
+    FeatureGate::TypeHoles,
 ];
 
 const DEVELOPMENT_FEATURES: &[FeatureGate] = &[FeatureGate::CleverAssertions, FeatureGate::Enums];

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -132,7 +132,7 @@ pub(crate) use debug_print_internal;
 
 /// Macro for a small DSL for compactling printing debug information based on the provided flag.
 ///
-///  ```
+///  ```text
 ///  debug_print!(
 ///      context.debug_flags.match_compilation,
 ///      ("subject" => subject),

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_call.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_call.exp
@@ -14,7 +14,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_call.move:4:12
   │
 4 │         foo!(|| ())
-  │            ^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │            ^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition.move:2:12
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:2:17
   │
 2 │     fun tfun(_: |u64| u64) {}
-  │                 ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                 ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:4:17
   │
 4 │         let _ = |x| x;
-  │                 ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                 ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_invalid_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_invalid_usage.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_invalid_usage.move:2:22
   │
 2 │     struct S<T> { f: _ }
-  │                      ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                      ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -16,7 +16,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_invalid_usage.move:3:16
   │
 3 │     fun foo(_: _) {}
-  │                ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_valid_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_valid_usage.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_valid_usage.move:3:23
   │
 3 │         let v: vector<_> = vector[0];
-  │                       ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                       ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
   │
 3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │               ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 


### PR DESCRIPTION
## Description 

- Change edition gating for macros and type holes to beta

## Test plan 

- ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Move `macro fun`s and associated features are now available in 2024.beta
- [ ] Rust SDK: 
