### PR TITLE
Add print eth address in cli

### DIFF
--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -43,12 +43,12 @@ use tracing::info;
 #[clap(rename_all = "kebab-case")]
 pub struct Args {
     #[clap(subcommand)]
-    pub command: BridgeValidatorCommand,
+    pub command: BridgeCommand,
 }
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
-pub enum BridgeValidatorCommand {
+pub enum BridgeCommand {
     #[clap(name = "create-bridge-validator-key")]
     CreateBridgeValidatorKey { path: PathBuf },
     #[clap(name = "create-bridge-client-key")]
@@ -81,6 +81,14 @@ pub enum BridgeValidatorCommand {
         chain_id: u8,
         #[clap(subcommand)]
         cmd: GovernanceClientCommands,
+    },
+    /// Given proxy address of SuiBridge contract, print other contract addresses
+    #[clap(name = "print-eth-bridge-addresses")]
+    PrintEthBridgeAddresses {
+        #[clap(long = "bridge-proxy")]
+        bridge_proxy: EthAddress,
+        #[clap(long = "eth-rpc-url")]
+        eth_rpc_url: String,
     },
     /// Client to facilitate and execute Bridge actions
     #[clap(name = "client")]


### PR DESCRIPTION
## Description 

A subcommand to print eth contract addresses in sui-bridge-cli. We may end up expanding this subcommand to display onchain config but let's start with this for now.

## Test plan 


```
sui-bridge-cli print-eth-bridge-addresses --bridge-proxy 0x80a22938b7b19a9c6da7c7dd3ba674b912198018 --eth-rpc-url https://ethereum-sepolia-rpc.publicnode.com
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
