### PR TITLE
[GraphQL/MovePackage] Paginate by checkpoint

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/versioning.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/versioning.exp
@@ -1,4 +1,4 @@
-processed 14 tasks
+processed 15 tasks
 
 init:
 A: object(0,0)
@@ -13,7 +13,7 @@ task 2, line 11:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 13-21:
+task 3, lines 13-28:
 //# run-graphql
 Response: {
   "data": {
@@ -28,21 +28,45 @@ Response: {
           ]
         }
       }
+    },
+    "packages": {
+      "nodes": [
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "version": 1
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "version": 1
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+          "version": 1
+        },
+        {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+          "version": 1
+        },
+        {
+          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "version": 1
+        }
+      ]
     }
   }
 }
 
-task 4, lines 23-27:
+task 4, lines 30-34:
 //# upgrade --package P0 --upgrade-capability 1,1 --sender A
 created: object(4,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5251600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 5, line 29:
+task 5, line 36:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 6, lines 31-39:
+task 6, lines 38-53:
 //# run-graphql
 Response: {
   "data": {
@@ -60,21 +84,49 @@ Response: {
           ]
         }
       }
+    },
+    "packages": {
+      "nodes": [
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "version": 1
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "version": 1
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+          "version": 1
+        },
+        {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+          "version": 1
+        },
+        {
+          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "version": 1
+        },
+        {
+          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "version": 2
+        }
+      ]
     }
   }
 }
 
-task 7, lines 41-46:
+task 7, lines 55-60:
 //# upgrade --package P1 --upgrade-capability 1,1 --sender A
 created: object(7,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5426400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 8, line 48:
+task 8, line 62:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 9, lines 50-58:
+task 9, lines 64-79:
 //# run-graphql
 Response: {
   "data": {
@@ -95,11 +147,43 @@ Response: {
           ]
         }
       }
+    },
+    "packages": {
+      "nodes": [
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "version": 1
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "version": 1
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+          "version": 1
+        },
+        {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+          "version": 1
+        },
+        {
+          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "version": 1
+        },
+        {
+          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "version": 2
+        },
+        {
+          "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+          "version": 3
+        }
+      ]
     }
   }
 }
 
