### PR TITLE
[move][move-id] Move IDE autocomplete information to IDEInfo form

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/compiler_info.rs
+++ b/external-crates/move/crates/move-analyzer/src/compiler_info.rs
@@ -10,6 +10,7 @@ use move_ir_types::location::Loc;
 pub struct CompilerInfo {
     pub macro_info: BTreeMap<Loc, CI::MacroCallInfo>,
     pub expanded_lambdas: BTreeSet<Loc>,
+    pub autocomplete_info: BTreeMap<Loc, CI::AutocompleteInfo>,
 }
 
 impl CompilerInfo {
@@ -36,6 +37,13 @@ impl CompilerInfo {
                 CI::IDEAnnotation::ExpandedLambda => {
                     self.expanded_lambdas.insert(loc);
                 }
+                CI::IDEAnnotation::AutocompleteInfo(info) => {
+                    // TODO: what if we find two autocomplete info sets? Intersection may be better
+                    // than union, as it's likely in a lambda body.
+                    if let Some(_old) = self.autocomplete_info.insert(loc, *info) {
+                        eprintln!("Repeated autocomplete info");
+                    }
+                }
             }
         }
     }
@@ -46,5 +54,9 @@ impl CompilerInfo {
 
     pub fn is_expanded_lambda(&mut self, loc: &Loc) -> bool {
         self.expanded_lambdas.contains(loc)
+    }
+
+    pub fn get_autocomplete_info(&mut self, loc: &Loc) -> Option<&CI::AutocompleteInfo> {
+        self.autocomplete_info.get(loc)
     }
 }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2939,9 +2939,6 @@ impl<'a> TypingSymbolicator<'a> {
                 self.exp_symbols(exp, scope);
                 self.add_type_id_use_def(t);
             }
-            E::AutocompleteDotAccess { base_exp, .. } => {
-                self.exp_symbols(base_exp, scope);
-            }
             E::Unit { .. }
             | E::Value(_)
             | E::Continue(_)

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1289,7 +1289,6 @@ pub fn get_symbols(
             Ok(v) => v,
             Err((_pass, diags)) => {
                 let failure = true;
-                // report_diagnostics(&files, diags);
                 diagnostics = Some((diags, failure));
                 eprintln!("typed AST compilation failed");
                 eprintln!("diagnostics: {:#?}", diagnostics);

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -526,8 +526,7 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::UnaryExp(_, base_exp)
         | E::Borrow(_, base_exp, _)
         | E::Cast(base_exp, _)
-        | E::TempBorrow(_, base_exp)
-        | E::AutocompleteDotAccess { base_exp, .. } => value_report!(base_exp),
+        | E::TempBorrow(_, base_exp) => value_report!(base_exp),
 
         E::BorrowLocal(_, _) => None,
 
@@ -739,7 +738,6 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::ErrorConstant { .. }
         | E::Move { .. }
         | E::Copy { .. }
-        | E::AutocompleteDotAccess { .. }
         | E::UnresolvedError => value(context, e),
 
         E::Value(_) | E::Unit { .. } => None,

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -15,12 +15,7 @@ use crate::{
     parser::ast::{
         Ability_, BinOp, BinOp_, ConstantName, DatatypeName, Field, FunctionName, VariantName,
     },
-    shared::{
-        process_binops,
-        string_utils::{debug_print, format_oxford_list},
-        unique_map::UniqueMap,
-        *,
-    },
+    shared::{process_binops, string_utils::debug_print, unique_map::UniqueMap, *},
     sui_mode::ID_FIELD_NAME,
     typing::ast as T,
     FullyCompiledProgram,
@@ -1687,28 +1682,6 @@ fn value(
             assert!(context.env.has_errors());
             make_exp(HE::UnresolvedError)
         }
-        E::AutocompleteDotAccess {
-            base_exp: _,
-            methods,
-            fields,
-        } => {
-            if !(context.env.ide_mode()) {
-                context
-                    .env
-                    .add_diag(ice!((eloc, "Found autocomplete outside of IDE mode")));
-            };
-            let names = methods
-                .into_iter()
-                .map(|(m, f)| format!("{m}::{f}"))
-                .chain(fields.into_iter().map(|n| format!("{n}")))
-                .collect::<Vec<_>>();
-            let msg = format!(
-                "Autocompletes to: {}",
-                format_oxford_list!("or", "'{}'", names)
-            );
-            context.env.add_diag(diag!(IDE::Autocomplete, (eloc, msg)));
-            make_exp(HE::UnresolvedError)
-        }
     };
     maybe_freeze(context, block, expected_type.cloned(), preresult)
 }
@@ -2049,7 +2022,6 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         | E::Move { .. }
         | E::Copy { .. }
         | E::UnresolvedError
-        | E::AutocompleteDotAccess { .. }
         | E::NamedBlock(_, _)) => value_statement(context, block, make_exp(e_)),
 
         E::Value(_) | E::Unit { .. } => (),

