### PR TITLE
[suiop] add autocomplete for basic pulumi projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14293,7 +14293,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.2.1"
+version = "0.2.2"
 
 [lib]
 name = "suioplib"
@@ -33,18 +33,18 @@ open = "5.1.2"
 prettytable-rs.workspace = true
 rand.workspace = true
 regex.workspace = true
-reqwest = {workspace = true, features = [
+reqwest = { workspace = true, features = [
   "rustls-tls",
   "json",
-], default-features = false}
+], default-features = false }
 semver.workspace = true
-serde = {workspace = true, features = ["derive"]}
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2 = "0.10.6"
 spinners.workspace = true
 strum.workspace = true
-tokio = {workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 toml_edit.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/crates/suiop-cli/src/cli/lib/autocomplete/mod.rs
+++ b/crates/suiop-cli/src/cli/lib/autocomplete/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::io::ErrorKind;
 
 use inquire::{
@@ -12,14 +15,6 @@ pub struct FilePathCompleter {
 }
 
 impl FilePathCompleter {
-    pub fn new(input: String) -> Self {
-        Self {
-            input,
-            paths: Vec::new(),
-            lcp: String::new(),
-        }
-    }
-
     fn update_input(&mut self, input: &str) -> Result<(), CustomUserError> {
         if input == self.input {
             return Ok(());

--- a/crates/suiop-cli/src/cli/lib/autocomplete/mod.rs
+++ b/crates/suiop-cli/src/cli/lib/autocomplete/mod.rs
@@ -1,0 +1,127 @@
+use std::io::ErrorKind;
+
+use inquire::{
+    autocompletion::{Autocomplete, Replacement},
+    CustomUserError,
+};
+#[derive(Clone, Default)]
+pub struct FilePathCompleter {
+    input: String,
+    paths: Vec<String>,
+    lcp: String,
+}
+
+impl FilePathCompleter {
+    pub fn new(input: String) -> Self {
+        Self {
+            input,
+            paths: Vec::new(),
+            lcp: String::new(),
+        }
+    }
+
+    fn update_input(&mut self, input: &str) -> Result<(), CustomUserError> {
+        if input == self.input {
+            return Ok(());
+        }
+
+        self.input = input.to_owned();
+        self.paths.clear();
+
+        let input_path = std::path::PathBuf::from(input);
+
+        let fallback_parent = input_path
+            .parent()
+            .map(|p| {
+                if p.to_string_lossy() == "" {
+                    std::path::PathBuf::from(".")
+                } else {
+                    p.to_owned()
+                }
+            })
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+        let scan_dir = if input.ends_with('/') {
+            input_path
+        } else {
+            fallback_parent.clone()
+        };
+
+        let entries = match std::fs::read_dir(scan_dir) {
+            Ok(read_dir) => Ok(read_dir),
+            Err(err) if err.kind() == ErrorKind::NotFound => std::fs::read_dir(fallback_parent),
+            Err(err) => Err(err),
+        }?
+        .collect::<Result<Vec<_>, _>>()?;
+
+        let mut idx = 0;
+        let limit = 15;
+
+        while idx < entries.len() && self.paths.len() < limit {
+            let entry = entries.get(idx).unwrap();
+
+            let path = entry.path();
+            let path_str = if path.is_dir() {
+                format!("{}/", path.to_string_lossy())
+            } else {
+                path.to_string_lossy().to_string()
+            };
+
+            if path_str.starts_with(&self.input) && path_str.len() != self.input.len() {
+                self.paths.push(path_str);
+            }
+
+            idx = idx.saturating_add(1);
+        }
+
+        self.lcp = self.longest_common_prefix();
+
+        Ok(())
+    }
+
+    fn longest_common_prefix(&self) -> String {
+        let mut ret: String = String::new();
+
+        let mut sorted = self.paths.clone();
+        sorted.sort();
+        if sorted.is_empty() {
+            return ret;
+        }
+
+        let mut first_word = sorted.first().unwrap().chars();
+        let mut last_word = sorted.last().unwrap().chars();
+
+        loop {
+            match (first_word.next(), last_word.next()) {
+                (Some(c1), Some(c2)) if c1 == c2 => {
+                    ret.push(c1);
+                }
+                _ => return ret,
+            }
+        }
+    }
+}
+
+impl Autocomplete for FilePathCompleter {
+    fn get_suggestions(&mut self, input: &str) -> Result<Vec<String>, CustomUserError> {
+        self.update_input(input)?;
+
+        Ok(self.paths.clone())
+    }
+
+    fn get_completion(
+        &mut self,
+        input: &str,
+        highlighted_suggestion: Option<String>,
+    ) -> Result<Replacement, CustomUserError> {
+        self.update_input(input)?;
+
+        Ok(match highlighted_suggestion {
+            Some(suggestion) => Replacement::Some(suggestion),
+            None => match self.lcp.is_empty() {
+                true => Replacement::None,
+                false => Replacement::Some(self.lcp.clone()),
+            },
+        })
+    }
+}

--- a/crates/suiop-cli/src/cli/lib/mod.rs
+++ b/crates/suiop-cli/src/cli/lib/mod.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod autocomplete;
 mod oauth;
 
+pub use autocomplete::FilePathCompleter;
 pub use oauth::get_oauth_token;
 
 pub fn get_api_server() -> String {


### PR DESCRIPTION
## Description 

Make it easier to identify paths by adding autocomplete.

## Test plan 

```
> suiop p i
2024-05-21T22:23:18.536725Z  INFO suioplib::cli::pulumi::init: raw path: git@github.com:MystenLabs/sui-operations.git
2024-05-21T22:23:18.622178Z  INFO suioplib::cli::pulumi::init: suipop path: /Users/jkjensen/mysten/sui-operations
> project name: yeet
? project subdir (under sui-operations/pulumi/): /Users/jkjensen/mysten/sui-operations/pulumi/ 
  /Users/jkjensen/mysten/sui-operations/pulumi/meta/
  /Users/jkjensen/mysten/sui-operations/pulumi/gcp/
  /Users/jkjensen/mysten/sui-operations/pulumi/components/
  /Users/jkjensen/mysten/sui-operations/pulumi/common/
  /Users/jkjensen/mysten/sui-operations/pulumi/.dockerignore
  /Users/jkjensen/mysten/sui-operations/pulumi/examples/
v /Users/jkjensen/mysten/sui-operations/pulumi/scripts/
[↑↓ to move, tab to autocomplete, enter to submit]
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
