### PR TITLE
[GraphQL][v2024.1] Fix missing route inside init_router function

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -225,6 +225,7 @@ impl ServerBuilder {
                 .route("/", post(graphql_handler))
                 .route("/:version", post(graphql_handler))
                 .route("/graphql", post(graphql_handler))
+                .route("/graphql/:version", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
                 .with_state(self.state.clone())
                 .route_layer(CallbackLayer::new(MetricsMakeCallbackHandler {


### PR DESCRIPTION
## Description 

A previous [PR](https://github.com/MystenLabs/sui/pull/17420) only introduced one route, but both routes are needed. 

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
