### PR TITLE
[GraphQL/MovePackage] Query by ID and version

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/versioning.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/versioning.exp
@@ -1,0 +1,318 @@
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-9:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5076800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 11-15:
+//# upgrade --package P0 --upgrade-capability 1,1 --sender A
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5251600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3, lines 17-22:
+//# upgrade --package P1 --upgrade-capability 1,1 --sender A
+created: object(3,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5426400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4, line 24:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 26-45:
+//# run-graphql
+Response: {
+  "data": {
+    "v1": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            }
+          ]
+        }
+      }
+    },
+    "v2": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            }
+          ]
+        }
+      }
+    },
+    "v3": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            },
+            {
+              "name": "h"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 6, lines 47-84:
+//# run-graphql
+Response: {
+  "data": {
+    "v1_from_p1": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            }
+          ]
+        }
+      }
+    },
+    "v1_from_p2": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            }
+          ]
+        }
+      }
+    },
+    "v2_from_p0": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            }
+          ]
+        }
+      }
+    },
+    "v2_from_p2": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            }
+          ]
+        }
+      }
+    },
+    "v3_from_p0": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            },
+            {
+              "name": "h"
+            }
+          ]
+        }
+      }
+    },
+    "v3_from_p1": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            },
+            {
+              "name": "h"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 7, lines 86-141:
+//# run-graphql
+Response: {
+  "data": {
+    "v1": {
+      "v1": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              }
+            ]
+          }
+        }
+      },
+      "v2": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              }
+            ]
+          }
+        }
+      },
+      "v3": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              },
+              {
+                "name": "h"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "v2": {
+      "v1": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              }
+            ]
+          }
+        }
+      },
+      "v2": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              }
+            ]
+          }
+        }
+      },
+      "v3": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              },
+              {
+                "name": "h"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "v3": {
+      "v1": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              }
+            ]
+          }
+        }
+      },
+      "v2": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              }
+            ]
+          }
+        }
+      },
+      "v3": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              },
+              {
+                "name": "h"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 8, lines 143-171:
+//# run-graphql
+Response: {
+  "data": {
+    "v0": null,
+    "v1": {
+      "v0": null,
+      "v4": null
+    },
+    "v4": null
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/packages/versioning.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/versioning.move
@@ -1,0 +1,171 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 P2=0x0 --accounts A --simulator
+
+//# publish --upgradeable --sender A
+module P0::m {
+    public fun f(): u64 { 42 }
+}
+
+//# upgrade --package P0 --upgrade-capability 1,1 --sender A
+module P1::m {
+    public fun f(): u64 { 42 }
+    public fun g(): u64 { 43 }
+}
+
+//# upgrade --package P1 --upgrade-capability 1,1 --sender A
+module P2::m {
+    public fun f(): u64 { 42 }
+    public fun g(): u64 { 43 }
+    public fun h(): u64 { 44 }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{   # Test fetching by ID
+    v1: package(address: "@{P0}") {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v2: package(address: "@{P1}") {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v3: package(address: "@{P2}") {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+}
+
+//# run-graphql
+{   # Test fetching by version
+    v1_from_p1: package(address: "@{P1}", version: 1) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v1_from_p2: package(address: "@{P2}", version: 1) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v2_from_p0: package(address: "@{P0}", version: 2) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v2_from_p2: package(address: "@{P2}", version: 2) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v3_from_p0: package(address: "@{P0}", version: 3) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    v3_from_p1: package(address: "@{P1}", version: 3) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+}
+
+//# run-graphql
+{   # Go from one version to another using packageAtVersion
+    v1: package(address: "@{P1}") {
+        v1: packageAtVersion(version: 1) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+        v2: packageAtVersion(version: 2) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+        v3: packageAtVersion(version: 3) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+    }
+
+    v2: package(address: "@{P2}") {
+        v1: packageAtVersion(version: 1) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+        v2: packageAtVersion(version: 2) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+        v3: packageAtVersion(version: 3) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+    }
+
+    v3: package(address: "@{P2}") {
+        v1: packageAtVersion(version: 1) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+        v2: packageAtVersion(version: 2) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+        v3: packageAtVersion(version: 3) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+    }
+}
+
+//# run-graphql
+{   # Fetch out of range versions (should return null)
+    v0: package(address: "@{P0}", version: 0) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+
+    # This won't return null, but its inner queries will
+    v1: package(address: "@{P0}") {
+        v0: packageAtVersion(version: 0) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+
+        v4: packageAtVersion(version: 4) {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
+    }
+
+    v4: package(address: "@{P0}", version: 4) {
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2168,6 +2168,11 @@ type MovePackage implements IObject & IOwner {
 	"""
 	bcs: Base64
 	"""
+	Fetch another version of this package (the package that shares this package's original ID,
+	but has the specified `version`).
+	"""
+	packageAtVersion(version: Int!): MovePackage
+	"""
 	A representation of the module called `name` in this package, including the
 	structs and functions it defines.
 	"""
@@ -3039,6 +3044,19 @@ type Query {
 	When no version is given, the latest version is returned.
 	"""
 	object(address: SuiAddress!, version: UInt53): Object
+	"""
+	The package corresponding to the given address at the (optionally) given version.
+	
+	When no version is given, the package is loaded directly from the address given. Otherwise,
+	the address is translated before loading to point to the package whose original ID matches
+	the package at `address`, but whose version is `version`. For non-system packages, this may
+	result in a different address than `address` because different versions of a package,
+	introduced by upgrades, exist at distinct addresses.
+	
+	Note that this interpretation of `version` is different from a historical object read (the
+	interpretation of `version` for the `object` query).
+	"""
+	package(address: SuiAddress!, version: UInt53): MovePackage
 	"""
 	Look-up an Account by its SuiAddress.
 	"""

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -15,7 +15,6 @@ use super::datatype::MoveDatatype;
 use super::move_enum::MoveEnum;
 use super::move_function::MoveFunction;
 use super::move_struct::MoveStruct;
-use super::object::Object;
 use super::{base64::Base64, move_package::MovePackage, sui_address::SuiAddress};
 
 #[derive(Clone)]
@@ -40,7 +39,7 @@ impl MoveModule {
         MovePackage::query(
             ctx,
             self.storage_id,
-            Object::latest_at(self.checkpoint_viewed_at),
+            MovePackage::by_id_at(self.checkpoint_viewed_at),
         )
         .await
         .extend()?
@@ -91,7 +90,7 @@ impl MoveModule {
         let Some(package) = MovePackage::query(
             ctx,
             self.storage_id,
-            Object::latest_at(checkpoint_viewed_at),
+            MovePackage::by_id_at(checkpoint_viewed_at),
         )
         .await
         .extend()?
@@ -482,7 +481,7 @@ impl MoveModule {
         checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
         let Some(package) =
-            MovePackage::query(ctx, address, Object::latest_at(checkpoint_viewed_at)).await?
+            MovePackage::query(ctx, address, MovePackage::by_id_at(checkpoint_viewed_at)).await?
         else {
             return Ok(None);
         };

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -17,6 +17,7 @@ use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
+use super::sui_address::addr;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
@@ -181,6 +182,7 @@ pub(crate) struct AddressOwner {
     owner: Option<Owner>,
 }
 
+/// Filter for a point query of an Object.
 pub(crate) enum ObjectLookup {
     LatestAt {
         /// The checkpoint sequence number at which this was viewed at
@@ -1457,15 +1459,6 @@ impl From<&Object> for OwnerImpl {
             checkpoint_viewed_at: object.checkpoint_viewed_at,
         }
     }
-}
-
-/// Parse a `SuiAddress` from its stored representation.  Failure is an internal error: the
-/// database should never contain a malformed address (containing the wrong number of bytes).
-fn addr(bytes: impl AsRef<[u8]>) -> Result<SuiAddress, Error> {
-    SuiAddress::from_bytes(bytes.as_ref()).map_err(|e| {
-        let bytes = bytes.as_ref().to_vec();
-        Error::Internal(format!("Error deserializing address: {bytes:?}: {e}"))
-    })
 }
 
 pub(crate) async fn deserialize_move_struct(

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2172,6 +2172,11 @@ type MovePackage implements IObject & IOwner {
 	"""
 	bcs: Base64
 	"""
+	Fetch another version of this package (the package that shares this package's original ID,
+	but has the specified `version`).
+	"""
+	packageAtVersion(version: Int!): MovePackage
+	"""
 	A representation of the module called `name` in this package, including the
 	structs and functions it defines.
 	"""
@@ -3043,6 +3048,19 @@ type Query {
 	When no version is given, the latest version is returned.
 	"""
 	object(address: SuiAddress!, version: UInt53): Object
+	"""
+	The package corresponding to the given address at the (optionally) given version.
+	
+	When no version is given, the package is loaded directly from the address given. Otherwise,
+	the address is translated before loading to point to the package whose original ID matches
+	the package at `address`, but whose version is `version`. For non-system packages, this may
+	result in a different address than `address` because different versions of a package,
+	introduced by upgrades, exist at distinct addresses.
+	
+	Note that this interpretation of `version` is different from a historical object read (the
+	interpretation of `version` for the `object` query).
+	"""
+	package(address: SuiAddress!, version: UInt53): MovePackage
 	"""
 	Look-up an Account by its SuiAddress.
 	"""


### PR DESCRIPTION
## Description

Implement `Query.package` and `MovePackage.atVersion` to query a package at a specific version, using the new fields added to the `packages` table, exposed via some new data loaders.

## Test plan

New transactional tests:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests \
  --features pg_integration                     \
  -- packages/versioning
```

## Stack

- #17686 
- #17687 
- #17688 
- #17689 
- #17691
- #17694 
- #17695 
- #17542 
- #17726
- #17543
- #17692

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Introduce `Query.package` and `MovePackage.atVersion` to query packages at specific versions.
- [ ] CLI: 
- [ ] Rust SDK: 
