### PR TITLE
[cherry-pick][graphql] Add support for clever error resolution in graphql (#17338)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13356,6 +13356,7 @@ dependencies = [
  "insta",
  "lru 0.10.0",
  "move-binary-format",
+ "move-command-line-common",
  "move-compiler",
  "move-core-types",
  "serde",

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.exp
@@ -1,0 +1,248 @@
+processed 29 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-81:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9743200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 83-83:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 9223372161408827393
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("callU8") }, 9223372161408827393), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372161408827393), message: Some("P0::m::callU8 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 3 'run'. lines 85-85:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 9223372174293860355
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("callU16") }, 9223372174293860355), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372174293860355), message: Some("P0::m::callU16 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
+
+task 4 'run'. lines 87-87:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 9223372187178893317
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("callU32") }, 9223372187178893317), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372187178893317), message: Some("P0::m::callU32 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
+
+task 5 'run'. lines 89-89:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 9223372200063926279
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 3, instruction: 1, function_name: Some("callU64") }, 9223372200063926279), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372200063926279), message: Some("P0::m::callU64 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
+
+task 6 'run'. lines 91-91:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 9223372212948959241
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("callU128") }, 9223372212948959241), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372212948959241), message: Some("P0::m::callU128 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
+
+task 7 'run'. lines 93-93:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 9223372225833992203
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("callU256") }, 9223372225833992203), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372225833992203), message: Some("P0::m::callU256 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
+
+task 8 'run'. lines 95-95:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 9223372238719156239
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("callAddress") }, 9223372238719156239), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372238719156239), message: Some("P0::m::callAddress at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
+
+task 9 'run'. lines 97-97:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 9223372251604189201
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 9223372251604189201), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372251604189201), message: Some("P0::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+
+task 10 'run'. lines 99-99:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 9223372264489222163
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callU64vec") }, 9223372264489222163), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372264489222163), message: Some("P0::m::callU64vec at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+
+task 11 'run'. lines 101-101:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 9, instruction: 1, function_name: Some("normalAbort") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("P0::m::normalAbort at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
+
+task 12 'run'. lines 103-103:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 10) at offset 1, Abort Code: 9223372294552813567
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 10, instruction: 1, function_name: Some("assertLineNo") }, 9223372294552813567), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372294552813567), message: Some("P0::m::assertLineNo at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
+
+task 13 'create-checkpoint'. lines 105-105:
+Checkpoint created: 1
+
+task 14 'run-graphql'. lines 107-117:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU8' (line 29), abort 'ImAU8': 0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU16' (line 32), abort 'ImAU16': 1"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU32' (line 35), abort 'ImAU32': 2"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU64' (line 38), abort 'ImAU64': 3"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU128' (line 41), abort 'ImAU128': 4"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU256' (line 44), abort 'ImAU256': 5"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callAddress' (line 47), abort 'ImAnAddress': 0x0000000000000000000000000000000000000000000000000000000000000006"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callString' (line 50), abort 'ImAString': This is a string"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::callU64vec' (line 53), abort 'ImNotAString': BQEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAA="
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::normalAbort' (instruction 1), abort code: 0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0xc3ae63b89de6031e21331453c2886219014f129579ad88f0a425dde191c92526::m::assertLineNo' (line 59)"
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 15 'upgrade'. lines 119-197:
+created: object(15,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 9849600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 16 'run'. lines 199-199:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU8 (function index 0) at offset 1, Abort Code: 9223372659625033729
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("callU8") }, 9223372659625033729), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372659625033729), message: Some("fake(1,0)::m::callU8 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 17 'run'. lines 201-201:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU16 (function index 1) at offset 1, Abort Code: 9223372672510066691
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("callU16") }, 9223372672510066691), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372672510066691), message: Some("fake(1,0)::m::callU16 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
+
+task 18 'run'. lines 203-203:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU32 (function index 2) at offset 1, Abort Code: 9223372685395099653
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("callU32") }, 9223372685395099653), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372685395099653), message: Some("fake(1,0)::m::callU32 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
+
+task 19 'run'. lines 205-205:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU64 (function index 3) at offset 1, Abort Code: 9223372698280132615
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 3, instruction: 1, function_name: Some("callU64") }, 9223372698280132615), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372698280132615), message: Some("fake(1,0)::m::callU64 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
+
+task 20 'run'. lines 207-207:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU128 (function index 4) at offset 1, Abort Code: 9223372711165165577
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("callU128") }, 9223372711165165577), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372711165165577), message: Some("fake(1,0)::m::callU128 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
+
+task 21 'run'. lines 209-209:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU256 (function index 5) at offset 1, Abort Code: 9223372724050198539
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("callU256") }, 9223372724050198539), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372724050198539), message: Some("fake(1,0)::m::callU256 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
+
+task 22 'run'. lines 211-211:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callAddress (function index 6) at offset 1, Abort Code: 9223372736935362575
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("callAddress") }, 9223372736935362575), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372736935362575), message: Some("fake(1,0)::m::callAddress at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
+
+task 23 'run'. lines 213-213:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callString (function index 7) at offset 1, Abort Code: 9223372749820395537
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 9223372749820395537), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372749820395537), message: Some("fake(1,0)::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+
+task 24 'run'. lines 215-215:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::callU64vec (function index 8) at offset 1, Abort Code: 9223372762705428499
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callU64vec") }, 9223372762705428499), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372762705428499), message: Some("fake(1,0)::m::callU64vec at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+
+task 25 'run'. lines 217-217:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::normalAbort (function index 9) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 9, instruction: 1, function_name: Some("normalAbort") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("fake(1,0)::m::normalAbort at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
+
+task 26 'run'. lines 219-219:
+Error: Transaction Effects Status: Move Runtime Abort. Location: fake(1,0)::m::assertLineNo (function index 10) at offset 1, Abort Code: 9223372792769019903
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: fake(1,0), name: Identifier("m") }, function: 10, instruction: 1, function_name: Some("assertLineNo") }, 9223372792769019903), source: Some(VMError { major_status: ABORTED, sub_status: Some(9223372792769019903), message: Some("fake(1,0)::m::assertLineNo at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
+
+task 27 'create-checkpoint'. lines 221-221:
+Checkpoint created: 2
+
+task 28 'run-graphql'. lines 223-233:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU32' (line 151), abort 'ImAU32': 9"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU64' (line 154), abort 'ImAU64': 10"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU128' (line 157), abort 'ImAU128': 11"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU256' (line 160), abort 'ImAU256': 12"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callAddress' (line 163), abort 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callString' (line 166), abort 'ImAString': This is a string in v2"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::callU64vec' (line 169), abort 'ImNotAString': BgEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAAGAAAAAAAAAA=="
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::normalAbort' (instruction 1), abort code: 0"
+          }
+        },
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Error in 1st command, from '0x1725b2137e1ce086337ba6c67bb89c390645ff898fbf218647090ea1f9bbd5f1::m::assertLineNo' (line 175)"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/errors/clever_errors.move
@@ -1,0 +1,233 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 --accounts A --simulator 
+
+//# publish --upgradeable --sender A
+module P0::m {
+    #[error]
+    const ImAU8: u8 = 0;
+
+    #[error]
+    const ImAU16: u16 = 1;
+
+    #[error]
+    const ImAU32: u32 = 2;
+
+    #[error]
+    const ImAU64: u64 = 3;
+
+    #[error]
+    const ImAU128: u128 = 4;
+
+    #[error]
+    const ImAU256: u256 = 5;
+
+    #[error]
+    const ImABool: bool = true;
+
+    #[error]
+    const ImAnAddress: address = @6;
+
+    #[error]
+    const ImAString: vector<u8> = b"This is a string";
+
+    #[error]
+    const ImNotAString: vector<u64> = vector[1,2,3,4,5];
+
+    public fun callU8() {
+        abort ImAU8
+    }
+
+    public fun callU16() {
+        abort ImAU16
+    }
+
+    public fun callU32() {
+        abort ImAU32
+    }
+
+    public fun callU64() {
+        abort ImAU64
+    }
+
+    public fun callU128() {
+        abort ImAU128
+    }
+
+    public fun callU256() {
+        abort ImAU256
+    }
+
+    public fun callAddress() {
+        abort ImAnAddress
+    }
+
+    public fun callString() {
+        abort ImAString
+    }
+
+    public fun callU64vec() {
+        abort ImNotAString
+    }
+
+    public fun normalAbort() {
+        abort 0
+    }
+
+    public fun assertLineNo() {
+        assert!(false);
+    }
+}
+
+//# run P0::m::callU8
+
+//# run P0::m::callU16
+
+//# run P0::m::callU32
+
+//# run P0::m::callU64
+
+//# run P0::m::callU128
+
+//# run P0::m::callU256
+
+//# run P0::m::callAddress
+
+//# run P0::m::callString
+
+//# run P0::m::callU64vec
+
+//# run P0::m::normalAbort
+
+//# run P0::m::assertLineNo
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(last: 11) {
+    nodes {
+      effects {
+        status
+        errors
+      }
+    }
+  }
+}
+
+//# upgrade --package P0 --upgrade-capability 1,1 --sender A
+// Upgrade the module with new error values but using the same constant names
+// (etc) to make sure we properly resolve the module location for clever
+// errors.
+module P0::m {
+    #[error]
+    const ImAU8: u8 = 7;
+
+    #[error]
+    const ImAU16: u16 = 8;
+
+    #[error]
+    const ImAU32: u32 = 9;
+
+    #[error]
+    const ImAU64: u64 = 10;
+
+    #[error]
+    const ImAU128: u128 = 11;
+
+    #[error]
+    const ImAU256: u256 = 12;
+
+    #[error]
+    const ImABool: bool = false;
+
+    #[error]
+    const ImAnAddress: address = @13;
+
+    #[error]
+    const ImAString: vector<u8> = b"This is a string in v2";
+
+    #[error]
+    const ImNotAString: vector<u64> = vector[1,2,3,4,5,6];
+
+    public fun callU8() {
+        abort ImAU8
+    }
+
+    public fun callU16() {
+        abort ImAU16
+    }
+
+    public fun callU32() {
+        abort ImAU32
+    }
+
+    public fun callU64() {
+        abort ImAU64
+    }
+
+    public fun callU128() {
+        abort ImAU128
+    }
+
+    public fun callU256() {
+        abort ImAU256
+    }
+
+    public fun callAddress() {
+        abort ImAnAddress
+    }
+
+    public fun callString() {
+        abort ImAString
+    }
+
+    public fun callU64vec() {
+        abort ImNotAString
+    }
+
+    public fun normalAbort() {
+        abort 0
+    }
+
+    public fun assertLineNo() {
+        assert!(false);
+    }
+}
+
+//# run P0::m::callU8
+
+//# run P0::m::callU16
+
+//# run P0::m::callU32
+
+//# run P0::m::callU64
+
+//# run P0::m::callU128
+
+//# run P0::m::callU256
+
+//# run P0::m::callAddress
+
+//# run P0::m::callString
+
+//# run P0::m::callU64vec
+
+//# run P0::m::normalAbort
+
+//# run P0::m::assertLineNo
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(last: 9) {
+    nodes {
+      effects {
+        status
+        errors
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
@@ -20,7 +20,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42 in 1st command."
+            "errors": "Error in 1st command, from '0x83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom' (instruction 1), abort code: 42"
           }
         }
       ]
