### PR TITLE
Revert "Revert "[std] Better ASCII methods + minor cleanup in std (#1…

### DIFF
--- a/crates/sui-cost/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/sui-cost/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -3,10 +3,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use sui::coin::{Self, TreasuryCap};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/crates/sui-framework/docs/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/move-stdlib/ascii.md
@@ -16,14 +16,24 @@ that characters are valid ASCII, and that strings consist of only valid ASCII ch
 -  [Function `push_char`](#0x1_ascii_push_char)
 -  [Function `pop_char`](#0x1_ascii_pop_char)
 -  [Function `length`](#0x1_ascii_length)
+-  [Function `append`](#0x1_ascii_append)
+-  [Function `insert`](#0x1_ascii_insert)
+-  [Function `substring`](#0x1_ascii_substring)
 -  [Function `as_bytes`](#0x1_ascii_as_bytes)
 -  [Function `into_bytes`](#0x1_ascii_into_bytes)
 -  [Function `byte`](#0x1_ascii_byte)
 -  [Function `is_valid_char`](#0x1_ascii_is_valid_char)
 -  [Function `is_printable_char`](#0x1_ascii_is_printable_char)
+-  [Function `is_empty`](#0x1_ascii_is_empty)
+-  [Function `to_uppercase`](#0x1_ascii_to_uppercase)
+-  [Function `to_lowercase`](#0x1_ascii_to_lowercase)
+-  [Function `index_of`](#0x1_ascii_index_of)
+-  [Function `char_to_uppercase`](#0x1_ascii_char_to_uppercase)
+-  [Function `char_to_lowercase`](#0x1_ascii_char_to_lowercase)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../move-stdlib/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -93,12 +103,22 @@ An ASCII character.
 ## Constants
 
 
-<a name="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
+<a name="0x1_ascii_EInvalidASCIICharacter"></a>
 
 An invalid ASCII character was encountered when creating an ASCII string.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>: u64 = 65536;
+<pre><code><b>const</b> <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidASCIICharacter">EInvalidASCIICharacter</a>: u64 = 65536;
+</code></pre>
+
+
+
+<a name="0x1_ascii_EInvalidIndex"></a>
+
+An invalid index was encountered when creating a substring.
+
+
+<pre><code><b>const</b> <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>: u64 = 65537;
 </code></pre>
 
 
@@ -120,7 +140,7 @@ Convert a <code>byte</code> into a <code><a href="../move-stdlib/ascii.md#0x1_as
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a> {
-    <b>assert</b>!(<a href="../move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(byte), <a href="../move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>);
+    <b>assert</b>!(<a href="../move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(byte), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidASCIICharacter">EInvalidASCIICharacter</a>);
     <a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a> { byte }
 }
 </code></pre>
@@ -148,7 +168,7 @@ Convert a vector of bytes <code>bytes</code> into an <code><a href="../move-stdl
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string">string</a>(bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
    <b>let</b> x = <a href="../move-stdlib/ascii.md#0x1_ascii_try_string">try_string</a>(bytes);
-   <b>assert</b>!(x.is_some(), <a href="../move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>);
+   <b>assert</b>!(x.is_some(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidASCIICharacter">EInvalidASCIICharacter</a>);
    x.destroy_some()
 }
 </code></pre>
@@ -228,6 +248,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 ## Function `push_char`
 
+Push a <code><a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> to the end of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_push_char">push_char</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, char: <a href="../move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>)
@@ -252,6 +273,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 ## Function `pop_char`
 
+Pop a <code><a href="../move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> from the end of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_pop_char">pop_char</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>
@@ -276,6 +298,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 ## Function `length`
 
+Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> in bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): u64
@@ -289,6 +312,91 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="../move-stdl
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): u64 {
     <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_as_bytes">as_bytes</a>().<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_append"></a>
+
+## Function `append`
+
+Append the <code>other</code> string to the end of <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, other: <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, other: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
+    <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_append">append</a>(other.<a href="../move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_insert"></a>
+
+## Function `insert`
+
+Insert the <code>other</code> string at the <code>at</code> index of <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, at: u64, o: <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, at: u64, o: <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>) {
+    <b>assert</b>!(at &lt;= s.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
+    <b>let</b> <b>mut</b> bytes = o.<a href="../move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>();
+    <b>while</b> (!bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>()) {
+        s.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_insert">insert</a>(bytes.pop_back(), at);
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_substring"></a>
+
+## Function `substring`
+
+Copy the slice of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> from <code>i</code> to <code>j</code> into a new <code><a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_substring">substring</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, <b>mut</b> i: u64, j: u64): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+    <b>assert</b>!(i &lt;= j && j &lt;= <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), <a href="../move-stdlib/ascii.md#0x1_ascii_EInvalidIndex">EInvalidIndex</a>);
+    <b>let</b> <b>mut</b> bytes = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
+    <b>while</b> (i &lt; j) {
+        bytes.push_back(<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i]);
+        i = i + 1;
+    };
+    <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> { bytes }
 }
 </code></pre>
 
@@ -351,7 +459,7 @@ Unpack the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>
 
 ## Function `byte`
 
-Unpack the <code>char</code> into its underlying byte.
+Unpack the <code>char</code> into its underlying bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a>(char: <a href="../move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>): u8
@@ -377,7 +485,8 @@ Unpack the <code>char</code> into its underlying byte.
 
 ## Function `is_valid_char`
 
-Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
+Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character.
+Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool
@@ -402,7 +511,8 @@ Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. R
 
 ## Function `is_printable_char`
 
-Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
+Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character.
+Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool
@@ -417,6 +527,185 @@ Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII char
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool {
    byte &gt;= 0x20 && // Disallow metacharacters
    <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7E // Don't allow DEL metacharacter
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_is_empty"></a>
+
+## Function `is_empty`
+
+Returns <code><b>true</b></code> if <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): bool {
+    <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes.<a href="../move-stdlib/ascii.md#0x1_ascii_is_empty">is_empty</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_to_uppercase"></a>
+
+## Function `to_uppercase`
+
+Convert a <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> to its uppercase equivalent.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_uppercase">to_uppercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_uppercase">to_uppercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+    <b>let</b> (<b>mut</b> i, <b>mut</b> bytes) = (0, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[]);
+    <b>while</b> (i &lt; <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>()) {
+        bytes.push_back(<a href="../move-stdlib/ascii.md#0x1_ascii_char_to_uppercase">char_to_uppercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i]));
+        i = i + 1;
+    };
+    <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_to_lowercase"></a>
+
+## Function `to_lowercase`
+
+Convert a <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> to its lowercase equivalent.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_lowercase">to_lowercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_to_lowercase">to_lowercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> {
+    <b>let</b> (<b>mut</b> i, <b>mut</b> bytes) = (0, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[]);
+    <b>while</b> (i &lt; <a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>()) {
+        bytes.push_back(<a href="../move-stdlib/ascii.md#0x1_ascii_char_to_lowercase">char_to_lowercase</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i]));
+        i = i + 1;
+    };
+    <a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a> { bytes }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_index_of"></a>
+
+## Function `index_of`
+
+Computes the index of the first occurrence of the <code>substr</code> in the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code>.
+Returns the length of the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> if the <code>substr</code> is not found.
+Returns 0 if the <code>substr</code> is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_index_of">index_of</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>, substr: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_index_of">index_of</a>(<a href="../move-stdlib/string.md#0x1_string">string</a>: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>, substr: &<a href="../move-stdlib/ascii.md#0x1_ascii_String">String</a>): u64 {
+    <b>let</b> <b>mut</b> i = 0;
+    <b>let</b> (n, m) = (<a href="../move-stdlib/string.md#0x1_string">string</a>.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>(), substr.<a href="../move-stdlib/ascii.md#0x1_ascii_length">length</a>());
+    <b>if</b> (n &lt; m) <b>return</b> n;
+    <b>while</b> (i &lt;= n - m) {
+        <b>let</b> <b>mut</b> j = 0;
+        <b>while</b> (j &lt; m && <a href="../move-stdlib/string.md#0x1_string">string</a>.bytes[i + j] == substr.bytes[j]) j = j + 1;
+        <b>if</b> (j == m) <b>return</b> i;
+        i = i + 1;
+    };
+    n
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_char_to_uppercase"></a>
+
+## Function `char_to_uppercase`
+
+Convert a <code>char</code> to its lowercase equivalent.
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_uppercase">char_to_uppercase</a>(byte: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_uppercase">char_to_uppercase</a>(byte: u8): u8 {
+    <b>if</b> (byte &gt;= 0x61 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x7A) {
+        byte - 0x20
+    } <b>else</b> {
+        byte
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ascii_char_to_lowercase"></a>
+
+## Function `char_to_lowercase`
+
+Convert a <code>char</code> to its lowercase equivalent.
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_lowercase">char_to_lowercase</a>(byte: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="../move-stdlib/ascii.md#0x1_ascii_char_to_lowercase">char_to_lowercase</a>(byte: u8): u8 {
+    <b>if</b> (byte &gt;= 0x41 && <a href="../move-stdlib/ascii.md#0x1_ascii_byte">byte</a> &lt;= 0x5A) {
+        byte + 0x20
+    } <b>else</b> {
+        byte
+    }
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/move-stdlib/option.md
+++ b/crates/sui-framework/docs/move-stdlib/option.md
@@ -65,24 +65,24 @@ zero or one because Move bytecode does not have ADTs.
 ## Constants
 
 
-<a name="0x1_option_EOPTION_IS_SET"></a>
+<a name="0x1_option_EOptionIsSet"></a>
 
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>Some</code> while it should be <code>None</code>.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>: u64 = 262144;
+<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOptionIsSet">EOptionIsSet</a>: u64 = 262144;
 </code></pre>
 
 
 
-<a name="0x1_option_EOPTION_NOT_SET"></a>
+<a name="0x1_option_EOptionNotSet"></a>
 
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
 The <code><a href="../move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>None</code> while it should be <code>Some</code>.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>: u64 = 262145;
+<pre><code><b>const</b> <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>: u64 = 262145;
 </code></pre>
 
 
@@ -231,7 +231,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     &t.vec[0]
 }
 </code></pre>
@@ -319,7 +319,7 @@ Aborts if <code>t</code> already holds a value
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element) {
     <b>let</b> vec_ref = &<b>mut</b> t.vec;
     <b>if</b> (vec_ref.is_empty()) vec_ref.push_back(e)
-    <b>else</b> <b>abort</b> <a href="../move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>
+    <b>else</b> <b>abort</b> <a href="../move-stdlib/option.md#0x1_option_EOptionIsSet">EOptionIsSet</a>
 }
 </code></pre>
 
@@ -345,7 +345,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     t.vec.pop_back()
 }
 </code></pre>
@@ -372,7 +372,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &<b>mut</b> Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     &<b>mut</b> t.vec[0]
 }
 </code></pre>
@@ -399,7 +399,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     <b>let</b> vec_ref = &<b>mut</b> t.vec;
     <b>let</b> old_value = vec_ref.pop_back();
     vec_ref.push_back(e);
@@ -487,7 +487,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_some">is_some</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionNotSet">EOptionNotSet</a>);
     <b>let</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a> { <b>mut</b> vec } = t;
     <b>let</b> elem = vec.pop_back();
     vec.destroy_empty();
@@ -517,7 +517,7 @@ Aborts if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="../move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt;) {
-    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_none">is_none</a>(), <a href="../move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>);
+    <b>assert</b>!(t.<a href="../move-stdlib/option.md#0x1_option_is_none">is_none</a>(), <a href="../move-stdlib/option.md#0x1_option_EOptionIsSet">EOptionIsSet</a>);
     <b>let</b> <a href="../move-stdlib/option.md#0x1_option_Option">Option</a> { vec } = t;
     vec.destroy_empty()
 }

--- a/crates/sui-framework/docs/move-stdlib/string.md
+++ b/crates/sui-framework/docs/move-stdlib/string.md
@@ -2,7 +2,8 @@
 title: Module `0x1::string`
 ---
 
-The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
+The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded
+strings.
 
 
 -  [Struct `String`](#0x1_string_String)
@@ -11,18 +12,21 @@ The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module
 -  [Function `from_ascii`](#0x1_string_from_ascii)
 -  [Function `to_ascii`](#0x1_string_to_ascii)
 -  [Function `try_utf8`](#0x1_string_try_utf8)
--  [Function `bytes`](#0x1_string_bytes)
+-  [Function `as_bytes`](#0x1_string_as_bytes)
+-  [Function `into_bytes`](#0x1_string_into_bytes)
 -  [Function `is_empty`](#0x1_string_is_empty)
 -  [Function `length`](#0x1_string_length)
 -  [Function `append`](#0x1_string_append)
 -  [Function `append_utf8`](#0x1_string_append_utf8)
 -  [Function `insert`](#0x1_string_insert)
--  [Function `sub_string`](#0x1_string_sub_string)
+-  [Function `substring`](#0x1_string_substring)
 -  [Function `index_of`](#0x1_string_index_of)
 -  [Function `internal_check_utf8`](#0x1_string_internal_check_utf8)
 -  [Function `internal_is_char_boundary`](#0x1_string_internal_is_char_boundary)
 -  [Function `internal_sub_string`](#0x1_string_internal_sub_string)
 -  [Function `internal_index_of`](#0x1_string_internal_index_of)
+-  [Function `bytes`](#0x1_string_bytes)
+-  [Function `sub_string`](#0x1_string_sub_string)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/ascii.md#0x1_ascii">0x1::ascii</a>;
@@ -36,7 +40,8 @@ The <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> module
 
 ## Struct `String`
 
-A <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
+A <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8
+format.
 
 
 <pre><code><b>struct</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -65,22 +70,22 @@ A <code><a href="../move-stdlib/string.md#0x1_string_String">String</a></code> h
 ## Constants
 
 
-<a name="0x1_string_EINVALID_INDEX"></a>
+<a name="0x1_string_EInvalidIndex"></a>
 
 Index out of range.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>: u64 = 2;
+<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>: u64 = 2;
 </code></pre>
 
 
 
-<a name="0x1_string_EINVALID_UTF8"></a>
+<a name="0x1_string_EInvalidUTF8"></a>
 
 An invalid UTF8 encoding.
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>: u64 = 1;
+<pre><code><b>const</b> <a href="../move-stdlib/string.md#0x1_string_EInvalidUTF8">EInvalidUTF8</a>: u64 = 1;
 </code></pre>
 
 
@@ -89,7 +94,8 @@ An invalid UTF8 encoding.
 
 ## Function `utf8`
 
-Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
+Creates a new string from a sequence of bytes. Aborts if the bytes do
+not represent valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -102,7 +108,7 @@ Creates a new string from a sequence of bytes. Aborts if the bytes do not repres
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
-    <b>assert</b>!(<a href="../move-stdlib/string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(&bytes), <a href="../move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>);
+    <b>assert</b>!(<a href="../move-stdlib/string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(&bytes), <a href="../move-stdlib/string.md#0x1_string_EInvalidUTF8">EInvalidUTF8</a>);
     <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes }
 }
 </code></pre>
@@ -128,7 +134,7 @@ Convert an ASCII string to a UTF8 string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_from_ascii">from_ascii</a>(s: <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
-    <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes: <a href="../move-stdlib/ascii.md#0x1_ascii_into_bytes">ascii::into_bytes</a>(s) }
+    <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes: s.<a href="../move-stdlib/string.md#0x1_string_into_bytes">into_bytes</a>() }
 }
 </code></pre>
 
@@ -155,7 +161,7 @@ Aborts if <code>s</code> is not valid ASCII
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_to_ascii">to_ascii</a>(s: <a href="../move-stdlib/string.md#0x1_string_String">String</a>): <a href="../move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a> {
     <b>let</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes } = s;
-    <a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(bytes)
+    bytes.to_ascii_string()
 }
 </code></pre>
 
@@ -192,14 +198,14 @@ Tries to create a new string from a sequence of bytes.
 
 </details>
 
-<a name="0x1_string_bytes"></a>
+<a name="0x1_string_as_bytes"></a>
 
-## Function `bytes`
+## Function `as_bytes`
 
 Returns a reference to the underlying byte vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_as_bytes">as_bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -208,8 +214,34 @@ Returns a reference to the underlying byte vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_as_bytes">as_bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     &s.bytes
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_into_bytes"></a>
+
+## Function `into_bytes`
+
+Unpack the <code><a href="../move-stdlib/string.md#0x1_string">string</a></code> to get its underlying bytes.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_into_bytes">into_bytes</a>(s: <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_into_bytes">into_bytes</a>(s: <a href="../move-stdlib/string.md#0x1_string_String">String</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes } = s;
+    bytes
 }
 </code></pre>
 
@@ -321,8 +353,8 @@ Appends bytes which must be in valid utf8 format.
 
 ## Function `insert`
 
-Insert the other string at the byte index in given string. The index must be at a valid utf8 char
-boundary.
+Insert the other string at the byte index in given string. The index
+must be at a valid utf8 char boundary.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -336,10 +368,13 @@ boundary.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../move-stdlib/string.md#0x1_string_String">String</a>, at: u64, o: <a href="../move-stdlib/string.md#0x1_string_String">String</a>) {
     <b>let</b> bytes = &s.bytes;
-    <b>assert</b>!(at &lt;= bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>() && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, at), <a href="../move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>);
+    <b>assert</b>!(
+        at &lt;= bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>() && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, at),
+        <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>
+    );
     <b>let</b> l = s.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
-    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(0, at);
-    <b>let</b> end = s.<a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(at, l);
+    <b>let</b> <b>mut</b> front = s.<a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(0, at);
+    <b>let</b> end = s.<a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(at, l);
     front.<a href="../move-stdlib/string.md#0x1_string_append">append</a>(o);
     front.<a href="../move-stdlib/string.md#0x1_string_append">append</a>(end);
     *s = front;
@@ -350,16 +385,17 @@ boundary.
 
 </details>
 
-<a name="0x1_string_sub_string"></a>
+<a name="0x1_string_substring"></a>
 
-## Function `sub_string`
+## Function `substring`
 
-Returns a sub-string using the given byte indices, where <code>i</code> is the first byte position and <code>j</code> is the start
-of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+Returns a sub-string using the given byte indices, where <code>i</code> is the first
+byte position and <code>j</code> is the start of the first byte not included (or the
+length of the string). The indices must be at valid utf8 char boundaries,
 guaranteeing that the result is valid utf8.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
@@ -368,14 +404,17 @@ guaranteeing that the result is valid utf8.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
     <b>let</b> bytes = &s.bytes;
     <b>let</b> l = bytes.<a href="../move-stdlib/string.md#0x1_string_length">length</a>();
     <b>assert</b>!(
-        j &lt;= l && i &lt;= j && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, i) && <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, j),
-        <a href="../move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>
+        j &lt;= l &&
+        i &lt;= j &&
+        <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, i) &&
+        <a href="../move-stdlib/string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, j),
+        <a href="../move-stdlib/string.md#0x1_string_EInvalidIndex">EInvalidIndex</a>
     );
-    <a href="../move-stdlib/string.md#0x1_string_String">String</a>{bytes: <a href="../move-stdlib/string.md#0x1_string_internal_sub_string">internal_sub_string</a>(bytes, i, j)}
+    <a href="../move-stdlib/string.md#0x1_string_String">String</a> { bytes: <a href="../move-stdlib/string.md#0x1_string_internal_sub_string">internal_sub_string</a>(bytes, i, j) }
 }
 </code></pre>
 
@@ -387,7 +426,8 @@ guaranteeing that the result is valid utf8.
 
 ## Function `index_of`
 
-Computes the index of the first occurrence of a string. Returns <code><a href="../move-stdlib/string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
+Computes the index of the first occurrence of a string. Returns <code>s.<a href="../move-stdlib/string.md#0x1_string_length">length</a>()</code>
+if no occurrence found.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_index_of">index_of</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, r: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): u64
@@ -490,6 +530,56 @@ Computes the index of the first occurrence of a string. Returns <code><a href=".
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_internal_index_of">internal_index_of</a>(v: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, r: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_bytes"></a>
+
+## Function `bytes`
+
+[DEPRECATED]
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>): &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    s.<a href="../move-stdlib/string.md#0x1_string_as_bytes">as_bytes</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_sub_string"></a>
+
+## Function `sub_string`
+
+[DEPRECATED]
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../move-stdlib/string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="../move-stdlib/string.md#0x1_string_String">String</a> {
+    s.<a href="../move-stdlib/string.md#0x1_string_substring">substring</a>(i, j)
+}
 </code></pre>
 
 

--- a/crates/sui-framework/docs/move-stdlib/type_name.md
+++ b/crates/sui-framework/docs/move-stdlib/type_name.md
@@ -282,17 +282,7 @@ Aborts if given a primitive type.
 
     // Base16 (<a href="../move-stdlib/string.md#0x1_string">string</a>) representation of an <b>address</b> <b>has</b> 2 symbols per byte.
     <b>let</b> len = <a href="../move-stdlib/address.md#0x1_address_length">address::length</a>() * 2;
-    <b>let</b> str_bytes = self.name.as_bytes();
-    <b>let</b> <b>mut</b> addr_bytes = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> <b>mut</b> i = 0;
-
-    // Read `len` bytes from the type name and push them <b>to</b> addr_bytes.
-    <b>while</b> (i &lt; len) {
-        addr_bytes.push_back(str_bytes[i]);
-        i = i + 1;
-    };
-
-    <a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(addr_bytes)
+    self.name.substring(0, len)
 }
 </code></pre>
 
@@ -335,7 +325,7 @@ Aborts if given a primitive type.
         }
     };
 
-    <a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(module_name)
+    module_name.to_ascii_string()
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/move-stdlib/vector.md
+++ b/crates/sui-framework/docs/move-stdlib/vector.md
@@ -35,12 +35,12 @@ vectors are growable. This module has many native functions.
 ## Constants
 
 
-<a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
+<a name="0x1_vector_EIndexOutOfBounds"></a>
 
 The index into the vector is out of bounds
 
 
-<pre><code><b>const</b> <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
+<pre><code><b>const</b> <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 131072;
 </code></pre>
 
 
@@ -432,7 +432,7 @@ Aborts if <code>i</code> is out of bounds.
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, <b>mut</b> i: u64): Element {
     <b>let</b> <b>mut</b> len = v.<a href="../move-stdlib/vector.md#0x1_vector_length">length</a>();
     // i out of bounds; <b>abort</b>
-    <b>if</b> (i &gt;= len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
+    <b>if</b> (i &gt;= len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>;
 
     len = len - 1;
     <b>while</b> (i &lt; len) v.<a href="../move-stdlib/vector.md#0x1_vector_swap">swap</a>(i, { i = i + 1; i });
@@ -467,7 +467,7 @@ Aborts if <code>i &gt; v.<a href="../move-stdlib/vector.md#0x1_vector_length">le
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, <b>mut</b> i: u64) {
     <b>let</b> len = v.<a href="../move-stdlib/vector.md#0x1_vector_length">length</a>();
     // i too big <b>abort</b>
-    <b>if</b> (i &gt; len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
+    <b>if</b> (i &gt; len) <b>abort</b> <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>;
 
     v.<a href="../move-stdlib/vector.md#0x1_vector_push_back">push_back</a>(e);
     <b>while</b> (i &lt; len) {
@@ -500,7 +500,7 @@ Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
-    <b>assert</b>!(!v.<a href="../move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>(), <a href="../move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+    <b>assert</b>!(!v.<a href="../move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>(), <a href="../move-stdlib/vector.md#0x1_vector_EIndexOutOfBounds">EIndexOutOfBounds</a>);
     <b>let</b> last_idx = v.<a href="../move-stdlib/vector.md#0x1_vector_length">length</a>() - 1;
     v.<a href="../move-stdlib/vector.md#0x1_vector_swap">swap</a>(i, last_idx);
     v.<a href="../move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>()

--- a/crates/sui-framework/docs/sui-framework/vec_map.md
+++ b/crates/sui-framework/docs/sui-framework/vec_map.md
@@ -105,6 +105,16 @@ An entry in the map
 ## Constants
 
 
+<a name="0x2_vec_map_EIndexOutOfBounds"></a>
+
+Trying to access an element of the map at an invalid index
+
+
+<pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 3;
+</code></pre>
+
+
+
 <a name="0x2_vec_map_EKeyAlreadyExists"></a>
 
 This key already exists in the map
@@ -121,16 +131,6 @@ This key does not exist in the map
 
 
 <pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x2_vec_map_EIndexOutOfBounds"></a>
-
-Trying to access an element of the map at an invalid index
-
-
-<pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 3;
 </code></pre>
 
 

--- a/crates/sui-framework/packages/move-stdlib/sources/bit_vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/bit_vector.move
@@ -3,9 +3,9 @@
 
 module std::bit_vector {
     /// The provided index is out of bounds
-    const EINDEX: u64 = 0x20000;
+    const EIndexOutOfBounds: u64 = 0x20000;
     /// An invalid length of bitvector was given
-    const ELENGTH: u64 = 0x20001;
+    const EInvalidLength: u64 = 0x20001;
 
     #[allow(unused_const)]
     const WORD_SIZE: u64 = 1;
@@ -18,8 +18,8 @@ module std::bit_vector {
     }
 
     public fun new(length: u64): BitVector {
-        assert!(length > 0, ELENGTH);
-        assert!(length < MAX_SIZE, ELENGTH);
+        assert!(length > 0, EInvalidLength);
+        assert!(length < MAX_SIZE, EInvalidLength);
         let mut counter = 0;
         let mut bit_field = vector::empty();
         while (counter < length) {
@@ -35,14 +35,14 @@ module std::bit_vector {
 
     /// Set the bit at `bit_index` in the `bitvector` regardless of its previous state.
     public fun set(bitvector: &mut BitVector, bit_index: u64) {
-        assert!(bit_index < bitvector.bit_field.length(), EINDEX);
+        assert!(bit_index < bitvector.bit_field.length(), EIndexOutOfBounds);
         let x = &mut bitvector.bit_field[bit_index];
         *x = true;
     }
 
     /// Unset the bit at `bit_index` in the `bitvector` regardless of its previous state.
     public fun unset(bitvector: &mut BitVector, bit_index: u64) {
-        assert!(bit_index < bitvector.bit_field.length(), EINDEX);
+        assert!(bit_index < bitvector.bit_field.length(), EIndexOutOfBounds);
         let x = &mut bitvector.bit_field[bit_index];
         *x = false;
     }
@@ -79,7 +79,7 @@ module std::bit_vector {
     /// Return the value of the bit at `bit_index` in the `bitvector`. `true`
     /// represents "1" and `false` represents a 0
     public fun is_index_set(bitvector: &BitVector, bit_index: u64): bool {
-        assert!(bit_index < bitvector.bit_field.length(), EINDEX);
+        assert!(bit_index < bitvector.bit_field.length(), EIndexOutOfBounds);
         bitvector.bit_field[bit_index]
     }
 
@@ -92,7 +92,7 @@ module std::bit_vector {
     /// including) `start_index` in the `bitvector`. If there is no such
     /// sequence, then `0` is returned.
     public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
-        assert!(start_index < bitvector.length, EINDEX);
+        assert!(start_index < bitvector.length, EIndexOutOfBounds);
         let mut index = start_index;
 
         // Find the greatest index in the vector such that all indices less than it are set.

--- a/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
@@ -21,15 +21,15 @@ module std::fixed_point32 {
     const MAX_U64: u128 = 18446744073709551615;
 
     /// The denominator provided was zero
-    const EDENOMINATOR: u64 = 0x10001;
+    const EDenominatorIsZero: u64 = 0x10001;
     /// The quotient value would be too large to be held in a `u64`
-    const EDIVISION: u64 = 0x20002;
+    const EDivValueTooLarge: u64 = 0x20002;
     /// The multiplied value would be too large to be held in a `u64`
-    const EMULTIPLICATION: u64 = 0x20003;
+    const EMulValueTooLarge: u64 = 0x20003;
     /// A division by zero was encountered
-    const EDIVISION_BY_ZERO: u64 = 0x10004;
+    const EDivisionByZero: u64 = 0x10004;
     /// The computed ratio when converting to a `FixedPoint32` would be unrepresentable
-    const ERATIO_OUT_OF_RANGE: u64 = 0x20005;
+    const ERatioOutOfRange: u64 = 0x20005;
 
     /// Multiply a u64 integer by a fixed-point number, truncating any
     /// fractional part of the product. This will abort if the product
@@ -43,7 +43,7 @@ module std::fixed_point32 {
         // so rescale it by shifting away the low bits.
         let product = unscaled_product >> 32;
         // Check whether the value is too large.
-        assert!(product <= MAX_U64, EMULTIPLICATION);
+        assert!(product <= MAX_U64, EMulValueTooLarge);
         product as u64
     }
 
@@ -52,13 +52,13 @@ module std::fixed_point32 {
     /// is zero or if the quotient overflows.
     public fun divide_u64(val: u64, divisor: FixedPoint32): u64 {
         // Check for division by zero.
-        assert!(divisor.value != 0, EDIVISION_BY_ZERO);
+        assert!(divisor.value != 0, EDivisionByZero);
         // First convert to 128 bits and then shift left to
         // add 32 fractional zero bits to the dividend.
         let scaled_value = val as u128 << 32;
         let quotient = scaled_value / (divisor.value as u128);
         // Check whether the value is too large.
-        assert!(quotient <= MAX_U64, EDIVISION);
+        assert!(quotient <= MAX_U64, EDivValueTooLarge);
         // the value may be too large, which will cause the cast to fail
         // with an arithmetic error.
         quotient as u64
@@ -81,12 +81,12 @@ module std::fixed_point32 {
         // fractional bits.
         let scaled_numerator = numerator as u128 << 64;
         let scaled_denominator = denominator as u128 << 32;
-        assert!(scaled_denominator != 0, EDENOMINATOR);
+        assert!(scaled_denominator != 0, EDenominatorIsZero);
         let quotient = scaled_numerator / scaled_denominator;
-        assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
+        assert!(quotient != 0 || numerator == 0, ERatioOutOfRange);
         // Return the quotient as a fixed-point number. We first need to check whether the cast
         // can succeed.
-        assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        assert!(quotient <= MAX_U64, ERatioOutOfRange);
         FixedPoint32 { value: quotient as u64 }
     }
 

--- a/crates/sui-framework/packages/move-stdlib/sources/option.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/option.move
@@ -11,10 +11,10 @@ module std::option {
 
     /// The `Option` is in an invalid state for the operation attempted.
     /// The `Option` is `Some` while it should be `None`.
-    const EOPTION_IS_SET: u64 = 0x40000;
+    const EOptionIsSet: u64 = 0x40000;
     /// The `Option` is in an invalid state for the operation attempted.
     /// The `Option` is `None` while it should be `Some`.
-    const EOPTION_NOT_SET: u64 = 0x40001;
+    const EOptionNotSet: u64 = 0x40001;
 
     /// Return an empty `Option`
     public fun none<Element>(): Option<Element> {
@@ -45,7 +45,7 @@ module std::option {
     /// Return an immutable reference to the value inside `t`
     /// Aborts if `t` does not hold a value
     public fun borrow<Element>(t: &Option<Element>): &Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         &t.vec[0]
     }
 
@@ -73,27 +73,27 @@ module std::option {
     public fun fill<Element>(t: &mut Option<Element>, e: Element) {
         let vec_ref = &mut t.vec;
         if (vec_ref.is_empty()) vec_ref.push_back(e)
-        else abort EOPTION_IS_SET
+        else abort EOptionIsSet
     }
 
     /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
     /// Aborts if `t` does not hold a value
     public fun extract<Element>(t: &mut Option<Element>): Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         t.vec.pop_back()
     }
 
     /// Return a mutable reference to the value inside `t`
     /// Aborts if `t` does not hold a value
     public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         &mut t.vec[0]
     }
 
     /// Swap the old value inside `t` with `e` and return the old value
     /// Aborts if `t` does not hold a value
     public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         let vec_ref = &mut t.vec;
         let old_value = vec_ref.pop_back();
         vec_ref.push_back(e);
@@ -121,7 +121,7 @@ module std::option {
     /// Unpack `t` and return its contents
     /// Aborts if `t` does not hold a value
     public fun destroy_some<Element>(t: Option<Element>): Element {
-        assert!(t.is_some(), EOPTION_NOT_SET);
+        assert!(t.is_some(), EOptionNotSet);
         let Option { mut vec } = t;
         let elem = vec.pop_back();
         vec.destroy_empty();
@@ -131,7 +131,7 @@ module std::option {
     /// Unpack `t`
     /// Aborts if `t` holds a value
     public fun destroy_none<Element>(t: Option<Element>) {
-        assert!(t.is_none(), EOPTION_IS_SET);
+        assert!(t.is_none(), EOptionIsSet);
         let Option { vec } = t;
         vec.destroy_empty()
     }

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -1,38 +1,40 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// The `string` module defines the `String` type which represents UTF8 encoded strings.
+/// The `string` module defines the `String` type which represents UTF8 encoded
+/// strings.
 module std::string {
     use std::ascii;
-    use std::option::{Self, Option};
 
     /// An invalid UTF8 encoding.
-    const EINVALID_UTF8: u64 = 1;
+    const EInvalidUTF8: u64 = 1;
 
     /// Index out of range.
-    const EINVALID_INDEX: u64 = 2;
+    const EInvalidIndex: u64 = 2;
 
-    /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
+    /// A `String` holds a sequence of bytes which is guaranteed to be in utf8
+    /// format.
     public struct String has copy, drop, store {
         bytes: vector<u8>,
     }
 
-    /// Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
+    /// Creates a new string from a sequence of bytes. Aborts if the bytes do
+    /// not represent valid utf8.
     public fun utf8(bytes: vector<u8>): String {
-        assert!(internal_check_utf8(&bytes), EINVALID_UTF8);
+        assert!(internal_check_utf8(&bytes), EInvalidUTF8);
         String { bytes }
     }
 
     /// Convert an ASCII string to a UTF8 string
     public fun from_ascii(s: ascii::String): String {
-        String { bytes: ascii::into_bytes(s) }
+        String { bytes: s.into_bytes() }
     }
 
     /// Convert an UTF8 string to an ASCII string.
     /// Aborts if `s` is not valid ASCII
     public fun to_ascii(s: String): ascii::String {
         let String { bytes } = s;
-        ascii::string(bytes)
+        bytes.to_ascii_string()
     }
 
     /// Tries to create a new string from a sequence of bytes.
@@ -45,8 +47,14 @@ module std::string {
     }
 
     /// Returns a reference to the underlying byte vector.
-    public fun bytes(s: &String): &vector<u8> {
+    public fun as_bytes(s: &String): &vector<u8> {
         &s.bytes
+    }
+
+    /// Unpack the `string` to get its underlying bytes.
+    public fun into_bytes(s: String): vector<u8> {
+        let String { bytes } = s;
+        bytes
     }
 
     /// Checks whether this string is empty.
@@ -69,33 +77,41 @@ module std::string {
         s.append(utf8(bytes))
     }
 
-    /// Insert the other string at the byte index in given string. The index must be at a valid utf8 char
-    /// boundary.
+    /// Insert the other string at the byte index in given string. The index
+    /// must be at a valid utf8 char boundary.
     public fun insert(s: &mut String, at: u64, o: String) {
         let bytes = &s.bytes;
-        assert!(at <= bytes.length() && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
+        assert!(
+            at <= bytes.length() && internal_is_char_boundary(bytes, at),
+            EInvalidIndex
+        );
         let l = s.length();
-        let mut front = s.sub_string(0, at);
-        let end = s.sub_string(at, l);
+        let mut front = s.substring(0, at);
+        let end = s.substring(at, l);
         front.append(o);
         front.append(end);
         *s = front;
     }
 
-    /// Returns a sub-string using the given byte indices, where `i` is the first byte position and `j` is the start
-    /// of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+    /// Returns a sub-string using the given byte indices, where `i` is the first
+    /// byte position and `j` is the start of the first byte not included (or the
+    /// length of the string). The indices must be at valid utf8 char boundaries,
     /// guaranteeing that the result is valid utf8.
-    public fun sub_string(s: &String, i: u64, j: u64): String {
+    public fun substring(s: &String, i: u64, j: u64): String {
         let bytes = &s.bytes;
         let l = bytes.length();
         assert!(
-            j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
-            EINVALID_INDEX
+            j <= l &&
+            i <= j &&
+            internal_is_char_boundary(bytes, i) &&
+            internal_is_char_boundary(bytes, j),
+            EInvalidIndex
         );
-        String{bytes: internal_sub_string(bytes, i, j)}
+        String { bytes: internal_sub_string(bytes, i, j) }
     }
 
-    /// Computes the index of the first occurrence of a string. Returns `length(s)` if no occurrence found.
+    /// Computes the index of the first occurrence of a string. Returns `s.length()`
+    /// if no occurrence found.
     public fun index_of(s: &String, r: &String): u64 {
         internal_index_of(&s.bytes, &r.bytes)
     }
@@ -106,4 +122,16 @@ module std::string {
     native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;
     native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
     native fun internal_index_of(v: &vector<u8>, r: &vector<u8>): u64;
+
+    // === Deprecated ===
+
+    /// [DEPRECATED]
+    public fun bytes(s: &String): &vector<u8> {
+        s.as_bytes()
+    }
+
+    /// [DEPRECATED]
+    public fun sub_string(s: &String, i: u64, j: u64): String {
+        s.substring(i, j)
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -4,7 +4,7 @@
 #[allow(implicit_const_copy)]
 /// Functionality for converting Move types into values. Use with care!
 module std::type_name {
-    use std::ascii::{Self, String};
+    use std::ascii::String;
     use std::address;
 
     /// ASCII Character code for the `:` (colon) symbol.
@@ -84,17 +84,7 @@ module std::type_name {
 
         // Base16 (string) representation of an address has 2 symbols per byte.
         let len = address::length() * 2;
-        let str_bytes = self.name.as_bytes();
-        let mut addr_bytes = vector[];
-        let mut i = 0;
-
-        // Read `len` bytes from the type name and push them to addr_bytes.
-        while (i < len) {
-            addr_bytes.push_back(str_bytes[i]);
-            i = i + 1;
-        };
-
-        ascii::string(addr_bytes)
+        self.name.substring(0, len)
     }
 
     /// Get name of the module.
@@ -117,7 +107,7 @@ module std::type_name {
             }
         };
 
-        ascii::string(module_name)
+        module_name.to_ascii_string()
     }
 
     /// Convert `self` into its inner String

--- a/crates/sui-framework/packages/move-stdlib/sources/vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/vector.move
@@ -21,7 +21,7 @@ module std::vector {
     public use fun std::ascii::try_string as vector.try_to_ascii_string;
 
     /// The index into the vector is out of bounds
-    const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
+    const EIndexOutOfBounds: u64 = 0x20000;
 
     #[bytecode_instruction]
     /// Create an empty vector.
@@ -125,7 +125,7 @@ module std::vector {
     public fun remove<Element>(v: &mut vector<Element>, mut i: u64): Element {
         let mut len = v.length();
         // i out of bounds; abort
-        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+        if (i >= len) abort EIndexOutOfBounds;
 
         len = len - 1;
         while (i < len) v.swap(i, { i = i + 1; i });
@@ -140,7 +140,7 @@ module std::vector {
     public fun insert<Element>(v: &mut vector<Element>, e: Element, mut i: u64) {
         let len = v.length();
         // i too big abort
-        if (i > len) abort EINDEX_OUT_OF_BOUNDS;
+        if (i > len) abort EIndexOutOfBounds;
 
         v.push_back(e);
         while (i < len) {
@@ -153,7 +153,7 @@ module std::vector {
     /// This is O(1), but does not preserve ordering of elements in the vector.
     /// Aborts if `i` is out of bounds.
     public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
-        assert!(!v.is_empty(), EINDEX_OUT_OF_BOUNDS);
+        assert!(!v.is_empty(), EIndexOutOfBounds);
         let last_idx = v.length() - 1;
         v.swap(i, last_idx);
         v.pop_back()

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -120,4 +120,104 @@ module std::ascii_tests {
             i = i + 1;
         };
     }
+
+    #[test]
+    fun test_append() {
+        let mut str = b"hello".to_ascii_string();
+        str.append(b" world".to_ascii_string());
+
+        assert!(str == b"hello world".to_ascii_string(), 0);
+    }
+
+    #[test]
+    fun test_to_uppercase() {
+        let str = b"azhello_world_!".to_ascii_string();
+        assert!(str.to_uppercase() == b"AZHELLO_WORLD_!".to_ascii_string(), 0);
+    }
+
+    #[test]
+    fun test_to_lowercase() {
+        let str = b"AZHELLO_WORLD_!".to_ascii_string();
+        assert!(str.to_lowercase() == b"azhello_world_!".to_ascii_string(), 0);
+    }
+
+    #[test]
+    fun test_substring() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.substring(0, 5) == b"hello".to_ascii_string(), 0);
+        assert!(str.substring(6, 11) == b"world".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_substring_len_one() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.substring(0, 1) == b"h".to_ascii_string(), 0);
+        assert!(str.substring(6, 7) == b"w".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_substring_len_zero() {
+        let str = b"hello world".to_ascii_string();
+        assert!(str.substring(0, 0).is_empty(), 0);
+    }
+
+    #[test]
+    fun test_index_of() {
+        let str = b"hello world orwell".to_ascii_string();
+        assert!(str.index_of(&b"hello".to_ascii_string()) == 0, 0);
+        assert!(str.index_of(&b"world".to_ascii_string()) == 6, 1);
+        assert!(str.index_of(&b"o".to_ascii_string()) == 4, 2);
+        assert!(str.index_of(&b"z".to_ascii_string()) == str.length(), 3);
+        assert!(str.index_of(&b"o ".to_ascii_string()) == 4, 4);
+        assert!(str.index_of(&b"or".to_ascii_string()) == 7, 4);
+        assert!(str.index_of(&b"".to_ascii_string()) == 0, 4);
+        assert!(str.index_of(&b"orwell".to_ascii_string()) == 12, 4);
+        assert!(
+            b"ororwell"
+                .to_ascii_string()
+                .index_of(&b"orwell".to_ascii_string()) == 2,
+            0
+        );
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_substring_i_out_of_bounds_fail() {
+        let str = b"hello world".to_ascii_string();
+        str.substring(12, 13);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_substring_j_lt_i_fail() {
+        let str = b"hello world".to_ascii_string();
+        str.substring(9, 8);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_substring_j_out_of_bounds_fail() {
+        let str = b"hello world".to_ascii_string();
+        str.substring(9, 13);
+    }
+
+    #[test]
+    fun test_insert() {
+        let mut str = b"hello".to_ascii_string();
+        str.insert(5, b" world".to_ascii_string());
+        assert!(str == b"hello world".to_ascii_string(), 0);
+
+        str.insert(5, b" cruel".to_ascii_string());
+        assert!(str == b"hello cruel world".to_ascii_string(), 1);
+    }
+
+    #[test]
+    fun test_insert_empty() {
+        let mut str = b"hello".to_ascii_string();
+        str.insert(5, b"".to_ascii_string());
+        assert!(str == b"hello".to_ascii_string(), 0);
+    }
+
+    #[test, expected_failure(abort_code = ascii::EInvalidIndex)]
+    fun test_insert_out_of_bounds_fail() {
+        let mut str = b"hello".to_ascii_string();
+        str.insert(6, b" world".to_ascii_string());
+    }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
@@ -37,21 +37,21 @@ module std::bit_vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    #[expected_failure(abort_code = bit_vector::EIndexOutOfBounds)]
     fun set_bit_out_of_bounds() {
         let mut bitvector = bit_vector::new(bit_vector::word_size());
         bitvector.set(bit_vector::word_size());
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    #[expected_failure(abort_code = bit_vector::EIndexOutOfBounds)]
     fun unset_bit_out_of_bounds() {
         let mut bitvector = bit_vector::new(bit_vector::word_size());
         bitvector.unset(bit_vector::word_size());
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    #[expected_failure(abort_code = bit_vector::EIndexOutOfBounds)]
     fun index_bit_out_of_bounds() {
         let bitvector = bit_vector::new(bit_vector::word_size());
         bitvector.is_index_set(bit_vector::word_size());
@@ -215,7 +215,7 @@ module std::bit_vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = bit_vector::ELENGTH)]
+    #[expected_failure(abort_code = bit_vector::EInvalidLength)]
     fun empty_bitvector() {
         bit_vector::new(0);
     }

--- a/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
@@ -8,14 +8,14 @@ module std::fixed_point32_tests {
     use std::fixed_point32;
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDENOMINATOR)]
+    #[expected_failure(abort_code = fixed_point32::EDenominatorIsZero)]
     fun create_div_zero() {
         // A denominator of zero should cause an arithmetic error.
         fixed_point32::create_from_rational(2, 0);
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::ERATIO_OUT_OF_RANGE)]
+    #[expected_failure(abort_code = fixed_point32::ERatioOutOfRange)]
     fun create_overflow() {
         // The maximum value is 2^32 - 1. Check that anything larger aborts
         // with an overflow.
@@ -23,7 +23,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::ERATIO_OUT_OF_RANGE)]
+    #[expected_failure(abort_code = fixed_point32::ERatioOutOfRange)]
     fun create_underflow() {
         // The minimum non-zero value is 2^-32. Check that anything smaller
         // aborts.
@@ -37,7 +37,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDIVISION_BY_ZERO)]
+    #[expected_failure(abort_code = fixed_point32::EDivisionByZero)]
     fun divide_by_zero() {
         // Dividing by zero should cause an arithmetic error.
         let f = fixed_point32::create_from_raw_value(0);
@@ -45,7 +45,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDIVISION)]
+    #[expected_failure(abort_code = fixed_point32::EDivValueTooLarge)]
     fun divide_overflow_small_divisore() {
         let f = fixed_point32::create_from_raw_value(1); // 0x0.00000001
         // Divide 2^32 by the minimum fractional value. This should overflow.
@@ -53,7 +53,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EDIVISION)]
+    #[expected_failure(abort_code = fixed_point32::EDivValueTooLarge)]
     fun divide_overflow_large_numerator() {
         let f = fixed_point32::create_from_rational(1, 2); // 0.5
         // Divide the maximum u64 value by 0.5. This should overflow.
@@ -61,7 +61,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EMULTIPLICATION)]
+    #[expected_failure(abort_code = fixed_point32::EMulValueTooLarge)]
     fun multiply_overflow_small_multiplier() {
         let f = fixed_point32::create_from_rational(3, 2); // 1.5
         // Multiply the maximum u64 value by 1.5. This should overflow.
@@ -69,7 +69,7 @@ module std::fixed_point32_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = fixed_point32::EMULTIPLICATION)]
+    #[expected_failure(abort_code = fixed_point32::EMulValueTooLarge)]
     fun multiply_overflow_large_multiplier() {
         let f = fixed_point32::create_from_raw_value(18446744073709551615);
         // Multiply 2^33 by the maximum fixed-point value. This should overflow.

--- a/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
@@ -5,8 +5,6 @@
 
 #[test_only]
 module std::option_tests {
-    use std::option;
-
     #[test]
     fun option_none_is_none() {
         let none = option::none<u64>();
@@ -41,7 +39,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun option_borrow_none() {
         option::none<u64>().borrow();
     }
@@ -55,7 +53,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun borrow_mut_none() {
         option::none<u64>().borrow_mut();
     }
@@ -84,7 +82,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun extract_none() {
         option::none<u64>().extract();
     }
@@ -111,7 +109,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun swap_none() {
         option::none<u64>().swap(1);
     }
@@ -125,7 +123,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_IS_SET)]
+    #[expected_failure(abort_code = option::EOptionIsSet)]
     fun fill_some() {
         option::some(3).fill(0);
     }
@@ -142,7 +140,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    #[expected_failure(abort_code = option::EOptionNotSet)]
     fun destroy_some_none() {
         option::none<u64>().destroy_some();
     }
@@ -153,7 +151,7 @@ module std::option_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = option::EOPTION_IS_SET)]
+    #[expected_failure(abort_code = option::EOptionIsSet)]
     fun destroy_none_some() {
         option::some<u64>(0).destroy_none();
     }

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -15,7 +15,7 @@ module std::string_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = string::EINVALID_UTF8)]
+    #[expected_failure(abort_code = string::EInvalidUTF8)]
     fun test_invalid_utf8() {
         let no_sparkle_heart = vector[0, 159, 146, 150];
         let s = no_sparkle_heart.to_string();
@@ -23,31 +23,31 @@ module std::string_tests {
     }
 
     #[test]
-    fun test_sub_string() {
+    fun test_substring() {
         let s = b"abcd".to_string();
-        let sub = s.sub_string(2, 4);
+        let sub = s.substring(2, 4);
         assert!(sub == b"cd".to_string(), 22)
     }
 
     #[test]
-    #[expected_failure(abort_code = string::EINVALID_INDEX)]
-    fun test_sub_string_invalid_boundary() {
+    #[expected_failure(abort_code = string::EInvalidIndex)]
+    fun test_substring_invalid_boundary() {
         let sparkle_heart = vector[240, 159, 146, 150];
         let s = sparkle_heart.to_string();
-        let _sub = s.sub_string(1, 4);
+        let _sub = s.substring(1, 4);
     }
 
     #[test]
-    #[expected_failure(abort_code = string::EINVALID_INDEX)]
-    fun test_sub_string_invalid_index() {
+    #[expected_failure(abort_code = string::EInvalidIndex)]
+    fun test_substring_invalid_index() {
         let s = b"abcd".to_string();
-        let _sub = s.sub_string(4, 5);
+        let _sub = s.substring(4, 5);
     }
 
     #[test]
-    fun test_sub_string_empty() {
+    fun test_substring_empty() {
         let s = b"abcd".to_string();
-        let sub = s.sub_string(4, 4);
+        let sub = s.substring(4, 4);
         assert!(sub.is_empty(), 22)
     }
 
@@ -79,5 +79,10 @@ module std::string_tests {
         let mut s = b"abcd".to_string();
         s.insert(1, b"xy".to_string());
         assert!(s == b"axybcd".to_string(), 22)
+    }
+
+    #[test]
+    fun test_into_bytes() {
+        assert!(b"abcd" == b"abcd".to_string().into_bytes(), 0)
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
@@ -5,8 +5,6 @@
 
 #[test_only]
 module std::vector_tests {
-    use std::vector;
-
     public struct R has store { }
     public struct Droppable has drop {}
     public struct NotDroppable {}
@@ -235,14 +233,14 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = vector::EIndexOutOfBounds)]
     fun remove_empty_vector() {
         let mut v = vector<u64>[];
         v.remove(0);
     }
 
     #[test]
-    #[expected_failure(abort_code = vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = vector::EIndexOutOfBounds)]
     fun remove_out_of_bound_index() {
         let mut v = vector<u64>[];
         v.push_back(0);
@@ -326,7 +324,7 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = std::vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = std::vector::EIndexOutOfBounds)]
     fun swap_remove_empty() {
         let mut v = vector<u64>[];
         v.swap_remove(0);
@@ -541,7 +539,7 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = std::vector::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = std::vector::EIndexOutOfBounds)]
     fun insert_out_of_range() {
         let mut v = vector[7];
         v.insert(6, 2);

--- a/crates/sui-framework/published_api.txt
+++ b/crates/sui-framework/published_api.txt
@@ -4147,6 +4147,15 @@ pop_char
 length
 	public fun
 	0x1::ascii
+append
+	public fun
+	0x1::ascii
+insert
+	public fun
+	0x1::ascii
+substring
+	public fun
+	0x1::ascii
 as_bytes
 	public fun
 	0x1::ascii
@@ -4161,6 +4170,24 @@ is_valid_char
 	0x1::ascii
 is_printable_char
 	public fun
+	0x1::ascii
+is_empty
+	public fun
+	0x1::ascii
+to_uppercase
+	public fun
+	0x1::ascii
+to_lowercase
+	public fun
+	0x1::ascii
+index_of
+	public fun
+	0x1::ascii
+char_to_uppercase
+	fun
+	0x1::ascii
+char_to_lowercase
+	fun
 	0x1::ascii
 BitVector
 	public struct
@@ -4201,7 +4228,10 @@ to_ascii
 try_utf8
 	public fun
 	0x1::string
-bytes
+as_bytes
+	public fun
+	0x1::string
+into_bytes
 	public fun
 	0x1::string
 is_empty
@@ -4219,7 +4249,7 @@ append_utf8
 insert
 	public fun
 	0x1::string
-sub_string
+substring
 	public fun
 	0x1::string
 index_of
@@ -4236,6 +4266,12 @@ internal_sub_string
 	0x1::string
 internal_index_of
 	fun
+	0x1::string
+bytes
+	public fun
+	0x1::string
+sub_string
+	public fun
 	0x1::string
 length
 	public fun

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1359,7 +1359,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "45",
+              "maxSupportedProtocolVersion": "46",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 45;
+const MAX_PROTOCOL_VERSION: u64 = 46;
 
 // Record history of protocol version allocations here:
 //
@@ -127,6 +127,7 @@ const MAX_PROTOCOL_VERSION: u64 = 45;
 //             Add native bridge.
 //             Enable native bridge in devnet
 //             Enable Leader Scoring & Schedule Change for Mysticeti consensus.
+// Version 46: Move framework improvements.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2184,6 +2185,7 @@ impl ProtocolConfig {
                         cfg.feature_flags.bridge = true;
                     }
                 }
+                46 => {}
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_46.snap
@@ -1,0 +1,267 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 46
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound_delta: 30
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_46.snap
@@ -1,0 +1,269 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 46
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  reject_mutable_random_on_entry_functions: true
+  consensus_choice: SwapEachEpoch
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_46.snap
@@ -1,0 +1,279 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 46
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  reject_mutable_random_on_entry_functions: true
+  consensus_choice: SwapEachEpoch
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 10
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1600
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 150
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 45
+  protocol_version: 46
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 45
+protocol_version: 46
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x1e5773eb8f81ccd747709921939df28c05188b1395070b9f5690c764947aac5d"
+            id: "0x1451a8b36d69833f156b4bb080683abe5708605b837aa816d45ddc0093f21985"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x0d1a5c294b5996646f3435623f136ae4ba5c9e1dc961858c6ac475525afb128c"
+      operation_cap_id: "0xc57552a436c52108755812be602bbd2be079382d1ba7a4ff2d43e35986972869"
       gas_price: 1000
       staking_pool:
-        id: "0x3310cf5675fb7d1f42766ee930970f864fb7376567e9447358a86a1f07956e89"
+        id: "0x64c615b71a6dc3d264d02c6bef83431ce0d3100c35f93a41ada446db1d7f3086"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x2bbe5867597a194c7c999648b22ec3f676c61614026fa4554ed65dd0833c9080"
+          id: "0xb1f502dd7ed0e2c153e90dd28ed0e0ba19227b9a4e49273da9433ef62a7dd1ef"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xdc0ae63c48ecda095497d3578ceedc63de0ed3adff864d5c6ab257b73b1d323f"
+            id: "0xa6dad883e3d7022cdcd9a6e09d97adb89e60d2153921e228ff77623cb177077a"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x2eaf7912524f9692ddd3305a6f827651f7e6c2ca4b54ff00bfc5f58c83441d4d"
+          id: "0xac3aa6f60a48b0fa4609cb42c194583a7d38063e11807384b2a5713671785865"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x38ba6e4f0d3957df0fbc95e6e3615add90b3df762d7e7fe8565397ccb16f2cb8"
+      id: "0xb5297ee32ccbf163757da050f1a1d9f25f58200b1b7d2299cbacb5560cfa6b18"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xb97abf7663041775d1f7752b37ac6f79e133b96bd396d84488c3864cac2e7216"
+    id: "0x8f673f2d496099a6863d91f5001631612b41808ccf41975ba05968271993f62a"
     size: 1
   inactive_validators:
-    id: "0xad529919b3fbad3aebd63db4800b617f87035ab2dee0ab60da6648633a88d5d5"
+    id: "0x31acc3a129a9bc26f976c8bc581a63d610b7eb3a025e6172756c788e93cf344c"
     size: 0
   validator_candidates:
-    id: "0x2e11a62fe6d8736553aa4a55fc87f516c0099cdec4334792845bc3d054c823d3"
+    id: "0xc51e011b9aea0c1424a681645917a2082b5c7cfd7e8b0fcbd6632200377a903a"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x2e8a5ac3ebe9e1507a65ff594ee4243d4a9e1ce034a7af97464cc9d2aed328f5"
+      id: "0x6769f91baac119061d271fb6c275832ef54d8a981ed6675988bf593a62aa03ab"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x79e231ff3dddff653bf001fb911e8175e4fd0061abef5695f455ee060a211968"
+      id: "0xa4cdbab5f1f509cf05c7385ff6c1109c71db92dc86194233278b4623c0c969a0"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x6da55fa8272b97c5ddc0b69346e78186622bf51eaf41742e83e41066eca8d51c"
+      id: "0x1eb0b7e2726445689f91d7c5d6cc8d7ad05ba7ea91d3ca1c1df9abd9f06e28d0"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xd384193b74aef48d618bc887303d3088ddf56256b32299140fa8fd0659ce4e15"
+    id: "0x7a6d2e01dbdddcc0fd1c0e901bc27f5154bd5d57da17fef746a9d4f80fa0c761"
   size: 0
 

--- a/crates/sui/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/sui/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -3,10 +3,7 @@
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module examples::trusted_coin {
-    use std::option;
     use sui::coin::{Self, TreasuryCap};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
 
     /// Name of the coin
     public struct TRUSTED_COIN has drop {}

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -26,10 +26,12 @@ mod checked {
     use sui_types::{BRIDGE_ADDRESS, SUI_BRIDGE_OBJECT_ID, SUI_RANDOMNESS_STATE_OBJECT_ID};
     use tracing::{info, instrument, trace, warn};
 
+    use crate::adapter::new_move_vm;
     use crate::programmable_transactions;
     use crate::type_layout_resolver::TypeLayoutResolver;
     use crate::{gas_charger::GasCharger, temporary_store::TemporaryStore};
     use move_core_types::ident_str;
+    use sui_move_natives::all_natives;
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::authenticator_state::{
         AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME, AUTHENTICATOR_STATE_EXPIRE_JWKS_FUNCTION_NAME,
@@ -890,6 +892,13 @@ mod checked {
             }
         }
 
+        let new_vm = new_move_vm(
+            all_natives(/* silent */ true),
+            protocol_config,
+            /* enable_profiler */ None,
+        )
+        .expect("Failed to create new MoveVM");
+
         let binary_config = to_binary_config(protocol_config);
         for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
             let deserialized_modules: Vec<_> = modules
@@ -910,7 +919,7 @@ mod checked {
                 programmable_transactions::execution::execute::<execution_mode::System>(
                     protocol_config,
                     metrics.clone(),
-                    move_vm,
+                    &new_vm,
                     temporary_store,
                     tx_ctx,
                     gas_charger,

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -21,9 +21,11 @@ mod checked {
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
     use tracing::{info, instrument, trace, warn};
 
+    use crate::adapter::new_move_vm;
     use crate::programmable_transactions;
     use crate::type_layout_resolver::TypeLayoutResolver;
     use crate::{gas_charger::GasCharger, temporary_store::TemporaryStore};
+    use sui_move_natives::all_natives;
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::authenticator_state::{
         AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME, AUTHENTICATOR_STATE_EXPIRE_JWKS_FUNCTION_NAME,
@@ -849,6 +851,13 @@ mod checked {
             }
         }
 
+        let new_vm = new_move_vm(
+            all_natives(/* silent */ true),
+            protocol_config,
+            /* enable_profiler */ None,
+        )
+        .expect("Failed to create new MoveVM");
+
         let binary_config = to_binary_config(protocol_config);
         for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
             let deserialized_modules: Vec<_> = modules
@@ -869,7 +878,7 @@ mod checked {
                 programmable_transactions::execution::execute::<execution_mode::System>(
                     protocol_config,
                     metrics.clone(),
-                    move_vm,
+                    &new_vm,
                     temporary_store,
                     tx_ctx,
                     gas_charger,


### PR DESCRIPTION
…7380)""

This reverts commit 85b44329a869c51f250932b05b023fadca2115ba.

## Description 

Re-enable @damirka's framework improvements.
Also create a fresh VM when verifying new framework upgrade.
We got 3 commits: 
- the first one is the change @damirka pushed to the framework which introduces the problem (the code is perfect, the problem is not in that change)
- the second PR is the protocol version bump and the snapshots related
- the third PR is the creation of a fresh VM to do verification of the framework so all code comes from the new framework and there is no reference to code in the old framework. If old code is referenced it may create verification failures.

We are having a conversation on slack about the problem

## Test plan 

This is it

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
