### PR TITLE
Update ecvrf.mdx for hexdecimal mismatch

### DIFF
--- a/docs/content/guides/developer/cryptography/ecvrf.mdx
+++ b/docs/content/guides/developer/cryptography/ecvrf.mdx
@@ -30,7 +30,7 @@ Public key: 928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015
 
 ### Compute VRF output and proof
 
-To compute the VRF output and proof for the input string `Hello, World!`, which is `48656c6c6f2c20776f726c6421` in hexadecimal, with the key pair generated previously, run the following command:
+To compute the VRF output and proof for the input string `Hello, world!`, which is `48656c6c6f2c20776f726c6421` in hexadecimal, with the key pair generated previously, run the following command:
 
 ```shell
 cargo run --bin ecvrf-cli prove --input 48656c6c6f2c20776f726c6421 --secret-key c0cbc5bf0b2f992fe14fee0327463c7b03d14cbbcb38ce2584d95ee0c112b40b


### PR DESCRIPTION
The hexdecimal of `Hello, World!` is not `48656c6c6f2c20776f726c6421`, in which `W`'s hexdecimal should be 57, while 77 corresponds to `w`.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
