### PR TITLE
[move] Make usage of move serialization version explicit

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4984,7 +4984,7 @@ pub mod framework_injection {
             .iter()
             .map(|m| {
                 let mut buf = Vec::new();
-                m.serialize(&mut buf).unwrap();
+                m.serialize_with_version(m.version, &mut buf).unwrap();
                 buf
             })
             .collect()

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -214,10 +214,12 @@ async fn init_genesis(
     // add object_basics package object to genesis
     let modules: Vec<_> = compile_basics_package().get_modules().cloned().collect();
     let genesis_move_packages: Vec<_> = BuiltInFramework::genesis_move_packages().collect();
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
     let pkg = Object::new_package(
         &modules,
         TransactionDigest::genesis_marker(),
-        ProtocolConfig::get_for_max_version_UNSAFE().max_move_package_size(),
+        config.max_move_package_size(),
+        config.move_binary_format_version(),
         &genesis_move_packages,
     )
     .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1751,7 +1751,9 @@ async fn test_publish_dependent_module_ok() {
     let dependent_module = make_dependent_module(&genesis_module);
     let dependent_module_bytes = {
         let mut bytes = Vec::new();
-        dependent_module.serialize(&mut bytes).unwrap();
+        dependent_module
+            .serialize_with_version(dependent_module.version, &mut bytes)
+            .unwrap();
         bytes
     };
 
@@ -1806,7 +1808,9 @@ async fn test_publish_module_no_dependencies_ok() {
 
     let module = file_format::empty_module();
     let mut module_bytes = Vec::new();
-    module.serialize(&mut module_bytes).unwrap();
+    module
+        .serialize_with_version(module.version, &mut module_bytes)
+        .unwrap();
     let module_bytes = vec![module_bytes];
     let dependencies = vec![]; // no dependencies
     let data = TransactionData::new_module(
@@ -1859,7 +1863,9 @@ async fn test_publish_non_existing_dependent_module() {
     });
     let dependent_module_bytes = {
         let mut bytes = Vec::new();
-        dependent_module.serialize(&mut bytes).unwrap();
+        dependent_module
+            .serialize_with_version(dependent_module.version, &mut bytes)
+            .unwrap();
         bytes
     };
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
@@ -1914,7 +1920,9 @@ async fn test_package_size_limit() {
             Identifier::new(format!("TestModule{:0>21000?}", modules_size)).unwrap();
         let module_bytes = {
             let mut bytes = Vec::new();
-            module.serialize(&mut bytes).unwrap();
+            module
+                .serialize_with_version(module.version, &mut bytes)
+                .unwrap();
             bytes
         };
         modules_size += module_bytes.len() as u64;

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -410,7 +410,7 @@ async fn test_publish_extraneous_bytes_modules() {
             value: vec![1],
         });
         let mut buf = vec![];
-        m.serialize(&mut buf).unwrap();
+        m.serialize_with_version(m.version, &mut buf).unwrap();
         buf
     };
     modules[0] = new_bytes;

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::file_format::CompiledModule;
+use move_binary_format::{file_format::CompiledModule, file_format_common::VERSION_MAX};
 
 use std::{collections::BTreeMap, path::PathBuf};
 use sui_move_build::{BuildConfig, CompiledPackage};
@@ -46,13 +46,20 @@ macro_rules! linkage_table {
 #[test]
 fn test_new_initial() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let b_id1 = ObjectID::from_single_byte(0xb1);
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_pkg])
+        .unwrap();
 
-    let a_pkg =
-        MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg, &c_pkg]).unwrap();
+    let a_pkg = MovePackage::new_initial(
+        &build_test_modules("A"),
+        u64::MAX,
+        VERSION_MAX,
+        [&b_pkg, &c_pkg],
+    )
+    .unwrap();
 
     assert_eq!(
         a_pkg.linkage_table(),
@@ -97,7 +104,8 @@ fn test_new_initial() {
 #[test]
 fn test_upgraded() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -125,7 +133,8 @@ fn test_upgraded() {
 #[test]
 fn test_depending_on_upgrade() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -137,7 +146,8 @@ fn test_depending_on_upgrade() {
         )
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_new])
+        .unwrap();
 
     assert_eq!(
         b_pkg.linkage_table(),
@@ -150,7 +160,8 @@ fn test_depending_on_upgrade() {
 #[test]
 fn test_upgrade_upgrades_linkage() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -162,7 +173,8 @@ fn test_upgrade_upgrades_linkage() {
         )
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_pkg])
+        .unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
     let b_new = b_pkg
@@ -192,7 +204,8 @@ fn test_upgrade_upgrades_linkage() {
 #[test]
 fn test_upgrade_linkage_digest_to_new_dep() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -204,7 +217,8 @@ fn test_upgrade_linkage_digest_to_new_dep() {
         )
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_pkg])
+        .unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
     let b_new = b_pkg
