### PR TITLE
[move] Fix linter categories

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -187,7 +187,7 @@ impl BuildConfig {
 /// (optionally report diagnostics themselves if files argument is provided).
 pub fn decorate_warnings(warning_diags: Diagnostics, files: Option<&FilesSourceText>) {
     let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX);
-    let (filtered_diags_num, filtered_categories) =
+    let (filtered_diags_num, unique) =
         warning_diags.filtered_source_diags_with_prefix(LINT_WARNING_PREFIX);
     if let Some(f) = files {
         report_warnings(f, warning_diags);
@@ -196,7 +196,7 @@ pub fn decorate_warnings(warning_diags: Diagnostics, files: Option<&FilesSourceT
         eprintln!("Please report feedback on the linter warnings at https://forums.sui.io\n");
     }
     if filtered_diags_num > 0 {
-        eprintln!("Total number of linter warnings suppressed: {filtered_diags_num} (filtered categories: {filtered_categories})");
+        eprintln!("Total number of linter warnings suppressed: {filtered_diags_num} (unique lints: {unique})");
     }
 }
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2994,8 +2994,7 @@ async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Resul
 
 #[tokio::test]
 async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
-    const LINTER_MSG: &str =
-        "Total number of linter warnings suppressed: 5 (filtered categories: 3)";
+    const LINTER_MSG: &str = "Total number of linter warnings suppressed: 5 (unique lints: 3)";
     let mut cmd = assert_cmd::Command::cargo_bin("sui").unwrap();
     let args = vec!["move", "test", "--path", "tests/data/linter"];
     let output = cmd
@@ -3003,7 +3002,10 @@ async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
         .output()
         .expect("failed to run 'sui move test'");
     let out_str = str::from_utf8(&output.stderr).unwrap();
-    assert!(out_str.contains(LINTER_MSG));
+    assert!(
+        out_str.contains(LINTER_MSG),
+        "Expected to match {LINTER_MSG}, got: {out_str}"
+    );
     // test no-lint suppresses
     let args = vec!["move", "test", "--no-lint", "--path", "tests/data/linter"];
     let output = cmd
@@ -3011,7 +3013,10 @@ async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
         .output()
         .expect("failed to run 'sui move test'");
     let out_str = str::from_utf8(&output.stderr).unwrap();
-    assert!(!out_str.contains(LINTER_MSG));
+    assert!(
+        !out_str.contains(LINTER_MSG),
+        "Expected _not to_ match {LINTER_MSG}, got: {out_str}"
+    );
     Ok(())
 }
 

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -660,9 +660,8 @@ impl Diagnostics {
             .any(|d| d.info().category() == Category::Syntax as u8 && d.primary_label.0 == loc)
     }
 
