### PR TITLE
indexer patch: cherry pick of  #17796

### DIFF
--- a/crates/sui-indexer/src/framework/fetcher.rs
+++ b/crates/sui-indexer/src/framework/fetcher.rs
@@ -117,11 +117,6 @@ impl CheckpointFetcher {
                 checkpoint = checkpoint.checkpoint_summary.sequence_number(),
                 "successfully downloaded checkpoint"
             );
-            self.metrics.download_lag_ms.set(
-                chrono::Utc::now().timestamp_millis()
-                    - checkpoint.checkpoint_summary.timestamp_ms as i64,
-            );
-
             let checkpoint_bytes_size = bcs::serialized_size(&checkpoint)?;
             self.metrics
                 .checkpoint_download_bytes_size

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -123,6 +123,13 @@ where
     T: R2D2Connection + 'static,
 {
     async fn process_checkpoint(&self, checkpoint: CheckpointData) -> anyhow::Result<()> {
+        let cp_download_lag = chrono::Utc::now().timestamp_millis()
+            - checkpoint.checkpoint_summary.timestamp_ms as i64;
+        info!(
+            "checkpoint download lag for cp {}: {} ms",
+            checkpoint.checkpoint_summary.sequence_number, cp_download_lag
+        );
+        self.metrics.download_lag_ms.set(cp_download_lag);
         let checkpoint_data = Self::index_checkpoint(
             self.state.clone().into(),
             checkpoint.clone(),


### PR DESCRIPTION
…#17796)

## Description 

I found that the download lag metric was always 0
https://metrics.sui.io/goto/KFEC2VPIg?orgId=1
it turns out that after data ingestion framework migration, the download is no longer in the fetcher.rs, thus we will need to update this metric

## Test plan 

local run and verify in logs
```
sui_indexer::handlers::checkpoint_handler: checkpoint download lag: 242224874
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
