### PR TITLE
[Bridge] consolidate key reading functions to `read_key`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12088,6 +12088,7 @@ dependencies = [
  "sui-config",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
+ "sui-keys",
  "sui-sdk",
  "sui-test-transaction-builder",
  "sui-types",

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -25,6 +25,7 @@ rocksdb.workspace = true
 typed-store.workspace = true
 mysten-metrics.workspace = true
 sui-sdk.workspace = true
+sui-keys.workspace = true
 sui-config.workspace = true
 clap.workspace = true
 tracing.workspace = true

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -781,7 +781,7 @@ pub(crate) async fn start_bridge_cluster(
         let config = BridgeNodeConfig {
             server_listen_port: *server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
-            bridge_authority_key_path_base64_raw: authority_key_path,
+            bridge_authority_key_path: authority_key_path,
             approved_governance_actions,
             run_client: true,
             db_path: Some(db_path),
@@ -795,7 +795,7 @@ pub(crate) async fn start_bridge_cluster(
             sui: SuiConfig {
                 sui_rpc_url: test_cluster.fullnode_handle.rpc_url.clone(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
-                bridge_client_key_path_base64_sui_key: None,
+                bridge_client_key_path: None,
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: None,
             },

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -352,11 +352,11 @@ mod tests {
         let config = BridgeNodeConfig {
             server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
-            bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
+            bridge_authority_key_path: tmp_dir.join(authority_key_path),
             sui: SuiConfig {
                 sui_rpc_url: bridge_test_cluster.sui_rpc_url(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
-                bridge_client_key_path_base64_sui_key: None,
+                bridge_client_key_path: None,
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: None,
             },
@@ -406,11 +406,11 @@ mod tests {
         let config = BridgeNodeConfig {
             server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
-            bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
+            bridge_authority_key_path: tmp_dir.join(authority_key_path),
             sui: SuiConfig {
                 sui_rpc_url: bridge_test_cluster.sui_rpc_url(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
-                bridge_client_key_path_base64_sui_key: None,
+                bridge_client_key_path: None,
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: Some(EventID {
                     tx_digest: TransactionDigest::random(),
@@ -474,11 +474,11 @@ mod tests {
         let config = BridgeNodeConfig {
             server_listen_port,
             metrics_port: get_available_port("127.0.0.1"),
-            bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
+            bridge_authority_key_path: tmp_dir.join(authority_key_path),
             sui: SuiConfig {
                 sui_rpc_url: bridge_test_cluster.sui_rpc_url(),
                 sui_bridge_chain_id: BridgeChainId::SuiCustom as u8,
-                bridge_client_key_path_base64_sui_key: Some(tmp_dir.join(client_key_path)),
+                bridge_client_key_path: Some(tmp_dir.join(client_key_path)),
                 bridge_client_gas_object: Some(gas_obj),
                 sui_bridge_module_last_processed_event_id_override: Some(EventID {
                     tx_digest: TransactionDigest::random(),

--- a/crates/sui-bridge/src/tools/mod.rs
+++ b/crates/sui-bridge/src/tools/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::abi::{eth_sui_bridge, EthSuiBridge};
-use crate::config::read_key;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::error::BridgeResult;
 use crate::sui_client::SuiBridgeClient;
@@ -28,6 +27,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use sui_config::Config;
 use sui_json_rpc_types::SuiObjectDataOptions;
+use sui_keys::keypair_file::read_key;
 use sui_sdk::SuiClientBuilder;
 use sui_types::base_types::SuiAddress;
 use sui_types::base_types::{ObjectID, ObjectRef};
@@ -55,7 +55,7 @@ pub enum BridgeValidatorCommand {
     #[clap(name = "create-bridge-client-key")]
     CreateBridgeClientKey {
         path: PathBuf,
-        #[clap(name = "use-ecdsa", long)]
+        #[clap(name = "use-ecdsa", long, default_value = "false")]
         use_ecdsa: bool,
     },
     #[clap(name = "create-bridge-node-config-template")]

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -88,11 +88,11 @@ pub fn generate_bridge_node_config_and_write_to_file(
     let mut config = BridgeNodeConfig {
         server_listen_port: 9191,
         metrics_port: 9184,
-        bridge_authority_key_path_base64_raw: PathBuf::from("/path/to/your/bridge_authority_key"),
+        bridge_authority_key_path: PathBuf::from("/path/to/your/bridge_authority_key"),
         sui: SuiConfig {
             sui_rpc_url: "your_sui_rpc_url".to_string(),
             sui_bridge_chain_id: BridgeChainId::SuiTestnet as u8,
-            bridge_client_key_path_base64_sui_key: None,
+            bridge_client_key_path: None,
             bridge_client_gas_object: None,
             sui_bridge_module_last_processed_event_id_override: None,
         },
@@ -108,8 +108,7 @@ pub fn generate_bridge_node_config_and_write_to_file(
         db_path: None,
     };
     if run_client {
-        config.sui.bridge_client_key_path_base64_sui_key =
-            Some(PathBuf::from("/path/to/your/bridge_client_key"));
+        config.sui.bridge_client_key_path = Some(PathBuf::from("/path/to/your/bridge_client_key"));
         config.db_path = Some(PathBuf::from("/path/to/your/client_db"));
     }
     config.save(path)

--- a/crates/sui-keys/src/keypair_file.rs
+++ b/crates/sui-keys/src/keypair_file.rs
@@ -1,9 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+
 use anyhow::anyhow;
-use fastcrypto::traits::EncodeDecodeBase64;
-use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair, SuiKeyPair};
+use fastcrypto::encoding::{Encoding, Hex};
+use fastcrypto::{secp256k1::Secp256k1KeyPair, traits::EncodeDecodeBase64};
+use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair, SuiKeyPair, ToFromBytes};
 
 /// Write Base64 encoded `flag || privkey` to file.
 pub fn write_keypair_to_file<P: AsRef<std::path::Path>>(
@@ -49,4 +52,49 @@ pub fn read_network_keypair_from_file<P: AsRef<std::path::Path>>(
     } else {
         Err(anyhow!("Invalid scheme for network keypair"))
     }
+}
+
+/// Read a SuiKeyPair from a file. The content could be any of the following:
+/// - Base64 encoded `flag || privkey` for ECDSA key
+/// - Base64 encoded `privkey` for Raw key
+/// - Bech32 encoded private key prefixed with `suiprivkey`
+/// - Hex encoded `privkey` for Raw key
+/// If `require_secp256k1` is true, it will return an error if the key is not Secp256k1.
+pub fn read_key(path: &PathBuf, require_secp256k1: bool) -> Result<SuiKeyPair, anyhow::Error> {
+    if !path.exists() {
+        return Err(anyhow::anyhow!("Key file not found at path: {:?}", path));
+    }
+    let file_contents = std::fs::read_to_string(path)?;
+    let contents = file_contents.as_str().trim();
+
+    // Try base64 encoded SuiKeyPair `flag || privkey`
+    if let Ok(key) = SuiKeyPair::decode_base64(contents) {
+        if require_secp256k1 && !matches!(key, SuiKeyPair::Secp256k1(_)) {
+            return Err(anyhow!("Key is not Secp256k1"));
+        }
+        return Ok(key);
+    }
+
+    // Try base64 encoded Raw Secp256k1 key `privkey`
+    if let Ok(key) = Secp256k1KeyPair::decode_base64(contents) {
+        return Ok(SuiKeyPair::Secp256k1(key));
+    }
+
+    // Try Bech32 encoded 33-byte `flag || private key` starting with `suiprivkey`A prefix.
+    // This is the format of a private key exported from Sui Wallet or sui.keystore.
+    if let Ok(key) = SuiKeyPair::decode(contents) {
+        if require_secp256k1 && !matches!(key, SuiKeyPair::Secp256k1(_)) {
+            return Err(anyhow!("Key is not Secp256k1"));
+        }
+        return Ok(key);
+    }
+
+    // Try hex encoded Raw key `privkey`
+    if let Ok(bytes) = Hex::decode(contents).map_err(|e| anyhow!("Error decoding hex: {:?}", e)) {
+        if let Ok(key) = Secp256k1KeyPair::from_bytes(&bytes) {
+            return Ok(SuiKeyPair::Secp256k1(key));
+        }
+    }
+
+    Err(anyhow!("Error decoding key from {:?}", path))
 }


### PR DESCRIPTION
## Description 

We have been using `read_bridge_client_key` and `read_bridge_authority_key` to read keys for different purposes which is confusing to say the least. This PR consolidates them to `read_key`

## Test plan 

exiting unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
