### PR TITLE
[cherry-pick][graphql] Cherry pick available versions PR to 2024.1

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -1,4 +1,4 @@
-processed 25 tasks
+processed 26 tasks
 
 init:
 validator_0: object(0,0)
@@ -269,3 +269,14 @@ task 24 'run'. lines 184-184:
 created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25 'run-graphql'. lines 183-188:
+Response: {
+  "data": {
+    "serviceConfig": {
+      "availableVersions": [
+        "2024.4"
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -270,12 +270,12 @@ created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 25 'run-graphql'. lines 183-188:
+task 25 'run-graphql'. lines 186-191:
 Response: {
   "data": {
     "serviceConfig": {
       "availableVersions": [
-        "2024.4"
+        "2024.1"
       ]
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -182,3 +182,10 @@ module Test::M1 {
 //# run Test::M1::create --args 0 @A --gas-price 1000
 
 //# run Test::M1::create --args 0 @A --gas-price 235
+
+//# run-graphql
+{
+  serviceConfig {
+    availableVersions
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3008,6 +3008,10 @@ type ServiceConfig {
 	"""
 	isEnabled(feature: Feature!): Boolean!
 	"""
+	List the available versions for this GraphQL service.
+	"""
+	availableVersions: [String!]!
+	"""
 	List of all features that are enabled on this GraphQL service.
 	"""
 	enabledFeatures: [Feature!]!

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -416,6 +416,7 @@ type AvailableRange {
 }
 
 type ServiceConfig {
+  availableVersions: [String!]
   enabledFeatures: [Feature!]
   isEnabled(feature: Feature!): Boolean!
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -7,7 +7,6 @@ use async_graphql::*;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt::Display, time::Duration};
 use sui_json_rpc::name_service::NameServiceConfig;
-
 // TODO: calculate proper cost limits
 
 /// These values are set to support TS SDK shim layer queries for json-rpc compatibility.
@@ -89,6 +88,9 @@ pub struct ConnectionConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceConfig {
     #[serde(default)]
+    pub(crate) versions: Versions,
+
+    #[serde(default)]
     pub(crate) limits: Limits,
 
     #[serde(default)]
@@ -105,6 +107,13 @@ pub struct ServiceConfig {
 
     #[serde(default)]
     pub(crate) zklogin: ZkLoginConfig,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct Versions {
+    #[serde(default)]
+    versions: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Copy)]
@@ -254,6 +263,11 @@ impl ServiceConfig {
     /// Check whether `feature` is enabled on this GraphQL service.
     async fn is_enabled(&self, feature: FunctionalGroup) -> bool {
         !self.disabled_features.contains(&feature)
+    }
+
+    /// List the available versions for this GraphQL service.
+    async fn available_versions(&self) -> Vec<String> {
+        self.versions.versions.clone()
     }
 
     /// List of all features that are enabled on this GraphQL service.
@@ -451,6 +465,18 @@ impl BackgroundTasksConfig {
     pub fn test_defaults() -> Self {
         Self {
             watermark_update_ms: 100, // Set to 100ms for testing
+        }
+    }
+}
+
+impl Default for Versions {
+    fn default() -> Self {
+        Self {
+            versions: vec![format!(
+                "{}.{}",
+                env!("CARGO_PKG_VERSION_MAJOR"),
+                env!("CARGO_PKG_VERSION_MINOR")
+            )],
         }
     }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3012,6 +3012,10 @@ type ServiceConfig {
 	"""
 	isEnabled(feature: Feature!): Boolean!
 	"""
+	List the available versions for this GraphQL service.
+	"""
+	availableVersions: [String!]!
+	"""
 	List of all features that are enabled on this GraphQL service.
 	"""
 	enabledFeatures: [Feature!]!


### PR DESCRIPTION
## Description 

Adds available versions query to the service config. Uses the crate's version if no `versions` section exists in the `config.toml` file.

## Test plan 

Existing tests. Manual query on local instance. 

## No versions in config.toml file
```graphql
{
  serviceConfig {
    availableVersions
  }
}
```

```json
{
  "data": {
    "serviceConfig": {
      "availableVersions": [
        "2024.7"
      ]
    }
  }
}
```

## Start server with config toml file
```toml
[limits]
max-query-depth = 15
max-query-nodes = 500
max-output-nodes = 100000
max-query-payload-size = 5000
max-db-query-cost = 20000
default-page-size = 5
max-page-size = 10
request-timeout-ms = 15000
max-type-argument-depth = 16
max-type-argument-width = 32
max-type-nodes = 256
max-move-value-depth = 128

[versions]
versions = ["2024.1", "2024.4", "2024.7"]
```
Same query
```json
{
  "data": {
    "serviceConfig": {
      "availableVersions": [
        "2024.1",
        "2024.4",
        "2024.7"
      ]
    }
  }
}
```
 
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Added the `availableVersions` field to the `serviceConfig` type.
- [ ] CLI: 
- [ ] Rust SDK: