### PR TITLE
[CI] do not specify pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,5 @@
 		"tsx": "^3.12.7",
 		"turbo": "^1.10.8",
 		"typescript": "^5.3.3"
-	},
-	"packageManager": "pnpm@9.1.0+sha512.67f5879916a9293e5cf059c23853d571beaf4f753c707f40cb22bed5fb1578c6aad3b6c4107ccb3ba0b35be003eb621a16471ac836c87beb53f9d54bb4612724"
+	}
 }


### PR DESCRIPTION
## Description 

pnpm version is not specified in the package.json file and github workflows. So it cannot be locked to a specific version yet.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
