### PR TITLE
[x/extend ignore] extend the path ignore functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16243,6 +16243,7 @@ name = "x"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "camino",
  "clap",
  "nexlint",
  "nexlint-lints",

--- a/crates/x/Cargo.toml
+++ b/crates/x/Cargo.toml
@@ -10,3 +10,4 @@ anyhow.workspace = true
 nexlint.workspace = true
 nexlint-lints.workspace = true
 clap.workspace = true
+camino.workspace = true

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -130,7 +130,7 @@ pub fn handle_lint_results_exclude_external_crate_checks(
 ) -> crate::Result<()> {
     // ignore_funcs is a slice of funcs to execute against lint sources and their path
     // if a func returns true, it means it will be ignored and not throw a lint error
-    let ignore_funcs = vec![
+    let ignore_funcs = [
         // legacy ignore checks
         |source: &LintSource, path: &Utf8Path| -> bool {
             (path.starts_with(EXTERNAL_CRATE_DIR)

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -150,7 +150,7 @@ pub fn handle_lint_results_exclude_external_crate_checks(
         if let LintKind::Content(path) = source.kind() {
             if ignore_funcs
                 .iter()
-                .fold(false, |acc, func| acc && func(source, path))
+                .any(|func| func(source, path))
             {
                 continue;
             }

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use camino::Utf8Path;
 use clap::Parser;
 use nexlint::{prelude::*, NexLintContext};
 use nexlint_lints::{
@@ -127,14 +128,29 @@ pub fn run(args: Args) -> crate::Result<()> {
 pub fn handle_lint_results_exclude_external_crate_checks(
     results: LintResults,
 ) -> crate::Result<()> {
+    // ignore_funcs is a slice of funcs to execute against lint sources and their path
+    // if a func returns true, it means it will be ignored and not throw a lint error
+    let ignore_funcs = vec![
+        // legacy ignore checks
+        |source: &LintSource, path: &Utf8Path| -> bool {
+            (path.starts_with(EXTERNAL_CRATE_DIR)
+                || path.starts_with(CREATE_DAPP_TEMPLATE_DIR)
+                || path.to_string().contains("/generated/"))
+                && source.name() == "license-header"
+        },
+        // ignore check to skip buck related code paths, meta (fb) derived starlark, etc.
+        |_source: &LintSource, path: &Utf8Path| -> bool {
+            path.starts_with("buck/") || path.starts_with("third-party/")
+        },
+    ];
+
     // TODO: handle skipped results
     let mut errs = false;
     for (source, message) in &results.messages {
         if let LintKind::Content(path) = source.kind() {
-            if (path.starts_with(EXTERNAL_CRATE_DIR)
-                || path.starts_with(CREATE_DAPP_TEMPLATE_DIR)
-                || path.to_string().contains("/generated/"))
-                && source.name() == "license-header"
+            if ignore_funcs
+                .iter()
+                .fold(false, |acc, func| acc && func(source, path))
             {
                 continue;
             }

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -148,10 +148,7 @@ pub fn handle_lint_results_exclude_external_crate_checks(
     let mut errs = false;
     for (source, message) in &results.messages {
         if let LintKind::Content(path) = source.kind() {
-            if ignore_funcs
-                .iter()
-                .any(|func| func(source, path))
-            {
+            if ignore_funcs.iter().any(|func| func(source, path)) {
                 continue;
             }
         }


### PR DESCRIPTION
## Description
convert the existing compound if block into a func that does the same thing and allow for more funcs that also do similar work.  If the ignore_funcs return true, any of them, they will not count as a lint error

## Test Plan
cargo build

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
