### PR TITLE
Add randomness generation backlog warning message

### DIFF
--- a/crates/sui-network/src/randomness/metrics.rs
+++ b/crates/sui-network/src/randomness/metrics.rs
@@ -42,10 +42,14 @@ impl Metrics {
         }
     }
 
-    pub fn set_num_rounds_pending(&self, num_rounds_pending: usize) {
+    pub fn set_num_rounds_pending(&self, num_rounds_pending: i64) {
         if let Some(inner) = &self.0 {
-            inner.num_rounds_pending.set(num_rounds_pending as i64);
+            inner.num_rounds_pending.set(num_rounds_pending);
         }
+    }
+
+    pub fn num_rounds_pending(&self) -> Option<i64> {
+        self.0.as_ref().map(|inner| inner.num_rounds_pending.get())
     }
 
     pub fn round_generation_latency_metric(&self) -> Option<&Histogram> {

--- a/crates/sui-network/src/randomness/mod.rs
+++ b/crates/sui-network/src/randomness/mod.rs
@@ -764,7 +764,15 @@ impl RandomnessEventLoop {
     }
 
     fn update_rounds_pending_metric(&self) {
-        self.metrics
-            .set_num_rounds_pending(self.pending_tasks.len() + self.send_tasks.len());
+        let num_rounds_pending = (self.pending_tasks.len() + self.send_tasks.len()) as i64;
+        let prev_value = self.metrics.num_rounds_pending().unwrap_or_default();
+        if num_rounds_pending / 100 > prev_value / 100 {
+            warn!(
+                // Recording multiples of 100 so tests can match on the log message.
+                "RandomnessEventLoop randomness generation backlog: over {} rounds are pending",
+                (num_rounds_pending / 100) * 100
+            );
+        }
+        self.metrics.set_num_rounds_pending(num_rounds_pending);
     }
 }


### PR DESCRIPTION
To aid in debugging, and enable tests that match on log messages.