--- a/external-crates/move/crates/move-compiler/src/shared/ide.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/ide.rs
@@ -1,11 +1,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_ir_types::location::Loc;
+use std::collections::BTreeSet;
 
 use crate::{
     expansion::ast as E, naming::ast as N, parser::ast as P, shared::Name, typing::ast as T,
 };
+
+use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
 
 //*************************************************************************************************
 // Types
@@ -19,10 +22,12 @@ pub struct IDEInfo {
 #[derive(Debug, Clone)]
 /// An individual IDE annotation.
 pub enum IDEAnnotation {
-    /// Indicates a macro call site.
+    /// A macro call site.
     MacroCallInfo(Box<MacroCallInfo>),
-    /// Indicates an expanded lambda site.
+    /// An expanded lambda site.
     ExpandedLambda,
+    /// Autocomplete information.
+    AutocompleteInfo(Box<AutocompleteInfo>),
 }
 
 #[derive(Debug, Clone)]
@@ -37,6 +42,15 @@ pub struct MacroCallInfo {
     pub type_arguments: Vec<N::Type>,
     /// By-value args (at this point there should only be one, representing receiver arg)
     pub by_value_args: Vec<T::SequenceItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AutocompleteInfo {
+    /// Methods that are valid autocompletes
+    pub methods: BTreeSet<(E::ModuleIdent, P::FunctionName)>,
+    /// Fields that are valid autocompletes (e.g., for a struct)
+    /// TODO: possibly extend this with type information?
+    pub fields: BTreeSet<Symbol>,
 }
 
 //*************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -237,14 +237,6 @@ pub enum UnannotatedExp_ {
 
     Cast(Box<Exp>, Box<Type>),
     Annotate(Box<Exp>, Box<Type>),
-
-    // unfinished dot access (e.g. `some_field.`) with autocomplete information on it.
-    AutocompleteDotAccess {
-        base_exp: Box<Exp>,
-        methods: BTreeSet<(ModuleIdent, FunctionName)>,
-        fields: BTreeSet<Symbol>,
-    },
-
     ErrorConstant {
         line_number_loc: Loc,
         error_constant: Option<ConstantName>,
@@ -838,21 +830,6 @@ impl AstDebug for UnannotatedExp_ {
                 w.write(": ");
                 ty.ast_debug(w);
                 w.write(")");
-            }
-            E::AutocompleteDotAccess {
-                base_exp,
-                methods,
-                fields,
-            } => {
-                base_exp.ast_debug(w);
-                w.write(".{");
-                let names = methods
-                    .iter()
-                    .map(|(m, f)| format!("{m}::{f}"))
-                    .chain(fields.iter().map(|n| format!("{n}")))
-                    .collect::<Vec<_>>();
-                w.comma(names, |w, n| w.write(n));
-                w.write("}");
             }
             E::UnresolvedError => w.write("_|_"),
             E::ErrorConstant {

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -484,7 +484,7 @@ impl<'env> Context<'env> {
         self.use_funs.last().unwrap().color.unwrap()
     }
 
-    pub fn reset_for_module_item(&mut self) {
+    pub fn reset_for_module_item(&mut self, loc: Loc) {
         self.named_block_map = BTreeMap::new();
         self.return_type = None;
         self.locals = UniqueMap::new();
@@ -497,7 +497,8 @@ impl<'env> Context<'env> {
         self.lambda_expansion = vec![];
 
         if !self.ide_info.is_empty() {
-            eprintln!("IDE info should be cleared after each item");
+            self.env
+                .add_diag(ice!((loc, "IDE info should be cleared after each item")));
             self.ide_info = IDEInfo::new();
         }
     }

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -471,11 +471,6 @@ fn exp(context: &mut Context, e: &T::Exp) {
             exp(context, e);
             type_(context, ty)
         }
-        E::AutocompleteDotAccess {
-            base_exp,
-            methods: _,
-            fields: _,
-        } => exp(context, base_exp),
         E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -274,12 +274,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::Dereference(base_exp)
         | E::UnaryExp(_, base_exp)
         | E::Borrow(_, base_exp, _)
-        | E::TempBorrow(_, base_exp)
-        | E::AutocompleteDotAccess {
-            base_exp,
-            methods: _,
-            fields: _,
-        } => exp(context, base_exp),
+        | E::TempBorrow(_, base_exp) => exp(context, base_exp),
         E::Mutate(el, er) => {
             exp(context, el);
             exp(context, er)
@@ -529,5 +524,6 @@ pub fn ide_annotation(context: &mut Context, annotation: &mut IDEAnnotation) {
             }
         }
         IDEAnnotation::ExpandedLambda => (),
+        IDEAnnotation::AutocompleteInfo(_) => (),
     }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -276,12 +276,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::Dereference(base_exp)
         | E::UnaryExp(_, base_exp)
         | E::Borrow(_, base_exp, _)
-        | E::TempBorrow(_, base_exp)
-        | E::AutocompleteDotAccess {
-            base_exp,
-            methods: _,
-            fields: _,
-        } => exp(context, base_exp),
+        | E::TempBorrow(_, base_exp) => exp(context, base_exp),
         E::Mutate(el, er) | E::BinopExp(el, _, _, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -222,11 +222,6 @@ pub trait TypingVisitorContext {
             E::TempBorrow(_, e) => self.visit_exp(e),
             E::Cast(e, _) => self.visit_exp(e),
             E::Annotate(e, _) => self.visit_exp(e),
-            E::AutocompleteDotAccess {
-                base_exp,
-                methods: _,
-                fields: _,
-            } => self.visit_exp(base_exp),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.exp
@@ -1,9 +1,3 @@
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:13:21
-   │
-13 │         let _tmp1 = _s.;                // incomplete with `;` (next line should parse)
-   │                     ^^^ Autocompletes to: 'a'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/dot_incomplete.move:13:24
    │
@@ -13,12 +7,6 @@ error[E01002]: unexpected token
    │                        Unexpected ';'
    │                        Expected an identifier or a decimal number
 
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:14:21
-   │
-14 │         let _tmp2 = _s.a.;  // incomplete with `;` (next line should parse)
-   │                     ^^^^^ Autocompletes to: 'x'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/dot_incomplete.move:14:26
    │
@@ -27,12 +15,6 @@ error[E01002]: unexpected token
    │                          │
    │                          Unexpected ';'
    │                          Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:15:21
-   │
-15 │         let _tmp3 = _s.a.   // incomplete without `;` (unexpected `let`)
-   │                     ^^^^^ Autocompletes to: 'x'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/dot_incomplete.move:16:9

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.exp
@@ -1,9 +1,3 @@
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:17:17
-   │
-17 │         let _ = &in.0.0[1]. ;
-   │                 ^^^^^^^^^^^ Autocompletes to: '0'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/index_autocomplete.move:17:29
    │
@@ -13,12 +7,6 @@ error[E01002]: unexpected token
    │                             Unexpected ';'
    │                             Expected an identifier or a decimal number
 
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:21:17
-   │
-21 │         let _ = &in.0.0[1].0[0]. ;
-   │                 ^^^^^^^^^^^^^^^^ Autocompletes to: 
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/index_autocomplete.move:21:34
    │
@@ -27,12 +15,6 @@ error[E01002]: unexpected token
    │                                  │
    │                                  Unexpected ';'
    │                                  Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:25:17
-   │
-25 │         let _ = &in.0.0[1].0[0]. ;
-   │                 ^^^^^^^^^^^^^^^^ Autocompletes to: 'c' or 'd'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/index_autocomplete.move:25:34

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.exp
@@ -1,9 +1,3 @@
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:13:21
-   │
-13 │         let _tmp1 = _s.;
-   │                     ^^^ Autocompletes to: 'a'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:13:24
    │
@@ -12,12 +6,6 @@ error[E01002]: unexpected token
    │                        │
    │                        Unexpected ';'
    │                        Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:14:21
-   │
-14 │         let _tmp2 = _s.a.;
-   │                     ^^^^^ Autocompletes to: 'x'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:14:26

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.exp
@@ -1,9 +1,3 @@
-error[E15001]: IDE autocomplete
-  ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:9:21
-  │
-9 │         let _tmp1 = _s.;
-  │                     ^^^ Autocompletes to: '0'
-
 error[E01002]: unexpected token
   ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:9:24
   │
@@ -12,12 +6,6 @@ error[E01002]: unexpected token
   │                        │
   │                        Unexpected ';'
   │                        Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:10:21
-   │
-10 │         let _tmp2 = _s.0.;
-   │                     ^^^^^ Autocompletes to: '0'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:10:26

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_autocomplete.exp
@@ -1,9 +1,3 @@
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:18:21
-   │
-18 │         let _tmp1 = _a.;
-   │                     ^^^ Autocompletes to: 'a::m::t0', 'a::m::t1', or 'a::m::t2'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:18:24
    │
@@ -12,12 +6,6 @@ error[E01002]: unexpected token
    │                        │
    │                        Unexpected ';'
    │                        Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:19:21
-   │
-19 │         let _tmp2 = _b.;
-   │                     ^^^ Autocompletes to: 'a::m::t3', 'a::m::t4', or 'a::m::t5'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_method_autocomplete.move:19:24

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_scoped_autocomplete.exp
@@ -1,9 +1,3 @@
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:17:21
-   │
-17 │         let _tmp1 = _a.;
-   │                     ^^^ Autocompletes to: 'a::m::t0'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:17:24
    │
@@ -12,12 +6,6 @@ error[E01002]: unexpected token
    │                        │
    │                        Unexpected ';'
    │                        Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:18:21
-   │
-18 │         let _tmp2 = _b.;
-   │                     ^^^ Autocompletes to: 'a::m::t1'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/struct_scoped_autocomplete.move:18:24

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/dot_incomplete.exp
@@ -1,17 +1,3 @@
-warning[W09003]: unused assignment
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:12:13
-   │
-12 │         let s = AnotherStruct { another_field: SomeStruct { some_field: 0 } };
-   │             ^ Unused assignment for variable 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
-   │
-   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:13:21
-   │
-13 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
-   │                     ^^ Autocompletes to: 'another_field'
-
 error[E01002]: unexpected token
    ┌─ tests/move_check/ide_mode/dot_incomplete.move:13:23
    │
@@ -20,12 +6,6 @@ error[E01002]: unexpected token
    │                       │
    │                       Unexpected ';'
    │                       Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:14:21
-   │
-14 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
-   │                     ^^^^^^^^^^^^^^^^ Autocompletes to: 'some_field'
 
 error[E01002]: unexpected token
    ┌─ tests/move_check/ide_mode/dot_incomplete.move:14:37
@@ -36,12 +16,6 @@ error[E01002]: unexpected token
    │                                     Unexpected ';'
    │                                     Expected an identifier or a decimal number
 
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:15:21
-   │
-15 │         let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
-   │                     ^^^^^^^^^^^^^^^^ Autocompletes to: 'some_field'
-
 error[E01002]: unexpected token
    ┌─ tests/move_check/ide_mode/dot_incomplete.move:16:9
    │
@@ -50,12 +24,6 @@ error[E01002]: unexpected token
    │         │
    │         Unexpected 'let'
    │         Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_check/ide_mode/dot_incomplete.move:17:20
-   │
-17 │         let _tmp = s.                  // incomplete without `;` (unexpected `}`)
-   │                    ^^ Autocompletes to: 'another_field'
 
 error[E01002]: unexpected token
    ┌─ tests/move_check/ide_mode/dot_incomplete.move:18:5

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/struct_method_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/struct_method_autocomplete.exp
@@ -22,12 +22,6 @@ error[E13001]: feature is not supported in specified edition
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:18:21
-   │
-18 │         let _tmp1 = _a.;
-   │                     ^^^ Autocompletes to: 
-
 error[E01002]: unexpected token
    ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:18:24
    │
@@ -36,12 +30,6 @@ error[E01002]: unexpected token
    │                        │
    │                        Unexpected ';'
    │                        Expected an identifier or a decimal number
-
-error[E15001]: IDE autocomplete
-   ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:19:21
-   │
-19 │         let _tmp2 = _b.;
-   │                     ^^^ Autocompletes to: 
 
 error[E01002]: unexpected token
    ┌─ tests/move_check/ide_mode/struct_method_autocomplete.move:19:24


### PR DESCRIPTION
## Description 

This adds autocomplete information collection to the `IDEInfo` form.

## Test plan 

Testing is difficult without the analyzer calling it with a location, but I anticipate working with Adam on that over the next few days.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
