### PR TITLE
[Traffic Control] Distinguish IP source in traffic sketch

### DIFF
--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -9,10 +9,20 @@ use mysten_metrics::spawn_monitored_task;
 use parking_lot::RwLock;
 use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::time::Duration;
 use std::time::{Instant, SystemTime};
 use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType, Weight};
 use tracing::info;
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum IpType {
+    Connection,
+    Proxy,
+}
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+struct SketchKey(IpAddr, IpType);
 
 pub struct TrafficSketch {
     /// Circular buffer Count Min Sketches representing a sliding window
@@ -24,7 +34,7 @@ pub struct TrafficSketch {
     /// expect 100,000, which can be represented in 17 bits, but not 16. We can
     /// potentially lower the memory consumption by using CountMinSketch16, which
     /// will reliably support up to ~65,000 unique IP addresses in the window.
-    sketches: VecDeque<CountMinSketch32<IpAddr>>,
+    sketches: VecDeque<CountMinSketch32<SketchKey>>,
     window_size: Duration,
     update_interval: Duration,
     last_reset_time: Instant,
@@ -76,7 +86,7 @@ impl TrafficSketch {
         let mut sketches = VecDeque::with_capacity(num_sketches as usize);
         for _ in 0..num_sketches {
             sketches.push_back(
-                CountMinSketch32::<IpAddr>::new(
+                CountMinSketch32::<SketchKey>::new(
                     sketch_capacity,
                     sketch_probability,
                     sketch_tolerance,
@@ -93,7 +103,7 @@ impl TrafficSketch {
         }
     }
 
-    pub fn increment_count(&mut self, ip: IpAddr) {
+    fn increment_count(&mut self, key: &SketchKey) {
         // reset all expired intervals
         let current_time = Instant::now();
         let mut elapsed = current_time.duration_since(self.last_reset_time);
@@ -102,11 +112,15 @@ impl TrafficSketch {
             elapsed -= self.update_interval;
         }
         // Increment in the current active sketch
-        self.sketches[self.current_sketch_index].increment(&ip);
+        self.sketches[self.current_sketch_index].increment(key);
     }
 
-    pub fn get_request_rate(&self, ip: &IpAddr) -> f64 {
-        let count: u32 = self.sketches.iter().map(|sketch| sketch.estimate(ip)).sum();
+    fn get_request_rate(&self, key: &SketchKey) -> f64 {
+        let count: u32 = self
+            .sketches
+            .iter()
+            .map(|sketch| sketch.estimate(key))
+            .sum();
         count as f64 / self.window_size.as_secs() as f64
     }
 
@@ -217,14 +231,16 @@ impl TrafficControlPolicy {
 pub struct FreqThresholdPolicy {
     config: PolicyConfig,
     sketch: TrafficSketch,
-    threshold: u64,
+    connection_threshold: u64,
+    proxy_threshold: u64,
 }
 
 impl FreqThresholdPolicy {
     pub fn new(
         config: PolicyConfig,
         FreqThresholdConfig {
-            threshold,
+            connection_threshold,
+            proxy_threshold,
             window_size_secs,
             update_interval_secs,
             sketch_capacity,
@@ -242,21 +258,38 @@ impl FreqThresholdPolicy {
         Self {
             config,
             sketch,
-            threshold,
+            connection_threshold,
+            proxy_threshold,
         }
     }
 
     fn handle_tally(&mut self, tally: TrafficTally) -> PolicyResponse {
-        if let Some(ip) = tally.connection_ip {
-            self.sketch.increment_count(ip);
-            if self.sketch.get_request_rate(&ip) >= self.threshold as f64 {
-                return PolicyResponse {
-                    block_connection_ip: Some(ip),
-                    block_proxy_ip: None,
-                };
+        let block_connection_ip = if let Some(ip) = tally.connection_ip {
+            let key = SketchKey(ip, IpType::Connection);
+            self.sketch.increment_count(&key);
+            if self.sketch.get_request_rate(&key) >= self.connection_threshold as f64 {
+                Some(ip)
+            } else {
+                None
             }
+        } else {
+            None
+        };
+        let block_proxy_ip = if let Some(ip) = tally.proxy_ip {
+            let key = SketchKey(ip, IpType::Proxy);
+            self.sketch.increment_count(&key);
+            if self.sketch.get_request_rate(&key) >= self.proxy_threshold as f64 {
+                Some(ip)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        PolicyResponse {
+            block_connection_ip,
+            block_proxy_ip,
         }
-        PolicyResponse::default()
     }
 
     fn policy_config(&self) -> &PolicyConfig {
@@ -394,25 +427,36 @@ mod tests {
     #[sim_test]
     async fn test_freq_threshold_policy() {
         // Create freq policy that will block on average frequency 2 requests per second
-        // as observed over a 5 second window
+        // for proxied connections and 4 requests per second for direct connections
+        // as observed over a 5 second window.
         let mut policy = TrafficControlPolicy::FreqThreshold(FreqThresholdPolicy::new(
             PolicyConfig::default(),
             FreqThresholdConfig {
-                threshold: 2,
+                connection_threshold: 5,
+                proxy_threshold: 2,
                 window_size_secs: 5,
                 update_interval_secs: 1,
                 ..Default::default()
             },
         ));
+        // alice and bob connection from different IPs through the
+        // same fullnode, thus have the same connection IP on
+        // validator, but different proxy IPs
         let alice = TrafficTally {
-            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
-            proxy_ip: None,
+            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
+            proxy_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
             error_weight: Weight::zero(),
             timestamp: SystemTime::now(),
         };
         let bob = TrafficTally {
-            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
-            proxy_ip: None,
+            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
+            proxy_ip: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
+            error_weight: Weight::zero(),
+            timestamp: SystemTime::now(),
+        };
+        let charlie = TrafficTally {
+            connection_ip: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
+            proxy_ip: Some(IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8))),
             error_weight: Weight::zero(),
             timestamp: SystemTime::now(),
         };
@@ -420,8 +464,8 @@ mod tests {
         // initial 2 tallies for alice, should not block
         for _ in 0..2 {
             let response = policy.handle_tally(alice.clone());
-            assert_eq!(response.block_connection_ip, None);
             assert_eq!(response.block_proxy_ip, None);
+            assert_eq!(response.block_connection_ip, None);
         }
 
         // meanwhile bob spams 10 requests at once and is blocked
@@ -431,8 +475,8 @@ mod tests {
             assert_eq!(response.block_proxy_ip, None);
         }
         let response = policy.handle_tally(bob.clone());
-        assert_eq!(response.block_proxy_ip, None);
-        assert_eq!(response.block_connection_ip, bob.connection_ip);
+        assert_eq!(response.block_connection_ip, None);
+        assert_eq!(response.block_proxy_ip, bob.proxy_ip);
 
         // 2 more tallies, so far we are above 2 tallies
         // per second, but over the average window of 5 seconds
@@ -447,22 +491,43 @@ mod tests {
         // in the sliding window
         let _ = policy.handle_tally(bob.clone());
         let response = policy.handle_tally(bob.clone());
-        assert_eq!(response.block_proxy_ip, None);
-        assert_eq!(response.block_connection_ip, bob.connection_ip);
+        assert_eq!(response.block_connection_ip, None);
+        assert_eq!(response.block_proxy_ip, bob.proxy_ip);
 
         // close to threshold for alice, but still below
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        for _ in 0..5 {
+        for i in 0..5 {
             let response = policy.handle_tally(alice.clone());
-            assert_eq!(response.block_connection_ip, None);
+            assert_eq!(response.block_connection_ip, None, "Blocked at i = {}", i);
             assert_eq!(response.block_proxy_ip, None);
         }
 
         // should block alice now
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         let response = policy.handle_tally(alice.clone());
-        assert_eq!(response.block_connection_ip, alice.connection_ip);
+        assert_eq!(response.block_connection_ip, None);
+        assert_eq!(response.block_proxy_ip, alice.proxy_ip);
+
+        // spam through charlie to block connection
+        for i in 0..2 {
+            let response = policy.handle_tally(charlie.clone());
+            assert_eq!(response.block_connection_ip, None, "Blocked at i = {}", i);
+            assert_eq!(response.block_proxy_ip, None);
+        }
+        // Now we block connection IP
+        let response = policy.handle_tally(charlie.clone());
         assert_eq!(response.block_proxy_ip, None);
+        assert_eq!(response.block_connection_ip, charlie.connection_ip);
+
+        // Ensure that if we wait another second, we are no longer blocked
+        // as the bursty first second has finally rotated out of the sliding
+        // window
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        for i in 0..3 {
+            let response = policy.handle_tally(charlie.clone());
+            assert_eq!(response.block_connection_ip, None, "Blocked at i = {}", i);
+            assert_eq!(response.block_proxy_ip, None);
+        }
     }
 
     #[sim_test]

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -291,7 +291,8 @@ async fn test_traffic_control_manual_set_dead_mans_switch() -> Result<(), anyhow
 #[sim_test]
 async fn test_traffic_sketch_no_blocks() {
     let sketch_config = FreqThresholdConfig {
-        threshold: 10_100,
+        connection_threshold: 10_100,
+        proxy_threshold: 10_100,
         window_size_secs: 4,
         update_interval_secs: 1,
         ..Default::default()
@@ -329,7 +330,8 @@ async fn test_traffic_sketch_no_blocks() {
 #[sim_test]
 async fn test_traffic_sketch_with_slow_blocks() {
     let sketch_config = FreqThresholdConfig {
-        threshold: 9_900,
+        connection_threshold: 9_900,
+        proxy_threshold: 9_900,
         window_size_secs: 4,
         update_interval_secs: 1,
         ..Default::default()
@@ -367,7 +369,8 @@ async fn test_traffic_sketch_with_slow_blocks() {
 #[sim_test]
 async fn test_traffic_sketch_with_sampled_spam() {
     let sketch_config = FreqThresholdConfig {
-        threshold: 4_500,
+        connection_threshold: 4_500,
+        proxy_threshold: 4_500,
         window_size_secs: 4,
         update_interval_secs: 1,
         ..Default::default()

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -83,8 +83,10 @@ fn default_drain_timeout() -> u64 {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct FreqThresholdConfig {
-    #[serde(default = "default_threshold")]
-    pub threshold: u64,
+    #[serde(default = "default_connection_threshold")]
+    pub connection_threshold: u64,
+    #[serde(default = "default_proxy_threshold")]
+    pub proxy_threshold: u64,
     #[serde(default = "default_window_size_secs")]
     pub window_size_secs: u64,
     #[serde(default = "default_update_interval_secs")]
@@ -100,7 +102,8 @@ pub struct FreqThresholdConfig {
 impl Default for FreqThresholdConfig {
     fn default() -> Self {
         Self {
-            threshold: default_threshold(),
+            connection_threshold: default_connection_threshold(),
+            proxy_threshold: default_proxy_threshold(),
             window_size_secs: default_window_size_secs(),
             update_interval_secs: default_update_interval_secs(),
             sketch_capacity: default_sketch_capacity(),
@@ -110,7 +113,16 @@ impl Default for FreqThresholdConfig {
     }
 }
 
-fn default_threshold() -> u64 {
+fn default_connection_threshold() -> u64 {
+    // by default only block connection IPs with unreasonably
+    // high qps, as a single fullnode could be routing the vast
+    // majority of all traffic in normal operations. If used as a
+    // spam policy, all requests would count against this threshold
+    // within the window time. In practice this should always be set
+    1_000_000
+}
+
+fn default_proxy_threshold() -> u64 {
     10
 }
 


### PR DESCRIPTION
## Description 

We curently only handle connection IP traffic for traffic sketch based policy. This is fine for rpc nodes, which should never receive proxy IP in tally (as it is only connecting to client directly).

This PR adds support for proxy IP in this policy. To achieve this, we need to distinguish the IP types in the count min sketch key whose frequency is estimated. We also need a separate threshold config, as generally it makes little sense to use the same threshold given that RPC nodes route traffic from many clients, thus they will naturally have a much higher tally frequency compared to client IP frequency.

## Test plan 

Updated tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
