### PR TITLE
[move] Added special support for clever errors in macros

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors_in_macros.exp
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors_in_macros.exp
@@ -1,0 +1,52 @@
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-34:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4187600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 36-36:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_a (function index 0) at offset 1, Abort Code: 9223372127049089023
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("t_a") }, 9223372127049089023), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372127049089023), message: Some("P0::m::t_a at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 3 'run'. lines 38-38:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_calls_a (function index 1) at offset 1, Abort Code: 9223372139933990911
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("t_calls_a") }, 9223372139933990911), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372139933990911), message: Some("P0::m::t_calls_a at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
+
+task 4 'run'. lines 40-40:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_const_assert (function index 2) at offset 1, Abort Code: 9223372075509481473
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("t_const_assert") }, 9223372075509481473), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372075509481473), message: Some("P0::m::t_const_assert at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
+
+task 5 'create-checkpoint'. lines 42-42:
+Checkpoint created: 1
+
+task 6 'run-graphql'. lines 44-54:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x74917b255f596b31d78cd2a29f487f764de9a8fd6bdc8b7ff0eae55ff1456cba::m::t_a' (line 20)"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x74917b255f596b31d78cd2a29f487f764de9a8fd6bdc8b7ff0eae55ff1456cba::m::t_calls_a' (line 23)"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x74917b255f596b31d78cd2a29f487f764de9a8fd6bdc8b7ff0eae55ff1456cba::m::t_const_assert' (line 9), abort 'EMsg': This is a string"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors_in_macros.move
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors_in_macros.move
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A --simulator
+
+//# publish --sender A
+module P0::m {
+    macro fun const_assert() {
+        assert!(false, EMsg) // putting this early to make the line number clear
+    }
+
+    #[error]
+    const EMsg: vector<u8> = b"This is a string";
+
+    macro fun a() {
+        assert!(false)
+    }
+
+    macro fun calls_a() {
+        a!()
+    }
+
+    entry fun t_a() {
+        a!() // assert should point to this line
+    }
+
+    entry fun t_calls_a() {
+        calls_a!() // assert should point to this line
+    }
+
+    entry fun t_const_assert() {
+        const_assert!() // this assert will _not_ have its line number changed
+    }
+}
+
+//# run P0::m::t_a
+
+//# run P0::m::t_calls_a
+
+//# run P0::m::t_const_assert
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(last: 3) {
+    nodes {
+      effects {
+        status
+        errors
+      }
+    }
+  }
+}

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.exp
@@ -1,0 +1,19 @@
+processed 4 tasks
+
+task 2 'run'. lines 25-25:
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(9223372105574252543),
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 3 'run'. lines 27-27:
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(9223372118459154431),
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+}

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.move
@@ -1,0 +1,27 @@
+// NB: Do _not_ change the number of lines in this file. Any changes to the
+// number of lines in this file may break the expected output of this test.
+
+//# init --edition development
+
+//# publish
+module 0x42::m {
+    macro fun a() {
+        assert!(false)
+    }
+
+    macro fun calls_a() {
+        a!()
+    }
+
+    entry fun t_a() {
+        a!() // assert should point to this line
+    }
+
+    entry fun t_calls_a() {
+        calls_a!() // assert should point to this line
+    }
+}
+
+//# run 0x42::m::t_a
+
+//# run 0x42::m::t_calls_a

--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -325,7 +325,7 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
         }
 
         E::Unit { .. } => vec![],
-        E::Value(_) | E::Constant(_) | E::UnresolvedError | E::ErrorConstant(_) => svalue(),
+        E::Value(_) | E::Constant(_) | E::UnresolvedError | E::ErrorConstant { .. } => svalue(),
 
         E::Cast(e, _) | E::UnaryExp(_, e) => {
             let v = exp(context, e);

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -130,7 +130,7 @@ fn exp(state: &mut LivenessState, parent_e: &Exp) {
         | E::Value(_)
         | E::Constant(_)
         | E::UnresolvedError
-        | E::ErrorConstant(_) => (),
+        | E::ErrorConstant { .. } => (),
 
         E::BorrowLocal(_, var) | E::Copy { var, .. } | E::Move { var, .. } => {
             state.0.insert(*var);
@@ -323,7 +323,7 @@ mod last_usage {
             | E::Value(_)
             | E::Constant(_)
             | E::UnresolvedError
-            | E::ErrorConstant(_) => (),
+            | E::ErrorConstant { .. } => (),
 
             E::BorrowLocal(_, var) | E::Move { var, .. } => {
                 // remove it from context to prevent accidental dropping in previous usages

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -369,7 +369,7 @@ fn exp(context: &mut Context, parent_e: &Exp) {
         | E::Value(_)
         | E::Constant(_)
         | E::UnresolvedError
-        | E::ErrorConstant(_) => (),
+        | E::ErrorConstant { .. } => (),
 
         E::BorrowLocal(mut_, var) => {
             if *mut_ {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -96,7 +96,7 @@ fn optimize_exp(consts: &UniqueMap<ConstantName, Value>, e: &mut Exp) -> bool {
         | E::BorrowLocal(_, _)
         | E::Move { .. }
         | E::Copy { .. }
-        | E::ErrorConstant(_)
+        | E::ErrorConstant { .. }
         | E::Unreachable => false,
 
         e_ @ E::Constant(_) => {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -158,7 +158,7 @@ mod count {
             | E::Value(_)
             | E::Constant(_)
             | E::UnresolvedError
-            | E::ErrorConstant(_) => (),
+            | E::ErrorConstant { .. } => (),
 
             E::BorrowLocal(_, var) => context.used(var, false),
 
@@ -210,7 +210,7 @@ mod count {
         use UnannotatedExp_ as E;
         match &parent_e.exp.value {
             E::UnresolvedError
-            | E::ErrorConstant(_)
+            | E::ErrorConstant { .. }
             | E::BorrowLocal(_, _)
             | E::Copy { .. }
             | E::Freeze(_)
@@ -370,7 +370,7 @@ mod eliminate {
             | E::Value(_)
             | E::Constant(_)
             | E::UnresolvedError
-            | E::ErrorConstant(_)
+            | E::ErrorConstant { .. }
             | E::BorrowLocal(_, _) => (),
 
             E::ModuleCall(mcall) => {

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -410,7 +410,7 @@ pub trait SimpleAbsInt: Sized {
             }
 
             E::Unit { .. } => vec![],
-            E::Value(_) | E::Constant(_) | E::UnresolvedError | E::ErrorConstant(_) => {
+            E::Value(_) | E::Constant(_) | E::UnresolvedError | E::ErrorConstant { .. } => {
                 default_values(1)
             }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -381,7 +381,10 @@ pub enum UnannotatedExp_ {
         var: Var,
     },
     Constant(ConstantName),
-    ErrorConstant(Option<ConstantName>),
+    ErrorConstant {
+        line_number_loc: Loc,
+        error_constant: Option<ConstantName>,
+    },
 
     ModuleCall(Box<ModuleCall>),
     Freeze(Box<Exp>),
@@ -1556,9 +1559,12 @@ impl AstDebug for UnannotatedExp_ {
             }
             E::UnresolvedError => w.write("_|_"),
             E::Unreachable => w.write("unreachable"),
-            E::ErrorConstant(c) => {
+            E::ErrorConstant {
+                line_number_loc: _,
+                error_constant,
+            } => {
                 w.write("ErrorConstant");
-                if let Some(c) = c {
+                if let Some(c) = error_constant {
                     w.write(&format!("({})", c))
                 }
             }

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -545,7 +545,7 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::Constant(_, _)
         | E::Move { .. }
         | E::Copy { .. }
-        | E::ErrorConstant(_) => None,
+        | E::ErrorConstant { .. } => None,
 
         // -----------------------------------------------------------------------------------------
         //  statements
@@ -744,7 +744,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::Annotate(_, _)
         | E::BorrowLocal(_, _)
         | E::Constant(_, _)
-        | E::ErrorConstant(_)
+        | E::ErrorConstant { .. }
         | E::Move { .. }
         | E::Copy { .. }
         | E::InvalidAccess(_)

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1824,7 +1824,13 @@ fn value(
         }
         E::Value(ev) => make_exp(HE::Value(process_value(context, ev))),
         E::Constant(_m, c) => make_exp(HE::Constant(c)), // only private constants (for now)
-        E::ErrorConstant(c) => make_exp(HE::ErrorConstant(c)),
+        E::ErrorConstant {
+            line_number_loc,
+            error_constant,
+        } => make_exp(HE::ErrorConstant {
+            line_number_loc,
+            error_constant,
+        }),
         E::Move { from_user, var } => {
             let annotation = if from_user {
                 MoveOpAnnotation::FromUser
@@ -2212,7 +2218,7 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         | E::Annotate(_, _)
         | E::BorrowLocal(_, _)
         | E::Constant(_, _)
-        | E::ErrorConstant(_)
+        | E::ErrorConstant { .. }
         | E::Move { .. }
         | E::Copy { .. }
         | E::UnresolvedError

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -460,7 +460,9 @@ pub enum Exp_ {
     Cast(Box<Exp>, Type),
     Annotate(Box<Exp>, Type),
 
-    ErrorConstant,
+    ErrorConstant {
+        line_number_loc: Loc,
+    },
 
     UnresolvedError,
 }
@@ -1813,7 +1815,7 @@ impl AstDebug for Exp_ {
                 w.write(")");
             }
             E::UnresolvedError => w.write("_|_"),
-            E::ErrorConstant => w.write("ErrorConstant"),
+            E::ErrorConstant { .. } => w.write("ErrorConstant"),
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -317,7 +317,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
         | N::Exp_::Constant(_, _)
         | N::Exp_::Continue(_)
         | N::Exp_::Unit { .. }
-        | N::Exp_::ErrorConstant
+        | N::Exp_::ErrorConstant { .. }
         | N::Exp_::UnresolvedError => (),
         N::Exp_::Return(e)
         | N::Exp_::Abort(e)

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2465,7 +2465,12 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
                             FeatureGate::CleverAssertions,
                             bloc,
                         );
-                        nes.value.push(sp(bloc, NE::ErrorConstant));
+                        nes.value.push(sp(
+                            bloc,
+                            NE::ErrorConstant {
+                                line_number_loc: bloc,
+                            },
+                        ));
                     }
                     NE::Builtin(sp(bloc, BF::Assert(is_macro)), nes)
                 }
@@ -3745,7 +3750,7 @@ fn remove_unused_bindings_exp(
         | N::Exp_::Constant(_, _)
         | N::Exp_::Continue(_)
         | N::Exp_::Unit { .. }
-        | N::Exp_::ErrorConstant
+        | N::Exp_::ErrorConstant { .. }
         | N::Exp_::UnresolvedError => (),
         N::Exp_::Return(e)
         | N::Exp_::Abort(e)

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -962,8 +962,16 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
 
         E::Constant(c) => code.push(sp(loc, B::LdNamedConst(context.constant_name(c)))),
 
-        E::ErrorConstant(const_name) => {
-            let line_no = context.env.file_mapping().location(loc).start.line;
+        E::ErrorConstant {
+            line_number_loc,
+            error_constant,
+        } => {
+            let line_no = context
+                .env
+                .file_mapping()
+                .location(line_number_loc)
+                .start
+                .line;
 
             // Clamp line number to u16::MAX -- so if the line number exceeds u16::MAX, we don't
             // record the line number essentially.
@@ -973,7 +981,7 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
                 loc,
                 B::ErrorConstant {
                     line_number,
-                    constant: const_name.map(|n| context.constant_name(n)),
+                    constant: error_constant.map(|n| context.constant_name(n)),
                 },
             ));
         }

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -236,7 +236,10 @@ pub enum UnannotatedExp_ {
     // unfinished dot access (e.g. `some_field.`)
     InvalidAccess(Box<Exp>),
 
-    ErrorConstant(Option<ConstantName>),
+    ErrorConstant {
+        line_number_loc: Loc,
+        error_constant: Option<ConstantName>,
+    },
     UnresolvedError,
 }
 pub type UnannotatedExp = Spanned<UnannotatedExp_>;
@@ -832,9 +835,12 @@ impl AstDebug for UnannotatedExp_ {
                 w.write(".");
             }
             E::UnresolvedError => w.write("_|_"),
-            E::ErrorConstant(constant) => {
+            E::ErrorConstant {
+                line_number_loc: _,
+                error_constant,
+            } => {
                 w.write("ErrorConstant");
-                if let Some(c) = constant {
+                if let Some(c) = error_constant {
                     w.write(&format!("({})", c))
                 }
             }

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -486,7 +486,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::Constant(..)
         | E::Continue(_)
         | E::BorrowLocal(..)
-        | E::ErrorConstant(_)
+        | E::ErrorConstant { .. }
         | E::UnresolvedError => (),
     }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -217,7 +217,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::Copy { .. }
         | E::BorrowLocal(_, _)
         | E::Continue(_)
-        | E::ErrorConstant(_)
+        | E::ErrorConstant { .. }
         | E::UnresolvedError => (),
 
         E::ModuleCall(call) => module_call(context, call),

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -231,7 +231,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::Copy { .. }
         | E::BorrowLocal(_, _)
         | E::Continue(_)
-        | E::ErrorConstant(_)
+        | E::ErrorConstant { .. }
         | E::UnresolvedError => (),
 
         E::ModuleCall(call) => {

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -5,6 +5,7 @@ use crate::{
     diag,
     diagnostics::Diagnostic,
     expansion::ast::{ModuleIdent, Mutability},
+    ice,
     naming::ast::{
         self as N, BlockLabel, Color, MatchArm_, TParamID, Type, Type_, UseFuns, Var, Var_,
     },
@@ -59,12 +60,31 @@ pub(crate) fn call(
     args: Vec<Arg>,
     return_type: Type,
 ) -> Option<ExpandedMacro> {
+    let reloc_clever_errors = match &context.macro_expansion[0] {
+        core::MacroExpansion::Call(call) => call.invocation,
+        core::MacroExpansion::Argument { .. } => {
+            context.env.add_diag(ice!((
+                call_loc,
+                "ICE top level macro scope should never be an argument"
+            )));
+            call_loc
+        }
+    };
     let next_color = context.next_variable_color();
     // If none, there is no body to expand, likely because of an error in the macro definition
     let macro_body = context.macro_body(&m, &f)?;
     let macro_info = context.function_info(&m, &f);
+
     let (macro_type_params, macro_params, mut macro_body, return_label, max_color) =
-        match recolor_macro(call_loc, &m, &f, macro_info, macro_body, next_color) {
+        match recolor_macro(
+            reloc_clever_errors,
+            call_loc,
+            &m,
+            &f,
+            macro_info,
+            macro_body,
+            next_color,
+        ) {
             Ok(res) => res,
             Err(None) => {
                 assert!(context.env.has_errors());
@@ -180,6 +200,7 @@ pub(crate) fn call(
 }
 
 fn recolor_macro(
+    reloc_clever_errors: Loc,
     call_loc: Loc,
     _m: &ModuleIdent,
     _f: &FunctionName,
@@ -221,8 +242,14 @@ fn recolor_macro(
         label,
         is_implicit: true,
     };
+    let reloc_clever_errors = Some(reloc_clever_errors);
     let recolor_use_funs = true;
-    let recolor = &mut Recolor::new(color, Some(return_label), recolor_use_funs);
+    let recolor = &mut Recolor::new(
+        reloc_clever_errors,
+        color,
+        Some(return_label),
+        recolor_use_funs,
+    );
     recolor.add_params(parameters);
     let parameters = parameters
         .iter()
@@ -279,11 +306,14 @@ mod recolor_struct {
         expansion::ast::Mutability,
         naming::ast::{self as N, BlockLabel, Color, Var},
     };
+    use move_ir_types::location::Loc;
     use std::collections::{BTreeMap, BTreeSet};
+
     // handles all of the recoloring of variables, labels, and use funs.
     // The mask of known vars and labels is here to handle the case where a variable was captured
     // by a lambda
     pub(super) struct Recolor {
+        clever_error_loc: Option<Loc>,
         next_color: Color,
         remapping: BTreeMap<Color, Color>,
         recolor_use_funs: bool,
@@ -293,8 +323,14 @@ mod recolor_struct {
     }
 
     impl Recolor {
-        pub fn new(color: u16, return_label: Option<BlockLabel>, recolor_use_funs: bool) -> Self {
+        pub fn new(
+            reloc_clever_errors: Option<Loc>,
+            color: u16,
+            return_label: Option<BlockLabel>,
+            recolor_use_funs: bool,
+        ) -> Self {
             Self {
+                clever_error_loc: reloc_clever_errors,
                 next_color: color,
                 remapping: BTreeMap::new(),
                 recolor_use_funs,
@@ -302,6 +338,10 @@ mod recolor_struct {
                 vars: BTreeSet::new(),
                 block_labels: BTreeSet::new(),
             }
+        }
+
+        pub fn clever_error_loc(&self) -> Option<Loc> {
+            self.clever_error_loc
         }
 
         pub fn add_params(&mut self, params: &[(Mutability, Var, N::Type)]) {
@@ -385,6 +425,12 @@ mod recolor_struct {
         pub fn contains_block_label(&self, label: &BlockLabel) -> bool {
             self.block_labels.contains(label)
         }
+    }
+}
+
+fn reloc_error_constant(ctx: &mut Recolor, line_number_loc: &mut Loc) {
+    if let Some(clever_error_loc) = ctx.clever_error_loc() {
+        *line_number_loc = clever_error_loc
     }
 }
 
@@ -472,7 +518,8 @@ fn recolor_lvalue(ctx: &mut Recolor, sp!(_, lvalue_): &mut N::LValue) {
 #[growing_stack]
 fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
     match e_ {
-        N::Exp_::Value(_) | N::Exp_::Constant(_, _) | N::Exp_::ErrorConstant => (),
+        N::Exp_::ErrorConstant { line_number_loc } => reloc_error_constant(ctx, line_number_loc),
+        N::Exp_::Value(_) | N::Exp_::Constant(_, _) => (),
         N::Exp_::Give(_usage, label, e) => {
             recolor_block_label(ctx, label);
             recolor_exp(ctx, e)
@@ -766,7 +813,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
         | N::Exp_::Constant(_, _)
         | N::Exp_::Continue(_)
         | N::Exp_::Unit { .. }
-        | N::Exp_::ErrorConstant
+        | N::Exp_::ErrorConstant { .. }
         | N::Exp_::UnresolvedError => (),
         N::Exp_::Give(_, _, e)
         | N::Exp_::Return(e)
@@ -938,8 +985,10 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             ) = context.lambdas.get(v_).unwrap().clone();
             // recolor in case the lambda is used more than once
             let next_color = context.core.next_variable_color();
+            let reloc_clever_errors = None;
             let recolor_use_funs = false;
             let recolor = &mut Recolor::new(
+                reloc_clever_errors,
                 next_color,
                 /* return already labeled */ None,
                 recolor_use_funs,
@@ -1014,8 +1063,10 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             let (mut arg, expected_ty) = context.by_name_args.get(v_).cloned().unwrap();
             // recolor the arg in case it is used more than once
             let next_color = context.core.next_variable_color();
+            let reloc_clever_errors = None;
             let recolor_use_funs = false;
             let recolor = &mut Recolor::new(
+                reloc_clever_errors,
                 next_color,
                 /* return already labeled */ None,
                 recolor_use_funs,

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -231,7 +231,7 @@ pub trait TypingVisitorContext {
             | E::Constant(..)
             | E::Continue(_)
             | E::BorrowLocal(..)
-            | E::ErrorConstant(_)
+            | E::ErrorConstant { .. }
             | E::UnresolvedError => (),
         }
     }


### PR DESCRIPTION
## Description 

- Added support for `assert!(cond)` line numbers inside of macros. The line number will point to the invocation of the macro, instead of the line where the assert was written. This should be helpful for cross-module macro invocations with `assert` and error codes
- Thanks @alnoki for the discussion leading to this improvement! 

## Test plan 

- Added new tests
- The line numbers are a bit off in transactional tests, so I temporarily and localy added compiler warnings to verify the line numbers correspond to the correct loc. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
