### PR TITLE
Soft Bundle authority API implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12316,6 +12316,7 @@ dependencies = [
  "narwhal-test-utils",
  "narwhal-types",
  "narwhal-worker",
+ "nonempty",
  "num-bigint 0.4.4",
  "num_cpus",
  "object_store 0.7.0",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -187,6 +187,9 @@ pub struct NodeConfig {
 
     #[serde(default = "bool_true")]
     pub state_accumulator_v2: bool,
+
+    #[serde(default = "bool_true")]
+    pub enable_soft_bundle: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -96,6 +96,7 @@ sui-simulator.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 zeroize.workspace = true
+nonempty.workspace = true
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1822,6 +1822,26 @@ impl AuthorityPerEpochStore {
         ))
     }
 
+    /// Check whether certificates were processed by consensus.
+    /// This handles multiple certificates at once.
+    pub fn is_all_tx_certs_consensus_message_processed(
+        &self,
+        certificates: &[VerifiedCertificate],
+    ) -> SuiResult<bool> {
+        let keys: Vec<_> = certificates
+            .iter()
+            .map(|cert| {
+                SequencedConsensusTransactionKey::External(ConsensusTransactionKey::Certificate(
+                    *cert.digest(),
+                ))
+            })
+            .collect();
+        Ok(self
+            .check_consensus_messages_processed(keys.iter())?
+            .into_iter()
+            .all(|processed| processed))
+    }
+
     pub fn is_consensus_message_processed(
         &self,
         key: &SequencedConsensusTransactionKey,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1822,9 +1822,9 @@ impl AuthorityPerEpochStore {
         ))
     }
 
-    /// Check whether certificates were processed by consensus.
+    /// Check whether any certificates were processed by consensus.
     /// This handles multiple certificates at once.
