### PR TITLE
[dapp-kit] fix edge case where the theme style element breaks when used in Next apps

### DIFF
--- a/.changeset/green-penguins-attack.md
+++ b/.changeset/green-penguins-attack.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': patch
+---
+
+Fix broken theme style tag in canary versions of React

--- a/.changeset/green-penguins-attack.md
+++ b/.changeset/green-penguins-attack.md
@@ -2,4 +2,4 @@
 '@mysten/dapp-kit': patch
 ---
 
-Fix broken theme style tag in canary versions of React
+Fix broken theme style tag in canary versions of React when the provider is placed outside of the body tag

--- a/sdk/dapp-kit/src/components/styling/InjectedThemeStyles.tsx
+++ b/sdk/dapp-kit/src/components/styling/InjectedThemeStyles.tsx
@@ -18,6 +18,10 @@ export function InjectedThemeStyles({ theme }: InjectedThemeStylesProps) {
 
 	return (
 		<style
+			// @ts-expect-error The precedence prop hasn't made it to the stable release of React, but we
+			// don't want this to break in frameworks like Next which use the latest canary build.
+			precedence="medium"
+			href="mysten-dapp-kit-theme"
 			dangerouslySetInnerHTML={{
 				__html: themeStyles,
 			}}

--- a/sdk/dapp-kit/src/components/styling/InjectedThemeStyles.tsx
+++ b/sdk/dapp-kit/src/components/styling/InjectedThemeStyles.tsx
@@ -16,11 +16,13 @@ export function InjectedThemeStyles({ theme }: InjectedThemeStylesProps) {
 		? getDynamicThemeStyles(theme)
 		: getStaticThemeStyles(theme);
 
+	console.log(themeStyles);
+
 	return (
 		<style
 			// @ts-expect-error The precedence prop hasn't made it to the stable release of React, but we
 			// don't want this to break in frameworks like Next which use the latest canary build.
-			precedence="medium"
+			precedence="default"
 			href="mysten-dapp-kit-theme"
 			dangerouslySetInnerHTML={{
 				__html: themeStyles,

--- a/sdk/dapp-kit/src/components/styling/InjectedThemeStyles.tsx
+++ b/sdk/dapp-kit/src/components/styling/InjectedThemeStyles.tsx
@@ -16,8 +16,6 @@ export function InjectedThemeStyles({ theme }: InjectedThemeStylesProps) {
 		? getDynamicThemeStyles(theme)
 		: getStaticThemeStyles(theme);
 
-	console.log(themeStyles);
-
 	return (
 		<style
 			// @ts-expect-error The precedence prop hasn't made it to the stable release of React, but we

--- a/sdk/deepbook/package.json
+++ b/sdk/deepbook/package.json
@@ -26,8 +26,6 @@
 		"clean": "rm -rf tsconfig.tsbuildinfo ./dist",
 		"build": "build-package",
 		"prepublishOnly": "pnpm build",
-		"dev": "ts-node src/deepbook_sdk.ts",
-		"bfs": "ts-node src/bfs.ts",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"eslint:check": "eslint --max-warnings=0 .",


### PR DESCRIPTION
## Description 

If you render a `style` tag outside of the `body` element in canary versions of React, you get a breaking error informing you to specify a precedence/href prop. This PR adds those props which should fix https://github.com/MystenLabs/sui/issues/17794

## Test plan 
- Tested manually with a Next 14.2.3 app
- https://sui-typescript-docs-git-wrobertson-dappkitstylefix-mysten-labs.vercel.app/dapp-kit/wallet-components/ConnectButton still works

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
