### PR TITLE
honor run-with-range in config.yaml

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -49,10 +49,18 @@ struct Args {
     #[clap(long, help = "Specify address to listen on")]
     listen_address: Option<Multiaddr>,
 
-    #[clap(long, group = "exclusive")]
+    #[clap(
+        long,
+        group = "exclusive",
+        help = "Specify epoch to stop sui-node after i.e stop at Epoch_n+1. This flag takes precedence over config"
+    )]
     run_with_range_epoch: Option<EpochId>,
 
-    #[clap(long, group = "exclusive")]
+    #[clap(
+        long,
+        group = "exclusive",
+        help = "Specify checkpoint to stop sui-node after i.e stop at CheckpointSeq_n+1. This flag takes precedence over config"
+    )]
     run_with_range_checkpoint: Option<CheckpointSequenceNumber>,
 }
 
@@ -73,16 +81,13 @@ fn main() {
     );
     config.supported_protocol_versions = Some(SupportedProtocolVersions::SYSTEM_DEFAULT);
 
-    // match run_with_range args
-    // this means that we always modify the config used to start the node
-    // for run_with_range. i.e if this is set in the config, it is ignored. only the cli args
-    // enable/disable run_with_range
+    // match run_with_range args. this will override epoch/checkpoint set in config
     match (args.run_with_range_epoch, args.run_with_range_checkpoint) {
         (None, Some(checkpoint)) => {
             config.run_with_range = Some(RunWithRange::Checkpoint(checkpoint))
         }
         (Some(epoch), None) => config.run_with_range = Some(RunWithRange::Epoch(epoch)),
-        _ => config.run_with_range = None,
+        _ => {}
     };
 
     let runtimes = SuiRuntimes::new(&config);


### PR DESCRIPTION
## Description 

The run_with_range feature was initially implemented to only support executing run_with_range via sui-node flags at start time. This is a one-off to most everything else. We should probably just honor the config to remain consistent. The cli flags will take precedence over run_with_range settings in configuration.

## Test plan 

How did you test the new or updated feature?

Started sui-node with run_with_range in configuration.
Started sui-node with run_with_range with cli flags.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
