### PR TITLE
[pruner] improve smoothing over the epoch

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -20,6 +20,7 @@ use sui_archival::reader::ArchiveReaderBalancer;
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_storage::mutex_table::RwLockTable;
 use sui_types::base_types::SequenceNumber;
+use sui_types::committee::EpochId;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::message_envelope::Message;
@@ -310,17 +311,20 @@ impl AuthorityStorePruner {
         indirect_objects_threshold: usize,
         epoch_duration_ms: u64,
     ) -> anyhow::Result<()> {
-        let mut max_eligible_checkpoint_number = checkpoint_store
+        let (mut max_eligible_checkpoint_number, epoch_id) = checkpoint_store
             .get_highest_executed_checkpoint()?
-            .map(|c| *c.sequence_number())
+            .map(|c| (*c.sequence_number(), c.epoch))
             .unwrap_or_default();
         let pruned_checkpoint_number = perpetual_db.get_highest_pruned_checkpoint()?;
         if config.smooth && config.num_epochs_to_retain > 0 {
             max_eligible_checkpoint_number = Self::smoothed_max_eligible_checkpoint_number(
-                pruned_checkpoint_number,
+                checkpoint_store,
                 max_eligible_checkpoint_number,
+                pruned_checkpoint_number,
+                epoch_id,
                 epoch_duration_ms,
-            );
+                config.num_epochs_to_retain,
+            )?;
         }
         Self::prune_for_eligible_epochs(
             perpetual_db,
@@ -349,9 +353,9 @@ impl AuthorityStorePruner {
     ) -> anyhow::Result<()> {
         let pruned_checkpoint_number =
             checkpoint_store.get_highest_pruned_checkpoint_seq_number()?;
-        let last_executed_checkpoint = checkpoint_store
+        let (last_executed_checkpoint, epoch_id) = checkpoint_store
             .get_highest_executed_checkpoint()?
-            .map(|c| *c.sequence_number())
+            .map(|c| (*c.sequence_number(), c.epoch))
             .unwrap_or_default();
         let latest_archived_checkpoint = archive_readers
             .get_archive_watermark()
@@ -365,11 +369,16 @@ impl AuthorityStorePruner {
             );
         }
         if config.smooth {
-            max_eligible_checkpoint = Self::smoothed_max_eligible_checkpoint_number(
-                pruned_checkpoint_number,
-                max_eligible_checkpoint,
-                epoch_duration_ms,
-            );
+            if let Some(num_epochs_to_retain) = config.num_epochs_to_retain_for_checkpoints {
+                max_eligible_checkpoint = Self::smoothed_max_eligible_checkpoint_number(
+                    checkpoint_store,
+                    max_eligible_checkpoint,
+                    pruned_checkpoint_number,
+                    epoch_id,
+                    epoch_duration_ms,
+                    num_epochs_to_retain,
+                )?;
+            }
         }
         debug!("Max eligible checkpoint {}", max_eligible_checkpoint);
         Self::prune_for_eligible_epochs(
@@ -560,12 +569,23 @@ impl AuthorityStorePruner {
     }
 
     fn smoothed_max_eligible_checkpoint_number(
+        checkpoint_store: &Arc<CheckpointStore>,
+        mut max_eligible_checkpoint: CheckpointSequenceNumber,
         pruned_checkpoint: CheckpointSequenceNumber,
-        max_eligible_checkpoint: CheckpointSequenceNumber,
+        epoch_id: EpochId,
         epoch_duration_ms: u64,
-    ) -> CheckpointSequenceNumber {
+        num_epochs_to_retain: u64,
+    ) -> anyhow::Result<CheckpointSequenceNumber> {
+        if epoch_id < num_epochs_to_retain {
+            return Ok(0);
+        }
+        let last_checkpoint_in_epoch = checkpoint_store
+            .get_epoch_last_checkpoint(epoch_id - num_epochs_to_retain)?
+            .map(|checkpoint| checkpoint.sequence_number)
+            .unwrap_or_default();
+        max_eligible_checkpoint = max_eligible_checkpoint.min(last_checkpoint_in_epoch);
         if max_eligible_checkpoint == 0 {
-            return max_eligible_checkpoint;
+            return Ok(max_eligible_checkpoint);
         }
         let num_intervals = epoch_duration_ms
             .checked_div(Self::pruning_tick_duration_ms(epoch_duration_ms))
@@ -575,7 +595,7 @@ impl AuthorityStorePruner {
             .unwrap_or_default()
             .checked_div(num_intervals)
             .unwrap_or(1);
-        pruned_checkpoint + delta
+        Ok(pruned_checkpoint + delta)
     }
 
     fn setup_pruning(


### PR DESCRIPTION
Improves smoothing effect by at least 2X.
Currently, the smoother roughly processes `(last_executed_checkpoint - last_pruned_checkpoint) / number_of_tick_intervals_in_epoch` per interval tick. 
This method is not ideal because `last_executed_checkpoint != max_eligible_checkpoint_for_pruning`.
For instance, for effects and transactions num_epochs_to_retain is >= 2. 
Thus we can achieve even smoother traffic.
This PR addresses the issue by utilizing the `epoch_last_checkpoint_map` table