### PR TITLE
[move-ide] Dummy function no longer shows on-display info

### DIFF
--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -83,6 +83,7 @@ impl FilterContext for Context<'_> {
 
 const UNIT_TEST_MODULE_NAME: Symbol = symbol!("unit_test");
 const STDLIB_ADDRESS_NAME: Symbol = symbol!("std");
+pub const UNIT_TEST_POISON_FUN_NAME: Symbol = symbol!("unit_test_poison");
 
 // This filters out all test, and test-only annotated module member from `prog` if the `test` flag
 // in `compilation_env` is not set. If the test flag is set, no filtering is performed, and instead

--- a/external-crates/move/crates/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/crates/move-symbol-pool/src/lib.rs
@@ -47,6 +47,7 @@ static_symbols!(
     "_",
     "init",
     "unit_test",
+    "unit_test_poison",
     "legacy",
     "2024",
     "alpha",


### PR DESCRIPTION
## Description 

This PR prevents on-hover info from being displayed by the IDE for a dummy function that does not exist in source as it's auto-inserted by the compiler. This is what was happening before:
![image](https://github.com/MystenLabs/sui/assets/1724397/d760290a-a038-4c8f-af20-96f10509fe74)


## Test plan 

Verified that on-hover info is no longer displayed
