### PR TITLE
[Consensus 2.0] Calculate committed sub dag digest

### DIFF
--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -675,10 +675,7 @@ mod tests {
             subdag.blocks.len(),
             (num_authorities * wave_length) as usize + 1
         );
-        assert_eq!(
-            subdag.commit_ref,
-            commit.reference()
-        );
+        assert_eq!(subdag.commit_ref, commit.reference());
     }
 
     #[tokio::test]

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -341,7 +341,7 @@ impl Display for CommittedSubDag {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "CommittedSubDag(leader={}, index={}, blocks=[",
+            "CommittedSubDag(leader={}, ref={}, blocks=[",
             self.leader, self.commit_ref
         )?;
         for (idx, block) in self.blocks.iter().enumerate() {
@@ -350,7 +350,7 @@ impl Display for CommittedSubDag {
             }
             write!(f, "{}", block.digest())?;
         }
-        write!(f, "], digest={})", self.commit_ref.digest)
+        write!(f, "])")
     }
 }
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -94,7 +94,7 @@ impl CommitObserver {
             }
             tracing::debug!(
                 "Sending to execution commit {} leader {}",
-                committed_sub_dag.commit_index,
+                committed_sub_dag.commit_ref,
                 committed_sub_dag.leader
             );
             sent_sub_dags.push(committed_sub_dag);
@@ -283,7 +283,7 @@ mod tests {
                 expected_stored_refs.push(block.reference());
                 assert!(block.round() <= leaders[idx].round());
             }
-            assert_eq!(subdag.commit_index, idx as CommitIndex + 1);
+            assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
         }
 
         // Check commits sent over consensus output channel is accurate
