### PR TITLE
[sui-client] Add basic auth option to client rpc config

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -354,6 +354,7 @@ pub fn new_wallet_context_from_cluster(
             alias: "localnet".to_string(),
             rpc: fullnode_url.into(),
             ws: None,
+            basic_auth: None,
         }],
         active_address: Some(address),
         active_env: Some("localnet".to_string()),

--- a/crates/sui-sdk/src/sui_client_config.rs
+++ b/crates/sui-sdk/src/sui_client_config.rs
@@ -64,6 +64,8 @@ pub struct SuiEnv {
     pub alias: String,
     pub rpc: String,
     pub ws: Option<String>,
+    /// Basic HTTP access authentication in the format of username:password, if needed.
+    pub basic_auth: Option<String>,
 }
 
 impl SuiEnv {
@@ -79,6 +81,15 @@ impl SuiEnv {
         if let Some(ws_url) = &self.ws {
             builder = builder.ws_url(ws_url);
         }
+        if let Some(basic_auth) = &self.basic_auth {
+            let fields: Vec<_> = basic_auth.split(':').collect();
+            if fields.len() != 2 {
+                return Err(anyhow!(
+                    "Basic auth should be in the format `username:password`"
+                ));
+            }
+            builder = builder.basic_auth(fields[0], fields[1]);
+        }
 
         if let Some(max_concurrent_requests) = max_concurrent_requests {
             builder = builder.max_concurrent_requests(max_concurrent_requests as usize);
@@ -91,6 +102,7 @@ impl SuiEnv {
             alias: "devnet".to_string(),
             rpc: SUI_DEVNET_URL.into(),
             ws: None,
+            basic_auth: None,
         }
     }
     pub fn testnet() -> Self {
@@ -98,6 +110,7 @@ impl SuiEnv {
             alias: "testnet".to_string(),
             rpc: SUI_TESTNET_URL.into(),
             ws: None,
+            basic_auth: None,
         }
     }
 
@@ -106,6 +119,7 @@ impl SuiEnv {
             alias: "local".to_string(),
             rpc: SUI_LOCAL_NETWORK_URL.into(),
             ws: None,
+            basic_auth: None,
         }
     }
 }
@@ -118,6 +132,10 @@ impl Display for SuiEnv {
         if let Some(ws) = &self.ws {
             writeln!(writer)?;
             write!(writer, "Websocket URL: {ws}")?;
+        }
+        if let Some(basic_auth) = &self.basic_auth {
+            writeln!(writer)?;
+            write!(writer, "Basic Auth: {}", basic_auth)?;
         }
         write!(f, "{}", writer)
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -252,6 +252,8 @@ pub enum SuiClientCommands {
         rpc: String,
         #[clap(long, value_hint = ValueHint::Url)]
         ws: Option<String>,
+        #[clap(long, help = "Basic auth in the format of username:password")]
+        basic_auth: Option<String>,
     },
 
     /// Get object info
@@ -1497,13 +1499,23 @@ impl SuiClientCommands {
                 let response = context.execute_transaction_may_fail(transaction).await?;
                 SuiClientCommandResult::TransactionBlock(response)
             }
-            SuiClientCommands::NewEnv { alias, rpc, ws } => {
+            SuiClientCommands::NewEnv {
+                alias,
+                rpc,
+                ws,
+                basic_auth,
+            } => {
                 if context.config.envs.iter().any(|env| env.alias == alias) {
                     return Err(anyhow!(
                         "Environment config with name [{alias}] already exists."
                     ));
                 }
-                let env = SuiEnv { alias, rpc, ws };
+                let env = SuiEnv {
+                    alias,
+                    rpc,
+                    ws,
+                    basic_auth,
+                };
 
                 // Check urls are valid and server is reachable
                 env.create_rpc_client(None, None).await?;

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -637,6 +637,7 @@ async fn genesis(
         alias: "localnet".to_string(),
         rpc: format!("http://{}", fullnode_config.json_rpc_address),
         ws: None,
+        basic_auth: None,
     });
     client_config.add_env(SuiEnv::devnet());
 
@@ -661,6 +662,7 @@ async fn prompt_if_no_config(
                 alias: "custom".to_string(),
                 rpc: v.into_string().unwrap(),
                 ws: None,
+                basic_auth: None,
             }),
             None => {
                 if accept_defaults {
@@ -696,6 +698,7 @@ async fn prompt_if_no_config(
                             alias,
                             rpc: url,
                             ws: None,
+                            basic_auth: None,
                         }
                     })
                 } else {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1143,6 +1143,7 @@ impl TestClusterBuilder {
             alias: "localnet".to_string(),
             rpc: fullnode_handle.rpc_url.clone(),
             ws: Some(fullnode_handle.ws_url.clone()),
+            basic_auth: None,
         });
         wallet_conf.active_env = Some("localnet".to_string());
 


### PR DESCRIPTION
## Description 

Add option to provide basic auth in a client environment. This is then used to create the RPC client.

## Test plan 

Tried locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
