### PR TITLE
[Traffic Control] Disable ip injection by default

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -180,7 +180,7 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub firewall_config: Option<RemoteFirewallConfig>,
 
-    /// Only applicable to noes running json rpc server.
+    /// Only applicable to nodes running json rpc server.
     /// If true, node will inject client IP into headers
     /// in validator requests for eligible rpc endpoints.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -179,6 +179,12 @@ pub struct NodeConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub firewall_config: Option<RemoteFirewallConfig>,
+
+    /// Only applicable to noes running json rpc server.
+    /// If true, node will inject client IP into headers
+    /// in validator requests for eligible rpc endpoints.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub with_client_ip_injection: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -46,6 +46,7 @@ async fn test_validator_traffic_control_ok() -> Result<(), anyhow::Error> {
         .build();
     let test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
+        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
 
@@ -113,7 +114,6 @@ async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
     };
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
-        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_dry_run(test_cluster, n as usize).await
@@ -136,7 +136,6 @@ async fn test_validator_traffic_control_spam_blocked() -> Result<(), anyhow::Err
         .build();
     let test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
-        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_blocked(test_cluster, n as usize).await
@@ -156,7 +155,6 @@ async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Erro
     };
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
-        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_blocked(test_cluster, n as usize).await
@@ -189,7 +187,6 @@ async fn test_validator_traffic_control_spam_delegated() -> Result<(), anyhow::E
         .build();
     let test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
-        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_delegated(test_cluster, n as usize, 65000).await
@@ -219,7 +216,6 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
         .with_fullnode_fw_config(Some(firewall_config.clone()))
-        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_delegated(test_cluster, n as usize, 65000).await

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -113,6 +113,7 @@ async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
     };
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
+        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_dry_run(test_cluster, n as usize).await
@@ -135,6 +136,7 @@ async fn test_validator_traffic_control_spam_blocked() -> Result<(), anyhow::Err
         .build();
     let test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
+        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_blocked(test_cluster, n as usize).await
@@ -154,6 +156,7 @@ async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Erro
     };
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
+        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_blocked(test_cluster, n as usize).await
@@ -186,6 +189,7 @@ async fn test_validator_traffic_control_spam_delegated() -> Result<(), anyhow::E
         .build();
     let test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
+        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_delegated(test_cluster, n as usize, 65000).await
@@ -215,6 +219,7 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
         .with_fullnode_fw_config(Some(firewall_config.clone()))
+        .with_fullnode_client_ip_injection(Some(true))
         .build()
         .await;
     assert_traffic_control_spam_delegated(test_cluster, n as usize, 65000).await

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -158,8 +158,13 @@ pub async fn build_json_rpc_server<T: R2D2Connection>(
     config: &IndexerConfig,
     custom_runtime: Option<Handle>,
 ) -> Result<ServerHandle, IndexerError> {
-    let mut builder =
-        JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
+    let mut builder = JsonRpcServerBuilder::new(
+        env!("CARGO_PKG_VERSION"),
+        prometheus_registry,
+        None,
+        None,
+        None,
+    );
     let http_client = crate::get_http_client(config.rpc_client_url.as_str())?;
 
     let name_service_config =

--- a/crates/sui-json-rpc-tests/tests/routing_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/routing_tests.rs
@@ -20,7 +20,7 @@ use sui_open_rpc_macros::open_rpc;
 
 #[tokio::test]
 async fn test_rpc_backward_compatibility() {
-    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new(), None, None);
+    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new(), None, None, None);
     builder.register_module(TestApiModule).unwrap();
 
     let address = local_ip_utils::new_local_tcp_socket_for_testing();
