### PR TITLE
indexer fix: only start objects snapshot backfill mode when synced

### DIFF
--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -29,7 +29,8 @@ pub async fn start_tx_checkpoint_commit_task<S>(
     commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
     cancel: CancellationToken,
-) where
+) -> IndexerResult<()>
+where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
     use futures::StreamExt;
@@ -43,7 +44,17 @@ pub async fn start_tx_checkpoint_commit_task<S>(
 
     let mut stream = mysten_metrics::metered_channel::ReceiverStream::new(tx_indexing_receiver)
         .ready_chunks(checkpoint_commit_batch_size);
+
     let mut object_snapshot_backfill_mode = true;
+    let latest_object_snapshot_seq = state
+        .get_latest_object_snapshot_checkpoint_sequence_number()
+        .await?;
+    let latest_cp_seq = state.get_latest_checkpoint_sequence_number().await?;
+    if latest_object_snapshot_seq != latest_cp_seq {
+        info!("Flipping object_snapshot_backfill_mode to false because objects_snapshot is behind already!");
+        object_snapshot_backfill_mode = false;
+    }
+
     let mut unprocessed = HashMap::new();
     let mut batch = vec![];
 
@@ -103,9 +114,11 @@ pub async fn start_tx_checkpoint_commit_task<S>(
         // this is a one-way flip in case indexer falls behind again, so that the objects snapshot
         // table will not be populated by both committer and async snapshot processor at the same time.
         if latest_committed_cp + OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG > latest_fn_cp {
+            info!("Flipping object_snapshot_backfill_mode to false because objects_snapshot is close to up-to-date.");
             object_snapshot_backfill_mode = false;
         }
     }
+    Ok(())
 }
 
 // Unwrap: Caller needs to make sure indexed_checkpoint_batch is not empty

--- a/crates/sui-indexer/src/handlers/objects_snapshot_processor.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_processor.rs
@@ -99,6 +99,11 @@ where
             .get_latest_object_snapshot_checkpoint_sequence_number()
             .await?
             .unwrap_or_default();
+        let latest_indexer_cp = self
+            .store
+            .get_latest_checkpoint_sequence_number()
+            .await?
+            .unwrap_or_default();
         // make sure cp 0 is handled
         let mut start_cp = if latest_snapshot_cp == 0 {
             0
@@ -113,23 +118,27 @@ where
         // While the below is true, we are in backfill mode, and so `ObjectsSnapshotProcessor` will
         // no-op. Once we exit the loop, this task will then be responsible for updating the
         // `objects_snapshot` table.
-        while latest_fn_cp > start_cp + self.config.snapshot_max_lag as u64 {
-            tokio::select! {
-                _ = self.cancel.cancelled() => {
-                    info!("Shutdown signal received, terminating object snapshot processor");
-                    return Ok(());
-                }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(self.config.sleep_duration)) => {
-                    latest_fn_cp = self.client.get_latest_checkpoint().await?.sequence_number;
-                    start_cp = self
-                        .store
-                        .get_latest_object_snapshot_checkpoint_sequence_number()
-                        .await?
-                        .unwrap_or_default();
+        if latest_snapshot_cp == latest_indexer_cp {
+            while latest_fn_cp > start_cp + self.config.snapshot_max_lag as u64 {
+                tokio::select! {
+                    _ = self.cancel.cancelled() => {
+                        info!("Shutdown signal received, terminating object snapshot processor");
+                        return Ok(());
+                    }
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(self.config.sleep_duration)) => {
+                        info!("Objects snapshot is in backfill mode, objects snapshot processor is sleeping for {} seconds", self.config.sleep_duration);
+                        latest_fn_cp = self.client.get_latest_checkpoint().await?.sequence_number;
+                        start_cp = self
+                            .store
+                            .get_latest_object_snapshot_checkpoint_sequence_number()
+                            .await?
+                            .unwrap_or_default();
+                    }
                 }
             }
         }
 
+        info!("Objects snapshot processor starts updating objects_snapshot periodically...");
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => {
@@ -144,6 +153,7 @@ where
                         .unwrap_or_default();
 
                     if latest_cp > start_cp + self.config.snapshot_max_lag as u64 {
+                        info!("Objects snapshot processor is updating objects snapshot table from {} to {}", start_cp, start_cp + snapshot_window);
                         self.store
                             .update_objects_snapshot(start_cp, start_cp + snapshot_window)
                             .await?;


### PR DESCRIPTION
## Description 

objects snapshot backfill mode was introduced to speed backfill speed, following the idea that populating `objects` and `objects_snapshot` while backfilling is faster than running the periodical updating query.

however one assumption of doing this is that, `objects` and `objects_snapshot` should always be in sync. this is is not true when `objects_snapshot` was behind already.

the consequence is that, the objects_snspshot backfill mode ingestion will skip data in the middle and only populate the latest object info.

this pr is to fix that by limit backfill mode to be triggered only when `objects_snapshot` table is in sync.

## Test plan 

1. local run DB to backfill
2. delete some recent rows from `objects_snapshot` to make it behind
3. restart the indexer writer to make sure that it will not trigger the backfill mode


```
INFO sui_indexer::handlers::committer: Flipping object_snapshot_backfill_mode to false because objects_snapshot is behind already!

INFO sui_indexer::handlers::objects_snapshot_processor: Objects snapshot processor starts updating objects_snapshot periodically...

INFO sui_indexer::handlers::objects_snapshot_processor: Objects snapshot processor is updating objects snapshot table from 6001 to 6601
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
