### PR TITLE
[cli] Fix error when `--serialize` flags are used with PTBs

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2641,10 +2641,12 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         opts.serialize_unsigned_transaction,
         opts.serialize_signed_transaction,
     );
-    assert!(
-        !serialize_unsigned_transaction || !serialize_signed_transaction,
-        "Cannot specify both --serialize-unsigned-transaction and --serialize-signed-transaction"
-    );
+
+    if serialize_signed_transaction && serialize_unsigned_transaction {
+        bail!(
+            "Cannot specify both --serialize-unsigned-transaction and --serialize-signed-transaction."
+        );
+    }
     let gas_price = if let Some(gas_price) = gas_price {
         gas_price
     } else {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2641,12 +2641,10 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         opts.serialize_unsigned_transaction,
         opts.serialize_signed_transaction,
     );
-
-    if serialize_signed_transaction && serialize_unsigned_transaction {
-        bail!(
-            "Cannot specify both --serialize-unsigned-transaction and --serialize-signed-transaction."
-        );
-    }
+    ensure!(
+        !serialize_unsigned_transaction || !serialize_signed_transaction,
+        "Cannot specify both flags: --serialize-unsigned-transaction and --serialize-signed-transaction."
+    );
     let gas_price = if let Some(gas_price) = gas_price {
         gas_price
     } else {

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use expect_test::expect;
 use move_package::{lock_file::schema::ManagedPackage, BuildConfig as MoveBuildConfig};
 use serde_json::json;
+use sui::client_ptb::ptb::PTB;
 use sui::key_identity::{get_identity_address, KeyIdentity};
 use sui_sdk::SuiClient;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
@@ -2803,6 +2804,28 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
     }
     .execute(context)
     .await?;
+
+    let ptb_args = vec![
+        "--split-coins".to_string(),
+        "gas".to_string(),
+        "[1000]".to_string(),
+        "--assign".to_string(),
+        "new_coin".to_string(),
+        "--transfer-objects".to_string(),
+        "[new_coin]".to_string(),
+        format!("@{}", address1),
+        "--gas-budget".to_string(),
+        "50000000".to_string(),
+    ];
+    let mut args = ptb_args.clone();
+    args.push("--serialize-signed-transaction".to_string());
+    let ptb = PTB { args };
+    SuiClientCommands::PTB(ptb).execute(context).await.unwrap();
+    let mut args = ptb_args.clone();
+    args.push("--serialize-unsigned-transaction".to_string());
+    let ptb = PTB { args };
+    SuiClientCommands::PTB(ptb).execute(context).await.unwrap();
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

PR #17431 introduced the `dry_run_or_execute_or_serialize` function and messed up the output for the `sui client ptb` when the `serialize-` flags were used. This fixes it and adds a test.

## Test plan 

Added a new test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL:
- [ ] CLI: Fixed a bug when passing the `serialize-*` flag to the `sui client ptb`, which used to return an error after a recent change.
- [ ] Rust SDK: 