@@ -233,7 +247,9 @@ fn test_upgrade_linkage_digest_to_new_dep() {
                 .iter()
                 .map(|module| {
                     let mut bytes = Vec::new();
-                    module.serialize(&mut bytes).unwrap();
+                    module
+                        .serialize_with_version(module.version, &mut bytes)
+                        .unwrap();
                     bytes
                 })
                 .collect::<Vec<_>>(),
@@ -246,7 +262,8 @@ fn test_upgrade_linkage_digest_to_new_dep() {
 #[test]
 fn test_upgrade_downngrades_linkage() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -258,7 +275,8 @@ fn test_upgrade_downngrades_linkage() {
         )
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_new])
+        .unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
     let b_new = b_pkg
@@ -288,7 +306,8 @@ fn test_upgrade_downngrades_linkage() {
 #[test]
 fn test_transitively_depending_on_upgrade() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -301,10 +320,16 @@ fn test_transitively_depending_on_upgrade() {
         .unwrap();
 
     let b_id1 = ObjectID::from_single_byte(0xb1);
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_pkg])
+        .unwrap();
 
-    let a_pkg =
-        MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg, &c_new]).unwrap();
+    let a_pkg = MovePackage::new_initial(
+        &build_test_modules("A"),
+        u64::MAX,
+        VERSION_MAX,
+        [&b_pkg, &c_new],
+    )
+    .unwrap();
 
     assert_eq!(
         a_pkg.linkage_table(),
@@ -317,7 +342,8 @@ fn test_transitively_depending_on_upgrade() {
 
 #[test]
 fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest() {
-    let c_v1 = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_v1 =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_v2 = c_v1
@@ -329,8 +355,10 @@ fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest
         )
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_v1]).unwrap();
-    let b_v2 = MovePackage::new_initial(&build_test_modules("Bv2"), u64::MAX, [&c_v2]).unwrap();
+    let b_pkg =
+        MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_v1]).unwrap();
+    let b_v2 = MovePackage::new_initial(&build_test_modules("Bv2"), u64::MAX, VERSION_MAX, [&c_v2])
+        .unwrap();
 
     let with_unpublished_deps = false;
     let local_v1 = build_test_package("B").get_package_digest(with_unpublished_deps);
