### PR TITLE
[move][stdlib] Add vec_map::from_key_values and vec_set::from_keys

### DIFF
--- a/crates/sui-framework/docs/sui-framework/vec_map.md
+++ b/crates/sui-framework/docs/sui-framework/vec_map.md
@@ -19,6 +19,7 @@ title: Module `0x2::vec_map`
 -  [Function `is_empty`](#0x2_vec_map_is_empty)
 -  [Function `destroy_empty`](#0x2_vec_map_destroy_empty)
 -  [Function `into_keys_values`](#0x2_vec_map_into_keys_values)
+-  [Function `from_keys_values`](#0x2_vec_map_from_keys_values)
 -  [Function `keys`](#0x2_vec_map_keys)
 -  [Function `get_idx_opt`](#0x2_vec_map_get_idx_opt)
 -  [Function `get_idx`](#0x2_vec_map_get_idx)
@@ -151,6 +152,16 @@ Trying to destroy a map that is not empty
 
 
 <pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EMapNotEmpty">EMapNotEmpty</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x2_vec_map_EUnequalLengths"></a>
+
+Trying to construct a map from keys and values of different lengths
+
+
+<pre><code><b>const</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_EUnequalLengths">EUnequalLengths</a>: u64 = 5;
 </code></pre>
 
 
@@ -483,6 +494,45 @@ The output keys and values are stored in insertion order, *not* sorted by key.
     };
     contents.<a href="../sui-framework/vec_map.md#0x2_vec_map_destroy_empty">destroy_empty</a>();
     (keys, values)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_map_from_keys_values"></a>
+
+## Function `from_keys_values`
+
+Construct a new <code><a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a></code> from two vectors, one for keys and one for values.
+The key value pairs are associated via their indices in the vectors, e.g. the key at index i
+in <code>keys</code> is associated with the value at index i in <code>values</code>.
+The key value pairs are stored in insertion order (the original vectors ordering)
+and are *not* sorted.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_from_keys_values">from_keys_values</a>&lt;K: <b>copy</b>, V&gt;(keys: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;V&gt;): <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_from_keys_values">from_keys_values</a>&lt;K: <b>copy</b>, V&gt;(
+    <b>mut</b> keys: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;,
+    <b>mut</b> values: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;V&gt;,
+): <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt; {
+    <b>assert</b>!(keys.length() == values.length(), <a href="../sui-framework/vec_map.md#0x2_vec_map_EUnequalLengths">EUnequalLengths</a>);
+    keys.reverse();
+    values.reverse();
+    <b>let</b> <b>mut</b> map = <a href="../sui-framework/vec_map.md#0x2_vec_map_empty">empty</a>();
+    <b>while</b> (!keys.<a href="../sui-framework/vec_map.md#0x2_vec_map_is_empty">is_empty</a>()) map.<a href="../sui-framework/vec_map.md#0x2_vec_map_insert">insert</a>(keys.pop_back(), values.pop_back());
+    keys.<a href="../sui-framework/vec_map.md#0x2_vec_map_destroy_empty">destroy_empty</a>();
+    values.<a href="../sui-framework/vec_map.md#0x2_vec_map_destroy_empty">destroy_empty</a>();
+    map
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-framework/vec_set.md
+++ b/crates/sui-framework/docs/sui-framework/vec_set.md
@@ -14,6 +14,7 @@ title: Module `0x2::vec_set`
 -  [Function `size`](#0x2_vec_set_size)
 -  [Function `is_empty`](#0x2_vec_set_is_empty)
 -  [Function `into_keys`](#0x2_vec_set_into_keys)
+-  [Function `from_keys`](#0x2_vec_set_from_keys)
 -  [Function `keys`](#0x2_vec_set_keys)
 -  [Function `get_idx_opt`](#0x2_vec_set_get_idx_opt)
 -  [Function `get_idx`](#0x2_vec_set_get_idx)
@@ -280,6 +281,36 @@ The output keys are stored in insertion order, *not* sorted.
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_set.md#0x2_vec_set_into_keys">into_keys</a>&lt;K: <b>copy</b> + drop&gt;(self: <a href="../sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt; {
     <b>let</b> <a href="../sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a> { contents } = self;
     contents
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_from_keys"></a>
+
+## Function `from_keys`
+
+Construct a new <code><a href="../sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> from a vector of keys.
+The keys are stored in insertion order (the original <code>keys</code> ordering)
+and are *not* sorted.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_set.md#0x2_vec_set_from_keys">from_keys</a>&lt;K: <b>copy</b>, drop&gt;(keys: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;): <a href="../sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_set.md#0x2_vec_set_from_keys">from_keys</a>&lt;K: <b>copy</b> + drop&gt;(<b>mut</b> keys: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;): <a href="../sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt; {
+    keys.reverse();
+    <b>let</b> <b>mut</b> set = <a href="../sui-framework/vec_set.md#0x2_vec_set_empty">empty</a>();
+    <b>while</b> (!keys.<a href="../sui-framework/vec_set.md#0x2_vec_set_is_empty">is_empty</a>()) set.<a href="../sui-framework/vec_set.md#0x2_vec_set_insert">insert</a>(keys.pop_back());
+    set
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-framework/sources/vec_map.move
+++ b/crates/sui-framework/packages/sui-framework/sources/vec_map.move
@@ -18,6 +18,9 @@ module sui::vec_map {
     /// Trying to pop from a map that is empty
     const EMapEmpty: u64 = 4;
 
+    /// Trying to construct a map from keys and values of different lengths
+    const EUnequalLengths: u64 = 5;
+
     /// A map data structure backed by a vector. The map is guaranteed not to contain duplicate keys, but entries
     /// are *not* sorted by key--entries are included in insertion order.
     /// All operations are O(N) in the size of the map--the intention of this data structure is only to provide
@@ -129,6 +132,25 @@ module sui::vec_map {
         };
         contents.destroy_empty();
         (keys, values)
+    }
+
+    /// Construct a new `VecMap` from two vectors, one for keys and one for values.
+    /// The key value pairs are associated via their indices in the vectors, e.g. the key at index i
+    /// in `keys` is associated with the value at index i in `values`.
+    /// The key value pairs are stored in insertion order (the original vectors ordering)
+    /// and are *not* sorted.
+    public fun from_keys_values<K: copy, V>(
+        mut keys: vector<K>,
+        mut values: vector<V>,
+    ): VecMap<K, V> {
+        assert!(keys.length() == values.length(), EUnequalLengths);
+        keys.reverse();
+        values.reverse();
+        let mut map = empty();
+        while (!keys.is_empty()) map.insert(keys.pop_back(), values.pop_back());
+        keys.destroy_empty();
+        values.destroy_empty();
+        map
     }
 
     /// Returns a list of keys in the map.

--- a/crates/sui-framework/packages/sui-framework/sources/vec_set.move
+++ b/crates/sui-framework/packages/sui-framework/sources/vec_set.move
@@ -63,6 +63,16 @@ module sui::vec_set {
         contents
     }
 
+    /// Construct a new `VecSet` from a vector of keys.
+    /// The keys are stored in insertion order (the original `keys` ordering)
+    /// and are *not* sorted.
+    public fun from_keys<K: copy + drop>(mut keys: vector<K>): VecSet<K> {
+        keys.reverse();
+        let mut set = empty();
+        while (!keys.is_empty()) set.insert(keys.pop_back());
+        set
+    }
+
     /// Borrow the `contents` of the `VecSet` to access content by index
     /// without unpacking. The contents are stored in insertion order,
     /// *not* sorted.

--- a/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
@@ -131,4 +131,46 @@ module sui::vec_map_tests {
 
         assert!(m.keys() == vector[1, 5], 1);
     }
+
+    #[test, allow(lint(collection_equality))]
+    fun round_trip() {
+        let mut m = vec_map::empty();
+        assert!(m == vec_map::from_keys_values(vector[], vector[]));
+        let mut i = 0;
+        let mut s = b"";
+        while (i < 50) {
+            let k = i + 2;
+            s.append(b"x");
+            m.insert(k, s);
+            let (keys, values) = m.into_keys_values();
+            let m2 = vec_map::from_keys_values(keys, values);
+            assert!(m == m2);
+            i = i + 1;
+        };
+    }
+
+    #[test, expected_failure(abort_code = vec_map::EUnequalLengths)]
+    fun mismatched_key_values_1() {
+        let keys = vector[1];
+        let values = vector[];
+        vec_map::from_keys_values<u64, u64>(keys, values);
+    }
+
+    #[test, expected_failure(abort_code = vec_map::EUnequalLengths)]
+    fun mismatched_key_values_2() {
+        let keys = vector[];
+        let values = vector[1];
+        vec_map::from_keys_values<u64, u64>(keys, values);
+    }
+
+    #[test, expected_failure(abort_code = vec_map::EUnequalLengths)]
+    fun mismatched_key_values_3() {
+        let keys = vector[1, 2, 3, 4, 5, 6];
+        let values = {
+            let mut v = keys;
+            v.pop_back();
+            v
+        };
+        vec_map::from_keys_values<u64, u64>(keys, values);
+    }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
@@ -173,4 +173,9 @@ module sui::vec_map_tests {
         };
         vec_map::from_keys_values<u64, u64>(keys, values);
     }
+
+    #[test, expected_failure(abort_code = vec_map::EKeyAlreadyExists)]
+    fun from_keys_values_duplicate_key_abort() {
+        vec_map::from_keys_values<u64, address>(vector[1, 0, 1], vector[@0, @1, @2]);
+    }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
@@ -61,4 +61,18 @@ module sui::vec_set_tests {
         assert!(m.size() == 3, 0);
         assert!(m.keys() == &vector[1, 2, 3], 1);
     }
+
+    #[test, allow(lint(collection_equality))]
+    fun round_trip() {
+        let mut s = vec_set::empty();
+        assert!(s == vec_set::from_keys(vector[]));
+        let mut i = 0;
+        while (i < 50) {
+            let k = i + 2;
+            s.insert(k);
+            let s2 = vec_set::from_keys(s.into_keys());
+            assert!(s == s2);
+            i = i + 1;
+        };
+    }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
@@ -75,4 +75,9 @@ module sui::vec_set_tests {
             i = i + 1;
         };
     }
+
+    #[test, expected_failure(abort_code = vec_set::EKeyAlreadyExists)]
+    fun from_keys_values_duplicate_key_abort() {
+        vec_set::from_keys<u64>(vector[1, 0, 1]);
+    }
 }

--- a/crates/sui-framework/published_api.txt
+++ b/crates/sui-framework/published_api.txt
@@ -1753,6 +1753,9 @@ is_empty
 into_keys
 	public fun
 	0x2::vec_set
+from_keys
+	public fun
+	0x2::vec_set
 keys
 	public fun
 	0x2::vec_set
@@ -1988,6 +1991,9 @@ destroy_empty
 	public fun
 	0x2::vec_map
 into_keys_values
+	public fun
+	0x2::vec_map
+from_keys_values
 	public fun
 	0x2::vec_map
 keys

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xaa1f81615726f743a44d460de2f93a2d3d2d8cf5304cdcff7e0630efd3e1add2"
+            id: "0xc13911100d5a2985cef990e462441e758b5330fabd470be10a4a203f8821b7b2"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x47e3f1223ad17dd878503d1b53d6328ba003739bcd48c802f23cf1ae139e0dca"
+      operation_cap_id: "0x5dba33e66d4f3274a5decb22d6fae8df7f575a15bc62c3a8926c763fbf298d33"
       gas_price: 1000
       staking_pool:
-        id: "0xdbae44f768932c55ec5c4d2353ef383412ff46ece64fd7e627dc478a8a983b85"
+        id: "0xa887b599da4f8d9301ebf52d35d6c4633cca8f50b66e1b2c5af98b2b06f6d979"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xd9c4fa6435a92316e35b4cad08c275e0d253d094e088ecc2e11612e059f4bcc1"
+          id: "0xde6ebbe5bc4c4595fadad591b92f856cac0aeb29354e07fddd3485a966e482f8"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x611cd0036780b5f5b48c4450a1c1e101187a3051fe5304b1614f09b821a1ea16"
+            id: "0xf881fd0927d6bcdf7ff74dbd570e86ccda6271ea9c77576e9fc09bf6c298b135"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xbcf528f56cdf5f086fa182caa99e4f61232e85fa253faf471473981a39b1bbfb"
+          id: "0x9ba5d49e3e261c67c573374ed41b1236742f6e37038445300cce1cc43afdb929"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x52dbbc972f61964c94f821673e4456871ee8b4280379469883797cde9a7e75c2"
+      id: "0x51dfe4d3e6de4200c16b5f5496c6ad69fdb201214956367200a5f79bdfd123d5"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xd7b77390caad378d1d2f4589ded333643396ca90fbe47731253a365841d22c7b"
+    id: "0x9ba05ebdd2bceb56353b340ca8d0c123564668f629b1e0d0c3515a963178e0c1"
     size: 1
   inactive_validators:
-    id: "0xd7502286e0070887f753b8a4e68aa6e9ac1efcdd9519d997805cdf44f8e02b91"
+    id: "0xc4c2c99c83f43bc7a475c52aff0b59d04ef6e9423666d05ea763f220a05a0c52"
     size: 0
   validator_candidates:
-    id: "0x87c0342f7b777631eb5afc7c0cc21e287aa448c28f97d5d16ec57f5a4127d8f7"
+    id: "0xa607f0b3f80f7b8f2373655c664c9926ddea6fb9a2aae8a3e93204e406a00469"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xf6344e8ae8b62ca78e477400f08d67bfd1c831b7a65b2d27d6942167111c4d45"
+      id: "0xa9d30b4b319819d98b921477749c5a096b6d85da1531b178a9b87f2c5475408f"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x2fa928349e0701ded15f5a6b9b8934d73a350ba419119cae5605b679780b5244"
+      id: "0x6f3ccf6aba5e65b014009931ee8a04664ace8833be8fc69facd61595eb149345"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xe6764c48ab10ea4ac1e210c3786bdef3dcfc18d0d2dadd42ba019546b87ae64c"
+      id: "0xf527d81366bc6b17f2aa1f0ffdb98327de2aa13ecc95868933b2cce4c0ad4b5c"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x41f2308e40998f1ff547ad1497181ce0ea5771a10fe0b0dc89958cc3f16f171e"
+    id: "0xafd94076f9d38d9eae4688568ff1ee43c25c338e6404c5684a8111bcb2c6afd3"
   size: 0
 


### PR DESCRIPTION
## Description 

- There was no easy way to make a VecMap or VecSet from a PTB 

## Test plan 

- New functions and tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: New Move functions for `vec_map::from_key_values` and `vec_set::from_key_values`
- [ ] Rust SDK: 
