### PR TITLE
[suins-indexer] fix metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14255,6 +14255,7 @@ dependencies = [
  "futures",
  "move-core-types",
  "mysten-metrics",
+ "mysten-service",
  "notify",
  "object_store 0.7.0",
  "prometheus",

--- a/crates/suins-indexer/Cargo.toml
+++ b/crates/suins-indexer/Cargo.toml
@@ -32,6 +32,7 @@ url.workspace = true
 sui-json-rpc.workspace = true
 dotenvy = "0.15"
 move-core-types.workspace = true
+mysten-service.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use diesel::{dsl::sql, BoolExpressionMethods, Connection, ExpressionMethods, RunQueryDsl};
+use mysten_service::metrics::start_basic_prometheus_server;
 use prometheus::Registry;
 use std::path::PathBuf;
 use sui_data_ingestion_core::{
@@ -124,7 +125,10 @@ async fn main() -> Result<()> {
 
     let (_exit_sender, exit_receiver) = oneshot::channel();
     let progress_store = FileProgressStore::new(PathBuf::from(backfill_progress_file_path));
-    let metrics = DataIngestionMetrics::new(&Registry::new());
+
+    let registry: Registry = mysten_service::metrics::start_basic_prometheus_server();
+    mysten_metrics::init_metrics(&registry);
+    let metrics = DataIngestionMetrics::new(&registry);
     let mut executor = IndexerExecutor::new(progress_store, 1, metrics);
 
     let indexer_setup =

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -104,8 +104,8 @@ impl Worker for SuinsIndexerWorker {
         let checkpoint_seq_number = checkpoint.checkpoint_summary.sequence_number;
         let (updates, removals) = self.indexer.process_checkpoint(&checkpoint);
 
-        /// every 1000 checkpoints, we will print the checkpoint sequence number
-        /// to the console to keep track of progress
+        // every 1000 checkpoints, we will print the checkpoint sequence number
+        // to the console to keep track of progress
         if checkpoint_seq_number % 1000 == 0 {
             info!("Checkpoint sequence number: {}", checkpoint_seq_number);
         }

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
     let (_exit_sender, exit_receiver) = oneshot::channel();
     let progress_store = FileProgressStore::new(PathBuf::from(backfill_progress_file_path));
 
-    let registry: Registry = mysten_service::metrics::start_basic_prometheus_server();
+    let registry: Registry = start_basic_prometheus_server();
     mysten_metrics::init_metrics(&registry);
     let metrics = DataIngestionMetrics::new(&registry);
     let mut executor = IndexerExecutor::new(progress_store, 1, metrics);

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -11,6 +11,7 @@ use sui_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
 };
 use sui_types::full_checkpoint_content::CheckpointData;
+use tracing::info;
 
 use suins_indexer::{
     get_connection_pool,
@@ -103,6 +104,11 @@ impl Worker for SuinsIndexerWorker {
         let checkpoint_seq_number = checkpoint.checkpoint_summary.sequence_number;
         let (updates, removals) = self.indexer.process_checkpoint(&checkpoint);
 
+        /// every 1000 checkpoints, we will print the checkpoint sequence number
+        /// to the console to keep track of progress
+        if checkpoint_seq_number % 1000 == 0 {
+            info!("Checkpoint sequence number: {}", checkpoint_seq_number);
+        }
         self.commit_to_db(&updates, &removals, checkpoint_seq_number)?;
         Ok(())
     }


### PR DESCRIPTION
## Description 

Attempt to fix metrics for suins-indexer by initializing a real registry.

## Test plan 

builds successfully:
```
> c b

...

warning: `sui-core` (lib) generated 2 warnings
   Compiling suins-indexer v0.1.0 (/Users/jkjensen/mysten/sui/crates/suins-indexer)
    Finished dev [unoptimized + debuginfo] target(s) in 2.80s
```

I will deploy testnet after landing this change to validate e2e correctness.

```
> c t
running 5 tests
test process_22279944_checkpoint ... ok
test process_22279365_checkpoint ... ok
test process_22279496_checkpoint ... ok
test process_22280030_checkpoint ... ok
test process_22279187_checkpoint ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests suins-indexer

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
