### PR TITLE
Consensus changes for SIP-19

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -616,7 +616,7 @@ mod tests {
             submitted_transactions.insert(txn.clone());
             authorities[i as usize % authorities.len()]
                 .transaction_client()
-                .submit(txn)
+                .submit(vec![txn])
                 .await
                 .unwrap();
         }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -331,6 +331,7 @@ impl Core {
                     .saturating_duration_since(self.threshold_clock.get_quorum_ts())
                     .as_millis() as u64,
             );
+
         self.context
             .metrics
             .node_metrics
@@ -1022,7 +1023,7 @@ mod test {
             total += transaction.len();
             index += 1;
             let _w = transaction_client
-                .submit_no_wait(transaction)
+                .submit_no_wait(vec![transaction])
                 .await
                 .unwrap();
 

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -76,13 +76,10 @@ impl TransactionConsumer {
                 .transactions
                 .into_iter()
                 .filter_map(|tx| {
-                    if (total_size + tx.data().len()) as u64 > self.max_consumed_bytes_per_request {
-                        // Adding this tx would exceed the size limit, cache it for the next pull.
-                        Some(tx)
-                    } else if transactions.len() as u64
-                        >= self.max_consumed_transactions_per_request
+                    if (total_size + tx.data().len()) as u64 > self.max_consumed_bytes_per_request
+                        || transactions.len() as u64 >= self.max_consumed_transactions_per_request
                     {
-                        // Adding this tx would exceed the number of transactions limit, cache it for the next pull.
+                        // Adding this tx would exceed the size limit or the number of txs limit, cache it for the next pull.
                         Some(tx)
                     } else {
                         total_size += tx.data().len();

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1682,30 +1682,41 @@ impl AuthorityPerEpochStore {
     /// and verify that it allows new user certificates
     pub fn insert_pending_consensus_transactions(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &[ConsensusTransaction],
         lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> SuiResult {
+        let key_value_pairs = transactions.iter().map(|tx| (tx.key(), tx));
         self.tables()?
             .pending_consensus_transactions
-            .insert(&transaction.key(), transaction)?;
-        if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
-            let state = lock.expect("Must pass reconfiguration lock when storing certificate");
-            // Caller is responsible for performing graceful check
-            assert!(
-                state.should_accept_user_certs(),
-                "Reconfiguration state should allow accepting user transactions"
-            );
-            self.pending_consensus_certificates
-                .lock()
-                .insert(*cert.digest());
+            .multi_insert(key_value_pairs)?;
+
+        for transaction in transactions {
+            if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
+                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
+                // Caller is responsible for performing graceful check
+                assert!(
+                    state.should_accept_user_certs(),
+                    "Reconfiguration state should allow accepting user transactions"
+                );
+                self.pending_consensus_certificates
+                    .lock()
+                    .insert(*cert.digest());
+            }
         }
         Ok(())
     }
 
-    pub fn remove_pending_consensus_transaction(&self, key: &ConsensusTransactionKey) -> SuiResult {
-        self.tables()?.pending_consensus_transactions.remove(key)?;
-        if let ConsensusTransactionKey::Certificate(cert) = key {
-            self.pending_consensus_certificates.lock().remove(cert);
+    pub fn remove_pending_consensus_transactions(
+        &self,
+        keys: &[ConsensusTransactionKey],
+    ) -> SuiResult {
+        self.tables()?
+            .pending_consensus_transactions
+            .multi_remove(keys)?;
+        for key in keys {
+            if let ConsensusTransactionKey::Certificate(cert) = key {
+                self.pending_consensus_certificates.lock().remove(cert);
+            }
         }
         Ok(())
     }
@@ -1764,18 +1775,6 @@ impl AuthorityPerEpochStore {
             .tables()?
             .consensus_message_processed
             .contains_key(key)?)
-    }
-
-    pub async fn consensus_message_processed_notify(
-        &self,
-        key: SequencedConsensusTransactionKey,
-    ) -> Result<(), SuiError> {
-        let registration = self.consensus_notify_read.register_one(&key);
-        if self.is_consensus_message_processed(&key)? {
-            return Ok(());
-        }
-        registration.await;
-        Ok(())
     }
 
     pub fn check_consensus_messages_processed<'a>(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1690,6 +1690,7 @@ impl AuthorityPerEpochStore {
             .pending_consensus_transactions
             .multi_insert(key_value_pairs)?;
 
+        // TODO: lock once for all insert() calls.
         for transaction in transactions {
             if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
                 let state = lock.expect("Must pass reconfiguration lock when storing certificate");
@@ -1713,6 +1714,7 @@ impl AuthorityPerEpochStore {
         self.tables()?
             .pending_consensus_transactions
             .multi_remove(keys)?;
+        // TODO: lock once for all remove() calls.
         for key in keys {
             if let ConsensusTransactionKey::Certificate(cert) = key {
                 self.pending_consensus_certificates.lock().remove(cert);

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -94,7 +94,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         let message = CheckpointSignatureMessage { summary };
         let transaction = ConsensusTransaction::new_checkpoint_signature_message(message);
         self.sender
-            .submit_to_consensus(&transaction, epoch_store)
+            .submit_to_consensus(&vec![transaction], epoch_store)
             .await?;
         self.metrics
             .last_sent_checkpoint_signature

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -184,7 +184,7 @@ impl ConsensusAdapterMetrics {
 pub trait SubmitToConsensus: Sync + Send + 'static {
     async fn submit_to_consensus(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &Vec<ConsensusTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult;
 }
@@ -193,15 +193,21 @@ pub trait SubmitToConsensus: Sync + Send + 'static {
 impl SubmitToConsensus for TransactionsClient<sui_network::tonic::transport::Channel> {
     async fn submit_to_consensus(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &Vec<ConsensusTransaction>,
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        let serialized =
-            bcs::to_bytes(transaction).expect("Serializing consensus transaction cannot fail");
-        let bytes = Bytes::from(serialized.clone());
-
+        let transactions_bytes = transactions
+            .iter()
+            .map(|t| {
+                let serialized =
+                    bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail");
+                Bytes::from(serialized)
+            })
+            .collect::<Vec<_>>();
         self.clone()
-            .submit_transaction(TransactionProto { transaction: bytes })
+            .submit_transaction(TransactionProto {
+                transactions: transactions_bytes,
+            })
             .await
             .map_err(|e| SuiError::ConsensusConnectionBroken(format!("{:?}", e)))
             .tap_err(|r| {
@@ -216,11 +222,13 @@ impl SubmitToConsensus for TransactionsClient<sui_network::tonic::transport::Cha
 impl SubmitToConsensus for LazyNarwhalClient {
     async fn submit_to_consensus(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &Vec<ConsensusTransaction>,
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        let transaction =
-            bcs::to_bytes(transaction).expect("Serializing consensus transaction cannot fail");
+        let transactions = transactions
+            .iter()
+            .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
+            .collect::<Vec<_>>();
         // The retrieved LocalNarwhalClient can be from the past epoch. Submit would fail after
         // Narwhal shuts down, so there should be no correctness issue.
         let client = {
@@ -234,7 +242,7 @@ impl SubmitToConsensus for LazyNarwhalClient {
         };
         let client = client.as_ref().unwrap().load();
         client
-            .submit_transaction(transaction)
+            .submit_transaction(transactions)
             .await
             .map_err(|e| SuiError::FailedToSubmitToConsensus(format!("{:?}", e)))
             .tap_err(|r| {
@@ -368,20 +376,28 @@ impl ConsensusAdapter {
             recovered.len()
         );
         for transaction in recovered {
-            self.submit_unchecked(transaction, epoch_store);
+            self.submit_unchecked(&[transaction], epoch_store);
         }
     }
 
     fn await_submit_delay(
         &self,
         committee: &Committee,
-        transaction: &ConsensusTransaction,
+        transactions: &[ConsensusTransaction],
     ) -> (impl Future<Output = ()>, usize, usize, usize) {
-        let (duration, position, positions_moved, preceding_disconnected) = match &transaction.kind
-        {
-            ConsensusTransactionKind::UserTransaction(certificate) => {
-                self.await_submit_delay_user_transaction(committee, certificate.digest())
-            }
+        // Use the minimum digest to compute submit delay.
+        let min_digest = transactions
+            .iter()
+            .filter_map(|tx| match &tx.kind {
+                ConsensusTransactionKind::UserTransaction(certificate) => {
+                    Some(certificate.digest())
+                }
+                _ => None,
+            })
+            .min();
+
+        let (duration, position, positions_moved, preceding_disconnected) = match min_digest {
+            Some(digest) => self.await_submit_delay_user_transaction(committee, digest),
             _ => (Duration::ZERO, 0, 0, 0),
         };
         (
@@ -576,8 +592,31 @@ impl ConsensusAdapter {
         lock: Option<&RwLockReadGuard<ReconfigState>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<JoinHandle<()>> {
-        epoch_store.insert_pending_consensus_transactions(&transaction, lock)?;
-        Ok(self.submit_unchecked(transaction, epoch_store))
+        self.submit_batch(&[transaction], lock, epoch_store)
+    }
+
+    pub fn submit_batch(
+        self: &Arc<Self>,
+        transactions: &[ConsensusTransaction],
+        lock: Option<&RwLockReadGuard<ReconfigState>>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult<JoinHandle<()>> {
+        if transactions.len() > 1 {
+            // In soft bundle, we need to check if all transactions are of UserTransaction kind.
+            // The check is required because we assume this in submit_and_wait_inner.
+            for transaction in transactions {
+                fp_ensure!(
+                    matches!(
+                        transaction.kind,
+                        ConsensusTransactionKind::UserTransaction(_)
+                    ),
+                    SuiError::InvalidTxKindInSoftBundle
+                );
+            }
+        }
+
+        epoch_store.insert_pending_consensus_transactions(transactions, lock)?;
+        Ok(self.submit_unchecked(transactions, epoch_store))
     }
 
     /// Performs weakly consistent checks on internal buffers to quickly
@@ -603,13 +642,13 @@ impl ConsensusAdapter {
 
     fn submit_unchecked(
         self: &Arc<Self>,
-        transaction: ConsensusTransaction,
+        transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> JoinHandle<()> {
         // Reconfiguration lock is dropped when pending_consensus_transactions is persisted, before it is handled by consensus
         let async_stage = self
             .clone()
-            .submit_and_wait(transaction, epoch_store.clone());
+            .submit_and_wait(transactions.to_vec(), epoch_store.clone());
         // Number of these tasks is weakly limited based on `num_inflight_transactions`.
         // (Limit is not applied atomically, and only to user transactions.)
         let join_handle = spawn_monitored_task!(async_stage);
@@ -618,7 +657,7 @@ impl ConsensusAdapter {
 
     async fn submit_and_wait(
         self: Arc<Self>,
-        transaction: ConsensusTransaction,
+        transactions: Vec<ConsensusTransaction>,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) {
         // When epoch_terminated signal is received all pending submit_and_wait_inner are dropped.
@@ -633,7 +672,7 @@ impl ConsensusAdapter {
         // this means we might be sending transactions from previous epochs to narwhal of
         // new epoch if we have not had this barrier.
         epoch_store
-            .within_alive_epoch(self.submit_and_wait_inner(transaction, &epoch_store))
+            .within_alive_epoch(self.submit_and_wait_inner(transactions, &epoch_store))
             .await
             .ok(); // result here indicates if epoch ended earlier, we don't care about it
     }
@@ -641,26 +680,46 @@ impl ConsensusAdapter {
     #[allow(clippy::option_map_unit_fn)]
     async fn submit_and_wait_inner(
         self: Arc<Self>,
-        transaction: ConsensusTransaction,
+        transactions: Vec<ConsensusTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
-        if matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..)) {
-            info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to Narwhal");
-            epoch_store.record_epoch_pending_certs_process_time_metric();
+        if transactions.is_empty() {
+            return;
         }
 
-        let tx_type = classify(&transaction);
-        let transaction_key = SequencedConsensusTransactionKey::External(transaction.key());
+        // Current code path ensures:
+        // - If transactions.len() > 1, it is a soft bundle. Otherwise transactions should have been submitted individually.
+        // - If is_soft_bundle, then all transactions are of UserTransaction kind.
+        // - If not is_soft_bundle, then transactions must contain exactly 1 tx, and transactions[0] can be of any kind.
+        let is_soft_bundle = transactions.len() > 1;
+
+        let mut transaction_keys = Vec::new();
+
+        for transaction in &transactions {
+            if matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..)) {
+                info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to Narwhal");
+                epoch_store.record_epoch_pending_certs_process_time_metric();
+            }
+
+            let transaction_key = SequencedConsensusTransactionKey::External(transaction.key());
+            transaction_keys.push(transaction_key);
+        }
+        let tx_type = if !is_soft_bundle {
+            classify(&transactions[0])
+        } else {
+            "soft_bundle"
+        };
+
         let processed_waiter = epoch_store
-            .consensus_message_processed_notify(transaction_key)
+            .consensus_messages_processed_notify(transaction_keys.clone())
             .boxed();
 
         pin_mut!(processed_waiter);
 
         let (await_submit, position, positions_moved, preceding_disconnected) =
-            self.await_submit_delay(epoch_store.committee(), &transaction);
-        let mut guard = InflightDropGuard::acquire(&self, tx_type.to_string());
+            self.await_submit_delay(epoch_store.committee(), &transactions[..]);
 
+        let mut guard = InflightDropGuard::acquire(&self, tx_type.to_string());
         let processed_waiter = tokio::select! {
             // We need to wait for some delay until we submit transaction to the consensus
             _ = await_submit => Some(processed_waiter),
@@ -678,16 +737,16 @@ impl ConsensusAdapter {
             }
         };
 
-        let transaction_key = transaction.key();
         // Log warnings for administrative transactions that fail to get sequenced
-        let _monitor = if matches!(
-            transaction.kind,
-            ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotification(_)
-                | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
-        ) {
-            let transaction_key = transaction_key.clone();
+        let _monitor = if !is_soft_bundle
+            && matches!(
+                transactions[0].kind,
+                ConsensusTransactionKind::EndOfPublish(_)
+                    | ConsensusTransactionKind::CapabilityNotification(_)
+                    | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
+                    | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
+            ) {
+            let transaction_keys = transaction_keys.clone();
             Some(CancelOnDrop(spawn_monitored_task!(async {
                 let mut i = 0u64;
                 loop {
@@ -696,8 +755,8 @@ impl ConsensusAdapter {
                     tokio::time::sleep(Duration::from_secs(WARN_DELAY_S)).await;
                     let total_wait = i * WARN_DELAY_S;
                     warn!(
-                        "Still waiting {} seconds for transaction {:?} to commit in consensus",
-                        total_wait, transaction_key
+                        "Still waiting {} seconds for transactions {:?} to commit in consensus",
+                        total_wait, transaction_keys
                     );
                 }
             })))
@@ -705,7 +764,7 @@ impl ConsensusAdapter {
             None
         };
         if let Some(processed_waiter) = processed_waiter {
-            debug!("Submitting {:?} to consensus", transaction_key);
+            debug!("Submitting {:?} to consensus", transaction_keys);
 
             // populate the position only when this authority submits the transaction
             // to consensus
@@ -729,14 +788,16 @@ impl ConsensusAdapter {
                 let mut retries: u32 = 0;
                 while let Err(e) = self
                     .consensus_client
-                    .submit_to_consensus(&transaction, epoch_store)
+                    .submit_to_consensus(&transactions, epoch_store)
                     .await
                 {
                     // This can happen during reconfig, or when consensus has full internal buffers
                     // and needs to back pressure, so retry a few times before logging warnings.
-                    if retries > 30 || (retries > 3 && !transaction.kind.is_dkg()) {
+                    if retries > 30
+                        || (retries > 3 && (is_soft_bundle || !transactions[0].kind.is_dkg()))
+                    {
                         warn!(
-                            "Failed to submit transaction {transaction_key:?} to consensus: {e:?}. Retry #{retries}"
+                            "Failed to submit transactions {transaction_keys:?} to consensus: {e:?}. Retry #{retries}"
                         );
                     }
                     self.metrics
@@ -745,7 +806,7 @@ impl ConsensusAdapter {
                         .inc();
                     retries += 1;
 
-                    if transaction.kind.is_dkg() {
+                    if !is_soft_bundle && transactions[0].kind.is_dkg() {
                         // Shorter delay for DKG messages, which are time-sensitive and happen at
                         // start-of-epoch when submit errors due to active reconfig are likely.
                         time::sleep(Duration::from_millis(100)).await;
@@ -773,19 +834,25 @@ impl ConsensusAdapter {
             match select(processed_waiter, submit_inner.boxed()).await {
                 Either::Left((processed, _submit_inner)) => processed,
                 Either::Right(((), processed_waiter)) => {
-                    debug!("Submitted {transaction_key:?} to consensus");
+                    debug!("Submitted {transaction_keys:?} to consensus");
                     processed_waiter.await
                 }
             }
             .expect("Storage error when waiting for consensus message processed");
         }
-        debug!("{transaction_key:?} processed by consensus");
+        debug!("{transaction_keys:?} processed by consensus");
+
+        let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
         epoch_store
-            .remove_pending_consensus_transaction(&transaction.key())
+            .remove_pending_consensus_transactions(&consensus_keys[..])
             .expect("Storage error when removing consensus transaction");
-        let send_end_of_publish = if let ConsensusTransactionKind::UserTransaction(_cert) =
-            &transaction.kind
-        {
+
+        let is_user_tx = is_soft_bundle
+            || matches!(
+                transactions[0].kind,
+                ConsensusTransactionKind::UserTransaction(_)
+            );
+        let send_end_of_publish = if is_user_tx {
             // If we are in RejectUserCerts state and we just drained the list we need to
             // send EndOfPublish to signal other validators that we are not submitting more certificates to the epoch.
             // Note that there could be a race condition here where we enter this check in RejectAllCerts state.
@@ -1037,10 +1104,10 @@ impl<'a> Drop for InflightDropGuard<'a> {
 impl SubmitToConsensus for Arc<ConsensusAdapter> {
     async fn submit_to_consensus(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &Vec<ConsensusTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        self.submit(transaction.clone(), None, epoch_store)
+        self.submit_batch(&transactions[..], None, epoch_store)
             .map(|_| ())
     }
 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -242,7 +242,7 @@ impl SubmitToConsensus for LazyNarwhalClient {
         };
         let client = client.as_ref().unwrap().load();
         client
-            .submit_transaction(transactions)
+            .submit_transactions(transactions)
             .await
             .map_err(|e| SuiError::FailedToSubmitToConsensus(format!("{:?}", e)))
             .tap_err(|r| {
@@ -697,7 +697,7 @@ impl ConsensusAdapter {
 
         for transaction in &transactions {
             if matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..)) {
-                info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to Narwhal");
+                info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to consensus");
                 epoch_store.record_epoch_pending_certs_process_time_metric();
             }
 
@@ -844,7 +844,7 @@ impl ConsensusAdapter {
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
         epoch_store
-            .remove_pending_consensus_transactions(&consensus_keys[..])
+            .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");
 
         let is_user_tx = is_soft_bundle

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -184,7 +184,7 @@ impl ConsensusAdapterMetrics {
 pub trait SubmitToConsensus: Sync + Send + 'static {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult;
 }
@@ -193,7 +193,7 @@ pub trait SubmitToConsensus: Sync + Send + 'static {
 impl SubmitToConsensus for TransactionsClient<sui_network::tonic::transport::Channel> {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let transactions_bytes = transactions
@@ -222,7 +222,7 @@ impl SubmitToConsensus for TransactionsClient<sui_network::tonic::transport::Cha
 impl SubmitToConsensus for LazyNarwhalClient {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let transactions = transactions
@@ -788,7 +788,7 @@ impl ConsensusAdapter {
                 let mut retries: u32 = 0;
                 while let Err(e) = self
                     .consensus_client
-                    .submit_to_consensus(&transactions, epoch_store)
+                    .submit_to_consensus(&transactions[..], epoch_store)
                     .await
                 {
                     // This can happen during reconfig, or when consensus has full internal buffers
@@ -1104,10 +1104,10 @@ impl<'a> Drop for InflightDropGuard<'a> {
 impl SubmitToConsensus for Arc<ConsensusAdapter> {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        self.submit_batch(&transactions[..], None, epoch_store)
+        self.submit_batch(transactions, None, epoch_store)
             .map(|_| ())
     }
 }

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -300,11 +300,11 @@ impl ConsensusClient {
 impl SubmitToConsensus for ConsensusClient {
     async fn submit_to_consensus(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &Vec<ConsensusTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let client = self.get().await;
-        client.submit_to_consensus(transaction, epoch_store).await
+        client.submit_to_consensus(transactions, epoch_store).await
     }
 }
 

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -300,7 +300,7 @@ impl ConsensusClient {
 impl SubmitToConsensus for ConsensusClient {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         let client = self.get().await;

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -752,10 +752,12 @@ mod tests {
             let tx_consensus = tx_consensus.clone();
             mock_consensus_client
                 .expect_submit_to_consensus()
-                .withf(move |transaction: &ConsensusTransaction, _epoch_store| {
-                    tx_consensus.try_send(transaction.clone()).unwrap();
-                    true
-                })
+                .withf(
+                    move |transactions: &Vec<ConsensusTransaction>, _epoch_store| {
+                        tx_consensus.try_send(transactions.clone()).unwrap();
+                        true
+                    },
+                )
                 .returning(|_, _| Ok(()));
 
             let state = TestAuthorityBuilder::new()
@@ -792,8 +794,9 @@ mod tests {
         for randomness_manager in randomness_managers.iter_mut() {
             randomness_manager.start_dkg().unwrap();
 
-            let dkg_message = rx_consensus.recv().await.unwrap();
-            match dkg_message.kind {
+            let mut dkg_message = rx_consensus.recv().await.unwrap();
+            assert!(dkg_message.len() == 1);
+            match dkg_message.remove(0).kind {
                 ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
                     let msg: fastcrypto_tbls::dkg::Message<PkG, EncG> = bcs::from_bytes(&bytes)
                         .expect("DKG message deserialization should not fail");
@@ -823,8 +826,9 @@ mod tests {
         // Generate and distribute Confirmations.
         let mut dkg_confirmations = Vec::new();
         for _ in 0..randomness_managers.len() {
-            let dkg_confirmation = rx_consensus.recv().await.unwrap();
-            match dkg_confirmation.kind {
+            let mut dkg_confirmation = rx_consensus.recv().await.unwrap();
+            assert!(dkg_confirmation.len() == 1);
+            match dkg_confirmation.remove(0).kind {
                 ConsensusTransactionKind::RandomnessDkgConfirmation(_, bytes) => {
                     let msg: fastcrypto_tbls::dkg::Confirmation<EncG> = bcs::from_bytes(&bytes)
                         .expect("DKG confirmation deserialization should not fail");
@@ -873,10 +877,12 @@ mod tests {
             let tx_consensus = tx_consensus.clone();
             mock_consensus_client
                 .expect_submit_to_consensus()
-                .withf(move |transaction: &ConsensusTransaction, _epoch_store| {
-                    tx_consensus.try_send(transaction.clone()).unwrap();
-                    true
-                })
+                .withf(
+                    move |transactions: &Vec<ConsensusTransaction>, _epoch_store| {
+                        tx_consensus.try_send(transactions.clone()).unwrap();
+                        true
+                    },
+                )
                 .returning(|_, _| Ok(()));
 
             let state = TestAuthorityBuilder::new()
@@ -913,8 +919,9 @@ mod tests {
         for randomness_manager in randomness_managers.iter_mut() {
             randomness_manager.start_dkg().unwrap();
 
-            let dkg_message = rx_consensus.recv().await.unwrap();
-            match dkg_message.kind {
+            let mut dkg_message = rx_consensus.recv().await.unwrap();
+            assert!(dkg_message.len() == 1);
+            match dkg_message.remove(0).kind {
                 ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
                     let msg: fastcrypto_tbls::dkg::Message<PkG, EncG> = bcs::from_bytes(&bytes)
                         .expect("DKG message deserialization should not fail");

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -752,12 +752,10 @@ mod tests {
             let tx_consensus = tx_consensus.clone();
             mock_consensus_client
                 .expect_submit_to_consensus()
-                .withf(
-                    move |transactions: &Vec<ConsensusTransaction>, _epoch_store| {
-                        tx_consensus.try_send(transactions.clone()).unwrap();
-                        true
-                    },
-                )
+                .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
+                    tx_consensus.try_send(transactions.to_vec()).unwrap();
+                    true
+                })
                 .returning(|_, _| Ok(()));
 
             let state = TestAuthorityBuilder::new()
@@ -877,12 +875,10 @@ mod tests {
             let tx_consensus = tx_consensus.clone();
             mock_consensus_client
                 .expect_submit_to_consensus()
-                .withf(
-                    move |transactions: &Vec<ConsensusTransaction>, _epoch_store| {
-                        tx_consensus.try_send(transactions.clone()).unwrap();
-                        true
-                    },
-                )
+                .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
+                    tx_consensus.try_send(transactions.to_vec()).unwrap();
+                    true
+                })
                 .returning(|_, _| Ok(()));
 
             let state = TestAuthorityBuilder::new()

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -74,7 +74,7 @@ impl LazyMysticetiClient {
 impl SubmitToConsensus for LazyMysticetiClient {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         // TODO(mysticeti): confirm comment is still true

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -128,7 +128,7 @@ async fn submit_transaction_to_consensus_adapter() {
     impl SubmitToConsensus for SubmitDirectly {
         async fn submit_to_consensus(
             &self,
-            transactions: &Vec<ConsensusTransaction>,
+            transactions: &[ConsensusTransaction],
             epoch_store: &Arc<AuthorityPerEpochStore>,
         ) -> SuiResult {
             let sequenced_transactions = transactions

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -128,12 +128,16 @@ async fn submit_transaction_to_consensus_adapter() {
     impl SubmitToConsensus for SubmitDirectly {
         async fn submit_to_consensus(
             &self,
-            transaction: &ConsensusTransaction,
+            transactions: &Vec<ConsensusTransaction>,
             epoch_store: &Arc<AuthorityPerEpochStore>,
         ) -> SuiResult {
+            let sequenced_transactions = transactions
+                .iter()
+                .map(|txn| SequencedConsensusTransaction::new_test(txn.clone()))
+                .collect();
             epoch_store
                 .process_consensus_transactions_for_tests(
-                    vec![SequencedConsensusTransaction::new_test(transaction.clone())],
+                    sequenced_transactions,
                     &Arc::new(CheckpointServiceNoop {}),
                     self.0.get_cache_reader().as_ref(),
                     &self.0.metrics,

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -42,7 +42,7 @@ async fn send_transactions(
     let mut client = TransactionsClient::new(channel);
     // Make a transaction to submit forever.
     let tx = TransactionProto {
-        transaction: Bytes::from(epoch.to_be_bytes().to_vec()),
+        transactions: vec![Bytes::from(epoch.to_be_bytes().to_vec())],
     };
     // Repeatedly send transactions.
     let interval = interval(Duration::from_millis(1));

--- a/crates/sui-single-node-benchmark/src/mock_consensus.rs
+++ b/crates/sui-single-node-benchmark/src/mock_consensus.rs
@@ -86,9 +86,10 @@ impl MockConsensusClient {
 impl SubmitToConsensus for MockConsensusClient {
     async fn submit_to_consensus(
         &self,
-        transactions: &Vec<ConsensusTransaction>,
+        transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
+        // TODO: maybe support multi-transactions and remove this check
         assert!(transactions.len() == 1);
         let transaction = &transactions[0];
         self.tx_sender.send(transaction.clone()).await.unwrap();

--- a/crates/sui-single-node-benchmark/src/mock_consensus.rs
+++ b/crates/sui-single-node-benchmark/src/mock_consensus.rs
@@ -86,9 +86,11 @@ impl MockConsensusClient {
 impl SubmitToConsensus for MockConsensusClient {
     async fn submit_to_consensus(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &Vec<ConsensusTransaction>,
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
+        assert!(transactions.len() == 1);
+        let transaction = &transactions[0];
         self.tx_sender.send(transaction.clone()).await.unwrap();
         Ok(())
     }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -332,6 +332,9 @@ pub enum SuiError {
         threshold: u64,
     },
 
+    #[error("Soft bundle must only contain transactions of UserTransaction kind")]
+    InvalidTxKindInSoftBundle,
+
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -187,7 +187,7 @@ async fn test_internal_consensus_output() {
         // serialise and send
         let tr = bcs::to_bytes(&tx).unwrap();
         let txn = TransactionProto {
-            transaction: Bytes::from(tr),
+            transactions: vec![Bytes::from(tr)],
         };
         client.submit_transaction(txn).await.unwrap();
 

--- a/narwhal/node/src/benchmark_client.rs
+++ b/narwhal/node/src/benchmark_client.rs
@@ -390,7 +390,7 @@ async fn submit_to_consensus(
     };
     let client = client.as_ref().unwrap().load();
     client
-        .submit_transaction(vec![transaction])
+        .submit_transactions(vec![transaction])
         .await
         .map_err(|e| eyre::Report::msg(format!("Failed to submit to consensus: {:?}", e)))?;
     Ok(())

--- a/narwhal/node/src/benchmark_client.rs
+++ b/narwhal/node/src/benchmark_client.rs
@@ -250,7 +250,7 @@ impl Client {
                         }
                     } else {
                         let tx_proto = TransactionProto {
-                            transaction: Bytes::from(transaction),
+                            transactions: vec![Bytes::from(transaction)],
                         };
                         if let Err(e) = grpc_client.submit_transaction(tx_proto).await {
                             submission_error = Some(eyre::Report::msg(format!("{e}")));
@@ -390,7 +390,7 @@ async fn submit_to_consensus(
     };
     let client = client.as_ref().unwrap().load();
     client
-        .submit_transaction(transaction)
+        .submit_transaction(vec![transaction])
         .await
         .map_err(|e| eyre::Report::msg(format!("Failed to submit to consensus: {:?}", e)))?;
     Ok(())

--- a/narwhal/primary/tests/causal_completion_tests.rs
+++ b/narwhal/primary/tests/causal_completion_tests.rs
@@ -42,7 +42,7 @@ async fn test_restore_from_disk() {
         tokio::spawn(async move {
             let tr = bcs::to_bytes(&tx).unwrap();
             let txn = TransactionProto {
-                transaction: Bytes::from(tr),
+                transactions: vec![Bytes::from(tr)],
             };
 
             c.submit_transaction(txn).await.unwrap();

--- a/narwhal/primary/tests/nodes_bootstrapping_tests.rs
+++ b/narwhal/primary/tests/nodes_bootstrapping_tests.rs
@@ -33,7 +33,7 @@ async fn test_response_error_after_shutdown_internal_consensus() {
     let tx_str = "test transaction".to_string();
     let tx = bcs::to_bytes(&tx_str).unwrap();
     let txn = TransactionProto {
-        transaction: Bytes::from(tx),
+        transactions: vec![Bytes::from(tx)],
     };
 
     // Should fail submitting to consensus.

--- a/narwhal/types/proto/narwhal.proto
+++ b/narwhal/types/proto/narwhal.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 package narwhal;
 
 message Transaction {
-    bytes transaction = 1;
+    repeated bytes transactions = 1;
 }
 
 // Empty message for when we don't have anything to return

--- a/narwhal/types/src/proto.rs
+++ b/narwhal/types/src/proto.rs
@@ -30,13 +30,15 @@ pub use narwhal::{
 impl From<Transaction> for TransactionProto {
     fn from(transaction: Transaction) -> Self {
         TransactionProto {
-            transaction: Bytes::from(transaction),
+            transactions: vec![Bytes::from(transaction)],
         }
     }
 }
 
-impl From<TransactionProto> for Transaction {
-    fn from(transaction: TransactionProto) -> Self {
-        transaction.transaction.to_vec()
+impl From<Vec<Transaction>> for TransactionProto {
+    fn from(transactions: Vec<Transaction>) -> Self {
+        TransactionProto {
+            transactions: transactions.into_iter().map(Bytes::from).collect(),
+        }
     }
 }

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -47,7 +47,7 @@ pub struct BatchMaker {
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Channel to receive transactions from the network.
-    rx_batch_maker: Receiver<(Transaction, TxResponse)>,
+    rx_batch_maker: Receiver<(Vec<Transaction>, TxResponse)>,
     /// Output channel to deliver sealed batches to the `QuorumWaiter`.
     tx_quorum_waiter: Sender<(Batch, tokio::sync::oneshot::Sender<()>)>,
     /// Metrics handler
@@ -69,7 +69,7 @@ impl BatchMaker {
         batch_size_limit: usize,
         max_batch_delay: Duration,
         rx_shutdown: ConditionalBroadcastReceiver,
-        rx_batch_maker: Receiver<(Transaction, TxResponse)>,
+        rx_batch_maker: Receiver<(Vec<Transaction>, TxResponse)>,
         tx_quorum_waiter: Sender<(Batch, tokio::sync::oneshot::Sender<()>)>,
         node_metrics: Arc<WorkerMetrics>,
         client: NetworkClient,
@@ -115,26 +115,32 @@ impl BatchMaker {
                 // Note that transactions are only consumed when the number of batches
                 // 'in-flight' are below a certain number (MAX_PARALLEL_BATCH). This
                 // condition will be met eventually if the store and network are functioning.
-                Some((transaction, response_sender)) = self.rx_batch_maker.recv(), if batch_pipeline.len() < MAX_PARALLEL_BATCH => {
+                Some((transactions, response_sender)) = self.rx_batch_maker.recv(), if batch_pipeline.len() < MAX_PARALLEL_BATCH => {
                     let _scope = monitored_scope("BatchMaker::recv");
-                    current_batch_size += transaction.len();
-                    current_batch.transactions_mut().push(transaction);
+
+                    // If there are multiple transactions, we only send back the digest of the first Batch.
+                    // This currently poses no issue but needs to be fixed should a caller need to know the digest of all batches.
                     current_responses.push(response_sender);
-                    if current_batch_size >= self.batch_size_limit {
-                        if let Some(seal) = self.seal(false, current_batch, current_batch_size, current_responses).await{
-                            batch_pipeline.push(seal);
+                    for transaction in transactions {
+                        current_batch_size += transaction.len();
+                        current_batch.transactions_mut().push(transaction);
+
+                        if current_batch_size >= self.batch_size_limit {
+                            if let Some(seal) = self.seal(false, current_batch, current_batch_size, current_responses).await{
+                                batch_pipeline.push(seal);
+                            }
+                            self.node_metrics.parallel_worker_batches.set(batch_pipeline.len() as i64);
+
+                            current_batch = Batch::new(vec![], &self.protocol_config);
+                            current_responses = Vec::new();
+                            current_batch_size = 0;
+
+                            timer.as_mut().reset(Instant::now() + self.max_batch_delay);
+                            self.batch_start_timestamp = Instant::now();
+
+                            // Yield once per size threshold to allow other tasks to run.
+                            tokio::task::yield_now().await;
                         }
-                        self.node_metrics.parallel_worker_batches.set(batch_pipeline.len() as i64);
-
-                        current_batch = Batch::new(vec![], &self.protocol_config);
-                        current_responses = Vec::new();
-                        current_batch_size = 0;
-
-                        timer.as_mut().reset(Instant::now() + self.max_batch_delay);
-                        self.batch_start_timestamp = Instant::now();
-
-                        // Yield once per size threshold to allow other tasks to run.
-                        tokio::task::yield_now().await;
                     }
                 },
 

--- a/narwhal/worker/src/client.rs
+++ b/narwhal/worker/src/client.rs
@@ -146,7 +146,7 @@ impl LocalNarwhalClient {
     }
 
     /// Submits a transaction to the local Narwhal worker.
-    pub async fn submit_transaction(
+    pub async fn submit_transactions(
         &self,
         transactions: Vec<Transaction>,
     ) -> Result<(), NarwhalError> {

--- a/narwhal/worker/src/client.rs
+++ b/narwhal/worker/src/client.rs
@@ -113,11 +113,11 @@ impl LazyNarwhalClient {
 #[derive(Clone)]
 pub struct LocalNarwhalClient {
     /// TODO: maybe use tx_batch_maker for load schedding.
-    tx_batch_maker: Sender<(Transaction, TxResponse)>,
+    tx_batch_maker: Sender<(Vec<Transaction>, TxResponse)>,
 }
 
 impl LocalNarwhalClient {
-    pub fn new(tx_batch_maker: Sender<(Transaction, TxResponse)>) -> Arc<Self> {
+    pub fn new(tx_batch_maker: Sender<(Vec<Transaction>, TxResponse)>) -> Arc<Self> {
         Arc::new(Self { tx_batch_maker })
     }
 
@@ -146,17 +146,23 @@ impl LocalNarwhalClient {
     }
 
     /// Submits a transaction to the local Narwhal worker.
-    pub async fn submit_transaction(&self, transaction: Transaction) -> Result<(), NarwhalError> {
-        if transaction.len() > MAX_ALLOWED_TRANSACTION_SIZE {
-            return Err(NarwhalError::TransactionTooLarge(
-                transaction.len(),
-                MAX_ALLOWED_TRANSACTION_SIZE,
-            ));
+    pub async fn submit_transaction(
+        &self,
+        transactions: Vec<Transaction>,
+    ) -> Result<(), NarwhalError> {
+        for transaction in &transactions {
+            if transaction.len() > MAX_ALLOWED_TRANSACTION_SIZE {
+                return Err(NarwhalError::TransactionTooLarge(
+                    transaction.len(),
+                    MAX_ALLOWED_TRANSACTION_SIZE,
+                ));
+            }
         }
+
         // Send the transaction to the batch maker.
         let (notifier, when_done) = tokio::sync::oneshot::channel();
         self.tx_batch_maker
-            .send((transaction, notifier))
+            .send((transactions, notifier))
             .await
             .map_err(|_| NarwhalError::ShuttingDown)?;
 

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -33,7 +33,7 @@ async fn make_batch() {
     let id = 0;
     let _batch_maker_handle = BatchMaker::spawn(
         id,
-        /* max_batch_size */ 200,
+        /* max_batch_size */ 500,
         /* max_batch_delay */
         Duration::from_millis(1_000_000), // Ensure the timer is not triggered.
         tx_shutdown.subscribe(),
@@ -47,13 +47,25 @@ async fn make_batch() {
 
     // Send enough transactions to seal a batch.
     let tx = transaction();
+    let txs = vec![transaction(), transaction(), transaction()];
     let (s0, r0) = tokio::sync::oneshot::channel();
     let (s1, r1) = tokio::sync::oneshot::channel();
-    tx_batch_maker.send((tx.clone(), s0)).await.unwrap();
-    tx_batch_maker.send((tx.clone(), s1)).await.unwrap();
+    let (s2, r2) = tokio::sync::oneshot::channel();
+    tx_batch_maker.send((vec![tx.clone()], s0)).await.unwrap();
+    tx_batch_maker.send((txs.clone(), s1)).await.unwrap();
+    tx_batch_maker.send((vec![tx.clone()], s2)).await.unwrap();
 
     // Ensure the batch is as expected.
-    let expected_batch = Batch::new(vec![tx.clone(), tx.clone()], &latest_protocol_version());
+    let expected_batch = Batch::new(
+        vec![
+            tx.clone(),
+            txs[0].clone(),
+            txs[1].clone(),
+            txs[2].clone(),
+            tx.clone(),
+        ],
+        &latest_protocol_version(),
+    );
     let (batch, resp) = rx_quorum_waiter.recv().await.unwrap();
 
     assert_eq!(batch.transactions(), expected_batch.transactions());
@@ -64,6 +76,7 @@ async fn make_batch() {
     // Batch maker should finish creating the batch.
     assert!(r0.await.is_ok());
     assert!(r1.await.is_ok());
+    assert!(r2.await.is_ok());
 
     // Ensure the batch is stored
     assert!(store.get(&expected_batch.digest()).unwrap().is_some());
@@ -104,7 +117,7 @@ async fn batch_timeout() {
     // Do not send enough transactions to seal a batch.
     let tx = transaction();
     let (s0, r0) = tokio::sync::oneshot::channel();
-    tx_batch_maker.send((tx.clone(), s0)).await.unwrap();
+    tx_batch_maker.send((vec![tx.clone()], s0)).await.unwrap();
 
     // Ensure the batch is as expected.
     let (batch, resp) = rx_quorum_waiter.recv().await.unwrap();

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -108,7 +108,7 @@ async fn reject_invalid_clients_transactions() {
     let mut client = TransactionsClient::new(channel);
     let tx = transaction();
     let txn = TransactionProto {
-        transaction: Bytes::from(tx.clone()),
+        transactions: vec![Bytes::from(tx.clone())],
     };
 
     // Check invalid transactions are rejected
@@ -240,7 +240,7 @@ async fn handle_remote_clients_transactions() {
         let mut fut_list = FuturesOrdered::new();
         for tx in batch.transactions() {
             let txn = TransactionProto {
-                transaction: Bytes::from(tx.clone()),
+                transactions: vec![Bytes::from(tx.clone())],
             };
 
             // Calls to submit_transaction are now blocking, so we need to drive them
@@ -359,7 +359,10 @@ async fn handle_local_clients_transactions() {
             // all at the same time, rather than sequentially.
             let inner_client = client.clone();
             fut_list.push_back(async move {
-                inner_client.submit_transaction(txn.clone()).await.unwrap();
+                inner_client
+                    .submit_transaction(vec![txn.clone()])
+                    .await
+                    .unwrap();
             });
         }
 

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -360,7 +360,7 @@ async fn handle_local_clients_transactions() {
             let inner_client = client.clone();
             fut_list.push_back(async move {
                 inner_client
-                    .submit_transaction(vec![txn.clone()])
+                    .submit_transactions(vec![txn.clone()])
                     .await
                     .unwrap();
             });

--- a/narwhal/worker/src/transactions_server.rs
+++ b/narwhal/worker/src/transactions_server.rs
@@ -155,7 +155,7 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
         // Send the transaction to Narwhal via the local client.
         let submit_scope = monitored_scope("SubmitTransaction_SubmitTx");
         self.local_client
-            .submit_transaction(transactions.iter().map(|x| x.to_vec()).collect())
+            .submit_transactions(transactions.iter().map(|x| x.to_vec()).collect())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         drop(submit_scope);
@@ -191,7 +191,7 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
             // mean that we process only a single message from this stream at a
             // time. Instead we gather them and resolve them once the stream is over.
             let submit_scope = monitored_scope("SubmitTransactionStream_SubmitTx");
-            requests.push(self.local_client.submit_transaction(vec![txn.to_vec()]));
+            requests.push(self.local_client.submit_transactions(vec![txn.to_vec()]));
             drop(submit_scope);
         }
 

--- a/narwhal/worker/src/transactions_server.rs
+++ b/narwhal/worker/src/transactions_server.rs
@@ -36,7 +36,7 @@ impl<V: TransactionValidator> TxServer<V> {
         address: Multiaddr,
         rx_shutdown: ConditionalBroadcastReceiver,
         endpoint_metrics: WorkerEndpointMetrics,
-        tx_batch_maker: Sender<(Transaction, TxResponse)>,
+        tx_batch_maker: Sender<(Vec<Transaction>, TxResponse)>,
         validator: V,
     ) -> JoinHandle<()> {
         // create and initialize local Narwhal client.
@@ -142,18 +142,20 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
         request: Request<TransactionProto>,
     ) -> Result<Response<Empty>, Status> {
         let _scope = monitored_scope("SubmitTransaction");
-        let transaction = request.into_inner().transaction;
+        let transactions = request.into_inner().transactions;
 
         let validate_scope = monitored_scope("SubmitTransaction_ValidateTx");
-        if self.validator.validate(transaction.as_ref()).is_err() {
-            return Err(Status::invalid_argument("Invalid transaction"));
+        for transaction in &transactions {
+            if self.validator.validate(transaction.as_ref()).is_err() {
+                return Err(Status::invalid_argument("Invalid transaction"));
+            }
         }
         drop(validate_scope);
 
         // Send the transaction to Narwhal via the local client.
         let submit_scope = monitored_scope("SubmitTransaction_SubmitTx");
         self.local_client
-            .submit_transaction(transaction.to_vec())
+            .submit_transaction(transactions.iter().map(|x| x.to_vec()).collect())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         drop(submit_scope);
@@ -168,9 +170,16 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
         let mut requests = FuturesUnordered::new();
 
         let _scope = monitored_scope("SubmitTransactionStream");
-        while let Some(Ok(txn)) = transactions.next().await {
+        while let Some(Ok(request)) = transactions.next().await {
+            let num_txns = request.transactions.len();
+            if num_txns != 1 {
+                return Err(Status::invalid_argument(format!(
+                    "Stream contains an invalid number of transactions: {num_txns}"
+                )));
+            }
+            let txn = &request.transactions[0];
             let validate_scope = monitored_scope("SubmitTransactionStream_ValidateTx");
-            if let Err(err) = self.validator.validate(txn.transaction.as_ref()) {
+            if let Err(err) = self.validator.validate(txn.as_ref()) {
                 // If the transaction is invalid (often cryptographically), better to drop the client
                 return Err(Status::invalid_argument(format!(
                     "Stream contains an invalid transaction {err}"
@@ -182,10 +191,7 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
             // mean that we process only a single message from this stream at a
             // time. Instead we gather them and resolve them once the stream is over.
             let submit_scope = monitored_scope("SubmitTransactionStream_SubmitTx");
-            requests.push(
-                self.local_client
-                    .submit_transaction(txn.transaction.to_vec()),
-            );
+            requests.push(self.local_client.submit_transaction(vec![txn.to_vec()]));
             drop(submit_scope);
         }
 


### PR DESCRIPTION
## Description 

Please refer to this SIP draft: 
https://github.com/sui-foundation/sips/pull/19

The PR focuses only on consensus related changes, covering both Narwhal and Mysticeti.
We will proceed to work on the remaining parts once this gets merged.

The PR includes a commit from @mwtian that changes `TransactionConsumer` for ack handling in a bundle context.
Special thanks to @mwtian for taking time to discussions and authoring the change above!


## Test Plan 

The feature is not exactly user-facing and do not break anything.

### Type of Change (Check all that apply)

- [x] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration
