### PR TITLE
[cherry-pick][graphql] Add support for clever error resolution in graphql (#17338)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12957,6 +12957,7 @@ dependencies = [
  "insta",
  "lru 0.10.0",
  "move-binary-format",
+ "move-command-line-common",
  "move-compiler",
  "move-core-types",
  "serde",

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
@@ -20,7 +20,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: e1bb62a7d23eb9be7c04a5f582dd19cf65f327aa5a493b3d7b973cb9e727324f::m::boom (function index 1) at offset 1, Abort Code: 42 in 1st command."
+            "errors": "Error in 1st command, from '0xe1bb62a7d23eb9be7c04a5f582dd19cf65f327aa5a493b3d7b973cb9e727324f::m::boom' (instruction 1), abort code: 42"
           }
         }
       ]
@@ -43,7 +43,7 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: e1bb62a7d23eb9be7c04a5f582dd19cf65f327aa5a493b3d7b973cb9e727324f::m::boom (function index 1) at offset 1, Abort Code: 42 in 3rd command."
+            "errors": "Error in 3rd command, from '0xe1bb62a7d23eb9be7c04a5f582dd19cf65f327aa5a493b3d7b973cb9e727324f::m::boom' (instruction 1), abort code: 42"
           }
         }
       ]

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3700,6 +3700,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
+	If the error is a Move abort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to displaying the abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -1,18 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{consistency::ConsistentIndexCursor, error::Error};
+use crate::{
+    consistency::ConsistentIndexCursor, data::package_resolver::PackageResolver, error::Error,
+};
 use async_graphql::{
     connection::{Connection, ConnectionNameType, CursorType, Edge, EdgeNameType, EmptyFields},
     *,
 };
+use fastcrypto::encoding::{Base64 as FBase64, Encoding};
 use sui_indexer::models_v2::transactions::StoredTransaction;
+use sui_package_resolver::{CleverError, ErrorConstants};
 use sui_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
     event::Event as NativeEvent,
-    execution_status::ExecutionStatus as NativeExecutionStatus,
-    transaction::SenderSignedData as NativeSenderSignedData,
-    transaction::TransactionData as NativeTransactionData,
+    execution_status::{
+        ExecutionFailureStatus, ExecutionStatus as NativeExecutionStatus, MoveLocation,
+        MoveLocationOpt,
+    },
+    transaction::{
+        Command, ProgrammableTransaction, SenderSignedData as NativeSenderSignedData,
+        TransactionData as NativeTransactionData, TransactionDataAPI,
+        TransactionKind as NativeTransactionKind,
+    },
 };
 
 use super::{
@@ -105,19 +115,74 @@ impl TransactionBlockEffects {
     }
 
     /// The reason for a transaction failure, if it did fail.
-    async fn errors(&self) -> Option<String> {
-        match self.native().status() {
-            NativeExecutionStatus::Success => None,
+    /// If the error is a Move abort, the error message will be resolved to a human-readable form if
+    /// possible, otherwise it will fall back to displaying the abort code and location.
+    async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+        let resolver: &PackageResolver = ctx.data_unchecked();
+        let status = self.resolve_native_status_impl(resolver).await?;
+
+        match status {
+            NativeExecutionStatus::Success => Ok(None),
 
             NativeExecutionStatus::Failure {
                 error,
                 command: None,
-            } => Some(error.to_string()),
+            } => Ok(Some(error.to_string())),
 
             NativeExecutionStatus::Failure {
                 error,
                 command: Some(command),
             } => {
+                let error = 'error: {
+                    let ExecutionFailureStatus::MoveAbort(loc, code) = &error else {
+                        break 'error error.to_string();
+                    };
+                    let fname_string = if let Some(fname) = &loc.function_name {
+                        format!("::{}'", fname)
+                    } else {
+                        "'".to_string()
+                    };
+
+                    let Some(CleverError {
+                        module_id,
+                        source_line_number,
+                        error_info,
+                    }) = resolver
+                        .resolve_clever_error(loc.module.clone(), *code)
+                        .await
+                    else {
+                        break 'error format!(
+                            "from '{}{fname_string} (instruction {}), abort code: {code}",
+                            loc.module.to_canonical_display(true),
+                            loc.instruction,
+                        );
+                    };
+
+                    match error_info {
+                        ErrorConstants::Rendered {
+                            identifier,
+                            constant,
+                        } => {
+                            format!(
+                                "from '{}{fname_string} (line {source_line_number}), abort '{identifier}': {constant}",
+                                module_id.to_canonical_display(true)
+                            )
+                        }
+                        ErrorConstants::Raw { identifier, bytes } => {
+                            let const_str = FBase64::encode(bytes);
+                            format!(
+                                "from '{}{fname_string} (line {source_line_number}), abort '{identifier}': {const_str}",
+                                module_id.to_canonical_display(true)
+                            )
+                        }
+                        ErrorConstants::None => {
+                            format!(
+                                "from '{}{fname_string} (line {source_line_number})",
+                                module_id.to_canonical_display(true)
+                            )
+                        }
+                    }
+                };
                 // Convert the command index into an ordinal.
                 let command = command + 1;
                 let suffix = match command % 10 {
@@ -126,8 +191,7 @@ impl TransactionBlockEffects {
                     3 => "rd",
                     _ => "th",
                 };
-
-                Some(format!("{error} in {command}{suffix} command."))
+                Ok(Some(format!("Error in {command}{suffix} command, {error}")))
             }
         }
     }
