### PR TITLE
use env var to set consensus min delay in tests

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -76,7 +76,7 @@ impl Parameters {
     }
 
     pub(crate) fn default_min_round_delay() -> Duration {
-        if cfg!(msim) {
+        if cfg!(msim) || std::env::var("__TEST_ONLY_CONSENSUS_UES_LONG_MIN_ROUND_DELAY").is_ok() {
             // Checkpoint building and execution cannot keep up with high commit rate in simtests,
             // leading to long reconfiguration delays. This is because simtest is single threaded,
             // and spending too much time in consensus can lead to starvation elsewhere.

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -76,7 +76,7 @@ impl Parameters {
     }
 
     pub(crate) fn default_min_round_delay() -> Duration {
-        if cfg!(msim) || std::env::var("__TEST_ONLY_CONSENSUS_UES_LONG_MIN_ROUND_DELAY").is_ok() {
+        if cfg!(msim) || std::env::var("__TEST_ONLY_CONSENSUS_USE_LONG_MIN_ROUND_DELAY").is_ok() {
             // Checkpoint building and execution cannot keep up with high commit rate in simtests,
             // leading to long reconfiguration delays. This is because simtest is single threaded,
             // and spending too much time in consensus can lead to starvation elsewhere.

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -124,6 +124,8 @@ impl BridgeTestClusterBuilder {
 
     pub async fn build(self) -> BridgeTestCluster {
         init_all_struct_tags();
+        std::env::set_var("__TEST_ONLY_CONSENSUS_UES_LONG_MIN_ROUND_DELAY", "1");
+
         let mut bridge_keys = vec![];
         let mut bridge_keys_copy = vec![];
         for _ in 0..=3 {

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -124,7 +124,7 @@ impl BridgeTestClusterBuilder {
 
     pub async fn build(self) -> BridgeTestCluster {
         init_all_struct_tags();
-        std::env::set_var("__TEST_ONLY_CONSENSUS_UES_LONG_MIN_ROUND_DELAY", "1");
+        std::env::set_var("__TEST_ONLY_CONSENSUS_USE_LONG_MIN_ROUND_DELAY", "1");
 
         let mut bridge_keys = vec![];
         let mut bridge_keys_copy = vec![];


### PR DESCRIPTION
## Description 

bridge e2e tests can't use sim tests today because of several reasons. With `tokio::test` we stumble into a case where high commit rate (50ms) can cause reconfiguration to take long and eventually build up the checkpoint queue (interesting it is the checkpoint content downloading queue). This PR introduces an env var to keep the commit rate normal.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
