### PR TITLE
[replay] Remove bcs serde support for sandbox data

### DIFF
--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -48,6 +48,12 @@ pub struct OnChainTransactionInfo {
     pub gas_price: u64,
     pub executed_epoch: u64,
     pub dependencies: Vec<TransactionDigest>,
+    // TODO: There are two problems with this being a json-rpc type:
+    // 1. The json-rpc type is not a perfect mirror with TransactionEffects since v2. We lost the
+    // ability to replay effects v2 specific forks. We need to fix this asap. Unfortunately at the moment
+    // it is really difficult to get the raw effects given a transaction digest.
+    // 2. This data structure is not bcs/bincode friendly. It makes it much more expensive to
+    // store the sandbox state for batch replay.
     pub effects: SuiTransactionBlockEffects,
     pub protocol_version: ProtocolVersion,
     pub epoch_start_timestamp: u64,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -48,7 +48,7 @@ use sui_move_build::{
     gather_published_ids, BuildConfig, CompiledPackage, PackageDependencies, PublishedAtError,
 };
 use sui_package_management::LockCommand;
-use sui_replay::{ReplayToolCommand, SandboxFileFormat};
+use sui_replay::ReplayToolCommand;
 use sui_sdk::{
     apis::ReadApi,
     sui_client_config::{SuiClientConfig, SuiEnv},
@@ -755,7 +755,6 @@ impl SuiClientCommands {
                     terminate_early,
                     num_tasks: 16,
                     persist_path: None,
-                    sandbox_format: SandboxFileFormat::Json,
                 };
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =


### PR DESCRIPTION
## Description 

Unfortunately the json-rpc types cannot be stably serde-ed.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
