### PR TITLE
[bridge] add examine-key command for sui-bridge-cli

### DIFF
--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -57,6 +57,14 @@ pub enum BridgeValidatorCommand {
         #[clap(name = "use-ecdsa", long, default_value = "false")]
         use_ecdsa: bool,
     },
+    /// Read bridge key from a file and print related information
+    /// If `is-validator-key` is true, the key must be a secp256k1 key
+    #[clap(name = "examine-key")]
+    ExamineKey {
+        path: PathBuf,
+        #[clap(name = "is-validator-key", long)]
+        is_validator_key: bool,
+    },
     #[clap(name = "create-bridge-node-config-template")]
     CreateBridgeNodeConfigTemplate {
         path: PathBuf,

--- a/crates/sui-bridge-cli/src/main.rs
+++ b/crates/sui-bridge-cli/src/main.rs
@@ -10,8 +10,8 @@ use sui_bridge::eth_transaction_builder::build_eth_transaction;
 use sui_bridge::sui_client::SuiClient;
 use sui_bridge::sui_transaction_builder::build_sui_transaction;
 use sui_bridge::utils::{
-    generate_bridge_authority_key_and_write_to_file, generate_bridge_client_key_and_write_to_file,
-    generate_bridge_node_config_and_write_to_file,
+    examine_key, generate_bridge_authority_key_and_write_to_file,
+    generate_bridge_client_key_and_write_to_file, generate_bridge_node_config_and_write_to_file,
 };
 use sui_bridge_cli::{
     make_action, select_contract_address, Args, BridgeCliConfig, BridgeValidatorCommand,
@@ -39,6 +39,12 @@ async fn main() -> anyhow::Result<()> {
         BridgeValidatorCommand::CreateBridgeClientKey { path, use_ecdsa } => {
             generate_bridge_client_key_and_write_to_file(&path, use_ecdsa)?;
             println!("Bridge client key generated at {}", path.display());
+        }
+        BridgeValidatorCommand::ExamineKey {
+            path,
+            is_validator_key,
+        } => {
+            examine_key(&path, is_validator_key)?;
         }
         BridgeValidatorCommand::CreateBridgeNodeConfigTemplate { path, run_client } => {
             generate_bridge_node_config_and_write_to_file(&path, run_client)?;


### PR DESCRIPTION
## Description 

Add examine-key command to read key file and print related info (pubkey, addresses etc).

## Test plan 

tried locally:
```
sui-bridge-cli create-bridge-client-key bar
sui-bridge-cli examine-key bar
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
