### PR TITLE
[bridge] provide raw metadata for BridgeCommitteeRegistration commands

### DIFF
--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use fastcrypto::traits::{KeyPair, ToFromBytes};
+use fastcrypto::traits::ToFromBytes;
 use move_core_types::ident_str;
 use std::{collections::HashMap, str::FromStr};
 use sui_types::bridge::{
@@ -17,7 +17,6 @@ use sui_types::{
 };
 use sui_types::{Identifier, BRIDGE_PACKAGE_ID};
 
-use crate::crypto::BridgeAuthorityKeyPair;
 use crate::{
     error::{BridgeError, BridgeResult},
     types::{BridgeAction, VerifiedCertifiedBridgeAction},
@@ -551,16 +550,17 @@ pub fn build_committee_register_transaction(
     validator_address: SuiAddress,
     gas_object_ref: &ObjectRef,
     bridge_object_arg: ObjectArg,
-    bridge_key: BridgeAuthorityKeyPair,
+    bridge_authority_pub_key_bytes: Vec<u8>,
     bridge_url: &str,
     ref_gas_price: u64,
 ) -> BridgeResult<TransactionData> {
     let mut builder = ProgrammableTransactionBuilder::new();
     let system_state = builder.obj(ObjectArg::SUI_SYSTEM_MUT).unwrap();
     let bridge = builder.obj(bridge_object_arg).unwrap();
-    let pub_key = bridge_key.public().as_bytes().to_vec();
     let bridge_pubkey = builder
-        .input(CallArg::Pure(bcs::to_bytes(&pub_key).unwrap()))
+        .input(CallArg::Pure(
+            bcs::to_bytes(&bridge_authority_pub_key_bytes).unwrap(),
+        ))
         .unwrap();
     let url = builder
         .input(CallArg::Pure(bcs::to_bytes(bridge_url.as_bytes()).unwrap()))

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -40,7 +40,7 @@ use sui_swarm_config::network_config::NetworkConfig;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_swarm_config::node_config_builder::FullnodeConfigBuilder;
 use sui_types::base_types::SuiAddress;
-use sui_types::crypto::{SignatureScheme, SuiKeyPair};
+use sui_types::crypto::{SignatureScheme, SuiKeyPair, ToFromBytes};
 use tracing::info;
 
 #[allow(clippy::large_enum_variant)]
@@ -404,7 +404,7 @@ impl SuiCommand {
                         sui_address,
                         &gas_obj_ref,
                         bridge_arg,
-                        kp,
+                        kp.public().as_bytes().to_vec(),
                         &format!("http://127.0.0.1:{port}"),
                         rgp,
                     )

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -57,8 +57,8 @@ use sui_types::bridge::{get_bridge, TOKEN_ID_BTC, TOKEN_ID_ETH, TOKEN_ID_USDC, T
 use sui_types::bridge::{get_bridge_obj_initial_shared_version, BridgeSummary, BridgeTrait};
 use sui_types::committee::CommitteeTrait;
 use sui_types::committee::{Committee, EpochId};
-use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::SuiKeyPair;
+use sui_types::crypto::{KeypairTraits, ToFromBytes};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::SuiResult;
 use sui_types::governance::MIN_VALIDATOR_JOINING_STAKE_MIST;
@@ -1263,7 +1263,7 @@ impl TestClusterBuilder {
                 validator_address,
                 &gas,
                 bridge_arg,
-                kp.copy(),
+                kp.public().as_bytes().to_vec(),
                 &server_url,
                 ref_gas_price,
             )


### PR DESCRIPTION
## Description 

When validators register their info, most likely they don't have BridgeNodeConfig yet. In this PR we provide the authority key path directly to avoid depending on the config.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
