### PR TITLE
[move-ide] Fix pre-compiled libs construction problems

### DIFF
--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1907,6 +1907,7 @@ pub static PRE_COMPILED: Lazy<FullyCompiledProgram> = Lazy::new(|| {
         }],
         None,
         Flags::empty(),
+        None,
     )
     .unwrap();
     match fully_compiled_res {

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1596,6 +1596,7 @@ dependencies = [
  "move-package",
  "move-symbol-pool",
  "serde_json",
+ "sha2",
  "tempfile",
  "url",
  "vfs",

--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -18,6 +18,7 @@ itertools.workspace = true
 lsp-server.workspace = true
 lsp-types.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tempfile.workspace = true
 url.workspace = true
 vfs.workspace = true

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
 	"publisher": "mysten",
 	"icon": "images/move.png",
 	"license": "Apache-2.0",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"preview": true,
 	"repository": {
 		"url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1319,7 +1319,6 @@ pub fn get_symbols(
     let mut references = BTreeMap::new();
     let mut def_info = BTreeMap::new();
 
-    eprintln!("PREPROCESS REGULAR");
     pre_process_typed_modules(
         &parsed_program,
         &typed_modules,
@@ -1335,7 +1334,6 @@ pub fn get_symbols(
         &edition,
     );
 
-    eprintln!("PREPROCESS DEPS");
     if let Some(libs) = compiled_libs.clone() {
         pre_process_typed_modules(
             &parsed_program,

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -623,6 +623,7 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
     targets: Vec<PackagePaths<Paths, NamedAddress>>,
     interface_files_dir_opt: Option<String>,
     flags: Flags,
+    vfs_root: Option<VfsPath>,
 ) -> anyhow::Result<Result<FullyCompiledProgram, (FilesSourceText, Diagnostics)>> {
     let hook = SaveHook::new([
         SaveFlag::Parser,
@@ -634,7 +635,7 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
         SaveFlag::CFGIR,
     ]);
     let (files, pprog_and_comments_res) = Compiler::from_package_paths(
-        None,
+        vfs_root,
         targets,
         Vec::<PackagePaths<Paths, NamedAddress>>::new(),
     )?

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -308,6 +308,7 @@ static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
         }],
         None,
         move_compiler::Flags::empty(),
+        None,
     )
     .unwrap();
     match program_res {


### PR DESCRIPTION
## Description 

This PR fixes a problem related to construction of pre-compiled libraries in the IDE. In particular:
- we need to use virtual file system while constructing pre-compiled libraries to make sure that file hashes remain consistent throughout the symbolication process
- we need to invalidate pre-compiled library for a package if dependency source files changed since last symbolication

## Test plan 

Verified that a crash previously happening when trying the following test procedure can no longer happen:
- Add a method in module M, save the file
- Use the method in module X, save the file
- Remove the method in module M DO NOT save the file
- Reload vscode using "Developer: Reload Window"
