### PR TITLE
[CLI] Add module binary version check when publishing and upgrading modules

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -39,8 +39,8 @@ use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     Coin, DryRunTransactionBlockResponse, DynamicFieldPage, ObjectChange, SuiCoinMetadata, SuiData,
     SuiExecutionStatus, SuiObjectData, SuiObjectDataOptions, SuiObjectResponse,
-    SuiObjectResponseQuery, SuiParsedData, SuiRawData, SuiTransactionBlockEffectsAPI,
-    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+    SuiObjectResponseQuery, SuiParsedData, SuiProtocolConfigValue, SuiRawData,
+    SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_move_build::{
@@ -2214,6 +2214,53 @@ pub(crate) async fn compile_package(
         run_bytecode_verifier,
         print_diags_to_stderr,
     )?;
+    let protocol_config = read_api.get_protocol_config(None).await?;
+
+    // Check that the package's Move version is compatible with the chain's
+    if let Some(Some(SuiProtocolConfigValue::U32(min_version))) = protocol_config
+        .attributes
+        .get("min_move_binary_format_version")
+    {
+        for module in compiled_package.get_modules_and_deps() {
+            if module.version() < *min_version {
+                return Err(SuiError::ModulePublishFailure {
+                    error: format!(
+                        "Module {} has a version {} that is \
+                         lower than the minimum version {min_version} supported by the chain.",
+                        module.self_id(),
+                        module.version(),
+                    ),
+                }
+                .into());
+            }
+        }
+    }
+
+    // Check that the package's Move version is compatible with the chain's
+    if let Some(Some(SuiProtocolConfigValue::U32(max_version))) =
+        protocol_config.attributes.get("move_binary_format_version")
+    {
+        for module in compiled_package.get_modules_and_deps() {
+            if module.version() > *max_version {
+                let help_msg = if module.version() == 7 {
+                    "This is because you used enums in your Move package but tried to publish it to \
+                    a chain that does not yet support enums in Move."
+                } else {
+                    ""
+                };
+                return Err(SuiError::ModulePublishFailure {
+                    error: format!(
+                        "Module {} has a version {} that is \
+                         higher than the maximum version {max_version} supported by the chain.{help_msg}",
+                        module.self_id(),
+                        module.version(),
+                    ),
+                }
+                .into());
+            }
+        }
+    }
+
     if !compiled_package.is_system_package() {
         if let Some(already_published) = compiled_package.published_root_module() {
             return Err(SuiError::ModulePublishFailure {


### PR DESCRIPTION
## Description 

Adds two small checks to give better error messages if a package with an unsupported binary version number is published to a specific network.

## Test plan 

Tested locally against enum changes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Added more descriptive errors if modules are published with an unsupported binary version number for the given network. 
- [ ] Rust SDK: 
