### PR TITLE
Bridge Indexer Latest Eth Syncer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12159,6 +12159,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "bcs",
  "bin-version",
  "clap",

--- a/crates/sui-bridge-indexer/Cargo.toml
+++ b/crates/sui-bridge-indexer/Cargo.toml
@@ -24,6 +24,7 @@ sui-data-ingestion-core.workspace = true
 sui-types.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true
+backoff.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-bridge-indexer/src/eth_worker.rs
+++ b/crates/sui-bridge-indexer/src/eth_worker.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::postgres_manager::{write, PgPool};
+use crate::{BridgeDataSource, TokenTransfer, TokenTransferData, TokenTransferStatus};
+use ethers::providers::Provider;
+use ethers::providers::{Http, Middleware};
+use ethers::types::Address as EthAddress;
+use std::sync::Arc;
+use sui_bridge::abi::{EthBridgeEvent, EthSuiBridgeEvents};
+use sui_bridge::types::EthLog;
+use tracing::info;
+use tracing::log::error;
+
+pub async fn process_eth_events(
+    mut eth_events_rx: mysten_metrics::metered_channel::Receiver<(EthAddress, u64, Vec<EthLog>)>,
+    provider: Arc<Provider<Http>>,
+    pool: &PgPool,
+    finalized: bool,
+) {
+    while let Some((_, _, logs)) = eth_events_rx.recv().await {
+        for log in logs.iter() {
+            let eth_bridge_event = EthBridgeEvent::try_from_eth_log(log);
+            if eth_bridge_event.is_none() {
+                continue;
+            }
+            let bridge_event = eth_bridge_event.unwrap();
+            let block_number = log.block_number;
+            let block = provider.get_block(log.block_number).await.unwrap().unwrap();
+            let timestamp = block.timestamp.as_u64() * 1000;
+            let transaction = provider
+                .get_transaction(log.tx_hash)
+                .await
+                .unwrap()
+                .unwrap();
+            let gas = transaction.gas;
+            let tx_hash = log.tx_hash;
+
+            let transfer: TokenTransfer = match bridge_event {
+                EthBridgeEvent::EthSuiBridgeEvents(bridge_event) => match bridge_event {
+                    EthSuiBridgeEvents::TokensDepositedFilter(bridge_event) => {
+                        info!(
+                            "Observed {} Eth Deposit",
+                            if finalized {
+                                "Finalized"
+                            } else {
+                                "Unfinalized"
+                            }
+                        );
+                        TokenTransfer {
+                            chain_id: bridge_event.source_chain_id,
+                            nonce: bridge_event.nonce,
+                            block_height: block_number,
+                            timestamp_ms: timestamp,
+                            txn_hash: tx_hash.as_bytes().to_vec(),
+                            txn_sender: bridge_event.sender_address.as_bytes().to_vec(),
+                            status: if finalized {
+                                TokenTransferStatus::Deposited
+                            } else {
+                                TokenTransferStatus::DepositedUnfinalized
+                            },
+                            gas_usage: gas.as_u64() as i64,
+                            data_source: BridgeDataSource::Eth,
+                            data: Some(TokenTransferData {
+                                sender_address: bridge_event.sender_address.as_bytes().to_vec(),
+                                destination_chain: bridge_event.destination_chain_id,
+                                recipient_address: bridge_event.recipient_address.to_vec(),
+                                token_id: bridge_event.token_id,
+                                amount: bridge_event.sui_adjusted_amount,
+                            }),
+                        }
+                    }
+                    EthSuiBridgeEvents::TokensClaimedFilter(bridge_event) => {
+                        // Only write unfinalized claims
+                        if finalized {
+                            continue;
+                        }
+                        info!("Observed Unfinalized Eth Claim");
+                        TokenTransfer {
+                            chain_id: bridge_event.source_chain_id,
+                            nonce: bridge_event.nonce,
+                            block_height: block_number,
+                            timestamp_ms: timestamp,
+                            txn_hash: tx_hash.as_bytes().to_vec(),
+                            txn_sender: bridge_event.sender_address.to_vec(),
+                            status: TokenTransferStatus::Claimed,
+                            gas_usage: gas.as_u64() as i64,
+                            data_source: BridgeDataSource::Eth,
+                            data: None,
+                        }
+                    }
+                    EthSuiBridgeEvents::PausedFilter(_)
+                    | EthSuiBridgeEvents::UnpausedFilter(_)
+                    | EthSuiBridgeEvents::UpgradedFilter(_)
+                    | EthSuiBridgeEvents::InitializedFilter(_) => {
+                        continue;
+                    }
+                },
+                EthBridgeEvent::EthBridgeCommitteeEvents(_)
+                | EthBridgeEvent::EthBridgeLimiterEvents(_)
+                | EthBridgeEvent::EthBridgeConfigEvents(_)
+                | EthBridgeEvent::EthCommitteeUpgradeableContractEvents(_) => {
+                    continue;
+                }
+            };
+
+            if let Err(e) = write(pool, vec![transfer]) {
+                error!("Error writing token transfer to database: {:?}", e);
+            }
+        }
+    }
+
+    panic!("Eth event stream ended unexpectedly");
+}