@@ -43,7 +43,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: 83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom (function index 1) at offset 1, Abort Code: 42 in 3rd command."
+            "errors": "Error in 3rd command, from '0x83f3be7571dccac8f0fd562cf4aa66707bafe3996c49b6f659be49a9841653fe::m::boom' (instruction 1), abort code: 42"
           }
         }
       ]

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3709,6 +3709,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
+	If the error is a Move abort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to displaying the abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -1,18 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{consistency::ConsistentIndexCursor, error::Error};
+use crate::{
+    consistency::ConsistentIndexCursor, data::package_resolver::PackageResolver, error::Error,
+};
 use async_graphql::{
     connection::{Connection, ConnectionNameType, CursorType, Edge, EdgeNameType, EmptyFields},
     *,
 };
+use fastcrypto::encoding::{Base64 as FBase64, Encoding};
 use sui_indexer::models::transactions::StoredTransaction;
+use sui_package_resolver::{CleverError, ErrorConstants};
 use sui_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
     event::Event as NativeEvent,
-    execution_status::ExecutionStatus as NativeExecutionStatus,
-    transaction::SenderSignedData as NativeSenderSignedData,
-    transaction::TransactionData as NativeTransactionData,
+    execution_status::{
+        ExecutionFailureStatus, ExecutionStatus as NativeExecutionStatus, MoveLocation,
+        MoveLocationOpt,
+    },
+    transaction::{
+        Command, ProgrammableTransaction, SenderSignedData as NativeSenderSignedData,
+        TransactionData as NativeTransactionData, TransactionDataAPI,
+        TransactionKind as NativeTransactionKind,
+    },
 };
 
 use super::{
@@ -105,19 +115,74 @@ impl TransactionBlockEffects {
     }
 
     /// The reason for a transaction failure, if it did fail.
-    async fn errors(&self) -> Option<String> {
-        match self.native().status() {
-            NativeExecutionStatus::Success => None,
+    /// If the error is a Move abort, the error message will be resolved to a human-readable form if
+    /// possible, otherwise it will fall back to displaying the abort code and location.
+    async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+        let resolver: &PackageResolver = ctx.data_unchecked();
+        let status = self.resolve_native_status_impl(resolver).await?;
+
+        match status {
+            NativeExecutionStatus::Success => Ok(None),
 
             NativeExecutionStatus::Failure {
                 error,
                 command: None,
-            } => Some(error.to_string()),
+            } => Ok(Some(error.to_string())),
 
             NativeExecutionStatus::Failure {
                 error,
                 command: Some(command),
             } => {
+                let error = 'error: {
+                    let ExecutionFailureStatus::MoveAbort(loc, code) = &error else {
+                        break 'error error.to_string();
+                    };
+                    let fname_string = if let Some(fname) = &loc.function_name {
+                        format!("::{}'", fname)
+                    } else {
+                        "'".to_string()
+                    };
+
+                    let Some(CleverError {
+                        module_id,
+                        source_line_number,
+                        error_info,
+                    }) = resolver
+                        .resolve_clever_error(loc.module.clone(), *code)
+                        .await
+                    else {
+                        break 'error format!(
+                            "from '{}{fname_string} (instruction {}), abort code: {code}",
+                            loc.module.to_canonical_display(true),
+                            loc.instruction,
+                        );
+                    };
+
+                    match error_info {
+                        ErrorConstants::Rendered {
+                            identifier,
+                            constant,
+                        } => {
+                            format!(
+                                "from '{}{fname_string} (line {source_line_number}), abort '{identifier}': {constant}",
+                                module_id.to_canonical_display(true)
+                            )
+                        }
+                        ErrorConstants::Raw { identifier, bytes } => {
+                            let const_str = FBase64::encode(bytes);
+                            format!(
+                                "from '{}{fname_string} (line {source_line_number}), abort '{identifier}': {const_str}",
+                                module_id.to_canonical_display(true)
+                            )
+                        }
+                        ErrorConstants::None => {
+                            format!(
+                                "from '{}{fname_string} (line {source_line_number})",
+                                module_id.to_canonical_display(true)
+                            )
+                        }
+                    }
+                };
                 // Convert the command index into an ordinal.
                 let command = command + 1;
                 let suffix = match command % 10 {
@@ -126,8 +191,7 @@ impl TransactionBlockEffects {
                     3 => "rd",
                     _ => "th",
                 };
-
-                Some(format!("{error} in {command}{suffix} command."))
+                Ok(Some(format!("Error in {command}{suffix} command, {error}")))
             }
         }
     }
