### PR TITLE
[fix][homebrew] don't panic if git commit unavailable

### DIFF
--- a/crates/bin-version/src/lib.rs
+++ b/crates/bin-version/src/lib.rs
@@ -23,8 +23,13 @@ macro_rules! bin_version {
     () => {
         $crate::git_revision!();
 
-        const VERSION: &str =
-            $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+        const VERSION: &str = {
+            if GIT_REVISION.is_empty() {
+                env!("CARGO_PKG_VERSION")
+            } else {
+                $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION)
+            }
+        };
     };
 }
 
@@ -54,9 +59,6 @@ macro_rules! git_revision {
                     fallback = ""
                 );
 
-                if version.is_empty() {
-                    panic!("unable to query git revision");
-                }
                 version
             }
         };


### PR DESCRIPTION
## Description 

https://github.com/MystenLabs/sui/pull/17478 breaks our homebrew releases (https://github.com/Homebrew/homebrew-core/pull/171726#issuecomment-2111545964), as it reversed the changes made in https://github.com/MystenLabs/sui/pull/15727. 

## Test plan 

```
$ mv .git .notgit
$ cargo install --path crates/sui
$ /Users/johnmartin/.cargo/bin/sui -V                                                                                                                                                           sui 1.26.0
```
