### PR TITLE
[move][ide] Add dot autocomplete behavior

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2806,8 +2806,12 @@ impl<'a> TypingSymbolicator<'a> {
                 self.exp_symbols(exp, scope);
                 self.add_type_id_use_def(t);
             }
-            E::AutocompleteDotAccess(e, _) => {
-                self.exp_symbols(e, scope);
+            E::AutocompleteDotAccess {
+                base_exp,
+                methods: _,
+                fields: _,
+            } => {
+                self.exp_symbols(base_exp, scope);
             }
             _ => (),
         }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2806,7 +2806,7 @@ impl<'a> TypingSymbolicator<'a> {
                 self.exp_symbols(exp, scope);
                 self.add_type_id_use_def(t);
             }
-            E::InvalidAccess(e) => {
+            E::AutocompleteDotAccess(e, _) => {
                 self.exp_symbols(e, scope);
             }
             _ => (),

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -374,7 +374,10 @@ codes!(
         MakePubPackage: { msg: "move 2024 migration: make 'public(package)'", severity: NonblockingError },
         AddressRemove: { msg: "move 2024 migration: address remove", severity: NonblockingError },
         AddressAdd: { msg: "move 2024 migration: address add", severity: NonblockingError },
-    ]
+    ],
+    IDE: [
+        Autocomplete: { msg: "IDE autocomplete", severity: NonblockingError },
+    ],
 );
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -527,7 +527,7 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::Borrow(_, base_exp, _)
         | E::Cast(base_exp, _)
         | E::TempBorrow(_, base_exp)
-        | E::AutocompleteDotAccess(base_exp, _) => value_report!(base_exp),
+        | E::AutocompleteDotAccess { base_exp, .. } => value_report!(base_exp),
 
         E::BorrowLocal(_, _) => None,
 
@@ -739,7 +739,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::ErrorConstant { .. }
         | E::Move { .. }
         | E::Copy { .. }
-        | E::AutocompleteDotAccess(_, _)
+        | E::AutocompleteDotAccess { .. }
         | E::UnresolvedError => value(context, e),
 
         E::Value(_) | E::Unit { .. } => None,

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -527,7 +527,7 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::Borrow(_, base_exp, _)
         | E::Cast(base_exp, _)
         | E::TempBorrow(_, base_exp)
-        | E::InvalidAccess(base_exp) => value_report!(base_exp),
+        | E::AutocompleteDotAccess(base_exp, _) => value_report!(base_exp),
 
         E::BorrowLocal(_, _) => None,
 
@@ -739,7 +739,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::ErrorConstant { .. }
         | E::Move { .. }
         | E::Copy { .. }
-        | E::InvalidAccess(_)
+        | E::AutocompleteDotAccess(_, _)
         | E::UnresolvedError => value(context, e),
 
         E::Value(_) | E::Unit { .. } => None,

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1699,8 +1699,9 @@ fn value(
             };
             let names = methods
                 .into_iter()