@@ -417,6 +481,76 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::Executed { native, .. } => native,
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
         }
+    }
+
+    /// Get the transaction data from the transaction block effects.
+    /// Will error if the transaction data is not available/invalid, but this should not occur.
+    fn transaction_data(&self) -> Result<NativeTransactionData> {
+        Ok(match &self.kind {
+            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                let s: NativeSenderSignedData = bcs::from_bytes(&stored_tx.raw_transaction)
+                    .map_err(|e| {
+                        Error::Internal(format!("Error deserializing transaction data: {e}"))
+                    })?;
+                s.transaction_data().clone()
+            }
+            TransactionBlockEffectsKind::Executed { tx_data, .. } => {
+                tx_data.transaction_data().clone()
+            }
+            TransactionBlockEffectsKind::DryRun { tx_data, .. } => tx_data.clone(),
+        })
+    }
+
+    /// Get the programmable transaction from the transaction block effects.
+    /// * If the transaction was unable to be retrieved, this will return an Err.
+    /// * If the transaction was able to be retrieved but was not a programmable transaction, this
+    ///   will return Ok(None).
+    /// * If the transaction was a programmable transaction, this will return Ok(Some(tx)).
+    fn programmable_transaction(&self) -> Result<Option<ProgrammableTransaction>> {
+        let tx_data = self.transaction_data()?;
+        match tx_data.into_kind() {
+            NativeTransactionKind::ProgrammableTransaction(tx) => Ok(Some(tx)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Resolves the module ID within a Move abort to the storage ID of the package that the
+    /// abort occured in.
+    /// * If the error is not a Move abort, or the Move call in the programmable transaction cannot
+    ///   be found, this function will do nothing.
+    /// * If the error is a Move abort and the storage ID is unable to be resolved an error is
+    ///   returned.
+    async fn resolve_native_status_impl(
+        &self,
+        resolver: &PackageResolver,
+    ) -> Result<NativeExecutionStatus> {
+        let mut status = self.native().status().clone();
+        if let NativeExecutionStatus::Failure {
+            error:
+                ExecutionFailureStatus::MoveAbort(MoveLocation { module, .. }, _)
+                | ExecutionFailureStatus::MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation {
+                    module,
+                    ..
+                }))),
+            command: Some(command_idx),
+        } = &mut status
+        {
+            // Get the Move call that this error is associated with.
+            if let Some(Command::MoveCall(ptb_call)) = self
+                .programmable_transaction()?
+                .and_then(|ptb| ptb.commands.into_iter().nth(*command_idx))
+            {
+                let module_new = module.clone();
+                // Resolve the runtime module ID in the Move abort to the storage ID of the package
+                // that the abort occured in. This is important to make sure that we look at the
+                // correct version of the module when resolving the error.
+                *module = resolver
+                    .resolve_module_id(module_new, ptb_call.package.into())
+                    .await
+                    .map_err(|e| Error::Internal(format!("Error resolving Move location: {e}")))?;
+            }
+        }
+        Ok(status)
     }
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3713,6 +3713,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
+	If the error is a Move abort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to displaying the abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-package-resolver/Cargo.toml
+++ b/crates/sui-package-resolver/Cargo.toml
@@ -13,6 +13,10 @@ async-trait.workspace = true
 bcs.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
