### PR TITLE
[move] Add minimum binary version

### DIFF
--- a/.changeset/four-experts-boil.md
+++ b/.changeset/four-experts-boil.md
@@ -1,0 +1,5 @@
+---
+'@mysten/graphql-transport': minor
+---
+
+Added a new field for `min_move_binary_format_version` to the protocol config

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1847,6 +1847,7 @@
                 "max_verifier_meter_ticks_per_function": {
                   "u64": "6000000"
                 },
+                "min_move_binary_format_version": null,
                 "move_binary_format_version": {
                   "u32": "6"
                 },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -122,6 +122,7 @@ const MAX_PROTOCOL_VERSION: u64 = 45;
 // Version 44: Enable consensus fork detection on mainnet.
 //             Switch between Narwhal and Mysticeti consensus in tests, devnet and testnet.
 // Version 45: Use tonic networking for Mysticeti consensus.
+//             Set min Move binary format version to 6.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -573,6 +574,8 @@ pub struct ProtocolConfig {
     // ==== Move VM, Move bytecode verifier, and execution limits ===
     /// Maximum Move bytecode version the VM understands. All older versions are accepted.
     move_binary_format_version: Option<u32>,
+    min_move_binary_format_version: Option<u32>,
+
     /// Configuration controlling binary tables size.
     binary_module_handles: Option<u16>,
     binary_struct_handles: Option<u16>,
