### PR TITLE
[suiop] Build suiop-cli binaries workflow dispatch

### DIFF
--- a/.github/workflows/build-suiop-cli.yml
+++ b/.github/workflows/build-suiop-cli.yml
@@ -1,0 +1,28 @@
+name: Build suiop-cli binaries
+on:
+  push:
+    paths:
+      - 'crates/suiop-cli/**'
+  pull_request:
+    paths:
+      - 'crates/suiop-cli/**'
+
+# Do not run the same workflow concurrenctly
+# for the same branch.
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Trigger a gh action in MystenLabs/sui-operations
+      - name: Dispatch Build To Operations Repo
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0
+        with:
+          repository: MystenLabs/sui-operations
+          # Using the changeset's token for now,
+          # we could generate a different secret for this
+          # for separation of concerns:
+          token: ${{ secrets.CHANGESETS_DEPLOY_DISPATCH }}
+          event-type: build-binaries
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Description 

Create a workflow dispatch that will cause a github action to trigger on `Mystenlabs/sui-operations` which will generates binary builds for `suiop-cli` on different architectures.

Relative PR to sui operations: https://github.com/MystenLabs/sui-operations/pull/3769

## Test plan 

- Create a dummy PR to `Mystenlabs/sui`, that contains a change in the `crates/suiop-cli/` directory or its subdirectories.
- Check if the gh action is triggered in https://github.com/MystenLabs/sui-operations.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
