### PR TITLE
[GraphQL] 

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3965,12 +3965,22 @@ type Validator {
 	The validator's current staking pool object, used to track the amount of stake
 	and to compound staking rewards.
 	"""
-	stakingPool: MoveObject
+	stakingPool: MoveObject @deprecated(reason: "The staking pool is a wrapped object. Access its fields directly on the `Validator` type.")
+	"""
+	The ID of this validator's `0x3::staking_pool::StakingPool`.
+	"""
+	stakingPoolId: SuiAddress!
 	"""
 	The validator's current exchange object. The exchange rate is used to determine
 	the amount of SUI tokens that each past SUI staker can withdraw in the future.
 	"""
-	exchangeRates: MoveObject
+	exchangeRates: MoveObject @deprecated(reason: "The exchange object is a wrapped object. Access its dynamic fields through the `exchangeRatesTable` query.")
+	"""
+	A wrapped object containing the validator's exchange rates. This is a table from epoch
+	number to `PoolTokenExchangeRate` value. The exchange rate is used to determine the amount
+	of SUI tokens that each past SUI staker can withdraw in the future.
+	"""
+	exchangeRatesTable: Owner
 	"""
 	Number of exchange rates in the table.
 	"""

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -9,6 +9,7 @@ use async_graphql::connection::{Connection, CursorType, Edge};
 use super::big_int::BigInt;
 use super::move_object::MoveObject;
 use super::object::Object;
+use super::owner::Owner;
 use super::sui_address::SuiAddress;
 use super::validator_credentials::ValidatorCredentials;
 use super::{address::Address, base64::Base64};
@@ -106,26 +107,37 @@ impl Validator {
 
     /// The validator's current staking pool object, used to track the amount of stake
     /// and to compound staking rewards.
-    async fn staking_pool(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        MoveObject::query(
-            ctx,
-            self.staking_pool_id(),
-            Object::latest_at(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+    #[graphql(
+        deprecation = "The staking pool is a wrapped object. Access its fields directly on the \
+        `Validator` type."
+    )]
+    async fn staking_pool(&self) -> Result<Option<MoveObject>> {
+        Ok(None)
+    }
+
+    /// The ID of this validator's `0x3::staking_pool::StakingPool`.
+    async fn staking_pool_id(&self) -> SuiAddress {
+        self.validator_summary.staking_pool_id.into()
     }
 
     /// The validator's current exchange object. The exchange rate is used to determine
     /// the amount of SUI tokens that each past SUI staker can withdraw in the future.
-    async fn exchange_rates(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        MoveObject::query(
-            ctx,
-            self.exchange_rates_id(),
-            Object::latest_at(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+    #[graphql(
+        deprecation = "The exchange object is a wrapped object. Access its dynamic fields through \
+        the `exchangeRatesTable` query."
+    )]
+    async fn exchange_rates(&self) -> Result<Option<MoveObject>> {
+        Ok(None)
+    }
+
+    /// A wrapped object containing the validator's exchange rates. This is a table from epoch
+    /// number to `PoolTokenExchangeRate` value. The exchange rate is used to determine the amount
+    /// of SUI tokens that each past SUI staker can withdraw in the future.
+    async fn exchange_rates_table(&self) -> Result<Option<Owner>> {
+        Ok(Some(Owner {
+            address: self.validator_summary.exchange_rates_id.into(),
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
+        }))
     }
 
     /// Number of exchange rates in the table.
@@ -265,11 +277,5 @@ impl Validator {
 impl Validator {
     pub fn operation_cap_id(&self) -> SuiAddress {
         SuiAddress::from_array(**self.validator_summary.operation_cap_id)
-    }
-    pub fn staking_pool_id(&self) -> SuiAddress {
-        SuiAddress::from_array(**self.validator_summary.staking_pool_id)
-    }
-    pub fn exchange_rates_id(&self) -> SuiAddress {
-        SuiAddress::from_array(**self.validator_summary.exchange_rates_id)
     }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3969,12 +3969,22 @@ type Validator {
 	The validator's current staking pool object, used to track the amount of stake
 	and to compound staking rewards.
 	"""
-	stakingPool: MoveObject
+	stakingPool: MoveObject @deprecated(reason: "The staking pool is a wrapped object. Access its fields directly on the `Validator` type.")
+	"""
+	The ID of this validator's `0x3::staking_pool::StakingPool`.
+	"""
+	stakingPoolId: SuiAddress!
 	"""
 	The validator's current exchange object. The exchange rate is used to determine
 	the amount of SUI tokens that each past SUI staker can withdraw in the future.
 	"""
-	exchangeRates: MoveObject
+	exchangeRates: MoveObject @deprecated(reason: "The exchange object is a wrapped object. Access its dynamic fields through the `exchangeRatesTable` query.")
+	"""
+	A wrapped object containing the validator's exchange rates. This is a table from epoch
+	number to `PoolTokenExchangeRate` value. The exchange rate is used to determine the amount
+	of SUI tokens that each past SUI staker can withdraw in the future.
+	"""
+	exchangeRatesTable: Owner
 	"""
 	Number of exchange rates in the table.
 	"""


### PR DESCRIPTION
## Description 

Deprecates the ` exchange_rates` and `staking_pool` resolvers on validator type, and adds a `staking_pool_id` and `exchange_rates_table` resolver to correctly return the staking pool id and the wrapped exchange rates object.


## Test plan 

Existing tests:
```
cd sui-graphql-e2e-tests && cargo nextest run --features pg_integration
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL:  Deprecated the ` exchange_rates` and `staking_pool` resolvers on validator type, and added a `staking_pool_id` and `exchange_rates_table` resolver to correctly return the staking pool id and the wrapped exchange rates object.
- [ ] CLI: 
- [ ] Rust SDK: 