@@ -346,12 +374,13 @@ fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest
 #[test]
 #[should_panic]
 fn test_panic_on_empty_package() {
-    let _ = MovePackage::new_initial(&[], u64::MAX, []);
+    let _ = MovePackage::new_initial(&[], u64::MAX, VERSION_MAX, []);
 }
 
 #[test]
 fn test_fail_on_missing_dep() {
-    let err = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, []).unwrap_err();
+    let err =
+        MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, []).unwrap_err();
 
     assert_eq!(
         err.kind(),
@@ -361,11 +390,14 @@ fn test_fail_on_missing_dep() {
 
 #[test]
 fn test_fail_on_missing_transitive_dep() {
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_pkg])
+        .unwrap();
 
-    let err = MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg]).unwrap_err();
+    let err = MovePackage::new_initial(&build_test_modules("A"), u64::MAX, VERSION_MAX, [&b_pkg])
+        .unwrap_err();
 
     assert_eq!(
         err.kind(),
@@ -375,7 +407,8 @@ fn test_fail_on_missing_transitive_dep() {
 
 #[test]
 fn test_fail_on_transitive_dependency_downgrade() {
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
@@ -387,10 +420,16 @@ fn test_fail_on_transitive_dependency_downgrade() {
         )
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, VERSION_MAX, [&c_new])
+        .unwrap();
 
-    let err =
-        MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg, &c_pkg]).unwrap_err();
+    let err = MovePackage::new_initial(
+        &build_test_modules("A"),
+        u64::MAX,
+        VERSION_MAX,
+        [&b_pkg, &c_pkg],
+    )
+    .unwrap_err();
 
     assert_eq!(
         err.kind(),
@@ -400,7 +439,8 @@ fn test_fail_on_transitive_dependency_downgrade() {
 
 #[test]
 fn test_fail_on_upgrade_missing_type() {
-    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv2"), u64::MAX, []).unwrap();
+    let c_pkg =
+        MovePackage::new_initial(&build_test_modules("Cv2"), u64::MAX, VERSION_MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let err = c_pkg

--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -56,7 +56,7 @@ mod sim_only_tests {
 
     use super::*;
     use fastcrypto::encoding::Base64;
-    use move_binary_format::CompiledModule;
+    use move_binary_format::{file_format_common::VERSION_MAX, CompiledModule};
     use move_core_types::ident_str;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -1003,6 +1003,7 @@ mod sim_only_tests {
             &sui_system_modules(fixture),
             TransactionDigest::genesis_marker(),
             u64::MAX,
+            VERSION_MAX,
             &[
                 BuiltInFramework::get_package_by_id(&MOVE_STDLIB_PACKAGE_ID).genesis_move_package(),
                 BuiltInFramework::get_package_by_id(&SUI_FRAMEWORK_PACKAGE_ID)

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -281,7 +281,7 @@ fn serialize_modules_to_file<'a>(
         }
 
         let mut buf = Vec::new();
-        module.serialize(&mut buf)?;
+        module.serialize_with_version(module.version, &mut buf)?;
         serialized_modules.push(buf);
     }
     assert!(

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -987,7 +987,7 @@ fn process_package(
         .iter()
         .map(|m| {
             let mut buf = vec![];
-            m.serialize(&mut buf).unwrap();
+            m.serialize_with_version(m.version, &mut buf).unwrap();
             buf
         })
         .collect();

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -368,7 +368,7 @@ impl CompiledPackage {
             .iter()
             .map(|m| {
                 let mut bytes = Vec::new();
-                m.serialize(&mut bytes).unwrap(); // safe because package built successfully
+                m.serialize_with_version(m.version, &mut bytes).unwrap(); // safe because package built successfully
                 bytes
             })
             .collect()

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2184,6 +2184,7 @@ impl ProtocolConfig {
             allow_receiving_object_id: self.allow_receiving_object_id(),
             reject_mutable_random_on_entry_functions: self
                 .reject_mutable_random_on_entry_functions(),
+            bytecode_version: self.move_binary_format_version(),
         }
     }
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -389,7 +389,9 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
             .iter()
             .map(|m| {
                 let mut module_bytes = vec![];
-                m.module.serialize(&mut module_bytes).unwrap();
+                m.module
+                    .serialize_with_version(m.module.version, &mut module_bytes)
+                    .unwrap();
                 Ok(module_bytes)
             })
             .collect::<anyhow::Result<_>>()?;
@@ -750,7 +752,9 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
                                     .iter()
                                     .map(|m| {
                                         let mut buf = vec![];
-                                        m.module.serialize(&mut buf).unwrap();
+                                        m.module
+                                            .serialize_with_version(m.module.version, &mut buf)
+                                            .unwrap();
                                         buf
                                     })
                                     .collect();
@@ -942,7 +946,9 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
                     .iter()
                     .map(|m| {
                         let mut buf = vec![];
-                        m.module.serialize(&mut buf).unwrap();
+                        m.module
+                            .serialize_with_version(m.module.version, &mut buf)
+                            .unwrap();
                         buf
                     })
                     .collect::<Vec<_>>();
@@ -1256,7 +1262,8 @@ impl<'a> SuiTestAdapter {
             .iter()
             .map(|m| {
                 let mut module_bytes = vec![];
-                m.module.serialize(&mut module_bytes)?;
+                m.module
+                    .serialize_with_version(m.module.version, &mut module_bytes)?;
                 Ok(module_bytes)
             })
             .collect::<anyhow::Result<Vec<Vec<u8>>>>()?;

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -14,6 +14,7 @@ use derive_more::Display;
 use fastcrypto::hash::HashFunction;
 use move_binary_format::binary_config::BinaryConfig;
 use move_binary_format::file_format::CompiledModule;
+use move_binary_format::file_format_common::VERSION_6;
 use move_binary_format::normalized;
 use move_core_types::language_storage::ModuleId;
 use move_core_types::{
@@ -247,6 +248,7 @@ impl MovePackage {
     pub fn new_initial<'p>(
         modules: &[CompiledModule],
         max_move_package_size: u64,
+        move_binary_format_version: u32,
         transitive_dependencies: impl IntoIterator<Item = &'p MovePackage>,
     ) -> Result<Self, ExecutionError> {
         let module = modules
@@ -261,6 +263,7 @@ impl MovePackage {
             OBJECT_START_VERSION,
             modules,
             max_move_package_size,
+            move_binary_format_version,
             type_origin_table,
             transitive_dependencies,
         )
@@ -289,6 +292,7 @@ impl MovePackage {
             new_version,
             modules,
             protocol_config.max_move_package_size(),
+            protocol_config.move_binary_format_version(),
             type_origin_table,
             transitive_dependencies,
         )
@@ -328,7 +332,9 @@ impl MovePackage {
         let module_map = BTreeMap::from_iter(modules.iter().map(|module| {
             let name = module.name().to_string();
             let mut bytes = Vec::new();
-            module.serialize(&mut bytes).unwrap();
+            module
+                .serialize_with_version(module.version, &mut bytes)
+                .unwrap();
             (name, bytes)
         }));
 
@@ -349,6 +355,7 @@ impl MovePackage {
         version: SequenceNumber,
         modules: &[CompiledModule],
         max_move_package_size: u64,
+        move_binary_format_version: u32,
         type_origin_table: Vec<TypeOrigin>,
         transitive_dependencies: impl IntoIterator<Item = &'p MovePackage>,
     ) -> Result<Self, ExecutionError> {
@@ -366,7 +373,12 @@ impl MovePackage {
             );
 
             let mut bytes = Vec::new();
-            module.serialize(&mut bytes).unwrap();
+            let version = if move_binary_format_version > VERSION_6 {
+                module.version
+            } else {
+                VERSION_6
+            };
+            module.serialize_with_version(version, &mut bytes).unwrap();
             module_map.insert(name, bytes);
         }
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -641,12 +641,14 @@ impl Object {
         modules: &[CompiledModule],
         previous_transaction: TransactionDigest,
         max_move_package_size: u64,
+        move_binary_format_version: u32,
         dependencies: impl IntoIterator<Item = &'p MovePackage>,
     ) -> Result<Self, ExecutionError> {
         Ok(Self::new_package_from_data(
             Data::Package(MovePackage::new_initial(
                 modules,
                 max_move_package_size,
+                move_binary_format_version,
                 dependencies,
             )?),
             previous_transaction,
@@ -678,10 +680,12 @@ impl Object {
         dependencies: impl IntoIterator<Item = MovePackage>,
     ) -> Result<Self, ExecutionError> {
         let dependencies: Vec<_> = dependencies.into_iter().collect();
+        let config = ProtocolConfig::get_for_max_version_UNSAFE();
         Self::new_package(
             modules,
             previous_transaction,
-            ProtocolConfig::get_for_max_version_UNSAFE().max_move_package_size(),
+            config.max_move_package_size(),
+            config.move_binary_format_version(),
             &dependencies,
         )
     }

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -343,10 +343,12 @@ fn test_move_object_size_for_gas_metering() {
 #[test]
 fn test_move_package_size_for_gas_metering() {
     let module = file_format::empty_module();
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
     let package = Object::new_package(
         &[module],
         TransactionDigest::genesis_marker(),
-        ProtocolConfig::get_for_max_version_UNSAFE().max_move_package_size(),
+        config.max_move_package_size(),
+        config.move_binary_format_version(),
         &[], // empty dependencies for empty package (no modules)
     )
     .unwrap();

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_binary_format::file_format_common::VERSION_MAX;
 use move_vm_config::verifier::{
     MeterConfig, VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN, DEFAULT_MAX_IDENTIFIER_LENGTH,
 };
@@ -48,6 +49,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             allow_receiving_object_id: true,
             reject_mutable_random_on_entry_functions: true,
+            bytecode_version: VERSION_MAX,
         },
         MeterConfig::default(),
     )

--- a/external-crates/move/crates/language-benchmarks/src/move_vm.rs
+++ b/external-crates/move/crates/language-benchmarks/src/move_vm.rs
@@ -68,7 +68,7 @@ fn execute<M: Measurement + 'static>(
     for module in modules {
         let mut mod_blob = vec![];
         module
-            .serialize(&mut mod_blob)
+            .serialize_with_version(module.version, &mut mod_blob)
             .expect("Module serialization error");
         session
             .publish_module(mod_blob, sender, &mut UnmeteredGasMeter)

--- a/external-crates/move/crates/move-binary-format/src/serializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/serializer.rs
@@ -175,19 +175,9 @@ fn validate_version(version: u32) -> Result<()> {
 }
 
 impl CompiledModule {
-    /// Serializes a `CompiledModule` into a binary. The mutable `Vec<u8>` will contain the
-    /// binary blob on return.
-    pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
-        self.serialize_for_version(None, binary)
-    }
-
-    /// Serialize into binary, at given version.
-    pub fn serialize_for_version(
-        &self,
-        bytecode_version: Option<u32>,
-        binary: &mut Vec<u8>,
-    ) -> Result<()> {
-        let version = bytecode_version.unwrap_or(VERSION_MAX);
+    /// Serializes a `CompiledModule` into a binary at `version`. The mutable `Vec<u8>` will
+    /// contain the binary blob on return.
+    pub fn serialize_with_version(&self, version: u32, binary: &mut Vec<u8>) -> Result<()> {
         validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
         let mut ser = ModuleSerializer::new(version);
@@ -209,6 +199,13 @@ impl CompiledModule {
 
         *binary = binary_data.into_inner();
         Ok(())
+    }
+
+    /// Serializes a `CompiledModule` into a binary at VERSION_MAX. The mutable `Vec<u8>` will
+    /// contain the binary blob on return. To be used for testing only.
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
+        self.serialize_with_version(VERSION_MAX, binary)
     }
 }
 

--- a/external-crates/move/crates/move-bytecode-verifier/src/verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/verifier.rs
@@ -15,6 +15,7 @@ use move_binary_format::{
     check_bounds::BoundsChecker,
     errors::{Location, VMResult},
     file_format::CompiledModule,
+    file_format_common::VERSION_6,
 };
 use move_bytecode_verifier_meter::{dummy::DummyMeter, Meter};
 use move_vm_config::verifier::VerifierConfig;
@@ -42,7 +43,12 @@ pub fn verify_module_with_config_for_test(
 ) -> VMResult<()> {
     const MAX_MODULE_SIZE: usize = 65355;
     let mut bytes = vec![];
-    module.serialize(&mut bytes).unwrap();
+    let version = if config.bytecode_version > VERSION_6 {
+        module.version
+    } else {
+        VERSION_6
+    };
+    module.serialize_with_version(version, &mut bytes).unwrap();
     let now = Instant::now();
     let result = verify_module_with_config_metered(config, module, meter);
     eprintln!(

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/package_context.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/package_context.rs
@@ -50,7 +50,10 @@ impl PackageContext {
         for module in new_modules {
             let self_id = module.self_id();
             let mut module_bytes = vec![];
-            module.serialize_for_version(bytecode_version, &mut module_bytes)?;
+            module.serialize_with_version(
+                bytecode_version.unwrap_or(module.version),
+                &mut module_bytes,
+            )?;
             serialized_modules.push((self_id, module_bytes));
         }
         state.save_modules(&serialized_modules)?;

--- a/external-crates/move/crates/move-compiler/src/compiled_unit.rs
+++ b/external-crates/move/crates/move-compiler/src/compiled_unit.rs
@@ -10,7 +10,7 @@ use crate::{
     parser::ast::{FunctionName, ModuleName},
     shared::{unique_map::UniqueMap, Name, NumericalAddress},
 };
-use move_binary_format::file_format as F;
+use move_binary_format::{file_format as F, file_format_common::VERSION_MAX};
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier as MoveCoreIdentifier,
@@ -126,8 +126,9 @@ impl NamedCompiledModule {
 
     pub fn serialize(&self, bytecode_version: Option<u32>) -> Vec<u8> {
         let mut serialized = Vec::<u8>::new();
+        let bytecode_version = bytecode_version.unwrap_or(VERSION_MAX);
         self.module
-            .serialize_for_version(bytecode_version, &mut serialized)
+            .serialize_with_version(bytecode_version, &mut serialized)
             .unwrap();
         serialized
     }

--- a/external-crates/move/crates/move-ir-compiler/src/lib.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/lib.rs
@@ -36,7 +36,7 @@ impl<'a> Compiler<'a> {
         let compiled_module = self.compile_mod(code)?.0;
 
         let mut serialized_module = Vec::<u8>::new();
-        compiled_module.serialize(&mut serialized_module)?;
+        compiled_module.serialize_with_version(compiled_module.version, &mut serialized_module)?;
         Ok(serialized_module)
     }
 

--- a/external-crates/move/crates/move-ir-compiler/src/main.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/main.rs
@@ -127,7 +127,7 @@ fn main() {
 
     let mut module = vec![];
     compiled_module
-        .serialize(&mut module)
+        .serialize_with_version(compiled_module.version, &mut module)
         .expect("Unable to serialize module");
     write_output(&source_path.with_extension(mv_extension), &module);
 }

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -113,7 +113,9 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter {
                 |session, gas_status| {
                     for module in &*MOVE_STDLIB_COMPILED {
                         let mut module_bytes = vec![];
-                        module.serialize(&mut module_bytes).unwrap();
+                        module
+                            .serialize_with_version(module.version, &mut module_bytes)
+                            .unwrap();
 
                         let id = module.self_id();
                         let sender = *id.address();
@@ -153,7 +155,8 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter {
             .iter()
             .map(|m| {
                 let mut module_bytes = vec![];
-                m.module.serialize(&mut module_bytes)?;
+                m.module
+                    .serialize_with_version(m.module.version, &mut module_bytes)?;
                 Ok(module_bytes)
             })
             .collect::<Result<_>>()?;

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -81,7 +81,7 @@ fn setup_test_storage<'a>(
     {
         let module_id = module.self_id();
         let mut module_bytes = Vec::new();
-        module.serialize(&mut module_bytes)?;
+        module.serialize_with_version(module.version, &mut module_bytes)?;
         storage.publish_or_overwrite_module(module_id, module_bytes);
     }
 

--- a/external-crates/move/crates/move-vm-config/src/verifier.rs
+++ b/external-crates/move/crates/move-vm-config/src/verifier.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_binary_format::file_format_common::VERSION_MAX;
+
 pub const DEFAULT_MAX_CONSTANT_VECTOR_LEN: u64 = 1024 * 1024;
 pub const DEFAULT_MAX_IDENTIFIER_LENGTH: u64 = 128;
 
@@ -24,6 +26,7 @@ pub struct VerifierConfig {
     pub max_idenfitier_len: Option<u64>,
     pub allow_receiving_object_id: bool,
     pub reject_mutable_random_on_entry_functions: bool,
+    pub bytecode_version: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +69,7 @@ impl Default for VerifierConfig {
             max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             allow_receiving_object_id: true,
             reject_mutable_random_on_entry_functions: true,
+            bytecode_version: VERSION_MAX,
         }
     }
 }

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/binary_format_version.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/binary_format_version.rs
@@ -13,9 +13,8 @@ fn test_publish_module_with_custom_max_binary_format_version() {
     let m = basic_test_module();
     let mut b_new = vec![];
     let mut b_old = vec![];
-    m.serialize_for_version(Some(VERSION_MAX), &mut b_new)
-        .unwrap();
-    m.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
+    m.serialize_with_version(VERSION_MAX, &mut b_new).unwrap();
+    m.serialize_with_version(VERSION_MAX.checked_sub(1).unwrap(), &mut b_old)
         .unwrap();
 
     // Should accept both modules with the default settings

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
@@ -512,7 +512,7 @@ fn make_module(
 
     let mut mod_bytes = vec![];
     module
-        .serialize(&mut mod_bytes)
+        .serialize_with_version(module.version, &mut mod_bytes)
         .expect("Module must serialize");
     session
         .publish_module(mod_bytes, addr, &mut GasStatus::new_unmetered())

--- a/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_binary_format::file_format_common::VERSION_6;
 use move_vm_config::verifier::{
     MeterConfig, VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN, DEFAULT_MAX_IDENTIFIER_LENGTH,
 };
@@ -48,6 +49,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             allow_receiving_object_id: true,
             reject_mutable_random_on_entry_functions: true,
+            bytecode_version: VERSION_6,
         },
         MeterConfig::default(),
     )

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/verifier.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/verifier.rs
@@ -15,6 +15,7 @@ use move_binary_format::{
     check_bounds::BoundsChecker,
     errors::{Location, VMResult},
     file_format::CompiledModule,
+    file_format_common::VERSION_6,
 };
 use move_bytecode_verifier_meter::{dummy::DummyMeter, Meter};
 use move_vm_config::verifier::VerifierConfig;
@@ -42,7 +43,9 @@ pub fn verify_module_with_config_for_test(
 ) -> VMResult<()> {
     const MAX_MODULE_SIZE: usize = 65355;
     let mut bytes = vec![];
-    module.serialize(&mut bytes).unwrap();
+    module
+        .serialize_with_version(VERSION_6, &mut bytes)
+        .unwrap();
     let now = Instant::now();
     let result = verify_module_with_config_metered(config, module, meter);
     eprintln!(

--- a/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_binary_format::file_format_common::VERSION_6;
 use move_vm_config::verifier::{
     MeterConfig, VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN, DEFAULT_MAX_IDENTIFIER_LENGTH,
 };
@@ -48,6 +49,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             allow_receiving_object_id: true,
             reject_mutable_random_on_entry_functions: true,
+            bytecode_version: VERSION_6,
         },
         MeterConfig::default(),
     )

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/verifier.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/verifier.rs
@@ -15,6 +15,7 @@ use move_binary_format::{
     check_bounds::BoundsChecker,
     errors::{Location, VMResult},
     file_format::CompiledModule,
+    file_format_common::VERSION_6,
 };
 use move_bytecode_verifier_meter::{dummy::DummyMeter, Meter};
 use move_vm_config::verifier::VerifierConfig;
@@ -42,7 +43,9 @@ pub fn verify_module_with_config_for_test(
 ) -> VMResult<()> {
     const MAX_MODULE_SIZE: usize = 65355;
     let mut bytes = vec![];
-    module.serialize(&mut bytes).unwrap();
+    module
+        .serialize_with_version(VERSION_6, &mut bytes)
+        .unwrap();
     let now = Instant::now();
     let result = verify_module_with_config_metered(config, module, meter);
     eprintln!(

--- a/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_binary_format::file_format_common::VERSION_6;
 use move_vm_config::verifier::{
     MeterConfig, VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN, DEFAULT_MAX_IDENTIFIER_LENGTH,
 };
@@ -48,6 +49,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             allow_receiving_object_id: true,
             reject_mutable_random_on_entry_functions: true,
+            bytecode_version: VERSION_6,
         },
         MeterConfig::default(),
     )

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/verifier.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/verifier.rs
@@ -15,6 +15,7 @@ use move_binary_format::{
     check_bounds::BoundsChecker,
     errors::{Location, VMResult},
     file_format::CompiledModule,
+    file_format_common::VERSION_6,
 };
 use move_bytecode_verifier_meter::{dummy::DummyMeter, Meter};
 use move_vm_config::verifier::VerifierConfig;
@@ -42,7 +43,9 @@ pub fn verify_module_with_config_for_test(
 ) -> VMResult<()> {
     const MAX_MODULE_SIZE: usize = 65355;
     let mut bytes = vec![];
-    module.serialize(&mut bytes).unwrap();
+    module
+        .serialize_with_version(VERSION_6, &mut bytes)
+        .unwrap();
     let now = Instant::now();
     let result = verify_module_with_config_metered(config, module, meter);
     eprintln!(

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -548,6 +548,7 @@ mod checked {
             MovePackage::new_initial(
                 modules,
                 self.protocol_config.max_move_package_size(),
+                self.protocol_config.move_binary_format_version(),
                 dependencies,
             )
         }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -518,6 +518,7 @@ mod checked {
                 modules,
                 self.tx_context.digest(),
                 self.protocol_config.max_move_package_size(),
+                self.protocol_config.move_binary_format_version(),
                 dependencies,
             )
         }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
@@ -17,6 +17,7 @@ mod checked {
         compatibility::{Compatibility, InclusionCheck},
         errors::{Location, PartialVMResult, VMResult},
         file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
+        file_format_common::VERSION_6,
         normalized, CompiledModule,
     };
     use move_core_types::{
@@ -878,7 +879,7 @@ mod checked {
             .iter()
             .map(|m| {
                 let mut bytes = Vec::new();
-                m.serialize(&mut bytes).unwrap();
+                m.serialize_with_version(VERSION_6, &mut bytes).unwrap();
                 bytes
             })
             .collect();

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -531,6 +531,7 @@ mod checked {
             MovePackage::new_initial(
                 modules,
                 self.protocol_config.max_move_package_size(),
+                self.protocol_config.move_binary_format_version(),
                 dependencies,
             )
         }

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
@@ -10,6 +10,7 @@ mod checked {
         compatibility::{Compatibility, InclusionCheck},
         errors::{Location, PartialVMResult, VMResult},
         file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
+        file_format_common::VERSION_6,
         normalized, CompiledModule,
     };
     use move_core_types::{
@@ -815,7 +816,7 @@ mod checked {
             .iter()
             .map(|m| {
                 let mut bytes = Vec::new();
-                m.serialize(&mut bytes).unwrap();
+                m.serialize_with_version(VERSION_6, &mut bytes).unwrap();
                 bytes
             })
             .collect();

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -548,6 +548,7 @@ mod checked {
             MovePackage::new_initial(
                 modules,
                 self.protocol_config.max_move_package_size(),
+                self.protocol_config.move_binary_format_version(),
                 dependencies,
             )
         }

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
@@ -10,6 +10,7 @@ mod checked {
         compatibility::{Compatibility, InclusionCheck},
         errors::{Location, PartialVMResult, VMResult},
         file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
+        file_format_common::VERSION_6,
         normalized, CompiledModule,
     };
     use move_core_types::{
@@ -820,7 +821,7 @@ mod checked {
             .iter()
             .map(|m| {
                 let mut bytes = Vec::new();
-                m.serialize(&mut bytes).unwrap();
+                m.serialize_with_version(VERSION_6, &mut bytes).unwrap();
                 bytes
             })
             .collect();


### PR DESCRIPTION
## Description 

Require explicit binary version when serializing Move modules.

## Test plan 

Make sure existing tests pass. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
