### PR TITLE
[Indexer] Index Package original ID, version, cp sequence number

### DIFF
--- a/crates/sui-indexer/migrations/mysql/2024-04-24-180249_packages/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-04-24-180249_packages/up.sql
@@ -1,7 +1,14 @@
 CREATE TABLE packages
 (
-    package_id                   blob          NOT NULL,
+    package_id                   BLOB          NOT NULL,
+    original_id                  BLOB          NOT NULL,
+    package_version              BIGINT        NOT NULL,
     -- bcs serialized MovePackage
-    move_package                 MEDIUMBLOB          NOT NULL,
-        CONSTRAINT packages_pk PRIMARY KEY (package_id(255))
+    move_package                 MEDIUMBLOB    NOT NULL,
+    checkpoint_sequence_number   BIGINT        NOT NULL,
+    CONSTRAINT packages_pk PRIMARY KEY (package_id(32), original_id(32), package_version),
+    CONSTRAINT packages_unique_package_id UNIQUE (package_id(32))
 );
+
+CREATE INDEX packages_cp_id_version ON packages (checkpoint_sequence_number, original_id(32), package_version);
+CREATE INDEX packages_id_version_cp ON packages (original_id(32), package_version, checkpoint_sequence_number);

--- a/crates/sui-indexer/migrations/mysql/2024-05-05-155158_obj_indices/down.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-05-05-155158_obj_indices/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS objects_version;

--- a/crates/sui-indexer/migrations/mysql/2024-05-05-155158_obj_indices/up.sql
+++ b/crates/sui-indexer/migrations/mysql/2024-05-05-155158_obj_indices/up.sql
@@ -1,0 +1,9 @@
+-- The Postgres version of this table is partitioned by the first byte
+-- of object_id, but this kind of partition is not easily supported in
+-- MySQL, so this variant is unpartitioned for now.
+CREATE TABLE objects_version (
+    object_id           BLOB          NOT NULL,
+    object_version      BIGINT        NOT NULL,
+    cp_sequence_number  BIGINT        NOT NULL,
+    PRIMARY KEY (object_id(32), object_version)
+)

--- a/crates/sui-indexer/migrations/pg/2023-08-19-060729_packages/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-08-19-060729_packages/up.sql
@@ -1,6 +1,14 @@
-CREATE TABLE packages 
+CREATE TABLE packages
 (
-    package_id                   bytea          PRIMARY KEY,
+    package_id                   bytea          NOT NULL,
+    original_id                  bytea          NOT NULL,
+    package_version              bigint         NOT NULL,
     -- bcs serialized MovePackage
-    move_package                 bytea          NOT NULL
+    move_package                 bytea          NOT NULL,
+    checkpoint_sequence_number   bigint         NOT NULL,
+    CONSTRAINT packages_pkey PRIMARY KEY (package_id, original_id, package_version),
+    CONSTRAINT packages_unique_package_id UNIQUE (package_id)
 );
