### PR TITLE
[Indexer/TiDB][chore] Fix schema indentation and capitalization

### DIFF
--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -59,25 +59,55 @@ Run this command under `sui/crates/sui-indexer`, which will wipe DB; In case of 
 ```sh
 diesel database reset --database-url="<DATABASE_URL>"
 ```
-### Local Development(TiDB)
-1.Run TiDB
-```sh
+
+## Steps to run locally (TiDB)
+
+### Prerequisites
+
+1. Install TiDB
+
+``` sh
 curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+```
+
+2. Install a compatible version of MySQL (At the time of writing, this is MySQL 8.0 -- note that 8.3 is incompatible).
+
+``` sh
+brew install mysql@8.0
+```
+
+3. Install a version of `diesel_cli` that supports MySQL (and probably also Postgres). This version of the CLI needs to be built against the version of MySQL that was installed in the previous step (compatible with the local installation of TiDB, 8.0.37 at time of writing).
+
+``` sh
+MYSQLCLIENT_LIB_DIR=/opt/homebrew/Cellar/mysql@8.0/8.0.37/lib/ cargo install diesel_cli --no-default-features --features postgres --features mysql --force
+```
+
+### Run the indexer
+
+1.Run TiDB
+
+```sh
 tiup playground
 ```
+
 2.Verify tidb is running by connecting to it using the mysql client, create database `test`
+
 ```sh
 mysql --comments --host 127.0.0.1 --port 4000 -u root
 create database test;
-``` 
+```
+
 3.DB setup, under `sui/crates/sui-indexer` run:
+
 ```sh
 # an example DATABASE_URL is "mysql://root:password@127.0.0.1:4000/test"
 diesel setup --database-url="<DATABASE_URL> --migration-dir='migrations/mysql'"
 diesel database reset --database-url="<DATABASE_URL> --migration-dir='migrations/mysql'"
 ```
+
 Note that you'll need an existing database for the above to work. Replace `test` with the name of the database created.
 4. run indexer as a writer, which pulls data from fullnode and writes data to DB