@@ -291,7 +291,7 @@ mod tests {
         while let Ok(subdag) = receiver.try_recv() {
             assert_eq!(subdag, commits[processed_subdag_index]);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
-            processed_subdag_index = subdag.commit_index as usize;
+            processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == leaders.len() {
                 break;
             }
@@ -302,7 +302,10 @@ mod tests {
 
         // Check commits have been persisted to storage
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
-        assert_eq!(last_commit.index(), commits.last().unwrap().commit_index);
+        assert_eq!(
+            last_commit.index(),
+            commits.last().unwrap().commit_ref.index
+        );
         let all_stored_commits = mem_store
             .scan_commits((0..CommitIndex::MAX).into())
             .unwrap();
@@ -377,7 +380,7 @@ mod tests {
             tracing::info!("Processed {subdag}");
             assert_eq!(subdag, commits[processed_subdag_index]);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
-            processed_subdag_index = subdag.commit_index as usize;
+            processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_processed_index {
                 break;
             }
@@ -413,7 +416,7 @@ mod tests {
             tracing::info!("{subdag} was sent but not processed by consumer");
             assert_eq!(subdag, commits[processed_subdag_index]);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
-            processed_subdag_index = subdag.commit_index as usize;
+            processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_sent_index {
                 break;
             }
@@ -449,7 +452,7 @@ mod tests {
             tracing::info!("Processed {subdag} on resubmission");
             assert_eq!(subdag, commits[processed_subdag_index]);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
-            processed_subdag_index = subdag.commit_index as usize;
+            processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_sent_index {
                 break;
             }
@@ -517,7 +520,7 @@ mod tests {
             tracing::info!("Processed {subdag}");
             assert_eq!(subdag, commits[processed_subdag_index]);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
-            processed_subdag_index = subdag.commit_index as usize;
+            processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_processed_index {
                 break;
             }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1359,23 +1359,15 @@ mod test {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let subdag =
-                dag_builder.get_subdag(leader.clone(), last_committed_rounds.clone(), commit_index);
+            let (subdag, commit) = dag_builder.get_sub_dag_and_commit(
+                leader.clone(),
+                last_committed_rounds.clone(),
+                commit_index,
+            );
             for block in subdag.blocks.iter() {
                 last_committed_rounds[block.author().value()] =
                     max(block.round(), last_committed_rounds[block.author().value()]);
             }
-            let commit = TrustedCommit::new_for_test(
-                commit_index,
-                CommitDigest::MIN,
-                leader.timestamp_ms(),
-                leader.reference(),
-                subdag
-                    .blocks
-                    .iter()
-                    .map(|block| block.reference())
-                    .collect::<Vec<_>>(),
-            );
             commits.push(commit);
         }
 

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -650,7 +650,7 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let mut subdag =
+            let subdag =
                 dag_builder.get_subdag(leader.clone(), last_committed_rounds.clone(), commit_index);
             for block in subdag.blocks.iter() {
                 blocks_to_write.push(block.clone());
@@ -669,7 +669,6 @@ mod tests {
                     .collect::<Vec<_>>(),
             );
             expected_commits.push(commit);
-            subdag.sort();
             subdags.push(subdag);
         }
 
@@ -705,8 +704,7 @@ mod tests {
         );
         let actual_unscored_subdags = dag_state.read().unscored_committed_subdags();
         assert_eq!(1, dag_state.read().unscored_committed_subdags_count());
-        let mut actual_subdag = actual_unscored_subdags[0].clone();
-        actual_subdag.sort();
+        let actual_subdag = actual_unscored_subdags[0].clone();
         assert_eq!(*subdags.last().unwrap(), actual_subdag);
 
         let leader_schedule = LeaderSchedule::from_store(context.clone(), dag_state.clone());
@@ -783,7 +781,7 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let mut subdag =
+            let subdag =
                 dag_builder.get_subdag(leader.clone(), last_committed_rounds.clone(), commit_index);
             for block in subdag.blocks.iter() {
                 blocks_to_write.push(block.clone());
@@ -802,7 +800,6 @@ mod tests {
                     .collect::<Vec<_>>(),
             );
             expected_commits.push(commit);
-            subdag.sort();
             expected_unscored_subdags.push(subdag);
         }
 
@@ -832,8 +829,7 @@ mod tests {
             dag_state.read().unscored_committed_subdags_count()
         );
         for (idx, expected_subdag) in expected_unscored_subdags.into_iter().enumerate() {
-            let mut actual_subdag = actual_unscored_subdags[idx].clone();
-            actual_subdag.sort();
+            let actual_subdag = actual_unscored_subdags[idx].clone();
             assert_eq!(expected_subdag, actual_subdag);
         }
 

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -143,7 +143,7 @@ impl LeaderSchedule {
 
         reputation_scores.update_metrics(self.context.clone());
 
-        let last_commit_index = unscored_subdags.last().unwrap().commit_index;
+        let last_commit_index = unscored_subdags.last().unwrap().commit_ref.index;
         self.update_leader_swap_table(LeaderSwapTable::new(
             self.context.clone(),
             last_commit_index,
@@ -650,26 +650,19 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let subdag =
-                dag_builder.get_subdag(leader.clone(), last_committed_rounds.clone(), commit_index);
-            for block in subdag.blocks.iter() {
+            let (sub_dag, commit) = dag_builder.get_sub_dag_and_commit(
+                leader.clone(),
+                last_committed_rounds.clone(),
+                commit_index,
+            );
+            for block in sub_dag.blocks.iter() {
                 blocks_to_write.push(block.clone());
                 last_committed_rounds[block.author().value()] =
                     max(block.round(), last_committed_rounds[block.author().value()]);
             }
-            let commit = TrustedCommit::new_for_test(
-                commit_index,
-                CommitDigest::MIN,
-                leader.timestamp_ms(),
-                leader.reference(),
-                subdag
-                    .blocks
-                    .iter()
-                    .map(|block| block.reference())
-                    .collect::<Vec<_>>(),
-            );
+
             expected_commits.push(commit);
-            subdags.push(subdag);
+            subdags.push(sub_dag);
         }
 
         // The CommitInfo for the first 10 commits are written to store. This is the
@@ -677,7 +670,7 @@ mod tests {
         let commit_range = (1..11).into();
         let reputation_scores = ReputationScores::new(commit_range, vec![4, 1, 1, 3]);
         let committed_rounds = vec![9, 9, 10, 9];
-        let commit_ref = CommitRef::new(10, CommitDigest::MIN);
+        let commit_ref = expected_commits[9].reference();
         let commit_info = CommitInfo {
             reputation_scores,
             committed_rounds,
@@ -781,24 +774,16 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let subdag =
-                dag_builder.get_subdag(leader.clone(), last_committed_rounds.clone(), commit_index);
+            let (subdag, commit) = dag_builder.get_sub_dag_and_commit(
+                leader.clone(),
+                last_committed_rounds.clone(),
+                commit_index,
+            );
             for block in subdag.blocks.iter() {
                 blocks_to_write.push(block.clone());
                 last_committed_rounds[block.author().value()] =
                     max(block.round(), last_committed_rounds[block.author().value()]);
             }
-            let commit = TrustedCommit::new_for_test(
-                commit_index,
-                CommitDigest::MIN,
-                leader.timestamp_ms(),
-                leader.reference(),
-                subdag
-                    .blocks
-                    .iter()
-                    .map(|block| block.reference())
-                    .collect::<Vec<_>>(),
-            );
             expected_commits.push(commit);
             expected_unscored_subdags.push(subdag);
         }
@@ -855,7 +840,7 @@ mod tests {
             BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
             vec![],
             context.clock.timestamp_utc_ms(),
-            1,
+            CommitRef::new(1, CommitDigest::MIN),
         )];
         dag_state
             .write()
@@ -952,7 +937,7 @@ mod tests {
             leader_ref,
             blocks,
             context.clock.timestamp_utc_ms(),
-            commit_index,
+            last_commit.reference(),
         )];
 
         let mut dag_state_write = dag_state.write();

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -167,11 +167,11 @@ impl UnscoredSubdag {
                     subdag.blocks.iter()
                 } else {
                     let previous_subdag = &subdags[subdag_index - 1];
-                    let expected_next_subdag_index = previous_subdag.commit_index + 1;
+                    let expected_next_subdag_index = previous_subdag.commit_ref.index + 1;
                     assert_eq!(
-                        subdag.commit_index, expected_next_subdag_index,
+                        subdag.commit_ref.index, expected_next_subdag_index,
                         "Non-contiguous commit index (expected: {}, found: {})",
-                        expected_next_subdag_index, subdag.commit_index
+                        expected_next_subdag_index, subdag.commit_ref.index
                     );
                     subdag.blocks.iter()
                 }
@@ -181,7 +181,7 @@ impl UnscoredSubdag {
 
         // Guaranteed to have a contiguous list of commit indices
         let commit_range = CommitRange::new(
-            subdags.first().unwrap().commit_index..subdags.last().unwrap().commit_index + 1,
+            subdags.first().unwrap().commit_ref.index..subdags.last().unwrap().commit_ref.index + 1,
         );
 
         assert!(
@@ -313,6 +313,7 @@ mod tests {
     use std::cmp::max;
 
     use super::*;
+    use crate::commit::{CommitDigest, CommitRef};
     use crate::{leader_scoring_strategy::VoteScoringStrategy, test_dag_builder::DagBuilder};
 
     #[tokio::test]
@@ -396,8 +397,11 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let subdag =
-                dag_builder.get_subdag(leader, last_committed_rounds.clone(), commit_index);
+            let (subdag, _commit) = dag_builder.get_sub_dag_and_commit(
+                leader,
+                last_committed_rounds.clone(),
+                commit_index,
+            );
             for block in subdag.blocks.iter() {
                 last_committed_rounds[block.author().value()] =
                     max(block.round(), last_committed_rounds[block.author().value()]);
@@ -436,7 +440,7 @@ mod tests {
             BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
             blocks,
             context.clock.timestamp_utc_ms(),
-            1,
+            CommitRef::new(1, CommitDigest::MIN),
         )];
         let scoring_strategy = VoteScoringStrategy {};
         let mut calculator =
@@ -480,8 +484,11 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let subdag =
-                dag_builder.get_subdag(leader, last_committed_rounds.clone(), commit_index);
+            let (subdag, _commit) = dag_builder.get_sub_dag_and_commit(
+                leader,
+                last_committed_rounds.clone(),
+                commit_index,
+            );
             tracing::info!("{subdag:?}");
             for block in subdag.blocks.iter() {
                 last_committed_rounds[block.author().value()] =

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -356,8 +356,11 @@ mod tests {
         let mut last_committed_rounds = vec![0; 4];
         for (idx, leader) in leaders.into_iter().enumerate() {
             let commit_index = idx as u32 + 1;
-            let subdag =
-                dag_builder.get_subdag(leader, last_committed_rounds.clone(), commit_index);
+            let (subdag, _commit) = dag_builder.get_sub_dag_and_commit(
+                leader,
+                last_committed_rounds.clone(),
+                commit_index,
+            );
             for block in subdag.blocks.iter() {
                 last_committed_rounds[block.author().value()] =
                     max(block.round(), last_committed_rounds[block.author().value()]);

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -40,5 +40,5 @@ mod test_dag_parser;
 
 pub use authority_node::ConsensusAuthority;
 pub use block::{BlockAPI, Round};
-pub use commit::{CommitConsumer, CommitIndex, CommittedSubDag, CommittedSubDagDigest};
+pub use commit::{CommitConsumer, CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use transaction::{TransactionClient, TransactionVerifier, ValidationError};

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -40,5 +40,5 @@ mod test_dag_parser;
 
 pub use authority_node::ConsensusAuthority;
 pub use block::{BlockAPI, Round};
-pub use commit::{CommitConsumer, CommitIndex, CommittedSubDag};
+pub use commit::{CommitConsumer, CommitIndex, CommittedSubDag, CommittedSubDagDigest};
 pub use transaction::{TransactionClient, TransactionVerifier, ValidationError};

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -94,15 +94,12 @@ impl Linearizer {
             drop(dag_state);
 
             // Collect the sub-dag generated using each of these leaders.
-            let mut sub_dag = self.collect_sub_dag(
+            let sub_dag = self.collect_sub_dag(
                 leader_block,
                 last_commit_index,
                 last_commit_timestamp_ms,
                 last_committed_rounds,
             );
-
-            // [Optional] sort the sub-dag using a deterministic algorithm.
-            sub_dag.sort();
 
             // Summarize CommittedSubDag into Commit.
             let commit = Commit::new(

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -11,6 +11,7 @@ use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
+use crate::commit::{sort_sub_dag_blocks, CommitDigest, TrustedCommit};
 use crate::{
     block::{
         genesis_blocks, BlockAPI, BlockDigest, BlockRef, BlockTimestampMs, Round, Slot, TestBlock,
@@ -124,12 +125,12 @@ impl DagBuilder {
     }
 
     // TODO: reuse logic from Linearizer.
-    pub(crate) fn get_subdag(
+    pub(crate) fn get_sub_dag_and_commit(
         &self,
         leader_block: VerifiedBlock,
         last_committed_rounds: Vec<Round>,
         commit_index: u32,
-    ) -> CommittedSubDag {
+    ) -> (CommittedSubDag, TrustedCommit) {
         let mut to_commit = Vec::new();
         let mut committed = HashSet::new();
 
@@ -158,7 +159,28 @@ impl DagBuilder {
                 assert!(committed.insert(ancestor.reference()));
             }
         }
-        CommittedSubDag::new(leader_block_ref, to_commit, timestamp_ms, commit_index)
+
+        sort_sub_dag_blocks(&mut to_commit);
+
+        let commit = TrustedCommit::new_for_test(
+            commit_index,
+            CommitDigest::MIN,
+            timestamp_ms,
+            leader_block_ref,
+            to_commit
+                .iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        );
+
+        let sub_dag = CommittedSubDag::new(
+            leader_block_ref,
+            to_commit,
+            timestamp_ms,
+            commit.reference(),
+        );
+
+        (sub_dag, commit)
     }
 
     pub(crate) fn leader_blocks(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -435,7 +435,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 &self.last_consensus_stats,
                 &self.checkpoint_service,
                 self.cache_reader.as_ref(),
-                &ConsensusCommitInfo::new(&consensus_output),
+                &ConsensusCommitInfo::new(self.epoch_store.protocol_config(), &consensus_output),
                 &self.metrics,
             )
             .await
@@ -782,11 +782,11 @@ pub struct ConsensusCommitInfo {
 }
 
 impl ConsensusCommitInfo {
-    fn new(consensus_output: &impl ConsensusOutputAPI) -> Self {
+    fn new(protocol_config: &ProtocolConfig, consensus_output: &impl ConsensusOutputAPI) -> Self {
         Self {
             round: consensus_output.leader_round(),
             timestamp: consensus_output.commit_timestamp_ms(),
-            consensus_commit_digest: consensus_output.consensus_digest(),
+            consensus_commit_digest: consensus_output.consensus_digest(protocol_config),
 
             #[cfg(any(test, feature = "test-utils"))]
             skip_consensus_commit_prologue_in_test: false,

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::fmt::Display;
 
-use consensus_core::{BlockAPI, CommittedSubDagDigest};
+use consensus_core::{BlockAPI, CommitDigest};
 use fastcrypto::hash::Hash;
 use narwhal_types::{BatchAPI, CertificateAPI, ConsensusOutputDigest, HeaderAPI};
 use sui_protocol_config::ProtocolConfig;
@@ -132,7 +132,7 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
     }
 
     fn commit_sub_dag_index(&self) -> u64 {
-        self.commit_index.into()
+        self.commit_ref.index.into()
     }
 
     fn transactions(&self) -> ConsensusOutputTransactions {
@@ -165,10 +165,10 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
 
     fn consensus_digest(&self, protocol_config: &ProtocolConfig) -> ConsensusCommitDigest {
         if protocol_config.mysticeti_use_committed_subdag_digest() {
-            // We port CommittedSubDagDigest, a consensus space object, into ConsensusCommitDigest, a sui-core space object.
+            // We port CommitDigest, a consensus space object, into ConsensusCommitDigest, a sui-core space object.
             // We assume they always have the same format.
-            static_assertions::assert_eq_size!(ConsensusCommitDigest, CommittedSubDagDigest);
-            ConsensusCommitDigest::new(self.digest.into_inner())
+            static_assertions::assert_eq_size!(ConsensusCommitDigest, CommitDigest);
+            ConsensusCommitDigest::new(self.commit_ref.digest.into_inner())
         } else {
             ConsensusCommitDigest::default()
         }

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::fmt::Display;
 
-use consensus_core::BlockAPI;
+use consensus_core::{BlockAPI, CommittedSubDagDigest};
 use fastcrypto::hash::Hash;
 use narwhal_types::{BatchAPI, CertificateAPI, ConsensusOutputDigest, HeaderAPI};
 use sui_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
@@ -163,7 +163,9 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
     }
 
     fn consensus_digest(&self) -> ConsensusCommitDigest {
-        // TODO(mysticeti): implement consensus output digest.
-        ConsensusCommitDigest::default()
+        // We port CommittedSubDagDigest, a consensus space object, into ConsensusCommitDigest, a sui-core space object.
+        // We assume they always have the same format.
+        static_assertions::assert_eq_size!(ConsensusCommitDigest, CommittedSubDagDigest);
+        ConsensusCommitDigest::new(self.digest.into_inner())
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1387,6 +1387,7 @@
                 "loaded_child_objects_fixed": true,
                 "missing_type_is_compatibility_error": true,
                 "mysticeti_leader_scoring_and_schedule": false,
+                "mysticeti_use_committed_subdag_digest": false,
                 "narwhal_certificate_v2": false,
                 "narwhal_new_leader_election_schedule": false,
                 "narwhal_versioned_metadata": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -442,6 +442,12 @@ struct FeatureFlags {
     // Resolve Move abort locations to the package id instead of the runtime module ID.
     #[serde(skip_serializing_if = "is_false")]
     resolve_abort_locations_to_package_id: bool,
+
+    // Enables the use of the Mysticeti committed sub dag digest to the `ConsensusCommitInfo` in checkpoints.
+    // When disabled the default digest is used instead. It's important to have this guarded behind
+    // a flag as it will lead to checkpoint forks.
+    #[serde(skip_serializing_if = "is_false")]
+    mysticeti_use_committed_subdag_digest: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1330,6 +1336,10 @@ impl ProtocolConfig {
 
     pub fn resolve_abort_locations_to_package_id(&self) -> bool {
         self.feature_flags.resolve_abort_locations_to_package_id
+    }
+
+    pub fn mysticeti_use_committed_subdag_digest(&self) -> bool {
+        self.feature_flags.mysticeti_use_committed_subdag_digest
     }
 }
 


### PR DESCRIPTION
## Description 

Currently the default digest is being used on the mysticeti committed subdag making the fork detection in checkpoints weaker as included in the `ConsensusCommitInfo`. This PR is calculating the committed sub dag digest and enabling it behind a feature flag. It has to be noted that the reputation scores are not included in the sub dag digest as during crash recovery we don't restore the actual scores for every committed sub dag, but only restoring the last ones and sent as part of the last committed sub dag. 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
