### PR TITLE
[suiop][docker-gen] e2e ts dockerfile template generation

### DIFF
--- a/crates/suiop-cli/dockerfile-templates/typescript.Dockerfile
+++ b/crates/suiop-cli/dockerfile-templates/typescript.Dockerfile
@@ -1,0 +1,45 @@
+# this dockerfile was created based on a template that implements the
+# security practices outlined in 
+# https://cheatsheetseries.owasp.org/cheatsheets/NodeJS_Docker_Cheat_Sheet.html#nodejs-docker-cheat-sheet
+
+# we use node as the base image, pinned to a specific hash for reproducibility
+# and to avoid sbom vulnerabilities
+# --> build image
+FROM node:18.17.1-bookworm-slim@sha256:e5c8c319295f6cbc288e19506a9ac37afa3b330f4e38afb01d1269b579cf6a5b AS builder
+# this is the debian:12-slim build for node.
+
+WORKDIR /app
+
+RUN apt -qq update && apt -qq upgrade -y && apt -qq install -y npm && npm install -g typescript
+
+COPY --chown=node:node . /app
+
+COPY --chown=node:node src/ ./src
+COPY --chown=node:node package.json package-lock.json tsconfig.json ./
+COPY --chown=node:node src/ ./src/
+
+RUN npm ci --omit=dev
+RUN npm run build
+
+# same hash as above, but using a separate container to avoid copying our 
+# full build context
+# --> runtime image
+FROM node:18.17.1-bookworm-slim@sha256:e5c8c319295f6cbc288e19506a9ac37afa3b330f4e38afb01d1269b579cf6a5b 
+RUN apt -qq update && apt install -y wget
+# dumb-init serves as the init process, since node is not intended as one
+# https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
+RUN chmod +x /usr/local/bin/dumb-init
+WORKDIR /app
+
+COPY --chown=node:node --from=builder /app/dist ./js/
+COPY --chown=node:node --from=builder /app/node_modules/ ./node_modules/
+
+# should be set to ensure performance and security optimizations are applied
+ENV NODE_ENV production
+ENV PORT 8080
+
+EXPOSE ${PORT}
+
+USER node
+CMD ["dumb-init", "node", "js/index.js"]

--- a/crates/suiop-cli/src/cli/docker/mod.rs
+++ b/crates/suiop-cli/src/cli/docker/mod.rs
@@ -53,7 +53,7 @@ pub async fn docker_cmd(args: &DockerArgs) -> Result<()> {
             }
             DockerLanguageRuntime::Ts => {
                 info!("Generating Dockerfile for Typescript in {:?}", path);
-                generate_ts_dockerfile(&path)
+                generate_ts_dockerfile(path)
             }
         },
     }

--- a/crates/suiop-cli/src/cli/docker/mod.rs
+++ b/crates/suiop-cli/src/cli/docker/mod.rs
@@ -1,9 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs::create_dir_all;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+use include_dir::include_dir;
+use include_dir::Dir;
 use tracing::info;
