### PR TITLE
[pruner] yield on pruning iteration in prune_for_eligible_epochs

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -477,6 +477,8 @@ impl AuthorityStorePruner {
                 checkpoints_to_prune = vec![];
                 checkpoint_content_to_prune = vec![];
                 effects_to_prune = vec![];
+                // yield back to the tokio runtime. Prevent potential halt of other tasks
+                tokio::task::yield_now().await;
             }
         }
 


### PR DESCRIPTION
ensures that pruner periodically yields back to the tokio runtime and doesn't cause a potential halt of other tasks