### PR TITLE
[move-ide] Bump version number for publishing

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
 	"publisher": "mysten",
 	"icon": "images/move.png",
 	"license": "Apache-2.0",
-	"version": "0.0.3",
+	"version": "1.0.1",
 	"preview": true,
 	"repository": {
 		"url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
 	"publisher": "mysten",
 	"icon": "images/move.png",
 	"license": "Apache-2.0",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"preview": true,
 	"repository": {
 		"url": "https://github.com/MystenLabs/sui.git",


### PR DESCRIPTION
## Description 

A version of extension in`package.json` needs to be bumped in order to publish it (even if the only change is in the bundled binary).