-    pub fn is_all_tx_certs_consensus_message_processed(
+    pub fn is_any_tx_certs_consensus_message_processed(
         &self,
         certificates: &[VerifiedCertificate],
     ) -> SuiResult<bool> {
@@ -1836,7 +1836,7 @@ impl AuthorityPerEpochStore {
         Ok(self
             .check_consensus_messages_processed(keys)?
             .into_iter()
-            .all(|processed| processed))
+            .any(|processed| processed))
     }
 
     pub fn is_consensus_message_processed(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1828,16 +1828,13 @@ impl AuthorityPerEpochStore {
         &self,
         certificates: &[VerifiedCertificate],
     ) -> SuiResult<bool> {
-        let keys: Vec<_> = certificates
-            .iter()
-            .map(|cert| {
-                SequencedConsensusTransactionKey::External(ConsensusTransactionKey::Certificate(
-                    *cert.digest(),
-                ))
-            })
-            .collect();
+        let keys = certificates.iter().map(|cert| {
+            SequencedConsensusTransactionKey::External(ConsensusTransactionKey::Certificate(
+                *cert.digest(),
+            ))
+        });
         Ok(self
-            .check_consensus_messages_processed(keys.iter())?
+            .check_consensus_messages_processed(keys)?
             .into_iter()
             .all(|processed| processed))
     }
@@ -1852,9 +1849,9 @@ impl AuthorityPerEpochStore {
             .contains_key(key)?)
     }
 
-    pub fn check_consensus_messages_processed<'a>(
+    pub fn check_consensus_messages_processed(
         &self,
-        keys: impl Iterator<Item = &'a SequencedConsensusTransactionKey>,
+        keys: impl Iterator<Item = SequencedConsensusTransactionKey>,
     ) -> SuiResult<Vec<bool>> {
         Ok(self
             .tables()?
@@ -1870,7 +1867,7 @@ impl AuthorityPerEpochStore {
 
         let unprocessed_keys_registrations = registrations
             .into_iter()
-            .zip(self.check_consensus_messages_processed(keys.iter())?)
+            .zip(self.check_consensus_messages_processed(keys.iter().cloned())?)
             .filter(|(_, processed)| !processed)
             .map(|(registration, _)| registration);
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -28,6 +28,9 @@ use sui_types::messages_grpc::{
     HandleCertificateResponseV2, HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
     SubmitCertificateResponse, SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
 };
+use sui_types::messages_grpc::{
+    HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
+};
 use sui_types::multiaddr::Multiaddr;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight};
@@ -409,14 +412,16 @@ impl ValidatorService {
         Ok(tonic::Response::new(info))
     }
 
-    async fn handle_certificate(
+    async fn handle_certificates(
         &self,
-        request: HandleCertificateRequestV3,
+        certificates: Vec<CertifiedTransaction>,
+        include_events: bool,
+        include_input_objects: bool,
+        include_output_objects: bool,
+        _include_auxiliary_data: bool,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         wait_for_effects: bool,
-    ) -> Result<Option<HandleCertificateResponseV3>, tonic::Status> {
-        let certificate = request.certificate;
-
+    ) -> Result<Option<Vec<HandleCertificateResponseV3>>, tonic::Status> {
         // Validate if cert can be executed
         // Fullnode does not serve handle_certificate call.
         fp_ensure!(
@@ -424,7 +429,65 @@ impl ValidatorService {
             SuiError::FullNodeCantHandleCertificate.into()
         );
 
-        let shared_object_tx = certificate.contains_shared_object();
+        fp_ensure!(
+            !certificates.is_empty(),
+            SuiError::NoCertificateProvided.into()
+        );
+
+        // See [SIP-19](https://github.com/sui-foundation/sips/blob/main/sips/sip-19.md) for more details.
+        let is_soft_bundle = certificates.len() > 1;
+        if is_soft_bundle {
+            let protocol_config = epoch_store.protocol_config();
+            // The request is a Soft Bundle, enforce these checks per SIP-19:
+            // - All certs must access at least one shared object.
+            // - All certs must not be already executed.
+            // - All certs must have the same gas price.
+            // - Number of certs must not exceed the max allowed.
+            fp_ensure!(
+                certificates.len() as u64 <= protocol_config.max_soft_bundle_size(),
+                SuiError::UserInputError {
+                    error: UserInputError::TooManyTransactionsInSoftBundle {
+                        limit: protocol_config.max_soft_bundle_size()
+                    }
+                }
+                .into()
+            );
+            let mut gas_price = None;
+            for certificate in &certificates {
+                let tx_digest = *certificate.digest();
+                fp_ensure!(
+                    certificate.contains_shared_object(),
+                    SuiError::UserInputError {
+                        error: UserInputError::NoSharedObjectError { digest: tx_digest }
+                    }
+                    .into()
+                );
+                fp_ensure!(
+                    !self.state.is_tx_already_executed(&tx_digest)?,
+                    SuiError::UserInputError {
+                        error: UserInputError::AlreadyExecutedError { digest: tx_digest }
+                    }
+                    .into()
+                );
+                if let Some(gas) = gas_price {
+                    fp_ensure!(
+                        gas == certificate.gas_price(),
+                        SuiError::UserInputError {
+                            error: UserInputError::GasPriceMismatchError {
+                                digest: tx_digest,
+                                expected: gas,
+                                actual: certificate.gas_price()
+                            }
+                        }
+                        .into()
+                    );
+                } else {
+                    gas_price = Some(certificate.gas_price());
+                }
+            }
+        }
+
+        let shared_object_tx = is_soft_bundle || certificates[0].contains_shared_object();
 
         let _metrics_guard = if wait_for_effects {
             if shared_object_tx {
@@ -442,56 +505,67 @@ impl ValidatorService {
                 .start_timer()
         };
 
-        // 1) Check if cert already executed
-        let tx_digest = *certificate.digest();
-        if let Some(signed_effects) = self
-            .state
-            .get_signed_effects_and_maybe_resign(&tx_digest, epoch_store)?
-        {
-            let events = if request.include_events {
-                if let Some(digest) = signed_effects.events_digest() {
-                    Some(self.state.get_transaction_events(digest)?)
+        let mut responses = Vec::with_capacity(certificates.len());
+
+        // 1) Check if the certificate is already executed.
+        //    This is only needed when we have only one certificate (not a soft bundle).
+        if !is_soft_bundle {
+            assert!(certificates.len() == 1); // Guranateed by the above check.
+            let tx_digest = *certificates[0].digest();
+
+            if let Some(signed_effects) = self
+                .state
+                .get_signed_effects_and_maybe_resign(&tx_digest, epoch_store)?
+            {
+                let events = if include_events {
+                    if let Some(digest) = signed_effects.events_digest() {
+                        Some(self.state.get_transaction_events(digest)?)
+                    } else {
+                        None
+                    }
                 } else {
                     None
-                }
-            } else {
-                None
-            };
+                };
 
-            return Ok(Some(HandleCertificateResponseV3 {
-                effects: signed_effects.into_inner(),
-                events,
-                input_objects: None,
-                output_objects: None,
-                auxiliary_data: None,
-            }));
+                return Ok(Some(vec![HandleCertificateResponseV3 {
+                    effects: signed_effects.into_inner(),
+                    events,
+                    input_objects: None,
+                    output_objects: None,
+                    auxiliary_data: None,
+                }]));
+            };
         }
 
-        // 2) Verify the cert.
+        // 2) Verify the certificates.
         // Check system overload
-        let overload_check_res = self.state.check_system_overload(
-            &self.consensus_adapter,
-            certificate.data(),
-            self.state.check_system_overload_at_execution(),
-        );
-        if let Err(error) = overload_check_res {
-            self.metrics
-                .num_rejected_cert_during_overload
-                .with_label_values(&[error.as_ref()])
-                .inc();
-            return Err(error.into());
+        for certificate in &certificates {
+            let overload_check_res = self.state.check_system_overload(
+                &self.consensus_adapter,
+                certificate.data(),
+                self.state.check_system_overload_at_execution(),
+            );
+            if let Err(error) = overload_check_res {
+                self.metrics
+                    .num_rejected_cert_during_overload
+                    .with_label_values(&[error.as_ref()])
+                    .inc();
+                return Err(error.into());
+            }
         }
 
-        // code block within reconfiguration lock
-        let certificate = {
-            let certificate = {
-                let _timer = self.metrics.cert_verification_latency.start_timer();
-                epoch_store
-                    .signature_verifier
-                    .verify_cert(certificate)
-                    .await?
-            };
+        let mut verified_certificates = Vec::with_capacity(certificates.len());
+        for certificate in certificates {
+            let _timer = self.metrics.cert_verification_latency.start_timer();
+            let verified_certificate = epoch_store
+                .signature_verifier
+                .verify_cert(certificate)
+                .await?;
+            verified_certificates.push(verified_certificate);
+        }
 
+        let submit_to_consensus = || -> SuiResult<()> {
+            // code block within reconfiguration lock
             let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
             if !reconfiguration_lock.should_accept_user_certs() {
                 self.metrics.num_rejected_cert_in_epoch_boundary.inc();
@@ -502,18 +576,23 @@ impl ValidatorService {
             // For shared objects this will wait until either timeout or we have heard back from consensus.
             // For owned objects this will return without waiting for certificate to be sequenced
             // First do quick dirty non-async check
-            if !epoch_store.is_tx_cert_consensus_message_processed(&certificate)? {
+            if !epoch_store.is_all_tx_certs_consensus_message_processed(&verified_certificates)? {
                 let _metrics_guard = if shared_object_tx {
                     Some(self.metrics.consensus_latency.start_timer())
                 } else {
                     None
                 };
-                let transaction = ConsensusTransaction::new_certificate_message(
-                    &self.state.name,
-                    certificate.clone().into(),
-                );
-                self.consensus_adapter.submit(
-                    transaction,
+                let transactions = verified_certificates
+                    .iter()
+                    .map(|certificate| {
+                        ConsensusTransaction::new_certificate_message(
+                            &self.state.name,
+                            certificate.clone().into(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                self.consensus_adapter.submit_batch(
+                    &transactions,
                     Some(&reconfiguration_lock),
                     epoch_store,
                 )?;
@@ -521,52 +600,67 @@ impl ValidatorService {
                 // Instead, check or wait for the existence of certificate effects below.
             }
             drop(reconfiguration_lock);
-            certificate
+            Ok(())
         };
+
+        submit_to_consensus()?;
 
         if !wait_for_effects {
             // It is useful to enqueue owned object transaction for execution locally,
             // even when we are not returning effects to user
-            if !certificate.contains_shared_object() {
-                self.state
-                    .enqueue_certificates_for_execution(vec![certificate.clone()], epoch_store);
+            let certificates_without_shared_objects = verified_certificates
+                .iter()
+                .filter(|certificate| !certificate.contains_shared_object())
+                .cloned()
+                .collect::<Vec<_>>();
+            if !certificates_without_shared_objects.is_empty() {
+                self.state.enqueue_certificates_for_execution(
+                    certificates_without_shared_objects,
+                    epoch_store,
+                );
             }
             return Ok(None);
         }
 
-        // 4) Execute the certificate if it contains only owned object transactions, or wait for
-        // the execution results if it contains shared objects.
-        let effects = self
-            .state
-            .execute_certificate(&certificate, epoch_store)
-            .await?;
-        let events = if request.include_events {
-            if let Some(digest) = effects.events_digest() {
-                Some(self.state.get_transaction_events(digest)?)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        for certificate in verified_certificates {
+            // 4) Execute the certificate if it contains only owned object transactions, or wait for
+            // the execution results if it contains shared objects.
+            // TODO: for soft bundle, we can execute all the certs at once.
+            let response = {
+                let effects = self
+                    .state
+                    .execute_certificate(&certificate, epoch_store)
+                    .await?;
+                let events = if include_events {
+                    if let Some(digest) = effects.events_digest() {
+                        Some(self.state.get_transaction_events(digest)?)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
 
-        let input_objects = request
-            .include_input_objects
-            .then(|| self.state.get_transaction_input_objects(&effects))
-            .and_then(Result::ok);
+                let input_objects = include_input_objects
+                    .then(|| self.state.get_transaction_input_objects(&effects))
+                    .and_then(Result::ok);
 
-        let output_objects = request
-            .include_output_objects
-            .then(|| self.state.get_transaction_output_objects(&effects))
-            .and_then(Result::ok);
+                let output_objects = include_output_objects
+                    .then(|| self.state.get_transaction_output_objects(&effects))
+                    .and_then(Result::ok);
 
-        Ok(Some(HandleCertificateResponseV3 {
-            effects: effects.into_inner(),
-            events,
-            input_objects,
-            output_objects,
-            auxiliary_data: None, // We don't have any aux data generated presently
-        }))
+                HandleCertificateResponseV3 {
+                    effects: effects.into_inner(),
+                    events,
+                    input_objects,
+                    output_objects,
+                    auxiliary_data: None, // We don't have any aux data generated presently
+                }
+            };
+            responses.push(response);
+        }
+
+        Ok(Some(responses))
     }
 }
 
@@ -587,21 +681,22 @@ impl ValidatorService {
         Self::transaction_validity_check(&epoch_store, certificate.data())?;
 
         let span = error_span!("submit_certificate", tx_digest = ?certificate.digest());
-        let request = HandleCertificateRequestV3 {
-            certificate,
-            include_events: true,
-            include_input_objects: false,
-            include_output_objects: false,
-            include_auxiliary_data: false,
-        };
-        self.handle_certificate(request, &epoch_store, false)
-            .instrument(span)
-            .await
-            .map(|executed| {
-                tonic::Response::new(SubmitCertificateResponse {
-                    executed: executed.map(Into::into),
-                })
+        self.handle_certificates(
+            vec![certificate],
+            true,
+            false,
+            false,
+            false,
+            &epoch_store,
+            false,
+        )
+        .instrument(span)
+        .await
+        .map(|executed| {
+            tonic::Response::new(SubmitCertificateResponse {
+                executed: executed.map(|mut x| x.remove(0)).map(Into::into),
             })
+        })
     }
 
     async fn handle_certificate_v2_impl(
@@ -613,24 +708,24 @@ impl ValidatorService {
         Self::transaction_validity_check(&epoch_store, certificate.data())?;
 
         let span = error_span!("handle_certificate", tx_digest = ?certificate.digest());
-        let request = HandleCertificateRequestV3 {
-            certificate,
-            include_events: true,
-            include_input_objects: false,
-            include_output_objects: false,
-            include_auxiliary_data: false,
-        };
-        self.handle_certificate(request, &epoch_store, true)
-            .instrument(span)
-            .await
-            .map(|v| {
-                tonic::Response::new(
-                    v.expect(
-                        "handle_certificate should not return none with wait_for_effects=true",
-                    )
+        self.handle_certificates(
+            vec![certificate],
+            true,
+            false,
+            false,
+            false,
+            &epoch_store,
+            true,
+        )
+        .instrument(span)
+        .await
+        .map(|v| {
+            tonic::Response::new(
+                v.expect("handle_certificate should not return none with wait_for_effects=true")
+                    .remove(0)
                     .into(),
-                )
-            })
+            )
+        })
     }
 
     async fn handle_certificate_v3_impl(
@@ -642,17 +737,71 @@ impl ValidatorService {
         Self::transaction_validity_check(&epoch_store, request.certificate.data())?;
 
         let span = error_span!("handle_certificate_v3", tx_digest = ?request.certificate.digest());
+        self.handle_certificates(
+            vec![request.certificate],
+            request.include_events,
+            request.include_input_objects,
+            request.include_output_objects,
+            request.include_auxiliary_data,
+            &epoch_store,
+            true,
+        )
+        .instrument(span)
+        .await
+        .map(|v| {
+            tonic::Response::new(
+                v.expect("handle_certificate should not return none with wait_for_effects=true")
+                    .remove(0),
+            )
+        })
+    }
 
-        self.handle_certificate(request, &epoch_store, true)
-            .instrument(span)
-            .await
-            .map(|v| {
-                tonic::Response::new(
-                    v.expect(
-                        "handle_certificate should not return none with wait_for_effects=true",
-                    ),
-                )
+    async fn handle_soft_bundle_certificates_v3_impl(
+        &self,
+        request: tonic::Request<HandleSoftBundleCertificatesRequestV3>,
+    ) -> Result<tonic::Response<HandleSoftBundleCertificatesResponseV3>, tonic::Status> {
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        let protocol_config = epoch_store.protocol_config();
+        let node_config = &self.state.config;
+        // Soft Bundle MUST be enabled both in protocol config and local node config.
+        // This acts an extra safety measure where a validator node have the choice to turn this feature off, without
+        // having to upgrade the entire network.
+        fp_ensure!(
+            protocol_config.soft_bundle() && node_config.enable_soft_bundle,
+            SuiError::UnsupportedFeatureError {
+                error: "Soft Bundle".to_string()
+            }
+            .into()
+        );
+
+        let request = request.into_inner();
+        let certificates = request.certificates;
+
+        for certificate in &certificates {
+            // CRITICAL: DO NOT ADD ANYTHING BEFORE THIS CHECK.
+            // This must be the first thing to check before anything else, because the transaction
+            // may not even be valid to access for any other checks.
+            // We need to check this first because we haven't verified the cert signature.
+            Self::transaction_validity_check(&epoch_store, certificate.data())?;
+        }
+
+        let span = error_span!("handle_soft_bundle_certificates_v3");
+        self.handle_certificates(
+            certificates,
+            request.include_events,
+            request.include_input_objects,
+            request.include_output_objects,
+            request.include_auxiliary_data,
+            &epoch_store,
+            request.wait_for_effects,
+        )
+        .instrument(span)
+        .await
+        .map(|v| {
+            tonic::Response::new(HandleSoftBundleCertificatesResponseV3 {
+                responses: v.unwrap_or_default(),
             })
+        })
     }
 
     fn transaction_validity_check(
@@ -911,6 +1060,13 @@ impl Validator for ValidatorService {
         request: tonic::Request<HandleCertificateRequestV3>,
     ) -> Result<tonic::Response<HandleCertificateResponseV3>, tonic::Status> {
         handle_with_decoration!(self, handle_certificate_v3_impl, request)
+    }
+
+    async fn handle_soft_bundle_certificates_v3(
+        &self,
+        request: tonic::Request<HandleSoftBundleCertificatesRequestV3>,
+    ) -> Result<tonic::Response<HandleSoftBundleCertificatesResponseV3>, tonic::Status> {
+        handle_with_decoration!(self, handle_soft_bundle_certificates_v3_impl, request)
     }
 
     async fn object_info(

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -422,7 +422,6 @@ impl ValidatorService {
         _include_auxiliary_data: bool,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         wait_for_effects: bool,
-        is_soft_bundle: bool,
     ) -> Result<Option<Vec<HandleCertificateResponseV3>>, tonic::Status> {
         // Validate if cert can be executed
         // Fullnode does not serve handle_certificate call.
@@ -451,8 +450,8 @@ impl ValidatorService {
 
         // 1) Check if the certificate is already executed.
         //    This is only needed when we have only one certificate (not a soft bundle).
-        if !is_soft_bundle {
-            assert!(certificates.len() == 1); // Guranateed by caller.
+        //    When multiple certificates are provided, we will either submit all of them or none of them to consensus.
+        if certificates.len() == 1 {
             let tx_digest = *certificates[0].digest();
 
             if let Some(signed_effects) = self
@@ -628,7 +627,6 @@ impl ValidatorService {
             false,
             &epoch_store,
             false,
-            false,
         )
         .instrument(span)
         .await
@@ -656,7 +654,6 @@ impl ValidatorService {
             false,
             &epoch_store,
             true,
-            false,
         )
         .instrument(span)
         .await
@@ -686,7 +683,6 @@ impl ValidatorService {
             request.include_auxiliary_data,
             &epoch_store,
             true,
-            false,
         )
         .instrument(span)
         .await
@@ -812,7 +808,6 @@ impl ValidatorService {
             request.include_auxiliary_data,
             &epoch_store,
             request.wait_for_effects,
-            true,
         )
         .instrument(span)
         .await

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -51,6 +51,15 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
+                .name("handle_soft_bundle_certificates_v3")
+                .route_name("SoftBundleCertifiedTransactionsV3")
+                .input_type("sui_types::messages_grpc::HandleSoftBundleCertificatesRequestV3")
+                .output_type("sui_types::messages_grpc::HandleSoftBundleCertificatesResponseV3")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            Method::builder()
                 .name("submit_certificate")
                 .route_name("SubmitCertificate")
                 .input_type("sui_types::transaction::CertifiedTransaction")

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1342,6 +1342,7 @@
                 "shared_object_deletion": false,
                 "simple_conservation_checks": false,
                 "simplified_unwrap_then_delete": false,
+                "soft_bundle": false,
                 "throughput_aware_consensus_submission": false,
                 "txn_base_cost_as_multiplier": false,
                 "upgraded_multisig_supported": false,
@@ -1770,6 +1771,7 @@
                 "max_size_written_objects_system_tx": {
                   "u64": "50000000"
                 },
+                "max_soft_bundle_size": null,
                 "max_struct_definitions": {
                   "u64": "200"
                 },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -501,6 +501,10 @@ struct FeatureFlags {
     // Set number of leaders per round for Mysticeti commits.
     #[serde(skip_serializing_if = "Option::is_none")]
     mysticeti_num_leaders_per_round: Option<usize>,
+
+    // Enable Soft Bundle (SIP-19).
+    #[serde(skip_serializing_if = "is_false")]
+    soft_bundle: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1149,6 +1153,9 @@ pub struct ProtocolConfig {
 
     /// Version number to use for version_specific_data in `CheckpointSummary`.
     checkpoint_summary_version_specific_data: Option<u64>,
+
+    /// The max number of transactions that can be included in a single Soft Bundle.
+    max_soft_bundle_size: Option<u64>,
 }
 
 // feature flags
@@ -1432,6 +1439,10 @@ impl ProtocolConfig {
 
     pub fn mysticeti_num_leaders_per_round(&self) -> Option<usize> {
         self.feature_flags.mysticeti_num_leaders_per_round
+    }
+
+    pub fn soft_bundle(&self) -> bool {
+        self.feature_flags.soft_bundle
     }
 }
 
@@ -1889,6 +1900,8 @@ impl ProtocolConfig {
             min_checkpoint_interval_ms: None,
 
             checkpoint_summary_version_specific_data: None,
+
+            max_soft_bundle_size: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -238,6 +238,7 @@ impl ValidatorConfigBuilder {
             firewall_config: self.firewall_config,
             execution_cache: ExecutionCacheConfig::default(),
             state_accumulator_v2: self.state_accumulator_v2,
+            enable_soft_bundle: true,
         }
     }
 
@@ -507,6 +508,7 @@ impl FullnodeConfigBuilder {
             firewall_config: self.fw_config,
             execution_cache: ExecutionCacheConfig::default(),
             state_accumulator_v2: true,
+            enable_soft_bundle: true,
         }
     }
 }

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/sui-swarm-config/tests/snapshot_tests.rs
+assertion_line: 151
 expression: network_config
 ---
 validator_configs:
@@ -138,6 +139,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -273,6 +275,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -408,6 +411,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -543,6 +547,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -678,6 +683,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -813,6 +819,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -948,6 +955,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     state-accumulator-v2: true
+    enable-soft-bundle: true
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -140,28 +140,6 @@ pub enum UserInputError {
     #[error("The transaction inputs contain duplicated ObjectRef's")]
     DuplicateObjectRefInput,
 
-    // Soft Bundle related errors
-    #[error(
-        "Number of transactions exceeds the maximum allowed ({:?}) in a Soft Bundle",
-        limit
-    )]
-    TooManyTransactionsInSoftBundle { limit: u64 },
-    #[error("Transaction {:?} in Soft Bundle contains no shared objects", digest)]
-    NoSharedObjectError { digest: TransactionDigest },
-    #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]
-    AlreadyExecutedError { digest: TransactionDigest },
-    #[error(
-        "Gas price for transaction {:?} mismatch: want {:?}, have {:?}",
-        digest,
-        expected,
-        actual
-    )]
-    GasPriceMismatchError {
-        digest: TransactionDigest,
-        expected: u64,
-        actual: u64,
-    },
-
     // Gas related errors
     #[error("Transaction gas payment missing")]
     MissingGasPayment,
@@ -279,6 +257,28 @@ pub enum UserInputError {
 
     #[error("Commands following a command with Random can only be TransferObjects or MergeCoins")]
     PostRandomCommandRestrictions,
+
+    // Soft Bundle related errors
+    #[error(
+        "Number of transactions exceeds the maximum allowed ({:?}) in a Soft Bundle",
+        limit
+    )]
+    TooManyTransactionsInSoftBundle { limit: u64 },
+    #[error("Transaction {:?} in Soft Bundle contains no shared objects", digest)]
+    NoSharedObjectError { digest: TransactionDigest },
+    #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]
+    AlreadyExecutedError { digest: TransactionDigest },
+    #[error(
+        "Gas price for transaction {:?} mismatch: want {:?}, have {:?}",
+        digest,
+        expected,
+        actual
+    )]
+    GasPriceMismatchError {
+        digest: TransactionDigest,
+        expected: u64,
+        actual: u64,
+    },
 }
 
 #[derive(
@@ -418,8 +418,6 @@ pub enum SuiError {
     },
     #[error("Transaction is already finalized but with different user signatures")]
     TxAlreadyFinalizedWithDifferentUserSigs,
-    #[error("The request did not contain a certificate")]
-    NoCertificateProvided,
 
     // Account access
     #[error("Invalid authenticator")]
@@ -653,6 +651,9 @@ pub enum SuiError {
 
     #[error("Too many requests")]
     TooManyRequests,
+
+    #[error("The request did not contain a certificate")]
+    NoCertificateProvided,
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -268,10 +268,10 @@ pub enum UserInputError {
     NoSharedObjectError { digest: TransactionDigest },
     #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]
     AlreadyExecutedError { digest: TransactionDigest },
-    #[error("At least one certificate in Soft Bundlele has already been processed")]
+    #[error("At least one certificate in Soft Bundle has already been processed")]
     CeritificateAlreadyProcessed,
     #[error(
-        "Gas price for transaction {:?} mismatch: want {:?}, have {:?}",
+        "Gas price for transaction {:?} in Soft Bundle mismatch: want {:?}, have {:?}",
         digest,
         expected,
         actual
@@ -655,7 +655,7 @@ pub enum SuiError {
     TooManyRequests,
 
     #[error("The request did not contain a certificate")]
-    NoCertificateProvided,
+    NoCertificateProvidedError,
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -268,6 +268,8 @@ pub enum UserInputError {
     NoSharedObjectError { digest: TransactionDigest },
     #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]
     AlreadyExecutedError { digest: TransactionDigest },
+    #[error("At least one certificate in Soft Bundlele has already been processed")]
+    CeritificateAlreadyProcessed,
     #[error(
         "Gas price for transaction {:?} mismatch: want {:?}, have {:?}",
         digest,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -140,6 +140,28 @@ pub enum UserInputError {
     #[error("The transaction inputs contain duplicated ObjectRef's")]
     DuplicateObjectRefInput,
 
+    // Soft Bundle related errors
+    #[error(
+        "Number of transactions exceeds the maximum allowed ({:?}) in a Soft Bundle",
+        limit
+    )]
+    TooManyTransactionsInSoftBundle { limit: u64 },
+    #[error("Transaction {:?} in Soft Bundle contains no shared objects", digest)]
+    NoSharedObjectError { digest: TransactionDigest },
+    #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]
+    AlreadyExecutedError { digest: TransactionDigest },
+    #[error(
+        "Gas price for transaction {:?} mismatch: want {:?}, have {:?}",
+        digest,
+        expected,
+        actual
+    )]
+    GasPriceMismatchError {
+        digest: TransactionDigest,
+        expected: u64,
+        actual: u64,
+    },
+
     // Gas related errors
     #[error("Transaction gas payment missing")]
     MissingGasPayment,
@@ -396,6 +418,8 @@ pub enum SuiError {
     },
     #[error("Transaction is already finalized but with different user signatures")]
     TxAlreadyFinalizedWithDifferentUserSigs,
+    #[error("The request did not contain a certificate")]
+    NoCertificateProvided,
 
     // Account access
     #[error("Invalid authenticator")]

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -228,3 +228,25 @@ impl From<HandleCertificateResponseV3> for HandleCertificateResponseV2 {
         }
     }
 }
+
+/// Response type for the handle Soft Bundle certificates validator API.
+/// If `wait_for_effects` is true, it is guaranteed that:
+///  - Number of responses will be equal to the number of input transactions.
+///  - The order of the responses matches the order of the input transactions.
+/// Otherwise, `responses` will be empty.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HandleSoftBundleCertificatesResponseV3 {
+    pub responses: Vec<HandleCertificateResponseV3>,
+}
+
+/// Soft Bundle request.  See [SIP-19](https://github.com/sui-foundation/sips/blob/main/sips/sip-19.md).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HandleSoftBundleCertificatesRequestV3 {
+    pub certificates: Vec<CertifiedTransaction>,
+
+    pub wait_for_effects: bool,
+    pub include_events: bool,
+    pub include_input_objects: bool,
+    pub include_output_objects: bool,
+    pub include_auxiliary_data: bool,
+}


### PR DESCRIPTION
## Description 

This is a follow up change after PR #17508 , for [SIP-19](https://github.com/sui-foundation/sips/blob/main/sips/sip-19.md).

The changeset focuses on sui-core, particularly authority server, to add a new API `SoftBundleCertifiedTransactionsV3` that allows submission of a Soft Bundle through gRPC.

The API accepts a list of `CertifiedTransaction` for input, then returns either nothing (should `wait_for_effects` be `false`) or a list of `HandleCertificateResponseV3` containing the execution result.

The API is named `_v3` because it reuses `HandleCertificateResponseV3`. 

Besides introducing a new feature flag and a protocol config field, a local node config field `enable_soft_bundle` is also added, to allow a validator node to turn off soft bundle support without having to upgrade the entire network.  This can be useful should the feature causes undesired effect.

## Test plan 

The feature is not exactly user-facing and do not break anything.

---

## Release notes

- [x] Protocol:  New feature flag and protocol config fields will be introduced.
- [x] Nodes (Validators and Full nodes):  A new API `SoftBundleCertifiedTransactionsV3` will be added.
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