@@ -1415,6 +1418,7 @@ impl ProtocolConfig {
             max_pure_argument_size: Some(16 * 1024),
             max_programmable_tx_commands: Some(1024),
             move_binary_format_version: Some(6),
+            min_move_binary_format_version: None,
             binary_module_handles: None,
             binary_struct_handles: None,
             binary_function_handles: None,
@@ -2134,6 +2138,7 @@ impl ProtocolConfig {
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
                         cfg.feature_flags.consensus_network = ConsensusNetwork::Tonic;
                     }
+                    cfg.min_move_binary_format_version = Some(6);
                     // Also bumps framework snapshot to fix binop issue.
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_45.snap
@@ -58,6 +58,7 @@ max_type_argument_depth: 16
 max_pure_argument_size: 16384
 max_programmable_tx_commands: 1024
 move_binary_format_version: 6
+min_move_binary_format_version: 6
 binary_module_handles: 100
 binary_struct_handles: 300
 binary_function_handles: 1500
@@ -262,3 +263,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_45.snap
@@ -60,6 +60,7 @@ max_type_argument_depth: 16
 max_pure_argument_size: 16384
 max_programmable_tx_commands: 1024
 move_binary_format_version: 6
+min_move_binary_format_version: 6
 binary_module_handles: 100
 binary_struct_handles: 300
 binary_function_handles: 1500
@@ -264,3 +265,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_45.snap
@@ -64,6 +64,7 @@ max_type_argument_depth: 16
 max_pure_argument_size: 16384
 max_programmable_tx_commands: 1024
 move_binary_format_version: 6
+min_move_binary_format_version: 6
 binary_module_handles: 100
 binary_struct_handles: 300
 binary_function_handles: 1500

--- a/crates/sui-types/src/execution_config_utils.rs
+++ b/crates/sui-types/src/execution_config_utils.rs
@@ -1,13 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::binary_config::{BinaryConfig, TableConfig};
+use move_binary_format::{
+    binary_config::{BinaryConfig, TableConfig},
+    file_format_common::VERSION_1,
+};
 use sui_protocol_config::ProtocolConfig;
 
 /// Build a `BinaryConfig` from a `ProtocolConfig`
 pub fn to_binary_config(protocol_config: &ProtocolConfig) -> BinaryConfig {
     BinaryConfig::new(
         protocol_config.move_binary_format_version(),
+        protocol_config
+            .min_move_binary_format_version_as_option()
+            .unwrap_or(VERSION_1),
         protocol_config.no_extraneous_module_bytes(),
         TableConfig {
             module_handles: protocol_config

--- a/external-crates/move/crates/move-binary-format/src/binary_config.rs
+++ b/external-crates/move/crates/move-binary-format/src/binary_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::file_format_common::VERSION_MAX;
+use crate::file_format_common::{VERSION_1, VERSION_MAX};
 
 /// Configuration for the binary format related to table size.
 /// Maps to all tables in the binary format.
@@ -52,6 +52,7 @@ impl TableConfig {
 #[derive(Clone, Debug)]
 pub struct BinaryConfig {
     pub max_binary_format_version: u32,
+    pub min_binary_format_version: u32,
     pub check_no_extraneous_bytes: bool,
     pub table_config: TableConfig,
 }
@@ -59,20 +60,27 @@ pub struct BinaryConfig {
 impl BinaryConfig {
     pub fn new(
         max_binary_format_version: u32,
+        min_binary_format_version: u32,
         check_no_extraneous_bytes: bool,
         table_config: TableConfig,
     ) -> Self {
         Self {
             max_binary_format_version,
+            min_binary_format_version,
             check_no_extraneous_bytes,
             table_config,
         }
     }
 
     // We want to make this disappear from the public API in favor of a "true" config
-    pub fn legacy(max_binary_format_version: u32, check_no_extraneous_bytes: bool) -> Self {
+    pub fn legacy(
+        max_binary_format_version: u32,
+        min_binary_format_version: u32,
+        check_no_extraneous_bytes: bool,
+    ) -> Self {
         Self {
             max_binary_format_version,
+            min_binary_format_version,
             check_no_extraneous_bytes,
             table_config: TableConfig::legacy(),
         }
@@ -82,6 +90,7 @@ impl BinaryConfig {
     pub fn with_extraneous_bytes_check(check_no_extraneous_bytes: bool) -> Self {
         Self {
             max_binary_format_version: VERSION_MAX,
+            min_binary_format_version: VERSION_1,
             check_no_extraneous_bytes,
             table_config: TableConfig::legacy(),
         }
@@ -92,6 +101,7 @@ impl BinaryConfig {
     pub fn standard() -> Self {
         Self {
             max_binary_format_version: VERSION_MAX,
+            min_binary_format_version: VERSION_1,
             check_no_extraneous_bytes: true,
             table_config: TableConfig::legacy(),
         }

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -1778,7 +1778,8 @@ impl<'a, 'b> VersionedBinary<'a, 'b> {
                     .with_message("Bad binary header".to_string()));
             }
         };
-        if version == 0 || version > u32::min(binary_config.max_binary_format_version, VERSION_MAX)
+        if version < binary_config.min_binary_format_version
+            || version > u32::min(binary_config.max_binary_format_version, VERSION_MAX)
         {
             return Err(PartialVMError::new(StatusCode::UNKNOWN_VERSION));
         }

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -217,7 +217,7 @@ fn max_version_lower_than_hardcoded() {
 
     let res = CompiledModule::deserialize_with_config(
         &binary,
-        &BinaryConfig::legacy(VERSION_MAX.checked_sub(1).unwrap(), false),
+        &BinaryConfig::legacy(VERSION_MAX.checked_sub(1).unwrap(), VERSION_MIN, false),
     );
     assert_eq!(
         res.expect_err("Expected unknown version").major_status(),
@@ -330,4 +330,25 @@ fn no_metadata() {
         v
     };
     test(&test2);
+}
+
+#[test]
+fn deserialize_below_min_version() {
+    let mut module = basic_test_module();
+    module.version = VERSION_MIN;
+    let bytes = {
+        let mut v = vec![];
+        module
+            .serialize_with_version(module.version, &mut v)
+            .unwrap();
+        v
+    };
+
+    let res = CompiledModule::deserialize_with_config(
+        &bytes,
+        &BinaryConfig::legacy(VERSION_MAX, VERSION_MAX, true),
+    )
+    .unwrap_err()
+    .major_status();
+    assert_eq!(res, StatusCode::UNKNOWN_VERSION);
 }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
@@ -938,6 +938,7 @@ impl Loader {
             &bytes,
             &BinaryConfig::legacy(
                 self.vm_config.max_binary_format_version,
+                self.vm_config.binary_config.min_binary_format_version,
                 self.vm_config()
                     .check_no_extraneous_bytes_during_deserialization,
             ),

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/runtime.rs
@@ -82,6 +82,10 @@ impl VMRuntime {
                     blob,
                     &BinaryConfig::legacy(
                         self.loader.vm_config().max_binary_format_version,
+                        self.loader()
+                            .vm_config()
+                            .binary_config
+                            .min_binary_format_version,
                         self.loader
                             .vm_config()
                             .check_no_extraneous_bytes_during_deserialization,

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
@@ -939,6 +939,7 @@ impl Loader {
             &bytes,
             &BinaryConfig::legacy(
                 self.vm_config.max_binary_format_version,
+                self.vm_config.binary_config.min_binary_format_version,
                 self.vm_config()
                     .check_no_extraneous_bytes_during_deserialization,
             ),

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -85,6 +85,10 @@ impl VMRuntime {
                         self.loader.vm_config().max_binary_format_version,
                         self.loader
                             .vm_config()
+                            .binary_config
+                            .min_binary_format_version,
+                        self.loader
+                            .vm_config()
                             .check_no_extraneous_bytes_during_deserialization,
                     ),
                 )

--- a/sdk/graphql-transport/src/methods.ts
+++ b/sdk/graphql-transport/src/methods.ts
@@ -1335,6 +1335,7 @@ export const RPC_METHODS: {
 			max_type_argument_depth: 'u32',
 			max_type_arguments: 'u32',
 			move_binary_format_version: 'u32',
+			min_move_binary_format_version: 'u32',
 			random_beacon_reduction_allowed_delta: 'u16',
 			random_beacon_dkg_timeout_round: 'u32',
 			random_beacon_reduction_lower_bound: 'u32',


### PR DESCRIPTION
## Description 

Adds a minimum binary version to the deserializer, and plumbs this into the protocol config.

## Test plan 

Make sure existing tests pass, and also added a deserializer test to make sure we raise the correct error for a too-low binary version module. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
