### PR TITLE
Update sui-bridging.mdx for the correct anchor link

### DIFF
--- a/docs/content/concepts/tokenomics/sui-bridging.mdx
+++ b/docs/content/concepts/tokenomics/sui-bridging.mdx
@@ -24,7 +24,7 @@ The gas drop-off feature enables users to pay an additional fee on the source ch
 
 To learn more about Wormhole Connect, see their [FAQ](https://docs.wormhole.com/wormhole/faqs) page.
 
-## Wormhole Portal Bridge {#bridge}
+## Wormhole Portal Bridge {#wormhole-portal-bridge}
 
 The Wormhole powered [Portal Bridge](https://www.portalbridge.com/sui) supports bridging any asset from any of the [22 supported Wormhole chains](https://www.wormhole.com/network).
 

--- a/docs/content/concepts/tokenomics/sui-bridging.mdx
+++ b/docs/content/concepts/tokenomics/sui-bridging.mdx
@@ -24,7 +24,7 @@ The gas drop-off feature enables users to pay an additional fee on the source ch
 
 To learn more about Wormhole Connect, see their [FAQ](https://docs.wormhole.com/wormhole/faqs) page.
 
-## Wormhole Portal Bridge {#wormhole-portal-bridge}
+## Wormhole Portal Bridge
 
 The Wormhole powered [Portal Bridge](https://www.portalbridge.com/sui) supports bridging any asset from any of the [22 supported Wormhole chains](https://www.wormhole.com/network).
 


### PR DESCRIPTION
## Description 

In line 7:
Sui supports bridging through .... and [Wormhole Portal Bridge](#wormhole-portal-bridge).

Updating line 27 to make the anchor link match with line 7, or else the section jump from lin 7 would fail.

## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
