### PR TITLE
Prevent package from having hyphen

### DIFF
--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -47,6 +47,9 @@ impl New {
     ) -> anyhow::Result<()> {
         // TODO warn on build config flags
         let Self { name } = self;
+        if name.contains('-') {
+            Err("package name should not contain '-'")
+        }
         let p: PathBuf;
         let path: &Path = match path {
             Some(path) => {


### PR DESCRIPTION
## Description 

The current command `sui move new <NAME>` allows to create a package with `-` exists in the naming. However this violate the Sui package naming law.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: 
- [ ] Rust SDK: 
