### PR TITLE
fix rust sdk docs error

### DIFF
--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -5,7 +5,7 @@ This crate provides the Sui Rust SDK, containing APIs to interact with the Sui n
 Add the `sui-sdk` dependency as following:
 
 ```toml
-sui-sdk = { git = "https://github.com/mystenlabs/sui", package = "sui-sdk"}
+sui_sdk = { git = "https://github.com/mystenlabs/sui", package = "sui-sdk"}
 tokio = { version = "1.2", features = ["full"] }
 anyhow = "1.0"
 ```


### PR DESCRIPTION
fix rust sdk docs error

## Description 

fix rust sdk docs error

## Test plan 

Fix the code and run build

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
