### PR TITLE
[Traffic Control] Fix dry-run for fullnodes

### DIFF
--- a/crates/sui-core/src/traffic_controller/metrics.rs
+++ b/crates/sui-core/src/traffic_controller/metrics.rs
@@ -15,6 +15,7 @@ pub struct TrafficControllerMetrics {
     pub blocks_delegated_to_firewall: IntCounter,
     pub firewall_delegation_request_fail: IntCounter,
     pub tally_channel_overflow: IntCounter,
+    pub num_dry_run_blocked_requests: IntCounter,
 }
 
 impl TrafficControllerMetrics {
@@ -61,6 +62,12 @@ impl TrafficControllerMetrics {
             tally_channel_overflow: register_int_counter_with_registry!(
                 "tally_channel_overflow",
                 "Traffic controller tally channel overflow count",
+                registry
+            )
+            .unwrap(),
+            num_dry_run_blocked_requests: register_int_counter_with_registry!(
+                "traffic_control_num_dry_run_blocked_requests",
+                "Number of requests blocked in traffic controller dry run mode",
                 registry
             )
             .unwrap(),

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -74,11 +74,11 @@ async fn test_fullnode_traffic_control_ok() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_validator_traffic_control_dry_run() -> Result<(), anyhow::Error> {
+    let n = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 5,
-        // Test that IP forwarding works through this policy
-        spam_policy_type: PolicyType::TestInspectIp,
+        spam_policy_type: PolicyType::TestNConnIP(n - 1),
         spam_sample_rate: Weight::one(),
         // This should never be invoked when set as an error policy
         // as we are not sending requests that error
@@ -94,27 +94,28 @@ async fn test_validator_traffic_control_dry_run() -> Result<(), anyhow::Error> {
         .build()
         .await;
 
-    assert_traffic_control_dry_run(test_cluster).await
+    assert_traffic_control_dry_run(test_cluster, n as usize).await
 }
 
 #[tokio::test]
 async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
+    let n = 15;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 5,
+        spam_policy_type: PolicyType::TestNConnIP(n - 1),
         spam_sample_rate: Weight::one(),
         // This should never be invoked when set as an error policy
         // as we are not sending requests that error
         error_policy_type: PolicyType::TestPanicOnInvocation,
         channel_capacity: 100,
         dry_run: true,
-        ..Default::default()
     };
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
         .build()
         .await;
-    assert_traffic_control_dry_run(test_cluster).await
+    assert_traffic_control_dry_run(test_cluster, n as usize).await
 }
 
 #[tokio::test]
@@ -470,11 +471,10 @@ async fn assert_traffic_control_ok(mut test_cluster: TestCluster) -> Result<(), 
 /// are allowed to proceed.
 async fn assert_traffic_control_dry_run(
     mut test_cluster: TestCluster,
+    txn_count: usize,
 ) -> Result<(), anyhow::Error> {
     let context = &mut test_cluster.wallet;
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
-
-    let txn_count = 4;
     let mut txns = batch_make_transfer_transactions(context, txn_count).await;
     assert!(
         txns.len() >= txn_count,


### PR DESCRIPTION
## Description 

Dry run previously only applied to validators. This change refactors such that it will apply to all callsites of `TrafficController::check`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
