### PR TITLE
[SOD] Reshare objects at same initial_shared_version

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
@@ -14,7 +14,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5859600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 49-53:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: test::m::S {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
@@ -14,7 +14,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5859600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 39-39:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: test::m::S {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -40,7 +40,7 @@ Contents: t3::o3::Obj3 {
 }
 
 task 7 'view-object'. lines 80-82:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.exp
@@ -23,7 +23,7 @@ Error: Transaction Effects Status: The shared object operation is not allowed.
 Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5 'view-object'. lines 81-81:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: test::m::Child {
     id: sui::object::UID {
@@ -39,7 +39,7 @@ Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_fi
 Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) at command Some(0)
 
 task 7 'view-object'. lines 85-85:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: test::m::Child {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.exp
@@ -30,7 +30,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5 'view-object'. lines 24-24:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: test::m1::Pub {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.exp
@@ -14,7 +14,7 @@ mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 33-33:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.exp
@@ -14,7 +14,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 30-30:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: test::m1::Coin {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.exp
@@ -14,7 +14,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 21-21:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.exp
@@ -24,7 +24,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5 'view-object'. lines 30-32:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.exp
@@ -14,7 +14,7 @@ mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 26-26:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/basic_receive.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/basic_receive.exp
@@ -11,7 +11,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 34-34:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: tto::M1::A {
     id: sui::object::UID {
@@ -37,7 +37,7 @@ mutated: object(0,0), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200
 
 task 6 'view-object'. lines 40-40:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: tto::M1::A {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_dof_and_mutate.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_dof_and_mutate.exp
@@ -31,7 +31,7 @@ Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui
 }
 
 task 4 'view-object'. lines 40-40:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: tto::M1::A {
     id: sui::object::UID {
@@ -89,7 +89,7 @@ Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui
 }
 
 task 9 'view-object'. lines 50-50:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: tto::M1::A {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_multiple_times_in_row.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_multiple_times_in_row.exp
@@ -19,7 +19,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 4 'view-object'. lines 43-43:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: tto::M1::A {
     id: sui::object::UID {
@@ -45,7 +45,7 @@ mutated: object(0,1), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200
 
 task 7 'view-object'. lines 50-50:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: tto::M1::A {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/transfer_then_share.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/transfer_then_share.exp
@@ -11,7 +11,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 35-35:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: tto::M1::A {
     id: sui::object::UID {
@@ -37,7 +37,7 @@ mutated: object(0,0), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200
 
 task 6 'view-object'. lines 41-41:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: tto::M1::A {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/add_dynamic_field.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/add_dynamic_field.exp
@@ -14,7 +14,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 36-36:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: a::m::Obj {
     id: sui::object::UID {
@@ -35,7 +35,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 6 'view-object'. lines 42-42:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: a::m::Obj {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.exp
@@ -14,7 +14,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 43-43:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: a::m::Inner {
     id: sui::object::UID {
@@ -34,7 +34,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 6 'view-object'. lines 49-49:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: a::m::Inner {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.exp
@@ -14,7 +14,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 43-43:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: a::m::Inner {
     id: sui::object::UID {
@@ -34,7 +34,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 6 'view-object'. lines 49-49:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: a::m::Inner {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.exp
@@ -16,7 +16,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 40-42:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -37,7 +37,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 7 'view-object'. lines 47-49:
-Owner: Shared
+Owner: Shared( 6 )
 Version: 6
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.exp
@@ -16,7 +16,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 51-51:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -27,7 +27,7 @@ Contents: t2::o2::Obj2 {
 }
 
 task 5 'view-object'. lines 53-55:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -48,7 +48,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 8 'view-object'. lines 62-64:
-Owner: Shared
+Owner: Shared( 6 )
 Version: 6
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.exp
@@ -16,7 +16,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 103-103:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -27,7 +27,7 @@ Contents: t2::o2::Obj2 {
 }
 
 task 5 'view-object'. lines 105-107:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -79,7 +79,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 16 'view-object'. lines 159-162:
-Owner: Shared
+Owner: Shared( 14 )
 Version: 14
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.exp
@@ -19,7 +19,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 66-66:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -81,7 +81,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 11 'view-object'. lines 86-86:
-Owner: Shared
+Owner: Shared( 6 )
 Version: 6
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -95,7 +95,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 12 'view-object'. lines 88-90:
-Owner: Shared
+Owner: Shared( 7 )
 Version: 7
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -126,7 +126,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 17 'view-object'. lines 103-103:
-Owner: Shared
+Owner: Shared( 8 )
 Version: 8
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -140,7 +140,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 18 'view-object'. lines 105-105:
-Owner: Shared
+Owner: Shared( 9 )
 Version: 9
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -154,7 +154,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 19 'view-object'. lines 107-109:
-Owner: Shared
+Owner: Shared( 10 )
 Version: 10
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.exp
@@ -38,7 +38,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 6 'view-object'. lines 72-72:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -52,7 +52,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 7 'view-object'. lines 74-76:
-Owner: Shared
+Owner: Shared( 5 )
 Version: 5
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -98,7 +98,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 16 'view-object'. lines 109-109:
-Owner: Shared
+Owner: Shared( 6 )
 Version: 6
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -112,7 +112,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 17 'view-object'. lines 111-111:
-Owner: Shared
+Owner: Shared( 7 )
 Version: 7
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {
@@ -126,7 +126,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 18 'view-object'. lines 113-115:
-Owner: Shared
+Owner: Shared( 8 )
 Version: 8
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.exp
@@ -16,7 +16,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 41-41:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -27,7 +27,7 @@ Contents: t2::o2::Obj2 {
 }
 
 task 5 'view-object'. lines 43-45:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -48,7 +48,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 8 'view-object'. lines 52-54:
-Owner: Shared
+Owner: Shared( 6 )
 Version: 6
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.exp
@@ -16,7 +16,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 63-63:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -27,7 +27,7 @@ Contents: t2::o2::Obj2 {
 }
 
 task 5 'view-object'. lines 65-67:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -59,7 +59,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 11 'view-object'. lines 89-91:
-Owner: Shared
+Owner: Shared( 9 )
 Version: 9
 Contents: sui::coin::Coin<sui::sui::SUI> {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_v20.exp
@@ -16,7 +16,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 39-39:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/freeze.exp
@@ -11,7 +11,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 29-29:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/re_share_v45.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/re_share_v45.exp
@@ -41,7 +41,7 @@ mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 2204532, non_refundable_storage_fee: 22268
 
 task 7 'view-object'. lines 41-41:
-Owner: Shared( 3 )
+Owner: Shared( 0 )
 Version: 5
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -56,7 +56,7 @@ mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 2204532, non_refundable_storage_fee: 22268
 
 task 9 'view-object'. lines 45-45:
-Owner: Shared( 3 )
+Owner: Shared( 0 )
 Version: 6
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {
@@ -71,7 +71,7 @@ mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 2204532, non_refundable_storage_fee: 22268
 
 task 11 'view-object'. lines 49-49:
-Owner: Shared( 3 )
+Owner: Shared( 0 )
 Version: 7
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/re_share_v45.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/re_share_v45.move
@@ -3,7 +3,7 @@
 
 // tests that shared objects can be re-shared as shared objects
 
-//# init --addresses t1=0x0 t2=0x0
+//# init --addresses t1=0x0 t2=0x0 --protocol-version 45
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/transfer.exp
@@ -11,7 +11,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 28-28:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/shared/wrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/wrap.exp
@@ -11,7 +11,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 32-32:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: t2::o2::Obj2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -19,7 +19,7 @@ mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'view-object'. lines 31-31:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: test::m::S {
     id: sui::object::UID {
@@ -30,7 +30,7 @@ Contents: test::m::S {
 }
 
 task 5 'view-object'. lines 33-33:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: test::m::S2 {
     id: sui::object::UID {
@@ -49,7 +49,7 @@ Error: Transaction Effects Status: The shared object operation is not allowed.
 Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 8 'view-object'. lines 39-39:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: test::m::S {
     id: sui::object::UID {
@@ -60,7 +60,7 @@ Contents: test::m::S {
 }
 
 task 9 'view-object'. lines 41-41:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 5
 Contents: test::m::S2 {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared_v20.exp
@@ -14,7 +14,7 @@ mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'view-object'. lines 22-22:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: test::m::S {
     id: sui::object::UID {
@@ -29,7 +29,7 @@ Error: Transaction Effects Status: Invalid command argument at 0. Immutable obje
 Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidObjectByValue } at command Some(0)
 
 task 5 'view-object'. lines 26-26:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 4
 Contents: test::m::S {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.exp
@@ -49,7 +49,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 10 'view-object'. lines 89-89:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: sui::object::UID {
@@ -66,7 +66,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 12 'view-object'. lines 93-93:
-Owner: Shared
+Owner: Shared( 3 )
 Version: 3
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: sui::object::UID {
@@ -83,7 +83,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 14 'view-object'. lines 97-100:
-Owner: Shared
+Owner: Shared( 4 )
 Version: 4
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: sui::object::UID {
@@ -100,7 +100,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 16 'view-object'. lines 105-105:
-Owner: Shared
+Owner: Shared( 10 )
 Version: 10
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: sui::object::UID {
@@ -112,7 +112,7 @@ Contents: Test_DepDepV1::DepDepM1::Obj {
 }
 
 task 17 'view-object'. lines 107-112:
-Owner: Shared
+Owner: Shared( 10 )
 Version: 10
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: sui::object::UID {

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/new_types.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/new_types.exp
@@ -34,7 +34,7 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 7 'view-object'. lines 78-80:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 2
 Contents: Test_DepV1::DepM1::DepObj {
     id: sui::object::UID {
@@ -50,7 +50,7 @@ mutated: object(0,0), object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 2302344, non_refundable_storage_fee: 23256
 
 task 9 'view-object'. lines 85-88:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 7
 Contents: Test_DepV1::DepM1::DepObj {
     id: sui::object::UID {
@@ -66,7 +66,7 @@ mutated: object(0,0), object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 2302344, non_refundable_storage_fee: 23256
 
 task 11 'view-object'. lines 93-96:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 8
 Contents: Test_DepV1::DepM1::DepObj {
     id: sui::object::UID {
@@ -82,7 +82,7 @@ mutated: object(0,0), object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 2302344, non_refundable_storage_fee: 23256
 
 task 13 'view-object'. lines 101-101:
-Owner: Shared
+Owner: Shared( 2 )
 Version: 9
 Contents: Test_DepV1::DepM1::DepObj {
     id: sui::object::UID {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1397,6 +1397,7 @@
                 "receive_objects": false,
                 "recompute_has_public_transfer_in_execution": false,
                 "reject_mutable_random_on_entry_functions": false,
+                "reshare_at_same_initial_version": false,
                 "scoring_decision_with_validity_cutoff": true,
                 "shared_object_deletion": false,
                 "simple_conservation_checks": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -128,6 +128,7 @@ const MAX_PROTOCOL_VERSION: u64 = 46;
 //             Enable native bridge in devnet
 //             Enable Leader Scoring & Schedule Change for Mysticeti consensus.
 // Version 46: Enable native bridge in testnet
+//             Enable resharing at the same initial shared version.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -431,6 +432,10 @@ struct FeatureFlags {
     // Controls leader scoring & schedule change in Mysticeti consensus.
     #[serde(skip_serializing_if = "is_false")]
     mysticeti_leader_scoring_and_schedule: bool,
+
+    // Enable resharing of shared objects using the same initial shared version
+    #[serde(skip_serializing_if = "is_false")]
+    reshare_at_same_initial_version: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1312,6 +1317,10 @@ impl ProtocolConfig {
     pub fn mysticeti_leader_scoring_and_schedule(&self) -> bool {
         self.feature_flags.mysticeti_leader_scoring_and_schedule
     }
+
+    pub fn reshare_at_same_initial_version(&self) -> bool {
+        self.feature_flags.reshare_at_same_initial_version
+    }
 }
 
 #[cfg(not(msim))]
@@ -2190,6 +2199,9 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.bridge = true;
                     }
+
+                    // Enable resharing at same initial version
+                    cfg.feature_flags.reshare_at_same_initial_version = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_46.snap
@@ -44,6 +44,7 @@ feature_flags:
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
   zklogin_max_epoch_upper_bound_delta: 30
+  reshare_at_same_initial_version: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_46.snap
@@ -47,6 +47,7 @@ feature_flags:
   consensus_choice: SwapEachEpoch
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_46.snap
@@ -51,6 +51,7 @@ feature_flags:
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -554,8 +554,10 @@ impl Display for Owner {
             Self::Immutable => {
                 write!(f, "Immutable")
             }
-            Self::Shared { .. } => {
-                write!(f, "Shared")
+            Self::Shared {
+                initial_shared_version,
+            } => {
+                write!(f, "Shared( {} )", initial_shared_version.value())
             }
         }
     }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -110,8 +110,12 @@ impl<'backing> TemporaryStore<'backing> {
     }
 
     pub fn update_object_version_and_prev_tx(&mut self) {
-        self.execution_results
-            .update_version_and_previous_tx(self.lamport_timestamp, self.tx_digest);
+        self.execution_results.update_version_and_previous_tx(
+            self.lamport_timestamp,
+            self.tx_digest,
+            &self.input_objects,
+            self.protocol_config.reshare_at_same_initial_version(),
+        );
 
         #[cfg(debug_assertions)]
         {

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -93,8 +93,12 @@ impl<'backing> TemporaryStore<'backing> {
     }
 
     pub fn update_object_version_and_prev_tx(&mut self) {
-        self.execution_results
-            .update_version_and_previous_tx(self.lamport_timestamp, self.tx_digest);
+        self.execution_results.update_version_and_previous_tx(
+            self.lamport_timestamp,
+            self.tx_digest,
+            &self.input_objects,
+            false,
+        );
 
         #[cfg(debug_assertions)]
         {

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -111,8 +111,12 @@ impl<'backing> TemporaryStore<'backing> {
     }
 
     pub fn update_object_version_and_prev_tx(&mut self) {
-        self.execution_results
-            .update_version_and_previous_tx(self.lamport_timestamp, self.tx_digest);
+        self.execution_results.update_version_and_previous_tx(
+            self.lamport_timestamp,
+            self.tx_digest,
+            &self.input_objects,
+            false,
+        );
 
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
## Description 

Update the semantics of resharing so it preserves the initial shared version of the shared object.

## Test plan 

Updated display for tests, and made sure that the initial shared version is updated correctly under the new protocol version.

Bottom commit are the actual changes, and the updates to the meaningful tests. The top (fixup) commit are the changes to the rest of the tests to account for the update to the object owner display. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
