### PR TITLE
[Simtest] reduce surfer traffic and increase simtest nightly timeout

### DIFF
--- a/.github/workflows/simulator-nightly-mysticeti.yml
+++ b/.github/workflows/simulator-nightly-mysticeti.yml
@@ -5,7 +5,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 17 * * *' # UTC timing is every day at 9am PST
+    - cron: '0 15 * * *' # equivalent to 7am PST
   workflow_dispatch:
     inputs:
       sui_ref:
@@ -28,7 +28,8 @@ env:
 
 jobs:
   simtest:
-    timeout-minutes: 240
+    # Allow running the job for up to 6 hours, maximum for GitHub Actions.
+    timeout-minutes: 360
     permissions:
       # The "id-token: write" permission is required or Machine ID will not be
       # able to authenticate with the cluster.

--- a/.github/workflows/simulator-nightly-narwhal.yml
+++ b/.github/workflows/simulator-nightly-narwhal.yml
@@ -5,7 +5,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 13 * * *' # UTC timing is every day at 5am PST
+    - cron: '0 3 * * *' # equivalent to 7PM PST
   workflow_dispatch:
     inputs:
       sui_ref:
@@ -28,7 +28,8 @@ env:
 
 jobs:
   simtest:
-    timeout-minutes: 240
+    # Allow running the job for up to 6 hours, maximum for GitHub Actions.
+    timeout-minutes: 360
     permissions:
       # The "id-token: write" permission is required or Machine ID will not be
       # able to authenticate with the cluster.

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -5,7 +5,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 9 * * *' # UTC timing is every day at 1am PST
+    - cron: '0 9 * * *' # equivalent to 1am PST
   workflow_dispatch:
     inputs:
       sui_ref:
@@ -25,7 +25,8 @@ env:
 
 jobs:
   simtest:
-    timeout-minutes: 240
+    # Allow running the job for up to 6 hours, maximum for GitHub Actions.
+    timeout-minutes: 360
     permissions:
       # The "id-token: write" permission is required or Machine ID will not be
       # able to authenticate with the cluster.

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -775,7 +775,7 @@ mod test {
                 .collect();
             info!("using sui_surfer test packages: {test_package_paths:?}");
 
-            let surf_strategy = SurfStrategy::new(Duration::from_millis(250));
+            let surf_strategy = SurfStrategy::new(Duration::from_millis(400));
             let results = sui_surfer::run_with_test_cluster_and_strategy(
                 surf_strategy,
                 test_duration,


### PR DESCRIPTION
## Description 

Simtest has been timing out for awhile, because of increased transaction workload. Reducing the transactions sent from Sui surfer and increase simtest nightly timeout.

## Test plan 

CI
https://github.com/MystenLabs/sui/actions/runs/9012876888: probably will be cancel by other runs, but worth checking if it is taking too long.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
