### PR TITLE
[CLI] Add clever error support to Sui CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,9 +6787,11 @@ name = "move-command-line-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "difference",
  "dirs-next",
  "hex",
+ "move-binary-format",
  "move-core-types",
  "num-bigint 0.4.4",
  "once_cell",

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -7,10 +7,11 @@ use move_binary_format::file_format::{
     AbilitySet, DatatypeTyParameter, EnumDefinitionIndex, FunctionDefinitionIndex,
     Signature as MoveSignature, SignatureIndex, Visibility,
 };
-use move_command_line_common::error_bitset::ErrorBitset;
+use move_command_line_common::display::RenderResult;
+use move_command_line_common::{display::try_render_constant, error_bitset::ErrorBitset};
 use move_core_types::annotated_value::MoveEnumLayout;
 use move_core_types::language_storage::ModuleId;
-use move_core_types::u256::U256;
+use std::collections::btree_map::Entry;
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -594,40 +595,16 @@ impl<S: PackageStore> Resolver<S> {
             .and_then(|x| String::from_utf8(x).ok())?;
         let bytes = error_value_constant.data.clone();
 
-        let rendered = match &error_value_constant.type_ {
-            SignatureToken::Vector(inner_ty) if inner_ty.as_ref() == &SignatureToken::U8 => {
-                bcs::from_bytes::<Vec<u8>>(&bytes)
-                    .ok()
-                    .and_then(|x| String::from_utf8(x).ok())
-            }
-            SignatureToken::U8 => bcs::from_bytes::<u8>(&bytes).ok().map(|x| x.to_string()),
-            SignatureToken::U16 => bcs::from_bytes::<u16>(&bytes).ok().map(|x| x.to_string()),
-            SignatureToken::U32 => bcs::from_bytes::<u32>(&bytes).ok().map(|x| x.to_string()),
-            SignatureToken::U64 => bcs::from_bytes::<u64>(&bytes).ok().map(|x| x.to_string()),
-            SignatureToken::U128 => bcs::from_bytes::<u128>(&bytes).ok().map(|x| x.to_string()),
-            SignatureToken::U256 => bcs::from_bytes::<U256>(&bytes).ok().map(|x| x.to_string()),
-            SignatureToken::Address => bcs::from_bytes::<AccountAddress>(&bytes)
-                .ok()
-                .map(|x| x.to_canonical_string(true)),
-            SignatureToken::Bool => bcs::from_bytes::<bool>(&bytes).ok().map(|x| x.to_string()),
-
-            SignatureToken::Signer
-            | SignatureToken::Vector(_)
-            | SignatureToken::Datatype(_)
-            | SignatureToken::DatatypeInstantiation(_)
-            | SignatureToken::Reference(_)
-            | SignatureToken::MutableReference(_)
-            | SignatureToken::TypeParameter(_) => None,
-        };
+        let rendered = try_render_constant(error_value_constant);
 
         let error_info = match rendered {
-            None => ErrorConstants::Raw {
+            RenderResult::NotRendered => ErrorConstants::Raw {
                 identifier: error_identifier,
                 bytes,
             },
-            Some(error_constant) => ErrorConstants::Rendered {
+            RenderResult::AsString(s) | RenderResult::AsValue(s) => ErrorConstants::Rendered {
                 identifier: error_identifier,
-                constant: error_constant,
+                constant: s,
             },
         };
 

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -11,7 +11,6 @@ use move_command_line_common::display::RenderResult;
 use move_command_line_common::{display::try_render_constant, error_bitset::ErrorBitset};
 use move_core_types::annotated_value::MoveEnumLayout;
 use move_core_types::language_storage::ModuleId;
-use std::collections::btree_map::Entry;
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};

--- a/crates/sui/src/clever_error_rendering.rs
+++ b/crates/sui/src/clever_error_rendering.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use fastcrypto::encoding::{Base64, Encoding};
+use move_binary_format::{
+    binary_config::BinaryConfig, file_format::SignatureToken, CompiledModule,
+};
+use move_command_line_common::{
+    display::{try_render_constant, RenderResult},
+    error_bitset::ErrorBitset,
+};
+use move_core_types::account_address::AccountAddress;
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiRawData};
+use sui_sdk::apis::ReadApi;
+use sui_types::{base_types::ObjectID, Identifier};
+
+pub async fn render_clever_error_opt(error_string: &str, read_api: &ReadApi) -> Option<String> {
+    let (address, module_name, function_name, instruction, abort_code, command_index) =
+        parse_abort_status_string(error_string).ok()?;
+
+    let error = 'error: {
+        let Some(error_bitset) = ErrorBitset::from_u64(abort_code) else {
+            break 'error format!(
+                "function '{}::{}::{}' at instruction {} with code {}",
+                address.to_canonical_display(true),
+                module_name,
+                function_name,
+                instruction,
+                abort_code
+            );
+        };
+
+        let line_number = error_bitset.line_number()?;
+
+        if error_bitset.constant_index().is_none() && error_bitset.identifier_index().is_none() {
+            break 'error format!(
+                "function '{}::{}::{}' at line {}",
+                address.to_canonical_display(true),
+                module_name,
+                function_name,
+                line_number
+            );
+        }
+
+        let SuiRawData::Package(package) = read_api
+            .get_object_with_options(
+                ObjectID::from_address(address),
+                SuiObjectDataOptions::bcs_lossless(),
+            )
+            .await
+            .ok()?
+            .into_object()
+            .ok()?
+            .bcs?
+        else {
+            return None;
+        };
+
+        let module = package.module_map.get(module_name.as_str())?;
+        let module =
+            CompiledModule::deserialize_with_config(module, &BinaryConfig::standard()).ok()?;
+
+        let error_identifier_constant = module
+            .constant_pool()
+            .get(error_bitset.identifier_index()? as usize)?;
+        let error_value_constant = module
+            .constant_pool()
+            .get(error_bitset.constant_index()? as usize)?;
+
+        if !matches!(&error_identifier_constant.type_, SignatureToken::Vector(x) if x.as_ref() == &SignatureToken::U8)
+        {
+            return None;
+        };
+
+        let error_identifier = bcs::from_bytes::<Vec<u8>>(&error_identifier_constant.data)
+            .ok()
+            .and_then(|x| String::from_utf8(x).ok())?;
+
+        let const_str = match try_render_constant(error_value_constant) {
+            RenderResult::NotRendered => {
+                format!("'{}'", Base64::encode(&error_value_constant.data))
+            }
+            RenderResult::AsString(s) => format!("'{s}'"),
+            RenderResult::AsValue(v_str) => v_str,
+        };
+
+        format!(
+            "function '{}::{}::{}' at line {}. Aborted with '{}' -- {}",
+            address.to_canonical_display(true),
+            module_name,
+            function_name,
+            line_number,
+            error_identifier,
+            const_str
+        )
+    };
+
+    // Convert the command index into an ordinal.
+    let command = command_index + 1;
+    let suffix = match command % 10 {
+        1 => "st",
+        2 => "nd",
+        3 => "rd",
+        _ => "th",
+    };
+
+    Some(format!("{command}{suffix} command aborted within {error}"))
+}
+
+fn parse_abort_status_string(
+    s: &str,
+) -> Result<(AccountAddress, Identifier, Identifier, u16, u64, u16), anyhow::Error> {
+    use regex::Regex;
+    let re = Regex::new(r"MoveAbort.*address:\s*(.*?),.*Identifier...(.*?)\\.*instruction:\s+(\d+),.*function_name:\s*Some...(\w+?)\\.*},\s*(\d+).*in command\s*(\d+)").unwrap();
+    let captures = re.captures(s).unwrap();
+
+    let address = AccountAddress::from_hex(captures.get(1).unwrap().as_str())?;
+    let module_name = Identifier::new(captures.get(2).unwrap().as_str())?;
+    let instruction = captures.get(3).unwrap().as_str().parse::<u16>()?;
+    let function_name = Identifier::new(captures.get(4).unwrap().as_str())?;
+    let abort_code = captures.get(5).unwrap().as_str().parse::<u64>()?;
+    let command_index = captures.get(6).unwrap().as_str().parse::<u16>()?;
+    Ok((
+        address,
+        module_name,
+        function_name,
+        instruction,
+        abort_code,
+        command_index,
+    ))
+}

