### PR TITLE
[Traffic Control] Fix param injection in no-optionals case

### DIFF
--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -344,6 +344,12 @@ pub fn monitored_reroute(
 
             let params_str = match parsed_value {
                 Value::Array(mut params_vec) => {
+                    // explictly add null for optional arguments that
+                    // are not present in order to ensure client IP
+                    // is last
+                    for _ in 0..(4 - params_vec.len()) {
+                        params_vec.push(Value::Null);
+                    }
                     params_vec.push(Value::String(client_addr.to_string()));
                     serde_json::to_string(&params_vec).map_err(|err| {
                         SuiError::Unknown(format!("Failed to serialize params: {:?}", err))


### PR DESCRIPTION
## Description 

Fixes issue where we inject client IP param in the wrong order when optional arguments to `execute_transaction_block` are not provided. In such a case, when we deserialize the params as a json array, these optional arguments be omitted (rather than included as `null`). Thus, when we inject client IP at the end, and then later defaults are added, the client IP will no longer match its expected position at the end.

The fix explicitly adds the `null` values for non-included arguments then injects IP at the end.

## Test plan 

Was able to repro the original issue with newly added test. Confirmed that test passes with this change.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