+
+/// include the dockerfile templates dir in the binary
+static DOCKERFILES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/dockerfile-templates");
+const DEFAULT_PATH: &str = "docker/";
 
 #[derive(Parser, Debug, Clone)]
 pub struct DockerArgs {
@@ -11,17 +24,49 @@ pub struct DockerArgs {
     action: DockerAction,
 }
 
+#[derive(Parser, Debug, Clone, ValueEnum)]
+pub enum DockerLanguageRuntime {
+    /// Use the Rust template
+    Rust,
+    /// Use the Typescript template
+    Ts,
+}
 #[derive(clap::Subcommand, Debug, Clone)]
 pub enum DockerAction {
+    /// Generate a new dockerfile for an existing codebase
     #[command(name = "generate", aliases=["g"])]
-    Generate {},
+    Generate {
+        /// language runtime to use
+        #[arg(short, long, value_enum)]
+        runtime: DockerLanguageRuntime,
+        /// dir to put the generated dockerfile in
+        #[arg(short, long, default_value = DEFAULT_PATH)]
+        path: PathBuf,
+    },
 }
 
 pub async fn docker_cmd(args: &DockerArgs) -> Result<()> {
     match &args.action {
-        DockerAction::Generate {} => {
-            info!("Generating Dockerfile");
-            Ok(())
-        }
+        DockerAction::Generate { path, runtime } => match runtime {
+            DockerLanguageRuntime::Rust => {
+                todo!("Generating Dockerfile for Rust");
+            }
+            DockerLanguageRuntime::Ts => {
+                info!("Generating Dockerfile for Typescript in {:?}", path);
+                generate_ts_dockerfile(&path)
+            }
+        },
     }
+}
+
+fn generate_ts_dockerfile(path: &Path) -> Result<()> {
+    let dockerfile_template = DOCKERFILES_DIR
+        .get_file("typescript.Dockerfile")
+        .context("getting cargo toml file from boilerplate")?;
+    create_dir_all(path).context("creating dockerfile dir")?;
+    let mut main_file = File::create(path.join("Dockerfile")).context("creating dockefile")?;
+    main_file
+        .write_all(dockerfile_template.contents())
+        .context("writing dockerfile")?;
+    Ok(())
 }

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -22,7 +22,7 @@ pub(crate) struct SuiOpArgs {
 
 #[derive(clap::Subcommand, Debug)]
 pub(crate) enum Resource {
-    #[clap()]
+    #[clap(aliases = ["d"])]
     Docker(DockerArgs),
     #[clap()]
     Iam(IAMArgs),


### PR DESCRIPTION
## Description 

Working dockerfile generation for typescript express services

## Test plan 

```
> cr --bin suiop -- d g --runtime ts --path /tmp/docker
    Blocking waiting for file lock on build directory
   Compiling suiop-cli v0.2.0 (/Users/jkjensen/mysten/sui/crates/suiop-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 30.63s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop d g --runtime ts --path /tmp/docker`
2024-05-07T15:51:11.767616Z  INFO suioplib::cli::docker: Generating Dockerfile for Typescript in "/tmp/docker"
```
```
> docker build -t jk-exp-0 -f /tmp/docker/Dockerfile . && docker run -p 8080:8080 jk-exp-0 
[+] Building 2.5s (20/20) FINISHED                                             docker:desktop-linux
 => [internal] load build definition from Dockerfile                                           0.0s
 => => transferring dockerfile: 1.80kB                                                         0.0s
 => [internal] load metadata for docker.io/library/node:18.17.1-bookworm-slim@sha256:e5c8c319  0.0s
 => [internal] load .dockerignore                                                              0.0s
 => => transferring context: 2B                                                                0.0s
 => [builder 1/9] FROM docker.io/library/node:18.17.1-bookworm-slim@sha256:e5c8c319295f6cbc28  0.0s
 => [internal] load build context                                                              0.1s
 => => transferring context: 180.95kB                                                          0.1s
 => CACHED [builder 2/9] WORKDIR /app                                                          0.0s
 => CACHED [builder 3/9] RUN apt -qq update && apt -qq upgrade -y && apt -qq install -y npm &  0.0s
 => CACHED [builder 4/9] COPY --chown=node:node . /app                                         0.0s
 => CACHED [builder 5/9] COPY --chown=node:node src/ ./src                                     0.0s
 => CACHED [builder 6/9] COPY --chown=node:node package.json package-lock.json tsconfig.json   0.0s
 => CACHED [builder 7/9] COPY --chown=node:node src/ ./src/                                    0.0s
 => [builder 8/9] RUN npm ci --omit=dev                                                        1.1s
 => [builder 9/9] RUN npm run build                                                            1.3s
 => CACHED [stage-1 2/7] RUN apt -qq update && apt install -y wget                             0.0s 
 => CACHED [stage-1 3/7] RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-in  0.0s 
 => CACHED [stage-1 4/7] RUN chmod +x /usr/local/bin/dumb-init                                 0.0s
 => CACHED [stage-1 5/7] WORKDIR /app                                                          0.0s
 => CACHED [stage-1 6/7] COPY --chown=node:node --from=builder /app/dist ./js/                 0.0s
 => CACHED [stage-1 7/7] COPY --chown=node:node --from=builder /app/node_modules/ ./node_modu  0.0s
 => exporting to image                                                                         0.0s
 => => exporting layers                                                                        0.0s
 => => writing image sha256:9d204e51b9f428b750f3771e832690d5b44a39f724d10b213b0fdc82d4c530aa   0.0s
 => => naming to docker.io/library/jk-exp-0                                                    0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
Server is Successfully Running, and       App is listening on port 8080
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
