### PR TITLE
[sui-tool] check locked objects and rescue flow

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -10,15 +10,20 @@ use crate::{
     GroupedObjectOutput, VerboseObjectOutput,
 };
 use anyhow::Result;
-use std::env;
+use futures::{future::join_all, StreamExt};
 use std::path::PathBuf;
+use std::{collections::BTreeMap, env, sync::Arc};
 use sui_config::genesis::Genesis;
 use sui_core::authority_client::AuthorityAPI;
 use sui_protocol_config::Chain;
 use sui_replay::{execute_replay_command, ReplayToolCommand};
+use sui_sdk::{rpc_types::SuiTransactionBlockResponseOptions, SuiClient, SuiClientBuilder};
 use telemetry_subscribers::TracingHandle;
 
-use sui_types::{base_types::*, object::Owner};
+use sui_types::{
+    base_types::*, crypto::AuthorityPublicKeyBytes, messages_grpc::TransactionInfoRequest,
+    object::Owner,
+};
 
 use clap::*;
 use fastcrypto::encoding::Encoding;
@@ -40,6 +45,25 @@ pub enum Verbosity {
 
 #[derive(Parser)]
 pub enum ToolCommand {
+    /// Inspect if a specific object is or all gas objects owned by an address are locked by validators
+    #[command(name = "locked-object")]
+    LockedObject {
+        /// Either id or address must be provided
+        /// The object to check
+        #[arg(long, help = "The object ID to fetch")]
+        id: Option<ObjectID>,
+        /// Either id or address must be provided
+        /// If provided, check all gas objects owned by this account
+        #[arg(long = "address")]
+        address: Option<SuiAddress>,
+        /// RPC address to provide the up-to-date committee info
+        #[arg(long = "fullnode-rpc-url")]
+        fullnode_rpc_url: String,
+        /// Should attempt to rescue the object if it's locked but not fully locked
+        #[arg(long = "rescue")]
+        rescue: bool,
+    },
+
     /// Fetch the same object from all validators
     #[command(name = "fetch-object")]
     FetchObject {
@@ -55,14 +79,9 @@ pub enum ToolCommand {
         )]
         validator: Option<AuthorityName>,
 
-        // At least one of genesis or fullnode_rpc_url must be provided
-        #[arg(long = "genesis")]
-        genesis: Option<PathBuf>,
-
-        // At least one of genesis or fullnode_rpc_url must be provided
         // RPC address to provide the up-to-date committee info
         #[arg(long = "fullnode-rpc-url")]
-        fullnode_rpc_url: Option<String>,
+        fullnode_rpc_url: String,
 
         /// Concise mode groups responses by results.
         /// prints tabular output suitable for processing with unix tools. For
@@ -90,14 +109,9 @@ pub enum ToolCommand {
     /// Fetch the effects association with transaction `digest`
     #[command(name = "fetch-transaction")]
     FetchTransaction {
-        // At least one of genesis or fullnode_rpc_url must be provided
-        #[arg(long = "genesis")]
-        genesis: Option<PathBuf>,
-
-        // At least one of genesis or fullnode_rpc_url must be provided
         // RPC address to provide the up-to-date committee info
         #[arg(long = "fullnode-rpc-url")]
-        fullnode_rpc_url: Option<String>,
+        fullnode_rpc_url: String,
 
         #[arg(long, help = "The transaction ID to fetch")]
         digest: TransactionDigest,
@@ -206,14 +220,9 @@ pub enum ToolCommand {
     /// If sequence number is not specified, get the latest authenticated checkpoint.
     #[command(name = "fetch-checkpoint")]
     FetchCheckpoint {
-        // At least one of genesis or fullnode_rpc_url must be provided
-        #[arg(long = "genesis")]
-        genesis: Option<PathBuf>,
-
-        // At least one of genesis or fullnode_rpc_url must be provided
         // RPC address to provide the up-to-date committee info
         #[arg(long = "fullnode-rpc-url")]
-        fullnode_rpc_url: Option<String>,
+        fullnode_rpc_url: String,
 
         #[arg(long, help = "Fetch checkpoint at a specific sequence number")]
         sequence_number: Option<CheckpointSequenceNumber>,
@@ -458,24 +467,142 @@ impl std::fmt::Display for OwnerOutput {
     }
 }
 
+async fn check_locked_object(
+    sui_client: &Arc<SuiClient>,
+    committee: Arc<BTreeMap<AuthorityPublicKeyBytes, u64>>,
+    id: ObjectID,
+    rescue: bool,
+) -> anyhow::Result<()> {
+    let clients = Arc::new(make_clients(sui_client).await?);
+    let output = get_object(id, None, None, clients.clone()).await?;
+    let output = GroupedObjectOutput::new(output, committee);
+    if output.fully_locked {
+        println!("Object {} is fully locked.", id);
+        return Ok(());
+    }
+    let top_record = output.voting_power.first().unwrap();
+    let top_record_stake = top_record.1;
+    let top_record = top_record.0.unwrap();
+    if top_record.4.is_none() {
+        println!(
+            "Object {} does not seem to be locked by majority of validators (unlocked stake: {})",
+            id, top_record_stake
+        );
+        return Ok(());
+    }
+
+    let tx_digest = top_record.2;
+    if !rescue {
+        println!("Object {} is rescueable, top tx: {:?}", id, tx_digest);
+        return Ok(());
+    }
+    println!("Object {} is rescueable, trying tx {}", id, tx_digest);
+    let validator = output
+        .grouped_results
+        .get(&Some(top_record))
+        .unwrap()
+        .first()
+        .unwrap();
+    let client = &clients.get(validator).unwrap().1;
+    let tx = client
+        .handle_transaction_info_request(TransactionInfoRequest {
+            transaction_digest: tx_digest,
+        })
+        .await?
+        .transaction;
+    let res = sui_client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            Transaction::new(tx),
+            SuiTransactionBlockResponseOptions::full_content(),
+            None,
+        )
+        .await;
+    match res {
+        Ok(_) => {
+            println!("Transaction executed successfully ({:?})", tx_digest);
+        }
+        Err(e) => {
+            println!("Failed to execute transaction ({:?}): {:?}", tx_digest, e);
+        }
+    }
+    Ok(())
+}
+
 impl ToolCommand {
     #[allow(clippy::format_in_format_args)]
     pub async fn execute(self, tracing_handle: TracingHandle) -> Result<(), anyhow::Error> {
         match self {
+            ToolCommand::LockedObject {
+                id,
+                fullnode_rpc_url,
+                rescue,
+                address,
+            } => {
+                let sui_client =
+                    Arc::new(SuiClientBuilder::default().build(fullnode_rpc_url).await?);
+                let committee = Arc::new(
+                    sui_client
+                        .governance_api()
+                        .get_committee_info(None)
+                        .await?
+                        .validators
+                        .into_iter()
+                        .collect::<BTreeMap<_, _>>(),
+                );
+                let object_ids = match id {
+                    Some(id) => vec![id],
+                    None => {
+                        let address = address.expect("Either id or address must be provided");
+                        sui_client
+                            .coin_read_api()
+                            .get_coins_stream(address, None)
+                            .map(|c| c.coin_object_id)
+                            .collect()
+                            .await
+                    }
+                };
+                for ids in object_ids.chunks(30) {
+                    let mut tasks = vec![];
+                    for id in ids {
+                        tasks.push(check_locked_object(
+                            &sui_client,
+                            committee.clone(),
+                            *id,
+                            rescue,
+                        ))
+                    }
+                    join_all(tasks)
+                        .await
+                        .into_iter()
+                        .collect::<Result<Vec<_>, _>>()?;
+                }
+            }
             ToolCommand::FetchObject {
                 id,
                 validator,
-                genesis,
                 version,
                 fullnode_rpc_url,
                 verbosity,
                 concise_no_header,
             } => {
-                let output = get_object(id, version, validator, genesis, fullnode_rpc_url).await?;
+                let sui_client =
+                    Arc::new(SuiClientBuilder::default().build(fullnode_rpc_url).await?);
+                let clients = Arc::new(make_clients(&sui_client).await?);
+                let output = get_object(id, version, validator, clients).await?;
 
                 match verbosity {
                     Verbosity::Grouped => {
-                        println!("{}", GroupedObjectOutput(output));
+                        let committee = Arc::new(
+                            sui_client
+                                .governance_api()
+                                .get_committee_info(None)
+                                .await?
+                                .validators
+                                .into_iter()
+                                .collect::<BTreeMap<_, _>>(),
+                        );
+                        println!("{}", GroupedObjectOutput::new(output, committee));
                     }
                     Verbosity::Verbose => {
                         println!("{}", VerboseObjectOutput(output));
@@ -489,14 +616,13 @@ impl ToolCommand {
                 }
             }
             ToolCommand::FetchTransaction {
-                genesis,
                 digest,
                 show_input_tx,
                 fullnode_rpc_url,
             } => {
                 print!(
                     "{}",
-                    get_transaction_block(digest, genesis, show_input_tx, fullnode_rpc_url).await?
+                    get_transaction_block(digest, show_input_tx, fullnode_rpc_url).await?
                 );
             }
             ToolCommand::DbTool { db_path, cmd } => {
@@ -542,11 +668,12 @@ impl ToolCommand {
                 println!("{:#?}", genesis);
             }
             ToolCommand::FetchCheckpoint {
-                genesis,
                 sequence_number,
                 fullnode_rpc_url,
             } => {
-                let clients = make_clients(genesis, fullnode_rpc_url).await?;
+                let sui_client =
+                    Arc::new(SuiClientBuilder::default().build(fullnode_rpc_url).await?);
+                let clients = make_clients(&sui_client).await?;
 
                 for (name, (_, client)) in clients {
                     let resp = client

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -21,12 +21,14 @@ use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use sui_core::execution_cache::ExecutionCache;
 use sui_network::default_mysten_network_config;
 use sui_protocol_config::Chain;
+use sui_sdk::SuiClient;
 use sui_sdk::SuiClientBuilder;
 use sui_storage::object_store::http::HttpDownloaderBuilder;
 use sui_storage::object_store::util::Manifest;
 use sui_storage::object_store::util::PerEpochManifest;
 use sui_storage::object_store::util::MANIFEST_FILENAME;
 use sui_types::accumulator::Accumulator;
+use sui_types::committee::QUORUM_THRESHOLD;
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::messages_grpc::LayoutGenerationOption;
 use sui_types::multiaddr::Multiaddr;
@@ -71,51 +73,33 @@ pub mod pkg_dump;
 
 // This functions requires at least one of genesis or fullnode_rpc to be `Some`.
 async fn make_clients(
-    genesis: Option<PathBuf>,
-    fullnode_rpc: Option<String>,
+    sui_client: &Arc<SuiClient>,
 ) -> Result<BTreeMap<AuthorityName, (Multiaddr, NetworkAuthorityClient)>> {
     let mut net_config = default_mysten_network_config();
     net_config.connect_timeout = Some(Duration::from_secs(5));
     let mut authority_clients = BTreeMap::new();
 
-    if let Some(fullnode_rpc) = fullnode_rpc {
-        let sui_client = SuiClientBuilder::default().build(fullnode_rpc).await?;
-        let active_validators = sui_client
-            .governance_api()
-            .get_latest_sui_system_state()
-            .await?
-            .active_validators;
+    let active_validators = sui_client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await?
+        .active_validators;
 
-        for validator in active_validators {
-            let net_addr = Multiaddr::try_from(validator.net_address).unwrap();
-            let channel = net_config
-                .connect_lazy(&net_addr)
-                .map_err(|err| anyhow!(err.to_string()))?;
-            let client = NetworkAuthorityClient::new(channel);
-            let public_key_bytes =
-                AuthorityPublicKeyBytes::from_bytes(&validator.protocol_pubkey_bytes)?;
-            authority_clients.insert(public_key_bytes, (net_addr.clone(), client));
-        }
-    } else {
-        if genesis.is_none() {
-            return Err(anyhow!("Either genesis or fullnode_rpc must be specified"));
-        }
-        let genesis = Genesis::load(genesis.unwrap())?;
-        for validator in genesis.validator_set_for_tooling() {
-            let metadata = validator.verified_metadata();
-            let channel = net_config
-                .connect_lazy(&metadata.net_address)
-                .map_err(|err| anyhow!(err.to_string()))?;
-            let client = NetworkAuthorityClient::new(channel);
-            let public_key_bytes = metadata.sui_pubkey_bytes();
-            authority_clients.insert(public_key_bytes, (metadata.net_address.clone(), client));
-        }
+    for validator in active_validators {
+        let net_addr = Multiaddr::try_from(validator.net_address).unwrap();
+        let channel = net_config
+            .connect_lazy(&net_addr)
+            .map_err(|err| anyhow!(err.to_string()))?;
+        let client = NetworkAuthorityClient::new(channel);
+        let public_key_bytes =
+            AuthorityPublicKeyBytes::from_bytes(&validator.protocol_pubkey_bytes)?;
+        authority_clients.insert(public_key_bytes, (net_addr.clone(), client));
     }
 
     Ok(authority_clients)
 }
 
-type ObjectVersionResponses = Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)>;
+type ObjectVersionResponses = (Option<SequenceNumber>, Result<ObjectInfoResponse>, f64);
 pub struct ObjectData {
     requested_id: ObjectID,
     responses: Vec<(AuthorityName, Multiaddr, ObjectVersionResponses)>,
@@ -174,83 +158,107 @@ impl std::fmt::Display for OwnerOutput {
     }
 }
 
-pub struct GroupedObjectOutput(pub ObjectData);
+#[allow(clippy::type_complexity)]
+pub struct GroupedObjectOutput {
+    pub grouped_results: BTreeMap<
+        Option<(
+            Option<SequenceNumber>,
+            ObjectDigest,
+            TransactionDigest,
+            Owner,
+            Option<TransactionDigest>,
+        )>,
+        Vec<AuthorityName>,
+    >,
+    pub voting_power: Vec<(
+        Option<(
+            Option<SequenceNumber>,
+            ObjectDigest,
+            TransactionDigest,
+            Owner,
+            Option<TransactionDigest>,
+        )>,
+        u64,
+    )>,
+    pub available_voting_power: u64,
+    pub fully_locked: bool,
+}
+
+impl GroupedObjectOutput {
+    pub fn new(
+        object_data: ObjectData,
+        committee: Arc<BTreeMap<AuthorityPublicKeyBytes, u64>>,
+    ) -> Self {
+        let mut grouped_results = BTreeMap::new();
+        let mut voting_power = BTreeMap::new();
+        let mut available_voting_power = 0;
+        for (name, _, (version, resp, _elapsed)) in &object_data.responses {
+            let stake = committee.get(name).unwrap();
+            let key = match resp {
+                Ok(r) => {
+                    let obj_digest = r.object.compute_object_reference().2;
+                    let parent_tx_digest = r.object.previous_transaction;
+                    let owner = r.object.owner;
+                    let lock = r.lock_for_debugging.as_ref().map(|lock| *lock.digest());
+                    if lock.is_none() {
+                        available_voting_power += stake;
+                    }
+                    Some((*version, obj_digest, parent_tx_digest, owner, lock))
+                }
+                Err(_) => None,
+            };
+            let entry = grouped_results.entry(key).or_insert_with(Vec::new);
+            entry.push(*name);
+            let entry: &mut u64 = voting_power.entry(key).or_default();
+            *entry += stake;
+        }
+        let voting_power = voting_power
+            .into_iter()
+            .sorted_by(|(_, v1), (_, v2)| Ord::cmp(v2, v1))
+            .collect::<Vec<_>>();
+        let mut fully_locked = false;
+        if !voting_power.is_empty()
+            && voting_power.first().unwrap().1 + available_voting_power < QUORUM_THRESHOLD
+        {
+            fully_locked = true;
+        }
+        Self {
+            grouped_results,
+            voting_power,
+            available_voting_power,
+            fully_locked,
+        }
+    }
+}
 
 #[allow(clippy::format_in_format_args)]
 impl std::fmt::Display for GroupedObjectOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let responses = self
-            .0
-            .responses
-            .iter()
-            .flat_map(|(name, multiaddr, resp)| {
-                resp.iter().map(|(seq_num, r, timespent)| {
-                    (
-                        *name,
-                        multiaddr.clone(),
-                        seq_num,
-                        r,
-                        timespent,
-                        r.as_ref().err(),
-                    )
-                })
-            })
-            .sorted_by(|a, b| {
-                Ord::cmp(&b.2, &a.2)
-                    .then_with(|| Ord::cmp(&format!("{:?}", &b.5), &format!("{:?}", &a.5)))
-            })
-            .group_by(|(_, _, seq_num, _r, _ts, _)| **seq_num);
-        for (seq_num, group) in &responses {
-            writeln!(f, "seq num: {}", seq_num.opt_debug("latest-seq-num"))?;
-            let cur_version_resp = group.group_by(|(_, _, _, r, _, _)| match r {
-                Ok(result) => {
-                    let parent_tx_digest = result.object.previous_transaction;
-                    let obj_digest = result.object.compute_object_reference().2;
-                    let lock = result
-                        .lock_for_debugging
-                        .as_ref()
-                        .map(|lock| *lock.digest());
-                    let owner = result.object.owner;
-                    Some((parent_tx_digest, obj_digest, lock, owner))
+        writeln!(f, "available stake: {}", self.available_voting_power)?;
+        writeln!(f, "fully locked: {}", self.fully_locked)?;
+        writeln!(f, "{:<100}\n", "-".repeat(100))?;
+        for (key, stake) in &self.voting_power {
+            let val = self.grouped_results.get(key).unwrap();
+            writeln!(f, "total stake: {stake}")?;
+            match key {
+                Some((_version, obj_digest, parent_tx_digest, owner, lock)) => {
+                    let lock = lock.opt_debug("no-known-lock");
+                    writeln!(f, "obj ref: {obj_digest}")?;
+                    writeln!(f, "parent tx: {parent_tx_digest}")?;
+                    writeln!(f, "owner: {owner}")?;
+                    writeln!(f, "lock: {lock}")?;
+                    for (i, name) in val.iter().enumerate() {
+                        writeln!(f, "        {:<4} {:<20}", i, name.concise(),)?;
+                    }
                 }
-                Err(_) => None,
-            });
-            for (result, group) in &cur_version_resp {
-                match result {
-                    Some((parent_tx_digest, obj_digest, lock, owner)) => {
-                        let lock = lock.opt_debug("no-known-lock");
-                        writeln!(f, "obj ref: {obj_digest}")?;
-                        writeln!(f, "parent tx: {parent_tx_digest}")?;
-                        writeln!(f, "owner: {owner}")?;
-                        writeln!(f, "lock: {lock}")?;
-                        for (i, (name, multiaddr, _, _, timespent, _)) in group.enumerate() {
-                            writeln!(
-                                f,
-                                "        {:<4} {:<20} {:<56} ({:.3}s)",
-                                i,
-                                name.concise(),
-                                format!("{}", multiaddr),
-                                timespent
-                            )?;
-                        }
+                None => {
+                    writeln!(f, "ERROR")?;
+                    for (i, name) in val.iter().enumerate() {
+                        writeln!(f, "        {:<4} {:<20}", i, name.concise(),)?;
                     }
-                    None => {
-                        writeln!(f, "ERROR")?;
-                        for (i, (name, multiaddr, _, resp, timespent, _)) in group.enumerate() {
-                            writeln!(
-                                f,
-                                "        {:<4} {:<20} {:<56} ({:.3}s) {:?}",
-                                i,
-                                name.concise(),
-                                format!("{}", multiaddr),
-                                timespent,
-                                resp
-                            )?;
-                        }
-                    }
-                };
-                writeln!(f, "{:<100}\n", "-".repeat(100))?;
-            }
+                }
+            };
+            writeln!(f, "{:<100}\n", "-".repeat(100))?;
         }
         Ok(())
     }
@@ -269,29 +277,27 @@ impl ConciseObjectOutput {
 
 impl std::fmt::Display for ConciseObjectOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (name, _multi_addr, versions) in &self.0.responses {
-            for (version, resp, _time_elapsed) in versions {
-                write!(
+        for (name, _multi_addr, (version, resp, _time_elapsed)) in &self.0.responses {
+            write!(
+                f,
+                "{:<20} {:<8}",
+                format!("{:?}", name.concise()),
+                version.map(|s| s.value()).opt_debug("-")
+            )?;
+            match resp {
+                Err(_) => writeln!(
                     f,
-                    "{:<20} {:<8}",
-                    format!("{:?}", name.concise()),
-                    version.map(|s| s.value()).opt_debug("-")
-                )?;
-                match resp {
-                    Err(_) => writeln!(
-                        f,
-                        "{:<66} {:<45} {:<51}",
-                        "object-fetch-failed", "no-cert-available", "no-owner-available"
-                    )?,
-                    Ok(resp) => {
-                        let obj_digest = resp.object.compute_object_reference().2;
-                        let parent = resp.object.previous_transaction;
-                        let owner = resp.object.owner;
-                        write!(f, " {:<66} {:<45} {:<51}", obj_digest, parent, owner)?;
-                    }
+                    "{:<66} {:<45} {:<51}",
+                    "object-fetch-failed", "no-cert-available", "no-owner-available"
+                )?,
+                Ok(resp) => {
+                    let obj_digest = resp.object.compute_object_reference().2;
+                    let parent = resp.object.previous_transaction;
+                    let owner = resp.object.owner;
+                    write!(f, " {:<66} {:<45} {:<51}", obj_digest, parent, owner)?;
                 }
-                writeln!(f)?;
             }
+            writeln!(f)?;
         }
         Ok(())
     }
@@ -303,46 +309,43 @@ impl std::fmt::Display for VerboseObjectOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Object: {}", self.0.requested_id)?;
 
-        for (name, multiaddr, versions) in &self.0.responses {
+        for (name, multiaddr, (version, resp, timespent)) in &self.0.responses {
             writeln!(f, "validator: {:?}, addr: {:?}", name.concise(), multiaddr)?;
+            writeln!(
+                f,
+                "-- version: {} ({:.3}s)",
+                version.opt_debug("<version not available>"),
+                timespent,
+            )?;
 
-            for (version, resp, timespent) in versions {
-                writeln!(
-                    f,
-                    "-- version: {} ({:.3}s)",
-                    version.opt_debug("<version not available>"),
-                    timespent,
-                )?;
-
-                match resp {
-                    Err(e) => writeln!(f, "Error fetching object: {}", e)?,
-                    Ok(resp) => {
+            match resp {
+                Err(e) => writeln!(f, "Error fetching object: {}", e)?,
+                Ok(resp) => {
+                    writeln!(
+                        f,
+                        "  -- object digest: {}",
+                        resp.object.compute_object_reference().2
+                    )?;
+                    if resp.object.is_package() {
+                        writeln!(f, "  -- object: <Move Package>")?;
+                    } else if let Some(layout) = &resp.layout {
                         writeln!(
                             f,
-                            "  -- object digest: {}",
-                            resp.object.compute_object_reference().2
-                        )?;
-                        if resp.object.is_package() {
-                            writeln!(f, "  -- object: <Move Package>")?;
-                        } else if let Some(layout) = &resp.layout {
-                            writeln!(
-                                f,
-                                "  -- object: Move Object: {}",
-                                resp.object
-                                    .data
-                                    .try_as_move()
-                                    .unwrap()
-                                    .to_move_struct(layout)
-                                    .unwrap()
-                            )?;
-                        }
-                        writeln!(f, "  -- owner: {}", resp.object.owner)?;
-                        writeln!(
-                            f,
-                            "  -- locked by: {}",
-                            resp.lock_for_debugging.opt_debug("<not locked>")
+                            "  -- object: Move Object: {}",
+                            resp.object
+                                .data
+                                .try_as_move()
+                                .unwrap()
+                                .to_move_struct(layout)
+                                .unwrap()
                         )?;
                     }
+                    writeln!(f, "  -- owner: {}", resp.object.owner)?;
+                    writeln!(
+                        f,
+                        "  -- locked by: {}",
+                        resp.lock_for_debugging.opt_debug("<not locked>")
+                    )?;
                 }
             }
         }
@@ -354,11 +357,8 @@ pub async fn get_object(
     obj_id: ObjectID,
     version: Option<u64>,
     validator: Option<AuthorityName>,
-    genesis: Option<PathBuf>,
-    fullnode_rpc: Option<String>,
+    clients: Arc<BTreeMap<AuthorityName, (Multiaddr, NetworkAuthorityClient)>>,
 ) -> Result<ObjectData> {
-    let clients = make_clients(genesis, fullnode_rpc).await?;
-
     let responses = join_all(
         clients
             .iter()
@@ -370,8 +370,8 @@ pub async fn get_object(
                 }
             })
             .map(|(name, (address, client))| async {
-                let object_versions = get_object_impl(client, obj_id, version).await;
-                (*name, address.clone(), object_versions)
+                let object_version = get_object_impl(client, obj_id, version).await;
+                (*name, address.clone(), object_version)
             }),
     )
     .await;
@@ -384,11 +384,11 @@ pub async fn get_object(
 
 pub async fn get_transaction_block(
     tx_digest: TransactionDigest,
-    genesis: Option<PathBuf>,
     show_input_tx: bool,
-    fullnode_rpc: Option<String>,
+    fullnode_rpc: String,
 ) -> Result<String> {
-    let clients = make_clients(genesis, fullnode_rpc).await?;
+    let sui_client = Arc::new(SuiClientBuilder::default().build(fullnode_rpc).await?);
+    let clients = make_clients(&sui_client).await?;
     let timer = Instant::now();
     let responses = join_all(clients.iter().map(|(name, (address, client))| async {
         let result = client
@@ -483,14 +483,11 @@ pub async fn get_transaction_block(
     Ok(s)
 }
 
-// Keep the return type a vector in case we need support for lamport versions in the near future
 async fn get_object_impl(
     client: &NetworkAuthorityClient,
     id: ObjectID,
     version: Option<u64>,
-) -> Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)> {
-    let mut ret = Vec::new();
-
+) -> (Option<SequenceNumber>, Result<ObjectInfoResponse>, f64) {
     let start = Instant::now();
     let resp = client
         .handle_object_info_request(ObjectInfoRequest {
@@ -506,9 +503,7 @@ async fn get_object_impl(
     let elapsed = start.elapsed().as_secs_f64();
 
     let resp_version = resp.as_ref().ok().map(|r| r.object.version().value());
-    ret.push((resp_version.map(SequenceNumber::from), resp, elapsed));
-
-    ret
+    (resp_version.map(SequenceNumber::from), resp, elapsed)
 }
 
 pub(crate) fn make_anemo_config() -> anemo_cli::Config {


### PR DESCRIPTION
## Description 

1. add `LockedObject` command to check if a object is locked and rescue it if possible (by `--rescue` flag). It can also check all gas objects owned by one accounts in case there are potentially many gas objects get locked.
2. rework the grouping logic for `FetchObject`, now it displays more clear aggregated lock info .
3. remove `genesis` param from a few commands, and replace with `fullnode-url` to fetch committee info.


## Test plan 


```
sui-tool locked-object --address 0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331 --fullnode-rpc-url https://rpc.mainnet.sui.io:443

sui-tool locked-object --id 0xd4c3ecf5eaa211da58c36495613899e70349f6048baaeca99596f1682e89c837 --fullnode-rpc-url https://rpc.mainnet.sui.io:443

```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