-task 10, lines 60-97:
+task 10, lines 81-118:
 //# run-graphql
 Response: {
   "data": {
@@ -199,7 +283,7 @@ Response: {
   }
 }
 
-task 11, lines 99-136:
+task 11, lines 120-157:
 //# run-graphql
 Response: {
   "data": {
@@ -290,7 +374,7 @@ Response: {
   }
 }
 
-task 12, lines 138-193:
+task 12, lines 159-214:
 //# run-graphql
 Response: {
   "data": {
@@ -429,7 +513,7 @@ Response: {
   }
 }
 
-task 13, lines 195-223:
+task 13, lines 216-244:
 //# run-graphql
 Response: {
   "data": {
@@ -439,5 +523,101 @@ Response: {
       "v4": null
     },
     "v4": null
+  }
+}
+
+task 14, lines 246-277:
+//# run-graphql
+Response: {
+  "data": {
+    "before": {
+      "nodes": [
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "version": 1,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "version": 1,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+          "version": 1,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+          "version": 1,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    "after": {
+      "nodes": [
+        {
+          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "version": 2,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+          "version": 3,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        }
+      ]
+    },
+    "between": {
+      "nodes": [
+        {
+          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "version": 2,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/packages/versioning.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/versioning.move
@@ -18,6 +18,13 @@ module P0::m {
             functions { nodes { name } }
         }
     }
+
+    packages(first: 10) {
+        nodes {
+            address
+            version
+        }
+    }
 }
 
 //# upgrade --package P0 --upgrade-capability 1,1 --sender A
@@ -34,6 +41,13 @@ module P1::m {
         version
         module(name: "m") {
             functions { nodes { name } }
+        }
+    }
+
+    packages(first: 10) {
+        nodes {
+            address
+            version
         }
     }
 }
@@ -53,6 +67,13 @@ module P2::m {
         version
         module(name: "m") {
             functions { nodes { name } }
+        }
+    }
+
+    packages(first: 10) {
+        nodes {
+            address
+            version
         }
     }
 }
@@ -218,6 +239,39 @@ module P2::m {
     v4: package(address: "@{P0}", version: 4) {
         module(name: "m") {
             functions { nodes { name } }
+        }
+    }
+}
+
+//# run-graphql
+{   # Querying packages with checkpoint bounds
+    before: packages(first: 10, filter: { beforeCheckpoint: 1 }) {
+        nodes {
+            address
+            version
+            previousTransactionBlock {
+                effects { checkpoint { sequenceNumber } }
+            }
+        }
+    }
+
+    after: packages(first: 10, filter: { afterCheckpoint: 1 }) {
+        nodes {
+            address
+            version
+            previousTransactionBlock {
+                effects { checkpoint { sequenceNumber } }
+            }
+        }
+    }
+
+    between: packages(first: 10, filter: { afterCheckpoint: 1, beforeCheckpoint: 3 }) {
+        nodes {
+            address
+            version
+            previousTransactionBlock {
+                effects { checkpoint { sequenceNumber } }
+            }
         }
     }
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2201,6 +2201,22 @@ type MovePackage implements IObject & IOwner {
 	moduleBcs: Base64
 }
 
+"""
+Filter for paginating `MovePackage`s that were created within a range of checkpoints.
+"""
+input MovePackageCheckpointFilter {
+	"""
+	Fetch packages that were published strictly after this checkpoint. Omitting this fetches
+	packages published since genesis.
+	"""
+	afterCheckpoint: UInt53
+	"""
+	Fetch packages that were published strictly before this checkpoint. Omitting this fetches
+	packages published up to the latest checkpoint (inclusive).
+	"""
+	beforeCheckpoint: UInt53
+}
+
 type MovePackageConnection {
 	"""
 	Information to aid in pagination.
@@ -3114,6 +3130,14 @@ type Query {
 	The objects that exist in the network.
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	"""
+	The Move packages that exist in the network, optionally filtered to be strictly before
+	`beforeCheckpoint` and/or strictly after `afterCheckpoint`.
+	
+	This query will return all versions of a given user package that appear between the
+	specified checkpoints, but only records the latest versions of system packages.
+	"""
+	packages(first: Int, after: String, last: Int, before: String, filter: MovePackageCheckpointFilter): MovePackageConnection!
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -143,13 +143,13 @@ impl Event {
     /// checkpoint sequence numbers as the cursor to determine the correct page of results. The
     /// query can optionally be further `filter`-ed by the `EventFilter`.
     ///
-    /// The `checkpoint_viewed_at` parameter is represents the checkpoint sequence number at which
-    /// this page was queried for. Each entity returned in the connection will inherit this
-    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
-    /// checkpoint_viewed_at parameter.
+    /// The `checkpoint_viewed_at` parameter represents the checkpoint sequence number at which this
+    /// page was queried. Each entity returned in the connection will inherit this checkpoint, so
+    /// that when viewing that entity's state, it will be as if it is being viewed at this
+    /// checkpoint.
     ///
-    /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
-    /// the cursor if they are consistent.
+    /// The cursors in `page` may also include checkpoint viewed at fields. If these are set, they
+    /// take precedence over the checkpoint that pagination is being conducted in.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2205,6 +2205,22 @@ type MovePackage implements IObject & IOwner {
 	moduleBcs: Base64
 }
 
+"""
+Filter for paginating `MovePackage`s that were created within a range of checkpoints.
+"""
+input MovePackageCheckpointFilter {
+	"""
+	Fetch packages that were published strictly after this checkpoint. Omitting this fetches
+	packages published since genesis.
+	"""
+	afterCheckpoint: UInt53
+	"""
+	Fetch packages that were published strictly before this checkpoint. Omitting this fetches
+	packages published up to the latest checkpoint (inclusive).
+	"""
+	beforeCheckpoint: UInt53
+}
+
 type MovePackageConnection {
 	"""
 	Information to aid in pagination.
@@ -3118,6 +3134,14 @@ type Query {
 	The objects that exist in the network.
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	"""
+	The Move packages that exist in the network, optionally filtered to be strictly before
+	`beforeCheckpoint` and/or strictly after `afterCheckpoint`.
+	
+	This query will return all versions of a given user package that appear between the
+	specified checkpoints, but only records the latest versions of system packages.
+	"""
+	packages(first: Int, after: String, last: Int, before: String, filter: MovePackageCheckpointFilter): MovePackageConnection!
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).


### PR DESCRIPTION
## Description

Adds a query, `Query.packages` for fetching all packages that were introduced within a given checkpoint range. Useful for fetching package contents in bulk, to do local analyses.

## Test plan

New E2E tests:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests \
  --features pg_integration                     \
  -- packages/versioning
```

Also tested for performance against a large read replica (the query planner quotes a high estimate for the query but the actual results do not take very long to run because queries on many sub-partitions are eliminated).

## Stack

- #17686 
- #17687 
- #17688 
- #17689 
- #17691
- #17694 
- #17695 
- #17542 
- #17726
- #17543
- #17692 
- #17693 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Introduces `Query.packages` for paginating through all packages (optionally bounding by the checkpoint the package was introduced in).
- [ ] CLI: 
- [ ] Rust SDK: 
