### PR TITLE
[GraphQL] Add available versions query to service config

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -1,4 +1,4 @@
-processed 25 tasks
+processed 26 tasks
 
 init:
 validator_0: object(0,0)
@@ -291,7 +291,7 @@ created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 25 'run'. lines 183-188:
+task 25 'run-graphql'. lines 183-188:
 Response: {
   "data": {
     "serviceConfig": {

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -295,7 +295,7 @@ task 25 'run'. lines 183-188:
 Response: {
   "data": {
     "serviceConfig": {
-      "versions": [
+      "availableVersions": [
         "2024.7"
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -290,3 +290,14 @@ task 24 'run'. lines 181-181:
 created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25 'run'. lines 183-188:
+Response: {
+  "data": {
+    "serviceConfig": {
+      "versions": [
+        "2024.7"
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -179,3 +179,10 @@ module Test::M1 {
 //# run Test::M1::create --args 0 @A --gas-price 1000
 
 //# run Test::M1::create --args 0 @A --gas-price 235
+
+//# run-graphql
+{
+  serviceConfig {
+    availableVersions
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3013,6 +3013,10 @@ type ServiceConfig {
 	"""
 	isEnabled(feature: Feature!): Boolean!
 	"""
+	List the available versions for this GraphQL service.
+	"""
+	availableVersions: [String!]!
+	"""
 	List of all features that are enabled on this GraphQL service.
 	"""
 	enabledFeatures: [Feature!]!

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -416,6 +416,7 @@ type AvailableRange {
 }
 
 type ServiceConfig {
+  availableVersions: [String!]
   enabledFeatures: [Feature!]
   isEnabled(feature: Feature!): Boolean!
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -103,10 +103,7 @@ pub struct ServiceConfig {
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-pub struct Versions {
-    #[serde(default)]
-    pub(crate) versions: Vec<String>,
-}
+pub struct Versions(pub Vec<String>);
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Copy)]
 #[serde(rename_all = "kebab-case")]
@@ -248,14 +245,14 @@ impl ServiceConfig {
 
     /// List the available versions for this GraphQL service.
     async fn available_versions(&self, ctx: &Context<'_>) -> Vec<String> {
-        if self.versions.versions.is_empty() {
+        if self.versions.0.is_empty() {
             let default_version: &Version = ctx.data_unchecked();
             return vec![format!(
                 "{}.{}",
                 default_version.year, default_version.month
             )];
         }
-        self.versions.versions.clone()
+        self.versions.0.clone()
     }
 
     /// List of all features that are enabled on this GraphQL service.

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -101,9 +101,12 @@ pub struct ServiceConfig {
     pub(crate) zklogin: ZkLoginConfig,
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-pub struct Versions(pub Vec<String>);
+pub struct Versions {
+    #[serde(default)]
+    versions: Vec<String>,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Copy)]
 #[serde(rename_all = "kebab-case")]
@@ -244,15 +247,8 @@ impl ServiceConfig {
     }
 
     /// List the available versions for this GraphQL service.
-    async fn available_versions(&self, ctx: &Context<'_>) -> Vec<String> {
-        if self.versions.0.is_empty() {
-            let default_version: &Version = ctx.data_unchecked();
-            return vec![format!(
-                "{}.{}",
-                default_version.year, default_version.month
-            )];
-        }
-        self.versions.0.clone()
+    async fn available_versions(&self) -> Vec<String> {
+        self.versions.versions.clone()
     }
 
     /// List of all features that are enabled on this GraphQL service.
@@ -440,6 +436,18 @@ impl BackgroundTasksConfig {
     pub fn test_defaults() -> Self {
         Self {
             watermark_update_ms: 100, // Set to 100ms for testing
+        }
+    }
+}
+
+impl Default for Versions {
+    fn default() -> Self {
+        Self {
+            versions: vec![format!(
+                "{}.{}",
+                env!("CARGO_PKG_VERSION_MAJOR").to_string(),
+                env!("CARGO_PKG_VERSION_MINOR")
+            )],
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -445,7 +445,7 @@ impl Default for Versions {
         Self {
             versions: vec![format!(
                 "{}.{}",
-                env!("CARGO_PKG_VERSION_MAJOR").to_string(),
+                env!("CARGO_PKG_VERSION_MAJOR"),
                 env!("CARGO_PKG_VERSION_MINOR")
             )],
         }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -415,7 +415,10 @@ impl ServerBuilder {
             None
         };
 
+        let version = version.clone();
+
         builder = builder
+            .context_data(version)
             .context_data(config.service.clone())
             .context_data(loader)
             .context_data(db)

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -414,7 +414,6 @@ impl ServerBuilder {
         };
 
         builder = builder
-            .context_data(*version)
             .context_data(config.service.clone())
             .context_data(loader)
             .context_data(db)

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -34,12 +34,10 @@ use async_graphql::{extensions::ExtensionFactory, Schema, SchemaBuilder};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::extract::FromRef;
 use axum::extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo, State};
-use axum::headers::Origin;
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::{self};
 use axum::response::IntoResponse;
 use axum::routing::{post, MethodRouter, Route};
-use axum::TypedHeader;
 use axum::{headers::Header, Router};
 use http::{HeaderValue, Method, Request};
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
@@ -470,7 +468,6 @@ pub fn export_schema() -> String {
 /// if set in the request headers, and the watermark as set by the background task.
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    TypedHeader(origin): TypedHeader<Origin>,
     schema: axum::Extension<SuiGraphQLSchema>,
     axum::Extension(watermark_lock): axum::Extension<WatermarkLock>,
     headers: HeaderMap,
@@ -481,7 +478,6 @@ async fn graphql_handler(
     if headers.contains_key(ShowUsage::name()) {
         req.data.insert(ShowUsage)
     }
-    req.data.insert(origin);
     // Capture the IP address of the client
     // Note: if a load balancer is used it must be configured to forward the client IP address
     req.data.insert(addr);

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -415,10 +415,8 @@ impl ServerBuilder {
             None
         };
 
-        let version = version.clone();
-
         builder = builder
-            .context_data(version)
+            .context_data(*version)
             .context_data(config.service.clone())
             .context_data(loader)
             .context_data(db)

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -34,10 +34,12 @@ use async_graphql::{extensions::ExtensionFactory, Schema, SchemaBuilder};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::extract::FromRef;
 use axum::extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo, State};
+use axum::headers::Origin;
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::{self};
 use axum::response::IntoResponse;
 use axum::routing::{post, MethodRouter, Route};
+use axum::TypedHeader;
 use axum::{headers::Header, Router};
 use http::{HeaderValue, Method, Request};
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
@@ -467,6 +469,7 @@ pub fn export_schema() -> String {
 /// if set in the request headers, and the watermark as set by the background task.
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    TypedHeader(origin): TypedHeader<Origin>,
     schema: axum::Extension<SuiGraphQLSchema>,
     axum::Extension(watermark_lock): axum::Extension<WatermarkLock>,
     headers: HeaderMap,
@@ -477,6 +480,7 @@ async fn graphql_handler(
     if headers.contains_key(ShowUsage::name()) {
         req.data.insert(ShowUsage)
     }
+    req.data.insert(origin);
     // Capture the IP address of the client
     // Note: if a load balancer is used it must be configured to forward the client IP address
     req.data.insert(addr);

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3017,6 +3017,10 @@ type ServiceConfig {
 	"""
 	isEnabled(feature: Feature!): Boolean!
 	"""
+	List the available versions for this GraphQL service.
+	"""
+	availableVersions: [String!]!
+	"""
 	List of all features that are enabled on this GraphQL service.
 	"""
 	enabledFeatures: [Feature!]!


### PR DESCRIPTION
## Description 

Adds available versions query to the service config. Uses the crate's version if no `versions` section exists in the `config.toml` file.

## Test plan 

Existing tests. Manual query on local instance. 

## No versions in config.toml file
```graphql
{
  serviceConfig {
    availableVersions
  }
}
```

```json
{
  "data": {
    "serviceConfig": {
      "availableVersions": [
        "2024.7"
      ]
    }
  }
}
```

## Start server with config toml file
```toml
[limits]
max-query-depth = 15
max-query-nodes = 500
max-output-nodes = 100000
max-query-payload-size = 5000
max-db-query-cost = 20000
default-page-size = 5
max-page-size = 10
request-timeout-ms = 15000
max-type-argument-depth = 16
max-type-argument-width = 32
max-type-nodes = 256
max-move-value-depth = 128

[versions]
versions = ["2024.1", "2024.4", "2024.7"]
```
Same query
```json
{
  "data": {
    "serviceConfig": {
      "availableVersions": [
        "2024.1",
        "2024.4",
        "2024.7"
      ]
    }
  }
}
```
 
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
