### PR TITLE
[suiop] add support for deploy key automation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14295,7 +14295,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.1.9"
+version = "0.2.0"
 
 [lib]
 name = "suioplib"

--- a/crates/suiop-cli/src/cli/ci/key.rs
+++ b/crates/suiop-cli/src/cli/ci/key.rs
@@ -100,7 +100,7 @@ Please add the public key above to your repository {} via the link below:
     } else {
         Err(anyhow::anyhow!(
             "Failed to manage keys: {} - {}",
-            status.yellow(),
+            status,
             json_resp.message.yellow()
         ))
     }

--- a/crates/suiop-cli/src/cli/ci/key.rs
+++ b/crates/suiop-cli/src/cli/ci/key.rs
@@ -100,7 +100,7 @@ Please add the public key above to your repository {} via the link below:
     } else {
         Err(anyhow::anyhow!(
             "Failed to manage keys: {} - {}",
-            status,
+            status.yellow(),
             json_resp.message.yellow()
         ))
     }

--- a/crates/suiop-cli/src/cli/ci/key.rs
+++ b/crates/suiop-cli/src/cli/ci/key.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli::lib::{get_oauth_token, API_SERVER};
+use crate::cli::lib::{get_api_server, get_oauth_token};
 use anyhow::Result;
 
 use clap::Parser;
 use colored::Colorize;
-use tracing::{debug, info};
+use tracing::debug;
 
 #[derive(Parser, Debug)]
 pub struct KeyArgs {
@@ -50,71 +50,97 @@ pub async fn key_cmd(args: &KeyArgs) -> Result<()> {
 
 #[derive(serde::Deserialize)]
 struct KeyResponse {
-    pub_key: String,
+    pub_key: Option<String>,
+    message: String,
 }
 
 async fn send_key_request(token: &str, action: &KeyAction) -> Result<()> {
-    let full_url = format!("{}{}", API_SERVER, ENDPOINT);
-    debug!("full_url: {}", full_url);
-    let client = reqwest::Client::new();
+    let req = generate_key_request(token, action);
 
-    let req = match action {
-        KeyAction::Create { repo_name } => client
-            .post(full_url)
-            .header("Authorization", format!("Bearer {}", token))
-            .json::<KeyRequest>(&KeyRequest {
-                repo_name: repo_name.clone(),
-            }),
-        KeyAction::ReCreate { repo_name } => client
-            .put(full_url)
-            .header("Authorization", format!("Bearer {}", token))
-            .json::<KeyRequest>(&KeyRequest {
-                repo_name: repo_name.clone(),
-            }),
-        KeyAction::Delete { repo_name } => client
-            .delete(full_url)
-            .header("Authorization", format!("Bearer {}", token))
-            .json::<KeyRequest>(&KeyRequest {
-                repo_name: repo_name.clone(),
-            }),
-    };
-
-    debug!("req: {:?}", req);
-
+    println!(
+        "Processing request... Please wait patiently. It may take about 20 seconds to complete."
+    );
     let resp = req.send().await?;
     debug!("resp: {:?}", resp);
 
     let status = resp.status();
+    let json_resp = resp.json::<KeyResponse>().await?;
 
     if status.is_success() {
         match action {
             KeyAction::Create { repo_name } | KeyAction::ReCreate { repo_name } => {
-                let json_resp = resp.json::<KeyResponse>().await?;
-                let add_key_link = format!(
-                    "https://github.com/MystenLabs/{}/settings/keys/new",
-                    repo_name
-                );
-                println!(
-                    "Public Key:
--------------------------\n
-{}\n
--------------------------\n
+                if let Some(pubkey) = json_resp.pub_key {
+                    let add_key_link = format!(
+                        "https://github.com/MystenLabs/{}/settings/keys/new",
+                        repo_name
+                    );
+                    println!(
+                        r#"Public Key:
+-------------------------
+{}
+-------------------------
 Please add the public key above to your repository {} via the link below:
-{}",
-                    json_resp.pub_key.yellow(),
-                    repo_name.bright_purple(),
-                    add_key_link.yellow()
-                )
+{}"#,
+                        pubkey.yellow(),
+                        repo_name.bright_purple(),
+                        add_key_link.yellow()
+                    )
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Failed to get public key for repo {}.",
+                        repo_name.bright_purple()
+                    ));
+                }
             }
             KeyAction::Delete { repo_name } => {
-                info!("Key for repo {} deleted", repo_name);
+                println!("Key for repo {} deleted", repo_name.bright_purple());
             }
         }
         Ok(())
     } else {
         Err(anyhow::anyhow!(
-            "Failed to manage keys, status code: {}",
-            status.to_string()
+            "Failed to manage keys: {} - {}",
+            status,
+            json_resp.message.yellow()
         ))
     }
+}
+
+fn generate_headers_with_auth(token: &str) -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)).unwrap(),
+    );
+    headers
+}
+
+fn generate_key_request(token: &str, action: &KeyAction) -> reqwest::RequestBuilder {
+    let client = reqwest::Client::new();
+    let api_server = get_api_server();
+    let full_url = format!("{}{}", api_server, ENDPOINT);
+    debug!("full_url: {}", full_url);
+    let req = match action {
+        KeyAction::Create { repo_name } => client
+            .post(full_url)
+            .headers(generate_headers_with_auth(token))
+            .json(&KeyRequest {
+                repo_name: repo_name.to_string(),
+            }),
+        KeyAction::ReCreate { repo_name } => client
+            .put(full_url)
+            .headers(generate_headers_with_auth(token))
+            .json(&KeyRequest {
+                repo_name: repo_name.to_string(),
+            }),
+        KeyAction::Delete { repo_name } => client
+            .delete(full_url)
+            .headers(generate_headers_with_auth(token))
+            .json(&KeyRequest {
+                repo_name: repo_name.to_string(),
+            }),
+    };
+    debug!("req: {:?}", req);
+
+    req
 }

