### PR TITLE
Update test util for creating shared objects

### DIFF
--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -410,8 +410,8 @@ mod tests {
     // Tests shared object version assignment for cancelled transaction.
     #[tokio::test]
     async fn test_assign_versions_from_consensus_with_cancellation() {
-        let shared_object_1 = Object::with_id_shared_for_testing(ObjectID::random());
-        let shared_object_2 = Object::with_id_shared_for_testing(ObjectID::random());
+        let shared_object_1 = Object::shared_for_testing();
+        let shared_object_2 = Object::shared_for_testing();
         let id1 = shared_object_1.id();
         let id2 = shared_object_2.id();
         let init_shared_version_1 = match shared_object_1.owner {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -841,7 +841,8 @@ mod tests {
     pub async fn test_consensus_handler() {
         // GIVEN
         let mut objects = test_gas_objects();
-        objects.push(Object::shared_for_testing());
+        let shared_object = Object::shared_for_testing();
+        objects.push(shared_object.clone());
 
         let latest_protocol_config = &latest_protocol_version();
 
@@ -876,7 +877,7 @@ mod tests {
 
         // AND
         // Create test transactions
-        let transactions = test_certificates(&state).await;
+        let transactions = test_certificates(&state, shared_object).await;
         let mut certificates = Vec::new();
         let mut batches = Vec::new();
 

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -216,7 +216,8 @@ mod tests {
         // Initialize an authority with a (owned) gas object and a shared object; then
         // make a test certificate.
         let mut objects = test_gas_objects();
-        objects.push(Object::shared_for_testing());
+        let shared_object = Object::shared_for_testing();
+        objects.push(shared_object.clone());
 
         let latest_protocol_config = &latest_protocol_version();
 
@@ -230,7 +231,7 @@ mod tests {
             .build()
             .await;
         let name1 = state.name;
-        let certificates = test_certificates(&state).await;
+        let certificates = test_certificates(&state, shared_object).await;
 
         let first_transaction = certificates[0].clone();
         let first_transaction_bytes: Vec<u8> = bcs::to_bytes(

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -39,13 +39,15 @@ pub fn test_gas_objects() -> Vec<Object> {
 }
 
 /// Fixture: a few test certificates containing a shared object.
-pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTransaction> {
+pub async fn test_certificates(
+    authority: &AuthorityState,
+    shared_object: Object,
+) -> Vec<CertifiedTransaction> {
     let epoch_store = authority.load_epoch_store_one_call_per_task();
     let (sender, keypair) = deterministic_random_account_key();
     let rgp = epoch_store.reference_gas_price();
 
     let mut certificates = Vec::new();
-    let shared_object = Object::shared_for_testing();
     let shared_object_arg = ObjectArg::SharedObject {
         id: shared_object.id(),
         initial_shared_version: shared_object.version(),
@@ -108,9 +110,13 @@ async fn submit_transaction_to_consensus_adapter() {
     // Initialize an authority with a (owned) gas object and a shared object; then
     // make a test certificate.
     let mut objects = test_gas_objects();
-    objects.push(Object::shared_for_testing());
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
     let state = init_state_with_objects(objects).await;
-    let certificate = test_certificates(&state).await.pop().unwrap();
+    let certificate = test_certificates(&state, shared_object)
+        .await
+        .pop()
+        .unwrap();
     let epoch_store = state.epoch_store_for_testing();
 
     let metrics = ConsensusAdapterMetrics::new_test();

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -193,8 +193,8 @@ async fn transaction_manager_object_dependency() {
             Object::with_id_owner_for_testing(gas_object_id, owner)
         })
         .collect();
-    let shared_object = Object::with_id_shared_for_testing(ObjectID::random());
-    let shared_object_2 = Object::with_id_shared_for_testing(ObjectID::random());
+    let shared_object = Object::shared_for_testing();
+    let shared_object_2 = Object::shared_for_testing();
 
     let state = init_state_with_objects(
         [
@@ -723,8 +723,8 @@ async fn transaction_manager_with_cancelled_transactions() {
     // Initialize an authority state, with gas objects and 3 shared objects.
     let (owner, _keypair) = deterministic_random_account_key();
     let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), owner);
-    let shared_object_1 = Object::with_id_shared_for_testing(ObjectID::random());
-    let shared_object_2 = Object::with_id_shared_for_testing(ObjectID::random());
+    let shared_object_1 = Object::shared_for_testing();
+    let shared_object_2 = Object::shared_for_testing();
     let owned_object = Object::with_id_owner_for_testing(ObjectID::random(), owner);
 
     let state = init_state_with_objects(vec![

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -926,17 +926,9 @@ impl Object {
         Self::immutable_with_id_for_testing(IMMUTABLE_OBJECT_ID.with(|id| *id))
     }
 
-    /// Make a test shared object. Note that this function returns the same object called from the same thread.
+    /// Make a new random test shared object.
     pub fn shared_for_testing() -> Object {
-        thread_local! {
-            static SHARED_OBJECT_ID: ObjectID = ObjectID::random();
-        }
-
-        Object::with_id_shared_for_testing(SHARED_OBJECT_ID.with(|id| *id))
-    }
-
-    /// Make a new test sahred object.
-    pub fn with_id_shared_for_testing(id: ObjectID) -> Object {
+        let id = ObjectID::random();
         let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, id, 10);
         let owner = Owner::Shared {
             initial_shared_version: obj.version(),


### PR DESCRIPTION
## Description 

We have two test utils that create a random shared object
 - shared_for_testing, which returns a shared object always with the same ID when calling from the same thread
 - with_id_shared_for_testing, which returns a random shared object each time called

Looking at the history of shared_for_testing, it was first created to be used in a specific test, where a random object ID
is hard coded. Later on, the function is gradually moved to be a global test util, but the move always tries to preserve the
function semantic that when called multiple times, same object ID is used. Particularly, test_certificates() expects using the same shared object as the tests calling this function.

Therefore, we probably don't want to have a shared_for_testing with a surprising semantics. This PR merges
with_id_shared_for_testing into shared_for_testing so that it always returns a random shared object, and explicitly
pass the shared object when calling test_certificates()

## Test plan 

Unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