@@ -417,6 +481,76 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::Executed { native, .. } => native,
             TransactionBlockEffectsKind::DryRun { native, .. } => native,
         }
+    }
+
+    /// Get the transaction data from the transaction block effects.
+    /// Will error if the transaction data is not available/invalid, but this should not occur.
+    fn transaction_data(&self) -> Result<NativeTransactionData> {
+        Ok(match &self.kind {
+            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                let s: NativeSenderSignedData = bcs::from_bytes(&stored_tx.raw_transaction)
+                    .map_err(|e| {
+                        Error::Internal(format!("Error deserializing transaction data: {e}"))
+                    })?;
+                s.transaction_data().clone()
+            }
+            TransactionBlockEffectsKind::Executed { tx_data, .. } => {
+                tx_data.transaction_data().clone()
+            }
+            TransactionBlockEffectsKind::DryRun { tx_data, .. } => tx_data.clone(),
+        })
+    }
+
+    /// Get the programmable transaction from the transaction block effects.
+    /// * If the transaction was unable to be retrieved, this will return an Err.
+    /// * If the transaction was able to be retrieved but was not a programmable transaction, this
+    ///   will return Ok(None).
+    /// * If the transaction was a programmable transaction, this will return Ok(Some(tx)).
+    fn programmable_transaction(&self) -> Result<Option<ProgrammableTransaction>> {
+        let tx_data = self.transaction_data()?;
+        match tx_data.into_kind() {
+            NativeTransactionKind::ProgrammableTransaction(tx) => Ok(Some(tx)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Resolves the module ID within a Move abort to the storage ID of the package that the
+    /// abort occured in.
+    /// * If the error is not a Move abort, or the Move call in the programmable transaction cannot
+    ///   be found, this function will do nothing.
+    /// * If the error is a Move abort and the storage ID is unable to be resolved an error is
+    ///   returned.
+    async fn resolve_native_status_impl(
+        &self,
+        resolver: &PackageResolver,
+    ) -> Result<NativeExecutionStatus> {
+        let mut status = self.native().status().clone();
+        if let NativeExecutionStatus::Failure {
+            error:
+                ExecutionFailureStatus::MoveAbort(MoveLocation { module, .. }, _)
+                | ExecutionFailureStatus::MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation {
+                    module,
+                    ..
+                }))),
+            command: Some(command_idx),
+        } = &mut status
+        {
+            // Get the Move call that this error is associated with.
+            if let Some(Command::MoveCall(ptb_call)) = self
+                .programmable_transaction()?
+                .and_then(|ptb| ptb.commands.into_iter().nth(*command_idx))
+            {
+                let module_new = module.clone();
+                // Resolve the runtime module ID in the Move abort to the storage ID of the package
+                // that the abort occured in. This is important to make sure that we look at the
+                // correct version of the module when resolving the error.
+                *module = resolver
+                    .resolve_module_id(module_new, ptb_call.package.into())
+                    .await
+                    .map_err(|e| Error::Internal(format!("Error resolving Move location: {e}")))?;
+            }
+        }
+        Ok(status)
     }
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3704,6 +3704,8 @@ type TransactionBlockEffects {
 	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
+	If the error is a Move abort, the error message will be resolved to a human-readable form if
+	possible, otherwise it will fall back to displaying the abort code and location.
 	"""
 	errors: String
 	"""

--- a/crates/sui-package-resolver/Cargo.toml
+++ b/crates/sui-package-resolver/Cargo.toml
@@ -13,6 +13,10 @@ async-trait.workspace = true
 bcs.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
+# TODO: `move-command-line-common` is used for `ErrorBitset`. We should
+# refactor the crate into a `move-utils` at some point and use that instead
+# here once we do.
+move-command-line-common.workspace = true
 sui-types.workspace = true
 thiserror.workspace = true
 sui-rest-api.workspace = true

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -6,6 +6,9 @@ use lru::LruCache;
 use move_binary_format::file_format::{
     AbilitySet, FunctionDefinitionIndex, Signature, SignatureIndex, StructTypeParameter, Visibility,
 };
+use move_command_line_common::error_bitset::ErrorBitset;
+use move_core_types::language_storage::ModuleId;
+use move_core_types::u256::U256;
 use std::collections::btree_map::Entry;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -89,6 +92,60 @@ pub struct Package {
 }
 
 type Linkage = BTreeMap<AccountAddress, AccountAddress>;
+
+/// A `CleverError` is a special kind of abort code that is used to encode more information than a
+/// normal abort code. These clever errors are used to encode the line number, error constant name,
+/// and error constant value as pool indicies packed into a format satisfying the `ErrorBitset`
+/// format. This struct is the "inflated" view of that data, providing the module ID, line number,
+/// and error constant name and value (if available).
+#[derive(Clone, Debug)]
+pub struct CleverError {
+    /// The (storage) module ID of the module that the assertion failed in.
+    pub module_id: ModuleId,
+    /// Inner error information. This is either a complete error, just a line number, or bytes that
+    /// should be treated opaquely.
+    pub error_info: ErrorConstants,
+    /// The line number in the source file where the error occured.
+    pub source_line_number: u16,
+}
+
+/// The `ErrorConstants` enum is used to represent the different kinds of error information that
+/// can be returned from a clever error when looking at the constant values for the clever error.
+/// These values are either:
+/// * `None` - No constant information is available, only a line number.
+/// * `Rendered` - The error is a complete error, with an error identifier and constant that can be
+///    rendered in a human-readable format (see in-line doc comments for exact types of values
+///    supported).
+/// * `Raw` - If there is an error constant value, but it is not a renderable type (e.g., a
+///   `vector<address>`), then it is treated as opaque and the bytes are returned.
+#[derive(Clone, Debug)]
+pub enum ErrorConstants {
+    /// No constant information is available, only a line number.
+    None,
+    /// The error is a complete error, with an error identifier and constant that can be rendered.
+    /// The the rendered string representation of the constant is returned only when the contant
+    /// value is one of the following types:
+    /// * A vector of bytes convertible to a valid UTF-8 string; or
+    /// * A numeric value (u8, u16, u32, u64, u128, u256); or
+    /// * A boolean value; or
+    /// * An address value
+    /// Otherwise, the `Raw` bytes of the error constant are returned.
+    Rendered {
+        /// The name of the error constant.
+        identifier: String,
+        /// The value of the error constant.
+        constant: String,
+    },
+    /// If there is an error constant value, but ii is not one of the above types, then it is
+    /// treated as opaque and the bytes are returned. The caller is responsible for determining how
+    /// best to display the error constant in this case.
+    Raw {
+        /// The name of the error constant.
+        identifier: String,
+        /// The raw (BCS) bytes of the error constant.
+        bytes: Vec<u8>,
+    },
+}
 
 #[derive(Clone, Debug)]
 pub struct Module {
@@ -300,6 +357,117 @@ impl<S: PackageStore> Resolver<S> {
 
         // (2). Use that information to calculate the type's abilities.
         context.resolve_abilities(&tag)
+    }
+
+    /// Resolves a runtime address in a `ModuleId` to a storage `ModuleId` according to the linkage
+    /// table in the `context` which must refer to a package.
+    /// * Will fail if the wrong context is provided, i.e., is not a package, or
+    ///   does not exist.
+    /// * Will fail if an invalid `context` is provided for the `location`, i.e., the package at
+    ///   `context` does not contain the module that `location` refers to.
+    pub async fn resolve_module_id(
+        &self,
+        module_id: ModuleId,
+        context: AccountAddress,
+    ) -> Result<ModuleId> {
+        let package = self.package_store.fetch(context).await?;
+        let storage_id = package.relocate(*module_id.address())?;
+        Ok(ModuleId::new(storage_id, module_id.name().to_owned()))
+    }
+
+    /// Resolves an abort code following the clever error format to a `CleverError` enum.
+    /// The `module_id` must be the storage ID of the module (which can e.g., be gotten from the
+    /// `resolve_module_id` function) and not the runtime ID.
+    ///
+    /// If the `abort_code` is not a clever error (i.e., does not follow the tagging and layout as
+    /// defined in `ErrorBitset`), this function will return `None`.
+    ///
+    /// In the case where it is a clever error but only a line number is present (i.e., the error
+    /// is the result of an `assert!(<cond>)` source expression) a `CleverError::LineNumberOnly` is
+    /// returned. Otherwise a `CleverError::CompleteError` is returned.
+    ///
+    /// If for any reason we are unable to resolve the abort code to a `CleverError`, this function
+    /// will return `None`.
+    pub async fn resolve_clever_error(
+        &self,
+        module_id: ModuleId,
+        abort_code: u64,
+    ) -> Option<CleverError> {
+        let bitset = ErrorBitset::from_u64(abort_code)?;
+        let package = self.package_store.fetch(*module_id.address()).await.ok()?;
+        let module = package.module(module_id.name().as_str()).ok()?.bytecode();
+        let source_line_number = bitset.line_number()?;
+
+        // We only have a line number in our clever error, so return early.
+        if bitset.identifier_index().is_none() && bitset.constant_index().is_none() {
+            return Some(CleverError {
+                module_id,
+                error_info: ErrorConstants::None,
+                source_line_number,
+            });
+        } else if bitset.identifier_index().is_none() || bitset.constant_index().is_none() {
+            return None;
+        }
+
+        let error_identifier_constant = module
+            .constant_pool()
+            .get(bitset.identifier_index()? as usize)?;
+        let error_value_constant = module
+            .constant_pool()
+            .get(bitset.constant_index()? as usize)?;
+
+        if !matches!(&error_identifier_constant.type_, SignatureToken::Vector(x) if x.as_ref() == &SignatureToken::U8)
+        {
+            return None;
+        };
+
+        let error_identifier = bcs::from_bytes::<Vec<u8>>(&error_identifier_constant.data)
+            .ok()
+            .and_then(|x| String::from_utf8(x).ok())?;
+        let bytes = error_value_constant.data.clone();
+
+        let rendered = match &error_value_constant.type_ {
+            SignatureToken::Vector(inner_ty) if inner_ty.as_ref() == &SignatureToken::U8 => {
+                bcs::from_bytes::<Vec<u8>>(&bytes)
+                    .ok()
+                    .and_then(|x| String::from_utf8(x).ok())
+            }
+            SignatureToken::U8 => bcs::from_bytes::<u8>(&bytes).ok().map(|x| x.to_string()),
+            SignatureToken::U16 => bcs::from_bytes::<u16>(&bytes).ok().map(|x| x.to_string()),
+            SignatureToken::U32 => bcs::from_bytes::<u32>(&bytes).ok().map(|x| x.to_string()),
+            SignatureToken::U64 => bcs::from_bytes::<u64>(&bytes).ok().map(|x| x.to_string()),
+            SignatureToken::U128 => bcs::from_bytes::<u128>(&bytes).ok().map(|x| x.to_string()),
+            SignatureToken::U256 => bcs::from_bytes::<U256>(&bytes).ok().map(|x| x.to_string()),
+            SignatureToken::Address => bcs::from_bytes::<AccountAddress>(&bytes)
+                .ok()
+                .map(|x| x.to_canonical_string(true)),
+            SignatureToken::Bool => bcs::from_bytes::<bool>(&bytes).ok().map(|x| x.to_string()),
+
+            SignatureToken::Signer
+            | SignatureToken::Vector(_)
+            | SignatureToken::Struct(_)
+            | SignatureToken::StructInstantiation(_, _)
+            | SignatureToken::Reference(_)
+            | SignatureToken::MutableReference(_)
+            | SignatureToken::TypeParameter(_) => None,
+        };
+
+        let error_info = match rendered {
+            None => ErrorConstants::Raw {
+                identifier: error_identifier,
+                bytes,
+            },
+            Some(error_constant) => ErrorConstants::Rendered {
+                identifier: error_identifier,
+                constant: error_constant,
+            },
+        };
+
+        Some(CleverError {
+            module_id,
+            error_info,
+            source_line_number,
+        })
     }
 }
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -669,42 +669,17 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
- "crossterm_winapi 0.8.0",
+ "crossterm_winapi",
  "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
+ "mio",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.9.0",
- "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
-dependencies = [
  "winapi",
 ]
 
@@ -1490,19 +1465,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
@@ -1511,15 +1473,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1629,7 +1582,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
- "crossterm 0.21.0",
+ "crossterm",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-disassembler",
@@ -1686,6 +1639,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
+ "proptest",
  "serde",
  "sha2",
  "walkdir",
@@ -2259,15 +2213,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "thiserror",
  "widestring",
- "winapi",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
  "winapi",
 ]
 
