### PR TITLE
[SuiNS Indexer] Mainnet values & stricter check

### DIFF
--- a/crates/suins-indexer/.env.sample
+++ b/crates/suins-indexer/.env.sample
@@ -2,6 +2,7 @@ DATABASE_URL=postgres://<pg_user>:<pg_password>@localhost:5432/<db_name>
 REMOTE_STORAGE=https://checkpoints.mainnet.sui.io
 BACKFILL_PROGRESS_FILE_PATH=/tmp/backfill_progress # expects a file in the format { "suins_indexing": <checkpoint> }
 CHECKPOINTS_DIR=/tmp/checkpoints
+REGISTRY_ID=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106
 SUBDOMAIN_WRAPPER_TYPE=0x00c2f85e07181b90c140b15c5ce27d863f93c4d9159d2a4e7bdaeb40e286d6f5::subdomain_registration::SubDomainRegistration
 NAME_RECORD_TYPE=0x2::dynamic_field::Field<0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::domain::Domain,0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::name_record::NameRecord>
 

--- a/crates/suins-indexer/.env.sample
+++ b/crates/suins-indexer/.env.sample
@@ -2,6 +2,6 @@ DATABASE_URL=postgres://<pg_user>:<pg_password>@localhost:5432/<db_name>
 REMOTE_STORAGE=https://checkpoints.mainnet.sui.io
 BACKFILL_PROGRESS_FILE_PATH=/tmp/backfill_progress # expects a file in the format { "suins_indexing": <checkpoint> }
 CHECKPOINTS_DIR=/tmp/checkpoints
-REGISTRY_ID=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106
-SUBDOMAIN_WRAPPER_TYPE=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106::subdomain_registration::SubDomainRegistration
+SUBDOMAIN_WRAPPER_TYPE=0x00c2f85e07181b90c140b15c5ce27d863f93c4d9159d2a4e7bdaeb40e286d6f5::subdomain_registration::SubDomainRegistration
+NAME_RECORD_TYPE=0x2::dynamic_field::Field<0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::domain::Domain,0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::name_record::NameRecord>
 

