### PR TITLE
[bridge] add ethereum events in Rust

### DIFF
--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -26,79 +26,67 @@ use serde::{Deserialize, Serialize};
 use sui_types::base_types::SuiAddress;
 use sui_types::bridge::BridgeChainId;
 
-// TODO: write a macro to handle variants
+macro_rules! gen_eth_events {
+    ($($contract:ident, $contract_event:ident, $abi_path:literal),* $(,)?) => {
+        $(
+            abigen!(
+                $contract,
+                $abi_path,
+                event_derives(serde::Deserialize, serde::Serialize)
+            );
+        )*
 
-// TODO: Add other events
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum EthBridgeEvent {
-    EthSuiBridgeEvents(EthSuiBridgeEvents),
-}
-
-abigen!(
-    EthSuiBridge,
-    "abi/sui_bridge.json",
-    event_derives(serde::Deserialize, serde::Serialize)
-);
-
-abigen!(
-    EthBridgeCommittee,
-    "abi/bridge_committee.json",
-    event_derives(serde::Deserialize, serde::Serialize)
-);
-
-abigen!(
-    EthBridgeVault,
-    "abi/bridge_vault.json",
-    event_derives(serde::Deserialize, serde::Serialize)
-);
-
-abigen!(
-    EthBridgeLimiter,
-    "abi/bridge_limiter.json",
-    event_derives(serde::Deserialize, serde::Serialize)
-);
-
-abigen!(
-    EthBridgeConfig,
-    "abi/bridge_config.json",
-    event_derives(serde::Deserialize, serde::Serialize)
-);
-
-abigen!(
-    EthCommitteeUpgradeableContract,
-    "abi/bridge_committee_upgradeable.json",
-    event_derives(serde::Deserialize, serde::Serialize)
-);
-
-impl EthBridgeEvent {
-    pub fn try_from_eth_log(log: &EthLog) -> Option<EthBridgeEvent> {
-        let raw_log = RawLog {
-            topics: log.log.topics.clone(),
-            data: log.log.data.to_vec(),
-        };
-
-        if let Ok(decoded) = EthSuiBridgeEvents::decode_log(&raw_log) {
-            return Some(EthBridgeEvent::EthSuiBridgeEvents(decoded));
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        pub enum EthBridgeEvent {
+            $(
+                $contract_event($contract_event),
+            )*
         }
 
-        // TODO: try other variants
-        None
-    }
+        impl EthBridgeEvent {
+            pub fn try_from_eth_log(log: &EthLog) -> Option<EthBridgeEvent> {
+                Self::try_from_log(&log.log)
+            }
 
-    pub fn try_from_log(log: &Log) -> Option<EthBridgeEvent> {
-        let raw_log = RawLog {
-            topics: log.topics.clone(),
-            data: log.data.to_vec(),
-        };
+            pub fn try_from_log(log: &Log) -> Option<EthBridgeEvent> {
+                let raw_log = RawLog {
+                    topics: log.topics.clone(),
+                    data: log.data.to_vec(),
+                };
 
-        if let Ok(decoded) = EthSuiBridgeEvents::decode_log(&raw_log) {
-            return Some(EthBridgeEvent::EthSuiBridgeEvents(decoded));
+                $(
+                    if let Ok(decoded) = $contract_event::decode_log(&raw_log) {
+                        return Some(EthBridgeEvent::$contract_event(decoded));
+                    }
+                )*
+
+                None
+            }
         }
+    };
 
-        // TODO: try other variants
-        None
-    }
+    // For contracts that don't have Events
+    ($($contract:ident, $abi_path:literal),* $(,)?) => {
+        $(
+            abigen!(
+                $contract,
+                $abi_path,
+                event_derives(serde::Deserialize, serde::Serialize)
+            );
+        )*
+    };
 }
+
+#[rustfmt::skip]
+gen_eth_events!(
+    EthSuiBridge, EthSuiBridgeEvents, "abi/sui_bridge.json",
+    EthBridgeCommittee, EthBridgeCommitteeEvents, "abi/bridge_committee.json",
+    EthBridgeLimiter, EthBridgeLimiterEvents, "abi/bridge_limiter.json",
+    EthBridgeConfig, EthBridgeConfigEvents, "abi/bridge_config.json",
+    EthCommitteeUpgradeableContract, EthCommitteeUpgradeableContractEvents, "abi/bridge_committee_upgradeable.json"
+);
+
+gen_eth_events!(EthBridgeVault, "abi/bridge_vault.json");
 
 impl EthBridgeEvent {
     pub fn try_into_bridge_action(
@@ -135,6 +123,28 @@ impl EthBridgeEvent {
                     EthSuiBridgeEvents::InitializedFilter(_event) => None,
                 }
             }
+            EthBridgeEvent::EthBridgeCommitteeEvents(event) => match event {
+                EthBridgeCommitteeEvents::BlocklistUpdatedFilter(_event) => None,
+                EthBridgeCommitteeEvents::InitializedFilter(_event) => None,
+                EthBridgeCommitteeEvents::UpgradedFilter(_event) => None,
+            },
+            EthBridgeEvent::EthBridgeLimiterEvents(event) => match event {
+                EthBridgeLimiterEvents::LimitUpdatedFilter(_event) => None,
+                EthBridgeLimiterEvents::InitializedFilter(_event) => None,
+                EthBridgeLimiterEvents::UpgradedFilter(_event) => None,
+                EthBridgeLimiterEvents::HourlyTransferAmountUpdatedFilter(_event) => None,
+                EthBridgeLimiterEvents::OwnershipTransferredFilter(_event) => None,
+            },
+            EthBridgeEvent::EthBridgeConfigEvents(event) => match event {
+                EthBridgeConfigEvents::InitializedFilter(_event) => None,
+                EthBridgeConfigEvents::UpgradedFilter(_event) => None,
+                EthBridgeConfigEvents::TokenAddedFilter(_event) => None,
+                EthBridgeConfigEvents::TokenPriceUpdatedFilter(_event) => None,
+            },
+            EthBridgeEvent::EthCommitteeUpgradeableContractEvents(event) => match event {
+                EthCommitteeUpgradeableContractEvents::InitializedFilter(_event) => None,
+                EthCommitteeUpgradeableContractEvents::UpgradedFilter(_event) => None,
+            },
         }
     }
 }
@@ -274,7 +284,10 @@ mod tests {
         crypto::BridgeAuthorityPublicKeyBytes,
         types::{BlocklistType, EmergencyActionType},
     };
+    use ethers::types::TxHash;
     use fastcrypto::encoding::{Encoding, Hex};
+    use hex_literal::hex;
+    use std::str::FromStr;
     use sui_types::{bridge::TOKEN_ID_ETH, crypto::ToFromBytes};
 
     #[test]
@@ -425,6 +438,61 @@ mod tests {
                 chain_id: BridgeChainId::EthCustom as u8,
                 payload: Hex::decode("0103636465030101010101010101010101010101010101010101020202020202020202020202020202020202020203030303030303030303030303030303030303030305060703000000003b9aca00000000007735940000000000b2d05e00").unwrap().into(),
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_token_deposit_eth_log_to_sui_bridge_event_regression() -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let tx_hash = TxHash::random();
+        let action = EthLog {
+            block_number: 33,
+            tx_hash,
+            log_index_in_tx: 1,
+            log: Log {
+                address: EthAddress::repeat_byte(1),
+                topics: vec![
+                    hex!("a0f1d54820817ede8517e70a3d0a9197c015471c5360d2119b759f0359858ce6").into(),
+                    hex!("000000000000000000000000000000000000000000000000000000000000000c").into(),
+                    hex!("0000000000000000000000000000000000000000000000000000000000000000").into(),
+                    hex!("0000000000000000000000000000000000000000000000000000000000000002").into(),
+                ],
+                data: ethers::types::Bytes::from(
+                    Hex::decode("0x000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000fa56ea0000000000000000000000000014dc79964da2c08b23698b3d3cc7ca32193d9955000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000203b1eb23133e94d08d0da9303cfd38e7d4f8f6951f235daa62cd64ea5b6d96d77").unwrap(),
+                ),
+                block_hash: None,
+                block_number: None,
+                transaction_hash: Some(tx_hash),
+                transaction_index: Some(ethers::types::U64::from(0)),
+                log_index: Some(ethers::types::U256::from(1)),
+                transaction_log_index: None,
+                log_type: None,
+                removed: Some(false),
+            }
+        };
+        let event = EthBridgeEvent::try_from_eth_log(&action).unwrap();
+        assert_eq!(
+            event,
+            EthBridgeEvent::EthSuiBridgeEvents(EthSuiBridgeEvents::TokensDepositedFilter(
+                TokensDepositedFilter {
+                    source_chain_id: 12,
+                    nonce: 0,
+                    destination_chain_id: 2,
+                    token_id: 2,
+                    sui_adjusted_amount: 4200000000,
+                    sender_address: EthAddress::from_str(
+                        "0x14dc79964da2c08b23698b3d3cc7ca32193d9955"
+                    )
+                    .unwrap(),
+                    recipient_address: ethers::types::Bytes::from(
+                        Hex::decode(
+                            "0x3b1eb23133e94d08d0da9303cfd38e7d4f8f6951f235daa62cd64ea5b6d96d77"
+                        )
+                        .unwrap(),
+                    ),
+                }
+            ))
         );
         Ok(())
     }

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -33,7 +33,7 @@ use sui_types::transaction::{ObjectArg, TransactionData};
 use sui_types::{TypeTag, BRIDGE_PACKAGE_ID};
 use tracing::info;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_bridge_from_eth_to_sui_to_eth() {
     telemetry_subscribers::init_for_testing();
 
@@ -169,7 +169,7 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_add_new_coins_on_sui() {
     telemetry_subscribers::init_for_testing();
     let mut bridge_test_cluster = BridgeTestClusterBuilder::new()
@@ -347,6 +347,7 @@ async fn initiate_bridge_eth_to_sui(
     token_id: u8,
     nonce: u64,
 ) {
+    info!("Depositing Eth to Solidity contract");
     let eth_tx = deposit_native_eth_to_sol_contract(
         eth_signer,
         sui_bridge_contract_address,
@@ -376,7 +377,7 @@ async fn initiate_bridge_eth_to_sui(
     assert_eq!(eth_bridge_event.sui_adjusted_amount, sui_amount);
     assert_eq!(eth_bridge_event.sender_address, eth_address);
     assert_eq!(eth_bridge_event.recipient_address, sui_address.to_vec());
-    info!("Deposited Eth to Sol contract");
+    info!("Deposited Eth to Solidity contract");
 
     wait_for_transfer_action_status(
         sui_bridge_client,

--- a/crates/sui-bridge/src/eth_syncer.rs
+++ b/crates/sui-bridge/src/eth_syncer.rs
@@ -166,12 +166,14 @@ where
                 .send((contract_address, end_block, events))
                 .await
                 .expect("All Eth event channel receivers are closed");
-            tracing::info!(
-                ?contract_address,
-                start_block,
-                end_block,
-                "Observed {len} new Eth events",
-            );
+            if len != 0 {
+                tracing::info!(
+                    ?contract_address,
+                    start_block,
+                    end_block,
+                    "Observed {len} new Eth events",
+                );
+            }
             start_block = end_block + 1;
         }
     }

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -432,7 +432,7 @@ pub mod tests {
         (event, bridge_action)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_bridge_events_conversion() {
         telemetry_subscribers::init_for_testing();
         init_all_struct_tags();

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -336,7 +336,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_starting_bridge_node() {
         telemetry_subscribers::init_for_testing();
         let bridge_test_cluster = setup().await;
@@ -380,7 +380,7 @@ mod tests {
         res.unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_starting_bridge_node_with_client() {
         telemetry_subscribers::init_for_testing();
         let bridge_test_cluster = setup().await;
@@ -439,7 +439,7 @@ mod tests {
         res.unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_starting_bridge_node_with_client_and_separate_client_key() {
         telemetry_subscribers::init_for_testing();
         let bridge_test_cluster = setup().await;

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -774,7 +774,7 @@ mod tests {
     // Test get_action_onchain_status.
     // Use validator secrets to bridge USDC from Ethereum initially.
     // TODO: we need an e2e test for this with published solidity contract and committee with BridgeNodes
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_get_action_onchain_status_for_sui_to_eth_transfer() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -605,7 +605,7 @@ mod tests {
     use sui_types::crypto::ToFromBytes;
     use test_cluster::TestClusterBuilder;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_build_sui_transaction_for_token_transfer() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -681,7 +681,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_build_sui_transaction_for_emergency_op() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -750,7 +750,7 @@ mod tests {
         assert!(!summary.is_frozen);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_build_sui_transaction_for_committee_blocklist() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -838,7 +838,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_build_sui_transaction_for_limit_update() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -907,7 +907,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_build_sui_transaction_for_price_update() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1302,6 +1302,10 @@ impl TestClusterBuilder {
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap();
+            info!(
+                "Waiting for token publish transactions took {:?} secs",
+                timer.elapsed().as_secs()
+            );
             for resp in &publish_tokens_responses {
                 assert_eq!(
                     resp.effects.as_ref().unwrap().status(),


### PR DESCRIPTION
## Description 

Add remaining ethereum events in Rust. Also change some e2e tests to multi-thread, which helps a little bit when i tested locally.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