--- a/crates/sui/src/clever_error_rendering.rs
+++ b/crates/sui/src/clever_error_rendering.rs
@@ -1,6 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module provides a function to render a Move abort status string into a more human-readable
+//! error message using the clever error rendering logic.
+//!
+//! The logic in this file is largely a stop-gap to provide Clever Error rendering in the CLI while
+//! it still uses the JSON-RPC API. The new GraphQL API already renderd Clever Errors on the server
+//! side in a much more robust and efficient way.
+//!
+//! Once the CLI is updated to use the GraphQL API, this file can be removed, and the GraphQL-based
+//! rendering logic for Clever Errors should be used instead.
+
 use fastcrypto::encoding::{Base64, Encoding};
 use move_binary_format::{
     binary_config::BinaryConfig, file_format::SignatureToken, CompiledModule,
@@ -14,7 +24,18 @@ use sui_json_rpc_types::{SuiObjectDataOptions, SuiRawData};
 use sui_sdk::apis::ReadApi;
 use sui_types::{base_types::ObjectID, Identifier};
 
-pub async fn render_clever_error_opt(error_string: &str, read_api: &ReadApi) -> Option<String> {
+/// Take a Move abort status string and render it into a more human-readable error message using
+/// by parsing the string (as best we can) and seeing if the abort code is a Clever Error abort
+/// code. If it is, we attempt to render the error in a more huma-readable manner using the Read
+/// API and decoding the Clever Error encoding in the abort code.
+///
+/// This function is used to render Clever Errors for on-chain errors only within the Sui CLI. This
+/// function is _not_ used at all for off-chain errors or Move unit tests. You should only use this
+/// function within this crate.
+pub(crate) async fn render_clever_error_opt(
+    error_string: &str,
+    read_api: &ReadApi,
+) -> Option<String> {
     let (address, module_name, function_name, instruction, abort_code, command_index) =
         parse_abort_status_string(error_string).ok()?;
 
@@ -107,6 +128,16 @@ pub async fn render_clever_error_opt(error_string: &str, read_api: &ReadApi) -> 
     Some(format!("{command}{suffix} command aborted within {error}"))
 }
 
+/// Parsing the error with a regex is not great, but it's the best we can do with the current
+/// JSON-RPC API since we only get error messages as strings. This function attempts to parse a
+/// Move abort status string into its different parts, and then parses it back into the structured
+/// format that we can then use to render a Clever Error.
+///
+/// If we are able to parse the string, we return a tuple with the address, module name, function
+/// name, instruction, abort code, and command index. If we are unable to parse the string, we
+/// return `Err`.
+///
+/// You should delete this function with glee once the CLI is updated to use the GraphQL API.
 fn parse_abort_status_string(
     s: &str,
 ) -> Result<(AccountAddress, Identifier, Identifier, u16, u64, u16), anyhow::Error> {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -43,7 +43,8 @@ use sui_json_rpc_types::{
     Coin, DryRunTransactionBlockResponse, DynamicFieldPage, SuiCoinMetadata, SuiData,
     SuiExecutionStatus, SuiObjectData, SuiObjectDataOptions, SuiObjectResponse,
     SuiObjectResponseQuery, SuiParsedData, SuiProtocolConfigValue, SuiRawData,
-    SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+    SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_move_build::{
@@ -664,7 +665,7 @@ impl SuiClientCommands {
         self,
         context: &mut WalletContext,
     ) -> Result<SuiClientCommandResult, anyhow::Error> {
-        let ret = Ok(match self {
+        let ret = match self {
             SuiClientCommands::ProfileTransaction {
                 tx_digest,
                 profile_output,
@@ -1584,8 +1585,9 @@ impl SuiClientCommands {
                 ptb.execute(context).await?;
                 SuiClientCommandResult::NoOutput
             }
-        });
-        ret
+        };
+        let client = context.get_client().await?;
+        Ok(ret.prerender_clever_errors(client.read_api()).await)
     }
 
     pub fn switch_env(config: &mut SuiClientConfig, env: &str) -> Result<(), anyhow::Error> {
@@ -2205,6 +2207,42 @@ impl SuiClientCommandResult {
             _ => None,
         }
     }
+
+    pub async fn prerender_clever_errors(mut self, read_api: &ReadApi) -> Self {
+        match &mut self {
+            SuiClientCommandResult::DryRun(DryRunTransactionBlockResponse { effects, .. })
+            | SuiClientCommandResult::TransactionBlock(SuiTransactionBlockResponse {
+                effects: Some(effects),
+                ..
+            }) => prerender_clever_errors(effects, read_api).await,
+
+            SuiClientCommandResult::TransactionBlock(SuiTransactionBlockResponse {
+                effects: None,
+                ..
+            }) => (),
+            SuiClientCommandResult::ActiveAddress(_)
+            | SuiClientCommandResult::ActiveEnv(_)
+            | SuiClientCommandResult::Addresses(_)
+            | SuiClientCommandResult::Balance(_, _)
+            | SuiClientCommandResult::ChainIdentifier(_)
+            | SuiClientCommandResult::DynamicFieldQuery(_)
+            | SuiClientCommandResult::Envs(_, _)
+            | SuiClientCommandResult::Gas(_)
+            | SuiClientCommandResult::NewAddress(_)
+            | SuiClientCommandResult::NewEnv(_)
+            | SuiClientCommandResult::NoOutput
+            | SuiClientCommandResult::Object(_)
+            | SuiClientCommandResult::Objects(_)
+            | SuiClientCommandResult::RawObject(_)
+            | SuiClientCommandResult::SerializedSignedTransaction(_)
+            | SuiClientCommandResult::SerializedUnsignedTransaction(_)
+            | SuiClientCommandResult::Switch(_)
+            | SuiClientCommandResult::SyncClientState
+            | SuiClientCommandResult::VerifyBytecodeMeter { .. }
+            | SuiClientCommandResult::VerifySource => (),
+        }
+        self
+    }
 }
 
 #[derive(Serialize)]
@@ -2569,7 +2607,10 @@ pub async fn execute_dry_run(
         .dry_run_transaction_block(dry_run_tx_data)
         .await
         .map_err(|e| anyhow!("Dry run failed: {e}"))?;
-    Ok(SuiClientCommandResult::DryRun(response))
+    let resp = SuiClientCommandResult::DryRun(response)
+        .prerender_clever_errors(client.read_api())
+        .await;
+    Ok(resp)
 }
 
 /// Call a dry run with the transaction data to estimate the gas budget.
@@ -2719,22 +2760,32 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
             ))
         } else {
             let transaction = Transaction::new(sender_signed_data);
-            let response = context.execute_transaction_may_fail(transaction).await?;
+            let mut response = context.execute_transaction_may_fail(transaction).await?;
+            if let Some(effects) = response.effects.as_mut() {
+                prerender_clever_errors(effects, client.read_api()).await;
+            }
             let effects = response.effects.as_ref().ok_or_else(|| {
                 anyhow!("Effects from SuiTransactionBlockResult should not be empty")
             })?;
-            if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
-                let error_string = if let Some(parsed_abort) =
-                    render_clever_error_opt(&format!("{:?}", effects.status()), client.read_api())
-                        .await
-                {
-                    parsed_abort
-                } else {
-                    format!("{:#?}", effects.status())
-                };
-                return Err(anyhow!("Error executing transaction: {error_string}",));
+            if let SuiExecutionStatus::Failure { error } = effects.status() {
+                return Err(anyhow!(
+                    "Error executing transaction '{}': {error}",
+                    response.digest
+                ));
             }
             Ok(SuiClientCommandResult::TransactionBlock(response))
+        }
+    }
+}
+
+pub(crate) async fn prerender_clever_errors(
+    effects: &mut SuiTransactionBlockEffects,
+    read_api: &ReadApi,
+) {
+    let SuiTransactionBlockEffects::V1(effects) = effects;
+    if let SuiExecutionStatus::Failure { error } = &mut effects.status {
+        if let Some(rendered) = render_clever_error_opt(error, read_api).await {
+            *error = rendered;
         }
     }
 }

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod client_commands;
 #[macro_use]
 pub mod client_ptb;
