### PR TITLE
[move] Support parsing doc comments before/after/in-between attributes

### DIFF
--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -1135,6 +1135,8 @@ fn parse_attributes(context: &mut Context) -> Result<Vec<Attributes>, Box<Diagno
         }
     }
 
+    // Attaches the doc comments to the start of the location of the member that these
+    // attributes/doc comments are attached to.
     if !doc_comments.is_empty() {
         context.tokens.attach_doc_comments(doc_comments.join("\n"));
     }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -1107,6 +1107,10 @@ fn parse_attribute(context: &mut Context) -> Result<Attribute, Box<Diagnostic>> 
 // Parse attributes. Used to annotate a variety of AST nodes
 //      Attributes = ("#" "[" Comma<Attribute> "]")*
 fn parse_attributes(context: &mut Context) -> Result<Vec<Attributes>, Box<Diagnostic>> {
+    let mut doc_comments = context
+        .tokens
+        .read_doc_comments()
+        .map_or_else(Vec::new, |doc_comments| vec![doc_comments]);
     let mut attributes_vec = vec![];
     while let Tok::NumSign = context.tokens.peek() {
         let start_loc = context.tokens.start_loc();
@@ -1125,8 +1129,16 @@ fn parse_attributes(context: &mut Context) -> Result<Vec<Attributes>, Box<Diagno
             start_loc,
             end_loc,
             attributes_,
-        ))
+        ));
+        if let Some(new_doc_comments) = context.tokens.read_doc_comments() {
+            doc_comments.push(new_doc_comments);
+        }
     }
+
+    if !doc_comments.is_empty() {
+        context.tokens.attach_doc_comments(doc_comments.join("\n"));
+    }
+
     Ok(attributes_vec)
 }
 
