### PR TITLE
[bridge] Add print registration info in cli

### DIFF
--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -90,6 +90,12 @@ pub enum BridgeCommand {
         #[clap(long = "eth-rpc-url")]
         eth_rpc_url: String,
     },
+    /// Print current registration info
+    #[clap(name = "print-bridge-registration-info")]
+    PrintBridgeRegistrationInfo {
+        #[clap(long = "sui-rpc-url")]
+        sui_rpc_url: String,
+    },
     /// Client to facilitate and execute Bridge actions
     #[clap(name = "client")]
     Client {


### PR DESCRIPTION
## Description 

Add a subcommand to display current registration info.

## Test plan 

```
sui-bridge-cli print-sui-bridge-info --sui-rpc-url https://rpc.testnet.sui.io:443
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
