### PR TITLE
[GraphQL] Add a separate timeout field in ServiceConfig for mutations

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3063,8 +3063,8 @@ type ServiceConfig {
 	"""
 	maxPageSize: Int!
 	"""
-	Maximum time in milliseconds that it will wait to get the results from the execution. Note,
-	that the transaction might be still queued for execution beyond this timeout.
+	Maximum time in milliseconds that it will wait to get the results from the execution. Note
+	that the transaction might take longer to execute than this timeout.
 	"""
 	mutationTimeoutMs: Int!
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3063,12 +3063,14 @@ type ServiceConfig {
 	"""
 	maxPageSize: Int!
 	"""
-	Maximum time in milliseconds that it will wait to get the results from the execution. Note
-	that the transaction might take longer to execute than this timeout.
+	Maximum time in milliseconds spent waiting for a response from fullnode after issuing a
+	a transaction to execute. Note that the transaction may still succeed even in the case of a
+	timeout. Transactions are idempotent, so a transaction that times out should be resubmitted
+	until the network returns a definite response (success or failure, not timeout).
 	"""
 	mutationTimeoutMs: Int!
 	"""
-	Maximum time in milliseconds that will be spent to serve one request.
+	Maximum time in milliseconds that will be spent to serve one query request.
 	"""
 	requestTimeoutMs: Int!
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3063,6 +3063,11 @@ type ServiceConfig {
 	"""
 	maxPageSize: Int!
 	"""
+	Maximum time in milliseconds that it will wait to get the results from the execution. Note,
+	that the transaction might be still queued for execution beyond this timeout.
+	"""
+	mutationTimeoutMs: Int!
+	"""
 	Maximum time in milliseconds that will be spent to serve one request.
 	"""
 	requestTimeoutMs: Int!

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -27,6 +27,7 @@ const MAX_TYPE_NODES: u32 = 256;
 const MAX_MOVE_VALUE_DEPTH: u32 = 128;
 
 pub(crate) const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
+pub(crate) const DEFAULT_MUTATION_TIMEOUT_MS: u64 = 60_000;
 
 const DEFAULT_IDE_TITLE: &str = "Sui GraphQL IDE";
 
@@ -125,6 +126,8 @@ pub struct Limits {
     pub default_page_size: u64,
     #[serde(default)]
     pub max_page_size: u64,
+    #[serde(default)]
+    pub mutation_timeout_ms: u64,
     #[serde(default)]
     pub request_timeout_ms: u64,
     #[serde(default)]
@@ -298,6 +301,12 @@ impl ServiceConfig {
     /// Maximum number of elements allowed on a single page of a connection.
     async fn max_page_size(&self) -> u64 {
         self.limits.max_page_size
+    }
+
+    /// Maximum time in milliseconds that it will wait to get the results from the execution. Note
+    /// that the transaction might take longer to execute than this timeout.
+    async fn mutation_timeout_ms(&self) -> u64 {
+        self.limits.mutation_timeout_ms
     }
 
     /// Maximum time in milliseconds that will be spent to serve one request.
@@ -483,6 +492,7 @@ impl Default for Limits {
             max_db_query_cost: MAX_DB_QUERY_COST,
             default_page_size: DEFAULT_PAGE_SIZE,
             max_page_size: MAX_PAGE_SIZE,
+            mutation_timeout_ms: DEFAULT_MUTATION_TIMEOUT_MS,
             request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
             max_type_argument_depth: MAX_TYPE_ARGUMENT_DEPTH,
             max_type_argument_width: MAX_TYPE_ARGUMENT_WIDTH,
@@ -537,6 +547,7 @@ mod tests {
                 max-db-query-cost = 50
                 default-page-size = 20
                 max-page-size = 50
+                mutation-timeout-ms = 60000
                 request-timeout-ms = 27000
                 max-type-argument-depth = 32
                 max-type-argument-width = 64
@@ -555,6 +566,7 @@ mod tests {
                 max_db_query_cost: 50,
                 default_page_size: 20,
                 max_page_size: 50,
+                mutation_timeout_ms: 60_000,
                 request_timeout_ms: 27_000,
                 max_type_argument_depth: 32,
                 max_type_argument_width: 64,
@@ -617,6 +629,7 @@ mod tests {
                 max-db-query-cost = 20
                 default-page-size = 10
                 max-page-size = 20
+                mutation-timeout-ms = 60000
                 request-timeout-ms = 30000
                 max-type-argument-depth = 32
                 max-type-argument-width = 64
@@ -638,6 +651,7 @@ mod tests {
                 max_db_query_cost: 20,
                 default_page_size: 10,
                 max_page_size: 20,
+                mutation_timeout_ms: 60_000,
                 request_timeout_ms: 30_000,
                 max_type_argument_depth: 32,
                 max_type_argument_width: 64,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -27,12 +27,15 @@ const MAX_TYPE_NODES: u32 = 256;
 const MAX_MOVE_VALUE_DEPTH: u32 = 128;
 
 pub(crate) const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
+
 /// The time to wait for a transaction to be executed such that the effects can be returned to the
 /// GraphQL query. If the transaction takes longer than this time to execute, the query will return
 /// a timeout error, but the transaction will continue its execution.
-/// <https://github.com/MystenLabs/sui/blob/main/crates/sui-core/src/authority_aggregator.rs#L84C1-L84C57>
-/// This value is the default one from [`sui_core::authority_aggregator::TimeoutConfig`]
-pub(crate) const DEFAULT_MUTATION_TIMEOUT_MS: u64 = 60_000;
+///
+/// It's the sum of pre+post quorum timeouts from [`sui_core::authority_aggregator::TimeoutConfig`]
+/// plus a small buffer of 10% rounded up: 60 + 7 => round_up(67 * 1.1) = 74
+/// <https://github.com/MystenLabs/sui/blob/eaf05fe5d293c06e3a2dfc22c87ba2aef419d8ea/crates/sui-core/src/authority_aggregator.rs#L84-L85>
+pub(crate) const DEFAULT_MUTATION_TIMEOUT_MS: u64 = 74_000;
 
 const DEFAULT_IDE_TITLE: &str = "Sui GraphQL IDE";
 
@@ -554,7 +557,7 @@ mod tests {
                 max-db-query-cost = 50
                 default-page-size = 20
                 max-page-size = 50
-                mutation-timeout-ms = 60000
+                mutation-timeout-ms = 74000
                 request-timeout-ms = 27000
                 max-type-argument-depth = 32
                 max-type-argument-width = 64
@@ -573,7 +576,7 @@ mod tests {
                 max_db_query_cost: 50,
                 default_page_size: 20,
                 max_page_size: 50,
-                mutation_timeout_ms: 60_000,
+                mutation_timeout_ms: 74_000,
                 request_timeout_ms: 27_000,
                 max_type_argument_depth: 32,
                 max_type_argument_width: 64,
@@ -636,7 +639,7 @@ mod tests {
                 max-db-query-cost = 20
                 default-page-size = 10
                 max-page-size = 20
-                mutation-timeout-ms = 60000
+                mutation-timeout-ms = 74000
                 request-timeout-ms = 30000
                 max-type-argument-depth = 32
                 max-type-argument-width = 64
@@ -658,7 +661,7 @@ mod tests {
                 max_db_query_cost: 20,
                 default_page_size: 10,
                 max_page_size: 20,
-                mutation_timeout_ms: 60_000,
+                mutation_timeout_ms: 74_000,
                 request_timeout_ms: 30_000,
                 max_type_argument_depth: 32,
                 max_type_argument_width: 64,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -27,6 +27,11 @@ const MAX_TYPE_NODES: u32 = 256;
 const MAX_MOVE_VALUE_DEPTH: u32 = 128;
 
 pub(crate) const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
+/// The time to wait for a transaction to be executed such that the effects can be returned to the
+/// GraphQL query. If the transaction takes longer than this time to execute, the query will return
+/// a timeout error, but the transaction will continue its execution.
+/// <https://github.com/MystenLabs/sui/blob/main/crates/sui-core/src/authority_aggregator.rs#L84C1-L84C57>
+/// This value is the default one from [`sui_core::authority_aggregator::TimeoutConfig`]
 pub(crate) const DEFAULT_MUTATION_TIMEOUT_MS: u64 = 60_000;
 
 const DEFAULT_IDE_TITLE: &str = "Sui GraphQL IDE";
@@ -303,13 +308,15 @@ impl ServiceConfig {
         self.limits.max_page_size
     }
 
-    /// Maximum time in milliseconds that it will wait to get the results from the execution. Note
-    /// that the transaction might take longer to execute than this timeout.
+    /// Maximum time in milliseconds spent waiting for a response from fullnode after issuing a
+    /// a transaction to execute. Note that the transaction may still succeed even in the case of a
+    /// timeout. Transactions are idempotent, so a transaction that times out should be resubmitted
+    /// until the network returns a definite response (success or failure, not timeout).
     async fn mutation_timeout_ms(&self) -> u64 {
         self.limits.mutation_timeout_ms
     }
 
-    /// Maximum time in milliseconds that will be spent to serve one request.
+    /// Maximum time in milliseconds that will be spent to serve one query request.
     async fn request_timeout_ms(&self) -> u64 {
         self.limits.request_timeout_ms
     }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -703,8 +703,14 @@ pub mod tests {
         assert_eq!(errs, vec![exp]);
 
         // Should timeout for mutation
-        let query = r#"mutation { executeTransactionBlock(txBytes: "testing", \
-                          signatures: "testing") { effects { status }}}"#;
+        let query = r#"
+mutation {
+  executeTransactionBlock(txBytes: "testing", signatures: "testing") {
+    effects {
+      status
+    }
+  }
+}"#;
         let errs: Vec<_> = test_timeout(delay, delay, query)
             .await
             .into_result()

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -703,7 +703,8 @@ pub mod tests {
         assert_eq!(errs, vec![exp]);
 
         // Should timeout for mutation
-        let query = "mutation { executeTransactionBlock(txBytes: '', signatures: '') { effects { status }}}";
+        let query = r#"mutation { executeTransactionBlock(txBytes: "testing", \
+                          signatures: "testing") { effects { status }}}"#;
         let errs: Vec<_> = test_timeout(delay, delay, query)
             .await
             .into_result()

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -677,7 +677,7 @@ pub mod tests {
             let mut cfg = ServiceConfig::default();
             cfg.limits.request_timeout_ms = timeout.as_millis() as u64;
             cfg.limits.mutation_timeout_ms = timeout.as_millis() as u64;
-            info!("prepping schema");
+
             let schema = prep_schema(None, Some(cfg))
                 .context_data(Some(sui_client.clone()))
                 .extension(Timeout)
@@ -686,10 +686,7 @@ pub mod tests {
                 })
                 .build_schema();
 
-            info!("executing schema");
-            let result = schema.execute(query).await;
-            info!("finished execution");
-            result
+            schema.execute(query).await
         }
 
         let query = "{ chainIdentifier }";
@@ -732,8 +729,6 @@ pub mod tests {
 
         let tx = wallet.sign_transaction(&tx_data);
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
-
-        println!("TX BYTES: {:?}", tx_bytes.encoded());
 
         let signature_base64 = &signatures[0];
         let query = format!(

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -852,7 +852,19 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_timeout() {
-        test_timeout_impl().await;
+        let _guard = telemetry_subscribers::TelemetryConfig::new()
+            .with_env()
+            .init();
+        let connection_config = ConnectionConfig::ci_integration_test_cfg();
+        let cluster =
+            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+        cluster
+            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .await;
+        // timeout test includes mutation timeout, which requies a [SuiClient] to be able to run
+        // the test
+        let sui_client = cluster.validator_fullnode_handle.fullnode_handle.sui_client;
+        test_timeout_impl(sui_client).await;
     }
 
     #[tokio::test]

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -862,9 +862,9 @@ mod tests {
             .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
             .await;
         // timeout test includes mutation timeout, which requies a [SuiClient] to be able to run
-        // the test
-        let sui_client = cluster.validator_fullnode_handle.fullnode_handle.sui_client;
-        test_timeout_impl(sui_client).await;
+        // the test, and a transaction. [WalletContext] gives access to everything that's needed.
+        let wallet = cluster.validator_fullnode_handle.wallet;
+        test_timeout_impl(wallet).await;
     }
 
     #[tokio::test]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3067,8 +3067,8 @@ type ServiceConfig {
 	"""
 	maxPageSize: Int!
 	"""
-	Maximum time in milliseconds that it will wait to get the results from the execution. Note,
-	that the transaction might be still queued for execution beyond this timeout.
+	Maximum time in milliseconds that it will wait to get the results from the execution. Note
+	that the transaction might take longer to execute than this timeout.
 	"""
 	mutationTimeoutMs: Int!
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3067,12 +3067,14 @@ type ServiceConfig {
 	"""
 	maxPageSize: Int!
 	"""
-	Maximum time in milliseconds that it will wait to get the results from the execution. Note
-	that the transaction might take longer to execute than this timeout.
+	Maximum time in milliseconds spent waiting for a response from fullnode after issuing a
+	a transaction to execute. Note that the transaction may still succeed even in the case of a
+	timeout. Transactions are idempotent, so a transaction that times out should be resubmitted
+	until the network returns a definite response (success or failure, not timeout).
 	"""
 	mutationTimeoutMs: Int!
 	"""
-	Maximum time in milliseconds that will be spent to serve one request.
+	Maximum time in milliseconds that will be spent to serve one query request.
 	"""
 	requestTimeoutMs: Int!
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3067,6 +3067,11 @@ type ServiceConfig {
 	"""
 	maxPageSize: Int!
 	"""
+	Maximum time in milliseconds that it will wait to get the results from the execution. Note,
+	that the transaction might be still queued for execution beyond this timeout.
+	"""
+	mutationTimeoutMs: Int!
+	"""
 	Maximum time in milliseconds that will be spent to serve one request.
 	"""
 	requestTimeoutMs: Int!
@@ -4213,3 +4218,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+


### PR DESCRIPTION
## Description 

Increases the timeout for mutation requests.

## Test plan 

Updated existing tests to also include this `mutation` timeout case.
```
cargo nextest run --features pg_integration -- tests::test_timeout                 
```


![image](https://github.com/MystenLabs/sui/assets/135084671/3e9b9d2d-dac2-4eef-8976-f012d6bc44d9)


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Added a separate and higher `timeout` value for when executing a transaction block.
- [ ] CLI: 
- [ ] Rust SDK: 