+mod clever_error_rendering;
 pub mod console;
 pub mod displays;
 pub mod fire_drill;

--- a/crates/sui/src/snapshots/sui__clever_error_rendering__tests__parse_abort_status_string.snap
+++ b/crates/sui/src/snapshots/sui__clever_error_rendering__tests__parse_abort_status_string.snap
@@ -1,0 +1,35 @@
+---
+source: crates/sui/src/clever_error_rendering.rs
+expression: "parsed.join(\"\\n------\\n\")"
+---
+original abort message: Failure { error: "MoveAbort(MoveLocation { module: ModuleId { address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20, name: Identifier(\"clever_errors\") }, function: 0, instruction: 1, function_name: Some(\"aborter\") }, 0) in command 0" }
+ address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20
+ module_name: clever_errors
+ function_name: aborter
+ instruction: 1
+ abort_code: 0
+ command_index: 0
+------
+original abort message: Failure { error: "MoveAbort(MoveLocation { module: ModuleId { address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20, name: Identifier(\"clever_errors\") }, function: 1, instruction: 1, function_name: Some(\"aborter_line_no\") }, 9223372105574252543) in command 0" }
+ address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20
+ module_name: clever_errors
+ function_name: aborter_line_no
+ instruction: 1
+ abort_code: 9223372105574252543
+ command_index: 0
+------
+original abort message: Failure { error: "MoveAbort(MoveLocation { module: ModuleId { address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20, name: Identifier(\"clever_errors\") }, function: 2, instruction: 1, function_name: Some(\"clever_aborter\") }, 9223372118459154433) in command 0" }
+ address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20
+ module_name: clever_errors
+ function_name: clever_aborter
+ instruction: 1
+ abort_code: 9223372118459154433
+ command_index: 0
+------
+original abort message: Failure { error: "MoveAbort(MoveLocation { module: ModuleId { address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20, name: Identifier(\"clever_errors\") }, function: 3, instruction: 1, function_name: Some(\"clever_aborter_not_a_string\") }, 9223372135639154691) in command 0" }
+ address: 60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20
+ module_name: clever_errors
+ function_name: clever_aborter_not_a_string
+ instruction: 1
+ abort_code: 9223372135639154691
+ command_index: 0

