### PR TITLE
[indexer] properly set key for cache in indexer reader

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1502,17 +1502,10 @@ impl<U: R2D2Connection> IndexerReader<U> {
             .package_obj_type_cache
             .lock()
             .unwrap()
-            .cache_get_or_set_with(
-                r#"{ format!("{}{}", package_id, obj_type) }"#.to_string(),
-                || {
-                    get_single_obj_id_from_package_publish(
-                        self,
-                        package_id,
-                        coin_metadata_type.clone(),
-                    )
+            .cache_get_or_set_with(format!("{}{}", package_id, coin_metadata_type), || {
+                get_single_obj_id_from_package_publish(self, package_id, coin_metadata_type.clone())
                     .unwrap()
-                },
-            );
+            });
         if let Some(id) = coin_metadata_obj_id {
             let metadata_object = self.get_object(&id, None)?;
             Ok(metadata_object.and_then(|v| SuiCoinMetadata::try_from(v).ok()))
@@ -1537,17 +1530,10 @@ impl<U: R2D2Connection> IndexerReader<U> {
             .package_obj_type_cache
             .lock()
             .unwrap()
-            .cache_get_or_set_with(
-                r#"{ format!("{}{}", package_id, treasury_cap_type) }"#.to_string(),
-                || {
-                    get_single_obj_id_from_package_publish(
-                        self,
-                        package_id,
-                        treasury_cap_type.clone(),
-                    )
+            .cache_get_or_set_with(format!("{}{}", package_id, treasury_cap_type), || {
+                get_single_obj_id_from_package_publish(self, package_id, treasury_cap_type.clone())
                     .unwrap()
-                },
-            )
+            })
             .ok_or(IndexerError::GenericError(format!(
                 "Cannot find treasury cap for type {}",
                 treasury_cap_type


### PR DESCRIPTION
## Description 

Right now we are setting the key of the cache to be the raw string `"{ format!("{}{}", package_id, obj_type) }"`, which does not change with the input causing the cache to essentially store the first entry and always returning it. This PR fixes that. I've scanned the code base and changed the only two occurrences of `cache_get_or_set_with`

## Test plan 

tested locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: 
- [x] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