--- a/crates/suins-indexer/src/indexer.rs
+++ b/crates/suins-indexer/src/indexer.rs
@@ -29,8 +29,8 @@ pub struct NameRecordChange(Field<Domain, NameRecord>);
 
 pub struct SuinsIndexer {
     registry_table_id: SuiAddress,
-    name_record_type: StructTag,
     subdomain_wrapper_type: StructTag,
+    name_record_type: StructTag,
 }
 
 impl std::default::Default for SuinsIndexer {

--- a/crates/suins-indexer/src/indexer.rs
+++ b/crates/suins-indexer/src/indexer.rs
@@ -18,8 +18,7 @@ use sui_types::{
 use crate::models::VerifiedDomain;
 
 /// We default to mainnet for both.
-const NAME_RECORD_TYPE: &str = 
-    "0x2::dynamic_field::Field<0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::domain::Domain,0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::name_record::NameRecord>";
+const NAME_RECORD_TYPE: &str = "0x2::dynamic_field::Field<0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::domain::Domain,0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::name_record::NameRecord>";
 const SUBDOMAIN_REGISTRATION_TYPE: &str =
     "0x00c2f85e07181b90c140b15c5ce27d863f93c4d9159d2a4e7bdaeb40e286d6f5::subdomain_registration::SubDomainRegistration";
 

--- a/crates/suins-indexer/src/indexer.rs
+++ b/crates/suins-indexer/src/indexer.rs
@@ -18,6 +18,8 @@ use sui_types::{
 use crate::models::VerifiedDomain;
 
 /// We default to mainnet for both.
+const REGISTRY_TABLE_ID: &str =
+    "0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106";
 const NAME_RECORD_TYPE: &str = "0x2::dynamic_field::Field<0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::domain::Domain,0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::name_record::NameRecord>";
 const SUBDOMAIN_REGISTRATION_TYPE: &str =
     "0x00c2f85e07181b90c140b15c5ce27d863f93c4d9159d2a4e7bdaeb40e286d6f5::subdomain_registration::SubDomainRegistration";
@@ -26,6 +28,7 @@ const SUBDOMAIN_REGISTRATION_TYPE: &str =
 pub struct NameRecordChange(Field<Domain, NameRecord>);
 
 pub struct SuinsIndexer {
+    registry_table_id: SuiAddress,
     name_record_type: StructTag,
     subdomain_wrapper_type: StructTag,
 }
@@ -33,8 +36,9 @@ pub struct SuinsIndexer {
 impl std::default::Default for SuinsIndexer {
     fn default() -> Self {
         Self::new(
-            NAME_RECORD_TYPE.to_owned(),
+            REGISTRY_TABLE_ID.to_owned(),
             SUBDOMAIN_REGISTRATION_TYPE.to_owned(),
+            NAME_RECORD_TYPE.to_owned(),
         )
     }
 }
@@ -42,11 +46,13 @@ impl std::default::Default for SuinsIndexer {
 impl SuinsIndexer {
     /// Create a new config by passing the table ID + subdomain wrapper type.
     /// Useful for testing or custom environments.
-    pub fn new(record_type: String, wrapper_type: String) -> Self {
+    pub fn new(registry_address: String, wrapper_type: String, record_type: String) -> Self {
+        let registry_table_id = SuiAddress::from_str(&registry_address).unwrap();
         let name_record_type = StructTag::from_str(&record_type).unwrap();
         let subdomain_wrapper_type = StructTag::from_str(&wrapper_type).unwrap();
 
         Self {
+            registry_table_id,
             name_record_type,
             subdomain_wrapper_type,
         }
@@ -62,11 +68,15 @@ impl SuinsIndexer {
     }
 
     // Filter by the dynamic field value type.
-    // A valid name record for an object has the type `Field<Domain,NameRecord>
+    // A valid name record for an object has the type `Field<Domain,NameRecord>,
+    // and the parent of it is the `registry` table id.
     pub fn is_name_record(&self, object: &Object) -> bool {
         object
-            .struct_tag()
-            .is_some_and(|tag| tag == self.name_record_type)
+            .get_single_owner()
+            .is_some_and(|owner| owner == self.registry_table_id)
+            && object
+                .struct_tag()
+                .is_some_and(|tag| tag == self.name_record_type)
     }
 
     /// Processes a checkpoint and produces a list of `updates` and a list of `removals`

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -110,9 +110,9 @@ impl Worker for SuinsIndexerWorker {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv().ok();
-    let (remote_storage, registry_id, subdomain_wrapper_type) = (
+    let (remote_storage, name_record_type, subdomain_wrapper_type) = (
         env::var("REMOTE_STORAGE").ok(),
-        env::var("REGISTRY_ID").ok(),
+        env::var("NAME_RECORD_TYPE").ok(),
         env::var("SUBDOMAIN_WRAPPER_TYPE").ok(),
     );
     let backfill_progress_file_path =
@@ -126,10 +126,10 @@ async fn main() -> Result<()> {
     let metrics = DataIngestionMetrics::new(&Registry::new());
     let mut executor = IndexerExecutor::new(progress_store, 1, metrics);
 
-    let indexer_setup = if let (Some(registry_id), Some(subdomain_wrapper_type)) =
-        (registry_id, subdomain_wrapper_type)
+    let indexer_setup = if let (Some(name_record_type), Some(subdomain_wrapper_type)) =
+        (name_record_type, subdomain_wrapper_type)
     {
-        SuinsIndexer::new(registry_id, subdomain_wrapper_type)
+        SuinsIndexer::new(name_record_type, subdomain_wrapper_type)
     } else {
         SuinsIndexer::default()
     };

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -110,10 +110,11 @@ impl Worker for SuinsIndexerWorker {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv().ok();
-    let (remote_storage, name_record_type, subdomain_wrapper_type) = (
+    let (remote_storage, registry_id, subdomain_wrapper_type, name_record_type) = (
         env::var("REMOTE_STORAGE").ok(),
-        env::var("NAME_RECORD_TYPE").ok(),
+        env::var("REGISTRY_ID").ok(),
         env::var("SUBDOMAIN_WRAPPER_TYPE").ok(),
+        env::var("NAME_RECORD_TYPE").ok(),
     );
     let backfill_progress_file_path =
         env::var("BACKFILL_PROGRESS_FILE_PATH").unwrap_or("/tmp/backfill_progress".to_string());
@@ -126,13 +127,14 @@ async fn main() -> Result<()> {
     let metrics = DataIngestionMetrics::new(&Registry::new());
     let mut executor = IndexerExecutor::new(progress_store, 1, metrics);
 
-    let indexer_setup = if let (Some(name_record_type), Some(subdomain_wrapper_type)) =
-        (name_record_type, subdomain_wrapper_type)
-    {
-        SuinsIndexer::new(name_record_type, subdomain_wrapper_type)
-    } else {
-        SuinsIndexer::default()
-    };
+    let indexer_setup =
+        if let (Some(registry_id), Some(subdomain_wrapper_type), Some(name_record_type)) =
+            (registry_id, subdomain_wrapper_type, name_record_type)
+        {
+            SuinsIndexer::new(registry_id, subdomain_wrapper_type, name_record_type)
+        } else {
+            SuinsIndexer::default()
+        };
 
     let worker_pool = WorkerPool::new(
         SuinsIndexerWorker {

--- a/crates/suins-indexer/tests/checkpoint_process_tests.rs
+++ b/crates/suins-indexer/tests/checkpoint_process_tests.rs
@@ -6,8 +6,7 @@ use sui_types::full_checkpoint_content::CheckpointData;
 use suins_indexer::indexer::SuinsIndexer;
 
 /// Test ids.
-const TEST_NAME_RECORD_TYPE: &str = 
-    "0x2::dynamic_field::Field<0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::domain::Domain,0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::name_record::NameRecord>";
+const TEST_NAME_RECORD_TYPE: &str = "0x2::dynamic_field::Field<0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::domain::Domain,0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::name_record::NameRecord>";
 const TEST_SUBDOMAIN_REGISTRATION_TYPE: &str = "0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::subdomain_registration::SubDomainRegistration";
 
 /// For our test policy, we have a few checkpoints that contain some data additions, deletions, replacements

--- a/crates/suins-indexer/tests/checkpoint_process_tests.rs
+++ b/crates/suins-indexer/tests/checkpoint_process_tests.rs
@@ -6,6 +6,8 @@ use sui_types::full_checkpoint_content::CheckpointData;
 use suins_indexer::indexer::SuinsIndexer;
 
 /// Test ids.
+const TEST_REGISTRY_TABLE_ID: &str =
+    "0xb120c0d55432630fce61f7854795a3463deb6e3b443cc4ae72e1282073ff56e4";
 const TEST_NAME_RECORD_TYPE: &str = "0x2::dynamic_field::Field<0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::domain::Domain,0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::name_record::NameRecord>";
 const TEST_SUBDOMAIN_REGISTRATION_TYPE: &str = "0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::subdomain_registration::SubDomainRegistration";
 
@@ -140,7 +142,8 @@ fn read_checkpoint_from_file(file: &[u8]) -> CheckpointData {
 /// Uses the testnet demo we used to extract the checkpoints being processed.
 fn get_test_indexer() -> SuinsIndexer {
     SuinsIndexer::new(
-        TEST_NAME_RECORD_TYPE.to_string(),
+        TEST_REGISTRY_TABLE_ID.to_string(),
         TEST_SUBDOMAIN_REGISTRATION_TYPE.to_string(),
+        TEST_NAME_RECORD_TYPE.to_string(),
     )
 }

--- a/crates/suins-indexer/tests/checkpoint_process_tests.rs
+++ b/crates/suins-indexer/tests/checkpoint_process_tests.rs
@@ -6,8 +6,8 @@ use sui_types::full_checkpoint_content::CheckpointData;
 use suins_indexer::indexer::SuinsIndexer;
 
 /// Test ids.
-const TEST_REGISTRY_TABLE_ID: &str =
-    "0xb120c0d55432630fce61f7854795a3463deb6e3b443cc4ae72e1282073ff56e4";
+const TEST_NAME_RECORD_TYPE: &str = 
+    "0x2::dynamic_field::Field<0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::domain::Domain,0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::name_record::NameRecord>";
 const TEST_SUBDOMAIN_REGISTRATION_TYPE: &str = "0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93::subdomain_registration::SubDomainRegistration";
 
 /// For our test policy, we have a few checkpoints that contain some data additions, deletions, replacements
@@ -141,7 +141,7 @@ fn read_checkpoint_from_file(file: &[u8]) -> CheckpointData {
 /// Uses the testnet demo we used to extract the checkpoints being processed.
 fn get_test_indexer() -> SuinsIndexer {
     SuinsIndexer::new(
-        TEST_REGISTRY_TABLE_ID.to_string(),
+        TEST_NAME_RECORD_TYPE.to_string(),
         TEST_SUBDOMAIN_REGISTRATION_TYPE.to_string(),
     )
 }


### PR DESCRIPTION
## Description 

- Adds the mainnet values
- Makes the `is_name_record` check stricter, by also checking the type (to avoid the possibility of breaking with TTO to the registry's table).

## Test plan 

Changed the type to the new expected, and re-run the tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
