### PR TITLE
[Consensus] break score ties in randomized and deterministic order

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -640,7 +640,7 @@ mod tests {
                         );
                     }
                 }
-                assert_eq!(committed_subdag.reputation_scores, vec![]);
+                assert_eq!(committed_subdag.reputation_scores_desc, vec![]);
                 if expected_transactions.is_empty() {
                     break;
                 }

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -298,12 +298,12 @@ pub struct CommittedSubDag {
     pub commit_index: CommitIndex,
     /// Optional scores that are provided as part of the consensus output to Sui
     /// that can then be used by Sui for future submission to consensus.
-    pub reputation_scores: Vec<(AuthorityIndex, u64)>,
+    pub reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
 }
 
 impl CommittedSubDag {
     /// Create new (empty) sub-dag.
-    pub fn new(
+    pub(crate) fn new(
         leader: BlockRef,
         blocks: Vec<VerifiedBlock>,
         timestamp_ms: BlockTimestampMs,
@@ -314,17 +314,17 @@ impl CommittedSubDag {
             blocks,
             timestamp_ms,
             commit_index,
-            reputation_scores: vec![],
+            reputation_scores_desc: vec![],
         }
     }
 
-    pub fn update_scores(&mut self, scores: Vec<(AuthorityIndex, u64)>) {
-        self.reputation_scores = scores;
+    pub(crate) fn update_scores(&mut self, reputation_scores_desc: Vec<(AuthorityIndex, u64)>) {
+        self.reputation_scores_desc = reputation_scores_desc;
     }
 
     /// Sort the blocks of the sub-dag by round number then authority index. Any
     /// deterministic & stable algorithm works.
-    pub fn sort(&mut self) {
+    pub(crate) fn sort(&mut self) {
         self.blocks.sort_by(|a, b| {
             a.round()
                 .cmp(&b.round())
@@ -359,7 +359,7 @@ impl fmt::Debug for CommittedSubDag {
         write!(
             f,
             "];{}ms;rs{:?})",
-            self.timestamp_ms, self.reputation_scores
+            self.timestamp_ms, self.reputation_scores_desc
         )
     }
 }
@@ -427,9 +427,7 @@ pub(crate) enum Decision {
     Indirect,
 }
 
-/// The status of every leader output by the committers. While the core only cares
-/// about committed leaders, providing a richer status allows for easier debugging,
-/// testing, and composition with advanced commit strategies.
+/// The status of a leader slot from the direct and indirect commit rules.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeaderStatus {
     Commit(VerifiedBlock),
@@ -446,14 +444,6 @@ impl LeaderStatus {
         }
     }
 
-    pub(crate) fn authority(&self) -> AuthorityIndex {
-        match self {
-            Self::Commit(block) => block.author(),
-            Self::Skip(leader) => leader.authority,
-            Self::Undecided(leader) => leader.authority,
-        }
-    }
-
     pub(crate) fn is_decided(&self) -> bool {
         match self {
             Self::Commit(_) => true,
@@ -462,21 +452,11 @@ impl LeaderStatus {
         }
     }
 
-    // Only should be called when the leader status is decided (Commit/Skip)
-    pub fn get_decided_slot(&self) -> Slot {
+    pub(crate) fn into_decided_leader(self) -> Option<DecidedLeader> {
         match self {
-            Self::Commit(block) => block.reference().into(),
-            Self::Skip(leader) => *leader,
-            Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
-        }
-    }
-
-    // Only should be called when the leader status is decided (Commit/Skip)
-    pub fn into_committed_block(self) -> Option<VerifiedBlock> {
-        match self {
-            Self::Commit(block) => Some(block),
-            Self::Skip(_leader) => None,
-            Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
+            Self::Commit(block) => Some(DecidedLeader::Commit(block)),
+            Self::Skip(slot) => Some(DecidedLeader::Skip(slot)),
+            Self::Undecided(..) => None,
         }
     }
 }
@@ -485,8 +465,58 @@ impl Display for LeaderStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Commit(block) => write!(f, "Commit({})", block.reference()),
-            Self::Skip(leader) => write!(f, "Skip({leader})"),
-            Self::Undecided(leader) => write!(f, "Undecided({leader})"),
+            Self::Skip(slot) => write!(f, "Skip({slot})"),
+            Self::Undecided(slot) => write!(f, "Undecided({slot})"),
+        }
+    }
+}
+
+/// Decision of each leader slot.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum DecidedLeader {
+    Commit(VerifiedBlock),
+    Skip(Slot),
+}
+
+impl DecidedLeader {
+    // Slot where the leader is decided.
+    pub(crate) fn slot(&self) -> Slot {
+        match self {
+            Self::Commit(block) => block.reference().into(),
+            Self::Skip(slot) => *slot,
+        }
+    }
+
+    // Converts to committed block if the decision is to commit. Returns None otherwise.
+    pub(crate) fn into_committed_block(self) -> Option<VerifiedBlock> {
+        match self {
+            Self::Commit(block) => Some(block),
+            Self::Skip(_) => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn round(&self) -> Round {
+        match self {
+            Self::Commit(block) => block.round(),
+            Self::Skip(leader) => leader.round,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn authority(&self) -> AuthorityIndex {
+        match self {
+            Self::Commit(block) => block.author(),
+            Self::Skip(leader) => leader.authority,
+        }
+    }
+}
+
+impl Display for DecidedLeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Commit(block) => write!(f, "Commit({})", block.reference()),
+            Self::Skip(slot) => write!(f, "Skip({slot})"),
         }
     }
 }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -789,17 +789,10 @@ impl DagState {
         panic!("Fatal error, no quorum has been detected in our DAG on the last two rounds.");
     }
 
-    pub(crate) fn last_reputation_scores_from_store(&self) -> Option<ReputationScores> {
-        let commit_info = self
-            .store
+    pub(crate) fn recover_last_commit_info(&self) -> Option<(CommitRef, CommitInfo)> {
+        self.store
             .read_last_commit_info()
-            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
-        if let Some((commit_ref, commit_info)) = commit_info {
-            assert!(commit_ref.index <= self.last_commit.as_ref().unwrap().index());
-            Some(commit_info.reputation_scores)
-        } else {
-            None
-        }
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e))
     }
 
     pub(crate) fn unscored_committed_subdags_count(&self) -> u64 {

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -177,7 +177,6 @@ impl ScoringStrategy for VoteScoringStrategy {
     fn calculate_scores_for_leader(&self, subdag: &UnscoredSubdag, leader_slot: Slot) -> Vec<u64> {
         let num_authorities = subdag.context.committee.size();
         let mut scores_per_authority = vec![0_u64; num_authorities];
-        let voting_round = leader_slot.round + 1;
 
         let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
 
@@ -192,8 +191,11 @@ impl ScoringStrategy for VoteScoringStrategy {
 
         let leader_block = leader_blocks.first().unwrap();
 
+        let voting_round = leader_slot.round + 1;
         let voting_blocks = subdag.get_blocks_at_round(voting_round);
         for potential_vote in voting_blocks {
+            // TODO: use the decided leader as input instead of leader slot. If the leader was skipped,
+            // votes to skip should be included in the score as well.
             if subdag.is_vote(&potential_vote, leader_block) {
                 let authority = potential_vote.author();
                 tracing::trace!(

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -8,7 +8,7 @@ use parking_lot::RwLock;
 
 use crate::{
     block::{BlockAPI, Slot, TestBlock, Transaction, VerifiedBlock},
-    commit::LeaderStatus,
+    commit::DecidedLeader,
     context::Context,
     dag_state::DagState,
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
@@ -43,11 +43,11 @@ async fn direct_commit() {
     // The universal committer should mark the potential leaders in leader round 6 as
     // undecided because there is no way to get enough certificates for leaders of
     // leader round 6 without completing wave 2.
-    let sequence = test_setup.committer.try_commit(last_decided);
+    let sequence = test_setup.committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block) = sequence[0] {
         assert_eq!(
             block.author(),
             test_setup.committer.get_leaders(leader_round_wave_1)[0]
@@ -74,10 +74,10 @@ async fn idempotence() {
 
     // Commit one leader.
     let last_decided = Slot::new_for_test(0, 0);
-    let first_sequence = committer.try_commit(last_decided);
+    let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
 
-    if let LeaderStatus::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), leader_round_wave_1);
         assert_eq!(
             block.author(),
@@ -89,10 +89,10 @@ async fn idempotence() {
 
     // Ensure that if try_commit is called again with the same last decided leader
     // input the commit decision will be the same.
-    let first_sequence = committer.try_commit(last_decided);
+    let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let LeaderStatus::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), leader_round_wave_1);
         assert_eq!(
             block.author(),
@@ -119,11 +119,11 @@ async fn idempotence() {
         leader_status_wave_1.authority(),
     );
     let leader_round_wave_2 = committer.committers[0].leader_round(2);
-    let second_sequence = committer.try_commit(last_decided);
+    let second_sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {second_sequence:#?}");
 
     assert_eq!(second_sequence.len(), 1);
-    if let LeaderStatus::Commit(ref block) = second_sequence[0] {
+    if let DecidedLeader::Commit(ref block) = second_sequence[0] {
         assert_eq!(second_sequence[0].round(), leader_round_wave_2);
         assert_eq!(
             block.author(),
@@ -154,11 +154,11 @@ async fn multiple_direct_commit() {
 
         // After each wave is complete try commit the leader of that wave.
         let leader_round = committer.committers[0].leader_round(n);
-        let sequence = committer.try_commit(last_decided);
+        let sequence = committer.try_decide(last_decided);
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
-        if let LeaderStatus::Commit(ref block) = sequence[0] {
+        if let DecidedLeader::Commit(ref block) = sequence[0] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -188,7 +188,7 @@ async fn direct_commit_late_call() {
     );
 
     let last_decided = Slot::new_for_test(0, 0);
-    let sequence = committer.try_commit(last_decided);
+    let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     // With 11 waves completed, excluding wave 0 with genesis round as its leader
@@ -196,7 +196,7 @@ async fn direct_commit_late_call() {
     assert_eq!(sequence.len(), num_waves - 1_usize);
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = committer.committers[0].leader_round(i as u32 + 1);
-        if let LeaderStatus::Commit(ref block) = leader_block {
+        if let DecidedLeader::Commit(ref block) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -217,7 +217,7 @@ async fn no_genesis_commit() {
         ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, r));
 
         let last_committed = Slot::new_for_test(0, 0);
-        let sequence = committer.try_commit(last_committed);
+        let sequence = committer.try_decide(last_committed);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert!(sequence.is_empty());
     }
@@ -259,11 +259,11 @@ async fn direct_skip_no_leader_votes() {
     // Ensure no blocks are committed because there are 2f+1 blame (non-votes) for
     // the leader of wave 1.
     let last_decided = Slot::new_for_test(0, 0);
-    let sequence = test_setup.committer.try_commit(last_decided);
+    let sequence = test_setup.committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader) = sequence[0] {
+    if let DecidedLeader::Skip(leader) = sequence[0] {
         assert_eq!(leader.authority, leader_wave_1);
         assert_eq!(leader.round, leader_round_wave_1);
     } else {
@@ -307,11 +307,11 @@ async fn direct_skip_missing_leader_block() {
 
     // Ensure the leader is skipped because the leader is missing.
     let last_committed = Slot::new_for_test(0, 0);
-    let sequence = test_setup.committer.try_commit(last_committed);
+    let sequence = test_setup.committer.try_decide(last_committed);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader) = sequence[0] {
+    if let DecidedLeader::Skip(leader) = sequence[0] {
         assert_eq!(
             leader.authority,
             test_setup.committer.get_leaders(leader_round_wave_1)[0]
@@ -381,14 +381,14 @@ async fn indirect_commit() {
     // Ensure we indirectly commit the leader of wave 1 via the directly committed
     // leader of wave 2.
     let last_decided = Slot::new_for_test(0, 0);
-    let sequence = committer.try_commit(last_decided);
+    let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 2);
 
     for (idx, decided_leader) in sequence.iter().enumerate() {
         let leader_round = committer.committers[0].leader_round(idx as u32 + 1);
         let expected_leader = committer.get_leaders(leader_round)[0];
-        if let LeaderStatus::Commit(ref block) = decided_leader {
+        if let DecidedLeader::Commit(ref block) = decided_leader {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), expected_leader);
         } else {
@@ -461,14 +461,14 @@ async fn indirect_skip() {
 
     // Ensure we make a commit decision for the leaders of wave 1 ~ 3
     let last_committed = Slot::new_for_test(0, 0);
-    let sequence = committer.try_commit(last_committed);
+    let sequence = committer.try_decide(last_committed);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 3);
 
     // Ensure we commit the leader of wave 1 directly.
     let leader_round_wave_1 = committer.committers[0].leader_round(1);
     let leader_wave_1 = committer.get_leaders(leader_round_wave_1)[0];
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block) = sequence[0] {
         assert_eq!(block.round(), leader_round_wave_1);
         assert_eq!(block.author(), leader_wave_1);
     } else {
@@ -479,7 +479,7 @@ async fn indirect_skip() {
     // This happens because we do not have enough votes in voting round of wave 2
     // for the certificates of decision round wave 2 to form a certified link to
     // the leader of wave 2.
-    if let LeaderStatus::Skip(leader) = sequence[1] {
+    if let DecidedLeader::Skip(leader) = sequence[1] {
         assert_eq!(leader.authority, leader_wave_2);
         assert_eq!(leader.round, leader_round_wave_2);
     } else {
@@ -489,7 +489,7 @@ async fn indirect_skip() {
     // Ensure we commit the 3rd leader directly.
     let leader_round_wave_3 = committer.committers[0].leader_round(3);
     let leader_wave_3 = committer.get_leaders(leader_round_wave_3)[0];
-    if let LeaderStatus::Commit(ref block) = sequence[2] {
+    if let DecidedLeader::Commit(ref block) = sequence[2] {
         assert_eq!(block.round(), leader_round_wave_3);
         assert_eq!(block.author(), leader_wave_3);
     } else {
@@ -549,7 +549,7 @@ async fn undecided() {
     // Ensure outcome of direct & indirect rule is undecided. So not commit decisions
     // should be returned.
     let last_committed = Slot::new_for_test(0, 0);
-    let sequence = committer.try_commit(last_committed);
+    let sequence = committer.try_decide(last_committed);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert!(sequence.is_empty());
 }
@@ -692,11 +692,11 @@ async fn test_byzantine_direct_commit() {
 
     // Expect a successful direct commit of A12 and leaders at rounds 9, 6 & 3.
     let last_decided = Slot::new_for_test(0, 0);
-    let sequence = committer.try_commit(last_decided);
+    let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 4);
-    if let LeaderStatus::Commit(ref block) = sequence[3] {
+    if let DecidedLeader::Commit(ref block) = sequence[3] {
         assert_eq!(
             block.author(),
             committer.get_leaders(leader_round_wave_4)[0]

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -105,9 +105,9 @@ impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
 
 impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
-        if !self.reputation_scores.is_empty() {
+        if !self.reputation_scores_desc.is_empty() {
             Some(
-                self.reputation_scores
+                self.reputation_scores_desc
                     .iter()
                     .map(|(id, score)| (id.value() as AuthorityIndex, *score))
                     .collect(),


### PR DESCRIPTION
## Description 

Currently score ties are broken with authority index, which can bias leader selection to nodes with lower authority index. Instead, shuffle the scores based on commit index, then stable sort scores.

Use a separate type `DecidedLeader` to represent leader slots that are either committed or skipped.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
