### PR TITLE
[docs][easy] Added redirtects

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -94,6 +94,10 @@
       { "source": "/guides/developer/app-examples/trustless-token-swap/:path*", "destination": "/guides/developer/app-examples/trustless-swap/:path*", "permanent": true},
       { "source": "/concepts/cryptography/zklogin/zklogin-example", "destination": "/guides/developer/cryptography/zklogin-integration/zklogin-example", "permanent": true},
       { "source": "/guides/developer/getting-started/sui-environment", "destination": "/references/contribute/sui-environment", "permanent": true},
-      { "source": "/concepts/sui-move-concepts/packages/:path*", "destination": "https://move-book.com/index.html", "permanent": true}
+      { "source": "/concepts/sui-move-concepts/patterns/capabilities", "destination": "https://move-book.com/programmability/capability.html", "permanent": true },
+      { "source": "/concepts/sui-move-concepts/patterns/witness", "destination": "https://move-book.com/programmability/capability.html", "permanent": true },
+      { "source": "/concepts/sui-move-concepts/patterns/hot-potato", "destination": "https://examples.sui.io/patterns/hot-potato.html", "permanent": false },
+      { "source": "/concepts/sui-move-concepts/patterns/id-pointer", "destination": "https://move-book.com/storage/uid-and-id.html", "permanent": true },
+      { "source": "/concepts/sui-move-concepts/patterns/transferrable-witness", "destination": "https://examples.sui.io/patterns/transferable-witness.html", "permanent": false }
     ]
   }


### PR DESCRIPTION
## Description 

Fixed error in redirects for the Patterns topics that now are (or soon will be) in the Move Book. Using some temporary redirects to examples.sui, which will go away when content is ported.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
