### PR TITLE
[bridge] extract sui-bridge-cli into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12104,6 +12104,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-bridge-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ethers",
+ "fastcrypto",
+ "move-core-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "shared-crypto",
+ "sui-bridge",
+ "sui-config",
+ "sui-json-rpc-types",
+ "sui-keys",
+ "sui-sdk",
+ "sui-types",
+ "telemetry-subscribers",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "sui-cluster-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ members = [
   "crates/sui-aws-orchestrator",
   "crates/sui-benchmark",
   "crates/sui-bridge",
+  "crates/sui-bridge-cli",
   "crates/sui-cluster-test",
   "crates/sui-common",
   "crates/sui-config",

--- a/crates/sui-bridge-cli/Cargo.toml
+++ b/crates/sui-bridge-cli/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "sui-bridge-cli"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+ethers = "2.0"
+sui-bridge.workspace = true
+sui-sdk.workspace = true
+sui-types.workspace = true
+sui-config.workspace = true
+sui-keys.workspace = true
+sui-json-rpc-types.workspace = true
+shared-crypto.workspace = true
+fastcrypto.workspace = true
+move-core-types.workspace = true
+anyhow.workspace = true
+clap.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+serde_json.workspace = true
+telemetry-subscribers.workspace = true

--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -1,15 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::abi::{eth_sui_bridge, EthSuiBridge};
-use crate::crypto::BridgeAuthorityPublicKeyBytes;
-use crate::error::BridgeResult;
-use crate::sui_client::SuiBridgeClient;
-use crate::types::{
-    AssetPriceUpdateAction, BlocklistCommitteeAction, BlocklistType, EmergencyAction,
-    EmergencyActionType, EvmContractUpgradeAction, LimitUpdateAction,
-};
-use crate::utils::{get_eth_signer_client, EthSigner};
 use anyhow::anyhow;
 use clap::*;
 use ethers::providers::Middleware;
@@ -25,6 +16,16 @@ use shared_crypto::intent::IntentMessage;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use sui_bridge::abi::{eth_sui_bridge, EthSuiBridge};
+use sui_bridge::crypto::BridgeAuthorityPublicKeyBytes;
+use sui_bridge::error::BridgeResult;
+use sui_bridge::sui_client::SuiBridgeClient;
+use sui_bridge::types::BridgeAction;
+use sui_bridge::types::{
+    AssetPriceUpdateAction, BlocklistCommitteeAction, BlocklistType, EmergencyAction,
+    EmergencyActionType, EvmContractUpgradeAction, LimitUpdateAction,
+};
+use sui_bridge::utils::{get_eth_signer_client, EthSigner};
 use sui_config::Config;
 use sui_json_rpc_types::SuiObjectDataOptions;
 use sui_keys::keypair_file::read_key;
@@ -37,8 +38,6 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{ObjectArg, Transaction, TransactionData};
 use sui_types::{TypeTag, BRIDGE_PACKAGE_ID};
 use tracing::info;
-
-use crate::types::BridgeAction;
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]

--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -565,7 +565,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_encode_call_data() {
-        let abi_json = std::fs::read_to_string("abi/tests/mock_sui_bridge_v2.json").unwrap();
+        let abi_json =
+            std::fs::read_to_string("../sui-bridge/abi/tests/mock_sui_bridge_v2.json").unwrap();
         let abi: ethers::abi::Abi = serde_json::from_str(&abi_json).unwrap();
 
         let function_selector = "initializeV2Params(uint256,bool,string)";

--- a/crates/sui-bridge-cli/src/main.rs
+++ b/crates/sui-bridge-cli/src/main.rs
@@ -9,13 +9,13 @@ use sui_bridge::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
 use sui_bridge::eth_transaction_builder::build_eth_transaction;
 use sui_bridge::sui_client::SuiClient;
 use sui_bridge::sui_transaction_builder::build_sui_transaction;
-use sui_bridge::tools::LoadedBridgeCliConfig;
-use sui_bridge::tools::{
-    make_action, select_contract_address, Args, BridgeCliConfig, BridgeValidatorCommand,
-};
 use sui_bridge::utils::{
     generate_bridge_authority_key_and_write_to_file, generate_bridge_client_key_and_write_to_file,
     generate_bridge_node_config_and_write_to_file,
+};
+use sui_bridge_cli::{
+    make_action, select_contract_address, Args, BridgeCliConfig, BridgeValidatorCommand,
+    LoadedBridgeCliConfig,
 };
 use sui_config::Config;
 use sui_sdk::SuiClient as SuiSdkClient;

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -56,7 +56,3 @@ sui-config.workspace = true
 sui-test-transaction-builder.workspace = true
 test-cluster.workspace = true
 hex-literal = "0.3.4"
-
-[[bin]]
-name = "sui-bridge-cli"
-path = "src/tools/cli.rs"

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -476,8 +476,9 @@ async fn wait_for_transfer_action_status(
         }
         if now.elapsed().as_secs() > 30 {
             panic!(
-                "Timeout waiting for token transfer action to be {:?}. chain_id: {chain_id}, nonce: {nonce}",
-                status
+                "Timeout waiting for token transfer action to be {:?}. chain_id: {chain_id}, nonce: {nonce}. Time elapsed: {:?}",
+                status,
+                now.elapsed(),
             );
         }
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -19,7 +19,6 @@ pub mod storage;
 pub mod sui_client;
 pub mod sui_syncer;
 pub mod sui_transaction_builder;
-pub mod tools;
 pub mod types;
 pub mod utils;
 


### PR DESCRIPTION
## Description 

Previously this binary is located in `sui-bridge`, which makes it impossible to install using `cargo install --git`. This PR moves it to its own crate.


## Test plan 

tested locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