+# TODO: `move-command-line-common` is used for `ErrorBitset`. We should
+# refactor the crate into a `move-utils` at some point and use that instead
+# here once we do.
+move-command-line-common.workspace = true
 sui-types.workspace = true
 thiserror.workspace = true
 sui-rest-api.workspace = true

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -332,7 +332,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
                     AccountAddress::ZERO.into_bytes(),
                     NumberFormat::Hex,
                 )),
-                Some(Edition::E2024_ALPHA),
+                Some(Edition::DEVELOPMENT),
                 flavor.or(Some(Flavor::Sui)),
             ),
             package_upgrade_mapping: BTreeMap::new(),


### PR DESCRIPTION
## Description 

Adds support for clever errors to GraphQL. So now, if you have code like the following:
```move
module p::m {
   #[error]
    const ENotFound: vector<u8> = b"Element was unable to be found in the vector"

    public fun abort() {
        assert!(false, ENotFound); // Can also be an `abort ENotFound` 
    }
}
```

This will result in a humand-readable output from graphql:
```
Error in 1st command
'ENotFound' from module '0x8fd7251015bfd1dc4283bb3d38dc95a2769f75d621c871a81bb9c191a2860aaf::m' in function 'abort' at source line 6
The element was unable to be found in the vector
```

## Test plan 

Added tests for all supported constant types, along with tests to make sure that we properly handle package upgrades and resolving to the correct version of a package when resolving clever errors.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [X] GraphQL: Adds support for more understandable and ergonomic Move error codes in Move 2024.
- [ ] CLI: 
- [ ] Rust SDK:
