### PR TITLE
Add internal build names  to dictionary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           mkdir -p ${{ env.TMP_BUILD_DIR }}
 
-          for binary in $(cat ./binary-build-list.json | jq -r '.[]'); do
+          for binary in $(cat ./binary-build-list.json | jq -r '.release_binaries[]'); do
             mv ./target/release/${binary}${{ env.extention }} ${{ env.TMP_BUILD_DIR }}/${binary}${{ env.extention }}
           done
 

--- a/binary-build-list.json
+++ b/binary-build-list.json
@@ -1,11 +1,20 @@
-[
-    "sui",
-    "sui-node",
-    "sui-tool",
-    "sui-faucet",
-    "sui-test-validator",
-    "sui-data-ingestion",
-    "sui-bridge",
-    "sui-bridge-cli",
-    "sui-graphql-rpc"
-]
+{
+    "release_binaries": [
+        "sui",
+        "sui-node",
+        "sui-tool",
+        "sui-faucet",
+        "sui-test-validator",
+        "sui-data-ingestion",
+        "sui-bridge",
+        "sui-bridge-cli",
+        "sui-graphql-rpc"
+    ],
+    "internal_binaries": [
+        "stress",
+        "sui-proxy",
+        "sui-metric-checker",
+        "sui-analytics-indexer",
+        "sui-security-watchdog"
+    ]
+}


### PR DESCRIPTION
## Description 
Add internal builds to the dictionary

## Test plan 
```
eugene@eugene-dev ~/code/sui (ebmifa/add_internal_binary_list) $ cat ./binary-build-list.json | jq -r '.release_binaries[]'
sui
sui-node
sui-tool
sui-faucet
sui-test-validator
sui-data-ingestion
sui-bridge
sui-bridge-cli
sui-graphql-rpc
```