--- a/crates/suiop-cli/src/cli/ci/key.rs
+++ b/crates/suiop-cli/src/cli/ci/key.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::lib::{get_oauth_token, API_SERVER};
+use anyhow::Result;
+
+use clap::Parser;
+use colored::Colorize;
+use tracing::{debug, info};
+
+#[derive(Parser, Debug)]
+pub struct KeyArgs {
+    #[command(subcommand)]
+    action: KeyAction,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum KeyAction {
+    #[command(name = "create")]
+    Create {
+        #[arg(short, long)]
+        repo_name: String,
+    },
+    #[command(name = "recreate")]
+    ReCreate {
+        #[arg(short, long)]
+        repo_name: String,
+    },
+    #[command(name = "delete")]
+    Delete {
+        #[arg(short, long)]
+        repo_name: String,
+    },
+}
+
+#[derive(serde::Serialize)]
+struct KeyRequest {
+    repo_name: String,
+}
+
+const ENDPOINT: &str = "/automation/deploy-key";
+
+pub async fn key_cmd(args: &KeyArgs) -> Result<()> {
+    let token = get_oauth_token().await?;
+    debug!("token: {}", token.access_token);
+    send_key_request(&token.access_token, &args.action).await?;
+
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct KeyResponse {
+    pub_key: String,
+}
+
+async fn send_key_request(token: &str, action: &KeyAction) -> Result<KeyResponse> {
+    let full_url = format!("{}{}", API_SERVER, ENDPOINT);
+    debug!("full_url: {}", full_url);
+    let client = reqwest::Client::new();
+
+    let req = match action {
+        KeyAction::Create { repo_name } => client
+            .post(full_url)
+            .header("Authorization", format!("Bearer {}", token))
+            .json::<KeyRequest>(&KeyRequest {
+                repo_name: repo_name.clone(),
+            }),
+        KeyAction::ReCreate { repo_name } => client
+            .put(full_url)
+            .header("Authorization", format!("Bearer {}", token))
+            .json::<KeyRequest>(&KeyRequest {
+                repo_name: repo_name.clone(),
+            }),
+        KeyAction::Delete { repo_name } => client
+            .delete(full_url)
+            .header("Authorization", format!("Bearer {}", token))
+            .json::<KeyRequest>(&KeyRequest {
+                repo_name: repo_name.clone(),
+            }),
+    };
+
+    debug!("req: {:?}", req);
+
+    let resp = req.send().await?;
+    debug!("resp: {:?}", resp);
+
+    let status = resp.status();
+
+    if status.is_success() {
+        let json_resp = resp.json::<KeyResponse>().await?;
+        match action {
+            KeyAction::Create { repo_name } | KeyAction::ReCreate { repo_name } => {
+                let add_key_link = format!(
+                    "https://github.com/MystenLabs/{}/settings/keys/new",
+                    repo_name
+                );
+                println!(
+                    "Public Key:
+-------------------------\n
+{}\n
+-------------------------\n
+Please add the public key above to your repository {} via the link below:
+{}",
+                    json_resp.pub_key.yellow(),
+                    repo_name.bright_purple(),
+                    add_key_link.yellow()
+                )
+            }
+            KeyAction::Delete { repo_name } => {
+                info!("Key for repo {} deleted", repo_name);
+            }
+        }
+        Ok(json_resp)
+    } else {
+        Err(anyhow::anyhow!(
+            "Failed to manage keys, status code: {}",
+            status.to_string()
+        ))
+    }
+}

--- a/crates/suiop-cli/src/cli/ci/key.rs
+++ b/crates/suiop-cli/src/cli/ci/key.rs
@@ -53,7 +53,7 @@ struct KeyResponse {
     pub_key: String,
 }
 
-async fn send_key_request(token: &str, action: &KeyAction) -> Result<KeyResponse> {
+async fn send_key_request(token: &str, action: &KeyAction) -> Result<()> {
     let full_url = format!("{}{}", API_SERVER, ENDPOINT);
     debug!("full_url: {}", full_url);
     let client = reqwest::Client::new();
@@ -87,9 +87,9 @@ async fn send_key_request(token: &str, action: &KeyAction) -> Result<KeyResponse
     let status = resp.status();
 
     if status.is_success() {
-        let json_resp = resp.json::<KeyResponse>().await?;
         match action {
             KeyAction::Create { repo_name } | KeyAction::ReCreate { repo_name } => {
+                let json_resp = resp.json::<KeyResponse>().await?;
                 let add_key_link = format!(
                     "https://github.com/MystenLabs/{}/settings/keys/new",
                     repo_name
@@ -110,7 +110,7 @@ Please add the public key above to your repository {} via the link below:
                 info!("Key for repo {} deleted", repo_name);
             }
         }
-        Ok(json_resp)
+        Ok(())
     } else {
         Err(anyhow::anyhow!(
             "Failed to manage keys, status code: {}",

--- a/crates/suiop-cli/src/cli/ci/mod.rs
+++ b/crates/suiop-cli/src/cli/ci/mod.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod key;
+
+use anyhow::Result;
+use key::key_cmd;
+
+use clap::Parser;
+
+use self::key::KeyArgs;
+
+#[derive(Parser, Debug)]
+pub struct CIArgs {
+    #[command(subcommand)]
+    action: CIAction,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub(crate) enum CIAction {
+    #[clap(aliases = ["k", "key"])]
+    Keys(KeyArgs),
+}
+
+pub async fn ci_cmd(args: &CIArgs) -> Result<()> {
+    match &args.action {
+        CIAction::Keys(keys) => key_cmd(keys).await?,
+    }
+
+    Ok(())
+}

--- a/crates/suiop-cli/src/cli/iam/mod.rs
+++ b/crates/suiop-cli/src/cli/iam/mod.rs
@@ -3,7 +3,7 @@
 
 mod whoami;
 
-use crate::cli::lib::{get_oauth_token, API_SERVER};
+use crate::cli::lib::{get_api_server, get_oauth_token};
 use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
@@ -27,7 +27,7 @@ pub async fn iam_cmd(args: &IAMArgs) -> Result<()> {
             let token_resp = get_oauth_token().await;
             match token_resp {
                 Ok(token) => {
-                    let resp = whoami::get_identity(API_SERVER, &token.access_token).await;
+                    let resp = whoami::get_identity(&get_api_server(), &token.access_token).await;
                     match resp {
                         Ok(username) => {
                             println!("You are: {}", username.bright_purple());

--- a/crates/suiop-cli/src/cli/iam/mod.rs
+++ b/crates/suiop-cli/src/cli/iam/mod.rs
@@ -3,12 +3,11 @@
 
 mod whoami;
 
-use crate::cli::lib::get_oauth_token;
+use crate::cli::lib::{get_oauth_token, API_SERVER};
 use anyhow::Result;
 use clap::Parser;
-use tracing::{error, info};
-
-const API_SERVER: &str = "https://meta-svc.api.mystenlabs.com";
+use colored::Colorize;
+use tracing::error;
 
 #[derive(Parser, Debug, Clone)]
 pub struct IAMArgs {
@@ -19,19 +18,19 @@ pub struct IAMArgs {
 #[derive(clap::Subcommand, Debug, Clone)]
 pub enum IAMAction {
     #[command(name = "whoami", aliases=["w"])]
-    WhoAmI {},
+    WhoAmI,
 }
 
 pub async fn iam_cmd(args: &IAMArgs) -> Result<()> {
     match &args.action {
-        IAMAction::WhoAmI {} => {
+        IAMAction::WhoAmI => {
             let token_resp = get_oauth_token().await;
             match token_resp {
                 Ok(token) => {
                     let resp = whoami::get_identity(API_SERVER, &token.access_token).await;
                     match resp {
                         Ok(username) => {
-                            info!("You are: {}", username);
+                            println!("You are: {}", username.bright_purple());
                             Ok(())
                         }
                         Err(e) => {

--- a/crates/suiop-cli/src/cli/iam/whoami.rs
+++ b/crates/suiop-cli/src/cli/iam/whoami.rs
@@ -12,7 +12,9 @@ pub async fn get_identity(base_url: &str, token: &str) -> Result<String> {
     debug!("full_url: {}", full_url);
     let client = reqwest::Client::new();
 
-    let req = client.get(full_url).header("token", token);
+    let req = client
+        .get(full_url)
+        .header("Authorization", format!("Bearer {}", token));
     debug!("req: {:?}", req);
 
     let resp = req.send().await?;

--- a/crates/suiop-cli/src/cli/iam/whoami.rs
+++ b/crates/suiop-cli/src/cli/iam/whoami.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 use reqwest;
 use tracing::debug;
@@ -13,10 +11,8 @@ pub async fn get_identity(base_url: &str, token: &str) -> Result<String> {
     let full_url = format!("{}{}", base_url, ENDPOINT);
     debug!("full_url: {}", full_url);
     let client = reqwest::Client::new();
-    let mut body = HashMap::new();
-    body.insert("token", token);
 
-    let req = client.post(full_url).json(&body);
+    let req = client.get(full_url).header("token", token);
     debug!("req: {:?}", req);
 
     let resp = req.send().await?;

--- a/crates/suiop-cli/src/cli/lib/mod.rs
+++ b/crates/suiop-cli/src/cli/lib/mod.rs
@@ -5,4 +5,11 @@ mod oauth;
 
 pub use oauth::get_oauth_token;
 
-pub const API_SERVER: &str = "https://meta-svc.api.mystenlabs.com";
+pub fn get_api_server() -> String {
+    // if env var is set, use that
+    if let Ok(api_server) = std::env::var("API_SERVER") {
+        return api_server.to_string();
+    }
+
+    "https://meta-svc.api.mystenlabs.com".to_string()
+}

--- a/crates/suiop-cli/src/cli/lib/mod.rs
+++ b/crates/suiop-cli/src/cli/lib/mod.rs
@@ -4,3 +4,5 @@
 mod oauth;
 
 pub use oauth::get_oauth_token;
+
+pub const API_SERVER: &str = "https://meta-svc.api.mystenlabs.com";

--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod ci;
 pub mod docker;
 mod iam;
 mod incidents;
@@ -8,6 +9,7 @@ mod lib;
 pub mod pulumi;
 pub mod service;
 
+pub use ci::{ci_cmd, CIArgs};
 pub use docker::{docker_cmd, DockerArgs};
 pub use iam::{iam_cmd, IAMArgs};
 pub use incidents::{incidents_cmd, IncidentsArgs};

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use clap::Parser;
 use suioplib::cli::{
-    docker_cmd, iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, DockerArgs, IAMArgs,
+    ci_cmd, docker_cmd, iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, DockerArgs, IAMArgs,
     IncidentsArgs, PulumiArgs, ServiceArgs,
 };
 use tracing_subscriber::{
@@ -32,6 +32,8 @@ pub(crate) enum Resource {
     Pulumi(PulumiArgs),
     #[clap(aliases = ["s", "svc"])]
     Service(ServiceArgs),
+    #[clap()]
+    CI(CIArgs),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -62,6 +64,12 @@ async fn main() -> Result<()> {
         }
         Resource::Service(args) => {
             service_cmd(&args).await?;
+        }
+        Resource::Iam(args) => {
+            iam_cmd(&args).await?;
+        }
+        Resource::CI(args) => {
+            ci_cmd(&args).await?;
         }
     }
 

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -4,8 +4,8 @@
 use anyhow::Result;
 use clap::Parser;
 use suioplib::cli::{
-    ci_cmd, docker_cmd, iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, DockerArgs, IAMArgs,
-    IncidentsArgs, PulumiArgs, ServiceArgs,
+    ci_cmd, docker_cmd, iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, CIArgs, DockerArgs,
+    IAMArgs, IncidentsArgs, PulumiArgs, ServiceArgs,
 };
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
@@ -64,9 +64,6 @@ async fn main() -> Result<()> {
         }
         Resource::Service(args) => {
             service_cmd(&args).await?;
-        }
-        Resource::Iam(args) => {
-            iam_cmd(&args).await?;
         }
         Resource::CI(args) => {
             ci_cmd(&args).await?;


### PR DESCRIPTION
## Description 

With this change, we can now create/recreate/delete deploy keys for our users and the private keys will be stored securely instead of on users' laptop.
suiop here is just a client, all it does is authn the user and use the returned Okta token to the infra-metadata-service endpoint for ssh key generation.

## Test plan 

Manually tested, for example, to create a deploy key:
`suiop ci key create --repo-name suiop-test`
```
Public Key:
-------------------------

ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPn4Rj84+AGRPJNx2QVV7R8gURJHxicC0YW1UKWLOlz0 pulumi_automation_deploy_key

-------------------------

Please add the public key above to your repository suiop-test via the link below:
https://github.com/MystenLabs/suiop-test/settings/keys/new
```
A new key will be created automatically and user will be prompted to put the corresponding pubkey to their private repo so that we can have control over it.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
