### PR TITLE
[indexer] primary key of tx_calls should include module and func

### DIFF
--- a/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
@@ -19,7 +19,7 @@ CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequenc
 CREATE TABLE tx_input_objects (
     cp_sequence_number          BIGINT       NOT NULL,
     tx_sequence_number          BIGINT       NOT NULL,
-    -- Object ID in bytes. 
+    -- Object ID in bytes.
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
 );
@@ -40,10 +40,10 @@ CREATE TABLE tx_calls (
     func                        TEXT         NOT NULL,
     -- 1. Using Primary Key as a unique index.
     -- 2. Diesel does not like tables with no primary key.
-    PRIMARY KEY(package, tx_sequence_number, cp_sequence_number)
+    PRIMARY KEY(package, module, func, tx_sequence_number, cp_sequence_number)
 );
+CREATE INDEX tx_calls_package ON tx_calls (package, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_module ON tx_calls (package, module, tx_sequence_number, cp_sequence_number);
-CREATE INDEX tx_calls_func ON tx_calls (package, module, func, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number, cp_sequence_number);
 
 -- un-partitioned table for tx_digest -> (cp_sequence_number, tx_sequence_number) lookup.

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -223,7 +223,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    tx_calls (package, tx_sequence_number, cp_sequence_number) {
+    tx_calls (package, module, func, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         package -> Bytea,


### PR DESCRIPTION
## Description 

One transaction can call multiple functions in a package so the primary key should include all parts of a function - package, module, func.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