@@ -4203,7 +4215,6 @@ fn parse_module(
     attributes: Vec<Attributes>,
     context: &mut Context,
 ) -> Result<(ModuleDefinition, Option<Vec<Attributes>>), Box<Diagnostic>> {
-    context.tokens.match_doc_comments();
     let start_loc = context.tokens.start_loc();
 
     let is_spec_module = if context.tokens.peek() == Tok::Spec {
@@ -4309,7 +4320,6 @@ fn parse_module_member(context: &mut Context) -> Result<ModuleMember, ErrCase> {
     match context.tokens.peek() {
         // Top-level specification constructs
         Tok::Invariant => {
-            context.tokens.match_doc_comments();
             let spec_string = consume_spec_string(context)?;
             consume_token(context.tokens, Tok::Semicolon)?;
             Ok(ModuleMember::Spec(spec_string))
@@ -4317,7 +4327,6 @@ fn parse_module_member(context: &mut Context) -> Result<ModuleMember, ErrCase> {
         Tok::Spec => {
             match context.tokens.lookahead() {
                 Ok(Tok::Fun) | Ok(Tok::Native) => {
-                    context.tokens.match_doc_comments();
                     context.tokens.advance()?;
                     // Add an extra check for better error message
                     // if old syntax is used
@@ -4342,7 +4351,6 @@ fn parse_module_member(context: &mut Context) -> Result<ModuleMember, ErrCase> {
             attributes, context,
         )?)),
         _ => {
-            context.tokens.match_doc_comments();
             let start_loc = context.tokens.start_loc();
             let modifiers = parse_module_member_modifiers(context)?;
             let tok = context.tokens.peek();

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_annotations.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_annotations.move
@@ -1,0 +1,32 @@
+/// This is a doc comment above an annotation.
+#[allow(unused_const)]
+module 0x42::m {
+    #[allow(dead_code)]
+    /// This is a doc comment on a constant with an annotation. Below the annotation.
+    const Error: u32 = 0;
+
+    /// This is a doc comment on a constant with an annotation. Above the annotation.
+    #[allow(dead_code)]
+    const OtherError: u32 = 0;
+
+    /// This is the top doc comment
+    #[allow(dead_code)]
+    /// This is the middle doc comment
+    #[ext(something)]
+    /// This is the bottom doc comment
+    const Woah: u32 = 0;
+
+    /// This is the top doc comment
+    #[allow(dead_code)]
+    /// This is the middle doc comment
+    #[ext(something)]
+    const Cool: u32 = 0;
+
+    /// This is a doc comment above a function with an annotation. Above the annotation.
+    #[allow(dead_code)]
+    fun test() { }
+
+    #[allow(dead_code)]
+    /// This is a doc comment above a function with an annotation. Below the annotation.
+    fun test1() { }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_annotations_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_annotations_invalid.exp
@@ -1,0 +1,6 @@
+warning[W01004]: invalid documentation comment
+  ┌─ tests/move_check/parser/doc_comments_annotations_invalid.move:2:5
+  │
+2 │     /// Can't have doc comments inside an attribute.
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_annotations_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_annotations_invalid.move
@@ -1,0 +1,6 @@
+#[ext(
+    /// Can't have doc comments inside an attribute.
+    something
+)]
+module 0x42::m {
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_placement.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/doc_comments_placement.move
@@ -3,7 +3,7 @@
 /// Documentation comments can have multiple blocks.
 /** They may use different limiters. */
 module 0x42::M {
-    /** There can be no doc comment on uses. */
+    /** There can be doc comments on uses. */
     use std::option::Option;
 
     /// This is f.

--- a/external-crates/move/crates/move-docgen/tests/sources/annotation_test.move
+++ b/external-crates/move/crates/move-docgen/tests/sources/annotation_test.move
@@ -1,0 +1,33 @@
+/// This is a doc comment above an annotation.
+#[allow(unused_const)]
+module 0x42::m {
+    #[allow(dead_code)]
+    /// This is a doc comment on a constant with an annotation. Below the annotation.
+    const Error: u32 = 0;
+
+    /// This is a doc comment on a constant with an annotation. Above the annotation.
+    #[allow(dead_code)]
+    const OtherError: u32 = 0;
+
+    /// This is the top doc comment
+    #[allow(dead_code)]
+    /// This is the middle doc comment
+    #[ext(something)]
+    /// This is the bottom doc comment
+    const Woah: u32 = 0;
+
+    /// This is the top doc comment
+    #[allow(dead_code)]
+    /// This is the middle doc comment
+    #[ext(something)]
+    const Cool: u32 = 0;
+
+    /// This is a doc comment above a function with an annotation. Above the annotation.
+    #[allow(dead_code)]
+    fun test() { }
+
+    #[allow(dead_code)]
+    /// This is a doc comment above a function with an annotation. Below the annotation.
+    fun test1() { }
+}
+

--- a/external-crates/move/crates/move-docgen/tests/sources/annotation_test.spec_inline.md
+++ b/external-crates/move/crates/move-docgen/tests/sources/annotation_test.spec_inline.md
@@ -1,0 +1,125 @@
+
+<a name="0x42_m"></a>
+
+# Module `0x42::m`
+
+This is a doc comment above an annotation.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `test`](#0x42_m_test)
+-  [Function `test1`](#0x42_m_test1)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x42_m_Cool"></a>
+
+This is the top doc comment
+This is the middle doc comment
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Cool">Cool</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_Error"></a>
+
+This is a doc comment on a constant with an annotation. Below the annotation.
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Error">Error</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_OtherError"></a>
+
+This is a doc comment on a constant with an annotation. Above the annotation.
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_OtherError">OtherError</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_Woah"></a>
+
+This is the top doc comment
+This is the middle doc comment
+This is the bottom doc comment
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Woah">Woah</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_test"></a>
+
+## Function `test`
+
+This is a doc comment above a function with an annotation. Above the annotation.
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test">test</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test">test</a>() { }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x42_m_test1"></a>
+
+## Function `test1`
+
+This is a doc comment above a function with an annotation. Below the annotation.
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test1">test1</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test1">test1</a>() { }
+</code></pre>
+
+
+
+</details>
+warning: unused function
+   ┌─ tests/sources/annotation_test.move:27:9
+   │
+27 │     fun test() { }
+   │         ^^^^ The non-'public', non-'entry' function 'test' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning: unused function
+   ┌─ tests/sources/annotation_test.move:31:9
+   │
+31 │     fun test1() { }
+   │         ^^^^^ The non-'public', non-'entry' function 'test1' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-docgen/tests/sources/annotation_test.spec_inline_no_fold.md
+++ b/external-crates/move/crates/move-docgen/tests/sources/annotation_test.spec_inline_no_fold.md
@@ -1,0 +1,117 @@
+
+<a name="0x42_m"></a>
+
+# Module `0x42::m`
+
+This is a doc comment above an annotation.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `test`](#0x42_m_test)
+-  [Function `test1`](#0x42_m_test1)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x42_m_Cool"></a>
+
+This is the top doc comment
+This is the middle doc comment
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Cool">Cool</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_Error"></a>
+
+This is a doc comment on a constant with an annotation. Below the annotation.
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Error">Error</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_OtherError"></a>
+
+This is a doc comment on a constant with an annotation. Above the annotation.
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_OtherError">OtherError</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_Woah"></a>
+
+This is the top doc comment
+This is the middle doc comment
+This is the bottom doc comment
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Woah">Woah</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_test"></a>
+
+## Function `test`
+
+This is a doc comment above a function with an annotation. Above the annotation.
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test">test</a>()
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test">test</a>() { }
+</code></pre>
+
+
+
+<a name="0x42_m_test1"></a>
+
+## Function `test1`
+
+This is a doc comment above a function with an annotation. Below the annotation.
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test1">test1</a>()
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test1">test1</a>() { }
+</code></pre>
+warning: unused function
+   ┌─ tests/sources/annotation_test.move:27:9
+   │
+27 │     fun test() { }
+   │         ^^^^ The non-'public', non-'entry' function 'test' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning: unused function
+   ┌─ tests/sources/annotation_test.move:31:9
+   │
+31 │     fun test1() { }
+   │         ^^^^^ The non-'public', non-'entry' function 'test1' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-docgen/tests/sources/annotation_test.spec_separate.md
+++ b/external-crates/move/crates/move-docgen/tests/sources/annotation_test.spec_separate.md
@@ -1,0 +1,125 @@
+
+<a name="0x42_m"></a>
+
+# Module `0x42::m`
+
+This is a doc comment above an annotation.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `test`](#0x42_m_test)
+-  [Function `test1`](#0x42_m_test1)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x42_m_Cool"></a>
+
+This is the top doc comment
+This is the middle doc comment
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Cool">Cool</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_Error"></a>
+
+This is a doc comment on a constant with an annotation. Below the annotation.
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Error">Error</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_OtherError"></a>
+
+This is a doc comment on a constant with an annotation. Above the annotation.
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_OtherError">OtherError</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_Woah"></a>
+
+This is the top doc comment
+This is the middle doc comment
+This is the bottom doc comment
+
+
+<pre><code><b>const</b> <a href="annotation_test.md#0x42_m_Woah">Woah</a>: u32 = 0;
+</code></pre>
+
+
+
+<a name="0x42_m_test"></a>
+
+## Function `test`
+
+This is a doc comment above a function with an annotation. Above the annotation.
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test">test</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test">test</a>() { }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x42_m_test1"></a>
+
+## Function `test1`
+
+This is a doc comment above a function with an annotation. Below the annotation.
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test1">test1</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="annotation_test.md#0x42_m_test1">test1</a>() { }
+</code></pre>
+
+
+
+</details>
+warning: unused function
+   ┌─ tests/sources/annotation_test.move:27:9
+   │
+27 │     fun test() { }
+   │         ^^^^ The non-'public', non-'entry' function 'test' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning: unused function
+   ┌─ tests/sources/annotation_test.move:31:9
+   │
+31 │     fun test1() { }
+   │         ^^^^^ The non-'public', non-'entry' function 'test1' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')


### PR DESCRIPTION
## Description 

Adds support for parsing doc comments with attributes either before, after, or in the middle of the doc comments.

Before, the following were all errors
```move
/// Doc comment
#[annotation]
fun foo() { }

/// Doc comment
#[annotation]
/// Other doc comment
fun foo() { }

/// Doc comment
#[annotation]
/// Other doc comment
#[annotation]
fun foo() { }
```

These are now all supported, and the previous behavior of 
```move
#[annotation]
/// Doc comments
fun foo() { }
```

is also maintained.

## Test plan 

Added additional tests for both the parser, and docgen to make sure we attach doc comments correctly. 