--- a/crates/sui/src/snapshots/sui__clever_error_rendering__tests__parse_abort_status_string.snap
+++ b/crates/sui/src/snapshots/sui__clever_error_rendering__tests__parse_abort_status_string.snap
@@ -33,3 +33,19 @@ original abort message: Failure { error: "MoveAbort(MoveLocation { module: Modul
  instruction: 1
  abort_code: 9223372135639154691
  command_index: 0
+------
+original abort message: MoveAbort(MoveLocation { module: ModuleId { address: 24bf9e624820625ac1e38076901421d2630b2b225b638aaf0b85264b857a608b, name: Identifier(\"tester\") }, function: 0, instruction: 1, function_name: Some(\"test\") }, 9223372071214514177) in command 0
+ address: 24bf9e624820625ac1e38076901421d2630b2b225b638aaf0b85264b857a608b
+ module_name: tester
+ function_name: test
+ instruction: 1
+ abort_code: 9223372071214514177
+ command_index: 0
+------
+original abort message: MoveAbort(MoveLocation { module: ModuleId { address: 24bf9e624820625ac1e38076901421d2630b2b225b638aaf0b85264b857a608b, name: Identifier("tester") }, function: 0, instruction: 1, function_name: Some("test") }, 9223372071214514177) in command 0
+ address: 24bf9e624820625ac1e38076901421d2630b2b225b638aaf0b85264b857a608b
+ module_name: tester
+ function_name: test
+ instruction: 1
+ abort_code: 9223372071214514177
+ command_index: 0

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3669,3 +3669,127 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
     }
     Ok(())
 }
+
+#[sim_test]
+async fn test_clever_errors() -> Result<(), anyhow::Error> {
+    // Publish the package
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    // Check log output contains all object ids.
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    // Provide path to well formed package sources
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("clever_errors");
+    let build_config = BuildConfig::new_for_testing().config;
+    let resp = SuiClientCommands::Publish {
+        package_path: package_path.clone(),
+        build_config,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+        opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+    }
+    .execute(context)
+    .await?;
+
+    // Print it out to CLI/logs
+    resp.print(true);
+
+    let SuiClientCommandResult::TransactionBlock(response) = resp else {
+        unreachable!("Invalid response");
+    };
+
+    let SuiTransactionBlockEffects::V1(effects) = response.effects.unwrap();
+
+    assert!(effects.status.is_ok());
+    assert_eq!(effects.gas_object().object_id(), gas_obj_id);
+    let package = effects
+        .created()
+        .iter()
+        .find(|refe| matches!(refe.owner, Owner::Immutable))
+        .unwrap();
+
+    // Normal abort
+    let non_clever_abort = SuiClientCommands::Call {
+        package: package.reference.object_id,
+        module: "clever_errors".to_string(),
+        function: "aborter".to_string(),
+        type_args: vec![],
+        opts: OptsWithGas::for_testing(None, rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+        gas_price: None,
+        args: vec![],
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+
+    // Line-only abort
+    let line_only_abort = SuiClientCommands::Call {
+        package: package.reference.object_id,
+        module: "clever_errors".to_string(),
+        function: "aborter_line_no".to_string(),
+        type_args: vec![],
+        opts: OptsWithGas::for_testing(None, rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+        gas_price: None,
+        args: vec![],
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+
+    // Full clever error with utf-8 string
+    let clever_error_utf8 = SuiClientCommands::Call {
+        package: package.reference.object_id,
+        module: "clever_errors".to_string(),
+        function: "clever_aborter".to_string(),
+        type_args: vec![],
+        opts: OptsWithGas::for_testing(None, rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+        gas_price: None,
+        args: vec![],
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+
+    // Full clever error with non-utf-8 string
+    let clever_error_non_utf8 = SuiClientCommands::Call {
+        package: package.reference.object_id,
+        module: "clever_errors".to_string(),
+        function: "clever_aborter_not_a_string".to_string(),
+        type_args: vec![],
+        opts: OptsWithGas::for_testing(None, rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+        gas_price: None,
+        args: vec![],
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+
+    insta::assert_snapshot!(
+        format!(
+            "Non-clever-abort\n---\n{}\n---\nLine-only-abort\n---\n{}\n---\nClever-error-utf8\n---\n{}\n---\nClever-error-non-utf8\n---\n{}\n---\n",
+             non_clever_abort, line_only_abort, clever_error_utf8, clever_error_non_utf8
+        )
+    );
+    Ok(())
+}

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3730,8 +3730,10 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
         .unwrap();
 
     let elide_transaction_digest = |s: String| -> String {
-        let mut x = s.splitn(3, '\'').collect::<Vec<_>>();
-        x[1] = "<ELIDED_TRANSACTION_DIGEST>";
+        let mut x = s.splitn(5, '\'').collect::<Vec<_>>();
+        x[1] = "ELIDED_TRANSACTION_DIGEST";
+        let tmp = format!("ELIDED_ADDRESS{}", &x[3][66..]);
+        x[3] = &tmp;
         x.join("'")
     };
 
@@ -3793,7 +3795,7 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
 
     let error_string = format!(
         "Non-clever-abort\n---\n{}\n---\nLine-only-abort\n---\n{}\n---\nClever-error-utf8\n---\n{}\n---\nClever-error-non-utf8\n---\n{}\n---\n",
-        elide_transaction_digest(non_clever_abort.to_string()), 
+        elide_transaction_digest(non_clever_abort.to_string()),
         elide_transaction_digest(line_only_abort.to_string()),
         elide_transaction_digest(clever_error_utf8.to_string()),
         elide_transaction_digest(clever_error_non_utf8.to_string())

--- a/crates/sui/tests/data/clever_errors/Move.toml
+++ b/crates/sui/tests/data/clever_errors/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "clever_errors"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[addresses]
+clever_errors = "0x0"

--- a/crates/sui/tests/data/clever_errors/sources/clever_errors.move
+++ b/crates/sui/tests/data/clever_errors/sources/clever_errors.move
@@ -1,0 +1,25 @@
+// Do _not_ edit this file (yes, even whitespace!). Editing this file will
+// cause the tests that use this module to fail.
+module clever_errors::clever_errors {
+    #[error]
+    const ENotFound: vector<u8> = b"Element not found in vector 💥 🚀 🌠";
+
+    #[error]
+    const ENotAString: vector<u64> = vector[1,2,3,4];
+
+    public fun aborter() {
+        abort 0
+    }
+
+    public fun aborter_line_no() {
+        assert!(false);
+    }
+
+    public fun clever_aborter() {
+        assert!(false, ENotFound);
+    }
+
+    public fun clever_aborter_not_a_string() {
+        assert!(false, ENotAString);
+    }
+}

--- a/crates/sui/tests/data/clever_errors/sources/clever_errors.move
+++ b/crates/sui/tests/data/clever_errors/sources/clever_errors.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Do _not_ edit this file (yes, even whitespace!). Editing this file will
 // cause the tests that use this module to fail.
 module clever_errors::clever_errors {

--- a/crates/sui/tests/snapshots/cli_tests__body_fn.snap
+++ b/crates/sui/tests/snapshots/cli_tests__body_fn.snap
@@ -4,18 +4,18 @@ expression: "format!(\"Non-clever-abort\\n---\\n{}\\n---\\nLine-only-abort\\n---
 ---
 Non-clever-abort
 ---
-Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::aborter' at instruction 1 with code 0
+Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::aborter' at instruction 1 with code 0
 ---
 Line-only-abort
 ---
-Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::aborter_line_no' at line 15
+Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::aborter_line_no' at line 15
 ---
 Clever-error-utf8
 ---
-Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::clever_aborter' at line 19. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
+Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::clever_aborter' at line 19. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
 ---
 Clever-error-non-utf8
 ---
-Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::clever_aborter_not_a_string' at line 23. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
+Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::clever_aborter_not_a_string' at line 23. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
 ---
 

--- a/crates/sui/tests/snapshots/cli_tests__body_fn.snap
+++ b/crates/sui/tests/snapshots/cli_tests__body_fn.snap
@@ -1,0 +1,21 @@
+---
+source: crates/sui/tests/cli_tests.rs
+expression: "format!(\"Non-clever-abort\\n---\\n{}\\n---\\nLine-only-abort\\n---\\n{}\\n---\\nClever-error-utf8\\n---\\n{}\\n---\\nClever-error-non-utf8\\n---\\n{}\\n---\\n\",\n    non_clever_abort, line_only_abort, clever_error_utf8,\n    clever_error_non_utf8)"
+---
+Non-clever-abort
+---
+Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::aborter' at instruction 1 with code 0
+---
+Line-only-abort
+---
+Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::aborter_line_no' at line 15
+---
+Clever-error-utf8
+---
+Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::clever_aborter' at line 19. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
+---
+Clever-error-non-utf8
+---
+Error executing transaction: 1st command aborted within function '0xc9d9682e45a4291cf2c7d86486f604fe19451bb367cc9fa4f2149eb5f1efac8a::clever_errors::clever_aborter_not_a_string' at line 23. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
+---
+

--- a/crates/sui/tests/snapshots/cli_tests__body_fn.snap
+++ b/crates/sui/tests/snapshots/cli_tests__body_fn.snap
@@ -4,18 +4,18 @@ expression: "format!(\"Non-clever-abort\\n---\\n{}\\n---\\nLine-only-abort\\n---
 ---
 Non-clever-abort
 ---
-Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::aborter' at instruction 1 with code 0
+Error executing transaction 'BQaYuRVbz7BjpjmDXUmFYyxADDK4WySrg1AfTqTao1jo': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::aborter' at instruction 1 with code 0
 ---
 Line-only-abort
 ---
-Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::aborter_line_no' at line 15
+Error executing transaction '3w3diTUzG3ryjpMA3WPrfx9eLNArYqRn1dMDWyTggKGA': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::aborter_line_no' at line 15
 ---
 Clever-error-utf8
 ---
-Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::clever_aborter' at line 19. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
+Error executing transaction '7YmFWxA3WKzKF7Bp3sJisD83EZTGXFosD4TKmq8ughLY': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::clever_aborter' at line 19. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
 ---
 Clever-error-non-utf8
 ---
-Error executing transaction: 1st command aborted within function '0x60197a0c146e31dd12689e890208767fe2fefb2f726710b4a9fa0b857f7a2c20::clever_errors::clever_aborter_not_a_string' at line 23. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
+Error executing transaction 'FK7UrheD4TWakAnK5j5tC3LySXd9obtixumbE9ZS5UYp': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::clever_aborter_not_a_string' at line 23. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
 ---
 

--- a/crates/sui/tests/snapshots/cli_tests__body_fn.snap
+++ b/crates/sui/tests/snapshots/cli_tests__body_fn.snap
@@ -1,21 +1,21 @@
 ---
 source: crates/sui/tests/cli_tests.rs
-expression: "format!(\"Non-clever-abort\\n---\\n{}\\n---\\nLine-only-abort\\n---\\n{}\\n---\\nClever-error-utf8\\n---\\n{}\\n---\\nClever-error-non-utf8\\n---\\n{}\\n---\\n\",\n    non_clever_abort, line_only_abort, clever_error_utf8,\n    clever_error_non_utf8)"
+expression: error_string
 ---
 Non-clever-abort
 ---
-Error executing transaction 'BQaYuRVbz7BjpjmDXUmFYyxADDK4WySrg1AfTqTao1jo': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::aborter' at instruction 1 with code 0
+Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::aborter' at instruction 1 with code 0
 ---
 Line-only-abort
 ---
-Error executing transaction '3w3diTUzG3ryjpMA3WPrfx9eLNArYqRn1dMDWyTggKGA': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::aborter_line_no' at line 15
+Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::aborter_line_no' at line 18
 ---
 Clever-error-utf8
 ---
-Error executing transaction '7YmFWxA3WKzKF7Bp3sJisD83EZTGXFosD4TKmq8ughLY': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::clever_aborter' at line 19. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
+Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::clever_aborter' at line 22. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
 ---
 Clever-error-non-utf8
 ---
-Error executing transaction 'FK7UrheD4TWakAnK5j5tC3LySXd9obtixumbE9ZS5UYp': 1st command aborted within function '0xb691b7e8d182a5d5c8dd834b234a2bd55d9c42210cba8e852cd134586a74390e::clever_errors::clever_aborter_not_a_string' at line 23. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
+Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::clever_aborter_not_a_string' at line 26. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
 ---
 

--- a/crates/sui/tests/snapshots/cli_tests__body_fn.snap
+++ b/crates/sui/tests/snapshots/cli_tests__body_fn.snap
@@ -4,18 +4,18 @@ expression: error_string
 ---
 Non-clever-abort
 ---
-Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::aborter' at instruction 1 with code 0
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': 1st command aborted within function 'ELIDED_ADDRESS::clever_errors::aborter' at instruction 1 with code 0
 ---
 Line-only-abort
 ---
-Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::aborter_line_no' at line 18
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': 1st command aborted within function 'ELIDED_ADDRESS::clever_errors::aborter_line_no' at line 18
 ---
 Clever-error-utf8
 ---
-Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::clever_aborter' at line 22. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': 1st command aborted within function 'ELIDED_ADDRESS::clever_errors::clever_aborter' at line 22. Aborted with 'ENotFound' -- 'Element not found in vector 💥 🚀 🌠'
 ---
 Clever-error-non-utf8
 ---
-Error executing transaction '<ELIDED_TRANSACTION_DIGEST>': 1st command aborted within function '0x04becddebc3ae9e7e48c3f31144860e0f99a7414e533716a16db14a831ac4be6::clever_errors::clever_aborter_not_a_string' at line 26. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': 1st command aborted within function 'ELIDED_ADDRESS::clever_errors::clever_aborter_not_a_string' at line 26. Aborted with 'ENotAString' -- 'BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA'
 ---
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1713,9 +1713,11 @@ name = "move-command-line-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "difference",
  "dirs-next",
  "hex",
+ "move-binary-format",
  "move-core-types",
  "num-bigint",
  "once_cell",

--- a/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/args.exp
@@ -14,19 +14,31 @@ struct As {
 
 public zf(): u64 {
 B0:
-	0: LdConst[0](U64: 01000000..)
+	0: LdConst[0](u64: 1)
 	1: Ret
 
 }
 public af(): u32 {
 B0:
-	0: LdConst[1](U32: 00000000)
+	0: LdConst[1](u32: 0)
+	1: Ret
+}
+public sf(): vector<u8> {
+B0:
+	0: LdConst[2](vector<u8>: "Thi..)
+	1: Ret
+}
+public nf(): vector<u16> {
+B0:
+	0: LdConst[3](vector<u16>: 0401..)
 	1: Ret
 
 }
 
 Constants [
-	0 => u64: 0100000000000000
-	1 => u32: 00000000
+	0 => u64: 1
+	1 => u32: 0
+	2 => vector<u8>: "This is some emojis 🤔🤔🤔" // interpreted as UTF8 string
+	3 => vector<u16>: 040100020003000400
 ]
 }

--- a/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/args.exp
@@ -22,11 +22,13 @@ public af(): u32 {
 B0:
 	0: LdConst[1](u32: 0)
 	1: Ret
+
 }
 public sf(): vector<u8> {
 B0:
 	0: LdConst[2](vector<u8>: "Thi..)
 	1: Ret
+
 }
 public nf(): vector<u16> {
 B0:

--- a/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/sources/m.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/sources/m.move
@@ -5,8 +5,11 @@ struct As {}
 
 const Zc: u64 = 1;
 const Ac: u32 = 0;
+const AString: vector<u8> = b"This is some emojis 🤔🤔🤔";
+const NotAString: vector<u16> = vector[1,2,3,4];
 
 public fun zf(): u64 { Zc }
 public fun af(): u32 { Ac }
-
+public fun sf(): vector<u8> { AString }
+public fun nf(): vector<u16> { NotAString }
 }

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/package_basics/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/package_basics/args.exp
@@ -63,7 +63,7 @@ B0:
 B1:
 [4]	4: Branch(7)
 B2:
-[2]	5: LdConst[0](U64: 00000000..)
+[2]	5: LdConst[0](u64: 0)
 [2]	6: Abort
 B3:
 [4]	7: CopyLoc[0](x#0#0: u64)
@@ -74,7 +74,7 @@ B3:
 }
 
 Constants [
-	0 => u64: 0000000000000000
+	0 => u64: 0
 ]
 }
 Command `disassemble --package MoveStdlib --name signer`:

--- a/external-crates/move/crates/move-command-line-common/Cargo.toml
+++ b/external-crates/move/crates/move-command-line-common/Cargo.toml
@@ -20,8 +20,10 @@ once_cell.workspace = true
 serde.workspace = true
 dirs-next.workspace = true
 vfs.workspace = true
+bcs.workspace = true
 
 move-core-types.workspace = true
+move-binary-format.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/external-crates/move/crates/move-command-line-common/src/display.rs
+++ b/external-crates/move/crates/move-command-line-common/src/display.rs
@@ -1,0 +1,63 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::file_format::{Constant, SignatureToken};
+use move_core_types::{account_address::AccountAddress, u256::U256};
+
+pub enum RenderResult {
+    AsString(String),
+    AsValue(String),
+    NotRendered,
+}
+
+pub fn try_render_constant(constant: &Constant) -> RenderResult {
+    let bytes = &constant.data;
+    match &constant.type_ {
+        SignatureToken::Vector(inner_ty) if inner_ty.as_ref() == &SignatureToken::U8 => {
+            bcs::from_bytes::<Vec<u8>>(bytes)
+                .ok()
+                .and_then(|x| String::from_utf8(x).ok())
+                .map_or(RenderResult::NotRendered, RenderResult::AsString)
+        }
+        SignatureToken::U8 => bcs::from_bytes::<u8>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::U16 => bcs::from_bytes::<u16>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::U32 => bcs::from_bytes::<u32>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::U64 => bcs::from_bytes::<u64>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::U128 => bcs::from_bytes::<u128>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::U256 => bcs::from_bytes::<U256>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::Address => bcs::from_bytes::<AccountAddress>(bytes)
+            .ok()
+            .map(|x| x.to_canonical_string(true))
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+        SignatureToken::Bool => bcs::from_bytes::<bool>(bytes)
+            .ok()
+            .map(|x| x.to_string())
+            .map_or(RenderResult::NotRendered, RenderResult::AsValue),
+
+        SignatureToken::Signer
+        | SignatureToken::Vector(_)
+        | SignatureToken::Struct(_)
+        | SignatureToken::StructInstantiation(_)
+        | SignatureToken::Reference(_)
+        | SignatureToken::MutableReference(_)
+        | SignatureToken::TypeParameter(_) => RenderResult::NotRendered,
+    }
+}

--- a/external-crates/move/crates/move-command-line-common/src/display.rs
+++ b/external-crates/move/crates/move-command-line-common/src/display.rs
@@ -54,8 +54,8 @@ pub fn try_render_constant(constant: &Constant) -> RenderResult {
 
         SignatureToken::Signer
         | SignatureToken::Vector(_)
-        | SignatureToken::Struct(_)
-        | SignatureToken::StructInstantiation(_)
+        | SignatureToken::Datatype(_)
+        | SignatureToken::DatatypeInstantiation(_)
         | SignatureToken::Reference(_)
         | SignatureToken::MutableReference(_)
         | SignatureToken::TypeParameter(_) => RenderResult::NotRendered,

--- a/external-crates/move/crates/move-command-line-common/src/lib.rs
+++ b/external-crates/move/crates/move-command-line-common/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod address;
 pub mod character_sets;
+pub mod display;
 pub mod env;
 pub mod error_bitset;
 pub mod files;

--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -28,6 +28,8 @@ use move_core_types::{identifier::IdentStr, language_storage::ModuleId};
 use move_coverage::coverage_map::{ExecCoverageMap, FunctionCoverage};
 use move_ir_types::location::Loc;
 
+const PREVIEW_LEN: usize = 4;
+
 /// Holds the various options that we support while disassembling code.
 #[derive(Debug, Default, Parser)]
 pub struct DisassemblerOptions {
@@ -438,18 +440,19 @@ impl<'a> Disassembler<'a> {
     }
 
     fn preview_const(slice: &[u8]) -> String {
-        if slice.len() <= 4 {
+        // Account for the .. in the preview
+        if slice.len() <= PREVIEW_LEN + 2 {
             hex::encode(slice)
         } else {
-            format!("{}..", hex::encode(&slice[..4]))
+            format!("{}..", hex::encode(&slice[..PREVIEW_LEN]))
         }
     }
 
     fn preview_string(s: &str) -> String {
-        if s.len() <= 4 {
+        if s.len() <= PREVIEW_LEN + 2 {
             s.to_string()
         } else {
-            format!("{}..", &s[..4])
+            format!("{}..", &s[..PREVIEW_LEN])
         }
     }
 


### PR DESCRIPTION
## Description 

Enables clever error rendering in the Sui CLI.

It also abstracts out some of the rendering logic for constants into their own file so it can be reused across the graphql and Sui CLI renderer. 

This also updates the Move disassembler to use this new (nicer!) renderer to that we support rendered values for constants in the Move disassembler instead of just strings in constants.

## Test plan 

Added new tests for this to the Sui CLI, and updated/added additional tests for the disassembler.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Add better rendering for Move aborts, and added support for rendering clever errors.
- [ ] Rust SDK: 