@@ -3181,7 +3126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
+ "mio",
  "signal-hook",
 ]
 
@@ -3485,7 +3430,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio 0.8.6",
+ "mio",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -3614,13 +3559,13 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "tui"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.22.1",
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/external-crates/move/crates/move-command-line-common/Cargo.toml
+++ b/external-crates/move/crates/move-command-line-common/Cargo.toml
@@ -21,3 +21,6 @@ serde.workspace = true
 dirs-next.workspace = true
 
 move-core-types.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/external-crates/move/crates/move-command-line-common/src/error_bitset.rs
+++ b/external-crates/move/crates/move-command-line-common/src/error_bitset.rs
@@ -1,0 +1,173 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+const BITSET_VALUE_UNAVAILABLE: u16 = u16::MAX;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErrorBitset {
+    // |<tagbit>|<reserved>|<line number>|<identifier index>|<constant index>|
+    //   1-bit    15-bits       16-bits        16-bits          16-bits
+    pub bits: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorBitsetField {
+    Tag,
+    #[allow(dead_code)]
+    Reserved,
+    LineNumber,
+    Identifier,
+    Constant,
+}
+
+pub struct ErrorBitsetBuilder {
+    line_number: u16,
+    identifier_index: Option<u16>,
+    constant_index: Option<u16>,
+}
+
+impl ErrorBitsetField {
+    const TAG_MASK: u64 = 0x8000_0000_0000_0000;
+    const RESERVED_AREA_MASK: u64 = 0x7fff_0000_0000_0000;
+    const LINE_NUMBER_MASK: u64 = 0x0000_ffff_0000_0000;
+    const IDENTIFIER_INDEX_MASK: u64 = 0x0000_0000_ffff_0000;
+    const CONSTANT_INDEX_MASK: u64 = 0x0000_0000_0000_ffff;
+
+    const TAG_SHIFT: u64 = Self::RESERVED_AREA_SHIFT + 15;
+    const RESERVED_AREA_SHIFT: u64 = Self::LINE_NUMBER_SHIFT + 16;
+    const LINE_NUMBER_SHIFT: u64 = Self::IDENTIFIER_INDEX_SHIFT + 16;
+    const IDENTIFIER_INDEX_SHIFT: u64 = Self::CONSTANT_INDEX_SHIFT + 16;
+    const CONSTANT_INDEX_SHIFT: u64 = 0;
+
+    const fn mask(&self) -> u64 {
+        match self {
+            Self::Tag => Self::TAG_MASK,
+            Self::Reserved => Self::RESERVED_AREA_MASK,
+            Self::LineNumber => Self::LINE_NUMBER_MASK,
+            Self::Identifier => Self::IDENTIFIER_INDEX_MASK,
+            Self::Constant => Self::CONSTANT_INDEX_MASK,
+        }
+    }
+
+    const fn shift(&self) -> u64 {
+        match self {
+            Self::Tag => Self::TAG_SHIFT,
+            Self::Reserved => Self::RESERVED_AREA_SHIFT,
+            Self::LineNumber => Self::LINE_NUMBER_SHIFT,
+            Self::Identifier => Self::IDENTIFIER_INDEX_SHIFT,
+            Self::Constant => Self::CONSTANT_INDEX_SHIFT,
+        }
+    }
+
+    const fn get_bits(&self, bits: u64) -> u16 {
+        ((bits & self.mask()) >> self.shift()) as u16
+    }
+}
+
+impl ErrorBitsetBuilder {
+    pub fn new(line_number: u16) -> Self {
+        Self {
+            line_number,
+            identifier_index: None,
+            constant_index: None,
+        }
+    }
+
+    pub fn with_identifier_index(&mut self, identifier_index: u16) {
+        self.identifier_index = Some(identifier_index);
+    }
+
+    pub fn with_constant_index(&mut self, constant_index: u16) {
+        self.constant_index = Some(constant_index);
+    }
+
+    pub fn build(self) -> ErrorBitset {
+        ErrorBitset::new(
+            self.line_number,
+            self.identifier_index.unwrap_or(BITSET_VALUE_UNAVAILABLE),
+            self.constant_index.unwrap_or(BITSET_VALUE_UNAVAILABLE),
+        )
+    }
+}
+
+impl ErrorBitset {
+    pub(crate) const fn new(line_number: u16, identifier_index: u16, constant_index: u16) -> Self {
+        use ErrorBitsetField as E;
+        let mut bits = 0u64;
+        bits |= 1u64 << E::Tag.shift();
+        bits |= (line_number as u64) << E::LineNumber.shift();
+        bits |= (identifier_index as u64) << E::Identifier.shift();
+        bits |= (constant_index as u64) << E::Constant.shift();
+        Self { bits }
+    }
+
+    pub const fn from_u64(bits: u64) -> Option<Self> {
+        if Self::is_tagged_error(bits) {
+            Some(Self { bits })
+        } else {
+            None
+        }
+    }
+
+    pub const fn is_tagged_error(bits: u64) -> bool {
+        ErrorBitsetField::Tag.get_bits(bits) == 1
+    }
+
+    const fn sentinel(v: u16) -> Option<u16> {
+        if v == BITSET_VALUE_UNAVAILABLE {
+            None
+        } else {
+            Some(v)
+        }
+    }
+
+    pub const fn line_number(&self) -> Option<u16> {
+        Self::sentinel(ErrorBitsetField::LineNumber.get_bits(self.bits))
+    }
+
+    pub const fn identifier_index(&self) -> Option<u16> {
+        Self::sentinel(ErrorBitsetField::Identifier.get_bits(self.bits))
+    }
+
+    pub const fn constant_index(&self) -> Option<u16> {
+        Self::sentinel(ErrorBitsetField::Constant.get_bits(self.bits))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ErrorBitset, ErrorBitsetBuilder};
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    proptest! {
+        #[test]
+        fn test_error_bitset(line_number in 0..u16::MAX, identifier_index in 0..u16::MAX, constant_index in 0..u16::MAX) {
+            let error_bitset = ErrorBitset::new(line_number, identifier_index, constant_index);
+            prop_assert_eq!(error_bitset.line_number(), Some(line_number));
+            prop_assert_eq!(error_bitset.identifier_index(), Some(identifier_index));
+            prop_assert_eq!(error_bitset.constant_index(), Some(constant_index));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_error_bitset_builder(line_number in 0..u16::MAX, identifier_index in 0..u16::MAX, constant_index in 0..u16::MAX) {
+            let error_bitset = ErrorBitset::new(line_number, identifier_index, constant_index);
+            let mut error_bitset_builder = ErrorBitsetBuilder::new(line_number);
+            error_bitset_builder.with_identifier_index(identifier_index);
+            error_bitset_builder.with_constant_index(constant_index);
+            let error_bitset_built = error_bitset_builder.build();
+            prop_assert_eq!(error_bitset.line_number(), Some(line_number));
+            prop_assert_eq!(error_bitset.identifier_index(), Some(identifier_index));
+            prop_assert_eq!(error_bitset.constant_index(), Some(constant_index));
+
+            prop_assert_eq!(error_bitset_built.line_number(), Some(line_number));
+            prop_assert_eq!(error_bitset_built.identifier_index(), Some(identifier_index));
+            prop_assert_eq!(error_bitset_built.constant_index(), Some(constant_index));
+
+            prop_assert_eq!(error_bitset.bits, error_bitset_built.bits);
+        }
+    }
+}

--- a/external-crates/move/crates/move-command-line-common/src/lib.rs
+++ b/external-crates/move/crates/move-command-line-common/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod address;
 pub mod character_sets;
 pub mod env;
+pub mod error_bitset;
 pub mod files;
 pub mod parser;
 pub mod testing;


### PR DESCRIPTION
Adds support for clever errors to GraphQL. So now, if you have code like the following:
```move
module p::m {
   #[error]
    const ENotFound: vector<u8> = b"Element was unable to be found in the vector"

    public fun abort() {
        assert!(false, ENotFound); // Can also be an `abort ENotFound`
    }
}
```

This will result in a humand-readable output from graphql:
```
Error in 1st command
'ENotFound' from module '0x8fd7251015bfd1dc4283bb3d38dc95a2769f75d621c871a81bb9c191a2860aaf::m' in function 'abort' at source line 6
The element was unable to be found in the vector
```

Note that this cherry-pick does not contain the tests as that requires cherry-picking the compiler changes for clever errors, which then involves further cherry-picks as well, so I removed it to keep this as simple as possible. 