+
+CREATE INDEX packages_cp_id_version ON packages (checkpoint_sequence_number, original_id, package_version);
+CREATE INDEX packages_id_version_cp ON packages (original_id, package_version, checkpoint_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-05-05-155158_obj_indices/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-05-05-155158_obj_indices/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS objects_version;

--- a/crates/sui-indexer/migrations/pg/2024-05-05-155158_obj_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-05-05-155158_obj_indices/up.sql
@@ -1,0 +1,31 @@
+-- Indexing table mapping an object's ID and version to its checkpoint
+-- sequence number, partitioned by the first byte of its Object ID.
+CREATE TABLE objects_version (
+    object_id           bytea         NOT NULL,
+    object_version      bigint        NOT NULL,
+    cp_sequence_number  bigint        NOT NULL,
+    PRIMARY KEY (object_id, object_version)
+) PARTITION BY RANGE (object_id);
+
+-- Create a partition for each first byte value.
+DO $$
+DECLARE
+    lo text;
+    hi text;
+BEGIN
+    FOR i IN 0..254 LOOP
+        lo := LPAD(TO_HEX(i), 2, '0');
+        hi := LPAD(TO_HEX(i + 1), 2, '0');
+        EXECUTE FORMAT($F$
+            CREATE TABLE objects_version_%1$s PARTITION OF objects_version FOR VALUES
+            FROM (E'\\x%1$s00000000000000000000000000000000000000000000000000000000000000')
+            TO   (E'\\x%2$s00000000000000000000000000000000000000000000000000000000000000');
+        $F$, lo, hi);
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Special case for the last partition, because of the upper bound.
+CREATE TABLE objects_version_ff PARTITION OF objects_version FOR VALUES
+FROM (E'\\xff00000000000000000000000000000000000000000000000000000000000000')
+TO   (MAXVALUE);

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod checkpoints;
 pub mod display;
 pub mod epoch;
 pub mod events;
+pub mod obj_indices;
 pub mod objects;
 pub mod packages;
 pub mod transactions;

--- a/crates/sui-indexer/src/models/obj_indices.rs
+++ b/crates/sui-indexer/src/models/obj_indices.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::prelude::*;
+
+use crate::schema::objects_version;
+
+use super::objects::StoredDeletedObject;
+use super::objects::StoredObject;
+
+/// Model types related to tables that support efficient execution of queries on the `objects`,
+/// `objects_history` and `objects_snapshot` tables.
+
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = objects_version, primary_key(object_id, object_version))]
+pub struct StoredObjectVersion {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub cp_sequence_number: i64,
+}
+
+impl From<&StoredObject> for StoredObjectVersion {
+    fn from(o: &StoredObject) -> Self {
+        Self {
+            object_id: o.object_id.clone(),
+            object_version: o.object_version,
+            cp_sequence_number: o.checkpoint_sequence_number,
+        }
+    }
+}
+
+impl From<&StoredDeletedObject> for StoredObjectVersion {
+    fn from(o: &StoredDeletedObject) -> Self {
+        Self {
+            object_id: o.object_id.clone(),
+            object_version: o.object_version,
+            cp_sequence_number: o.checkpoint_sequence_number,
+        }
+    }
+}

--- a/crates/sui-indexer/src/models/packages.rs
+++ b/crates/sui-indexer/src/models/packages.rs
@@ -10,14 +10,20 @@ use diesel::prelude::*;
 #[diesel(table_name = packages, primary_key(package_id))]
 pub struct StoredPackage {
     pub package_id: Vec<u8>,
+    pub original_id: Vec<u8>,
+    pub package_version: i64,
     pub move_package: Vec<u8>,
+    pub checkpoint_sequence_number: i64,
 }
 
 impl From<IndexedPackage> for StoredPackage {
     fn from(p: IndexedPackage) -> Self {
         Self {
             package_id: p.package_id.to_vec(),
+            original_id: p.move_package.original_package_id().to_vec(),
+            package_version: p.move_package.version().value() as i64,
             move_package: bcs::to_bytes(&p.move_package).unwrap(),
+            checkpoint_sequence_number: p.checkpoint_sequence_number as i64,
         }
     }
 }