-                .chain(fields.into_iter())
-                .collect::<BTreeSet<_>>();
+                .map(|(m, f)| format!("{m}::{f}"))
+                .chain(fields.into_iter().map(|n| format!("{n}")))
+                .collect::<Vec<_>>();
             let msg = format!(
                 "Autocompletes to: {}",
                 format_oxford_list!("or", "'{}'", names)

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1687,12 +1687,20 @@ fn value(
             assert!(context.env.has_errors());
             make_exp(HE::UnresolvedError)
         }
-        E::AutocompleteDotAccess(_, names) => {
+        E::AutocompleteDotAccess {
+            base_exp: _,
+            methods,
+            fields,
+        } => {
             if !(context.env.ide_mode()) {
                 context
                     .env
                     .add_diag(ice!((eloc, "Found autocomplete outside of IDE mode")));
             };
+            let names = methods
+                .into_iter()
+                .chain(fields.into_iter())
+                .collect::<BTreeSet<_>>();
             let msg = format!(
                 "Autocompletes to: {}",
                 format_oxford_list!("or", "'{}'", names)
@@ -2040,7 +2048,7 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         | E::Move { .. }
         | E::Copy { .. }
         | E::UnresolvedError
-        | E::AutocompleteDotAccess(_, _)
+        | E::AutocompleteDotAccess { .. }
         | E::NamedBlock(_, _)) => value_statement(context, block, make_exp(e_)),
 
         E::Value(_) | E::Unit { .. } => (),

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -356,7 +356,7 @@ pub enum ExpDotted_ {
     Exp(Box<Exp>),
     Dot(Box<ExpDotted>, Field),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
-    DotUnresolved(Loc, Box<ExpDotted>), // Dot (and its location) where Field could not be parsed
+    DotAutocomplete(Loc, Box<ExpDotted>), // Dot (and its location) where Field could not be parsed
 }
 pub type ExpDotted = Spanned<ExpDotted_>;
 
@@ -1890,7 +1890,7 @@ impl AstDebug for ExpDotted_ {
                 w.comma(args, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            D::DotUnresolved(_, e) => {
+            D::DotAutocomplete(_, e) => {
                 e.ast_debug(w);
                 w.write(".")
             }

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -400,7 +400,9 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => exp_dotted(context, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
+            exp_dotted(context, ed)
+        }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2614,7 +2614,7 @@ fn dotted(context: &mut Context, edot: E::ExpDotted) -> Option<N::ExpDotted> {
         }
         E::ExpDotted_::Dot(d, f) => N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), Field(f)),
         E::ExpDotted_::DotUnresolved(loc, d) => {
-            N::ExpDotted_::DotUnresolved(loc, Box::new(dotted(context, *d)?))
+            N::ExpDotted_::DotAutocomplete(loc, Box::new(dotted(context, *d)?))
         }
         E::ExpDotted_::Index(inner, args) => {
             let args = call_args(context, args);
@@ -3843,7 +3843,7 @@ fn remove_unused_bindings_exp_dotted(
 ) {
     match ed_ {
         N::ExpDotted_::Exp(e) => remove_unused_bindings_exp(context, used, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => {
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
             remove_unused_bindings_exp_dotted(context, used, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -22,7 +22,17 @@ pub fn is_upper_snake_case(s: &str) -> bool {
 // String Construction Helpers
 //**************************************************************************************************
 
-/// Formats a string into an oxford list as: `format_oxford_list("or", "{}", vs);`
+/// Converts the first letter of a string to uppercase (ascii-only)
+pub fn make_ascii_titlecase(in_s: &str) -> String {
+    let mut s = in_s.to_string();
+    if let Some(c) = s.get_mut(0..1) {
+        c.make_ascii_uppercase();
+    }
+    s
+}
+
+/// Formats a string into an oxford list as: `format_oxford_list("or", "{}", vs);`. Calls `iter()`
+/// and `len()` on `vs`.
 ///
 /// This will use `or` as the separator for the last two elements, interspersing commas as
 /// appropriate:

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -111,7 +111,9 @@ pub(crate) use debug_print_format;
 macro_rules! debug_print_internal {
     () => {};
     ((msg $msg:expr)) => {
+        {
         println!("{}", $msg);
+        }
     };
     (($name:expr => $val:expr $(; $fmt:ident)?)) => {
         {

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -22,21 +22,37 @@ pub fn is_upper_snake_case(s: &str) -> bool {
 // String Construction Helpers
 //**************************************************************************************************
 
+/// Formats a string into an oxford list as: `format_oxford_list("or", "{}", vs);`
+///
+/// This will use `or` as the separator for the last two elements, interspersing commas as
+/// appropriate:
+/// ```
+/// format_oxford_list("or", "{}", [1]);
+/// ==> "1"
+///
+/// format_oxford_list("or", "{}", [1, 2]);
+/// ==> "1 or 2"
+///
+/// format_oxford_list("or", "{}", [1, 2, 3]);
+/// ==> "1, 2, or 3"
+///```
+///
 macro_rules! format_oxford_list {
     ($sep:expr, $format_str:expr, $e:expr) => {{
-        let entries = $e;
-        match entries.len() {
+        let in_entries = $e;
+        let e_len = in_entries.len();
+        let mut entries = in_entries.iter();
+        match e_len {
             0 => String::new(),
-            1 => format!($format_str, entries[0]),
+            1 => format!($format_str, entries.next().unwrap()),
             2 => format!(
                 "{} {} {}",
-                format!($format_str, entries[0]),
+                format!($format_str, entries.next().unwrap()),
                 $sep,
-                format!($format_str, entries[1])
+                format!($format_str, entries.next().unwrap())
             ),
             _ => {
                 let entries = entries
-                    .iter()
                     .map(|entry| format!($format_str, entry))
                     .collect::<Vec<_>>();
                 if let Some((last, init)) = entries.split_last() {

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -238,8 +238,8 @@ pub enum UnannotatedExp_ {
     Cast(Box<Exp>, Box<Type>),
     Annotate(Box<Exp>, Box<Type>),
 
-    // unfinished dot access (e.g. `some_field.`)
-    InvalidAccess(Box<Exp>),
+    // unfinished dot access (e.g. `some_field.`) with autocomplete information on it.
+    AutocompleteDotAccess(Box<Exp>, BTreeSet<Symbol>),
 
     ErrorConstant {
         line_number_loc: Loc,
@@ -835,7 +835,7 @@ impl AstDebug for UnannotatedExp_ {
                 ty.ast_debug(w);
                 w.write(")");
             }
-            E::InvalidAccess(e) => {
+            E::AutocompleteDotAccess(e, _) => {
                 e.ast_debug(w);
                 w.write(".");
             }

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -835,9 +835,11 @@ impl AstDebug for UnannotatedExp_ {
                 ty.ast_debug(w);
                 w.write(")");
             }
-            E::AutocompleteDotAccess(e, _) => {
+            E::AutocompleteDotAccess(e, ns) => {
                 e.ast_debug(w);
-                w.write(".");
+                w.write(".{");
+                w.comma(ns, |w, n| w.write(format!("{n}")));
+                w.write("}");
             }
             E::UnresolvedError => w.write("_|_"),
             E::ErrorConstant {

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -241,7 +241,7 @@ pub enum UnannotatedExp_ {
     // unfinished dot access (e.g. `some_field.`) with autocomplete information on it.
     AutocompleteDotAccess {
         base_exp: Box<Exp>,
-        methods: BTreeSet<Symbol>,
+        methods: BTreeSet<(ModuleIdent, FunctionName)>,
         fields: BTreeSet<Symbol>,
     },
 
@@ -846,9 +846,12 @@ impl AstDebug for UnannotatedExp_ {
             } => {
                 base_exp.ast_debug(w);
                 w.write(".{");
-                w.comma(methods.iter().chain(fields.iter()), |w, n| {
-                    w.write(format!("{n}"))
-                });
+                let names = methods
+                    .iter()
+                    .map(|(m, f)| format!("{m}::{f}"))
+                    .chain(fields.iter().map(|n| format!("{n}")))
+                    .collect::<Vec<_>>();
+                w.comma(names, |w, n| w.write(n));
                 w.write("}");
             }
             E::UnresolvedError => w.write("_|_"),

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -239,7 +239,11 @@ pub enum UnannotatedExp_ {
     Annotate(Box<Exp>, Box<Type>),
 
     // unfinished dot access (e.g. `some_field.`) with autocomplete information on it.
-    AutocompleteDotAccess(Box<Exp>, BTreeSet<Symbol>),
+    AutocompleteDotAccess {
+        base_exp: Box<Exp>,
+        methods: BTreeSet<Symbol>,
+        fields: BTreeSet<Symbol>,
+    },
 
     ErrorConstant {
         line_number_loc: Loc,
@@ -835,10 +839,16 @@ impl AstDebug for UnannotatedExp_ {
                 ty.ast_debug(w);
                 w.write(")");
             }
-            E::AutocompleteDotAccess(e, ns) => {
-                e.ast_debug(w);
+            E::AutocompleteDotAccess {
+                base_exp,
+                methods,
+                fields,
+            } => {
+                base_exp.ast_debug(w);
                 w.write(".{");
-                w.comma(ns, |w, n| w.write(format!("{n}")));
+                w.comma(methods.iter().chain(fields.iter()), |w, n| {
+                    w.write(format!("{n}"))
+                });
                 w.write("}");
             }
             E::UnresolvedError => w.write("_|_"),

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -20,7 +20,10 @@ use crate::{
     parser::ast::{
         Ability_, ConstantName, DatatypeName, Field, FunctionName, VariantName, ENTRY_MODIFIER,
     },
-    shared::{known_attributes::TestingAttribute, program_info::*, unique_map::UniqueMap, *},
+    shared::{
+        known_attributes::TestingAttribute, program_info::*, string_utils::debug_print,
+        unique_map::UniqueMap, *,
+    },
     typing::match_compilation,
     FullyCompiledProgram,
 };
@@ -79,6 +82,7 @@ pub(super) struct TypingDebugFlags {
     pub(super) match_counterexample: bool,
     pub(super) match_work_queue: bool,
     pub(super) match_constant_conversion: bool,
+    pub(super) autocomplete_resolution: bool,
 }
 
 pub struct Context<'env> {
@@ -178,6 +182,7 @@ impl<'env> Context<'env> {
             match_counterexample: false,
             match_work_queue: false,
             match_constant_conversion: false,
+            autocomplete_resolution: false,
         };
         Context {
             use_funs: vec![global_use_funs],
@@ -854,6 +859,54 @@ impl<'env> Context<'env> {
     fn next_match_var_id(&mut self) -> usize {
         self.next_match_var_id += 1;
         self.next_match_var_id
+    }
+
+    //********************************************
+    // IDE Helpers
+    //********************************************
+
+    /// Find all valid methods in scope for a given `TypeName`. This is used for autocomplete.
+    pub fn find_all_methods(&mut self, tn: &TypeName) -> BTreeSet<Symbol> {
+        debug_print!(self.debug.autocomplete_resolution, (msg "methods"), ("name" => tn));
+        let cur_color = self.use_funs.last().unwrap().color;
+        let mut result = BTreeSet::new();
+        self.use_funs.iter().rev().for_each(|scope| {
+            if scope.color.is_some() && scope.color != cur_color {
+                return;
+            }
+            if let Some(names) = scope.use_funs.get(tn) {
+                let mut new_names = names.key_cloned_iter().map(|(k, _)| k.value).collect();
+                result.append(&mut new_names);
+            }
+        });
+        debug_print!(self.debug.autocomplete_resolution, (lines "result" => &result; fmt));
+        result
+    }
+
+    /// Find all valid fields in scope for a given `TypeName`. This is used for autocomplete.
+    pub fn find_all_fields(&mut self, tn: &TypeName) -> BTreeSet<Symbol> {
+        debug_print!(self.debug.autocomplete_resolution, (msg "fields"), ("name" => tn));
+        let fields = match &tn.value {
+            TypeName_::Multiple(_) => BTreeSet::new(),
+            // TODO(cswords): are there any valid builtin fielsd?
+            TypeName_::Builtin(_) => BTreeSet::new(),
+            TypeName_::ModuleType(m, _n) if !self.is_current_module(m) => BTreeSet::new(),
+            TypeName_::ModuleType(m, n) => match self.datatype_kind(m, n) {
+                DatatypeKind::Enum => BTreeSet::new(),
+                DatatypeKind::Struct => match &self.struct_definition(m, n).fields {
+                    N::StructFields::Native(_) => BTreeSet::new(),
+                    N::StructFields::Defined(is_positional, fields) => {
+                        if *is_positional {
+                            (0..fields.len()).map(|n| format!("{}", n).into()).collect()
+                        } else {
+                            fields.key_cloned_iter().map(|(k, _)| k.value()).collect()
+                        }
+                    }
+                },
+            },
+        };
+        debug_print!(self.debug.autocomplete_resolution, (lines "fields" => &fields; dbg));
+        fields
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -83,6 +83,7 @@ pub(super) struct TypingDebugFlags {
     pub(super) match_work_queue: bool,
     pub(super) match_constant_conversion: bool,
     pub(super) autocomplete_resolution: bool,
+    pub(super) function_translation: bool,
 }
 
 pub struct Context<'env> {
@@ -183,6 +184,7 @@ impl<'env> Context<'env> {
             match_work_queue: false,
             match_constant_conversion: false,
             autocomplete_resolution: false,
+            function_translation: false,
         };
         Context {
             use_funs: vec![global_use_funs],
@@ -868,7 +870,10 @@ impl<'env> Context<'env> {
     /// Find all valid methods in scope for a given `TypeName`. This is used for autocomplete.
     pub fn find_all_methods(&mut self, tn: &TypeName) -> BTreeSet<Symbol> {
         debug_print!(self.debug.autocomplete_resolution, (msg "methods"), ("name" => tn));
-        if !self.env.supports_feature(self.current_package(), FeatureGate::DotCall) {
+        if !self
+            .env
+            .supports_feature(self.current_package(), FeatureGate::DotCall)
+        {
             debug_print!(self.debug.autocomplete_resolution, (msg "dot call unsupported"));
             return BTreeSet::new();
         }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -868,6 +868,10 @@ impl<'env> Context<'env> {
     /// Find all valid methods in scope for a given `TypeName`. This is used for autocomplete.
     pub fn find_all_methods(&mut self, tn: &TypeName) -> BTreeSet<Symbol> {
         debug_print!(self.debug.autocomplete_resolution, (msg "methods"), ("name" => tn));
+        if !self.env.supports_feature(self.current_package(), FeatureGate::DotCall) {
+            debug_print!(self.debug.autocomplete_resolution, (msg "dot call unsupported"));
+            return BTreeSet::new();
+        }
         let cur_color = self.use_funs.last().unwrap().color;
         let mut result = BTreeSet::new();
         self.use_funs.iter().rev().for_each(|scope| {

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -868,7 +868,10 @@ impl<'env> Context<'env> {
     //********************************************
 
     /// Find all valid methods in scope for a given `TypeName`. This is used for autocomplete.
-    pub fn find_all_methods(&mut self, tn: &TypeName) -> BTreeSet<Symbol> {
+    pub fn find_all_methods(
+        &mut self,
+        tn: &TypeName,
+    ) -> BTreeSet<(Spanned<ModuleIdent_>, FunctionName)> {
         debug_print!(self.debug.autocomplete_resolution, (msg "methods"), ("name" => tn));
         if !self
             .env
@@ -884,11 +887,14 @@ impl<'env> Context<'env> {
                 return;
             }
             if let Some(names) = scope.use_funs.get(tn) {
-                let mut new_names = names.key_cloned_iter().map(|(k, _)| k.value).collect();
+                let mut new_names = names
+                    .iter()
+                    .map(|(_, _, use_fun)| use_fun.target_function)
+                    .collect();
                 result.append(&mut new_names);
             }
         });
-        debug_print!(self.debug.autocomplete_resolution, (lines "result" => &result; fmt));
+        debug_print!(self.debug.autocomplete_resolution, (lines "result" => &result; dbg));
         result
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -471,7 +471,11 @@ fn exp(context: &mut Context, e: &T::Exp) {
             exp(context, e);
             type_(context, ty)
         }
-        E::AutocompleteDotAccess(e, _) => exp(context, e),
+        E::AutocompleteDotAccess {
+            base_exp,
+            methods: _,
+            fields: _,
+        } => exp(context, base_exp),
         E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -471,7 +471,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
             exp(context, e);
             type_(context, ty)
         }
-        E::InvalidAccess(e) => exp(context, e),
+        E::AutocompleteDotAccess(e, _) => exp(context, e),
         E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -271,7 +271,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::UnaryExp(_, er)
         | E::Borrow(_, er, _)
         | E::TempBorrow(_, er)
-        | E::InvalidAccess(er) => exp(context, er),
+        | E::AutocompleteDotAccess(er, _) => exp(context, er),
         E::Mutate(el, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -264,14 +264,18 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
             exp(context, er);
         }
 
-        E::Return(er)
-        | E::Abort(er)
-        | E::Give(_, er)
-        | E::Dereference(er)
-        | E::UnaryExp(_, er)
-        | E::Borrow(_, er, _)
-        | E::TempBorrow(_, er)
-        | E::AutocompleteDotAccess(er, _) => exp(context, er),
+        E::Return(base_exp)
+        | E::Abort(base_exp)
+        | E::Give(_, base_exp)
+        | E::Dereference(base_exp)
+        | E::UnaryExp(_, base_exp)
+        | E::Borrow(_, base_exp, _)
+        | E::TempBorrow(_, base_exp)
+        | E::AutocompleteDotAccess {
+            base_exp,
+            methods: _,
+            fields: _,
+        } => exp(context, base_exp),
         E::Mutate(el, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -277,7 +277,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::UnaryExp(_, er)
         | E::Borrow(_, er, _)
         | E::TempBorrow(_, er)
-        | E::InvalidAccess(er) => exp(context, er),
+        | E::AutocompleteDotAccess(er, _) => exp(context, er),
         E::Mutate(el, er) | E::BinopExp(el, _, _, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -268,16 +268,20 @@ fn exp(context: &mut Context, e: &T::Exp) {
         E::Block(seq) => sequence(context, seq),
         E::Assign(_, _, er) => exp(context, er),
 
-        E::Builtin(_, er)
-        | E::Vector(_, _, _, er)
-        | E::Return(er)
-        | E::Abort(er)
-        | E::Give(_, er)
-        | E::Dereference(er)
-        | E::UnaryExp(_, er)
-        | E::Borrow(_, er, _)
-        | E::TempBorrow(_, er)
-        | E::AutocompleteDotAccess(er, _) => exp(context, er),
+        E::Builtin(_, base_exp)
+        | E::Vector(_, _, _, base_exp)
+        | E::Return(base_exp)
+        | E::Abort(base_exp)
+        | E::Give(_, base_exp)
+        | E::Dereference(base_exp)
+        | E::UnaryExp(_, base_exp)
+        | E::Borrow(_, base_exp, _)
+        | E::TempBorrow(_, base_exp)
+        | E::AutocompleteDotAccess {
+            base_exp,
+            methods: _,
+            fields: _,
+        } => exp(context, base_exp),
         E::Mutate(el, er) | E::BinopExp(el, _, _, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -677,7 +677,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
 fn recolor_exp_dotted(ctx: &mut Recolor, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => recolor_exp(ctx, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => {
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
             recolor_exp_dotted(ctx, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
@@ -1147,7 +1147,9 @@ fn builtin_function(context: &mut Context, sp!(_, bf_): &mut N::BuiltinFunction)
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => exp_dotted(context, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
+            exp_dotted(context, ed)
+        }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -3166,8 +3166,7 @@ fn process_exp_dotted(
         match ndot_ {
             N::ExpDotted_::Exp(e) => process_base_exp(context, constraint_verb, dloc, e),
             N::ExpDotted_::Dot(ndot, field) => {
-                let mut inner =
-                    process_exp_dotted_autocomplete(context, Some("dot access"), *ndot);
+                let mut inner = process_exp_dotted_autocomplete(context, Some("dot access"), *ndot);
                 if inner.for_autocomplete {
                     return inner;
                 }
@@ -3187,8 +3186,7 @@ fn process_exp_dotted(
                 inner
             }
             N::ExpDotted_::Index(ndot, sp!(argloc, nargs_)) => {
-                let mut inner =
-                    process_exp_dotted_autocomplete(context, Some("dot access"), *ndot);
+                let mut inner = process_exp_dotted_autocomplete(context, Some("dot access"), *ndot);
                 if inner.for_autocomplete {
                     return inner;
                 }
@@ -3199,8 +3197,7 @@ fn process_exp_dotted(
                 inner
             }
             N::ExpDotted_::DotAutocomplete(_loc, ndot) => {
-                let mut inner =
-                    process_exp_dotted_autocomplete(context, Some("dot access"), *ndot);
+                let mut inner = process_exp_dotted_autocomplete(context, Some("dot access"), *ndot);
                 if inner.for_autocomplete {
                     return inner;
                 }
@@ -3229,8 +3226,7 @@ fn process_exp_dotted(
                 inner
             }
             N::ExpDotted_::Index(ndot, sp!(argloc, nargs_)) => {
-                let mut inner =
-                    process_exp_dotted_inner(context, Some("dot access"), *ndot);
+                let mut inner = process_exp_dotted_inner(context, Some("dot access"), *ndot);
                 let inner_ty = inner.last_type();
                 let index_access = process_index_access(context, dloc, inner_ty, argloc, nargs_);
                 inner.loc = dloc;

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -222,7 +222,7 @@ pub trait TypingVisitorContext {
             E::TempBorrow(_, e) => self.visit_exp(e),
             E::Cast(e, _) => self.visit_exp(e),
             E::Annotate(e, _) => self.visit_exp(e),
-            E::InvalidAccess(e) => self.visit_exp(e),
+            E::AutocompleteDotAccess(e, _) => self.visit_exp(e),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -222,7 +222,11 @@ pub trait TypingVisitorContext {
             E::TempBorrow(_, e) => self.visit_exp(e),
             E::Cast(e, _) => self.visit_exp(e),
             E::Annotate(e, _) => self.visit_exp(e),
-            E::AutocompleteDotAccess(e, _) => self.visit_exp(e),
+            E::AutocompleteDotAccess {
+                base_exp,
+                methods: _,
+                fields: _,
+            } => self.visit_exp(base_exp),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.exp
@@ -1,36 +1,45 @@
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:12:23
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:13:21
    │
-12 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
-   │                       ^
-   │                       │
-   │                       Unexpected ';'
-   │                       Expected an identifier or a decimal number
+13 │         let _tmp1 = _s.;                // incomplete with `;` (next line should parse)
+   │                     ^^^ Autocompletes to: 'a'
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:13:37
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:13:24
    │
-13 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
-   │                                     ^
-   │                                     │
-   │                                     Unexpected ';'
-   │                                     Expected an identifier or a decimal number
+13 │         let _tmp1 = _s.;                // incomplete with `;` (next line should parse)
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:14:21
+   │
+14 │         let _tmp2 = _s.a.;  // incomplete with `;` (next line should parse)
+   │                     ^^^^^ Autocompletes to: 'x'
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:15:9
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:14:26
    │
-15 │         let _tmp4 = s;
+14 │         let _tmp2 = _s.a.;  // incomplete with `;` (next line should parse)
+   │                          ^
+   │                          │
+   │                          Unexpected ';'
+   │                          Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:15:21
+   │
+15 │         let _tmp3 = _s.a.   // incomplete without `;` (unexpected `let`)
+   │                     ^^^^^ Autocompletes to: 'x'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:16:9
+   │
+16 │         let _tmp4 = _s.
    │         ^^^
    │         │
    │         Unexpected 'let'
    │         Expected an identifier or a decimal number
-
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:17:5
-   │
-17 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier or a decimal number
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.move
@@ -1,18 +1,19 @@
 module a::m {
 
-    public struct SomeStruct has drop {
-        some_field: u64
+    public struct A has copy, drop {
+        x: u64
     }
 
-    public struct AnotherStruct has drop {
-        another_field: SomeStruct
+    public struct B has copy, drop {
+        a: A
     }
 
-    fun foo(s: AnotherStruct) {
-        let _tmp1 = s.;                // incomplete with `;` (next line should parse)
-        let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
-        let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
-        let _tmp4 = s;
-        let _tmp = s.                  // incomplete without `;` (unexpected `}`)
+    fun foo() {
+        let _s = B { a: A { x: 0 } };
+        let _tmp1 = _s.;                // incomplete with `;` (next line should parse)
+        let _tmp2 = _s.a.;  // incomplete with `;` (next line should parse)
+        let _tmp3 = _s.a.   // incomplete without `;` (unexpected `let`)
+        let _tmp4 = _s.
+        let _tmp5 = _s.                  // incomplete without `;` (unexpected `}`)
     }
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.exp
@@ -1,0 +1,45 @@
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:17:17
+   │
+17 │         let _ = &in.0.0[1]. ;
+   │                 ^^^^^^^^^^^ Autocompletes to: '0'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:17:29
+   │
+17 │         let _ = &in.0.0[1]. ;
+   │                             ^
+   │                             │
+   │                             Unexpected ';'
+   │                             Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:21:17
+   │
+21 │         let _ = &in.0.0[1].0[0]. ;
+   │                 ^^^^^^^^^^^^^^^^ Autocompletes to: 
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:21:34
+   │
+21 │         let _ = &in.0.0[1].0[0]. ;
+   │                                  ^
+   │                                  │
+   │                                  Unexpected ';'
+   │                                  Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:25:17
+   │
+25 │         let _ = &in.0.0[1].0[0]. ;
+   │                 ^^^^^^^^^^^^^^^^ Autocompletes to: 'c' or 'd'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:25:34
+   │
+25 │         let _ = &in.0.0[1].0[0]. ;
+   │                                  ^
+   │                                  │
+   │                                  Unexpected ';'
+   │                                  Expected an identifier or a decimal number
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.move
@@ -1,0 +1,27 @@
+
+#[defines_primitive(vector)]
+module std::vector {
+    #[syntax(index)]
+    native public fun vborrow<Element>(v: &vector<Element>, i: u64): &Element;
+    #[syntax(index)]
+    native public fun vborrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+}
+
+module a::m {
+
+    public struct A<T>(vector<T>) has drop;
+    public struct B<T>(A<T>) has drop;
+    public struct C { c: u64, d: u64 } has drop;
+
+    public fun test0(in: B<A<u64>>) {
+        let _ = &in.0.0[1]. ;
+    }
+
+    public fun test1(in: B<A<u64>>) {
+        let _ = &in.0.0[1].0[0]. ;
+    }
+
+    public fun test2(in: B<A<C>>) {
+        let _ = &in.0.0[1].0[0]. ;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.exp
@@ -1,0 +1,30 @@
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:13:21
+   │
+13 │         let _tmp1 = _s.;
+   │                     ^^^ Autocompletes to: 'a'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:13:24
+   │
+13 │         let _tmp1 = _s.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:14:21
+   │
+14 │         let _tmp2 = _s.a.;
+   │                     ^^^^^ Autocompletes to: 'x'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:14:26
+   │
+14 │         let _tmp2 = _s.a.;
+   │                          ^
+   │                          │
+   │                          Unexpected ';'
+   │                          Expected an identifier or a decimal number
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.move
@@ -1,0 +1,16 @@
+module a::m {
+
+    public struct A has copy, drop {
+        x: u64
+    }
+
+    public struct B has copy, drop {
+        a: A
+    }
+
+    fun foo() {
+        let _s = B { a: A { x: 0 } };
+        let _tmp1 = _s.;
+        let _tmp2 = _s.a.;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_middle_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_middle_autocomplete.exp
@@ -1,0 +1,6 @@
+error[E03010]: unbound field
+   ┌─ tests/move_2024/ide_mode/named_struct_middle_autocomplete.move:16:21
+   │
+16 │         let _tmp2 = _s.b.x;
+   │                     ^^^^ Unbound field 'b' in 'a::m::B'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_middle_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_middle_autocomplete.move
@@ -1,0 +1,18 @@
+// NOTE: the expected file does not demonstrate the autocomplete occurring, but debug_print calls
+// showcase the behavior as working.
+
+module a::m {
+
+    public struct A has copy, drop {
+        x: u64
+    }
+
+    public struct B has copy, drop {
+        a: A
+    }
+
+    fun foo() {
+        let _s = B { a: A { x: 0 } };
+        let _tmp2 = _s.b.x;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.exp
@@ -1,0 +1,30 @@
+error[E15001]: IDE autocomplete
+  ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:9:21
+  │
+9 │         let _tmp1 = _s.;
+  │                     ^^^ Autocompletes to: '0'
+
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:9:24
+  │
+9 │         let _tmp1 = _s.;
+  │                        ^
+  │                        │
+  │                        Unexpected ';'
+  │                        Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:10:21
+   │
+10 │         let _tmp2 = _s.0.;
+   │                     ^^^^^ Autocompletes to: '0'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:10:26
+   │
+10 │         let _tmp2 = _s.0.;
+   │                          ^
+   │                          │
+   │                          Unexpected ';'
+   │                          Expected an identifier or a decimal number
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.move
@@ -1,0 +1,12 @@
+module a::m {
+
+    public struct A(u64) has copy, drop;
+
+    public struct B(A) has copy, drop;
+
+    fun foo() {
+        let _s = B(A(0));
+        let _tmp1 = _s.;
+        let _tmp2 = _s.0.;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.exp
@@ -1,0 +1,30 @@
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:18:21
+   │
+18 │         let _tmp1 = _a.;
+   │                     ^^^ Autocompletes to: 't0', 't1', or 't2'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:18:24
+   │
+18 │         let _tmp1 = _a.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:19:21
+   │
+19 │         let _tmp2 = _b.;
+   │                     ^^^ Autocompletes to: 't3', 't4', or 't5'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:19:24
+   │
+19 │         let _tmp2 = _b.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.exp
@@ -2,7 +2,7 @@ error[E15001]: IDE autocomplete
    ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:18:21
    │
 18 │         let _tmp1 = _a.;
-   │                     ^^^ Autocompletes to: 't0', 't1', or 't2'
+   │                     ^^^ Autocompletes to: 'a::m::t0', 'a::m::t1', or 'a::m::t2'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:18:24
@@ -17,7 +17,7 @@ error[E15001]: IDE autocomplete
    ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:19:21
    │
 19 │         let _tmp2 = _b.;
-   │                     ^^^ Autocompletes to: 't3', 't4', or 't5'
+   │                     ^^^ Autocompletes to: 'a::m::t3', 'a::m::t4', or 'a::m::t5'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:19:24

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.move
@@ -1,0 +1,21 @@
+module a::m {
+
+    public struct A has copy, drop { }
+
+    public struct B() has copy, drop;
+
+    public fun t0(_s: A): u64 { abort 0 }
+    public fun t1(_s: &A): u64 { abort 0 }
+    public fun t2(_s: &A): u64 { abort 0 }
+
+    public fun t3(_s: B): u64 { abort 0 }
+    public fun t4(_s: &B): u64 { abort 0 }
+    public fun t5(_s: &B): u64 { abort 0 }
+
+    fun foo() {
+        let _a = A {};
+        let _b = B();
+        let _tmp1 = _a.;
+        let _tmp2 = _b.;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_invalid_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_invalid_autocomplete.exp
@@ -1,0 +1,18 @@
+error[E04023]: invalid method call
+   ┌─ tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move:22:21
+   │
+22 │         let _tmp1 = _a.t7();
+   │                     ^^^^^^^
+   │                     │  │
+   │                     │  No local 'use fun' alias was found for 'a::m::A.t7', and no function 't7' was found in the defining module 'a::m'
+   │                     Invalid method call. No known method 't7' on type 'a::m::A'
+
+error[E04023]: invalid method call
+   ┌─ tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move:23:21
+   │
+23 │         let _tmp2 = _b.t8();
+   │                     ^^^^^^^
+   │                     │  │
+   │                     │  No local 'use fun' alias was found for 'a::m::B.t8', and no function 't8' was found in the defining module 'a::m'
+   │                     Invalid method call. No known method 't8' on type 'a::m::B'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move
@@ -1,0 +1,25 @@
+
+// NOTE: the expected file does not demonstrate the autocomplete occurring, but debug_print calls
+// showcase the behavior as working.
+
+module a::m {
+
+    public struct A has copy, drop { }
+
+    public struct B() has copy, drop;
+
+    public fun t0(_s: A): u64 { abort 0 }
+    public fun t1(_s: &A): u64 { abort 0 }
+    public fun t2(_s: &A): u64 { abort 0 }
+
+    public fun t3(_s: B): u64 { abort 0 }
+    public fun t4(_s: &B): u64 { abort 0 }
+    public fun t5(_s: &B): u64 { abort 0 }
+
+    fun foo() {
+        let _a = A {};
+        let _b = B();
+        let _tmp1 = _a.t7();
+        let _tmp2 = _b.t8();
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.exp
@@ -2,7 +2,7 @@ error[E15001]: IDE autocomplete
    ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:17:21
    │
 17 │         let _tmp1 = _a.;
-   │                     ^^^ Autocompletes to: 't0'
+   │                     ^^^ Autocompletes to: 'a::m::t0'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:17:24
@@ -17,7 +17,7 @@ error[E15001]: IDE autocomplete
    ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:18:21
    │
 18 │         let _tmp2 = _b.;
-   │                     ^^^ Autocompletes to: 't1'
+   │                     ^^^ Autocompletes to: 'a::m::t1'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:18:24

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.exp
@@ -1,0 +1,30 @@
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:17:21
+   │
+17 │         let _tmp1 = _a.;
+   │                     ^^^ Autocompletes to: 't0'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:17:24
+   │
+17 │         let _tmp1 = _a.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:18:21
+   │
+18 │         let _tmp2 = _b.;
+   │                     ^^^ Autocompletes to: 't1'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:18:24
+   │
+18 │         let _tmp2 = _b.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.move
@@ -1,0 +1,20 @@
+module a::m {
+
+    public struct A(u64) has copy, drop;
+
+    public struct B has copy, drop {
+        a: A
+    }
+
+    public fun t0(_s: A): u64 { abort 0 }
+    public fun t1(_s: B): u64 { abort 0 }
+}
+
+module a::n {
+    use a::m::{A,B};
+
+    fun foo(_a: A, _b: B) {
+        let _tmp1 = _a.;
+        let _tmp2 = _b.;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/dot_incomplete.exp
@@ -1,66 +1,66 @@
-error[E13001]: feature is not supported in specified edition
-  ┌─ tests/move_check/ide_mode/dot_incomplete.move:3:5
-  │
-3 │     public struct SomeStruct has drop {
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
-  │
-  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+warning[W09003]: unused assignment
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:12:13
+   │
+12 │         let s = AnotherStruct { another_field: SomeStruct { some_field: 0 } };
+   │             ^ Unused assignment for variable 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
+   │
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-error[E01003]: invalid modifier
-  ┌─ tests/move_check/ide_mode/dot_incomplete.move:3:5
-  │
-3 │     public struct SomeStruct has drop {
-  │     ^^^^^^ Invalid struct declaration. Structs cannot have visibility modifiers as they are always 'public'
-  │
-  = Starting in the Move 2024 edition visibility must be annotated on struct declarations.
-
-error[E13001]: feature is not supported in specified edition
-  ┌─ tests/move_check/ide_mode/dot_incomplete.move:7:5
-  │
-7 │     public struct AnotherStruct has drop {
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
-  │
-  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
-
-error[E01003]: invalid modifier
-  ┌─ tests/move_check/ide_mode/dot_incomplete.move:7:5
-  │
-7 │     public struct AnotherStruct has drop {
-  │     ^^^^^^ Invalid struct declaration. Structs cannot have visibility modifiers as they are always 'public'
-  │
-  = Starting in the Move 2024 edition visibility must be annotated on struct declarations.
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:13:21
+   │
+13 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
+   │                     ^^ Autocompletes to: 'another_field'
 
 error[E01002]: unexpected token
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:12:23
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:13:23
    │
-12 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
+13 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
    │                       ^
    │                       │
    │                       Unexpected ';'
    │                       Expected an identifier or a decimal number
 
-error[E01002]: unexpected token
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:13:37
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:14:21
    │
-13 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
+14 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
+   │                     ^^^^^^^^^^^^^^^^ Autocompletes to: 'some_field'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:14:37
+   │
+14 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
    │                                     ^
    │                                     │
    │                                     Unexpected ';'
    │                                     Expected an identifier or a decimal number
 
-error[E01002]: unexpected token
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:15:9
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:15:21
    │
-15 │         let _tmp4 = s;
+15 │         let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
+   │                     ^^^^^^^^^^^^^^^^ Autocompletes to: 'some_field'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:16:9
+   │
+16 │         let _tmp4 = s;
    │         ^^^
    │         │
    │         Unexpected 'let'
    │         Expected an identifier or a decimal number
 
-error[E01002]: unexpected token
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:17:5
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:17:20
    │
-17 │     }
+17 │         let _tmp = s.                  // incomplete without `;` (unexpected `}`)
+   │                    ^^ Autocompletes to: 'another_field'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/ide_mode/dot_incomplete.move:18:5
+   │
+18 │     }
    │     ^
    │     │
    │     Unexpected '}'

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/dot_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/dot_incomplete.move
@@ -1,14 +1,15 @@
 module a::m {
 
-    public struct SomeStruct has drop {
+    struct SomeStruct has copy, drop {
         some_field: u64
     }
 
-    public struct AnotherStruct has drop {
+    struct AnotherStruct has copy, drop {
         another_field: SomeStruct
     }
 
-    fun foo(s: AnotherStruct) {
+    fun foo() {
+        let s = AnotherStruct { another_field: SomeStruct { some_field: 0 } };
         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
         let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/struct_method_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/struct_method_autocomplete.exp
@@ -1,0 +1,54 @@
+error[E13001]: feature is not supported in specified edition
+  ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:5:13
+  │
+5 │     struct B() has copy, drop;
+  │             ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │
+  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+
+error[E13001]: feature is not supported in specified edition
+  ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:5:16
+  │
+5 │     struct B() has copy, drop;
+  │                ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │
+  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+
+error[E13001]: feature is not supported in specified edition
+   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:17:18
+   │
+17 │         let _b = B();
+   │                  ^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │
+   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:18:21
+   │
+18 │         let _tmp1 = _a.;
+   │                     ^^^ Autocompletes to: 
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:18:24
+   │
+18 │         let _tmp1 = _a.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+
+error[E15001]: IDE autocomplete
+   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:19:21
+   │
+19 │         let _tmp2 = _b.;
+   │                     ^^^ Autocompletes to: 
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:19:24
+   │
+19 │         let _tmp2 = _b.;
+   │                        ^
+   │                        │
+   │                        Unexpected ';'
+   │                        Expected an identifier or a decimal number
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/struct_method_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/struct_method_autocomplete.move
@@ -1,0 +1,21 @@
+module a::m {
+
+    struct A has copy, drop { }
+
+    struct B() has copy, drop;
+
+    public fun t0(_s: A): u64 { abort 0 }
+    public fun t1(_s: &A): u64 { abort 0 }
+    public fun t2(_s: &A): u64 { abort 0 }
+
+    public fun t3(_s: B): u64 { abort 0 }
+    public fun t4(_s: &B): u64 { abort 0 }
+    public fun t5(_s: &B): u64 { abort 0 }
+
+    fun foo() {
+        let _a = A {};
+        let _b = B();
+        let _tmp1 = _a.;
+        let _tmp2 = _b.;
+    }
+}


### PR DESCRIPTION
## Description 

This updates the `DotUnexpected` form in typing to become an "Autocomplete" form. Note that this overrides any other behavior the dotted expression would have, leaving a list of symbols on the AST node that are valid dot completions (feature gated by dot calls for methods and visibility-restricted for struct field accesses).

## Test plan 

New tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
