### PR TITLE
[move-2024][enums][ide] Compile match in typing

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/mod.rs
@@ -4,5 +4,4 @@
 
 pub mod ast;
 pub(crate) mod detect_dead_code;
-mod match_compilation;
 pub(crate) mod translate;

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -31,13 +31,11 @@ use std::{
     sync::Arc,
 };
 
-use super::match_compilation;
-
 //**************************************************************************************************
 // Vars
 //**************************************************************************************************
 
-const NEW_NAME_DELIM: &str = "#";
+pub const NEW_NAME_DELIM: &str = "#";
 
 fn translate_var(sp!(loc, v_): N::Var) -> H::Var {
     let N::Var_ {
@@ -71,7 +69,7 @@ const TEMP_PREFIX: &str = "%";
 static TEMP_PREFIX_SYMBOL: Lazy<Symbol> = Lazy::new(|| TEMP_PREFIX.into());
 
 const MATCH_TEMP_PREFIX: &str = "__match_tmp%";
-static MATCH_TEMP_PREFIX_SYMBOL: Lazy<Symbol> = Lazy::new(|| MATCH_TEMP_PREFIX.into());
+pub static MATCH_TEMP_PREFIX_SYMBOL: Lazy<Symbol> = Lazy::new(|| MATCH_TEMP_PREFIX.into());
 
 fn new_temp_name(context: &mut Context) -> Symbol {
     format!(
@@ -120,18 +118,8 @@ type VariantFieldIndicies = UniqueMap<
     UniqueMap<DatatypeName, UniqueMap<VariantName, UniqueMap<Field, usize>>>,
 >;
 
-type VariantPositionalMap =
-    UniqueMap<ModuleIdent, UniqueMap<DatatypeName, UniqueMap<VariantName, bool>>>;
-
-type StructPositionalMap = UniqueMap<ModuleIdent, UniqueMap<DatatypeName, bool>>;
-
 pub(super) struct HLIRDebugFlags {
-    pub(super) match_translation: bool,
     pub(super) match_variant_translation: bool,
-    pub(super) match_specialization: bool,
-    pub(super) match_counterexample: bool,
-    pub(super) match_work_queue: bool,
-    pub(super) match_constant_conversion: bool,
     pub(super) function_translation: bool,
     pub(super) eval_order: bool,
 }
@@ -141,10 +129,7 @@ pub(super) struct Context<'env> {
     pub debug: HLIRDebugFlags,
     current_package: Option<Symbol>,
     structs: UniqueMap<ModuleIdent, UniqueMap<DatatypeName, UniqueMap<Field, usize>>>,
-    struct_positional_info: StructPositionalMap,
-    enum_variants: UniqueMap<ModuleIdent, UniqueMap<DatatypeName, Vec<VariantName>>>,
     variant_fields: VariantFieldIndicies,
-    variant_positional_info: VariantPositionalMap,
     function_locals: UniqueMap<H::Var, (Mutability, H::SingleType)>,
     signature: Option<H::FunctionSignature>,
     tmp_counter: usize,
@@ -163,7 +148,6 @@ impl<'env> Context<'env> {
         fn add_struct_fields(
             env: &mut CompilationEnv,
             structs: &mut UniqueMap<ModuleIdent, UniqueMap<DatatypeName, UniqueMap<Field, usize>>>,
-            struct_positional_info: &mut StructPositionalMap,
             mident: ModuleIdent,
             struct_defs: &UniqueMap<DatatypeName, N::StructDefinition>,
         ) {
@@ -193,23 +177,11 @@ impl<'env> Context<'env> {
                 diag.add_secondary_label((prev_loc, "Previously defined here"));
                 env.add_diag(diag);
             }
-            if let Err((_, prev_loc)) =
-                struct_positional_info.add(mident, cur_structs_positional_info)
-            {
-                let mut diag = ice!((
-                    mident.loc,
-                    format!("Struct for module {} redefined here", mident)
-                ));
-                diag.add_secondary_label((prev_loc, "Previously defined here"));
-                env.add_diag(diag);
-            }
         }
 
         fn add_enums(
             env: &mut CompilationEnv,
-            enum_variants: &mut UniqueMap<ModuleIdent, UniqueMap<DatatypeName, Vec<VariantName>>>,
             variant_fields: &mut VariantFieldIndicies,
-            variant_positional_info: &mut VariantPositionalMap,
             mident: ModuleIdent,
             enum_defs: &UniqueMap<DatatypeName, N::EnumDefinition>,
         ) {
@@ -253,25 +225,7 @@ impl<'env> Context<'env> {
                     .add(ename, enum_variant_positional_info)
                     .unwrap();
             }
-            if let Err((_, prev_loc)) = enum_variants.add(mident, cur_enums_variants) {
-                let mut diag = ice!((
-                    mident.loc,
-                    format!("Enums for module {} redefined here", mident)
-                ));
-                diag.add_secondary_label((prev_loc, "Previously defined here"));
-                env.add_diag(diag);
-            }
             if let Err((_, prev_loc)) = variant_fields.add(mident, cur_enums_variant_fields) {
-                let mut diag = ice!((
-                    mident.loc,
-                    format!("Variants for module {} redefined here", mident)
-                ));
-                diag.add_secondary_label((prev_loc, "Previously defined here"));
-                env.add_diag(diag);
-            }
-            if let Err((_, prev_loc)) =
-                variant_positional_info.add(mident, cur_enums_variant_positional_info)
-            {
                 let mut diag = ice!((
                     mident.loc,
                     format!("Variants for module {} redefined here", mident)
@@ -282,53 +236,19 @@ impl<'env> Context<'env> {
         }
 
         let mut structs = UniqueMap::new();
-        let mut struct_positional_info = UniqueMap::new();
-        let mut enum_variants = UniqueMap::new();
         let mut variant_fields = UniqueMap::new();
-        let mut variant_positional_info = UniqueMap::new();
         if let Some(pre_compiled_lib) = pre_compiled_lib_opt {
             for (mident, mdef) in pre_compiled_lib.typing.inner.modules.key_cloned_iter() {
-                add_struct_fields(
-                    env,
-                    &mut structs,
-                    &mut struct_positional_info,
-                    mident,
-                    &mdef.structs,
-                );
-                add_enums(
-                    env,
-                    &mut enum_variants,
-                    &mut variant_fields,
-                    &mut variant_positional_info,
-                    mident,
-                    &mdef.enums,
-                );
+                add_struct_fields(env, &mut structs, mident, &mdef.structs);
+                add_enums(env, &mut variant_fields, mident, &mdef.enums);
             }
         }
         for (mident, mdef) in prog.modules.key_cloned_iter() {
-            add_struct_fields(
-                env,
-                &mut structs,
-                &mut struct_positional_info,
-                mident,
-                &mdef.structs,
-            );
-            add_enums(
-                env,
-                &mut enum_variants,
-                &mut variant_fields,
-                &mut variant_positional_info,
-                mident,
-                &mdef.enums,
-            );
+            add_struct_fields(env, &mut structs, mident, &mdef.structs);
+            add_enums(env, &mut variant_fields, mident, &mdef.enums);
         }
         let debug = HLIRDebugFlags {
-            match_translation: false,
             match_variant_translation: false,
-            match_specialization: false,
-            match_counterexample: false,
-            match_work_queue: false,
-            match_constant_conversion: false,
             function_translation: false,
             eval_order: false,
         };
@@ -337,10 +257,7 @@ impl<'env> Context<'env> {
             debug,
             current_package: None,
             structs,
-            struct_positional_info,
-            enum_variants,
             variant_fields,
-            variant_positional_info,
             function_locals: UniqueMap::new(),
             signature: None,
             tmp_counter: 0,
@@ -366,26 +283,6 @@ impl<'env> Context<'env> {
             .unwrap();
 
         new_var
-    }
-
-    /// Makes a new `naming/ast.rs` variable. Does _not_ record it as a function local, since this
-    /// should only be called in match expansion, which will have its body processed in HLIR
-    /// translation after expansion.
-    pub fn new_match_var(&mut self, name: String, loc: Loc) -> N::Var {
-        let id = self.counter_next();
-        let name = format!(
-            "{}{NEW_NAME_DELIM}{name}{NEW_NAME_DELIM}{id}",
-            *MATCH_TEMP_PREFIX_SYMBOL,
-        )
-        .into();
-        sp(
-            loc,
-            N::Var_ {
-                name,
-                id: id as u16,
-                color: 1,
-            },
-        )
     }
 
     pub fn bind_local(&mut self, mut_: Mutability, v: N::Var, t: H::SingleType) {
@@ -432,13 +329,6 @@ impl<'env> Context<'env> {
         self.named_block_types.get(block_name).cloned()
     }
 
-    pub fn is_struct(&self, module: &ModuleIdent, datatype_name: &DatatypeName) -> bool {
-        self.structs
-            .get(module)
-            .map(|structs| structs.contains_key(datatype_name))
-            .unwrap_or(false)
-    }
-
     pub fn struct_fields(
         &self,
         module: &ModuleIdent,
@@ -452,28 +342,6 @@ impl<'env> Context<'env> {
         // in that case, there should be errors
         assert!(fields.is_some() || self.env.has_errors());
         fields
-    }
-
-    /// Indicates if the struct is positional. Returns false on empty or missing.
-    pub fn struct_is_positional(&self, module: &ModuleIdent, struct_name: &DatatypeName) -> bool {
-        self.struct_positional_info
-            .get(module)
-            .and_then(|structs| structs.get(struct_name))
-            .cloned()
-            .unwrap_or(false)
-    }
-
-    /// Returns the enum variant names in sorted order.
-    pub fn enum_variants(
-        &self,
-        module: &ModuleIdent,
-        enum_name: &DatatypeName,
-    ) -> Vec<VariantName> {
-        self.enum_variants
-            .get(module)
-            .and_then(|enums| enums.get(enum_name))
-            .expect("ICE enum resolution should have failed during naming")
-            .to_vec()
     }
 
     pub fn enum_variant_fields(
@@ -493,56 +361,6 @@ impl<'env> Context<'env> {
         fields
     }
 
-    /// Indicates if the enum variant is positional. Returns false on empty or missing.
-    pub fn enum_variant_is_positional(
-        &self,
-        module: &ModuleIdent,
-        enum_name: &DatatypeName,
-        variant_name: &VariantName,
-    ) -> bool {
-        self.variant_positional_info
-            .get(module)
-            .and_then(|enums| enums.get(enum_name))
-            .and_then(|variants| variants.get(variant_name))
-            .cloned()
-            .unwrap_or(false)
-    }
-
-    pub fn make_imm_ref_match_binders(
-        &mut self,
-        pattern_loc: Loc,
-        arg_types: Fields<N::Type>,
-    ) -> Vec<(Field, N::Var, N::Type)> {
-        let fields = match_compilation::order_fields_by_decl(None, arg_types.clone());
-        fields
-            .into_iter()
-            .map(|(_, field_name, field_type)| {
-                (
-                    field_name,
-                    self.new_match_var(field_name.to_string(), pattern_loc),
-                    make_imm_ref_ty(field_type),
-                )
-            })
-            .collect::<Vec<_>>()
-    }
-
-    pub fn make_unpack_binders(
-        &mut self,
-        pattern_loc: Loc,
-        arg_types: Fields<N::Type>,
-    ) -> Vec<(Field, N::Var, N::Type)> {
-        let fields = match_compilation::order_fields_by_decl(None, arg_types.clone());
-        fields
-            .into_iter()
-            .map(|(_, field_name, field_type)| {
-                (
-                    field_name,
-                    self.new_match_var(field_name.to_string(), pattern_loc),
-                    field_type,
-                )
-            })
-            .collect::<Vec<_>>()
-    }
     fn counter_next(&mut self) -> usize {
         self.tmp_counter += 1;
         self.tmp_counter
@@ -1100,21 +918,12 @@ fn tail(
             }
         }
 
-        E::Match(subject, arms) => {
-            debug_print!(context.debug.match_translation,
-                ("subject" => subject),
-                (lines "arms" => &arms.value)
-            );
-            let compiled = match_compilation::compile_match(context, in_type, *subject, arms);
-            debug_print!(context.debug.match_translation, ("compiled" => compiled));
-            let result = tail(context, block, expected_type, compiled);
-            debug_print!(context.debug.match_variant_translation,
-                         (lines "block" => block; verbose),
-                         (opt "result" => &result));
-            result
+        E::Match(_subject, _arms) => {
+            context.env.add_diag(ice!((eloc, "ICE unexpanded match")));
+            None
         }
 
-        E::VariantMatch(subject, enum_name, arms) => {
+        E::VariantMatch(subject, (_module, enum_name), arms) => {
             let subject = Box::new(value(context, block, None, *subject));
 
             let (binders, bound_exp) = make_binders(context, eloc, out_type.clone());
@@ -1144,7 +953,7 @@ fn tail(
                 arms,
             };
             block.push_back(sp(eloc, variant_switch));
-            if arms_unreachable {
+            let result = if arms_unreachable {
                 None
             } else {
                 Some(maybe_freeze(
@@ -1153,7 +962,11 @@ fn tail(
                     expected_type.cloned(),
                     bound_exp,
                 ))
-            }
+            };
+            debug_print!(context.debug.match_variant_translation,
+                         (lines "block" => block; verbose),
+                         (opt "result" => &result));
+            result
         }
 
         // While loops can't yield values, so we treat them as statements with no binders.
@@ -1440,19 +1253,7 @@ fn value(
             }
         }
 
-        E::Match(subject, arms) => {
-            debug_print!(context.debug.match_translation,
-                ("subject" => subject),
-                (lines "arms" => &arms.value)
-            );
-            let compiled = match_compilation::compile_match(context, in_type, *subject, arms);
-            debug_print!(context.debug.match_translation, ("compiled" => compiled));
-            let result = value(context, block, None, compiled);
-            debug_print!(context.debug.match_variant_translation, ("result" => &result));
-            result
-        }
-
-        E::VariantMatch(subject, enum_name, arms) => {
+        E::VariantMatch(subject, (_module, enum_name), arms) => {
             let subject_out_type = type_(context, subject.ty.clone());
             let subject = Box::new(value(context, block, Some(&subject_out_type), *subject));
 
@@ -1481,11 +1282,15 @@ fn value(
                 arms,
             };
             block.push_back(sp(eloc, variant_switch));
-            if arms_unreachable {
+            let result = if arms_unreachable {
                 make_exp(HE::Unreachable)
             } else {
                 bound_exp
-            }
+            };
+            debug_print!(context.debug.match_variant_translation,
+                         (lines "block" => block.iter(); verbose),
+                         ("result" => &result));
+            result
         }
 
         // While loops can't yield values, so we treat them as statements with no binders.
@@ -1869,6 +1674,10 @@ fn value(
             context.env.add_diag(ice!((eloc, "ICE unexpanded use")));
             error_exp(eloc)
         }
+        E::Match(_subject, _arms) => {
+            context.env.add_diag(ice!((eloc, "ICE unexpanded match")));
+            error_exp(eloc)
+        }
         E::UnresolvedError | E::InvalidAccess(_) => {
             assert!(context.env.has_errors());
             make_exp(HE::UnresolvedError)
@@ -2078,18 +1887,7 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
                 },
             ));
         }
-        E::Match(subject, arms) => {
-            debug_print!(context.debug.match_translation,
-                ("subject" => subject),
-                (lines "arms" => &arms.value)
-            );
-            let subject_type = subject.ty.clone();
-            let compiled = match_compilation::compile_match(context, &subject_type, *subject, arms);
-            debug_print!(context.debug.match_translation, ("compiled" => compiled));
-            statement(context, block, compiled);
-            debug_print!(context.debug.match_variant_translation, (lines "block" => block));
-        }
-        E::VariantMatch(subject, enum_name, arms) => {
+        E::VariantMatch(subject, (_module, enum_name), arms) => {
             let subject = Box::new(value(context, block, None, *subject));
             let arms = arms
                 .into_iter()
@@ -2105,6 +1903,8 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
                 arms,
             };
             block.push_back(sp(eloc, variant_switch));
+            debug_print!(context.debug.match_variant_translation,
+                         (lines "block" => block; verbose));
         }
         E::While(name, test, body) => {
             let mut cond_block = make_block!();
@@ -2232,6 +2032,9 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         // -----------------------------------------------------------------------------------------
         E::Use(_) => {
             context.env.add_diag(ice!((eloc, "ICE unexpanded use")));
+        }
+        E::Match(_subject, _arms) => {
+            context.env.add_diag(ice!((eloc, "ICE unexpanded match")));
         }
     }
 }
@@ -2410,17 +2213,6 @@ fn still_has_break(name: &BlockLabel, block: &Block) -> bool {
     }
 
     has_break_block(name, block)
-}
-
-pub fn make_imm_ref_ty(ty: N::Type) -> N::Type {
-    match ty {
-        sp!(_, N::Type_::Ref(false, _)) => ty,
-        sp!(loc, N::Type_::Ref(true, inner)) => sp(loc, N::Type_::Ref(false, inner)),
-        ty => {
-            let loc = ty.loc;
-            sp(loc, N::Type_::Ref(false, Box::new(ty)))
-        }
-    }
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -94,6 +94,9 @@ pub(crate) use debug_print_format;
 /// See `debug_print_format` for different `fmt` options.
 macro_rules! debug_print_internal {
     () => {};
+    ((msg $msg:expr)) => {
+        println!("{}", $msg);
+    };
     (($name:expr => $val:expr $(; $fmt:ident)?)) => {
         {
         print!("{}: ", $name);

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -196,7 +196,11 @@ pub enum UnannotatedExp_ {
 
     IfElse(Box<Exp>, Box<Exp>, Box<Exp>),
     Match(Box<Exp>, Spanned<Vec<MatchArm>>),
-    VariantMatch(Box<Exp>, DatatypeName, Vec<(VariantName, Exp)>),
+    VariantMatch(
+        Box<Exp>,
+        (ModuleIdent, DatatypeName),
+        Vec<(VariantName, Exp)>,
+    ),
     While(BlockLabel, Box<Exp>, Box<Exp>),
     Loop {
         name: BlockLabel,
@@ -699,10 +703,10 @@ impl AstDebug for UnannotatedExp_ {
                     })
                 });
             }
-            E::VariantMatch(esubject, enum_name, arms) => {
+            E::VariantMatch(esubject, (m, enum_name), arms) => {
                 w.write("variant_switch (");
                 esubject.ast_debug(w);
-                w.write(format!(" : {} ) ", enum_name));
+                w.write(format!(" : {m}::{enum_name} ) "));
                 w.block(|w| {
                     w.comma(arms.iter(), |w, (variant, rhs)| {
                         w.write(format!("{} =>", variant));

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -9,7 +9,8 @@ use crate::{
         Diagnostic,
     },
     editions::FeatureGate,
-    expansion::ast::{AbilitySet, ModuleIdent, ModuleIdent_, Mutability, Visibility},
+    expansion::ast::{AbilitySet, Fields, ModuleIdent, ModuleIdent_, Mutability, Visibility},
+    hlir::translate::{MATCH_TEMP_PREFIX_SYMBOL, NEW_NAME_DELIM},
     ice,
     naming::ast::{
         self as N, BlockLabel, BuiltinTypeName_, Color, DatatypeTypeParameter, EnumDefinition,
@@ -20,6 +21,7 @@ use crate::{
         Ability_, ConstantName, DatatypeName, Field, FunctionName, VariantName, ENTRY_MODIFIER,
     },
     shared::{known_attributes::TestingAttribute, program_info::*, unique_map::UniqueMap, *},
+    typing::match_compilation,
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
@@ -71,10 +73,22 @@ pub enum MacroExpansion {
     Argument { scope_color: Color },
 }
 
+pub(super) struct TypingDebugFlags {
+    pub(super) match_translation: bool,
+    pub(super) match_specialization: bool,
+    pub(super) match_counterexample: bool,
+    pub(super) match_work_queue: bool,
+    pub(super) match_constant_conversion: bool,
+}
+
 pub struct Context<'env> {
     pub modules: NamingProgramInfo,
     macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
     pub env: &'env mut CompilationEnv,
+    pub(super) debug: TypingDebugFlags,
+
+    // for generating new variables during match compilation
+    next_match_var_id: usize,
 
     use_funs: Vec<UseFunsScope>,
     pub current_package: Option<Symbol>,
@@ -158,6 +172,13 @@ impl<'env> Context<'env> {
         info: NamingProgramInfo,
     ) -> Self {
         let global_use_funs = UseFunsScope::global(&info);
+        let debug = TypingDebugFlags {
+            match_translation: false,
+            match_specialization: false,
+            match_counterexample: false,
+            match_work_queue: false,
+            match_constant_conversion: false,
+        };
         Context {
             use_funs: vec![global_use_funs],
             subst: Subst::empty(),
@@ -173,6 +194,8 @@ impl<'env> Context<'env> {
             macros: UniqueMap::new(),
             named_block_map: BTreeMap::new(),
             env,
+            debug,
+            next_match_var_id: 0,
             new_friends: BTreeSet::new(),
             used_module_members: BTreeMap::new(),
             macro_expansion: vec![],
@@ -672,6 +695,165 @@ impl<'env> Context<'env> {
             color,
         );
         *max_variable_color = color;
+    }
+
+    //********************************************
+    // Match Compilation Helpers
+    //********************************************
+
+    pub fn is_struct(&self, module: &ModuleIdent, datatype_name: &DatatypeName) -> bool {
+        matches!(
+            self.datatype_kind(module, datatype_name),
+            DatatypeKind::Struct
+        )
+    }
+
+    pub fn struct_fields(
+        &self,
+        module: &ModuleIdent,
+        struct_name: &DatatypeName,
+    ) -> Option<UniqueMap<Field, usize>> {
+        let fields = match &self.struct_definition(module, struct_name).fields {
+            N::StructFields::Defined(_, fields) => Some(fields.ref_map(|_, (ndx, _)| *ndx)),
+            N::StructFields::Native(_) => None,
+        };
+        assert!(fields.is_some() || self.env.has_errors());
+        fields
+    }
+
+    /// Indicates if the struct is positional. Returns false on native.
+    pub fn struct_is_positional(&self, module: &ModuleIdent, struct_name: &DatatypeName) -> bool {
+        match self.modules.struct_definition(module, struct_name).fields {
+            N::StructFields::Defined(is_positional, _) => is_positional,
+            N::StructFields::Native(_) => false,
+        }
+    }
+
+    /// Returns the enum variant names in sorted order.
+    pub fn enum_variants(
+        &self,
+        module: &ModuleIdent,
+        enum_name: &DatatypeName,
+    ) -> Vec<VariantName> {
+        let mut names = self
+            .enum_definition(module, enum_name)
+            .variants
+            .ref_map(|_, vdef| vdef.index)
+            .clone()
+            .into_iter()
+            .collect::<Vec<_>>();
+        names.sort_by(|(_, ndx0), (_, ndx1)| ndx0.cmp(ndx1));
+        names.into_iter().map(|(name, _ndx)| name).collect()
+    }
+
+    pub fn enum_variant_fields(
+        &self,
+        module: &ModuleIdent,
+        enum_name: &DatatypeName,
+        variant_name: &VariantName,
+    ) -> Option<UniqueMap<Field, usize>> {
+        let Some(variant) = self
+            .enum_definition(module, enum_name)
+            .variants
+            .get(variant_name)
+        else {
+            self.env.has_errors();
+            return None;
+        };
+        match &variant.fields {
+            N::VariantFields::Defined(_, fields) => Some(fields.ref_map(|_, (ndx, _)| *ndx)),
+            N::VariantFields::Empty => Some(UniqueMap::new()),
+        }
+    }
+
+    /// Indicates if the enum variant is positional. Returns false on empty or missing.
+    pub fn enum_variant_is_positional(
+        &self,
+        module: &ModuleIdent,
+        enum_name: &DatatypeName,
+        variant_name: &VariantName,
+    ) -> bool {
+        let vdef = self
+            .enum_definition(module, enum_name)
+            .variants
+            .get(variant_name)
+            .expect("ICE should have failed during naming");
+        match &vdef.fields {
+            N::VariantFields::Empty => false,
+            N::VariantFields::Defined(is_positional, _m) => *is_positional,
+        }
+    }
+
+    pub fn make_imm_ref_match_binders(
+        &mut self,
+        pattern_loc: Loc,
+        arg_types: Fields<N::Type>,
+    ) -> Vec<(Field, N::Var, N::Type)> {
+        fn make_imm_ref_ty(ty: N::Type) -> N::Type {
+            match ty {
+                sp!(_, N::Type_::Ref(false, _)) => ty,
+                sp!(loc, N::Type_::Ref(true, inner)) => sp(loc, N::Type_::Ref(false, inner)),
+                ty => {
+                    let loc = ty.loc;
+                    sp(loc, N::Type_::Ref(false, Box::new(ty)))
+                }
+            }
+        }
+
+        let fields = match_compilation::order_fields_by_decl(None, arg_types.clone());
+        fields
+            .into_iter()
+            .map(|(_, field_name, field_type)| {
+                (
+                    field_name,
+                    self.new_match_var(field_name.to_string(), pattern_loc),
+                    make_imm_ref_ty(field_type),
+                )
+            })
+            .collect::<Vec<_>>()
+    }
+
+    pub fn make_unpack_binders(
+        &mut self,
+        pattern_loc: Loc,
+        arg_types: Fields<N::Type>,
+    ) -> Vec<(Field, N::Var, N::Type)> {
+        let fields = match_compilation::order_fields_by_decl(None, arg_types.clone());
+        fields
+            .into_iter()
+            .map(|(_, field_name, field_type)| {
+                (
+                    field_name,
+                    self.new_match_var(field_name.to_string(), pattern_loc),
+                    field_type,
+                )
+            })
+            .collect::<Vec<_>>()
+    }
+
+    /// Makes a new `naming/ast.rs` variable. Does _not_ record it as a function local, since this
+    /// should only be called in match expansion, which will have its body processed in HLIR
+    /// translation after type expansion.
+    pub fn new_match_var(&mut self, name: String, loc: Loc) -> N::Var {
+        let id = self.next_match_var_id();
+        let name = format!(
+            "{}{NEW_NAME_DELIM}{name}{NEW_NAME_DELIM}{id}",
+            *MATCH_TEMP_PREFIX_SYMBOL,
+        )
+        .into();
+        sp(
+            loc,
+            N::Var_ {
+                name,
+                id: id as u16,
+                color: 1,
+            },
+        )
+    }
+
+    fn next_match_var_id(&mut self) -> usize {
+        self.next_match_var_id += 1;
+        self.next_match_var_id
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -757,7 +757,7 @@ impl<'env> Context<'env> {
             .variants
             .get(variant_name)
         else {
-            self.env.has_errors();
+            assert!(self.env.has_errors());
             return None;
         };
         match &variant.fields {

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -359,18 +359,15 @@ fn lvalue(context: &mut Context, sp!(loc, lv_): &T::LValue) {
     match lv_ {
         L::Ignore => (),
         L::Var { ty, .. } => type_(context, ty),
-        L::Unpack(m, _, tys, fields) | L::BorrowUnpack(_, m, _, tys, fields) => {
+        L::Unpack(m, _, tys, fields)
+        | L::BorrowUnpack(_, m, _, tys, fields)
+        | L::UnpackVariant(m, _, _, tys, fields)
+        | L::BorrowUnpackVariant(_, m, _, _, tys, fields) => {
             context.add_usage(*m, *loc);
             types(context, tys);
             for (_, _, (_, (_, field))) in fields {
                 lvalue(context, field)
             }
-        }
-        L::BorrowUnpackVariant(..) | L::UnpackVariant(..) => {
-            context.env.add_diag(ice!((
-                *loc,
-                "variant unpacking shouldn't occur before match expansion"
-            )));
         }
     }
 }
@@ -402,21 +399,18 @@ fn exp(context: &mut Context, e: &T::Exp) {
             exp(context, e2);
             exp(context, e3);
         }
-        E::Match(esubject, arms) => {
-            exp(context, esubject);
-            for sp!(_, arm) in &arms.value {
-                pat(context, &arm.pattern);
-                if let Some(guard) = arm.guard.as_ref() {
-                    exp(context, guard)
-                }
-                exp(context, &arm.rhs);
-            }
-        }
-        E::VariantMatch(..) => {
+        E::Match(_subject, _arms) => {
             context.env.add_diag(ice!((
                 e.exp.loc,
-                "shouldn't find variant match before HLIR lowering"
+                "shouldn't find match after match compilation step"
             )));
+        }
+        E::VariantMatch(subject, (module, _), arms) => {
+            exp(context, subject);
+            context.add_usage(*module, e.exp.loc);
+            for (_, rhs) in arms {
+                exp(context, rhs);
+            }
         }
         E::While(_, e1, e2) => {
             exp(context, e1);
@@ -488,27 +482,5 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::BorrowLocal(..)
         | E::ErrorConstant { .. }
         | E::UnresolvedError => (),
-    }
-}
-
-fn pat(context: &mut Context, p: &T::MatchPattern) {
-    use T::UnannotatedPat_ as P;
-    match &p.pat.value {
-        P::Variant(m, _, _, tys, fields)
-        | P::BorrowVariant(_, m, _, _, tys, fields)
-        | P::Struct(m, _, tys, fields)
-        | P::BorrowStruct(_, m, _, tys, fields) => {
-            context.add_usage(*m, p.pat.loc);
-            types(context, tys);
-            for (_, _, (_, (_, p))) in fields {
-                pat(context, p)
-            }
-        }
-        P::At(_, inner) => pat(context, inner),
-        P::Or(lhs, rhs) => {
-            pat(context, lhs);
-            pat(context, rhs);
-        }
-        P::Constant(_, _) | P::Wildcard | P::ErrorPat | P::Binder(_, _) | P::Literal(_) => (),
     }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -244,7 +244,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         E::VariantMatch(subject, _, arms) => {
             context.env.add_diag(ice!((
                 e.exp.loc,
-                "shouldn't find variant match before HLIR lowering"
+                "shouldn't find variant match before match compilation"
             )));
             exp(context, subject);
             for (_, rhs) in arms {

--- a/external-crates/move/crates/move-compiler/src/typing/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_compilation.rs
@@ -4,7 +4,6 @@
 use crate::{
     diag,
     expansion::ast::{Fields, ModuleIdent, Mutability, Value, Value_},
-    hlir::translate::Context,
     ice, ice_assert,
     naming::ast::{self as N, BuiltinTypeName_, Type, UseFuns, Var},
     parser::ast::{BinOp_, ConstantName, DatatypeName, Field, VariantName},
@@ -14,6 +13,7 @@ use crate::{
         unique_map::UniqueMap,
     },
     typing::ast::{self as T, MatchArm_, MatchPattern, UnannotatedPat_ as TP},
+    typing::core::Context,
 };
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
@@ -22,10 +22,61 @@ use std::{
     fmt::Display,
 };
 
+use super::visitor::TypingVisitorContext;
+
 //**************************************************************************************************
 // Description
 //**************************************************************************************************
 // This mostly follows the classical Maranget (2008) implementation toward optimal decision trees.
+
+//**************************************************************************************************
+// Entry and Visitor
+//**************************************************************************************************
+
+struct MatchCompiler<'ctx, 'env> {
+    context: &'ctx mut Context<'env>,
+}
+
+impl TypingVisitorContext for MatchCompiler<'_, '_> {
+    fn visit_exp_custom(&mut self, exp: &mut T::Exp) -> bool {
+        use T::UnannotatedExp_ as E;
+        if let E::Match(_, _) = &exp.exp.value {
+            let E::Match(mut subject, arms) =
+                std::mem::replace(&mut exp.exp.value, E::UnresolvedError)
+            else {
+                unreachable!()
+            };
+            self.visit_exp(&mut subject);
+            debug_print!(self.context.debug.match_translation,
+                ("subject" => subject),
+                (lines "arms" => &arms.value)
+            );
+            let _ = std::mem::replace(exp, compile_match(self.context, &exp.ty, *subject, arms));
+            debug_print!(self.context.debug.match_translation, ("compiled" => exp));
+            true
+        } else {
+            false
+        }
+    }
+
+    fn add_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
+        self.context.env.add_warning_filter_scope(filter);
+    }
+
+    fn pop_warning_filter_scope(&mut self) {
+        self.context.env.pop_warning_filter_scope();
+    }
+}
+
+pub fn function_body_(context: &mut Context, b_: &mut T::FunctionBody_) {
+    match b_ {
+        T::FunctionBody_::Native | T::FunctionBody_::Macro => (),
+        T::FunctionBody_::Defined(es) => {
+            let mut compiler = MatchCompiler { context };
+            compiler.visit_seq(es);
+        }
+    }
+}
 
 //**************************************************************************************************
 // Match Trees
@@ -422,6 +473,14 @@ impl PatternMatrix {
 
     fn patterns_empty(&self) -> bool {
         !self.patterns.is_empty() && self.patterns.iter().all(|pat| pat.pattern_empty())
+    }
+
+    fn all_errors(&self) -> bool {
+        self.patterns.iter().all(|arm| {
+            arm.pats
+                .iter()
+                .all(|pat| matches!(pat.pat.value, TP::ErrorPat))
+        })
     }
 
     fn wild_arm_opt(&mut self, fringe: &VecDeque<FringeEntry>) -> Option<Vec<ArmResult>> {
@@ -1233,8 +1292,8 @@ fn compile_match_head(
     }
 }
 
-pub fn order_fields_by_decl<T>(
-    decl_fields: Option<&UniqueMap<Field, usize>>,
+pub fn order_fields_by_decl<T: std::fmt::Debug>(
+    decl_fields: Option<UniqueMap<Field, usize>>,
     fields: Fields<T>,
 ) -> Vec<(usize, Field, T)> {
     let mut texp_fields: Vec<(usize, Field, T)> = if let Some(field_map) = decl_fields {
@@ -1350,7 +1409,7 @@ fn resolve_result(
                     blocks.push((v, rest_result));
                 }
             }
-            let out_exp = T::UnannotatedExp_::VariantMatch(make_var_ref(subject), e, blocks);
+            let out_exp = T::UnannotatedExp_::VariantMatch(make_var_ref(subject), (m, e), blocks);
             let body_exp = T::exp(context.output_type(), sp(context.arms_loc(), out_exp));
             make_copy_bindings(bindings, body_exp)
         }
@@ -2272,13 +2331,31 @@ fn find_counterexample(
     matrix: PatternMatrix,
     has_guards: bool,
 ) -> bool {
+    // If the matrix is only errors (or empty), it was all error or something else went wrong; no
+    // counterexample is required.
+    if !matrix.is_empty() && !matrix.patterns_empty() && matrix.all_errors() {
+        println!("matrix: {:#?}", matrix);
+        assert!(context.env.has_errors());
+        return true;
+    }
+
+    find_counterexample_impl(context, loc, matrix, has_guards)
+}
+
+/// Returns true if it found a counter-example.
+fn find_counterexample_impl(
+    context: &mut Context,
+    loc: Loc,
+    matrix: PatternMatrix,
+    has_guards: bool,
+) -> bool {
     fn make_wildcards(n: usize) -> Vec<CounterExample> {
         std::iter::repeat(CounterExample::Wildcard)
             .take(n)
             .collect()
     }
 
-    fn find_counterexample_bool(
+    fn counterexample_bool(
         context: &mut Context,
         matrix: PatternMatrix,
         arity: u32,
@@ -2290,7 +2367,7 @@ fn find_counterexample(
             // Saturated
             for lit in literals {
                 if let Some(counterexample) =
-                    find_counterexample(context, matrix.specialize_literal(&lit).1, arity - 1, ndx)
+                    counterexample_rec(context, matrix.specialize_literal(&lit).1, arity - 1, ndx)
                 {
                     let lit_str = format!("{}", lit);
                     let result = [CounterExample::Literal(lit_str)]
@@ -2303,7 +2380,7 @@ fn find_counterexample(
             None
         } else {
             let (_, default) = matrix.specialize_default();
-            if let Some(counterexample) = find_counterexample(context, default, arity - 1, ndx) {
+            if let Some(counterexample) = counterexample_rec(context, default, arity - 1, ndx) {
                 if literals.is_empty() {
                     let result = [CounterExample::Wildcard]
                         .into_iter()
@@ -2330,7 +2407,7 @@ fn find_counterexample(
         }
     }
 
-    fn find_counterexample_builtin(
+    fn counterexample_builtin(
         context: &mut Context,
         matrix: PatternMatrix,
         arity: u32,
@@ -2340,7 +2417,7 @@ fn find_counterexample(
         // saturated.
         let literals = matrix.first_lits();
         let (_, default) = matrix.specialize_default();
-        if let Some(counterexample) = find_counterexample(context, default, arity - 1, ndx) {
+        if let Some(counterexample) = counterexample_rec(context, default, arity - 1, ndx) {
             if literals.is_empty() {
                 let result = [CounterExample::Wildcard]
                     .into_iter()
@@ -2378,7 +2455,7 @@ fn find_counterexample(
         }
     }
 
-    fn find_counterexample_datatype(
+    fn counterexample_datatype(
         context: &mut Context,
         matrix: PatternMatrix,
         arity: u32,
@@ -2408,7 +2485,7 @@ fn find_counterexample(
                     .collect::<Vec<_>>();
                 let (_, inner_matrix) = matrix.specialize_struct(context, bind_tys);
                 if let Some(mut counterexample) =
-                    find_counterexample(context, inner_matrix, ctor_arity + arity - 1, ndx)
+                    counterexample_rec(context, inner_matrix, ctor_arity + arity - 1, ndx)
                 {
                     let ctor_args = counterexample
                         .drain(0..(ctor_arity as usize))
@@ -2430,8 +2507,7 @@ fn find_counterexample(
             } else {
                 let (_, default) = matrix.specialize_default();
                 // `_` is a reasonable counterexample since we never unpacked this struct
-                if let Some(counterexample) = find_counterexample(context, default, arity - 1, ndx)
-                {
+                if let Some(counterexample) = counterexample_rec(context, default, arity - 1, ndx) {
                     // If we didn't match any head constructor, `_` is a reasonable
                     // counter-example entry.
                     let mut result = vec![CounterExample::Wildcard];
@@ -2467,7 +2543,7 @@ fn find_counterexample(
                         .collect::<Vec<_>>();
                     let (_, inner_matrix) = matrix.specialize_variant(context, &ctor, bind_tys);
                     if let Some(mut counterexample) =
-                        find_counterexample(context, inner_matrix, ctor_arity + arity - 1, ndx)
+                        counterexample_rec(context, inner_matrix, ctor_arity + arity - 1, ndx)
                     {
                         let ctor_args = counterexample
                             .drain(0..(ctor_arity as usize))
@@ -2491,8 +2567,7 @@ fn find_counterexample(
                 None
             } else {
                 let (_, default) = matrix.specialize_default();
-                if let Some(counterexample) = find_counterexample(context, default, arity - 1, ndx)
-                {
+                if let Some(counterexample) = counterexample_rec(context, default, arity - 1, ndx) {
                     if ctors.is_empty() {
                         // If we didn't match any head constructor, `_` is a reasonable
                         // counter-example entry.
@@ -2534,7 +2609,7 @@ fn find_counterexample(
     }
 
     // \mathcal{I} from Maranget. Warning for pattern matching. 1992.
-    fn find_counterexample(
+    fn counterexample_rec(
         context: &mut Context,
         matrix: PatternMatrix,
         arity: u32,
@@ -2545,21 +2620,20 @@ fn find_counterexample(
             None
         } else if let Some(ty) = matrix.tys.first() {
             if let Some(sp!(_, BuiltinTypeName_::Bool)) = ty.value.unfold_to_builtin_type_name() {
-                find_counterexample_bool(context, matrix, arity, ndx)
+                counterexample_bool(context, matrix, arity, ndx)
             } else if let Some(_builtin) = ty.value.unfold_to_builtin_type_name() {
-                find_counterexample_builtin(context, matrix, arity, ndx)
+                counterexample_builtin(context, matrix, arity, ndx)
             } else if let Some((mident, datatype_name)) = ty
                 .value
                 .unfold_to_type_name()
                 .and_then(|sp!(_, name)| name.datatype_name())
             {
                 // This will need to also support structs if and when we add matching for them.
-                find_counterexample_datatype(context, matrix, arity, ndx, mident, datatype_name)
+                counterexample_datatype(context, matrix, arity, ndx, mident, datatype_name)
             } else {
                 // This can only be a binding or wildcard, so we act accordingly.
                 let (_, default) = matrix.specialize_default();
-                if let Some(counterexample) = find_counterexample(context, default, arity - 1, ndx)
-                {
+                if let Some(counterexample) = counterexample_rec(context, default, arity - 1, ndx) {
                     let result = [CounterExample::Wildcard]
                         .into_iter()
                         .chain(counterexample)
@@ -2578,7 +2652,8 @@ fn find_counterexample(
     }
 
     let mut ndx = 0;
-    if let Some(mut counterexample) = find_counterexample(context, matrix, 1, &mut ndx) {
+
+    if let Some(mut counterexample) = counterexample_rec(context, matrix, 1, &mut ndx) {
         debug_print!(
             context.debug.match_counterexample,
             ("counterexamples #" => counterexample.len(); fmt),

--- a/external-crates/move/crates/move-compiler/src/typing/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_compilation.rs
@@ -2334,7 +2334,7 @@ fn find_counterexample(
     // If the matrix is only errors (or empty), it was all error or something else went wrong; no
     // counterexample is required.
     if !matrix.is_empty() && !matrix.patterns_empty() && matrix.all_errors() {
-        println!("matrix: {:#?}", matrix);
+        debug_print!(context.debug.match_counterexample, (msg "errors"), ("matrix" => matrix; dbg));
         assert!(context.env.has_errors());
         return true;
     }

--- a/external-crates/move/crates/move-compiler/src/typing/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/mod.rs
@@ -8,6 +8,7 @@ mod dependency_ordering;
 mod expand;
 mod infinite_instantiations;
 mod macro_expand;
+mod match_compilation;
 mod recursive_datatypes;
 mod syntax_methods;
 pub(crate) mod translate;

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -32,7 +32,8 @@ use crate::{
         core::{
             self, public_testing_visibility, Context, PublicForTesting, ResolvedFunctionType, Subst,
         },
-        dependency_ordering, expand, infinite_instantiations, macro_expand, recursive_datatypes,
+        dependency_ordering, expand, infinite_instantiations, macro_expand, match_compilation,
+        recursive_datatypes,
         syntax_methods::validate_syntax_methods,
     },
     FullyCompiledProgram,
@@ -332,7 +333,7 @@ fn function_body(context: &mut Context, sp!(loc, nb_): N::FunctionBody) -> T::Fu
     };
     core::solve_constraints(context);
     expand::function_body_(context, &mut b_);
-    // freeze::function_body_(context, &mut b_);
+    match_compilation::function_body_(context, &mut b_);
     sp(loc, b_)
 }
 
@@ -550,7 +551,7 @@ mod check_valid_constant {
             E::VariantMatch(_subject, _, _arms) => {
                 context.env.add_diag(ice!((
                     *loc,
-                    "shouldn't find variant match before HLIR lowering"
+                    "shouldn't find variant match before match compilation"
                 )));
                 "'variant match' expressions are"
             }
@@ -2199,7 +2200,11 @@ fn match_pattern_(
                 targs.clone(),
                 fields,
             );
+            let mut field_error = false;
             let tfields = typed_fields.map(|f, (idx, (fty, tpat))| {
+                if matches!(fty.value, N::Type_::UnresolvedError) {
+                    field_error = true;
+                }
                 let tpat = match_pattern_(context, tpat, mut_ref, rhs_binders, wildcard_needs_drop);
                 let fty_ref = rtype!(fty.clone());
                 subtype(
@@ -2222,7 +2227,9 @@ fn match_pattern_(
                     .add_diag(diag!(TypeSafety::Visibility, (loc, msg)));
             }
             let bt = rtype!(bt);
-            let pat_ = if let Some(mut_) = mut_ref {
+            let pat_ = if field_error {
+                TP::ErrorPat
+            } else if let Some(mut_) = mut_ref {
                 TP::BorrowVariant(*mut_, m, enum_, variant, targs, tfields)
             } else {
                 TP::Variant(m, enum_, variant, targs, tfields)
@@ -2240,7 +2247,11 @@ fn match_pattern_(
                 targs.clone(),
                 fields,
             );
+            let mut field_error = false;
             let tfields = typed_fields.map(|f, (idx, (fty, tpat))| {
+                if matches!(fty.value, N::Type_::UnresolvedError) {
+                    field_error = true;
+                }
                 let tpat = match_pattern_(context, tpat, mut_ref, rhs_binders, wildcard_needs_drop);
                 let fty_ref = rtype!(fty.clone());
                 subtype(
@@ -2263,7 +2274,9 @@ fn match_pattern_(
                     .add_diag(diag!(TypeSafety::Visibility, (loc, msg)));
             }
             let bt = rtype!(bt);
-            let pat_ = if let Some(mut_) = mut_ref {
+            let pat_ = if field_error {
+                TP::ErrorPat
+            } else if let Some(mut_) = mut_ref {
                 TP::BorrowStruct(*mut_, m, struct_, targs, tfields)
             } else {
                 TP::Struct(m, struct_, targs, tfields)
@@ -2865,7 +2878,7 @@ fn add_variant_field_types<T>(
                 );
                 context
                     .env
-                    .add_diag(diag!(TypeSafety::InvalidNativeUsage, (loc, msg),));
+                    .add_diag(diag!(TypeSafety::TooManyArguments, (loc, msg),));
                 return fields.map(|f, (idx, x)| (idx, (context.error_type(f.loc()), x)));
             } else {
                 return Fields::new();

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_binding_var.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_binding_var.exp
@@ -1,3 +1,9 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/development/enums/matching/invalid_binding_var.move:8:16
+  │
+8 │         match (opt) {
+  │                ^^^ Pattern 'Option::Some(_)' not covered
+
 error[E02010]: invalid name
   ┌─ tests/development/enums/matching/invalid_binding_var.move:9:26
   │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_head_ctor.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_head_ctor.exp
@@ -1,9 +1,3 @@
-error[E04036]: non-exhaustive pattern
-  ┌─ tests/development/enums/matching/invalid_head_ctor.move:8:16
-  │
-8 │         match (opt) {
-  │                ^^^ Pattern '_' not covered
-
 error[E01002]: unexpected token
   ┌─ tests/development/enums/matching/invalid_head_ctor.move:9:13
   │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_head_ctor_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_head_ctor_2.exp
@@ -1,9 +1,3 @@
-error[E04036]: non-exhaustive pattern
-  ┌─ tests/development/enums/matching/invalid_head_ctor_2.move:8:16
-  │
-8 │         match (opt) {
-  │                ^^^ Pattern '_' not covered
-
 error[E01002]: unexpected token
   ┌─ tests/development/enums/matching/invalid_head_ctor_2.move:9:13
   │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_mut_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_mut_2.exp
@@ -1,3 +1,9 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/development/enums/matching/invalid_mut_2.move:9:16
+  │
+9 │         match (m) {
+  │                ^ Pattern 'Maybe::Nothing' not covered
+
 error[E02010]: invalid name
    ┌─ tests/development/enums/matching/invalid_mut_2.move:10:13
    │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_mut_3.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_mut_3.exp
@@ -1,3 +1,9 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/development/enums/matching/invalid_mut_3.move:9:16
+  │
+9 │         match (m) {
+  │                ^ Pattern 'Maybe::Nothing' not covered
+
 error[E02010]: invalid name
    ┌─ tests/development/enums/matching/invalid_mut_3.move:10:13
    │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_mut_4.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/invalid_mut_4.exp
@@ -1,3 +1,9 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/development/enums/matching/invalid_mut_4.move:9:16
+  │
+9 │         match (m) {
+  │                ^ Pattern 'Maybe::Nothing' not covered
+
 error[E02010]: invalid name
    ┌─ tests/development/enums/matching/invalid_mut_4.move:10:13
    │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/matching/multi_or_not_exhaustive.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/matching/multi_or_not_exhaustive.exp
@@ -1,11 +1,3 @@
-warning[W09003]: unused assignment
-   ┌─ tests/development/enums/matching/multi_or_not_exhaustive.move:11:13
-   │
-11 │         let subject = ABC::A(0);
-   │             ^^^^^^^ Unused assignment for variable 'subject'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_subject')
-   │
-   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
 error[E04036]: non-exhaustive pattern
    ┌─ tests/development/enums/matching/multi_or_not_exhaustive.move:12:16
    │

--- a/external-crates/move/crates/move-compiler/tests/development/enums/naming/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/naming/pattern_ellipsis_invalid.exp
@@ -31,7 +31,7 @@ error[E03013]: positional call mismatch
    │
    = Remove '()' arguments from this pattern
 
-error[E04015]: invalid use of native item
+error[E04017]: too many arguments
    ┌─ tests/development/enums/naming/pattern_ellipsis_invalid.move:18:13
    │
 18 │             Y::D(x, ..) => 0,
@@ -56,7 +56,7 @@ error[E03013]: positional call mismatch
    │
    = Remove '{ }' arguments from this pattern
 
-error[E04015]: invalid use of native item
+error[E04017]: too many arguments
    ┌─ tests/development/enums/naming/pattern_ellipsis_invalid.move:19:13
    │
 19 │             Y::D{x, ..} => 0,

--- a/external-crates/move/crates/move-compiler/tests/development/enums/parser/invalid_mut_usage_match.exp
+++ b/external-crates/move/crates/move-compiler/tests/development/enums/parser/invalid_mut_usage_match.exp
@@ -1,3 +1,9 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/development/enums/parser/invalid_mut_usage_match.move:9:15
+  │
+9 │        match (o) {
+  │               ^ Pattern 'Option::None' not covered
+
 error[E04016]: too few arguments
    ┌─ tests/development/enums/parser/invalid_mut_usage_match.move:10:10
    │


### PR DESCRIPTION
## Description 

This migrates match compilation to happen in typing, in order to better-support IDE integartion.

## Test plan 

A few updated tests, but everything else is still the same.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
