### PR TITLE
docs: add dapp-kit (vue) to reference docs on siderbar

### DIFF
--- a/docs/content/references/sui-sdks.mdx
+++ b/docs/content/references/sui-sdks.mdx
@@ -32,7 +32,7 @@ While the community projects are expertly developed, their maintenance and commu
 
 <Cards>
 <Card title="dApp Kit (Vue)" href="https://github.com/SuiFansCN/suiue">
-    Sui dApp kit for the Vue framework.
+    Sui dApp Kit for the Vue framework.
 </Card>
 <Card title="Dart SDK" href="https://github.com/mofalabs/sui">
     A cross-platform Sui SDK for mobile, web, and desktop.

--- a/docs/content/references/sui-sdks.mdx
+++ b/docs/content/references/sui-sdks.mdx
@@ -31,6 +31,9 @@ While the community projects are expertly developed, their maintenance and commu
 :::
 
 <Cards>
+<Card title="dApp Kit (Vue)" href="https://github.com/SuiFansCN/suiue">
+    Sui dApp kit for the Vue framework.
+</Card>
 <Card title="Dart SDK" href="https://github.com/mofalabs/sui">
     A cross-platform Sui SDK for mobile, web, and desktop.
 </Card>

--- a/docs/content/sidebars/references.js
+++ b/docs/content/sidebars/references.js
@@ -69,6 +69,11 @@ const references = [
 				label: 'dApp Kit',
 				href: 'https://sdk.mystenlabs.com/dapp-kit',
 			},
+			{
+				type: 'link',
+				label: 'dApp Kit (Vue)',
+				href: 'https://github.com/SuiFansCN/suiue',
+			},
 			'references/rust-sdk',
 			{
 				type: 'link',

--- a/docs/content/sidebars/references.js
+++ b/docs/content/sidebars/references.js
@@ -69,11 +69,6 @@ const references = [
 				label: 'dApp Kit',
 				href: 'https://sdk.mystenlabs.com/dapp-kit',
 			},
-			{
-				type: 'link',
-				label: 'dApp Kit (Vue)',
-				href: 'https://github.com/SuiFansCN/suiue',
-			},
 			'references/rust-sdk',
 			{
 				type: 'link',


### PR DESCRIPTION
add dapp-kit (vue) link to docs reference