### PR TITLE
[bridge] some refactoring for e2e tests

### DIFF
--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -48,6 +48,7 @@ shared-crypto.workspace = true
 backoff.workspace = true
 enum_dispatch.workspace = true
 sui-json-rpc-api.workspace = true
+sui-test-transaction-builder.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -3,7 +3,6 @@
 
 use crate::abi::{eth_sui_bridge, EthBridgeEvent, EthSuiBridge};
 use crate::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
-use crate::e2e_tests::test_utils::publish_coins_return_add_coins_on_sui_action;
 use crate::e2e_tests::test_utils::{get_signatures, BridgeTestClusterBuilder};
 use crate::events::{
     SuiBridgeEvent, SuiToEthTokenBridgeV1, TokenTransferApproved, TokenTransferClaimed,
@@ -11,6 +10,7 @@ use crate::events::{
 use crate::sui_client::SuiBridgeClient;
 use crate::sui_transaction_builder::build_add_tokens_on_sui_transaction;
 use crate::types::{BridgeAction, BridgeActionStatus, SuiToEthBridgeAction};
+use crate::utils::publish_and_register_coins_return_add_coins_on_sui_action;
 use crate::utils::EthSigner;
 use eth_sui_bridge::EthSuiBridgeEvents;
 use ethers::prelude::*;
@@ -184,17 +184,11 @@ async fn test_add_new_coins_on_sui() {
     let token_id = 42;
     let token_price = 10000;
     let sender = bridge_test_cluster.sui_user_address();
-    let tx = bridge_test_cluster
-        .test_transaction_builder_with_sender(sender)
-        .await
-        .publish(Path::new("../../bridge/move/tokens/mock/ka").into())
-        .build();
-    let publish_token_response = bridge_test_cluster.sign_and_execute_transaction(&tx).await;
     info!("Published new token");
-    let action = publish_coins_return_add_coins_on_sui_action(
-        bridge_test_cluster.wallet_mut(),
+    let action = publish_and_register_coins_return_add_coins_on_sui_action(
+        bridge_test_cluster.wallet(),
         bridge_arg,
-        vec![publish_token_response],
+        vec![Path::new("../../bridge/move/tokens/mock/ka").into()],
         vec![token_id],
         vec![token_price],
         1, // seq num

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -5,8 +5,7 @@ use crate::abi::EthBridgeCommittee;
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::events::*;
-use crate::server::APPLICATION_JSON;
-use crate::types::{AddTokensOnSuiAction, BridgeAction};
+use crate::types::BridgeAction;
 use crate::utils::get_eth_signer_client;
 use crate::utils::EthSigner;
 use ethers::types::Address as EthAddress;
@@ -30,15 +29,11 @@ use sui_json_rpc_types::SuiTransactionBlockResponseQuery;
 use sui_json_rpc_types::TransactionFilter;
 use sui_sdk::wallet_context::WalletContext;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::bridge::{
-    BridgeChainId, BRIDGE_MODULE_NAME, BRIDGE_REGISTER_FOREIGN_TOKEN_FUNCTION_NAME,
-};
+use sui_types::bridge::BridgeChainId;
 use sui_types::committee::TOTAL_VOTING_POWER;
 use sui_types::crypto::get_key_pair;
 use sui_types::digests::TransactionDigest;
-use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{ObjectArg, TransactionData};
-use sui_types::BRIDGE_PACKAGE_ID;
 use sui_types::SUI_BRIDGE_OBJECT_ID;
 use tokio::join;
 use tokio::task::JoinHandle;
@@ -369,108 +364,6 @@ impl BridgeTestCluster {
     }
 }
 
-pub async fn publish_coins_return_add_coins_on_sui_action(
-    wallet_context: &mut WalletContext,
-    bridge_arg: ObjectArg,
-    publish_coin_responses: Vec<SuiTransactionBlockResponse>,
-    token_ids: Vec<u8>,
-    token_prices: Vec<u64>,
-    nonce: u64,
-) -> BridgeAction {
-    assert!(token_ids.len() == publish_coin_responses.len());
-    assert!(token_prices.len() == publish_coin_responses.len());
-    let sender = wallet_context.active_address().unwrap();
-    let rgp = wallet_context.get_reference_gas_price().await.unwrap();
-    let mut token_type_names = vec![];
-    for response in publish_coin_responses {
-        let object_changes = response.object_changes.unwrap();
-        let mut tc = None;
-        let mut type_ = None;
-        let mut uc = None;
-        let mut metadata = None;
-        for object_change in &object_changes {
-            if let o @ sui_json_rpc_types::ObjectChange::Created { object_type, .. } = object_change
-            {
-                if object_type.name.as_str().starts_with("TreasuryCap") {
-                    assert!(tc.is_none() && type_.is_none());
-                    tc = Some(o.clone());
-                    type_ = Some(object_type.type_params.first().unwrap().clone());
-                } else if object_type.name.as_str().starts_with("UpgradeCap") {
-                    assert!(uc.is_none());
-                    uc = Some(o.clone());
-                } else if object_type.name.as_str().starts_with("CoinMetadata") {
-                    assert!(metadata.is_none());
-                    metadata = Some(o.clone());
-                }
-            }
-        }
-        let (tc, type_, uc, metadata) =
-            (tc.unwrap(), type_.unwrap(), uc.unwrap(), metadata.unwrap());
-
-        // register with the bridge
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let bridge_arg = builder.obj(bridge_arg).unwrap();
-        let uc_arg = builder
-            .obj(ObjectArg::ImmOrOwnedObject(uc.object_ref()))
-            .unwrap();
-        let tc_arg = builder
-            .obj(ObjectArg::ImmOrOwnedObject(tc.object_ref()))
-            .unwrap();
-        let metadata_arg = builder
-            .obj(ObjectArg::ImmOrOwnedObject(metadata.object_ref()))
-            .unwrap();
-        builder.programmable_move_call(
-            BRIDGE_PACKAGE_ID,
-            BRIDGE_MODULE_NAME.into(),
-            BRIDGE_REGISTER_FOREIGN_TOKEN_FUNCTION_NAME.into(),
-            vec![type_.clone()],
-            vec![bridge_arg, tc_arg, uc_arg, metadata_arg],
-        );
-        let pt = builder.finish();
-        let gas = wallet_context
-            .get_one_gas_object_owned_by_address(sender)
-            .await
-            .unwrap()
-            .unwrap();
-        let tx = TransactionData::new_programmable(sender, vec![gas], pt, 1_000_000_000, rgp);
-        let signed_tx = wallet_context.sign_transaction(&tx);
-        let _ = wallet_context
-            .execute_transaction_must_succeed(signed_tx)
-            .await;
-
-        token_type_names.push(type_);
-    }
-
-    BridgeAction::AddTokensOnSuiAction(AddTokensOnSuiAction {
-        nonce,
-        chain_id: BridgeChainId::SuiCustom,
-        native: false,
-        token_ids,
-        token_type_names,
-        token_prices,
-    })
-}
-
-pub async fn wait_for_server_to_be_up(server_url: String, timeout_sec: u64) -> anyhow::Result<()> {
-    let now = std::time::Instant::now();
-    loop {
-        if let Ok(true) = reqwest::Client::new()
-            .get(server_url.clone())
-            .header(reqwest::header::ACCEPT, APPLICATION_JSON)
-            .send()
-            .await
-            .map(|res| res.status().is_success())
-        {
-            break;
-        }
-        if now.elapsed().as_secs() > timeout_sec {
-            anyhow::bail!("Server is not up and running after {} seconds", timeout_sec);
-        }
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-    }
-    Ok(())
-}
-
 pub async fn get_eth_signer_client_e2e_test_only(
     eth_rpc_url: &str,
 ) -> anyhow::Result<(EthSigner, String)> {
@@ -770,13 +663,6 @@ pub(crate) async fn start_bridge_cluster(
         let authority_key_path = tmp_dir.join("bridge_authority_key");
         let base64_encoded = kp.encode_base64();
         std::fs::write(authority_key_path.clone(), base64_encoded).unwrap();
-
-        let client_sui_address = SuiAddress::from(kp.public());
-        let sender_address = test_cluster.get_address_0();
-        // send some gas to this address
-        test_cluster
-            .transfer_sui_must_exceed(sender_address, client_sui_address, 1000000000)
-            .await;
 
         let config = BridgeNodeConfig {
             server_listen_port: *server_listen_port,

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -191,9 +191,9 @@ mod tests {
     use crate::config::BridgeNodeConfig;
     use crate::config::EthConfig;
     use crate::config::SuiConfig;
-    use crate::e2e_tests::test_utils::wait_for_server_to_be_up;
     use crate::e2e_tests::test_utils::BridgeTestCluster;
     use crate::e2e_tests::test_utils::BridgeTestClusterBuilder;
+    use crate::utils::wait_for_server_to_be_up;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use sui_config::local_ip_utils::get_available_port;
     use sui_types::base_types::SuiAddress;

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -6,6 +6,8 @@ use crate::config::EthConfig;
 use crate::config::SuiConfig;
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
+use crate::server::APPLICATION_JSON;
+use crate::types::{AddTokensOnSuiAction, BridgeAction};
 use anyhow::anyhow;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::middleware::SignerMiddleware;
@@ -15,20 +17,21 @@ use ethers::signers::Wallet;
 use fastcrypto::ed25519::Ed25519KeyPair;
 use fastcrypto::secp256k1::Secp256k1KeyPair;
 use fastcrypto::traits::EncodeDecodeBase64;
+use futures::future::join_all;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use sui_config::Config;
+use sui_json_rpc_types::SuiExecutionStatus;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+use sui_sdk::wallet_context::WalletContext;
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::SuiAddress;
 use sui_types::bridge::BridgeChainId;
+use sui_types::bridge::{BRIDGE_MODULE_NAME, BRIDGE_REGISTER_FOREIGN_TOKEN_FUNCTION_NAME};
 use sui_types::crypto::get_key_pair;
 use sui_types::crypto::SuiKeyPair;
-
-use crate::server::APPLICATION_JSON;
-use crate::types::{AddTokensOnSuiAction, BridgeAction};
-
-use sui_json_rpc_types::SuiTransactionBlockResponse;
-use sui_sdk::wallet_context::WalletContext;
-use sui_types::bridge::{BRIDGE_MODULE_NAME, BRIDGE_REGISTER_FOREIGN_TOKEN_FUNCTION_NAME};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{ObjectArg, TransactionData};
 use sui_types::BRIDGE_PACKAGE_ID;
@@ -125,20 +128,65 @@ pub async fn get_eth_signer_client(url: &str, private_key_hex: &str) -> anyhow::
     Ok(SignerMiddleware::new(provider, wallet))
 }
 
-pub async fn publish_coins_return_add_coins_on_sui_action(
-    wallet_context: &mut WalletContext,
+pub async fn publish_and_register_coins_return_add_coins_on_sui_action(
+    wallet_context: &WalletContext,
     bridge_arg: ObjectArg,
-    publish_coin_responses: Vec<SuiTransactionBlockResponse>,
+    token_packages_dir: Vec<PathBuf>,
     token_ids: Vec<u8>,
     token_prices: Vec<u64>,
     nonce: u64,
 ) -> BridgeAction {
-    assert!(token_ids.len() == publish_coin_responses.len());
-    assert!(token_prices.len() == publish_coin_responses.len());
-    let sender = wallet_context.active_address().unwrap();
-    let rgp = wallet_context.get_reference_gas_price().await.unwrap();
+    assert!(token_ids.len() == token_packages_dir.len());
+    assert!(token_prices.len() == token_packages_dir.len());
+    let sui_client = wallet_context.get_client().await.unwrap();
+    let quorum_driver_api = Arc::new(sui_client.quorum_driver_api().clone());
+    let rgp = sui_client
+        .governance_api()
+        .get_reference_gas_price()
+        .await
+        .unwrap();
+
+    let senders = wallet_context.get_addresses();
+    // We want each sender to deal with one coin
+    assert!(senders.len() >= token_packages_dir.len());
+
+    // publish coin packages
+    let mut publish_tokens_tasks = vec![];
+
+    for (token_package_dir, sender) in token_packages_dir.iter().zip(senders.clone()) {
+        let gas = wallet_context
+            .get_one_gas_object_owned_by_address(sender)
+            .await
+            .unwrap()
+            .unwrap();
+        let tx = TestTransactionBuilder::new(sender, gas, rgp)
+            .publish(token_package_dir.to_path_buf())
+            .build();
+        let tx = wallet_context.sign_transaction(&tx);
+        let api_clone = quorum_driver_api.clone();
+        publish_tokens_tasks.push(tokio::spawn(async move {
+            api_clone.execute_transaction_block(
+                tx,
+                SuiTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_input()
+                    .with_events()
+                    .with_object_changes()
+                    .with_balance_changes(),
+                Some(sui_types::quorum_driver_types::ExecuteTransactionRequestType::WaitForLocalExecution),
+            ).await
+        }));
+    }
+    let publish_coin_responses = join_all(publish_tokens_tasks).await;
+
     let mut token_type_names = vec![];
-    for response in publish_coin_responses {
+    let mut register_tasks = vec![];
+    for (response, sender) in publish_coin_responses.into_iter().zip(senders.clone()) {
+        let response = response.unwrap().unwrap();
+        assert_eq!(
+            response.effects.unwrap().status(),
+            &SuiExecutionStatus::Success
+        );
         let object_changes = response.object_changes.unwrap();
         let mut tc = None;
         let mut type_ = None;
@@ -190,11 +238,23 @@ pub async fn publish_coins_return_add_coins_on_sui_action(
             .unwrap();
         let tx = TransactionData::new_programmable(sender, vec![gas], pt, 1_000_000_000, rgp);
         let signed_tx = wallet_context.sign_transaction(&tx);
-        let _ = wallet_context
-            .execute_transaction_must_succeed(signed_tx)
-            .await;
-
+        let api_clone = quorum_driver_api.clone();
+        register_tasks.push(async move {
+            api_clone
+                .execute_transaction_block(
+                    signed_tx,
+                    SuiTransactionBlockResponseOptions::new().with_effects(),
+                    None,
+                )
+                .await
+        });
         token_type_names.push(type_);
+    }
+    for response in join_all(register_tasks).await {
+        assert_eq!(
+            response.unwrap().effects.unwrap().status(),
+            &SuiExecutionStatus::Success
+        );
     }
 
     BridgeAction::AddTokensOnSuiAction(AddTokensOnSuiAction {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::Future;
 use futures::{future::join_all, StreamExt};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -20,7 +21,7 @@ use sui_bridge::sui_transaction_builder::build_committee_register_transaction;
 use sui_bridge::types::BridgeCommitteeValiditySignInfo;
 use sui_bridge::types::CertifiedBridgeAction;
 use sui_bridge::types::VerifiedCertifiedBridgeAction;
-use sui_bridge::utils::publish_coins_return_add_coins_on_sui_action;
+use sui_bridge::utils::publish_and_register_coins_return_add_coins_on_sui_action;
 use sui_bridge::utils::wait_for_server_to_be_up;
 use sui_config::local_ip_utils::get_available_port;
 use sui_config::node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange};
@@ -136,6 +137,10 @@ impl TestCluster {
 
     pub fn rpc_url(&self) -> &str {
         &self.fullnode_handle.rpc_url
+    }
+
+    pub fn wallet(&mut self) -> &WalletContext {
+        &self.wallet
     }
 
     pub fn wallet_mut(&mut self) -> &mut WalletContext {
@@ -775,7 +780,6 @@ impl TestCluster {
         receiver: SuiAddress,
         amount: u64,
     ) -> ObjectID {
-        // let sender = self.get_address_0();
         let tx = self
             .test_transaction_builder_with_sender(sender)
             .await
@@ -1170,7 +1174,17 @@ impl TestClusterBuilder {
         deploy_tokens: bool,
     ) -> TestCluster {
         let timer = Instant::now();
-        let mut test_cluster = self.build().await;
+        let gas_objects_for_authority_keys = bridge_authority_keys
+            .iter()
+            .map(|k| {
+                let address = SuiAddress::from(k.public());
+                Object::with_id_owner_for_testing(ObjectID::random(), address)
+            })
+            .collect::<Vec<_>>();
+        let mut test_cluster = self
+            .with_objects(gas_objects_for_authority_keys)
+            .build()
+            .await;
         info!(
             "TestCluster build took {:?} secs",
             timer.elapsed().as_secs()
@@ -1182,66 +1196,17 @@ impl TestClusterBuilder {
             test_cluster.swarm.active_validators().count()
         );
 
-        let publish_tokens_tasks = if deploy_tokens {
-            let quorum_driver_api = Arc::new(test_cluster.quorum_driver_api().clone());
-            // Register tokens
-            let token_packages_dir = [
-                Path::new("../../bridge/move/tokens/btc"),
-                Path::new("../../bridge/move/tokens/eth"),
-                Path::new("../../bridge/move/tokens/usdc"),
-                Path::new("../../bridge/move/tokens/usdt"),
-            ];
-
-            // publish coin packages
-            let mut publish_tokens_tasks = vec![];
-            let sender = test_cluster.get_address_0();
-            let gases = test_cluster
-                .wallet
-                .get_gas_objects_owned_by_address(sender, None)
-                .await
-                .unwrap();
-            assert!(gases.len() >= token_packages_dir.len());
-            for (token_package_dir, gas) in token_packages_dir.iter().zip(gases) {
-                let tx = test_cluster
-                    .test_transaction_builder_with_gas_object(sender, gas)
-                    .await
-                    .publish(token_package_dir.to_path_buf())
-                    .build();
-                let tx = test_cluster.wallet.sign_transaction(&tx);
-                let api_clone = quorum_driver_api.clone();
-                publish_tokens_tasks.push(tokio::spawn(async move {
-                    api_clone.execute_transaction_block(
-                        tx,
-                        SuiTransactionBlockResponseOptions::new()
-                            .with_effects()
-                            .with_input()
-                            .with_events()
-                            .with_object_changes()
-                            .with_balance_changes(),
-                        Some(sui_types::quorum_driver_types::ExecuteTransactionRequestType::WaitForLocalExecution),
-                    ).await
-                }));
-            }
-            Some(publish_tokens_tasks)
-        } else {
-            None
-        };
-
+        // Committee registers themselves
         let mut server_ports = vec![];
         let mut tasks = vec![];
-        // use a different sender address than the coin publish to avoid object locks
-        let sender_address = test_cluster.get_address_1();
+        let quorum_driver_api = test_cluster.quorum_driver_api().clone();
         for (node, kp) in test_cluster
             .swarm
             .active_validators()
             .zip(bridge_authority_keys.iter())
         {
             let validator_address = node.config().sui_address();
-            // 1, send some gas to validator
-            test_cluster
-                .transfer_sui_must_exceed(sender_address, validator_address, 1000000000)
-                .await;
-            // 2, create committee registration tx
+            // create committee registration tx
             let gas = test_cluster
                 .wallet
                 .get_one_gas_object_owned_by_address(validator_address)
@@ -1266,64 +1231,36 @@ impl TestClusterBuilder {
                 data,
                 vec![node.config().account_key_pair.keypair()],
             );
-            tasks.push(
-                test_cluster
-                    .sui_client()
-                    .quorum_driver_api()
+            let api_clone = quorum_driver_api.clone();
+            tasks.push(async move {
+                api_clone
                     .execute_transaction_block(
                         tx,
                         SuiTransactionBlockResponseOptions::new().with_effects(),
                         None,
-                    ),
-            );
-        }
-        // The tx may fail if a member tries to register when the committee is already finalized.
-        // In that case, we just need to check the committee members is not empty since once
-        // the committee is finalized, it should not be empty.
-        let responses = join_all(tasks).await;
-        let mut has_failure = false;
-        for response in responses {
-            if response.unwrap().effects.unwrap().status() != &SuiExecutionStatus::Success {
-                has_failure = true;
-            }
-        }
-        if has_failure {
-            let bridge_summary = test_cluster.get_bridge_summary().await.unwrap();
-            assert_ne!(bridge_summary.committee.members.len(), 0);
+                    )
+                    .await
+            });
         }
 
         if deploy_tokens {
             let timer = Instant::now();
-            let publish_tokens_responses = join_all(publish_tokens_tasks.unwrap())
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap()
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap();
-            info!(
-                "Waiting for token publish transactions took {:?} secs",
-                timer.elapsed().as_secs()
-            );
-            for resp in &publish_tokens_responses {
-                assert_eq!(
-                    resp.effects.as_ref().unwrap().status(),
-                    &SuiExecutionStatus::Success
-                );
-            }
             let token_ids = vec![TOKEN_ID_BTC, TOKEN_ID_ETH, TOKEN_ID_USDC, TOKEN_ID_USDT];
             let token_prices = vec![500_000_000u64, 30_000_000u64, 1_000u64, 1_000u64];
-
-            let action = publish_coins_return_add_coins_on_sui_action(
-                test_cluster.wallet_mut(),
+            let action = publish_and_register_coins_return_add_coins_on_sui_action(
+                test_cluster.wallet(),
                 bridge_arg,
-                publish_tokens_responses,
+                vec![
+                    Path::new("../../bridge/move/tokens/btc").into(),
+                    Path::new("../../bridge/move/tokens/eth").into(),
+                    Path::new("../../bridge/move/tokens/usdc").into(),
+                    Path::new("../../bridge/move/tokens/usdt").into(),
+                ],
                 token_ids,
                 token_prices,
                 0,
-            )
-            .await;
+            );
+            let action = action.await;
             info!("register tokens took {:?} secs", timer.elapsed().as_secs());
             let sig_map = bridge_authority_keys
                 .iter()
@@ -1343,6 +1280,8 @@ impl TestClusterBuilder {
             let verifired_action_cert =
                 VerifiedCertifiedBridgeAction::new_from_verified(certified_action);
             let sender_address = test_cluster.get_address_0();
+
+            await_committee_register_tasks(&test_cluster, tasks).await;
 
             // Wait until committee is set up
             test_cluster
@@ -1368,7 +1307,32 @@ impl TestClusterBuilder {
                 &SuiExecutionStatus::Success
             );
             info!("Deploy tokens took {:?} secs", timer.elapsed().as_secs());
+        } else {
+            await_committee_register_tasks(&test_cluster, tasks).await;
         }
+
+        async fn await_committee_register_tasks(
+            test_cluster: &TestCluster,
+            tasks: Vec<
+                impl Future<Output = Result<SuiTransactionBlockResponse, sui_sdk::error::Error>>,
+            >,
+        ) {
+            // The tx may fail if a member tries to register when the committee is already finalized.
+            // In that case, we just need to check the committee members is not empty since once
+            // the committee is finalized, it should not be empty.
+            let responses = join_all(tasks).await;
+            let mut has_failure = false;
+            for response in responses {
+                if response.unwrap().effects.unwrap().status() != &SuiExecutionStatus::Success {
+                    has_failure = true;
+                }
+            }
+            if has_failure {
+                let bridge_summary = test_cluster.get_bridge_summary().await.unwrap();
+                assert_ne!(bridge_summary.committee.members.len(), 0);
+            }
+        }
+
         info!(
             "TestCluster build_with_bridge took {:?} secs",
             timer.elapsed().as_secs()


### PR DESCRIPTION
## Description 
Some refactoring to make tests slightly faster:

1. consolidate `fn publish_coins_return_add_coins_on_sui_action` and `fn wait_for_server_to_be_up` in `crates/sui-bridge/src/e2e_tests/test_utils.rs` and `crates/sui-bridge/src/utils.rs`
2. refactor `publish_coins_return_add_coins_on_sui_action` to `publish_and_register_coins_return_add_coins_on_sui_action` which does token publish and token register.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
