### PR TITLE
Quorum driver take server requested retry interval into consideration

### DIFF
--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -39,7 +39,7 @@ pub struct LocalAuthorityClientFaultConfig {
     pub fail_after_handle_transaction: bool,
     pub fail_before_handle_confirmation: bool,
     pub fail_after_handle_confirmation: bool,
-    pub overload_retry_after_handle_transaction: bool,
+    pub overload_retry_after_handle_transaction: Option<Duration>,
 }
 
 impl LocalAuthorityClientFaultConfig {
@@ -76,9 +76,9 @@ impl AuthorityAPI for LocalAuthorityClient {
                 error: "Mock error after handle_transaction".to_owned(),
             });
         }
-        if self.fault_config.overload_retry_after_handle_transaction {
+        if let Some(duration) = self.fault_config.overload_retry_after_handle_transaction {
             return Err(SuiError::ValidatorOverloadedRetryAfter {
-                retry_after_secs: 0,
+                retry_after_secs: duration.as_secs(),
             });
         }
         result

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1960,20 +1960,18 @@ async fn test_handle_overload_retry_response() {
 
     let rpc_error = SuiError::RpcError("RPC".into(), "Error".into());
 
-    // Have 2f + 1 validators return the overload error and we should get the `SystemOverload` error.
+    // Have all validators return the overload error and we should get the `SystemOverload` error.
     // Uses different retry_after_secs for each validator.
-    set_retryable_tx_info_response_error(&mut clients, &authority_keys);
-    for (index, (name, _)) in authority_keys.iter().skip(1).enumerate() {
+    for (index, (name, _)) in authority_keys.iter().enumerate() {
         clients.get_mut(name).unwrap().set_tx_info_response_error(
             SuiError::ValidatorOverloadedRetryAfter {
                 retry_after_secs: index as u64,
             },
         );
     }
-
     let agg = get_genesis_agg(authorities.clone(), clients.clone());
-
-    // We should get the `SystemOverloadRetryAfter` error with the highest retry_after_secs.
+    // We should get the `SystemOverloadRetryAfter` error with the retry_after_secs corresponding to the quorum
+    // threshold of validators.
     assert_resp_err(
         &agg,
         txn.clone(),
@@ -1995,15 +1993,42 @@ async fn test_handle_overload_retry_response() {
     )
     .await;
 
-    // Change one of the valdiators' errors to RPC error so the system is considered not overloaded now and a `RetryableTransaction`
+    // Have 2f + 1 validators return the overload error (by setting one authority returning RPC error) and we
+    // should still get the `SystemOverload` error. The retry_after_secs corresponding to the quorum threshold
+    // now is the max of the retry_after_secs of the validators.
+    clients
+        .get_mut(&authority_keys[0].0)
+        .unwrap()
+        .set_tx_info_response_error(rpc_error.clone());
+    let agg = get_genesis_agg(authorities.clone(), clients.clone());
+    assert_resp_err(
+        &agg,
+        txn.clone(),
+        |e| {
+            matches!(
+                e,
+                AggregatorProcessTransactionError::SystemOverloadRetryAfter {
+                    retry_after_secs,
+                    ..
+                } if *retry_after_secs == (authority_keys.len() as u64 - 1)
+            )
+        },
+        |e| {
+            matches!(
+                e,
+                SuiError::ValidatorOverloadedRetryAfter { .. } | SuiError::RpcError(..)
+            )
+        },
+    )
+    .await;
+
+    // Change another valdiators' errors to RPC error so the system is considered not overloaded now and a `RetryableTransaction`
     // should be returned.
     clients
         .get_mut(&authority_keys[1].0)
         .unwrap()
         .set_tx_info_response_error(rpc_error);
-
     let agg = get_genesis_agg(authorities.clone(), clients.clone());
-
     assert_resp_err(
         &agg,
         txn.clone(),
@@ -2504,4 +2529,39 @@ fn set_tx_info_response_with_error<'a>(
             .unwrap()
             .set_tx_info_response_error(error.clone());
     }
+}
+
+#[test]
+fn test_retryable_overload_info() {
+    let mut retryable_overload_info = RetryableOverloadInfo::default();
+    assert_eq!(
+        retryable_overload_info.get_quorum_retry_after(3000, 7000),
+        Duration::from_secs(0)
+    );
+
+    for _ in 0..4 {
+        retryable_overload_info.add_stake_retryable_overload(1000, Duration::from_secs(1));
+    }
+    assert_eq!(
+        retryable_overload_info.get_quorum_retry_after(3000, 7000),
+        Duration::from_secs(1)
+    );
+
+    retryable_overload_info = RetryableOverloadInfo::default();
+    retryable_overload_info.add_stake_retryable_overload(1000, Duration::from_secs(1));
+    retryable_overload_info.add_stake_retryable_overload(3000, Duration::from_secs(10));
+    retryable_overload_info.add_stake_retryable_overload(2000, Duration::from_secs(1));
+    assert_eq!(
+        retryable_overload_info.get_quorum_retry_after(4000, 7000),
+        Duration::from_secs(1)
+    );
+
+    retryable_overload_info = RetryableOverloadInfo::default();
+    for i in 0..10 {
+        retryable_overload_info.add_stake_retryable_overload(1000, Duration::from_secs(i));
+    }
+    assert_eq!(
+        retryable_overload_info.get_quorum_retry_after(0, 7000),
+        Duration::from_secs(6)
+    );
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -820,6 +820,13 @@ impl SuiError {
     pub fn is_retryable_overload(&self) -> bool {
         matches!(self, SuiError::ValidatorOverloadedRetryAfter { .. })
     }
+
+    pub fn retry_after_secs(&self) -> u64 {
+        match self {
+            SuiError::ValidatorOverloadedRetryAfter { retry_after_secs } => *retry_after_secs,
+            _ => 0,
+        }
+    }
 }
 
 impl Ord for SuiError {


### PR DESCRIPTION
## Description 

ValidatorOverloadedRetryAfter error contains a server suggested retry after duration. So when the quorum driver retries under SystemOverloadRetryAfter error, it should take the suggested retry duration into consideration.

## Test plan 

Unit tests added.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
