### PR TITLE
[bridge] allow offline signing for committee registration

### DIFF
--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -166,13 +166,21 @@ pub enum SuiValidatorCommand {
         gas_budget: Option<u64>,
     },
     /// Sui native bridge committee member registration
-    BridgeCommitteeRegistration {
-        /// Path to Bridge Authority Key file
+    #[clap(name = "register-bridge-committee")]
+    RegisterBridgeCommittee {
+        /// Path to Bridge Authority Key file.
         #[clap(long)]
         bridge_authority_key_path: PathBuf,
-        /// Bridge authority URL which clients collects action signatures from
+        /// Bridge authority URL which clients collects action signatures from.
         #[clap(long)]
         bridge_authority_url: String,
+        /// If true, only print the unsigned transaction and do not execute it.
+        /// This is useful for offline signing.
+        #[clap(long, default_value = "false")]
+        print_unsigned_transaction_only: bool,
+        /// Must present if `print_unsigned_transaction_only` is true.
+        #[clap(long)]
+        validator_address: Option<SuiAddress>,
     },
 }
 
@@ -192,7 +200,10 @@ pub enum SuiValidatorCommandResponse {
         data: TransactionData,
         serialized_data: String,
     },
-    BridgeCommitteeRegistration(SuiTransactionBlockResponse),
+    RegisterBridgeCommittee {
+        execution_response: Option<SuiTransactionBlockResponse>,
+        serialized_unsigned_transaction: Option<String>,
+    },
 }
 
 fn make_key_files(
@@ -466,18 +477,46 @@ impl SuiValidatorCommand {
                     serialized_data,
                 }
             }
-            SuiValidatorCommand::BridgeCommitteeRegistration {
+            SuiValidatorCommand::RegisterBridgeCommittee {
                 bridge_authority_key_path,
                 bridge_authority_url,
+                print_unsigned_transaction_only,
+                validator_address,
             } => {
                 // Read bridge keypair
                 let ecdsa_keypair = match read_key(&bridge_authority_key_path, true)? {
                     SuiKeyPair::Secp256k1(key) => key,
                     _ => unreachable!("we required secp256k1 key in `read_key`"),
                 };
-
-                let address = context.active_address()?;
-                println!("Starting bridge committee registration for Sui validator: {address}, with bridge public key: {}", ecdsa_keypair.public);
+                let address = if !print_unsigned_transaction_only {
+                    let address = context.active_address()?;
+                    if let Some(validator_address) = validator_address {
+                        if validator_address != address {
+                            bail!(
+                                "`--validator-address` must be the same as the current active address: {}",
+                                address
+                            );
+                        }
+                    }
+                    address
+                } else {
+                    validator_address
+                        .ok_or_else(|| anyhow!("--validator-address must be provided when `print_unsigned_transaction_only` is true"))?
+                };
+                // Make sure the address is a validator
+                let sui_client = context.get_client().await?;
+                let active_validators = sui_client
+                    .governance_api()
+                    .get_latest_sui_system_state()
+                    .await?
+                    .active_validators;
+                if !active_validators
+                    .into_iter()
+                    .any(|s| s.sui_address == address)
+                {
+                    bail!("Address {} is not in the committee", address);
+                }
+                println!("Starting bridge committee registration for Sui validator: {address}, with bridge public key: {} and url: {}", ecdsa_keypair.public, bridge_authority_url);
                 let sui_rpc_url = &context.config.get_active_env().unwrap().rpc;
                 let bridge_client = SuiBridgeClient::new(sui_rpc_url).await?;
                 let bridge = bridge_client
@@ -499,14 +538,24 @@ impl SuiValidatorCommand {
                     gas_price,
                 )
                 .map_err(|e| anyhow!("{e:?}"))?;
-
-                let tx = context.sign_transaction(&tx_data);
-                let response = context.execute_transaction_must_succeed(tx).await;
-                println!(
-                    "Committee registration successful. Transaction digest: {}",
-                    response.digest
-                );
-                SuiValidatorCommandResponse::BridgeCommitteeRegistration(response)
+                if print_unsigned_transaction_only {
+                    let serialized_data = Base64::encode(bcs::to_bytes(&tx_data)?);
+                    SuiValidatorCommandResponse::RegisterBridgeCommittee {
+                        execution_response: None,
+                        serialized_unsigned_transaction: Some(serialized_data),
+                    }
+                } else {
+                    let tx = context.sign_transaction(&tx_data);
+                    let response = context.execute_transaction_must_succeed(tx).await;
+                    println!(
+                        "Committee registration successful. Transaction digest: {}",
+                        response.digest
+                    );
+                    SuiValidatorCommandResponse::RegisterBridgeCommittee {
+                        execution_response: Some(response),
+                        serialized_unsigned_transaction: None,
+                    }
+                }
             }
         });
         ret
@@ -743,8 +792,19 @@ impl Display for SuiValidatorCommandResponse {
                     data, serialized_data
                 )?;
             }
-            SuiValidatorCommandResponse::BridgeCommitteeRegistration(response) => {
-                write!(writer, "{}", response)?;
+            SuiValidatorCommandResponse::RegisterBridgeCommittee {
+                execution_response,
+                serialized_unsigned_transaction,
+            } => {
+                if let Some(response) = execution_response {
+                    write!(writer, "{}", write_transaction_response(response)?)?;
+                } else {
+                    write!(
+                        writer,
+                        "Serializecd transaction for signing: {:?}",
+                        serialized_unsigned_transaction
+                    )?;
+                }
             }
         }
         write!(f, "{}", writer.trim_end_matches('\n'))

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -176,7 +176,7 @@ pub enum SuiValidatorCommand {
         bridge_authority_url: String,
         /// If true, only print the unsigned transaction and do not execute it.
         /// This is useful for offline signing.
-        #[clap(long, default_value = "false")]
+        #[clap(name = "print-only", long, default_value = "false")]
         print_unsigned_transaction_only: bool,
         /// Must present if `print_unsigned_transaction_only` is true.
         #[clap(long)]


### PR DESCRIPTION
## Description 

This PR allows committee registration command to print unsigned transaction bytes for offline signing. This is important to validators who keep their account keys in cold storage. 

Also rename `BridgeCommitteeRegistration` to `RegisterBridgeCommittee` to keep command names consistent


## Test plan 

tested locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
