### PR TITLE
tx lookup table changes

### DIFF
--- a/crates/sui-indexer/migrations/pg/2023-08-19-044026_transactions/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-08-19-044026_transactions/up.sql
@@ -16,12 +16,10 @@ CREATE TABLE transactions (
     -- SystemTransaction/ProgrammableTransaction. See types.rs
     transaction_kind            smallint     NOT NULL,
     -- number of successful commands in this transaction, bound by number of command
-    -- in a programmaable transaction.
+    -- in a programmable transaction.
     success_command_count       smallint     NOT NULL,
     PRIMARY KEY (tx_sequence_number, checkpoint_sequence_number)
 ) PARTITION BY RANGE (checkpoint_sequence_number);
 CREATE TABLE transactions_partition_0 PARTITION OF transactions FOR VALUES FROM (0) TO (MAXVALUE);
-CREATE INDEX transactions_transaction_digest ON transactions (transaction_digest);
 CREATE INDEX transactions_checkpoint_sequence_number ON transactions (checkpoint_sequence_number);
--- only create index for system transactions (0). See types.rs
-CREATE INDEX transactions_transaction_kind ON transactions (transaction_kind) WHERE transaction_kind = 0;
+CREATE INDEX transactions_transaction_kind ON transactions (transaction_kind, tx_sequence_number, checkpoint_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
@@ -52,8 +52,9 @@ CREATE TABLE tx_calls (
     func                        TEXT         NOT NULL,
     address                     BYTEA        NOT NULL,
     rel                         smallint     NOT NULL,
-    -- 1. Using Primary Key as a unique index.
-    -- 2. Diesel does not like tables with no primary key.
+    -- The primary key is a composite key on the function type and address. In a single transaction
+    -- block, the same package, module, and even func may appear multiple times. This is then
+    -- broadcasted by the participants of a transaction block.
     PRIMARY KEY(package, module, func, address, tx_sequence_number, cp_sequence_number)
 );
 CREATE INDEX tx_calls_pkg_tx ON tx_calls (package, tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
@@ -3,34 +3,46 @@ CREATE TABLE tx_senders (
     tx_sequence_number          BIGINT       NOT NULL,
     -- SuiAddress in bytes.
     sender                      BYTEA        NOT NULL,
+    -- SystemTransaction/ProgrammableTransaction. See types.rs
+    transaction_kind            smallint     NOT NULL,
     PRIMARY KEY(sender, tx_sequence_number, cp_sequence_number)
 );
 CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number, cp_sequence_number);
+CREATE INDEX tx_senders_transaction_kind_index ON tx_senders (sender, transaction_kind, tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_recipients (
     cp_sequence_number          BIGINT       NOT NULL,
     tx_sequence_number          BIGINT       NOT NULL,
     -- SuiAddress in bytes.
     recipient                   BYTEA        NOT NULL,
+    -- SystemTransaction/ProgrammableTransaction. See types.rs
+    transaction_kind            smallint     NOT NULL,
     PRIMARY KEY(recipient, tx_sequence_number, cp_sequence_number)
 );
 CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number, cp_sequence_number);
+CREATE INDEX tx_recipients_transaction_kind_index ON tx_recipients (recipient, transaction_kind, tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_input_objects (
     cp_sequence_number          BIGINT       NOT NULL,
     tx_sequence_number          BIGINT       NOT NULL,
     -- Object ID in bytes.
     object_id                   BYTEA        NOT NULL,
+    address                     BYTEA        NOT NULL,
+    rel                         smallint     NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
 );
+CREATE INDEX tx_input_objects_addr_index ON tx_input_objects (object_id, address, tx_sequence_number, rel);
 
 CREATE TABLE tx_changed_objects (
     cp_sequence_number          BIGINT       NOT NULL,
     tx_sequence_number          BIGINT       NOT NULL,
     -- Object Id in bytes.
     object_id                   BYTEA        NOT NULL,
+    address                     BYTEA        NOT NULL,
+    rel                         smallint     NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
 );
+CREATE INDEX tx_changed_objects_addr_index ON tx_changed_objects (object_id, address, tx_sequence_number, rel);
 
 CREATE TABLE tx_calls (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -38,10 +50,16 @@ CREATE TABLE tx_calls (
     package                     BYTEA        NOT NULL,
     module                      TEXT         NOT NULL,
     func                        TEXT         NOT NULL,
+    address                     BYTEA        NOT NULL,
+    rel                         smallint     NOT NULL,
     -- 1. Using Primary Key as a unique index.
     -- 2. Diesel does not like tables with no primary key.
-    PRIMARY KEY(package, module, func, tx_sequence_number, cp_sequence_number)
+    PRIMARY KEY(package, module, func, address, tx_sequence_number, cp_sequence_number)
 );
+CREATE INDEX tx_calls_pkg_tx ON tx_calls (package, tx_sequence_number);
+CREATE INDEX tx_calls_pkg_addr_tx_rel ON tx_calls (package, address, tx_sequence_number, rel);
+CREATE INDEX tx_calls_pkg_module_tx ON tx_calls (package, module, tx_sequence_number);
+CREATE INDEX tx_calls_pkg_module_addr_tx_rel ON tx_calls (package, module, address, tx_sequence_number, rel);
 CREATE INDEX tx_calls_module ON tx_calls (package, module, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number, cp_sequence_number);
 

--- a/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
@@ -19,7 +19,7 @@ CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequenc
 CREATE TABLE tx_input_objects (
     cp_sequence_number          BIGINT       NOT NULL,
     tx_sequence_number          BIGINT       NOT NULL,
-    -- Object ID in bytes. 
+    -- Object ID in bytes.
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
 );
@@ -40,10 +40,9 @@ CREATE TABLE tx_calls (
     func                        TEXT         NOT NULL,
     -- 1. Using Primary Key as a unique index.
     -- 2. Diesel does not like tables with no primary key.
-    PRIMARY KEY(package, tx_sequence_number, cp_sequence_number)
+    PRIMARY KEY(package, module, func, tx_sequence_number, cp_sequence_number)
 );
 CREATE INDEX tx_calls_module ON tx_calls (package, module, tx_sequence_number, cp_sequence_number);
-CREATE INDEX tx_calls_func ON tx_calls (package, module, func, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number, cp_sequence_number);
 
 -- un-partitioned table for tx_digest -> (cp_sequence_number, tx_sequence_number) lookup.

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -414,7 +414,7 @@ where
                 object_changes,
                 balance_change,
                 events,
-                transaction_kind,
+                transaction_kind: transaction_kind.clone(),
                 successful_tx_num: if fx.status().is_ok() {
                     tx.kind().tx_count() as u64
                 } else {
@@ -473,6 +473,7 @@ where
                 payers,
                 recipients,
                 move_calls,
+                transaction_kind,
             });
         }
         Ok((db_transactions, db_events, db_indices, db_displays))

--- a/crates/sui-indexer/src/models/tx_indices.rs
+++ b/crates/sui-indexer/src/models/tx_indices.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use crate::{
     schema::{
         tx_calls, tx_changed_objects, tx_digests, tx_input_objects, tx_recipients, tx_senders,
@@ -8,6 +10,7 @@ use crate::{
     types::TxIndex,
 };
 use diesel::prelude::*;
+use sui_types::base_types::SuiAddress;
 
 #[derive(QueryableByName)]
 pub struct TxSequenceNumber {
@@ -27,6 +30,7 @@ pub struct StoredTxSenders {
     pub cp_sequence_number: i64,
     pub tx_sequence_number: i64,
     pub sender: Vec<u8>,
+    pub transaction_kind: i16,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -35,6 +39,7 @@ pub struct StoredTxRecipients {
     pub cp_sequence_number: i64,
     pub tx_sequence_number: i64,
     pub recipient: Vec<u8>,
+    pub transaction_kind: i16,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -43,6 +48,8 @@ pub struct StoredTxInputObject {
     pub cp_sequence_number: i64,
     pub tx_sequence_number: i64,
     pub object_id: Vec<u8>,
+    pub address: Vec<u8>,
+    pub rel: i16,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -51,6 +58,8 @@ pub struct StoredTxChangedObject {
     pub cp_sequence_number: i64,
     pub tx_sequence_number: i64,
     pub object_id: Vec<u8>,
+    pub address: Vec<u8>,
+    pub rel: i16,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -61,6 +70,8 @@ pub struct StoredTxCalls {
     pub package: Vec<u8>,
     pub module: String,
     pub func: String,
+    pub address: Vec<u8>,
+    pub rel: i16,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -85,6 +96,7 @@ impl TxIndex {
     ) {
         let tx_sequence_number = self.tx_sequence_number as i64;
         let cp_sequence_number = self.checkpoint_sequence_number as i64;
+        let transaction_kind = self.transaction_kind as i16;
         let tx_senders = self
             .senders
             .iter()
@@ -92,6 +104,7 @@ impl TxIndex {
                 cp_sequence_number,
                 tx_sequence_number,
                 sender: s.to_vec(),
+                transaction_kind,
             })
             .collect();
         let tx_recipients = self
@@ -101,37 +114,68 @@ impl TxIndex {
                 cp_sequence_number,
                 tx_sequence_number,
                 recipient: s.to_vec(),
+                transaction_kind,
             })
             .collect();
-        let tx_input_objects = self
-            .input_objects
-            .iter()
-            .map(|o| StoredTxInputObject {
-                cp_sequence_number,
-                tx_sequence_number,
-                object_id: bcs::to_bytes(&o).unwrap(),
-            })
-            .collect();
-        let tx_changed_objects = self
-            .changed_objects
-            .iter()
-            .map(|o| StoredTxChangedObject {
-                cp_sequence_number,
-                tx_sequence_number,
-                object_id: bcs::to_bytes(&o).unwrap(),
-            })
-            .collect();
-        let tx_calls = self
-            .move_calls
-            .iter()
-            .map(|(p, m, f)| StoredTxCalls {
-                cp_sequence_number,
-                tx_sequence_number,
-                package: p.to_vec(),
-                module: m.to_string(),
-                func: f.to_string(),
-            })
-            .collect();
+
+        let mut address_rel_map: HashMap<&SuiAddress, i16> = HashMap::new();
+        for sender in &self.senders {
+            address_rel_map.entry(sender).or_insert(0);
+        }
+
+        for recipient in &self.recipients {
+            address_rel_map
+                .entry(recipient)
+                .and_modify(|e| {
+                    if *e == 0 {
+                        *e = 1
+                    }
+                })
+                .or_insert(2);
+        }
+
+        let mut tx_input_objects = Vec::new();
+
+        for tx_input_object in self.input_objects {
+            for (address, rel) in &address_rel_map {
+                tx_input_objects.push(StoredTxInputObject {
+                    cp_sequence_number,
+                    tx_sequence_number,
+                    object_id: bcs::to_bytes(&tx_input_object).unwrap(),
+                    address: address.to_vec(),
+                    rel: *rel,
+                });
+            }
+        }
+
+        let mut tx_changed_objects = Vec::new();
+        for tx_changed_object in self.changed_objects {
+            for (address, rel) in &address_rel_map {
+                tx_changed_objects.push(StoredTxChangedObject {
+                    cp_sequence_number,
+                    tx_sequence_number,
+                    object_id: bcs::to_bytes(&tx_changed_object).unwrap(),
+                    address: address.to_vec(),
+                    rel: *rel,
+                });
+            }
+        }
+
+        let mut tx_calls = Vec::new();
+        for (p, m, f) in self.move_calls {
+            for (address, rel) in &address_rel_map {
+                tx_calls.push(StoredTxCalls {
+                    cp_sequence_number,
+                    tx_sequence_number,
+                    package: p.to_vec(),
+                    module: m.to_string(),
+                    func: f.to_string(),
+                    address: address.to_vec(),
+                    rel: *rel,
+                });
+            }
+        }
+
         let stored_tx_digest = StoredTxDigest {
             tx_digest: self.transaction_digest.into_inner().to_vec(),
             tx_sequence_number,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -223,12 +223,14 @@ diesel::table! {
 }
 
 diesel::table! {
-    tx_calls (package, tx_sequence_number, cp_sequence_number) {
+    tx_calls (package, module, func, address, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         package -> Bytea,
         module -> Text,
         func -> Text,
+        address -> Bytea,
+        rel -> Int2,
     }
 }
 
@@ -237,6 +239,8 @@ diesel::table! {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         object_id -> Bytea,
+        address -> Bytea,
+        rel -> Int2,
     }
 }
 
@@ -253,6 +257,8 @@ diesel::table! {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         object_id -> Bytea,
+        address -> Bytea,
+        rel -> Int2,
     }
 }
 
@@ -261,6 +267,7 @@ diesel::table! {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         recipient -> Bytea,
+        transaction_kind -> Int2,
     }
 }
 
@@ -269,6 +276,7 @@ diesel::table! {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         sender -> Bytea,
+        transaction_kind -> Int2,
     }
 }
 

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -364,6 +364,7 @@ pub struct TxIndex {
     pub senders: Vec<SuiAddress>,
     pub recipients: Vec<SuiAddress>,
     pub move_calls: Vec<(ObjectID, String, String)>,
+    pub transaction_kind: TransactionKind,
 }
 
 // ObjectChange is not bcs deserializable, IndexedObjectChange is.


### PR DESCRIPTION
## Description 

Add `address` and `rel` columns to the tx lookup tables to facilitate queries filtered on participant (sender or recipient) and another criteria.

In the same vein, augment the sender and recipient tables with a column and index on `transaction_kind`.

On graphql today, a user can query for transactions filtered on `changedObject`, `inputObject`, `transactionKind`, `function`, `signAddress`, and `recvAddress`. Because we allow arbitrary combinations, each filter corresponded to an unbounded query against a lookup table, which made performance susceptible to the underlying data distribution. To address this, we will reduce the valid combinations on graphql to `signAddress|recvAddress|signOrRecvAddress` + `changedObject|inputObject|transactionKind|function`, which necessitates the denormalization and other changes itemized above.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
