### PR TITLE
[move] Simplify binary version override logic

### DIFF
--- a/external-crates/move/crates/module-generation/src/generator.rs
+++ b/external-crates/move/crates/module-generation/src/generator.rs
@@ -328,6 +328,7 @@ impl<'a> ModuleGenerator<'a> {
             random_string(gen, len)
         };
         let current_module = ModuleDefinition {
+            specified_version: None,
             loc: Spanned::unsafe_no_loc(0).loc,
             identifier: ModuleIdent {
                 name: ModuleName(module_name.into()),

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use move_binary_format::errors::Location;
-use move_command_line_common::env::get_bytecode_version_from_env;
 use move_package::compilation::compiled_package::CompiledPackage;
 use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::gas_schedule::CostTable;
@@ -80,8 +79,6 @@ pub fn publish(
         return Ok(());
     }
 
-    let bytecode_version = get_bytecode_version_from_env();
-
     // use the publish_module API from the VM if we do not allow breaking changes
     if !ignore_breaking_changes {
         let vm = MoveVM::new(natives).unwrap();
@@ -94,7 +91,7 @@ pub fn publish(
             let mut sender_opt = None;
             let mut module_bytes_vec = vec![];
             for unit in &modules_to_publish {
-                let module_bytes = unit.unit.serialize(bytecode_version);
+                let module_bytes = unit.unit.serialize();
                 module_bytes_vec.push(module_bytes);
 
                 let module_address = *unit.unit.module.self_id().address();
@@ -134,7 +131,7 @@ pub fn publish(
         } else {
             // publish modules sequentially, one module at a time
             for unit in &modules_to_publish {
-                let module_bytes = unit.unit.serialize(bytecode_version);
+                let module_bytes = unit.unit.serialize();
                 let id = unit.unit.module.self_id();
                 let sender = *id.address();
 
@@ -168,7 +165,7 @@ pub fn publish(
         let mut serialized_modules = vec![];
         for unit in modules_to_publish {
             let id = unit.unit.module.self_id();
-            let module_bytes = unit.unit.serialize(bytecode_version);
+            let module_bytes = unit.unit.serialize();
             serialized_modules.push((id, module_bytes));
         }
         state.save_modules(&serialized_modules)?;

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/package_context.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/package_context.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{sandbox::utils::OnDiskStateView, DEFAULT_BUILD_DIR};
 use anyhow::Result;
-use move_command_line_common::env::get_bytecode_version_from_env;
 use move_package::{compilation::compiled_package::CompiledPackage, BuildConfig};
 use std::path::{Path, PathBuf};
 
@@ -35,7 +34,6 @@ impl PackageContext {
     /// to be run before every command that needs a state view, i.e., `publish`, `run`,
     /// `view`, and `doctor`.
     pub fn prepare_state(&self, storage_dir: &Path) -> Result<OnDiskStateView> {
-        let bytecode_version = get_bytecode_version_from_env();
         let state = OnDiskStateView::create(self.build_dir.as_path(), storage_dir)?;
 
         // preload the storage with library modules (if such modules do not exist yet)
@@ -50,10 +48,7 @@ impl PackageContext {
         for module in new_modules {
             let self_id = module.self_id();
             let mut module_bytes = vec![];
-            module.serialize_with_version(
-                bytecode_version.unwrap_or(module.version),
-                &mut module_bytes,
-            )?;
+            module.serialize_with_version(module.version, &mut module_bytes)?;
             serialized_modules.push((self_id, module_bytes));
         }
         state.save_modules(&serialized_modules)?;

--- a/external-crates/move/crates/move-compiler/src/bin/move-build.rs
+++ b/external-crates/move/crates/move-compiler/src/bin/move-build.rs
@@ -77,17 +77,10 @@ pub fn main() -> anyhow::Result<()> {
 
     let interface_files_dir = format!("{}/generated_interface_files", out_dir);
     let named_addr_map = verify_and_create_named_address_mapping(named_addresses)?;
-    let bytecode_version = flags.bytecode_version();
     let (files, compiled_units) =
         move_compiler::Compiler::from_files(None, source_files, dependencies, named_addr_map)
             .set_interface_files_dir(interface_files_dir)
             .set_flags(flags)
             .build_and_report()?;
-    move_compiler::output_compiled_units(
-        bytecode_version,
-        emit_source_map,
-        files,
-        compiled_units,
-        &out_dir,
-    )
+    move_compiler::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)
 }

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -702,7 +702,6 @@ pub fn sanity_check_compiled_units(
 
 /// Given a file map and a set of compiled programs, saves the compiled programs to disk
 pub fn output_compiled_units(
-    bytecode_version: Option<u32>,
     emit_source_maps: bool,
     files: FilesSourceText,
     compiled_units: Vec<AnnotatedCompiledUnit>,
@@ -724,7 +723,7 @@ pub fn output_compiled_units(
             }
 
             $path.set_extension(MOVE_COMPILED_EXTENSION);
-            fs::write($path.as_path(), &$unit.serialize(bytecode_version))?
+            fs::write($path.as_path(), &$unit.serialize())?
         }};
     }
 

--- a/external-crates/move/crates/move-compiler/src/compiled_unit.rs
+++ b/external-crates/move/crates/move-compiler/src/compiled_unit.rs
@@ -10,7 +10,7 @@ use crate::{
     parser::ast::{FunctionName, ModuleName},
     shared::{unique_map::UniqueMap, Name, NumericalAddress},
 };
-use move_binary_format::{file_format as F, file_format_common::VERSION_MAX};
+use move_binary_format::file_format as F;
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier as MoveCoreIdentifier,
@@ -124,11 +124,10 @@ impl NamedCompiledModule {
         &self.source_map
     }
 
-    pub fn serialize(&self, bytecode_version: Option<u32>) -> Vec<u8> {
+    pub fn serialize(&self) -> Vec<u8> {
         let mut serialized = Vec::<u8>::new();
-        let bytecode_version = bytecode_version.unwrap_or(VERSION_MAX);
         self.module
-            .serialize_with_version(bytecode_version, &mut serialized)
+            .serialize_with_version(self.module.version, &mut serialized)
             .unwrap();
         serialized
     }

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -219,6 +219,7 @@ fn module(
         }
     ) = ident;
     let ir_module = IR::ModuleDefinition {
+        specified_version: compilation_env.flags().bytecode_version(),
         loc: ident_loc,
         identifier: IR::ModuleIdent {
             address: MoveAddress::new(addr_bytes.into_bytes()),
@@ -233,11 +234,7 @@ fn module(
     };
     let deps: Vec<&F::CompiledModule> = vec![];
     let (mut module, source_map) =
-        match move_ir_to_bytecode::compiler::compile_module_with_version_opt(
-            ir_module,
-            deps,
-            compilation_env.flags().bytecode_version(),
-        ) {
+        match move_ir_to_bytecode::compiler::compile_module(ir_module, deps) {
             Ok(res) => res,
             Err(e) => {
                 compilation_env.add_diag(diag!(

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -233,7 +233,11 @@ fn module(
     };
     let deps: Vec<&F::CompiledModule> = vec![];
     let (mut module, source_map) =
-        match move_ir_to_bytecode::compiler::compile_module(ir_module, deps) {
+        match move_ir_to_bytecode::compiler::compile_module_with_version_opt(
+            ir_module,
+            deps,
+            compilation_env.flags().bytecode_version(),
+        ) {
             Ok(res) => res,
             Err(e) => {
                 compilation_env.add_diag(diag!(

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
@@ -1675,6 +1675,7 @@ fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, 
     let loc = make_loc(tokens.file_hash(), start_loc, end_loc);
 
     Ok(ModuleDefinition::new(
+        None,
         loc,
         identifier,
         friends,

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -435,11 +435,11 @@ pub fn compile_module_with_version_opt<'a>(
         struct_defs,
         function_defs,
     };
-    fix_module_version(&mut module, version);
+    set_module_version(&mut module, version);
     Ok((module, source_map))
 }
 
-fn fix_module_version(module: &mut CompiledModule, version: Option<u32>) {
+fn set_module_version(module: &mut CompiledModule, version: Option<u32>) {
     if let Some(version) = version.or_else(get_bytecode_version_from_env) {
         module.version = version;
     }

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -325,18 +325,10 @@ fn constant_name_as_constant_value_index(
     context.constant_index(name_constant)
 }
 
+/// Compile a module.
 pub fn compile_module<'a>(
     module: ModuleDefinition,
     dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-) -> Result<(CompiledModule, SourceMap)> {
-    compile_module_with_version_opt(module, dependencies, None)
-}
-
-/// Compile a module.
-pub fn compile_module_with_version_opt<'a>(
-    module: ModuleDefinition,
-    dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-    version: Option<u32>,
 ) -> Result<(CompiledModule, SourceMap)> {
     verify_module(&module)?;
 
@@ -416,7 +408,7 @@ pub fn compile_module_with_version_opt<'a>(
         _compiled_deps,
         source_map,
     ) = context.materialize_pools();
-    let mut module = CompiledModule {
+    let mut compiled_module = CompiledModule {
         version: VERSION_MAX,
         module_handles,
         self_module_handle_idx,
@@ -435,8 +427,8 @@ pub fn compile_module_with_version_opt<'a>(
         struct_defs,
         function_defs,
     };
-    set_module_version(&mut module, version);
-    Ok((module, source_map))
+    set_module_version(&mut compiled_module, module.specified_version);
+    Ok((compiled_module, source_map))
 }
 
 fn set_module_version(module: &mut CompiledModule, version: Option<u32>) {

--- a/external-crates/move/crates/move-ir-types/src/ast.rs
+++ b/external-crates/move/crates/move-ir-types/src/ast.rs
@@ -47,6 +47,8 @@ pub struct ModuleIdent {
 /// A Move module
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModuleDefinition {
+    /// The specified binary version of this module if a specific version is required.
+    pub specified_version: Option<u32>,
     /// The location of this module
     pub loc: Loc,
     /// name and address of the module
@@ -725,6 +727,7 @@ impl ModuleDefinition {
     /// and procedures
     /// Does not verify the correctness of any internal properties of its elements
     pub fn new(
+        specified_version: Option<u32>,
         loc: Loc,
         identifier: ModuleIdent,
         friends: Vec<ModuleIdent>,
@@ -735,6 +738,7 @@ impl ModuleDefinition {
         functions: Vec<(FunctionName, Function)>,
     ) -> Self {
         ModuleDefinition {
+            specified_version,
             loc,
             identifier,
             friends,

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -17,12 +17,9 @@ use itertools::{Either, Itertools};
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_source_map::utils::source_map_from_file;
 use move_bytecode_utils::Modules;
-use move_command_line_common::{
-    env::get_bytecode_version_from_env,
-    files::{
-        extension_equals, find_filenames, try_exists, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
-        SOURCE_MAP_EXTENSION,
-    },
+use move_command_line_common::files::{
+    extension_equals, find_filenames, try_exists, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
+    SOURCE_MAP_EXTENSION,
 };
 use move_compiler::{
     compiled_unit::{AnnotatedCompiledUnit, CompiledUnit, NamedCompiledModule},
@@ -315,10 +312,7 @@ impl OnDiskCompiledPackage {
             category_dir
                 .join(&file_path)
                 .with_extension(MOVE_COMPILED_EXTENSION),
-            compiled_unit
-                .unit
-                .serialize(get_bytecode_version_from_env())
-                .as_slice(),
+            compiled_unit.unit.serialize().as_slice(),
         )?;
         self.save_under(
             CompiledPackageLayout::SourceMaps


### PR DESCRIPTION
## Description 

The logic around overriding the binary version output by the compiler was spread out over a number of places, and in general was a bit nasty. This simplifies the logic so the version setting happens in only one place in the code base. 

## Test plan 

Make sure existing tests pass.


