### PR TITLE
[consensus] Fix for stuck leader schedule on recovery

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -80,7 +80,7 @@ impl Parameters {
             // Checkpoint building and execution cannot keep up with high commit rate in simtests,
             // leading to long reconfiguration delays. This is because simtest is single threaded,
             // and spending too much time in consensus can lead to starvation elsewhere.
-            Duration::from_millis(200)
+            Duration::from_millis(400)
         } else {
             Duration::from_millis(50)
         }

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -139,7 +139,7 @@ impl BaseCommitter {
 
     pub fn elect_leader(&self, round: Round) -> Option<Slot> {
         let wave = self.wave_number(round);
-        tracing::debug!(
+        tracing::trace!(
             "elect_leader: round={}, wave={}, leader_round={}, leader_offset={}",
             round,
             wave,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -613,8 +613,8 @@ impl DagState {
         assert!(self.unscored_committed_subdags.is_empty());
 
         let commit_info = CommitInfo {
-            reputation_scores,
             committed_rounds: self.last_committed_rounds.clone(),
+            reputation_scores,
         };
         let last_commit = self
             .last_commit
@@ -717,11 +717,16 @@ impl DagState {
             return;
         }
         debug!(
-            "Flushing {} blocks ({}) and {} commits ({}) to storage.",
+            "Flushing {} blocks ({}), {} commits ({}) and {} commit info ({}) to storage.",
             blocks.len(),
             blocks.iter().map(|b| b.reference().to_string()).join(","),
             commits.len(),
             commits.iter().map(|c| c.reference().to_string()).join(","),
+            commit_info_to_write.len(),
+            commit_info_to_write
+                .iter()
+                .map(|(commit_ref, _)| commit_ref.to_string())
+                .join(","),
         );
         self.store
             .write(WriteBatch::new(blocks, commits, commit_info_to_write))

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -71,6 +71,12 @@ impl LeaderSchedule {
                 )
             },
         );
+
+        tracing::debug!(
+            "LeaderSchedule recovered using {leader_swap_table:?}. There are {} pending unscored subdags in DagState.",
+            dag_state.read().unscored_committed_subdags_count(),
+        );
+
         // create the schedule
         Self::new(context, leader_swap_table)
     }

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -72,7 +72,7 @@ impl LeaderSchedule {
             },
         );
 
-        tracing::debug!(
+        tracing::info!(
             "LeaderSchedule recovered using {leader_swap_table:?}. There are {} pending unscored subdags in DagState.",
             dag_state.read().unscored_committed_subdags_count(),
         );
@@ -111,13 +111,13 @@ impl LeaderSchedule {
         let mut dag_state = dag_state.write();
         let unscored_subdags = dag_state.take_unscored_committed_subdags();
 
+        // TODO: move to initialization.
         // TODO: remove this once scoring strategy is finalized
         let scoring_strategy =
             if let Ok(scoring_strategy) = std::env::var("CONSENSUS_SCORING_STRATEGY") {
                 tracing::info!(
                     "Using scoring strategy {scoring_strategy} for ReputationScoreCalculator"
                 );
-
                 let scoring_strategy: Box<dyn ScoringStrategy> = match scoring_strategy.as_str() {
                     "vote" => Box::new(VoteScoringStrategy {}),
                     "certified_vote_v1" => Box::new(CertifiedVoteScoringStrategyV1 {}),
@@ -128,7 +128,7 @@ impl LeaderSchedule {
                 scoring_strategy
             } else {
                 tracing::info!(
-                    "Using scoring strategy VoteScoringStrategy for ReputationScoreCalculator"
+                    "Using scoring strategy vote for ReputationScoreCalculator"
                 );
                 Box::new(VoteScoringStrategy {})
             };
@@ -319,7 +319,7 @@ impl LeaderSwapTable {
             );
         });
 
-        tracing::debug!("Scores used for new LeaderSwapTable: {reputation_scores:?}");
+        tracing::info!("Scores used for new LeaderSwapTable: {reputation_scores:?}");
 
         Self {
             good_nodes,

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -78,11 +78,11 @@ impl<'a> ReputationScoreCalculator<'a> {
 
         for leader_round in scoring_round_range {
             for committer in self.committer.get_committers() {
-                tracing::debug!(
+                tracing::trace!(
                     "Electing leader for round {leader_round} with committer {committer}"
                 );
                 if let Some(leader_slot) = committer.elect_leader(leader_round) {
-                    tracing::debug!("Calculating score for leader {leader_slot}");
+                    tracing::trace!("Calculating score for leader {leader_slot}");
                     self.add_scores(self.scoring_strategy.calculate_scores_for_leader(
                         &self.unscored_subdag,
                         leader_slot,

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -263,7 +263,7 @@ impl UnscoredSubdag {
                 }
             } else {
                 // TODO: Add unit test for this case once dagbuilder is ready.
-                tracing::debug!(
+                tracing::trace!(
                     "Potential vote's ancestor block not found in unscored committed subdags: {:?}",
                     ancestor
                 );

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -78,11 +78,11 @@ impl<'a> ReputationScoreCalculator<'a> {
 
         for leader_round in scoring_round_range {
             for committer in self.committer.get_committers() {
-                tracing::info!(
+                tracing::debug!(
                     "Electing leader for round {leader_round} with committer {committer}"
                 );
                 if let Some(leader_slot) = committer.elect_leader(leader_round) {
-                    tracing::info!("Calculating score for leader {leader_slot}");
+                    tracing::debug!("Calculating score for leader {leader_slot}");
                     self.add_scores(self.scoring_strategy.calculate_scores_for_leader(
                         &self.unscored_subdag,
                         leader_slot,
@@ -263,7 +263,7 @@ impl UnscoredSubdag {
                 }
             } else {
                 // TODO: Add unit test for this case once dagbuilder is ready.
-                tracing::info!(
+                tracing::debug!(
                     "Potential vote's ancestor block not found in unscored committed subdags: {:?}",
                     ancestor
                 );

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -37,7 +37,7 @@ pub(crate) struct ReputationScoreCalculator<'a> {
     // and the `ReputationScoreCalculator` is responsible for applying the strategy.
     // For now this is dynamic while we are experimenting but eventually we can
     // replace this with the final strategy that works best.
-    scoring_strategy: Box<dyn ScoringStrategy>,
+    scoring_strategy: &'a dyn ScoringStrategy,
     // We use the `UniversalCommitter` to elect the leaders from the `UnscoredSubdag`
     // that need to be scored.
     committer: &'a UniversalCommitter,
@@ -48,7 +48,7 @@ impl<'a> ReputationScoreCalculator<'a> {
         context: Arc<Context>,
         committer: &'a UniversalCommitter,
         unscored_subdags: &Vec<CommittedSubDag>,
-        scoring_strategy: Box<dyn ScoringStrategy>,
+        scoring_strategy: &'a dyn ScoringStrategy,
     ) -> Self {
         let num_authorities = context.committee.size();
         let scores_per_authority = vec![0_u64; num_authorities];
@@ -490,11 +490,12 @@ mod tests {
             context.clock.timestamp_utc_ms(),
             commit_index,
         )];
+        let scoring_strategy = VoteScoringStrategy {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(VoteScoringStrategy {}),
+            &scoring_strategy,
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
@@ -523,11 +524,12 @@ mod tests {
         .build();
 
         let unscored_subdags = vec![];
+        let scoring_strategy = VoteScoringStrategy {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(VoteScoringStrategy {}),
+            &scoring_strategy,
         );
         calculator.calculate();
     }
@@ -560,11 +562,12 @@ mod tests {
             context.clock.timestamp_utc_ms(),
             1,
         )];
+        let scoring_strategy = VoteScoringStrategy {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(VoteScoringStrategy {}),
+            &scoring_strategy,
         );
         calculator.calculate();
     }
@@ -643,11 +646,12 @@ mod tests {
             context.clock.timestamp_utc_ms(),
             commit_index,
         )];
+        let scoring_strategy = VoteScoringStrategy {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(VoteScoringStrategy {}),
+            &scoring_strategy,
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -46,7 +46,7 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV2 {
         let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
 
         if leader_blocks.is_empty() {
-            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            tracing::trace!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
             return scores_per_authority;
         }
 
@@ -73,7 +73,7 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV2 {
                     stake_agg.add(authority, &subdag.context.committee);
                     all_votes.insert(*reference, (is_vote, stake_agg));
                 } else {
-                    tracing::info!(
+                    tracing::trace!(
                         "Potential vote not found in unscored committed subdags: {:?}",
                         reference
                     );
@@ -84,10 +84,10 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV2 {
         for (vote_ref, (is_vote, stake_agg)) in all_votes {
             if is_vote {
                 let authority = vote_ref.author;
-                tracing::info!(
+                tracing::trace!(
                     "Found a certified vote {vote_ref} for leader {leader_block} from authority {authority}"
                 );
-                tracing::info!(
+                tracing::trace!(
                     "[{}] scores +{} reputation for {authority}!",
                     subdag.context.own_index,
                     stake_agg.stake()
@@ -127,7 +127,7 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV1 {
         let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
 
         if leader_blocks.is_empty() {
-            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            tracing::trace!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
             return scores_per_authority;
         }
 
@@ -204,7 +204,7 @@ impl ScoringStrategy for VoteScoringStrategy {
         let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
 
         if leader_blocks.is_empty() {
-            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            tracing::trace!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
             return scores_per_authority;
         }
 
@@ -260,7 +260,7 @@ impl ScoringStrategy for CertificateScoringStrategy {
         let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
 
         if leader_blocks.is_empty() {
-            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            tracing::trace!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
             return scores_per_authority;
         }
 
@@ -275,11 +275,11 @@ impl ScoringStrategy for CertificateScoringStrategy {
         for potential_cert in decision_blocks {
             let authority = potential_cert.reference().author;
             if subdag.is_certificate(&potential_cert, leader_block, &mut all_votes) {
-                tracing::info!(
+                tracing::trace!(
                     "Found a certificate {} for leader {leader_block} from authority {authority}",
                     potential_cert.reference()
                 );
-                tracing::info!(
+                tracing::trace!(
                     "[{}] scores +1 reputation for {authority}!",
                     subdag.context.own_index
                 );

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -10,7 +10,7 @@ use crate::{
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
-pub(crate) trait ScoringStrategy {
+pub(crate) trait ScoringStrategy: Send + Sync {
     fn calculate_scores_for_leader(
         &self,
         subdag: &UnscoredSubdag,
@@ -319,12 +319,12 @@ mod tests {
     #[tokio::test]
     async fn test_certificate_scoring_strategy() {
         let (context, committer, unscored_subdags) = basic_setup();
-
+        let scoring_strategy = CertificateScoringStrategy {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(CertificateScoringStrategy {}),
+            &scoring_strategy,
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![2, 1, 1, 1]);
@@ -334,12 +334,12 @@ mod tests {
     #[tokio::test]
     async fn test_vote_scoring_strategy() {
         let (context, committer, unscored_subdags) = basic_setup();
-
+        let scoring_strategy = VoteScoringStrategy {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(VoteScoringStrategy {}),
+            &scoring_strategy,
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
@@ -349,12 +349,12 @@ mod tests {
     #[tokio::test]
     async fn test_certified_vote_scoring_strategy_v1() {
         let (context, committer, unscored_subdags) = basic_setup();
-
+        let scoring_strategy = CertifiedVoteScoringStrategyV1 {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(CertifiedVoteScoringStrategyV1 {}),
+            &scoring_strategy,
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![1, 1, 1, 1]);
@@ -364,12 +364,12 @@ mod tests {
     #[tokio::test]
     async fn test_certified_vote_scoring_strategy_v2() {
         let (context, committer, unscored_subdags) = basic_setup();
-
+        let scoring_strategy = CertifiedVoteScoringStrategyV2 {};
         let mut calculator = ReputationScoreCalculator::new(
             context.clone(),
             &committer,
             &unscored_subdags,
-            Box::new(CertifiedVoteScoringStrategyV2 {}),
+            &scoring_strategy,
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![5, 5, 5, 5]);

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -35,8 +35,8 @@ pub(crate) struct UniversalCommitter {
 }
 
 impl UniversalCommitter {
-    /// Try to commit part of the dag. This function is idempotent and returns a list of
-    /// ordered decided leaders.
+    /// Try to commit part of the dag. This function is idempotent and returns an ordered list of
+    /// decided slots.
     #[tracing::instrument(skip_all, fields(last_decided = %last_decided))]
     pub(crate) fn try_commit(&self, last_decided: Slot) -> Vec<LeaderStatus> {
         let highest_accepted_round = self.dag_state.read().highest_accepted_round();

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -696,7 +696,7 @@ impl ConsensusAdapter {
                     tokio::time::sleep(Duration::from_secs(WARN_DELAY_S)).await;
                     let total_wait = i * WARN_DELAY_S;
                     warn!(
-                        "Still waiting {} seconds for transaction {:?} to commit in narwhal",
+                        "Still waiting {} seconds for transaction {:?} to commit in consensus",
                         total_wait, transaction_key
                     );
                 }


### PR DESCRIPTION
Issue found via failining simtest

```
RUST_LOG=info,consensus=debug MSIM_TEST_SEED=161715360837 MSIM_TEST_NUM=1 MSIM_WATCHDOG_TIMEOUT_MS=60000 SIM_STRESS_TEST_DURATION_SECS=300   scripts/simtest/cargo-simtest simtest     --color always     --package sui-benchmark     --test-threads 1     --profile simtestnightly test_simulated_load_with_reconfig_and_correlated_crashes
```

Added logging to confirm
```
2022-03-02T00:44:12.689178Z  INFO node{id=5 name="k#99f25ef6.."}: consensus_core::leader_schedule: consensus/core/src/leader_schedule.rs:75: Recovering LeaderSchedule from store using LeaderSwapTable for CommitRange(21..31), good_nodes:[] with stake:0, bad_nodes:Map { iter: [] } with stake:0
2022-03-02T00:44:12.689178Z  INFO node{id=5 name="k#99f25ef6.."}: consensus_core::leader_schedule: consensus/core/src/leader_schedule.rs:80: There are 10 pending subdags to be scored in DagState.
...
2022-03-02T00:44:46.070364Z DEBUG node{id=5 name="k#99f25ef6.."}: consensus_core::core: consensus/core/src/core.rs:488: Sequenced 136 leaders and 0 commits can be made before next leader schedule change
```

Issue: 
If a node crashes on LeaderSchedule commit boundary it will recover but not update the schedule which will lead to the node getting stuck and not issuing more commits because there are no more commits that can be made on the current schedule.

Resolution:
Check if leader schedule needs to be updated before we attempt to commit in core, this will cover the recovery case as well.