-    /// Returns the number of diags filtered in source (user) code (an not in the dependencies) that
-    /// have a given prefix (first value returned) and how many different categories of diags were
-    /// filtered.
+    /// Returns the number of diags filtered in source (user) code (not in the dependencies) that
+    /// have a given prefix and how many different unique lints were filtered.
     pub fn filtered_source_diags_with_prefix(&self, prefix: &str) -> (usize, usize) {
         let Self {
             diags: Some(inner),
@@ -672,14 +671,14 @@ impl Diagnostics {
             return (0, 0);
         };
         let mut filtered_diags_num = 0;
-        let mut filtered_categories = HashSet::new();
+        let mut unique = HashSet::new();
         inner.filtered_source_diagnostics.iter().for_each(|d| {
             if d.info.external_prefix() == Some(prefix) {
                 filtered_diags_num += 1;
-                filtered_categories.insert(d.info.category());
+                unique.insert((d.info.category(), d.info.code()));
             }
         });
-        (filtered_diags_num, filtered_categories.len())
+        (filtered_diags_num, unique.len())
     }
 
     fn env_color(&self) -> ColorChoice {

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -15,6 +15,17 @@ pub enum LintLevel {
     All,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LinterDiagCategory {
+    Correctness,
+    Complexity,
+    Suspicious,
+    Deprecated,
+    Style,
+    Sui = 99,
+}
+
 pub const ALLOW_ATTR_CATEGORY: &str = "lint";
 pub const LINT_WARNING_PREFIX: &str = "Lint ";
 

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -17,7 +17,7 @@ pub enum LintLevel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum LinterDiagCategory {
+pub enum LinterDiagnosticCategory {
     Correctness,
     Complexity,
     Suspicious,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -15,15 +15,15 @@ use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
 use super::{
-    LinterDiagCategory, COIN_MOD_NAME, COIN_STRUCT_NAME, LINTER_DEFAULT_DIAG_CODE,
-    LINT_WARNING_PREFIX, SUI_PKG_NAME,
+    LinterDiagCategory, LinterDiagCode, COIN_MOD_NAME, COIN_STRUCT_NAME, LINT_WARNING_PREFIX,
+    SUI_PKG_NAME,
 };
 
 const COIN_FIELD_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::CoinField as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::CoinField as u8,
     "sub-optimal 'sui::coin::Coin' field type",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -15,15 +15,15 @@ use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
 use super::{
-    LinterDiagCategory, LinterDiagCode, COIN_MOD_NAME, COIN_STRUCT_NAME, LINT_WARNING_PREFIX,
-    SUI_PKG_NAME,
+    LinterDiagnosticCategory, LinterDiagnosticCode, COIN_MOD_NAME, COIN_STRUCT_NAME,
+    LINT_WARNING_PREFIX, SUI_PKG_NAME,
 };
 
 const COIN_FIELD_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::CoinField as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::CoinField as u8,
     "sub-optimal 'sui::coin::Coin' field type",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -21,8 +21,8 @@ use crate::{
 };
 
 use super::{
-    base_type, LinterDiagCategory, BAG_MOD_NAME, BAG_STRUCT_NAME, LINKED_TABLE_MOD_NAME,
-    LINKED_TABLE_STRUCT_NAME, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX, OBJECT_BAG_MOD_NAME,
+    base_type, LinterDiagCategory, LinterDiagCode, BAG_MOD_NAME, BAG_STRUCT_NAME,
+    LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME, LINT_WARNING_PREFIX, OBJECT_BAG_MOD_NAME,
     OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, SUI_PKG_NAME,
     TABLE_MOD_NAME, TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
     VEC_MAP_STRUCT_NAME, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
@@ -31,8 +31,8 @@ use super::{
 const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::CollectionEquality as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::CollectionEquality as u8,
     "possibly useless collections compare",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use super::{
-    base_type, LinterDiagCategory, LinterDiagCode, BAG_MOD_NAME, BAG_STRUCT_NAME,
+    base_type, LinterDiagnosticCategory, LinterDiagnosticCode, BAG_MOD_NAME, BAG_STRUCT_NAME,
     LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME, LINT_WARNING_PREFIX, OBJECT_BAG_MOD_NAME,
     OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, SUI_PKG_NAME,
     TABLE_MOD_NAME, TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
@@ -31,8 +31,8 @@ use super::{
 const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::CollectionEquality as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::CollectionEquality as u8,
     "possibly useless collections compare",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -33,8 +33,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    LinterDiagCategory, FREEZE_FUN, INVALID_LOC, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
-    RECEIVE_FUN, SHARE_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    LinterDiagCategory, LinterDiagCode, FREEZE_FUN, INVALID_LOC, LINT_WARNING_PREFIX, RECEIVE_FUN,
+    SHARE_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
 const PRIVATE_OBJ_FUNCTIONS: &[(&str, &str, &str)] = &[
@@ -47,8 +47,8 @@ const PRIVATE_OBJ_FUNCTIONS: &[(&str, &str, &str)] = &[
 const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::CustomStateChange as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::CustomStateChange as u8,
     "potentially unenforceable custom transfer/share/freeze policy",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -33,8 +33,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    LinterDiagCategory, LinterDiagCode, FREEZE_FUN, INVALID_LOC, LINT_WARNING_PREFIX, RECEIVE_FUN,
-    SHARE_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    LinterDiagnosticCategory, LinterDiagnosticCode, FREEZE_FUN, INVALID_LOC, LINT_WARNING_PREFIX,
+    RECEIVE_FUN, SHARE_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
 const PRIVATE_OBJ_FUNCTIONS: &[(&str, &str, &str)] = &[
@@ -47,8 +47,8 @@ const PRIVATE_OBJ_FUNCTIONS: &[(&str, &str, &str)] = &[
 const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::CustomStateChange as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::CustomStateChange as u8,
     "potentially unenforceable custom transfer/share/freeze policy",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -26,15 +26,15 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 
 use super::{
-    base_type, LinterDiagCategory, FREEZE_FUN, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
+    base_type, LinterDiagCategory, LinterDiagCode, FREEZE_FUN, LINT_WARNING_PREFIX,
     PUBLIC_FREEZE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
 };
 
 const FREEZE_WRAPPING_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::FreezeWrapped as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::FreezeWrapped as u8,
     "attempting to freeze wrapped objects",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -26,15 +26,15 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 
 use super::{
-    base_type, LinterDiagCategory, LinterDiagCode, FREEZE_FUN, LINT_WARNING_PREFIX,
+    base_type, LinterDiagnosticCategory, LinterDiagnosticCode, FREEZE_FUN, LINT_WARNING_PREFIX,
     PUBLIC_FREEZE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
 };
 
 const FREEZE_WRAPPING_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::FreezeWrapped as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::FreezeWrapped as u8,
     "attempting to freeze wrapped objects",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     diagnostics::codes::WarningFilter,
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
-    linters::{LintLevel, ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX},
+    linters::{LintLevel, LinterDiagCategory, ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX},
     naming::ast as N,
     typing::visitor::TypingVisitor,
 };
@@ -75,7 +75,8 @@ pub const RANDOM_GENERATOR_STRUCT_NAME: &str = "RandomGenerator";
 
 pub const INVALID_LOC: Loc = Loc::invalid();
 
-pub enum LinterDiagCategory {
+#[repr(u8)]
+pub enum LinterDiagCode {
     ShareOwned,
     SelfTransfer,
     CustomStateChange,
@@ -85,53 +86,49 @@ pub enum LinterDiagCategory {
     PublicRandom,
 }
 
-/// A default code for each linter category (as long as only one code per category is used, no other
-/// codes are needed, otherwise they should be defined to be unique per-category).
-pub const LINTER_DEFAULT_DIAG_CODE: u8 = 1;
-
 pub fn known_filters() -> (Option<Symbol>, Vec<WarningFilter>) {
     let filters = vec![
         WarningFilter::All(Some(LINT_WARNING_PREFIX)),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::ShareOwned as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::ShareOwned as u8,
             Some(SHARE_OWNED_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::SelfTransfer as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::SelfTransfer as u8,
             Some(SELF_TRANSFER_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::CustomStateChange as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::CustomStateChange as u8,
             Some(CUSTOM_STATE_CHANGE_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::CoinField as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::CoinField as u8,
             Some(COIN_FIELD_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::FreezeWrapped as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::FreezeWrapped as u8,
             Some(FREEZE_WRAPPED_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::CollectionEquality as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::CollectionEquality as u8,
             Some(COLLECTION_EQUALITY_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::PublicRandom as u8,
-            LINTER_DEFAULT_DIAG_CODE,
+            LinterDiagCategory::Sui as u8,
+            LinterDiagCode::PublicRandom as u8,
             Some(PUBLIC_RANDOM_FILTER_NAME),
         ),
     ];

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     diagnostics::codes::WarningFilter,
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
-    linters::{LintLevel, LinterDiagCategory, ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX},
+    linters::{LintLevel, LinterDiagnosticCategory, ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX},
     naming::ast as N,
     typing::visitor::TypingVisitor,
 };
@@ -76,7 +76,7 @@ pub const RANDOM_GENERATOR_STRUCT_NAME: &str = "RandomGenerator";
 pub const INVALID_LOC: Loc = Loc::invalid();
 
 #[repr(u8)]
-pub enum LinterDiagCode {
+pub enum LinterDiagnosticCode {
     ShareOwned,
     SelfTransfer,
     CustomStateChange,
@@ -91,44 +91,44 @@ pub fn known_filters() -> (Option<Symbol>, Vec<WarningFilter>) {
         WarningFilter::All(Some(LINT_WARNING_PREFIX)),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::ShareOwned as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::ShareOwned as u8,
             Some(SHARE_OWNED_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::SelfTransfer as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::SelfTransfer as u8,
             Some(SELF_TRANSFER_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::CustomStateChange as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::CustomStateChange as u8,
             Some(CUSTOM_STATE_CHANGE_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::CoinField as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::CoinField as u8,
             Some(COIN_FIELD_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::FreezeWrapped as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::FreezeWrapped as u8,
             Some(FREEZE_WRAPPED_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::CollectionEquality as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::CollectionEquality as u8,
             Some(COLLECTION_EQUALITY_FILTER_NAME),
         ),
         WarningFilter::code(
             Some(LINT_WARNING_PREFIX),
-            LinterDiagCategory::Sui as u8,
-            LinterDiagCode::PublicRandom as u8,
+            LinterDiagnosticCategory::Sui as u8,
+            LinterDiagnosticCode::PublicRandom as u8,
             Some(PUBLIC_RANDOM_FILTER_NAME),
         ),
     ];

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
@@ -18,15 +18,15 @@ use crate::{
 };
 
 use super::{
-    LinterDiagCategory, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
-    RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME, SUI_PKG_NAME,
+    LinterDiagCategory, LinterDiagCode, LINT_WARNING_PREFIX, RANDOM_GENERATOR_STRUCT_NAME,
+    RANDOM_MOD_NAME, RANDOM_STRUCT_NAME, SUI_PKG_NAME,
 };
 
 const PUBLIC_RANDOM_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::PublicRandom as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::PublicRandom as u8,
     "Risky use of 'sui::random'",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
@@ -18,15 +18,15 @@ use crate::{
 };
 
 use super::{
-    LinterDiagCategory, LinterDiagCode, LINT_WARNING_PREFIX, RANDOM_GENERATOR_STRUCT_NAME,
-    RANDOM_MOD_NAME, RANDOM_STRUCT_NAME, SUI_PKG_NAME,
+    LinterDiagnosticCategory, LinterDiagnosticCode, LINT_WARNING_PREFIX,
+    RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME, SUI_PKG_NAME,
 };
 
 const PUBLIC_RANDOM_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::PublicRandom as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::PublicRandom as u8,
     "Risky use of 'sui::random'",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -27,7 +27,7 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    type_abilities, LinterDiagCategory, INVALID_LOC, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
+    type_abilities, LinterDiagCategory, LinterDiagCode, INVALID_LOC, LINT_WARNING_PREFIX,
     PUBLIC_TRANSFER_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
@@ -39,8 +39,8 @@ const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
 const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::SelfTransfer as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::SelfTransfer as u8,
     "non-composable transfer to sender",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -27,8 +27,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    type_abilities, LinterDiagCategory, LinterDiagCode, INVALID_LOC, LINT_WARNING_PREFIX,
-    PUBLIC_TRANSFER_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    type_abilities, LinterDiagnosticCategory, LinterDiagnosticCode, INVALID_LOC,
+    LINT_WARNING_PREFIX, PUBLIC_TRANSFER_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
 const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
@@ -39,8 +39,8 @@ const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
 const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::SelfTransfer as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::SelfTransfer as u8,
     "non-composable transfer to sender",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -30,8 +30,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    type_abilities, LinterDiagCategory, LinterDiagCode, LINT_WARNING_PREFIX, PUBLIC_SHARE_FUN,
-    SHARE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
+    type_abilities, LinterDiagnosticCategory, LinterDiagnosticCode, LINT_WARNING_PREFIX,
+    PUBLIC_SHARE_FUN, SHARE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
 };
 
 const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
@@ -42,8 +42,8 @@ const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
 const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::Sui as u8,
-    LinterDiagCode::ShareOwned as u8,
+    LinterDiagnosticCategory::Sui as u8,
+    LinterDiagnosticCode::ShareOwned as u8,
     "possible owned object share",
 );
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -30,8 +30,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    type_abilities, LinterDiagCategory, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
-    PUBLIC_SHARE_FUN, SHARE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
+    type_abilities, LinterDiagCategory, LinterDiagCode, LINT_WARNING_PREFIX, PUBLIC_SHARE_FUN,
+    SHARE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
 };
 
 const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
@@ -42,8 +42,8 @@ const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
 const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::ShareOwned as u8,
-    LINTER_DEFAULT_DIAG_CODE,
+    LinterDiagCategory::Sui as u8,
+    LinterDiagCode::ShareOwned as u8,
     "possible owned object share",
 );
 

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/coin_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/coin_field.exp
@@ -1,4 +1,4 @@
-warning[Lint W03001]: sub-optimal 'sui::coin::Coin' field type
+warning[Lint W99003]: sub-optimal 'sui::coin::Coin' field type
    ┌─ tests/sui_mode/linter/coin_field.move:11:12
    │
 11 │     struct S2 has key, store {
@@ -9,7 +9,7 @@ warning[Lint W03001]: sub-optimal 'sui::coin::Coin' field type
    │
    = This warning can be suppressed with '#[allow(lint(coin_field))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W03001]: sub-optimal 'sui::coin::Coin' field type
+warning[Lint W99003]: sub-optimal 'sui::coin::Coin' field type
    ┌─ tests/sui_mode/linter/coin_field.move:25:12
    │
 25 │     struct S2 has key, store {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/collection_equality.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/collection_equality.exp
@@ -1,4 +1,4 @@
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:17:14
    │
 17 │         bag1 == bag2
@@ -7,7 +7,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::bag::Bag' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:21:14
    │
 21 │         bag1 != bag2
@@ -16,7 +16,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::object_bag::ObjectBag' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:25:16
    │
 25 │         table1 == table2
@@ -25,7 +25,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::table::Table' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:32:20
    │
 32 │             table1 == table2
@@ -34,7 +34,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::object_table::ObjectTable' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:36:16
    │
 36 │         table1 == table2
@@ -43,7 +43,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::linked_table::LinkedTable' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:40:16
    │
 40 │         table1 == table2
@@ -52,7 +52,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::table_vec::TableVec' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:44:14
    │
 44 │         vec1 == vec2
@@ -61,7 +61,7 @@ warning[Lint W05001]: possibly useless collections compare
    = Equality for collections of type 'sui::vec_map::VecMap' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W05001]: possibly useless collections compare
+warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:48:14
    │
 48 │         vec1 == vec2

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/custom_state_change.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/custom_state_change.exp
@@ -1,4 +1,4 @@
-warning[Lint W02001]: potentially unenforceable custom transfer/share/freeze policy
+warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:15:16
    │
 15 │     public fun custom_transfer_bad(o: S1, ctx: &TxContext) {
@@ -11,7 +11,7 @@ warning[Lint W02001]: potentially unenforceable custom transfer/share/freeze pol
    = A custom transfer policy for a given type is implemented through calling the private transfer function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W02001]: potentially unenforceable custom transfer/share/freeze policy
+warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:20:16
    │
 20 │     public fun custom_share_bad(o: S1) {
@@ -24,7 +24,7 @@ warning[Lint W02001]: potentially unenforceable custom transfer/share/freeze pol
    = A custom share policy for a given type is implemented through calling the private share_object function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W02001]: potentially unenforceable custom transfer/share/freeze policy
+warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:24:16
    │
 24 │     public fun custom_freeze_bad(o: S1) {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freeze_wrapped.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freeze_wrapped.exp
@@ -1,4 +1,4 @@
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:43:40
    │
 15 │         inner: Inner,
@@ -9,7 +9,7 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:47:40
    │
  9 │     struct Inner has key, store {
@@ -23,7 +23,7 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:52:40
    │
 15 │         inner: Inner,
@@ -34,7 +34,7 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:56:40
    │
 29 │         inner: T,
@@ -45,7 +45,7 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:60:40
    │
 32 │     struct S2<T: key + store> has store {
@@ -59,7 +59,7 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:64:40
    │
 15 │         inner: Inner,
@@ -70,7 +70,7 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W04001]: attempting to freeze wrapped objects
+warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:64:73
    │
 15 │         inner: Inner,

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/public_random_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/public_random_invalid.exp
@@ -1,4 +1,4 @@
-warning[Lint W06001]: Risky use of 'sui::random'
+warning[Lint W99006]: Risky use of 'sui::random'
   ┌─ tests/sui_mode/linter/public_random_invalid.move:7:42
   │
 7 │     public fun not_allowed1(_x: u64, _r: &Random) {}
@@ -8,7 +8,7 @@ warning[Lint W06001]: Risky use of 'sui::random'
   = Non-public functions are preferred
   = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W06001]: Risky use of 'sui::random'
+warning[Lint W99006]: Risky use of 'sui::random'
   ┌─ tests/sui_mode/linter/public_random_invalid.move:8:34
   │
 8 │     public fun not_allowed2(_rg: &RandomGenerator, _x: u64) {}
@@ -18,7 +18,7 @@ warning[Lint W06001]: Risky use of 'sui::random'
   = Non-public functions are preferred
   = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W06001]: Risky use of 'sui::random'
+warning[Lint W99006]: Risky use of 'sui::random'
   ┌─ tests/sui_mode/linter/public_random_invalid.move:9:33
   │
 9 │     public fun not_allowed3(_r: &Random, _rg: &RandomGenerator, _x: u64) {}
@@ -28,7 +28,7 @@ warning[Lint W06001]: Risky use of 'sui::random'
   = Non-public functions are preferred
   = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W06001]: Risky use of 'sui::random'
+warning[Lint W99006]: Risky use of 'sui::random'
   ┌─ tests/sui_mode/linter/public_random_invalid.move:9:47
   │
 9 │     public fun not_allowed3(_r: &Random, _rg: &RandomGenerator, _x: u64) {}
@@ -38,7 +38,7 @@ warning[Lint W06001]: Risky use of 'sui::random'
   = Non-public functions are preferred
   = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W06001]: Risky use of 'sui::random'
+warning[Lint W99006]: Risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:10:48
    │
 10 │     public entry fun not_allowed4(_x: u64, _r: &Random, _y: u64) {}

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/self_transfer.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/self_transfer.exp
@@ -1,4 +1,4 @@
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W99001]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:23:9
    │
 22 │     public fun public_transfer_bad(ctx: &mut TxContext) {
@@ -11,7 +11,7 @@ warning[Lint W01001]: non-composable transfer to sender
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W99001]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:27:9
    │
 26 │     public fun private_transfer_bad(ctx: &mut TxContext) {
@@ -24,7 +24,7 @@ warning[Lint W01001]: non-composable transfer to sender
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W99001]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:39:9
    │
 36 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/share_owned.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/share_owned.exp
@@ -1,4 +1,4 @@
-warning[Lint W00001]: possible owned object share
+warning[Lint W99000]: possible owned object share
    ┌─ tests/sui_mode/linter/share_owned.move:14:9
    │
 12 │     public entry fun arg_object(o: Obj) {
@@ -12,7 +12,7 @@ warning[Lint W00001]: possible owned object share
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W00001]: possible owned object share
+warning[Lint W99000]: possible owned object share
    ┌─ tests/sui_mode/linter/share_owned.move:34:9
    │
 33 │         let Wrapper { id, i: _, o } = w;

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/instantiation_loops.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/instantiation_loops.rs
@@ -14,7 +14,6 @@
 //! terminate eventually.
 
 use move_binary_format::{
-
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
         Bytecode, CompiledModule, FunctionDefinition, FunctionDefinitionIndex, FunctionHandleIndex,

--- a/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/check_duplication.rs
+++ b/external-crates/move/move-execution/v2/crates/move-bytecode-verifier/src/check_duplication.rs
@@ -10,7 +10,6 @@
 //! - the handles in struct and function definitions point to the self module index
 //! - all struct and function handles pointing to the self module index have a definition
 use move_binary_format::{
-
     errors::{verification_error, Location, PartialVMResult, VMResult},
     file_format::{
         CompiledModule, Constant, FunctionHandle, FunctionHandleIndex, FunctionInstantiation,


### PR DESCRIPTION
## Description 

- Fixing an issue exposed in #16819. Since Sui lints use the `lint` prefix for suppression, we need to make sure all category/code combos are distinct.
- Added new lint categories, with a specific one for Sui lints

## Test plan 

- Updated tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