@@ -99,7 +99,7 @@ async fn test_rpc_backward_compatibility() {
 async fn test_disable_routing() {
     env::set_var("DISABLE_BACKWARD_COMPATIBILITY", "true");
 
-    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new(), None, None);
+    let mut builder = JsonRpcServerBuilder::new("1.5", &Registry::new(), None, None, None);
     builder.register_module(TestApiModule).unwrap();
 
     let address = local_ip_utils::new_local_tcp_socket_for_testing();
@@ -135,10 +135,10 @@ async fn test_disable_routing() {
 // #[tokio::test]
 // async fn test_rpc_backward_compatibility_batched_request() {
 //     let mut builder = JsonRpcServerBuilder::new(
-//          "1.5", &Registry::new(), None, None,
+//          "1.5", &Registry::new(), None, None, None,
 //     );
 //     let mut builder = JsonRpcServerBuilder::new(
-//          "1.5", &Registry::new(), None, None,
+//          "1.5", &Registry::new(), None, None, None,
 //     );
 //     builder.register_module(TestApiModule).unwrap();
 

--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -41,6 +41,7 @@ pub struct JsonRpcService<L> {
     methods: Methods,
     rpc_router: RpcRouter,
     traffic_controller: Option<Arc<TrafficController>>,
+    // Will eventually remove after stable rollout
     with_client_ip_injection: bool,
 }
 

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -60,6 +60,7 @@ pub struct JsonRpcServerBuilder {
     registry: Registry,
     policy_config: Option<PolicyConfig>,
     firewall_config: Option<RemoteFirewallConfig>,
+    with_client_ip_injection: Option<bool>,
 }
 
 pub fn sui_rpc_doc(version: &str) -> Project {
@@ -86,6 +87,7 @@ impl JsonRpcServerBuilder {
         prometheus_registry: &Registry,
         policy_config: Option<PolicyConfig>,
         firewall_config: Option<RemoteFirewallConfig>,
+        with_client_ip_injection: Option<bool>,
     ) -> Self {
         Self {
             module: RpcModule::new(()),
@@ -93,6 +95,7 @@ impl JsonRpcServerBuilder {
             registry: prometheus_registry.clone(),
             policy_config,
             firewall_config,
+            with_client_ip_injection,
         }
     }
 
@@ -191,6 +194,7 @@ impl JsonRpcServerBuilder {
             self.firewall_config.clone(),
             self.policy_config.clone(),
             traffic_controller_metrics,
+            self.with_client_ip_injection.unwrap_or(false),
         );
 
         let mut router = axum::Router::new();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1831,6 +1831,7 @@ pub async fn build_http_server(
             prometheus_registry,
             config.policy_config.clone(),
             config.firewall_config.clone(),
+            config.with_client_ip_injection,
         );
 
         let kv_store = build_kv_store(&state, config, prometheus_registry)?;

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -226,6 +226,7 @@ impl ValidatorConfigBuilder {
             websocket_only: false,
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
+            with_client_ip_injection: Some(false),
         }
     }
 
@@ -260,6 +261,7 @@ pub struct FullnodeConfigBuilder {
     run_with_range: Option<RunWithRange>,
     policy_config: Option<PolicyConfig>,
     fw_config: Option<RemoteFirewallConfig>,
+    with_client_ip_injection: Option<bool>,
 }
 
 impl FullnodeConfigBuilder {
@@ -364,6 +366,11 @@ impl FullnodeConfigBuilder {
 
     pub fn with_fw_config(mut self, config: Option<RemoteFirewallConfig>) -> Self {
         self.fw_config = config;
+        self
+    }
+
+    pub fn with_client_ip_injection(mut self, with_ip_injection: Option<bool>) -> Self {
+        self.with_client_ip_injection = with_ip_injection;
         self
     }
 
@@ -493,6 +500,7 @@ impl FullnodeConfigBuilder {
             websocket_only: false,
             policy_config: self.policy_config,
             firewall_config: self.fw_config,
+            with_client_ip_injection: self.with_client_ip_injection,
         }
     }
 }

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -226,7 +226,7 @@ impl ValidatorConfigBuilder {
             websocket_only: false,
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
-            with_client_ip_injection: Some(false),
+            with_client_ip_injection: None,
         }
     }
 

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -41,6 +41,7 @@ pub struct SwarmBuilder<R = OsRng> {
     additional_objects: Vec<Object>,
     fullnode_count: usize,
     fullnode_rpc_port: Option<u16>,
+    with_fullnode_client_ip_injection: Option<bool>,
     fullnode_rpc_addr: Option<SocketAddr>,
     supported_protocol_versions_config: ProtocolVersionsConfig,
     // Default to supported_protocol_versions_config, but can be overridden.
@@ -69,6 +70,7 @@ impl SwarmBuilder {
             additional_objects: vec![],
             fullnode_count: 0,
             fullnode_rpc_port: None,
+            with_fullnode_client_ip_injection: None,
             fullnode_rpc_addr: None,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
@@ -97,6 +99,7 @@ impl<R> SwarmBuilder<R> {
             additional_objects: self.additional_objects,
             fullnode_count: self.fullnode_count,
             fullnode_rpc_port: self.fullnode_rpc_port,
+            with_fullnode_client_ip_injection: self.with_fullnode_client_ip_injection,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             supported_protocol_versions_config: self.supported_protocol_versions_config,
             fullnode_supported_protocol_versions_config: self
@@ -178,6 +181,11 @@ impl<R> SwarmBuilder<R> {
     pub fn with_fullnode_rpc_port(mut self, fullnode_rpc_port: u16) -> Self {
         assert!(self.fullnode_rpc_addr.is_none());
         self.fullnode_rpc_port = Some(fullnode_rpc_port);
+        self
+    }
+
+    pub fn with_fullnode_client_ip_injection(mut self, with_ip_injection: Option<bool>) -> Self {
+        self.with_fullnode_client_ip_injection = with_ip_injection;
         self
     }
 
@@ -378,6 +386,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                     }
                     if let Some(rpc_port) = self.fullnode_rpc_port {
                         builder = builder.with_rpc_port(rpc_port);
+                    }
+                    if let Some(with_ip_injection) = self.with_fullnode_client_ip_injection {
+                        builder = builder.with_client_ip_injection(Some(with_ip_injection));
                     }
                 }
                 let config = builder.build(&mut OsRng, &network_config);

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -870,6 +870,7 @@ pub struct TestClusterBuilder {
     additional_objects: Vec<Object>,
     num_validators: Option<usize>,
     fullnode_rpc_port: Option<u16>,
+    with_fullnode_client_ip_injection: Option<bool>,
     enable_fullnode_events: bool,
     validator_supported_protocol_versions_config: ProtocolVersionsConfig,
     // Default to validator_supported_protocol_versions_config, but can be overridden.
@@ -897,6 +898,7 @@ impl TestClusterBuilder {
             network_config: None,
             additional_objects: vec![],
             fullnode_rpc_port: None,
+            with_fullnode_client_ip_injection: None,
             num_validators: None,
             enable_fullnode_events: false,
             validator_supported_protocol_versions_config: ProtocolVersionsConfig::Default,
@@ -936,6 +938,11 @@ impl TestClusterBuilder {
 
     pub fn with_fullnode_rpc_port(mut self, rpc_port: u16) -> Self {
         self.fullnode_rpc_port = Some(rpc_port);
+        self
+    }
+
+    pub fn with_fullnode_client_ip_injection(mut self, with_ip_injection: Option<bool>) -> Self {
+        self.with_fullnode_client_ip_injection = with_ip_injection;
         self
     }
 
@@ -1394,7 +1401,8 @@ impl TestClusterBuilder {
             .with_db_checkpoint_config(self.db_checkpoint_config_fullnodes.clone())
             .with_fullnode_run_with_range(self.fullnode_run_with_range)
             .with_fullnode_policy_config(self.fullnode_policy_config.clone())
-            .with_fullnode_fw_config(self.fullnode_fw_config.clone());
+            .with_fullnode_fw_config(self.fullnode_fw_config.clone())
+            .with_fullnode_client_ip_injection(self.with_fullnode_client_ip_injection);
 
         if let Some(genesis_config) = self.genesis_config.take() {
             builder = builder.with_genesis_config(genesis_config);


### PR DESCRIPTION
## Description 

This will disable the client IP injection path altogether. Adds builder params in order to keep enabled in tests. 

## Test plan 

Existing tests

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
