### PR TITLE
[core] Cleanup protocol version cheecks in transaction validity check

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1511,7 +1511,7 @@ impl AuthorityState {
 
         // Cheap validity checks for a transaction, including input size limits.
         let tx_data = certificate.data().transaction_data();
-        tx_data.check_version_supported(epoch_store.protocol_config())?;
+        tx_data.check_version_and_features_supported(epoch_store.protocol_config())?;
         tx_data.validity_check(epoch_store.protocol_config())?;
 
         // The cost of partially re-auditing a transaction before execution is tolerated.
@@ -1639,7 +1639,7 @@ impl AuthorityState {
         Option<ObjectID>,
     )> {
         // Cheap validity checks for a transaction, including input size limits.
-        transaction.check_version_supported(epoch_store.protocol_config())?;
+        transaction.check_version_and_features_supported(epoch_store.protocol_config())?;
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
 
         let input_object_kinds = transaction.input_objects()?;
@@ -1859,7 +1859,7 @@ impl AuthorityState {
             vec![]
         };
 
-        transaction.check_version_supported(protocol_config)?;
+        transaction.check_version_and_features_supported(protocol_config)?;
         transaction.validity_check_no_gas_check(protocol_config)?;
 
         let input_object_kinds = transaction.input_objects()?;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1605,7 +1605,7 @@ impl AuthorityPerEpochStore {
         if !dkg_failed
             && !generating_randomness
             && self.randomness_state_enabled()
-            && cert.uses_randomness()
+            && cert.transaction_data().uses_randomness()
         {
             let deferred_from_round = previously_deferred_tx_digests
                 .get(cert.digest())
@@ -3182,7 +3182,10 @@ impl AuthorityPerEpochStore {
                     return Ok(deferral_result);
                 }
 
-                if dkg_failed && self.randomness_state_enabled() && certificate.uses_randomness() {
+                if dkg_failed
+                    && self.randomness_state_enabled()
+                    && certificate.transaction_data().uses_randomness()
+                {
                     // TODO: Cancel these immediately instead of waiting until end of epoch.
                     debug!(
                         "Ignoring randomness-using certificate for transaction {:?} because DKG failed",

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -333,7 +333,7 @@ impl ValidatorService {
         // CRITICAL: DO NOT ADD ANYTHING BEFORE THIS CHECK.
         // This must be the first thing to check before anything else, because the transaction
         // may not even be valid to access for any other checks.
-        Self::transaction_validity_check(&epoch_store, transaction.data())?;
+        transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
 
         // When authority is overloaded and decide to reject this tx, we still lock the object
         // and ask the client to retry in the future. This is because without locking, the
@@ -572,7 +572,7 @@ impl ValidatorService {
         // This must be the first thing to check before anything else, because the transaction
         // may not even be valid to access for any other checks.
         // We need to check this first because we haven't verified the cert signature.
-        Self::transaction_validity_check(&epoch_store, certificate.data())?;
+        certificate.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
 
         let span = error_span!("submit_certificate", tx_digest = ?certificate.digest());
         let request = HandleCertificateRequestV3 {
@@ -602,7 +602,7 @@ impl ValidatorService {
         // This must be the first thing to check before anything else, because the transaction
         // may not even be valid to access for any other checks.
         // We need to check this first because we haven't verified the cert signature.
-        Self::transaction_validity_check(&epoch_store, certificate.data())?;
+        certificate.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
 
         let span = error_span!("handle_certificate", tx_digest = ?certificate.digest());
         let request = HandleCertificateRequestV3 {
@@ -635,7 +635,9 @@ impl ValidatorService {
         // This must be the first thing to check before anything else, because the transaction
         // may not even be valid to access for any other checks.
         // We need to check this first because we haven't verified the cert signature.
-        Self::transaction_validity_check(&epoch_store, request.certificate.data())?;
+        request
+            .certificate
+            .validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
         let span = error_span!("handle_certificate_v3", tx_digest = ?request.certificate.digest());
 
         self.handle_certificate(request, &epoch_store, true)
@@ -648,37 +650,6 @@ impl ValidatorService {
                     ),
                 )
             })
-    }
-
-    fn transaction_validity_check(
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-        transaction: &SenderSignedData,
-    ) -> SuiResult<()> {
-        let config = epoch_store.protocol_config();
-        // CRITICAL: DO NOT ADD ANYTHING BEFORE THIS CHECK.
-        // This must be the first thing to check because the transaction may not even be valid to
-        // access for any other checks.
-        transaction.validity_check(config, epoch_store.epoch())?;
-
-        if !config.zklogin_auth() && transaction.has_zklogin_sig() {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "zklogin is not enabled on this network".to_string(),
-            });
-        }
-
-        if !config.supports_upgraded_multisig() && transaction.has_upgraded_multisig() {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "upgraded multisig format not enabled on this network".to_string(),
-            });
-        }
-
-        if !epoch_store.randomness_state_enabled() && transaction.uses_randomness() {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "randomness is not enabled on this network".to_string(),
-            });
-        }
-
-        Ok(())
     }
 
     async fn object_info_impl(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -733,7 +733,7 @@ impl SequencedConsensusTransaction {
         else {
             return false;
         };
-        certificate.uses_randomness()
+        certificate.transaction_data().uses_randomness()
     }
 
     pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -187,7 +187,7 @@ mod checked {
         gas_override: &[ObjectRef],
     ) -> SuiResult<SuiGasStatus> {
         // Cheap validity checks that is ok to run multiple times during processing.
-        transaction.check_version_supported(protocol_config)?;
+        transaction.check_version_and_features_supported(protocol_config)?;
         let gas = if gas_override.is_empty() {
             transaction.validity_check(protocol_config)?;
             transaction.gas()

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -69,7 +69,7 @@ impl VersionedProtocolMessage for TransactionEffects {
         })
     }
 
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         match self {
             Self::V1(_) => Ok(()),
             Self::V2(_) => {

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -92,8 +92,9 @@ impl<T: Message, S> Envelope<T, S> {
 }
 
 impl<T: Message + VersionedProtocolMessage, S> VersionedProtocolMessage for Envelope<T, S> {
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
-        self.data.check_version_supported(protocol_config)
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+        self.data
+            .check_version_and_features_supported(protocol_config)
     }
 }
 
@@ -299,8 +300,9 @@ impl<T: Message, S> VerifiedEnvelope<T, S> {
 }
 
 impl<T: Message + VersionedProtocolMessage, S> VersionedProtocolMessage for VerifiedEnvelope<T, S> {
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
-        self.inner().check_version_supported(protocol_config)
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+        self.inner()
+            .check_version_and_features_supported(protocol_config)
     }
 }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -445,7 +445,7 @@ impl EndOfEpochTransactionKind {
 }
 
 impl VersionedProtocolMessage for TransactionKind {
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         // When adding new cases, they must be guarded by a feature flag and return
         // UnsupportedFeatureError if the flag is not set.
         match &self {
@@ -1541,7 +1541,7 @@ impl VersionedProtocolMessage for TransactionData {
         })
     }
 
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         // First check the gross version
         let (message_version, supported) = match self {
             Self::V1(_) => (1, SupportedProtocolVersions::new_for_message(1, u64::MAX)),
@@ -1569,7 +1569,8 @@ impl VersionedProtocolMessage for TransactionData {
         }
 
         // Now check interior versioned data
-        self.kind().check_version_supported(protocol_config)?;
+        self.kind()
+            .check_version_and_features_supported(protocol_config)?;
 
         Ok(())
     }
@@ -2398,7 +2399,7 @@ impl SenderSignedData {
         );
 
         tx_data
-            .check_version_supported(config)
+            .check_version_and_features_supported(config)
             .map_err(Into::<SuiError>::into)?;
         tx_data
             .validity_check(config)
@@ -2413,9 +2414,9 @@ impl VersionedProtocolMessage for SenderSignedData {
         self.transaction_data().message_version()
     }
 
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
         self.transaction_data()
-            .check_version_supported(protocol_config)?;
+            .check_version_and_features_supported(protocol_config)?;
 
         // This code does nothing right now. Its purpose is to cause a compiler error when a
         // new signature type is added.
@@ -2814,7 +2815,8 @@ pub trait VersionedProtocolMessage {
     }
 
     /// Check that the version of the message is the correct one to use at this protocol version.
-    fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult;
+    /// Also checks whether the feauures used by the message are supported by the protocol config.
+    fn check_version_and_features_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult;
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord, Hash)]

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1562,12 +1562,6 @@ impl VersionedProtocolMessage for TransactionData {
             });
         }
 
-        if !protocol_config.random_beacon() && self.uses_randomness() {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "randomness is not enabled on this network".to_string(),
-            });
-        }
-
         // Now check interior versioned data
         self.kind()
             .check_version_and_features_supported(protocol_config)?;


### PR DESCRIPTION
## Description 

This PR consolidates protocol version support checks on transactions during validity check.
Specifically, it breaks down the protocol config version checks from authority_server into two pieces:
1. User signature related version checks. These are moved to a single function and called from validity_chec().
2. Transaction data related version checks. This is the randomness check, and is moved to check_version_supported() of TransactionData.

One notable change is that the randomness check now only checks the protocol config feature, without checking whether the randomness object exists. I believe this is fine because if the randomness object does not exist, it will fail latter when loading input objects anyway. But worth double check @aschran 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
