### PR TITLE
[gql] expose db_pool_size on ConnectionConfig (#17595)

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -31,6 +31,9 @@ pub enum Command {
         /// DB URL for data fetching
         #[clap(short, long)]
         db_url: Option<String>,
+        /// Pool size for DB connections
+        #[clap(long)]
+        db_pool_size: Option<u32>,
         /// Port to bind the server to
         #[clap(short, long)]
         port: Option<u16>,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -39,7 +39,7 @@ pub(crate) const DEFAULT_SERVER_CONNECTION_PORT: u16 = 8000;
 pub(crate) const DEFAULT_SERVER_CONNECTION_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_SERVER_DB_URL: &str =
     "postgres://postgres:postgrespw@localhost:5432/sui_indexer";
-pub(crate) const DEFAULT_SERVER_DB_POOL_SIZE: u32 = 3;
+pub(crate) const DEFAULT_SERVER_DB_POOL_SIZE: u32 = 10;
 pub(crate) const DEFAULT_SERVER_PROM_HOST: &str = "0.0.0.0";
 pub(crate) const DEFAULT_SERVER_PROM_PORT: u16 = 9184;
 pub(crate) const DEFAULT_WATERMARK_UPDATE_MS: u64 = 500;

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -86,6 +86,7 @@ async fn main() {
         Command::StartServer {
             ide_title,
             db_url,
+            db_pool_size,
             port,
             host,
             config,
@@ -93,7 +94,8 @@ async fn main() {
             prom_host,
             prom_port,
         } => {
-            let connection = ConnectionConfig::new(port, host, db_url, None, prom_host, prom_port);
+            let connection =
+                ConnectionConfig::new(port, host, db_url, db_pool_size, prom_host, prom_port);
             let service_config = service_config(config);
             let _guard = telemetry_subscribers::TelemetryConfig::new()
                 .with_env()


### PR DESCRIPTION
## Description 

There isn't a way to configure `db_pool_size` on `ConnectionConfig` since it's not exposed on `start_server`. This is a simple PR that exposes it, and bumps the default pool size from 3 to 10. This is because we already have a few background tasks in addition to the main graphql service.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Expose an additional parameter `db_pool_size` on `start-server` command so that users can configure how many db connections the graphql service will spin up for its pool.
- [ ] CLI: 
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
