### PR TITLE
[bridge] add get token payload for dev inspect

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -53,16 +53,10 @@ use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
 use ethers::prelude::*;
 use std::process::Child;
 use sui_config::local_ip_utils::get_available_port;
-use sui_json_rpc_types::SuiObjectDataOptions;
 use sui_sdk::SuiClient;
 use sui_types::base_types::SuiAddress;
-use sui_types::bridge::{MoveTypeBridgeMessageKey, MoveTypeBridgeRecord};
-use sui_types::collection_types::LinkedTableNode;
 use sui_types::crypto::EncodeDecodeBase64;
 use sui_types::crypto::KeypairTraits;
-use sui_types::dynamic_field::{DynamicFieldName, Field};
-use sui_types::object::Object;
-use sui_types::TypeTag;
 use tempfile::tempdir;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
@@ -815,42 +809,11 @@ pub(crate) async fn get_signatures(
     sui_bridge_client: &SuiBridgeClient,
     nonce: u64,
     sui_chain_id: u8,
-    sui_client: &SuiClient,
-    message_type: u8,
 ) -> Vec<Bytes> {
-    // Now collect sigs from the bridge record and submit to eth to claim
-    let summary = sui_bridge_client.get_bridge_summary().await.unwrap();
-    let records_id = summary.bridge_records_id;
-    let key = serde_json::json!(
-        {
-            // u64 is represented as string
-            "bridge_seq_num": nonce.to_string(),
-            "message_type": message_type,
-            "source_chain": sui_chain_id,
-        }
-    );
-    let status_object_id = sui_client.read_api().get_dynamic_field_object(records_id,
-        DynamicFieldName {
-            type_: TypeTag::from_str("0x000000000000000000000000000000000000000000000000000000000000000b::message::BridgeMessageKey").unwrap(),
-            value: key.clone(),
-        },
-    ).await.unwrap().into_object().unwrap().object_id;
-
-    let object_resp = sui_client
-        .read_api()
-        .get_object_with_options(
-            status_object_id,
-            SuiObjectDataOptions::full_content().with_bcs(),
-        )
+    let sigs = sui_bridge_client
+        .get_token_transfer_action_onchain_signatures_until_success(sui_chain_id, nonce)
         .await
         .unwrap();
-
-    let object: Object = object_resp.into_object().unwrap().try_into().unwrap();
-    let record: Field<
-        MoveTypeBridgeMessageKey,
-        LinkedTableNode<MoveTypeBridgeMessageKey, MoveTypeBridgeRecord>,
-    > = object.to_rust().unwrap();
-    let sigs = record.value.value.verified_signatures.unwrap();
 
     sigs.into_iter()
         .map(|sig: Vec<u8>| Bytes::from(sig))

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -12,7 +12,7 @@ use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::{EventFilter, EventPage, SuiEvent};
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
-use sui_types::bridge::BridgeSummary;
+use sui_types::bridge::{BridgeSummary, MoveTypeParsedTokenTransferMessage};
 use sui_types::digests::TransactionDigest;
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -222,6 +222,15 @@ impl SuiClientInner for SuiMockClient {
         _source_chain_id: u8,
         _seq_number: u64,
     ) -> Result<Option<Vec<Vec<u8>>>, BridgeError> {
+        unimplemented!()
+    }
+
+    async fn get_parsed_token_transfer_message(
+        &self,
+        _bridge_object_arg: ObjectArg,
+        _source_chain_id: u8,
+        _seq_number: u64,
+    ) -> Result<Option<MoveTypeParsedTokenTransferMessage>, BridgeError> {
         unimplemented!()
     }
 

--- a/crates/sui-framework/docs/bridge/bridge.md
+++ b/crates/sui-framework/docs/bridge/bridge.md
@@ -35,6 +35,7 @@ title: Module `0xb::bridge`
 -  [Function `get_current_seq_num_and_increment`](#0xb_bridge_get_current_seq_num_and_increment)
 -  [Function `get_token_transfer_action_status`](#0xb_bridge_get_token_transfer_action_status)
 -  [Function `get_token_transfer_action_signatures`](#0xb_bridge_get_token_transfer_action_signatures)
+-  [Function `get_parsed_token_transfer_message`](#0xb_bridge_get_parsed_token_transfer_message)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/ascii.md#0x1_ascii">0x1::ascii</a>;
@@ -475,6 +476,15 @@ title: Module `0xb::bridge`
 
 
 
+<a name="0xb_bridge_EMustBeTokenMessage"></a>
+
+
+
+<pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EMustBeTokenMessage">EMustBeTokenMessage</a>: u64 = 17;
+</code></pre>
+
+
+
 <a name="0xb_bridge_EBridgeAlreadyPaused"></a>
 
 
@@ -502,6 +512,15 @@ title: Module `0xb::bridge`
 
 
 
+<a name="0xb_bridge_EInvalidEvmAddress"></a>
+
+
+
+<pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EInvalidEvmAddress">EInvalidEvmAddress</a>: u64 = 18;
+</code></pre>
+
+
+
 <a name="0xb_bridge_EInvariantSuiInitializedTokenTransferShouldNotBeClaimed"></a>
 
 
@@ -525,15 +544,6 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EMessageNotFoundInRecords">EMessageNotFoundInRecords</a>: u64 = 11;
-</code></pre>
-
-
-
-<a name="0xb_bridge_EMustBeTokenMessage"></a>
-
-
-
-<pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EMustBeTokenMessage">EMustBeTokenMessage</a>: u64 = 17;
 </code></pre>
 
 
@@ -606,6 +616,15 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EUnexpectedTokenType">EUnexpectedTokenType</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0xb_bridge_EVM_ADDRESS_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EVM_ADDRESS_LENGTH">EVM_ADDRESS_LENGTH</a>: u64 = 20;
 </code></pre>
 
 
@@ -820,6 +839,8 @@ title: Module `0xb::bridge`
     <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>assert</b>!(!inner.paused, <a href="bridge.md#0xb_bridge_EBridgeUnavailable">EBridgeUnavailable</a>);
     <b>assert</b>!(<a href="chain_ids.md#0xb_chain_ids_is_valid_route">chain_ids::is_valid_route</a>(inner.chain_id, target_chain), <a href="bridge.md#0xb_bridge_EInvalidBridgeRoute">EInvalidBridgeRoute</a>);
+    <b>assert</b>!(target_address.length() == <a href="bridge.md#0xb_bridge_EVM_ADDRESS_LENGTH">EVM_ADDRESS_LENGTH</a>, <a href="bridge.md#0xb_bridge_EInvalidEvmAddress">EInvalidEvmAddress</a>);
+
     <b>let</b> amount = token.<a href="../sui-framework/balance.md#0x2_balance">balance</a>().value();
 
     <b>let</b> bridge_seq_num = inner.<a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(<a href="message_types.md#0xb_message_types_token">message_types::token</a>());
@@ -1408,7 +1429,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): u8
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): u8
 </code></pre>
 
 
@@ -1417,7 +1438,7 @@ title: Module `0xb::bridge`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(
     <a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     source_chain: u8,
     bridge_seq_num: u64,
@@ -1483,6 +1504,47 @@ title: Module `0xb::bridge`
 
     <b>let</b> record = &inner.token_transfer_records[key];
     record.verified_signatures
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0xb_bridge_get_parsed_token_transfer_message"></a>
+
+## Function `get_parsed_token_transfer_message`
+
+
+
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_parsed_token_transfer_message">get_parsed_token_transfer_message</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="message.md#0xb_message_ParsedTokenTransferMessage">message::ParsedTokenTransferMessage</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_parsed_token_transfer_message">get_parsed_token_transfer_message</a>(
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    source_chain: u8,
+    bridge_seq_num: u64,
+): Option&lt;ParsedTokenTransferMessage&gt; {
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner">load_inner</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
+    <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(
+        source_chain,
+        <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),
+        bridge_seq_num
+    );
+
+    <b>if</b> (!inner.token_transfer_records.contains(key)) {
+        <b>return</b> <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>()
+    };
+
+    <b>let</b> record = &inner.token_transfer_records[key];
+    <b>let</b> <a href="message.md#0xb_message">message</a> = &record.<a href="message.md#0xb_message">message</a>;
+    <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(to_parsed_token_transfer_message(<a href="message.md#0xb_message">message</a>))
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/bridge/message.md
+++ b/crates/sui-framework/docs/bridge/message.md
@@ -7,13 +7,15 @@ title: Module `0xb::message`
 
 -  [Struct `BridgeMessage`](#0xb_message_BridgeMessage)
 -  [Struct `BridgeMessageKey`](#0xb_message_BridgeMessageKey)
--  [Struct `TokenPayload`](#0xb_message_TokenPayload)
+-  [Struct `TokenTransferPayload`](#0xb_message_TokenTransferPayload)
 -  [Struct `EmergencyOp`](#0xb_message_EmergencyOp)
 -  [Struct `Blocklist`](#0xb_message_Blocklist)
 -  [Struct `UpdateBridgeLimit`](#0xb_message_UpdateBridgeLimit)
 -  [Struct `UpdateAssetPrice`](#0xb_message_UpdateAssetPrice)
 -  [Struct `AddTokenOnSui`](#0xb_message_AddTokenOnSui)
+-  [Struct `ParsedTokenTransferMessage`](#0xb_message_ParsedTokenTransferMessage)
 -  [Constants](#@Constants_0)
+-  [Function `to_parsed_token_transfer_message`](#0xb_message_to_parsed_token_transfer_message)
 -  [Function `extract_token_bridge_payload`](#0xb_message_extract_token_bridge_payload)
 -  [Function `extract_emergency_op_payload`](#0xb_message_extract_emergency_op_payload)
 -  [Function `extract_blocklist_payload`](#0xb_message_extract_blocklist_payload)
@@ -33,6 +35,7 @@ title: Module `0xb::message`
 -  [Function `message_type`](#0xb_message_message_type)
 -  [Function `seq_num`](#0xb_message_seq_num)
 -  [Function `source_chain`](#0xb_message_source_chain)
+-  [Function `payload`](#0xb_message_payload)
 -  [Function `token_target_chain`](#0xb_message_token_target_chain)
 -  [Function `token_target_address`](#0xb_message_token_target_address)
 -  [Function `token_type`](#0xb_message_token_type)
@@ -155,13 +158,13 @@ title: Module `0xb::message`
 
 </details>
 
-<a name="0xb_message_TokenPayload"></a>
+<a name="0xb_message_TokenTransferPayload"></a>
 
-## Struct `TokenPayload`
+## Struct `TokenTransferPayload`
 
 
 
-<pre><code><b>struct</b> <a href="message.md#0xb_message_TokenPayload">TokenPayload</a> <b>has</b> drop
+<pre><code><b>struct</b> <a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a> <b>has</b> drop
 </code></pre>
 
 
@@ -383,6 +386,57 @@ title: Module `0xb::message`
 
 </details>
 
+<a name="0xb_message_ParsedTokenTransferMessage"></a>
+
+## Struct `ParsedTokenTransferMessage`
+
+
+
+<pre><code><b>struct</b> <a href="message.md#0xb_message_ParsedTokenTransferMessage">ParsedTokenTransferMessage</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>message_version: u8</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>seq_num: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>source_chain: u8</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>payload: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>parsed_payload: <a href="message.md#0xb_message_TokenTransferPayload">message::TokenTransferPayload</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a name="@Constants_0"></a>
 
 ## Constants
@@ -451,6 +505,15 @@ title: Module `0xb::message`
 
 
 
+<a name="0xb_message_EMustBeTokenMessage"></a>
+
+
+
+<pre><code><b>const</b> <a href="message.md#0xb_message_EMustBeTokenMessage">EMustBeTokenMessage</a>: u64 = 6;
+</code></pre>
+
+
+
 <a name="0xb_message_ETrailingBytes"></a>
 
 
@@ -478,13 +541,13 @@ title: Module `0xb::message`
 
 
 
-<a name="0xb_message_extract_token_bridge_payload"></a>
+<a name="0xb_message_to_parsed_token_transfer_message"></a>
 
-## Function `extract_token_bridge_payload`
+## Function `to_parsed_token_transfer_message`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_extract_token_bridge_payload">extract_token_bridge_payload</a>(<a href="message.md#0xb_message">message</a>: &<a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>): <a href="message.md#0xb_message_TokenPayload">message::TokenPayload</a>
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_to_parsed_token_transfer_message">to_parsed_token_transfer_message</a>(<a href="message.md#0xb_message">message</a>: &<a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>): <a href="message.md#0xb_message_ParsedTokenTransferMessage">message::ParsedTokenTransferMessage</a>
 </code></pre>
 
 
@@ -493,7 +556,39 @@ title: Module `0xb::message`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_extract_token_bridge_payload">extract_token_bridge_payload</a>(<a href="message.md#0xb_message">message</a>: &<a href="message.md#0xb_message_BridgeMessage">BridgeMessage</a>): <a href="message.md#0xb_message_TokenPayload">TokenPayload</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_to_parsed_token_transfer_message">to_parsed_token_transfer_message</a>(<a href="message.md#0xb_message">message</a>: &<a href="message.md#0xb_message_BridgeMessage">BridgeMessage</a>): <a href="message.md#0xb_message_ParsedTokenTransferMessage">ParsedTokenTransferMessage</a> {
+    <b>assert</b>!(<a href="message.md#0xb_message">message</a>.<a href="message.md#0xb_message_message_type">message_type</a>() == <a href="message_types.md#0xb_message_types_token">message_types::token</a>(), <a href="message.md#0xb_message_EMustBeTokenMessage">EMustBeTokenMessage</a>);
+    <b>let</b> payload = <a href="message.md#0xb_message">message</a>.<a href="message.md#0xb_message_extract_token_bridge_payload">extract_token_bridge_payload</a>();
+    <a href="message.md#0xb_message_ParsedTokenTransferMessage">ParsedTokenTransferMessage</a> {
+        message_version: <a href="message.md#0xb_message">message</a>.<a href="message.md#0xb_message_message_version">message_version</a>(),
+        seq_num: <a href="message.md#0xb_message">message</a>.<a href="message.md#0xb_message_seq_num">seq_num</a>(),
+        source_chain: <a href="message.md#0xb_message">message</a>.<a href="message.md#0xb_message_source_chain">source_chain</a>(),
+        payload: <a href="message.md#0xb_message">message</a>.<a href="message.md#0xb_message_payload">payload</a>(),
+        parsed_payload: payload,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0xb_message_extract_token_bridge_payload"></a>
+
+## Function `extract_token_bridge_payload`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_extract_token_bridge_payload">extract_token_bridge_payload</a>(<a href="message.md#0xb_message">message</a>: &<a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>): <a href="message.md#0xb_message_TokenTransferPayload">message::TokenTransferPayload</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_extract_token_bridge_payload">extract_token_bridge_payload</a>(<a href="message.md#0xb_message">message</a>: &<a href="message.md#0xb_message_BridgeMessage">BridgeMessage</a>): <a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a> {
     <b>let</b> <b>mut</b> <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a> = bcs::new(<a href="message.md#0xb_message">message</a>.payload);
     <b>let</b> sender_address = <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.peel_vec_u8();
     <b>let</b> target_chain = <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.peel_u8();
@@ -506,7 +601,7 @@ title: Module `0xb::message`
     <a href="chain_ids.md#0xb_chain_ids_assert_valid_chain_id">chain_ids::assert_valid_chain_id</a>(target_chain);
     <b>assert</b>!(<a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.into_remainder_bytes().is_empty(), <a href="message.md#0xb_message_ETrailingBytes">ETrailingBytes</a>);
 
-    <a href="message.md#0xb_message_TokenPayload">TokenPayload</a> {
+    <a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a> {
         sender_address,
         target_chain,
         target_address,
@@ -1215,13 +1310,13 @@ Update Sui token message
 
 </details>
 
-<a name="0xb_message_token_target_chain"></a>
+<a name="0xb_message_payload"></a>
 
-## Function `token_target_chain`
+## Function `payload`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_chain">token_target_chain</a>(self: &<a href="message.md#0xb_message_TokenPayload">message::TokenPayload</a>): u8
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_payload">payload</a>(self: &<a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -1230,7 +1325,31 @@ Update Sui token message
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_chain">token_target_chain</a>(self: &<a href="message.md#0xb_message_TokenPayload">TokenPayload</a>): u8 {
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_payload">payload</a>(self: &<a href="message.md#0xb_message_BridgeMessage">BridgeMessage</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    self.payload
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0xb_message_token_target_chain"></a>
+
+## Function `token_target_chain`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_chain">token_target_chain</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">message::TokenTransferPayload</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_chain">token_target_chain</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a>): u8 {
     self.target_chain
 }
 </code></pre>
@@ -1245,7 +1364,7 @@ Update Sui token message
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_address">token_target_address</a>(self: &<a href="message.md#0xb_message_TokenPayload">message::TokenPayload</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_address">token_target_address</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">message::TokenTransferPayload</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -1254,7 +1373,7 @@ Update Sui token message
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_address">token_target_address</a>(self: &<a href="message.md#0xb_message_TokenPayload">TokenPayload</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_target_address">token_target_address</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     self.target_address
 }
 </code></pre>
@@ -1269,7 +1388,7 @@ Update Sui token message
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_type">token_type</a>(self: &<a href="message.md#0xb_message_TokenPayload">message::TokenPayload</a>): u8
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_type">token_type</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">message::TokenTransferPayload</a>): u8
 </code></pre>
 
 
@@ -1278,7 +1397,7 @@ Update Sui token message
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_type">token_type</a>(self: &<a href="message.md#0xb_message_TokenPayload">TokenPayload</a>): u8 {
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_type">token_type</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a>): u8 {
     self.token_type
 }
 </code></pre>
@@ -1293,7 +1412,7 @@ Update Sui token message
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_amount">token_amount</a>(self: &<a href="message.md#0xb_message_TokenPayload">message::TokenPayload</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_amount">token_amount</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">message::TokenTransferPayload</a>): u64
 </code></pre>
 
 
@@ -1302,7 +1421,7 @@ Update Sui token message
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_amount">token_amount</a>(self: &<a href="message.md#0xb_message_TokenPayload">TokenPayload</a>): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="message.md#0xb_message_token_amount">token_amount</a>(self: &<a href="message.md#0xb_message_TokenTransferPayload">TokenTransferPayload</a>): u64 {
     self.amount
 }
 </code></pre>

--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -17,7 +17,8 @@ module bridge::bridge {
     use bridge::limiter::{Self, TransferLimiter};
     use bridge::message::{
         Self, BridgeMessage, BridgeMessageKey, EmergencyOp, UpdateAssetPrice,
-        UpdateBridgeLimit, AddTokenOnSui
+        UpdateBridgeLimit, AddTokenOnSui, ParsedTokenTransferMessage,
+        to_parsed_token_transfer_message,
     };
     use bridge::message_types;
     use bridge::treasury::{Self, BridgeTreasury};
@@ -29,6 +30,8 @@ module bridge::bridge {
     const TRANSFER_STATUS_APPROVED: u8 = 1;
     const TRANSFER_STATUS_CLAIMED: u8 = 2;
     const TRANSFER_STATUS_NOT_FOUND: u8 = 3;
+
+    const EVM_ADDRESS_LENGTH: u64 = 20;
 
     public struct Bridge has key {
         id: UID,
@@ -89,6 +92,7 @@ module bridge::bridge {
     const ETokenAlreadyClaimed: u64 = 15;
     const EInvalidBridgeRoute: u64 = 16;
     const EMustBeTokenMessage: u64 = 17;
+    const EInvalidEvmAddress: u64 = 18;
 
     const CURRENT_VERSION: u64 = 1;
 
@@ -187,6 +191,8 @@ module bridge::bridge {
         let inner = load_inner_mut(bridge);
         assert!(!inner.paused, EBridgeUnavailable);
         assert!(chain_ids::is_valid_route(inner.chain_id, target_chain), EInvalidBridgeRoute);
+        assert!(target_address.length() == EVM_ADDRESS_LENGTH, EInvalidEvmAddress);
+
         let amount = token.balance().value();
 
         let bridge_seq_num = inner.get_current_seq_num_and_increment(message_types::token());
@@ -534,7 +540,11 @@ module bridge::bridge {
         seq_num
     }
 
-    public fun get_token_transfer_action_status(
+    /////////////////////////////////////////////////////////
+    //              DevInspect Functions for Read         //
+    /////////////////////////////////////////////////////////
+    #[allow(unused_function)]
+    fun get_token_transfer_action_status(
         bridge: &Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
@@ -581,6 +591,28 @@ module bridge::bridge {
 
         let record = &inner.token_transfer_records[key];
         record.verified_signatures
+    }
+
+    #[allow(unused_function)]
+    fun get_parsed_token_transfer_message(
+        bridge: &Bridge,
+        source_chain: u8,
+        bridge_seq_num: u64,
+    ): Option<ParsedTokenTransferMessage> {
+        let inner = load_inner(bridge);
+        let key = message::create_key(
+            source_chain,
+            message_types::token(),
+            bridge_seq_num
+        );
+
+        if (!inner.token_transfer_records.contains(key)) {
+            return option::none()
+        };
+
+        let record = &inner.token_transfer_records[key];
+        let message = &record.message;
+        option::some(to_parsed_token_transfer_message(message))
     }
 
     //
@@ -658,12 +690,30 @@ module bridge::bridge {
     }
 
     #[test_only]
+    public fun test_get_token_transfer_action_status(
+        bridge: &mut Bridge,
+        source_chain: u8,
+        bridge_seq_num: u64,
+    ): u8 {
+        bridge.get_token_transfer_action_status(source_chain, bridge_seq_num)
+    }
+
+    #[test_only]
     public fun test_get_token_transfer_action_signatures(
         bridge: &mut Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
     ): Option<vector<vector<u8>>> {
         bridge.get_token_transfer_action_signatures(source_chain, bridge_seq_num)
+    }
+
+    #[test_only]
+    public fun test_get_parsed_token_transfer_message(
+        bridge: &Bridge,
+        source_chain: u8,
+        bridge_seq_num: u64,
+    ): Option<ParsedTokenTransferMessage> {
+        bridge.get_parsed_token_transfer_message(source_chain, bridge_seq_num)
     }
 
     #[test_only]

--- a/crates/sui-framework/packages/bridge/tests/bridge_tests.move
+++ b/crates/sui-framework/packages/bridge/tests/bridge_tests.move
@@ -5,7 +5,7 @@
 module bridge::bridge_tests {
     use bridge::bridge::{
         assert_not_paused, assert_paused, create_bridge_for_testing, execute_system_message,
-        get_token_transfer_action_status, inner_limiter, inner_paused,
+        test_get_token_transfer_action_status, inner_limiter, inner_paused,
         inner_treasury, inner_token_transfer_records, new_bridge_record_for_testing,
         new_for_testing, send_token, test_execute_emergency_op, test_init_bridge_committee,
         test_get_current_seq_num_and_increment, test_execute_update_asset_price,
@@ -15,7 +15,7 @@ module bridge::bridge_tests {
         Bridge,
     };
     use bridge::chain_ids;
-    use bridge::message::{Self, create_blocklist_message};
+    use bridge::message::{Self, create_blocklist_message, to_parsed_token_transfer_message};
     use bridge::message_types;
     use bridge::treasury::{BTC, ETH};
 
@@ -287,7 +287,7 @@ module bridge::bridge_tests {
 
     //     scenario.next_tx(@0xAAAA);
     //     let mut bridge = scenario.take_shared<Bridge>();
-    //     let eth_address = b"01234"; // it does not really matter
+    //     let eth_address = x"0000000000000000000000000000000000000000";
     //     let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, scenario.ctx());
     //     bridge.send_token(
     //         chain_ids::eth_sepolia(),
@@ -301,6 +301,26 @@ module bridge::bridge_tests {
     // }
 
     #[test]
+    #[expected_failure(abort_code = bridge::bridge::EInvalidEvmAddress)]
+    fun test_execute_send_token_invalid_evem_address() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+
+        let eth_address = x"1234"; // invalid evm address
+        let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
+        bridge.send_token(
+            chain_ids::eth_sepolia(),
+            eth_address,
+            btc,
+            ctx,
+        );
+
+        abort TEST_DONE
+    }
+
+    #[test]
     #[expected_failure(abort_code = bridge::bridge::EBridgeUnavailable)]
     fun test_execute_send_token_frozen() {
         let mut scenario = test_scenario::begin(@0x0);
@@ -311,7 +331,7 @@ module bridge::bridge_tests {
         assert!(!bridge.test_load_inner_mut().inner_paused(), UNEXPECTED_ERROR);
         freeze_bridge(&mut bridge, UNEXPECTED_ERROR + 1);
 
-        let eth_address = b"01234"; // it does not really matter
+        let eth_address = x"0000000000000000000000000000000000000000";
         let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
         bridge.send_token(
             chain_ids::eth_sepolia(),
@@ -331,7 +351,7 @@ module bridge::bridge_tests {
         let chain_id = chain_ids::sui_testnet();
         let mut bridge = new_for_testing(chain_id, ctx);
 
-        let eth_address = b"01234"; // it does not really matter
+        let eth_address = x"0000000000000000000000000000000000000000";
         let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
         bridge.send_token(
             chain_ids::eth_mainnet(),
@@ -608,7 +628,7 @@ module bridge::bridge_tests {
     }
 
     #[test]
-    fun test_get_token_transfer_action_status() {
+    fun test_get_token_transfer_action_data() {
         let mut scenario = test_scenario::begin(@0x0);
         let ctx = scenario.ctx();
         let chain_id = chain_ids::sui_testnet();
@@ -632,7 +652,7 @@ module bridge::bridge_tests {
             new_bridge_record_for_testing(message, option::none(), false),
         );
         assert!(
-            bridge.get_token_transfer_action_status(chain_id, 10)
+            bridge.test_get_token_transfer_action_status(chain_id, 10)
                 == transfer_status_pending(),
             UNEXPECTED_ERROR,
         );
@@ -657,7 +677,7 @@ module bridge::bridge_tests {
             new_bridge_record_for_testing(message, option::some(vector[]), false),
         );
         assert!(
-            bridge.get_token_transfer_action_status(chain_id, 11)
+            bridge.test_get_token_transfer_action_status(chain_id, 11)
                 == transfer_status_approved(),
             UNEXPECTED_ERROR + 2,
         );
@@ -665,6 +685,13 @@ module bridge::bridge_tests {
             bridge.test_get_token_transfer_action_signatures(chain_id, 11)
                 == option::some(vector[]),
             UNEXPECTED_ERROR + 3,
+        );
+        assert!(
+            bridge.test_get_parsed_token_transfer_message(chain_id, 11)
+                == option::some(
+                    to_parsed_token_transfer_message(&message)
+                ),
+            UNEXPECTED_ERROR + 7,
         );
 
         // Test when already claimed
@@ -683,7 +710,7 @@ module bridge::bridge_tests {
             new_bridge_record_for_testing(message, option::some(vector[b"1234"]), true),
         );
         assert!(
-            bridge.get_token_transfer_action_status(chain_id, 12)
+            bridge.test_get_token_transfer_action_status(chain_id, 12)
                 == transfer_status_claimed(),
             UNEXPECTED_ERROR + 3,
         );
@@ -692,10 +719,17 @@ module bridge::bridge_tests {
                 == option::some(vector[b"1234"]),
             UNEXPECTED_ERROR + 4,
         );
+        assert!(
+            bridge.test_get_parsed_token_transfer_message(chain_id, 12)
+                == option::some(
+                    to_parsed_token_transfer_message(&message)
+                ),
+            UNEXPECTED_ERROR + 8,
+        );
 
         // Test when message not found
         assert!(
-            bridge.get_token_transfer_action_status(chain_id, 13)
+            bridge.test_get_token_transfer_action_status(chain_id, 13)
                 == transfer_status_not_found(),
             UNEXPECTED_ERROR + 5,
         );
@@ -703,6 +737,11 @@ module bridge::bridge_tests {
             bridge.test_get_token_transfer_action_signatures(chain_id, 13)
                 == option::none(),
             UNEXPECTED_ERROR + 6,
+        );
+        assert!(
+            bridge.test_get_parsed_token_transfer_message(chain_id, 13)
+                == option::none(),
+            UNEXPECTED_ERROR + 8,
         );
 
         destroy(bridge);

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x301001a2da5a8b89d39bbfb0db52e0750645b40280421ab360d886ea7a10a67c"
+            id: "0xc376408c48fc9dae428b77c003042ed36ab3e845c3f14fd80b3f031e3665abf4"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xcea25dc4c27a4b98a32c49d6c5f3e40eb050247d51430c41813c7ab12fe7e6f6"
+      operation_cap_id: "0xa73f4a1b5638e83624f63bc1cb85bd56b5d9ae54235302e0135d0cab6d12c5ea"
       gas_price: 1000
       staking_pool:
-        id: "0x91b44d5ed7c735997db131170400d11fe8ad85de99c28ebcda96892b513b5b93"
+        id: "0xb9e17bbc5b6d7b3c60be01cf450f2920cdf803aae8a382443fdbb11cd7133553"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x2996d8dc358db9faa46cbf628ebf48a07f4b30c950d0c7cee9138c4a68fcf2ba"
+          id: "0xdd4510280a040a7145755ee523b65ce34900ddbe06218f3bfbbcf6aea0c33cb9"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xbbc95c8d45a2bd951bfc5d3bed4aaab7ceae5930af943acdd61056ebe58fc246"
+            id: "0xfd66551b30b50a0ec8da2b15e6af70485208c8497a5a4051c886a86fa576d6cc"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xa88affe32e7e3443bc29ddbcfaa9c116970b4b8092115192c90e1e9f5a6391ed"
+          id: "0xeff26e59e7262396c0861e5155aa3e66bbf9668e527de7a61124721ec1a25087"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x369e2df71f9dd4f249ceef645df2cb61197b8d90f688b35324db31b00d30f4a7"
+      id: "0xd72855b715240ced6df3fe150ef1f823a27eb3e964885198bee21cb6a6c8d2ed"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x3bd68479772cbbab79cb8294595fd43cf82bfd070e0a76012806edffda4b0492"
+    id: "0xa89baad48faa8685fb6d3ed3db04d0ffc59541c1815a582db20cff63109bc9e6"
     size: 1
   inactive_validators:
-    id: "0xd7df14722d8e94e6d497180a1b4ee8a938926674225443b3bbf9c87f92c7d456"
+    id: "0xb262e80ac653eb8a8f5b277ed09efe9efae6a78e25882ce0bb8f99541bd329e0"
     size: 0
   validator_candidates:
-    id: "0xa401245a4acbebf49b117fd42b880f780330bf6ba332f5d0e91cebca82fe2ed5"
+    id: "0x279094294db09e435a645a662a46921d45bfdb6c5f3ad3798aadd56f160f41d1"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xbe9434e5941668f2b562e24515159284ac8439326374459fc4c455fce4fda11a"
+      id: "0x0bc121a2df62803f22136a078d8580a5ce79fcb225abc4db9710acab45c4a702"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x6759fedf0a67590481121e9e196d1038615d9fd97a057df996a935798cf5945b"
+      id: "0xb62b878db46510b3ee41579bfc968937267006035c6719b51fc7c985c9b9a0f8"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x955f9c3533be3df6a61471c23bc12ed334d5a928344fadd16b3f573c92a5d21f"
+      id: "0x17c08775beea75c6af6d8021544c2316d40125e925f34af49d07e5d54ebccc23"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x57a5ee6193393884e9e3f24584867ab7c1d93988c69cbab511c1f10e07e15d65"
+    id: "0x1524154f6a7176c53b2fd709e29c4e2e076f2287385b76d32c0789af32448d7d"
   size: 0
 

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -475,3 +475,23 @@ pub fn is_bridge_committee_initiated(object_store: &dyn ObjectStore) -> SuiResul
         Err(other) => Err(other),
     }
 }
+
+/// Rust version of the Move message::TokenTransferPayload type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct MoveTypeTokenTransferPayload {
+    pub sender_address: Vec<u8>,
+    pub target_chain: u8,
+    pub target_address: Vec<u8>,
+    pub token_type: u8,
+    pub amount: u64,
+}
+
+/// Rust version of the Move message::ParsedTokenTransferMessage type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct MoveTypeParsedTokenTransferMessage {
+    pub message_version: u8,
+    pub seq_num: u64,
+    pub source_chain: u8,
+    pub payload: Vec<u8>,
+    pub parsed_payload: MoveTypeTokenTransferPayload,
+}


### PR DESCRIPTION
## Description 

1. add move struct `ParsedTokenTransferMessage` and function `get_parsed_token_transfer_message` to get parsed token transfer data given chain id and seq num
3. make function `get_token_transfer_action_status` private
4. rename `TokenPayload` to `TokenTransferPayload`
5. refactor `get_token_transfer_xyz` and extract common logic to `dev_inspect_bridge` 

## Test plan 

existing tests and new tests added in this PR

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