+
 ```sh
 # Change the RPC_CLIENT_URL to http://0.0.0.0:9000 to run indexer against local validator & fullnode
 cargo run --bin sui-indexer --features mysql-feature --no-default-features -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker --reset-db

--- a/crates/sui-indexer/migrations/mysql/2024-03-22-052019_events/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-03-22-052019_events/up.sql
@@ -2,27 +2,27 @@ CREATE TABLE events
 (
     tx_sequence_number          BIGINT       NOT NULL,
     event_sequence_number       BIGINT       NOT NULL,
-    transaction_digest          blob        NOT NULL,
-    checkpoint_sequence_number  bigint       NOT NULL,
+    transaction_digest          BLOB         NOT NULL,
+    checkpoint_sequence_number  BIGINT       NOT NULL,
     -- array of SuiAddress in bytes. All signers of the transaction.
-    senders                     json      NOT NULL,
+    senders                     JSON         NOT NULL,
     -- bytes of the entry package ID. Notice that the package and module here
     -- are the package and module of the function that emitted the event, diffrent
     -- from the package and module of the event type.
-    package                     blob        NOT NULL,
+    package                     BLOB         NOT NULL,
     -- entry module name
-    module                      text         NOT NULL,
+    module                      TEXT         NOT NULL,
     -- StructTag in Display format, fully qualified including type parameters
-    event_type                  text         NOT NULL,
+    event_type                  TEXT         NOT NULL,
     -- Components of the StructTag of the event type: package, module,
     -- name (name of the struct, without type parameters)
-    event_type_package          blob        NOT NULL,
-    event_type_module           text         NOT NULL,
-    event_type_name             text         NOT NULL,
+    event_type_package          BLOB         NOT NULL,
+    event_type_module           TEXT         NOT NULL,
+    event_type_name             TEXT         NOT NULL,
     -- timestamp of the checkpoint when the event was emitted
     timestamp_ms                BIGINT       NOT NULL,
     -- bcs of the Event contents (Event.contents)
-    bcs                         MEDIUMBLOB        NOT NULL,
+    bcs                         MEDIUMBLOB   NOT NULL,
     PRIMARY KEY(tx_sequence_number, event_sequence_number, checkpoint_sequence_number)
 ) PARTITION BY RANGE (checkpoint_sequence_number) (
     PARTITION events_partition_0 VALUES LESS THAN MAXVALUE

--- a/crates/sui-indexer/migrations/mysql/2024-03-25-203621_objects/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-03-25-203621_objects/up.sql
@@ -1,38 +1,38 @@
 -- Your SQL goes here
 CREATE TABLE objects (
-                         object_id                   blob         NOT NULL,
-                         object_version              bigint        NOT NULL,
-                         object_digest               blob         NOT NULL,
-                         checkpoint_sequence_number  bigint        NOT NULL,
+    object_id                   BLOB          NOT NULL,
+    object_version              BIGINT        NOT NULL,
+    object_digest               BLOB          NOT NULL,
+    checkpoint_sequence_number  BIGINT        NOT NULL,
     -- Immutable/Address/Object/Shared, see types.rs
-                         owner_type                  smallint      NOT NULL,
+    owner_type                  SMALLINT      NOT NULL,
     -- bytes of SuiAddress/ObjectID of the owner ID.
     -- Non-null for objects with an owner: Addresso or Objects
-                         owner_id                    blob,
+    owner_id                    BLOB,
     -- Object type
-                         object_type                 text,
+    object_type                 TEXT,
     -- Components of the StructTag: package, module, name (name of the struct, without type parameters)
-                         object_type_package         blob,
-                         object_type_module          text,
-                         object_type_name            text,
+    object_type_package         BLOB,
+    object_type_module          TEXT,
+    object_type_name            TEXT,
     -- bcs serialized Object
-                         serialized_object           mediumblob         NOT NULL,
+    serialized_object           MEDIUMBLOB    NOT NULL,
     -- Non-null when the object is a coin.
     -- e.g. `0x2::sui::SUI`
-                         coin_type                   text,
+    coin_type                   TEXT,
     -- Non-null when the object is a coin.
-                         coin_balance                bigint,
+    coin_balance                BIGINT,
     -- DynamicField/DynamicObject, see types.rs
     -- Non-null when the object is a dynamic field
-                         df_kind                     smallint,
+    df_kind                     SMALLINT,
     -- bcs serialized DynamicFieldName
     -- Non-null when the object is a dynamic field
-                         df_name                     blob,
+    df_name                     BLOB,
     -- object_type in DynamicFieldInfo.
-                         df_object_type              text,
+    df_object_type              TEXT,
     -- object_id in DynamicFieldInfo.
-                         df_object_id                blob,
-                         CONSTRAINT objects_pk PRIMARY KEY (object_id(128))
+    df_object_id                BLOB,
+    CONSTRAINT objects_pk PRIMARY KEY (object_id(128))
 );
 
 -- OwnerType: 1: Address, 2: Object, see types.rs
@@ -47,26 +47,26 @@ CREATE INDEX objects_owner_package_module_name_full_type ON objects (owner_id(12
 -- 2. allow null values in some columns for deleted / wrapped objects
 -- 3. object_status to mark the status of the object, which is either Active or WrappedOrDeleted
 CREATE TABLE objects_history (
-                                 object_id                   blob         NOT NULL,
-                                 object_version              bigint        NOT NULL,
-                                 object_status               smallint      NOT NULL,
-                                 object_digest               blob,
-                                 checkpoint_sequence_number  bigint        NOT NULL,
-                                 owner_type                  smallint,
-                                 owner_id                    blob,
-                                 object_type                 text,
+    object_id                   BLOB          NOT NULL,
+    object_version              BIGINT        NOT NULL,
+    object_status               SMALLINT      NOT NULL,
+    object_digest               BLOB,
+    checkpoint_sequence_number  BIGINT        NOT NULL,
+    owner_type                  SMALLINT,
+    owner_id                    BLOB,
+    object_type                 TEXT,
     -- Components of the StructTag: package, module, name (name of the struct, without type parameters)
-                                 object_type_package         blob,
-                                 object_type_module          text,
-                                 object_type_name            text,
-                                 serialized_object           mediumblob,
-                                 coin_type                   text,
-                                 coin_balance                bigint,
-                                 df_kind                     smallint,
-                                 df_name                     blob,
-                                 df_object_type              text,
-                                 df_object_id                blob,
-                                 CONSTRAINT objects_history_pk PRIMARY KEY (checkpoint_sequence_number, object_id(128), object_version)
+    object_type_package         BLOB,
+    object_type_module          TEXT,
+    object_type_name            TEXT,
+    serialized_object           MEDIUMBLOB,
+    coin_type                   TEXT,
+    coin_balance                BIGINT,
+    df_kind                     SMALLINT,
+    df_name                     BLOB,
+    df_object_type              TEXT,
+    df_object_id                BLOB,
+    CONSTRAINT objects_history_pk PRIMARY KEY (checkpoint_sequence_number, object_id(128), object_version)
 ) PARTITION BY RANGE (checkpoint_sequence_number) (
     PARTITION objects_history_partition_0 VALUES LESS THAN MAXVALUE
 );
@@ -81,29 +81,28 @@ CREATE INDEX objects_history_owner_package_module_name_full_type ON objects_hist
 -- effectively the snapshot of objects at the same checkpoint,
 -- except that it also includes deleted or wrapped objects with the corresponding object_status.
 CREATE TABLE objects_snapshot (
-                                  object_id                   BLOB          NOT NULL,
-                                  object_version              bigint        NOT NULL,
-                                  object_status               smallint      NOT NULL,
-                                  object_digest               BLOB,
-                                  checkpoint_sequence_number  bigint        NOT NULL,
-                                  owner_type                  smallint,
-                                  owner_id                    BLOB,
-                                  object_type                 text,
-                                  object_type_package         blob,
-                                  object_type_module          text,
-                                  object_type_name            text,
-                                  serialized_object           mediumblob,
-                                  coin_type                   text,
-                                  coin_balance                bigint,
-                                  df_kind                     smallint,
-                                  df_name                     BLOB,
-                                  df_object_type              text,
-                                  df_object_id                BLOB,
-                                  CONSTRAINT objects_snapshot_pk PRIMARY KEY (object_id(128))
+    object_id                   BLOB          NOT NULL,
+    object_version              BIGINT        NOT NULL,
+    object_status               SMALLINT      NOT NULL,
+    object_digest               BLOB,
+    checkpoint_sequence_number  BIGINT        NOT NULL,
+    owner_type                  SMALLINT,
+    owner_id                    BLOB,
+    object_type                 TEXT,
+    object_type_package         BLOB,
+    object_type_module          TEXT,
+    object_type_name            TEXT,
+    serialized_object           MEDIUMBLOB,
+    coin_type                   TEXT,
+    coin_balance                BIGINT,
+    df_kind                     SMALLINT,
+    df_name                     BLOB,
+    df_object_type              TEXT,
+    df_object_id                BLOB,
+    CONSTRAINT objects_snapshot_pk PRIMARY KEY (object_id(128))
 );
 CREATE INDEX objects_snapshot_checkpoint_sequence_number ON objects_snapshot (checkpoint_sequence_number);
 CREATE INDEX objects_snapshot_owner ON objects_snapshot (owner_type, owner_id(128), object_id(128));
 CREATE INDEX objects_snapshot_coin ON objects_snapshot (owner_id(128), coin_type(128), object_id(128));
 CREATE INDEX objects_snapshot_package_module_name_full_type ON objects_snapshot (object_type_package(128), object_type_module(128), object_type_name(128), object_type(128));
 CREATE INDEX objects_snapshot_owner_package_module_name_full_type ON objects_snapshot (owner_id(128), object_type_package(128), object_type_module(128), object_type_name(128), object_type(128));
-

--- a/crates/sui-indexer/migrations/mysql/2024-03-26-004025_transactions/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-03-26-004025_transactions/up.sql
@@ -1,24 +1,24 @@
 CREATE TABLE transactions (
-                              tx_sequence_number          BIGINT       NOT NULL,
-                              transaction_digest          BLOB        NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
+    transaction_digest          BLOB         NOT NULL,
     -- bcs serialized SenderSignedData bytes
-                              raw_transaction             MEDIUMBLOB        NOT NULL,
+    raw_transaction             MEDIUMBLOB   NOT NULL,
     -- bcs serialized TransactionEffects bytes
-                              raw_effects                 MEDIUMBLOB        NOT NULL,
-                              checkpoint_sequence_number  BIGINT       NOT NULL,
-                              timestamp_ms                BIGINT       NOT NULL,
+    raw_effects                 MEDIUMBLOB   NOT NULL,
+    checkpoint_sequence_number  BIGINT       NOT NULL,
+    timestamp_ms                BIGINT       NOT NULL,
     -- array of bcs serialized IndexedObjectChange bytes
-                              object_changes              JSON      NOT NULL,
+    object_changes              JSON         NOT NULL,
     -- array of bcs serialized BalanceChange bytes
-                              balance_changes             JSON      NOT NULL,
+    balance_changes             JSON         NOT NULL,
     -- array of bcs serialized StoredEvent bytes
-                              events                      JSON      NOT NULL,
+    events                      JSON         NOT NULL,
     -- SystemTransaction/ProgrammableTransaction. See types.rs
-                              transaction_kind            smallint     NOT NULL,
+    transaction_kind            SMALLINT     NOT NULL,
     -- number of successful commands in this transaction, bound by number of command
     -- in a programmaable transaction.
-                              success_command_count       smallint     NOT NULL,
-                              CONSTRAINT transactions_pkey PRIMARY KEY (tx_sequence_number, checkpoint_sequence_number)
+    success_command_count       SMALLINT     NOT NULL,
+    CONSTRAINT transactions_pkey PRIMARY KEY (tx_sequence_number, checkpoint_sequence_number)
 ) PARTITION BY RANGE (checkpoint_sequence_number) (
     PARTITION transactions_partition_0 VALUES LESS THAN MAXVALUE
 );

--- a/crates/sui-indexer/migrations/mysql/2024-04-24-180008_checkpoints/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-04-24-180008_checkpoints/up.sql
@@ -1,13 +1,13 @@
 CREATE TABLE checkpoints
 (
     sequence_number                     bigint       PRIMARY KEY,
-    checkpoint_digest                   blob         NOT NULL,
-    epoch                               bigint       NOT NULL,
+    checkpoint_digest                   BLOB         NOT NULL,
+    epoch                               BIGINT       NOT NULL,
     -- total transactions in the network at the end of this checkpoint (including itself)
-    network_total_transactions          bigint       NOT NULL,
-    previous_checkpoint_digest          blob,
+    network_total_transactions          BIGINT       NOT NULL,
+    previous_checkpoint_digest          BLOB,
     -- if this checkpoitn is the last checkpoint of an epoch
-    end_of_epoch                        boolean      NOT NULL,
+    end_of_epoch                        BOOLEAN      NOT NULL,
     -- array of TranscationDigest in bytes included in this checkpoint
     tx_digests                          JSON         NOT NULL,
     timestamp_ms                        BIGINT       NOT NULL,
@@ -17,11 +17,11 @@ CREATE TABLE checkpoints
     storage_rebate                      BIGINT       NOT NULL,
     non_refundable_storage_fee          BIGINT       NOT NULL,
     -- bcs serialized Vec<CheckpointCommitment> bytes
-    checkpoint_commitments              MEDIUMBLOB         NOT NULL,
+    checkpoint_commitments              MEDIUMBLOB   NOT NULL,
     -- bcs serialized AggregateAuthoritySignature bytes
-    validator_signature                 blob         NOT NULL,
+    validator_signature                 BLOB         NOT NULL,
     -- bcs serialzied EndOfEpochData bytes, if the checkpoint marks end of an epoch
-    end_of_epoch_data                   blob
+    end_of_epoch_data                   BLOB
 );
 
 CREATE INDEX checkpoints_epoch ON checkpoints (epoch, sequence_number);

--- a/crates/sui-indexer/migrations/mysql/2024-04-24-180207_epochs/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-04-24-180207_epochs/up.sql
@@ -7,7 +7,7 @@ CREATE TABLE epochs
     protocol_version                BIGINT      NOT NULL,
     total_stake                     BIGINT      NOT NULL,
     storage_fund_balance            BIGINT      NOT NULL,
-    system_state                    MEDIUMBLOB       NOT NULL,
+    system_state                    MEDIUMBLOB  NOT NULL,
     -- The following fields are nullable because they are filled in
     -- only at the end of an epoch.
     epoch_total_transactions        BIGINT,

--- a/crates/sui-indexer/migrations/mysql/2024-04-24-180418_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-04-24-180418_tx_indices/up.sql
@@ -1,48 +1,48 @@
 -- Your SQL goes here
 CREATE TABLE tx_senders (
-                            cp_sequence_number          BIGINT       NOT NULL,
-                            tx_sequence_number          BIGINT       NOT NULL,
+    cp_sequence_number          BIGINT       NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
     -- SuiAddress in bytes.
-                            sender                      BLOB        NOT NULL,
-                            PRIMARY KEY(sender(255), tx_sequence_number, cp_sequence_number)
+    sender                      BLOB         NOT NULL,
+    PRIMARY KEY(sender(255), tx_sequence_number, cp_sequence_number)
 );
 CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number, cp_sequence_number);
 
 -- Your SQL goes here
 CREATE TABLE tx_recipients (
-                               cp_sequence_number          BIGINT       NOT NULL,
-                               tx_sequence_number          BIGINT       NOT NULL,
+    cp_sequence_number          BIGINT       NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
     -- SuiAddress in bytes.
-                               recipient                   BLOB        NOT NULL,
-                               PRIMARY KEY(recipient(255), tx_sequence_number)
+    recipient                   BLOB         NOT NULL,
+    PRIMARY KEY(recipient(255), tx_sequence_number)
 );
 CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_input_objects (
-                                  cp_sequence_number          BIGINT       NOT NULL,
-                                  tx_sequence_number          BIGINT       NOT NULL,
+    cp_sequence_number          BIGINT       NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
     -- Object ID in bytes.
-                                  object_id                   BLOB        NOT NULL,
-                                  PRIMARY KEY(object_id(255), tx_sequence_number, cp_sequence_number)
+    object_id                   BLOB         NOT NULL,
+    PRIMARY KEY(object_id(255), tx_sequence_number, cp_sequence_number)
 );
 
 CREATE TABLE tx_changed_objects (
-                                    cp_sequence_number          BIGINT       NOT NULL,
-                                    tx_sequence_number          BIGINT       NOT NULL,
+    cp_sequence_number          BIGINT       NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
     -- Object Id in bytes.
-                                    object_id                   BLOB        NOT NULL,
-                                    PRIMARY KEY(object_id(255), tx_sequence_number)
+    object_id                   BLOB         NOT NULL,
+    PRIMARY KEY(object_id(255), tx_sequence_number)
 );
 
 CREATE TABLE tx_calls (
-                          cp_sequence_number          BIGINT       NOT NULL,
-                          tx_sequence_number          BIGINT       NOT NULL,
-                          package                     BLOB        NOT NULL,
-                          module                      TEXT         NOT NULL,
-                          func                        TEXT         NOT NULL,
+    cp_sequence_number          BIGINT       NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
+    package                     BLOB         NOT NULL,
+    module                      TEXT         NOT NULL,
+    func                        TEXT         NOT NULL,
     -- 1. Using Primary Key as a unique index.
     -- 2. Diesel does not like tables with no primary key.
-                          PRIMARY KEY(package(255), tx_sequence_number, cp_sequence_number)
+    PRIMARY KEY(package(255), tx_sequence_number, cp_sequence_number)
 );
 
 CREATE INDEX tx_calls_module ON tx_calls (package(255), module(255), tx_sequence_number, cp_sequence_number);
@@ -50,8 +50,8 @@ CREATE INDEX tx_calls_func ON tx_calls (package(255), module(255), func(255), tx
 CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_digests (
-                            tx_digest                   BLOB         NOT NULL,
-                            cp_sequence_number          BIGINT       NOT NULL,
-                            tx_sequence_number          BIGINT       NOT NULL,
-                            PRIMARY KEY(tx_digest(255))
+    tx_digest                   BLOB         NOT NULL,
+    cp_sequence_number          BIGINT       NOT NULL,
+    tx_sequence_number          BIGINT       NOT NULL,
+    PRIMARY KEY(tx_digest(255))
 );

--- a/crates/sui-indexer/migrations/mysql/2024-04-24-180727_display/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-04-24-180727_display/up.sql
@@ -1,8 +1,8 @@
 CREATE TABLE display
 (
-    object_type     text        NOT NULL,
-    id              BLOB       NOT NULL,
+    object_type     TEXT        NOT NULL,
+    id              BLOB        NOT NULL,
     version         SMALLINT    NOT NULL,
-    bcs             MEDIUMBLOB       NOT NULL,
+    bcs             MEDIUMBLOB  NOT NULL,
     primary key (object_type(255))
 );


### PR DESCRIPTION
## Description

Fix up the formatting of MySQL schema files, to make them easier to port to from Postgres:

- Indent table column descriptors to 4 spaces.
- Make all types uppercase.
- Align column constraints.

## Test plan

```
sui-indexer$ diesel database reset --database-url="$DB" --migration-dir="migrations/mysql"
```

## Stack

- #17686 