### PR TITLE
[data ingestion] don't print noisy 404 errors

### DIFF
--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -132,11 +132,13 @@ impl CheckpointReader {
                 Ok(data) => return Ok(data),
                 Err(err) => match backoff.next_backoff() {
                     Some(duration) => {
-                        info!(
-                            "remote reader retry in {} ms. Error is {:?}",
-                            duration.as_millis(),
-                            err
-                        );
+                        if !err.to_string().contains("404") {
+                            debug!(
+                                "remote reader retry in {} ms. Error is {:?}",
+                                duration.as_millis(),
+                                err
+                            );
+                        }
                         tokio::time::sleep(duration).await
                     }
                     None => return Err(err),


### PR DESCRIPTION
make ingestion logs a bit less noisy. Transient 404 is a normal behaviour when indexer is tailing the latest checkpoints. 
There's another log available in case if 404s persist for a while  