--- a/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
+++ b/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
@@ -1,0 +1,149 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The EthSyncer module is responsible for synchronizing Events emitted on Ethereum blockchain from
+//! concerned contracts. Each contract is associated with a start block number, and the syncer will
+//! only query from that block number onwards. The syncer also keeps track of the last
+//! block on Ethereum and will only query for events up to that block number.
+
+use ethers::providers::{Http, Middleware, Provider};
+use ethers::types::Address as EthAddress;
+use mysten_metrics::spawn_logged_monitored_task;
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_bridge::error::BridgeResult;
+use sui_bridge::eth_client::EthClient;
+use sui_bridge::retry_with_max_elapsed_time;
+use sui_bridge::types::EthLog;
+use tokio::task::JoinHandle;
+use tokio::time::{self, Duration};
+use tracing::error;
+
+const ETH_LOG_QUERY_MAX_BLOCK_RANGE: u64 = 1000;
+const ETH_EVENTS_CHANNEL_SIZE: usize = 1000;
+const BLOCK_QUERY_INTERVAL: Duration = Duration::from_secs(2);
+
+pub struct LatestEthSyncer<P> {
+    eth_client: Arc<EthClient<P>>,
+    provider: Arc<Provider<Http>>,
+    contract_addresses: EthTargetAddresses,
+}
+
+/// Map from contract address to their start block.
+pub type EthTargetAddresses = HashMap<EthAddress, u64>;
+
+#[allow(clippy::new_without_default)]
+impl<P> LatestEthSyncer<P>
+where
+    P: ethers::providers::JsonRpcClient + 'static,
+{
+    pub fn new(
+        eth_client: Arc<EthClient<P>>,
+        provider: Arc<Provider<Http>>,
+        contract_addresses: EthTargetAddresses,
+    ) -> Self {
+        Self {
+            eth_client,
+            provider,
+            contract_addresses,
+        }
+    }
+
+    pub async fn run(
+        self,
+    ) -> BridgeResult<(
+        Vec<JoinHandle<()>>,
+        mysten_metrics::metered_channel::Receiver<(EthAddress, u64, Vec<EthLog>)>,
+    )> {
+        let (eth_evnets_tx, eth_events_rx) = mysten_metrics::metered_channel::channel(
+            ETH_EVENTS_CHANNEL_SIZE,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channel_inflight
+                .with_label_values(&["eth_events_queue"]),
+        );
+
+        let mut task_handles = vec![];
+        for (contract_address, start_block) in self.contract_addresses {
+            let eth_events_tx_clone = eth_evnets_tx.clone();
+            // let latest_block_rx_clone = latest_block_rx.clone();
+            let eth_client_clone = self.eth_client.clone();
+            let provider_clone = self.provider.clone();
+            task_handles.push(spawn_logged_monitored_task!(
+                Self::run_event_listening_task(
+                    contract_address,
+                    start_block,
+                    provider_clone,
+                    eth_events_tx_clone,
+                    eth_client_clone,
+                )
+            ));
+        }
+        Ok((task_handles, eth_events_rx))
+    }
+
+    async fn run_event_listening_task(
+        contract_address: EthAddress,
+        mut start_block: u64,
+        provider: Arc<Provider<Http>>,
+        events_sender: mysten_metrics::metered_channel::Sender<(EthAddress, u64, Vec<EthLog>)>,
+        eth_client: Arc<EthClient<P>>,
+    ) {
+        tracing::info!(contract_address=?contract_address, "Starting eth events listening task from block {start_block}");
+        loop {
+            let mut interval = time::interval(BLOCK_QUERY_INTERVAL);
+            interval.tick().await;
+            let Ok(Ok(new_block)) = retry_with_max_elapsed_time!(
+                provider.get_block_number(),
+                time::Duration::from_secs(10)
+            ) else {
+                error!("Failed to get latest block from eth client after retry");
+                continue;
+            };
+
+            let new_block: u64 = new_block.as_u64();
+
+            if new_block < start_block {
+                tracing::info!(
+                    contract_address=?contract_address,
+                    "New block {} is smaller than start block {}, ignore",
+                    new_block,
+                    start_block,
+                );
+                continue;
+            }
+
+            // Each query does at most ETH_LOG_QUERY_MAX_BLOCK_RANGE blocks.
+            let end_block =
+                std::cmp::min(start_block + ETH_LOG_QUERY_MAX_BLOCK_RANGE - 1, new_block);
+            let Ok(Ok(events)) = retry_with_max_elapsed_time!(
+                eth_client.get_events_in_range(contract_address, start_block, end_block),
+                Duration::from_secs(30)
+            ) else {
+                error!("Failed to get events from eth client after retry");
+                continue;
+            };
+            let len = events.len();
+
+            // Note 1: we always events to the channel even when it is empty. This is because of
+            // how `eth_getLogs` api is designed - we want cursor to move forward continuously.
+
+            // Note 2: it's extremely critical to make sure the Logs we send via this channel
+            // are complete per block height. Namely, we should never send a partial list
+            // of events for a block. Otherwise, we may end up missing events.
+            events_sender
+                .send((contract_address, end_block, events))
+                .await
+                .expect("All Eth event channel receivers are closed");
+            if len != 0 {
+                tracing::info!(
+                    ?contract_address,
+                    start_block,
+                    end_block,
+                    "Observed {len} new Eth events",
+                );
+            }
+            start_block = end_block + 1;
+        }
+    }
+}