--- a/crates/sui-indexer/src/schema/mod.rs
+++ b/crates/sui-indexer/src/schema/mod.rs
@@ -19,6 +19,7 @@ mod inner {
     pub use crate::schema::pg::objects;
     pub use crate::schema::pg::objects_history;
     pub use crate::schema::pg::objects_snapshot;
+    pub use crate::schema::pg::objects_version;
     pub use crate::schema::pg::packages;
     pub use crate::schema::pg::transactions;
     pub use crate::schema::pg::tx_calls;
@@ -39,6 +40,7 @@ mod inner {
     pub use crate::schema::mysql::objects;
     pub use crate::schema::mysql::objects_history;
     pub use crate::schema::mysql::objects_snapshot;
+    pub use crate::schema::mysql::objects_version;
     pub use crate::schema::mysql::packages;
     pub use crate::schema::mysql::transactions;
     pub use crate::schema::mysql::tx_calls;
@@ -56,6 +58,7 @@ pub use inner::events;
 pub use inner::objects;
 pub use inner::objects_history;
 pub use inner::objects_snapshot;
+pub use inner::objects_version;
 pub use inner::packages;
 pub use inner::transactions;
 pub use inner::tx_calls;

--- a/crates/sui-indexer/src/schema/mysql.rs
+++ b/crates/sui-indexer/src/schema/mysql.rs
@@ -153,7 +153,10 @@ diesel::table! {
 diesel::table! {
     packages (package_id) {
         package_id -> Blob,
+        original_id -> Blob,
+        package_version -> Bigint,
         move_package -> Mediumblob,
+        checkpoint_sequence_number -> Bigint,
     }
 }
 

--- a/crates/sui-indexer/src/schema/mysql.rs
+++ b/crates/sui-indexer/src/schema/mysql.rs
@@ -143,6 +143,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    objects_version (object_id, object_version) {
+        object_id -> Blob,
+        object_version -> Bigint,
+        cp_sequence_number -> Bigint,
+    }
+}
+
+diesel::table! {
     packages (package_id) {
         package_id -> Blob,
         move_package -> Mediumblob,

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -184,6 +184,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    objects_version (object_id, object_version) {
+        object_id -> Bytea,
+        object_version -> Int8,
+        cp_sequence_number -> Int8,
+    }
+}
+
+diesel::table! {
     packages (package_id) {
         package_id -> Bytea,
         move_package -> Bytea,
@@ -282,6 +290,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     objects_history,
     objects_history_partition_0,
     objects_snapshot,
+    objects_version,
     packages,
     transactions,
     transactions_partition_0,

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -194,7 +194,10 @@ diesel::table! {
 diesel::table! {
     packages (package_id) {
         package_id -> Bytea,
+        original_id -> Bytea,
+        package_version -> Int8,
         move_package -> Bytea,
+        checkpoint_sequence_number -> Int8,
     }
 }
 


### PR DESCRIPTION
## Description

Recreating #17690 which was accidentally closed.

Adding data to the `packages` table, to support the following GraphQL queries:

```graphql
type Query {
  # Fetch all packages created strictly `afterCheckpoint` and strictly
  # before `beforeCheckpoint`.
  packages(
    afterCheckpoint: Int,
    beforeCheckpoint: Int,
    first: Int,
    after: String,
    last: Int,
    before: String,
  ): MovePackageConnection

  # Fetch all packages in the same family as the package at `address`
  # with versions strictly after `afterVersion` and strictly before 
  # `beforeVersion`.
  packageVersions(
    address: SuiAddress!,
    afterVersion: Int,
    beforeVersion: Int,
    first: Int,
    after: String,
    last: Int,
    before: String,
  ): MovePackageConnection

  # Fetch a package by its address, and optionally supplying a
  # version. If the version is supplied, returns the package whose
  # Original ID matches the Original ID of the package at `address`,
  # but whose version is `version`, otherwise just fetches the package
  # directly.
  package(address: SuiAddress!, version: Int): MovePackage
}

type MovePackage {
  # Return the package whose Original ID matches this package's but
  # whose version matches `version`. If `version` is not supplied,
  # defaults to the latest version.
  atVersion(version: Int): MovePackage

  # Fetch all packages in the same family as this package, with
  # versions strictly after `afterVersion` and strictly before
  # `beforeVersion`.
  versions(
    afterVersion: Int,
    beforeVersion: Int,
    first: Int,
    after: String,
    last: Int,
    before: String,
  ): MovePackageConnection
}
```

These queries are important for writing tools that perform whole-chain package analyses, and also for the .move Registry.

## Test plan

Make sure nothing is broken:

```
sui$ cargo nextest run -p sui-indexer
```

Tests of new features will be included in a stacked change that uses these tables and indices in GraphQL.

## Stack

- #17686 
- #17687 
- #17688 
- #17689 
- #17691
- #17694 
- #17695 
- #17542  

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Adds the following fields: `packages.original_id`, `packages.package_version`, `packages.checkpoint_sequence_number` to support queries about package upgrades.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
