### PR TITLE
[GraphQL/MovePackage] Query for latest version

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/versioning.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/versioning.exp
@@ -1,4 +1,4 @@
-processed 9 tasks
+processed 14 tasks
 
 init:
 A: object(0,0)
@@ -9,27 +9,16 @@ created: object(1,0), object(1,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5076800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 11-15:
-//# upgrade --package P0 --upgrade-capability 1,1 --sender A
-created: object(2,0)
-mutated: object(0,0), object(1,1)
-gas summary: computation_cost: 1000000, storage_cost: 5251600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
-
-task 3, lines 17-22:
-//# upgrade --package P1 --upgrade-capability 1,1 --sender A
-created: object(3,0)
-mutated: object(0,0), object(1,1)
-gas summary: computation_cost: 1000000, storage_cost: 5426400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
-
-task 4, line 24:
+task 2, line 11:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 26-45:
+task 3, lines 13-21:
 //# run-graphql
 Response: {
   "data": {
-    "v1": {
+    "latestPackage": {
+      "version": 1,
       "module": {
         "functions": {
           "nodes": [
@@ -39,8 +28,26 @@ Response: {
           ]
         }
       }
-    },
-    "v2": {
+    }
+  }
+}
+
+task 4, lines 23-27:
+//# upgrade --package P0 --upgrade-capability 1,1 --sender A
+created: object(4,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5251600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 5, line 29:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 31-39:
+//# run-graphql
+Response: {
+  "data": {
+    "latestPackage": {
+      "version": 2,
       "module": {
         "functions": {
           "nodes": [
@@ -53,8 +60,26 @@ Response: {
           ]
         }
       }
-    },
-    "v3": {
+    }
+  }
+}
+
+task 7, lines 41-46:
+//# upgrade --package P1 --upgrade-capability 1,1 --sender A
+created: object(7,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5426400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 8, line 48:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 9, lines 50-58:
+//# run-graphql
+Response: {
+  "data": {
+    "latestPackage": {
+      "version": 3,
       "module": {
         "functions": {
           "nodes": [
@@ -74,7 +99,107 @@ Response: {
   }
 }
 
-task 6, lines 47-84:
+task 10, lines 60-97:
+//# run-graphql
+Response: {
+  "data": {
+    "v1": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            }
+          ]
+        }
+      },
+      "latestPackage": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              },
+              {
+                "name": "h"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "v2": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            }
+          ]
+        }
+      },
+      "latestPackage": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              },
+              {
+                "name": "h"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "v3": {
+      "module": {
+        "functions": {
+          "nodes": [
+            {
+              "name": "f"
+            },
+            {
+              "name": "g"
+            },
+            {
+              "name": "h"
+            }
+          ]
+        }
+      },
+      "latestPackage": {
+        "module": {
+          "functions": {
+            "nodes": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "g"
+              },
+              {
+                "name": "h"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 11, lines 99-136:
 //# run-graphql
 Response: {
   "data": {
@@ -165,7 +290,7 @@ Response: {
   }
 }
 
-task 7, lines 86-141:
+task 12, lines 138-193:
 //# run-graphql
 Response: {
   "data": {
@@ -304,7 +429,7 @@ Response: {
   }
 }
 
-task 8, lines 143-171:
+task 13, lines 195-223:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/versioning.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/versioning.move
@@ -8,10 +8,34 @@ module P0::m {
     public fun f(): u64 { 42 }
 }
 
+//# create-checkpoint
+
+//# run-graphql
+{
+    latestPackage(address: "@{P0}") {
+        version
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+}
+
 //# upgrade --package P0 --upgrade-capability 1,1 --sender A
 module P1::m {
     public fun f(): u64 { 42 }
     public fun g(): u64 { 43 }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+    latestPackage(address: "@{P0}") {
+        version
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
 }
 
 //# upgrade --package P1 --upgrade-capability 1,1 --sender A
@@ -24,10 +48,26 @@ module P2::m {
 //# create-checkpoint
 
 //# run-graphql
+{
+    latestPackage(address: "@{P0}") {
+        version
+        module(name: "m") {
+            functions { nodes { name } }
+        }
+    }
+}
+
+//# run-graphql
 {   # Test fetching by ID
     v1: package(address: "@{P0}") {
         module(name: "m") {
             functions { nodes { name } }
+        }
+
+        latestPackage {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
         }
     }
 
@@ -35,11 +75,23 @@ module P2::m {
         module(name: "m") {
             functions { nodes { name } }
         }
+
+        latestPackage {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
+        }
     }
 
     v3: package(address: "@{P2}") {
         module(name: "m") {
             functions { nodes { name } }
+        }
+
+        latestPackage {
+            module(name: "m") {
+                functions { nodes { name } }
+            }
         }
     }
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2173,6 +2173,11 @@ type MovePackage implements IObject & IOwner {
 	"""
 	packageAtVersion(version: Int!): MovePackage
 	"""
+	Fetch the latest version of this package (the package with the highest `version` that shares
+	this packages's original ID)
+	"""
+	latestPackage: MovePackage!
+	"""
 	A representation of the module called `name` in this package, including the
 	structs and functions it defines.
 	"""
@@ -3057,6 +3062,13 @@ type Query {
 	interpretation of `version` for the `object` query).
 	"""
 	package(address: SuiAddress!, version: UInt53): MovePackage
+	"""
+	The latest version of the package at `address`.
+	
+	This corresponds to the package with the highest `version` that shares its original ID with
+	the package at `address`.
+	"""
+	latestPackage(address: SuiAddress!): MovePackage
 	"""
 	Look-up an Account by its SuiAddress.
 	"""

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -248,6 +248,21 @@ impl Query {
         MovePackage::query(ctx, address, key).await.extend()
     }
 
+    /// The latest version of the package at `address`.
+    ///
+    /// This corresponds to the package with the highest `version` that shares its original ID with
+    /// the package at `address`.
+    async fn latest_package(
+        &self,
+        ctx: &Context<'_>,
+        address: SuiAddress,
+    ) -> Result<Option<MovePackage>> {
+        let Watermark { checkpoint, .. } = *ctx.data()?;
+        MovePackage::query(ctx, address, MovePackage::latest_at(checkpoint))
+            .await
+            .extend()
+    }
+
     /// Look-up an Account by its SuiAddress.
     async fn address(&self, ctx: &Context<'_>, address: SuiAddress) -> Result<Option<Address>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2177,6 +2177,11 @@ type MovePackage implements IObject & IOwner {
 	"""
 	packageAtVersion(version: Int!): MovePackage
 	"""
+	Fetch the latest version of this package (the package with the highest `version` that shares
+	this packages's original ID)
+	"""
+	latestPackage: MovePackage!
+	"""
 	A representation of the module called `name` in this package, including the
 	structs and functions it defines.
 	"""
@@ -3061,6 +3066,13 @@ type Query {
 	interpretation of `version` for the `object` query).
 	"""
 	package(address: SuiAddress!, version: UInt53): MovePackage
+	"""
+	The latest version of the package at `address`.
+	
+	This corresponds to the package with the highest `version` that shares its original ID with
+	the package at `address`.
+	"""
+	latestPackage(address: SuiAddress!): MovePackage
 	"""
 	Look-up an Account by its SuiAddress.
 	"""


### PR DESCRIPTION
## Description

Add a new kind of package point look-up to get the latest version of the package at a given ID (or from another `MovePackage`). For system packages, this is analogous to getting the latest version of the object at that ID, but the versions of other packages all exist at different IDs.

## Test plan

New transactional tests:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests \
  --features pg_integration                     \
  -- packages/versioning
```

## Stack

- #17686 
- #17687 
- #17688 
- #17689 
- #17691
- #17694 
- #17695 
- #17542 
- #17726
- #17543
- #17692

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Add `Query.latestPackage` and `MovePackage.latest` for fetching the latest version of a package.
- [ ] CLI: 
- [ ] Rust SDK: 