--- a/crates/sui-bridge-indexer/src/lib.rs
+++ b/crates/sui-bridge-indexer/src/lib.rs
@@ -6,11 +6,13 @@ use crate::models::TokenTransferData as DBTokenTransferData;
 use std::fmt::{Display, Formatter};
 
 pub mod config;
+pub mod eth_worker;
+pub mod latest_eth_syncer;
 pub mod metrics;
 pub mod models;
-pub mod postgres_writer;
+pub mod postgres_manager;
 pub mod schema;
-pub mod worker;
+pub mod sui_worker;
 
 pub struct TokenTransfer {
     chain_id: u8,
@@ -65,6 +67,7 @@ impl TokenTransfer {
 }
 
 pub(crate) enum TokenTransferStatus {
+    DepositedUnfinalized,
     Deposited,
     Approved,
     Claimed,
@@ -73,6 +76,7 @@ pub(crate) enum TokenTransferStatus {
 impl Display for TokenTransferStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let str = match self {
+            TokenTransferStatus::DepositedUnfinalized => "DepositedUnfinalized",
             TokenTransferStatus::Deposited => "Deposited",
             TokenTransferStatus::Approved => "Approved",
             TokenTransferStatus::Claimed => "Claimed",

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -13,20 +13,19 @@ use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use sui_bridge::{
-    abi::{EthBridgeCommittee, EthSuiBridge},
-    eth_client::EthClient,
-    eth_syncer::EthSyncer,
-};
-use sui_bridge_indexer::{
-    config::load_config, metrics::BridgeIndexerMetrics, postgres_writer::get_connection_pool,
-    worker::process_eth_transaction, worker::BridgeWorker,
-};
+use sui_bridge::{eth_client::EthClient, eth_syncer::EthSyncer};
+use sui_bridge_indexer::latest_eth_syncer::LatestEthSyncer;
+use sui_bridge_indexer::postgres_manager::get_connection_pool;
+use sui_bridge_indexer::postgres_manager::get_latest_eth_token_transfer;
+use sui_bridge_indexer::sui_worker::SuiBridgeWorker;
+use sui_bridge_indexer::{config::load_config, metrics::BridgeIndexerMetrics};
 use sui_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, WorkerPool,
 };
 use tokio::sync::oneshot;
 use tracing::info;
+
+use sui_bridge_indexer::eth_worker::process_eth_events;
 
 #[derive(Parser, Clone, Debug)]
 struct Args {
@@ -53,8 +52,6 @@ async fn main() -> Result<()> {
     };
     let config = load_config(&config_path).unwrap();
 
-    let (_exit_sender, exit_receiver) = oneshot::channel();
-
     // Init metrics server
     let registry_service = start_prometheus_server(
         format!("{}:{}", config.metric_url, config.metric_port,)
@@ -62,15 +59,74 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|err| panic!("Failed to parse metric address: {}", err)),
     );
     let registry: Registry = registry_service.default_registry();
+
     mysten_metrics::init_metrics(&registry);
+
     info!(
         "Metrics server started at {}::{}",
         config.metric_url, config.metric_port
     );
-    let metrics = DataIngestionMetrics::new(&registry);
     let indexer_meterics = BridgeIndexerMetrics::new(&registry);
 
-    // start eth client
+    // start indexing
+    start_processing_eth_events(&config).await?;
+
+    start_processing_sui_checkpoints(&config, indexer_meterics).await?;
+
+    Ok(())
+}
+
+async fn start_processing_sui_checkpoints(
+    config: &sui_bridge_indexer::config::Config,
+    indexer_meterics: BridgeIndexerMetrics,
+) -> Result<()> {
+    // metrics init
+    let (_exit_sender, exit_receiver) = oneshot::channel();
+    let metrics = DataIngestionMetrics::new(&Registry::new());
+
+    let progress_store = FileProgressStore::new(config.progress_store_file.clone().into());
+    let mut executor = IndexerExecutor::new(progress_store, 1 /* workflow types */, metrics);
+
+    let indexer_metrics_cloned = indexer_meterics.clone();
+
+    let worker_pool = WorkerPool::new(
+        SuiBridgeWorker::new(vec![], config.db_url.clone(), indexer_metrics_cloned),
+        "bridge worker".into(),
+        config.concurrency as usize,
+    );
+    executor.register(worker_pool).await?;
+    executor
+        .run(
+            config.checkpoints_path.clone().into(),
+            Some(config.remote_store_url.clone()),
+            vec![], // optional remote store access options
+            ReaderOptions::default(),
+            exit_receiver,
+        )
+        .await?;
+
+    Ok(())
+}
+
+async fn start_processing_eth_events(config: &sui_bridge_indexer::config::Config) -> Result<()> {
+    let pg_pool = get_connection_pool(config.db_url.clone());
+
+    let newest_unfinalized_block_recorded = match get_latest_eth_token_transfer(&pg_pool, false)? {
+        Some(transfer) => transfer.block_height as u64,
+        None => config.start_block,
+    };
+
+    let newest_finalized_block = match get_latest_eth_token_transfer(&pg_pool, true)? {
+        Some(transfer) => transfer.block_height as u64,
+        None => config.start_block,
+    };
+
+    info!(
+        "Starting from unfinalized block: {}",
+        newest_unfinalized_block_recorded
+    );
+    info!("Starting from finalized block: {}", newest_finalized_block);
+
     let provider = Arc::new(
         ethers::prelude::Provider::<ethers::providers::Http>::try_from(&config.eth_rpc_url)
             .unwrap_or_else(|_| {
@@ -82,65 +138,55 @@ async fn main() -> Result<()> {
             .interval(std::time::Duration::from_millis(2000)),
     );
     let bridge_address = EthAddress::from_str(&config.eth_sui_bridge_contract_address)?;
-    let sui_bridge = EthSuiBridge::new(bridge_address, provider.clone());
-    let committee_address: EthAddress = sui_bridge.committee().call().await?;
-    let limiter_address: EthAddress = sui_bridge.limiter().call().await?;
-    let vault_address: EthAddress = sui_bridge.vault().call().await?;
-    let committee = EthBridgeCommittee::new(committee_address, provider.clone());
-    let config_address: EthAddress = committee.config().call().await?;
 
     let eth_client = Arc::new(
         EthClient::<ethers::providers::Http>::new(
             &config.eth_rpc_url,
-            HashSet::from_iter(vec![
-                bridge_address,
-                committee_address,
-                config_address,
-                limiter_address,
-                vault_address,
-            ]),
+            HashSet::from_iter(vec![bridge_address]),
         )
         .await?,
     );
 
-    let contract_addresses = HashMap::from_iter(vec![(bridge_address, config.start_block)]);
+    // capture finalized blocks
 
-    let (_task_handles, eth_events_rx, _) = EthSyncer::new(eth_client, contract_addresses)
+    let contract_addresses = HashMap::from_iter(vec![(bridge_address, newest_finalized_block)]);
+
+    let (_task_handles, eth_events_rx, _) = EthSyncer::new(eth_client, contract_addresses.clone())
         .run()
         .await
         .expect("Failed to start eth syncer");
 
-    let pg_pool = get_connection_pool(config.db_url.clone());
+    let pool_clone = pg_pool.clone();
+    let provider_clone = provider.clone();
 
-    let indexer_metrics_cloned = indexer_meterics.clone();
-    let _task_handle = spawn_logged_monitored_task!(
-        process_eth_transaction(
-            eth_events_rx,
-            provider.clone(),
-            pg_pool,
-            indexer_metrics_cloned
-        ),
-        "indexer handler"
+    let _finalized_task_handle = spawn_logged_monitored_task!(
+        process_eth_events(eth_events_rx, provider_clone, &pool_clone, true),
+        "finalized indexer handler"
     );
 
-    // start sui side
-    let progress_store = FileProgressStore::new(config.progress_store_file.into());
-    let mut executor = IndexerExecutor::new(progress_store, 1 /* workflow types */, metrics);
-    let worker_pool = WorkerPool::new(
-        BridgeWorker::new(vec![], config.db_url.clone(), indexer_meterics.clone()),
-        "bridge worker".into(),
-        config.concurrency as usize,
-    );
-    executor.register(worker_pool).await?;
-    executor
-        .run(
-            config.checkpoints_path.into(),
-            Some(config.remote_store_url),
-            vec![], // optional remote store access options
-            ReaderOptions::default(),
-            exit_receiver,
+    // capture unfinalized blocks
+
+    let eth_client = Arc::new(
+        EthClient::<ethers::providers::Http>::new(
+            &config.eth_rpc_url,
+            HashSet::from_iter(vec![bridge_address]),
         )
-        .await?;
+        .await?,
+    );
+
+    let contract_addresses =
+        HashMap::from_iter(vec![(bridge_address, newest_unfinalized_block_recorded)]);
+
+    let (_task_handles, eth_events_rx) =
+        LatestEthSyncer::new(eth_client, provider.clone(), contract_addresses.clone())
+            .run()
+            .await
+            .expect("Failed to start eth syncer");
+
+    let _unfinalized_task_handle = spawn_logged_monitored_task!(
+        process_eth_events(eth_events_rx, provider.clone(), &pg_pool, false),
+        "unfinalized indexer handler"
+    );
 
     Ok(())
 }

--- a/crates/sui-bridge-indexer/src/metrics.rs
+++ b/crates/sui-bridge-indexer/src/metrics.rs
@@ -10,10 +10,6 @@ pub struct BridgeIndexerMetrics {
     pub(crate) total_sui_token_transfer_approved: IntCounter,
     pub(crate) total_sui_token_transfer_claimed: IntCounter,
     pub(crate) total_sui_bridge_txn_other: IntCounter,
-    pub(crate) total_eth_bridge_transactions: IntCounter,
-    pub(crate) total_eth_token_deposited: IntCounter,
-    pub(crate) total_eth_token_transfer_claimed: IntCounter,
-    pub(crate) total_eth_bridge_txn_other: IntCounter,
 }
 
 impl BridgeIndexerMetrics {
@@ -46,30 +42,6 @@ impl BridgeIndexerMetrics {
             total_sui_bridge_txn_other: register_int_counter_with_registry!(
                 "total_sui_bridge_txn_other",
                 "Total number of other sui bridge transactions",
-                registry,
-            )
-            .unwrap(),
-            total_eth_bridge_transactions: register_int_counter_with_registry!(
-                "total_eth_bridge_transactions",
-                "Total number of eth bridge transactions",
-                registry,
-            )
-            .unwrap(),
-            total_eth_token_deposited: register_int_counter_with_registry!(
-                "total_eth_token_deposited",
-                "Total number of eth token deposited transactions",
-                registry,
-            )
-            .unwrap(),
-            total_eth_token_transfer_claimed: register_int_counter_with_registry!(
-                "total_eth_token_transfer_claimed",
-                "Total number of eth token claimed transactions",
-                registry,
-            )
-            .unwrap(),
-            total_eth_bridge_txn_other: register_int_counter_with_registry!(
-                "total_eth_bridge_txn_other",
-                "Total number of other eth bridge transactions",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge-indexer/src/postgres_manager.rs
+++ b/crates/sui-bridge-indexer/src/postgres_manager.rs
@@ -5,6 +5,11 @@ use crate::models::TokenTransfer as DBTokenTransfer;
 use crate::models::TokenTransferData as DBTokenTransferData;
 use crate::schema::token_transfer_data;
 use crate::{schema::token_transfer, TokenTransfer};
+use diesel::result::Error;
+use diesel::BoolExpressionMethods;
+use diesel::ExpressionMethods;
+use diesel::OptionalExtension;
+use diesel::QueryDsl;
 use diesel::{
     pg::PgConnection,
     r2d2::{ConnectionManager, Pool},
@@ -21,6 +26,7 @@ pub fn get_connection_pool(database_url: String) -> PgPool {
         .expect("Could not build Postgres DB connection pool")
 }
 
+// TODO: add retry logic
 pub fn write(pool: &PgPool, token_txns: Vec<TokenTransfer>) -> Result<(), anyhow::Error> {
     let (transfers, data): (Vec<DBTokenTransfer>, Vec<Option<DBTokenTransferData>>) = token_txns
         .iter()
@@ -41,4 +47,27 @@ pub fn write(pool: &PgPool, token_txns: Vec<TokenTransfer>) -> Result<(), anyhow
             .execute(conn)
     })?;
     Ok(())
+}
+
+pub fn get_latest_eth_token_transfer(
+    pool: &PgPool,
+    finalized: bool,
+) -> Result<Option<DBTokenTransfer>, Error> {
+    use crate::schema::token_transfer::dsl::*;
+
+    let connection = &mut pool.get().unwrap();
+
+    if finalized {
+        token_transfer
+            .filter(data_source.eq("ETH").and(status.eq("Deposited")))
+            .order(block_height.desc())
+            .first::<DBTokenTransfer>(connection)
+            .optional()
+    } else {
+        token_transfer
+            .filter(status.eq("DepositedUnfinalized"))
+            .order(block_height.desc())
+            .first::<DBTokenTransfer>(connection)
+            .optional()
+    }
 }

--- a/crates/sui-bridge-indexer/src/sui_worker.rs
+++ b/crates/sui-bridge-indexer/src/sui_worker.rs
@@ -1,24 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::postgres_manager::{get_connection_pool, write, PgPool};
 use crate::{
-    metrics::BridgeIndexerMetrics,
-    postgres_writer::{get_connection_pool, write, PgPool},
-    BridgeDataSource, TokenTransfer, TokenTransferData, TokenTransferStatus,
+    metrics::BridgeIndexerMetrics, BridgeDataSource, TokenTransfer, TokenTransferData,
+    TokenTransferStatus,
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use ethers::providers::Provider;
-use ethers::providers::{Http, Middleware};
-use ethers::types::{Address as EthAddress, H256};
-use mysten_metrics::metered_channel::Receiver;
 use std::collections::BTreeSet;
-use std::sync::Arc;
-use sui_bridge::abi::{EthBridgeEvent, EthSuiBridgeEvents};
 use sui_bridge::events::{
     MoveTokenDepositedEvent, MoveTokenTransferApproved, MoveTokenTransferClaimed,
 };
-use sui_bridge::types::EthLog;
 use sui_data_ingestion_core::Worker;
 use sui_types::event::Event;
 use sui_types::{
@@ -30,13 +23,13 @@ use sui_types::{
 };
 use tracing::info;
 
-pub struct BridgeWorker {
+pub struct SuiBridgeWorker {
     bridge_object_ids: BTreeSet<ObjectID>,
     pg_pool: PgPool,
     metrics: BridgeIndexerMetrics,
 }
 
-impl BridgeWorker {
+impl SuiBridgeWorker {
     pub fn new(
         bridge_object_ids: Vec<ObjectID>,
         db_url: String,
@@ -174,115 +167,8 @@ impl BridgeWorker {
     }
 }
 
-pub async fn process_eth_transaction(
-    mut eth_events_rx: Receiver<(EthAddress, u64, Vec<EthLog>)>,
-    provider: Arc<Provider<Http>>,
-    pool: PgPool,
-    metrics: BridgeIndexerMetrics,
-) {
-    while let Some((_, _, logs)) = eth_events_rx.recv().await {
-        let mut data = vec![];
-        for log in &logs {
-            let Some(bridge_event) = EthBridgeEvent::try_from_eth_log(log) else {
-                continue;
-            };
-            let block_number = log.block_number;
-            let block = provider.get_block(log.block_number).await.unwrap().unwrap();
-            let timestamp = block.timestamp.as_u64() * 1000;
-            let transaction = provider
-                .get_transaction(log.tx_hash)
-                .await
-                .unwrap()
-                .unwrap();
-            let gas = transaction.gas;
-            let tx_hash = log.tx_hash;
-            info!("Observed Eth bridge event: {:?}", bridge_event);
-            metrics.total_eth_bridge_transactions.inc();
-            if let Some(token_transfer) = process_eth_event(
-                bridge_event,
-                block_number,
-                timestamp,
-                tx_hash,
-                gas.as_u64(),
-                &metrics,
-            ) {
-                data.push(token_transfer)
-            }
-        }
-        write(&pool, data).unwrap();
-        // TODO: record last processed block
-        // TODO: handle error for the ETH data ingestion
-    }
-}
-
-fn process_eth_event(
-    bridge_event: EthBridgeEvent,
-    block_height: u64,
-    timestamp_ms: u64,
-    tx_hash: H256,
-    gas: u64,
-    metrics: &BridgeIndexerMetrics,
-) -> Option<TokenTransfer> {
-    match bridge_event {
-        EthBridgeEvent::EthSuiBridgeEvents(bridge_event) => match bridge_event {
-            EthSuiBridgeEvents::TokensDepositedFilter(bridge_event) => {
-                info!("Observed Eth Deposit {:?}", bridge_event);
-                metrics.total_eth_token_deposited.inc();
-                Some(TokenTransfer {
-                    chain_id: bridge_event.source_chain_id,
-                    nonce: bridge_event.nonce,
-                    block_height,
-                    timestamp_ms,
-                    txn_hash: tx_hash.as_bytes().to_vec(),
-                    txn_sender: bridge_event.sender_address.as_bytes().to_vec(),
-                    status: TokenTransferStatus::Deposited,
-                    gas_usage: gas as i64,
-                    data_source: BridgeDataSource::Eth,
-                    data: Some(TokenTransferData {
-                        destination_chain: bridge_event.destination_chain_id,
-                        sender_address: bridge_event.sender_address.as_bytes().to_vec(),
-                        recipient_address: bridge_event.recipient_address.to_vec(),
-                        token_id: bridge_event.token_id,
-                        amount: bridge_event.sui_adjusted_amount,
-                    }),
-                })
-            }
-            EthSuiBridgeEvents::TokensClaimedFilter(bridge_event) => {
-                info!("Observed Eth Claim {:?}", bridge_event);
-                metrics.total_eth_token_transfer_claimed.inc();
-                Some(TokenTransfer {
-                    chain_id: bridge_event.source_chain_id,
-                    nonce: bridge_event.nonce,
-                    block_height,
-                    timestamp_ms,
-                    txn_hash: tx_hash.as_bytes().to_vec(),
-                    txn_sender: bridge_event.sender_address.to_vec(),
-                    status: TokenTransferStatus::Claimed,
-                    gas_usage: gas as i64,
-                    data_source: BridgeDataSource::Eth,
-                    data: None,
-                })
-            }
-            EthSuiBridgeEvents::PausedFilter(_)
-            | EthSuiBridgeEvents::UnpausedFilter(_)
-            | EthSuiBridgeEvents::UpgradedFilter(_)
-            | EthSuiBridgeEvents::InitializedFilter(_) => {
-                metrics.total_eth_bridge_txn_other.inc();
-                None
-            }
-        },
-        EthBridgeEvent::EthBridgeCommitteeEvents(_)
-        | EthBridgeEvent::EthBridgeLimiterEvents(_)
-        | EthBridgeEvent::EthBridgeConfigEvents(_)
-        | EthBridgeEvent::EthCommitteeUpgradeableContractEvents(_) => {
-            metrics.total_eth_bridge_txn_other.inc();
-            None
-        }
-    }
-}
-
 #[async_trait]
-impl Worker for BridgeWorker {
+impl Worker for SuiBridgeWorker {
     async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
         info!(
             "Processing checkpoint [{}] {}: {}",


### PR DESCRIPTION
## Description 

Added the following:

- DepositedUnfinalized TokenTransferStatus. This status indicates that this event was captured in an unfinalized block.  
- LatestEthSyncer component that enables the indexer to listen to unfinalized blocks. 
- Eth idempotency. This is so that we can start indexing from the block that was last processed when starting / restarting the indexer. 