### PR TITLE
[move-ide] Added on-hover for inlay type hints

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -91,6 +91,7 @@ Move source file (a file with a `.move` file extension) and:
   - go to references
   - type on hover
   - outline view showing symbol tree for Move source files
+  - inlay type hints (local declarations and lambda parameters)
 - If the opened Move source file is located within a buildable project you can build and (locally)
   test this project using `Move: Build a Move package` and `Move: Test a Move package` commands from
   VSCode's command palette

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -287,7 +287,7 @@ pub struct StructDef {
 
 impl StructDef {
     pub fn name_start(&self) -> Position {
-        self.name_start.clone()
+        self.name_start
     }
 }
 


### PR DESCRIPTION
## Description 

Added on-hover when hovering over struct type hints:

![image](https://github.com/MystenLabs/sui/assets/1724397/43043ee6-ebc9-4bb4-876c-0997dc16c16f)

## Test plan 

Verified that on-hover works for struct type hints
