### PR TITLE
Add a new clippy target to run on mysql feature protected code

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -24,5 +24,20 @@ move-clippy = [
     "-Aclippy::new_without_default",
 ]
 
+mysql-clippy = [
+    "clippy",
+    "--package",
+    "sui-indexer",
+    "--features",
+    "mysql-feature",
+    "--no-default-features",
+    "--",
+    "-Wclippy::all",
+    "-Wclippy::disallowed_methods",
+    "-Aclippy::upper_case_acronyms",
+    "-Aclippy::type_complexity",
+    "-Aclippy::new_without_default",
+]
+
 [build]
 rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -353,6 +353,9 @@ jobs:
       - name: cargo clippy
         run: cargo xclippy -D warnings
 
+      - name: cargo mysql-clippy
+        run: cargo mysql-clippy -D warnings
+
   rustfmt:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -53,7 +53,7 @@ pub struct StoredEvent {
     #[diesel(sql_type = diesel::sql_types::Text)]
     pub event_type: String,
 
-    #[diesel(sql_type = diesel::sql_types::Bytea)]
+    #[diesel(sql_type = diesel::sql_types::Binary)]
     pub event_type_package: Vec<u8>,
 
     #[diesel(sql_type = diesel::sql_types::Text)]

--- a/crates/sui-indexer/src/schema/mod.rs
+++ b/crates/sui-indexer/src/schema/mod.rs
@@ -3,7 +3,11 @@
 
 #![allow(clippy::all)]
 
+#[cfg(feature = "mysql-feature")]
+#[cfg(not(feature = "postgres-feature"))]
 mod mysql;
+
+#[cfg(feature = "postgres-feature")]
 mod pg;
 
 #[cfg(feature = "postgres-feature")]


### PR DESCRIPTION
## Description 

Without this PR, with xclippy we run `cargo clippy --all-features` but that does not get run on mysql protected code since we enable only one code path i.e. either postgres or mysql and postgres is set as default everywhere. We want to however run clippy on mysql code paths as well. With this, we should be able to do so.

## Test plan 

This PR
