### PR TITLE
[move] Fix issue where varcalls could persist into typing without an error.

### DIFF
--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -50,6 +50,7 @@ pub enum FeatureGate {
     CleverAssertions,
     NoParensCast,
     TypeHoles,
+    Lambda,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -152,6 +153,7 @@ const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::MacroFuns,
     FeatureGate::TypeHoles,
     FeatureGate::CleverAssertions,
+    FeatureGate::Lambda,
 ];
 
 const DEVELOPMENT_FEATURES: &[FeatureGate] = &[];
@@ -276,6 +278,7 @@ impl FeatureGate {
             FeatureGate::CleverAssertions => "Clever `assert!`, `abort`, and `#[error]` are",
             FeatureGate::NoParensCast => "'as' without parentheses is",
             FeatureGate::TypeHoles => "'_' placeholders for type inference are",
+            FeatureGate::Lambda => "lambda expressions are",
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -3974,14 +3974,18 @@ fn resolve_call(
             }
             // If this variable refers to a local (num > 0) or it isn't syntax, error.
             if !var.value.is_syntax_identifier() {
+                let name = var.value.name;
                 let msg = format!(
-                    "Unexpected invocation of parameter or local '{}'. \
-                                     Non-syntax variables cannot be invoked as functions.",
-                    var.value.name
+                    "Unexpected invocation of parameter or local '{name}'. \
+                                     Non-syntax variables cannot be invoked as functions",
                 );
-                context
-                    .env
-                    .add_diag(diag!(TypeSafety::InvalidCallTarget, (var.loc, msg)));
+                let note = format!(
+                    "Only macro syntax variables, e.g. '${name}', \
+                            may be invoked as functions."
+                );
+                let mut diag = diag!(TypeSafety::InvalidCallTarget, (var.loc, msg));
+                diag.add_note(note);
+                context.env.add_diag(diag);
                 N::Exp_::UnresolvedError
             } else if var.value.id != 0 {
                 let msg = format!(

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1643,7 +1643,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
         NE::Lambda(_) => {
             if context
                 .env
-                .check_feature(context.current_package, FeatureGate::MacroFuns, eloc)
+                .check_feature(context.current_package, FeatureGate::Lambda, eloc)
             {
                 let msg = "Lambdas can only be used directly as arguments to 'macro' functions";
                 context

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_missing.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_missing.exp
@@ -28,3 +28,9 @@ error[E02010]: invalid name
   │
   = 'macro' parameters start with '$' to indicate that their arguments are not evaluated before the macro is expanded, meaning the entire expression is substituted. This is different from regular function parameters that are evaluated before the function is called.
 
+error[E04029]: invalid function call
+  ┌─ tests/move_2024/expansion/macro_identifier_missing.move:3:9
+  │
+3 │         f(x)
+  │         ^ Unexpected invocation of parameter or local 'f'. Non-syntax variables cannot be invoked as functions.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_missing.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_missing.exp
@@ -32,5 +32,7 @@ error[E04029]: invalid function call
   ┌─ tests/move_2024/expansion/macro_identifier_missing.move:3:9
   │
 3 │         f(x)
-  │         ^ Unexpected invocation of parameter or local 'f'. Non-syntax variables cannot be invoked as functions.
+  │         ^ Unexpected invocation of parameter or local 'f'. Non-syntax variables cannot be invoked as functions
+  │
+  = Only macro syntax variables, e.g. '$f', may be invoked as functions.
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_parameter_assignment.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_parameter_assignment.exp
@@ -22,7 +22,9 @@ error[E04029]: invalid function call
   ┌─ tests/move_2024/naming/macro_parameter_assignment.move:5:9
   │
 5 │         f(x)
-  │         ^ Unexpected invocation of parameter or local 'f'. Non-syntax variables cannot be invoked as functions.
+  │         ^ Unexpected invocation of parameter or local 'f'. Non-syntax variables cannot be invoked as functions
+  │
+  = Only macro syntax variables, e.g. '$f', may be invoked as functions.
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_2024/naming/macro_parameter_assignment.move:10:15

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_parameter_assignment.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_parameter_assignment.exp
@@ -18,3 +18,25 @@ error[E02010]: invalid name
   │
   = 'macro' parameters start with '$' to indicate that their arguments are not evaluated before the macro is expanded, meaning the entire expression is substituted. This is different from regular function parameters that are evaluated before the function is called.
 
+error[E04029]: invalid function call
+  ┌─ tests/move_2024/naming/macro_parameter_assignment.move:5:9
+  │
+5 │         f(x)
+  │         ^ Unexpected invocation of parameter or local 'f'. Non-syntax variables cannot be invoked as functions.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_2024/naming/macro_parameter_assignment.move:10:15
+   │
+10 │         call!(|_| 1, 0) + 1;
+   │               ^^^^^ Unused macro argument. Its expression will not be type checked and it will not evaluated
+   │
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_2024/naming/macro_parameter_assignment.move:10:22
+   │
+10 │         call!(|_| 1, 0) + 1;
+   │                      ^ Unused macro argument. Its expression will not be type checked and it will not evaluated
+   │
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_var_as_fun_invalid.exp
@@ -1,0 +1,21 @@
+error[E03004]: unbound type
+  ┌─ tests/move_2024/naming/macro_var_as_fun_invalid.move:3:13
+  │
+3 │         let $var = 0;
+  │             ^^^^ Unbound type '$var' in current scope
+
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/naming/macro_var_as_fun_invalid.move:3:18
+  │
+3 │         let $var = 0;
+  │                  ^
+  │                  │
+  │                  Unexpected '='
+  │                  Expected '{'
+
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_2024/naming/macro_var_as_fun_invalid.move:4:9
+  │
+4 │         $var();
+  │         ^^^^ Unbound function '$var' in current scope
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_var_as_fun_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_var_as_fun_invalid.move
@@ -1,0 +1,6 @@
+module a::test_panic {
+    public fun test_panic() {
+        let $var = 0;
+        $var();
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_invalid.exp
@@ -1,0 +1,6 @@
+error[E04029]: invalid function call
+  ┌─ tests/move_2024/naming/var_as_fun_invalid.move:4:9
+  │
+4 │         var();
+  │         ^^^ Unexpected invocation of parameter or local 'var'. Non-syntax variables cannot be invoked as functions.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_invalid.exp
@@ -2,5 +2,7 @@ error[E04029]: invalid function call
   ┌─ tests/move_2024/naming/var_as_fun_invalid.move:4:9
   │
 4 │         var();
-  │         ^^^ Unexpected invocation of parameter or local 'var'. Non-syntax variables cannot be invoked as functions.
+  │         ^^^ Unexpected invocation of parameter or local 'var'. Non-syntax variables cannot be invoked as functions
+  │
+  = Only macro syntax variables, e.g. '$var', may be invoked as functions.
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_invalid.move
@@ -1,0 +1,6 @@
+module a::test_panic {
+    public fun test_panic() {
+        let var = 0;
+        var();
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_macro.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_macro.exp
@@ -1,0 +1,9 @@
+error[E04032]: unable to expand macro function
+  ┌─ tests/move_2024/naming/var_as_fun_macro.move:3:9
+  │
+3 │         $var();
+  │         ^^^^^^ Cannot call non-lambda argument
+  ·
+8 │         test_panic!(0)
+  │                     - Expected a lambda argument
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/var_as_fun_macro.move
@@ -1,0 +1,10 @@
+module a::test_panic {
+    public macro fun test_panic($var: u64): u64 {
+        $var();
+        0
+    }
+
+    public fun t(): u64 {
+        test_panic!(0)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/use_lambda_outside_call_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/use_lambda_outside_call_invalid.exp
@@ -8,7 +8,9 @@ error[E04029]: invalid function call
   ┌─ tests/move_2024/typing/use_lambda_outside_call_invalid.move:4:9
   │
 4 │         x();
-  │         ^ Unexpected invocation of parameter or local 'x'. Non-syntax variables cannot be invoked as functions.
+  │         ^ Unexpected invocation of parameter or local 'x'. Non-syntax variables cannot be invoked as functions
+  │
+  = Only macro syntax variables, e.g. '$x', may be invoked as functions.
 
 error[E02010]: invalid name
   ┌─ tests/move_2024/typing/use_lambda_outside_call_invalid.move:7:23

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/use_lambda_outside_call_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/use_lambda_outside_call_invalid.exp
@@ -4,6 +4,12 @@ error[E04031]: invalid usage of lambda
 3 │         let x = $f;
   │                 ^^ Lambdas can only be used directly as arguments to 'macro' functions
 
+error[E04029]: invalid function call
+  ┌─ tests/move_2024/typing/use_lambda_outside_call_invalid.move:4:9
+  │
+4 │         x();
+  │         ^ Unexpected invocation of parameter or local 'x'. Non-syntax variables cannot be invoked as functions.
+
 error[E02010]: invalid name
   ┌─ tests/move_2024/typing/use_lambda_outside_call_invalid.move:7:23
   │

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.exp
@@ -1,5 +1,5 @@
 error[E13001]: feature is not supported in specified edition
-  ┌─ tests/move_check/feature_gate/macro_definition.move:2:12
+  ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:2:12
   │
 2 │     public macro fun do($f: || ()) { $f() }
   │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
@@ -7,10 +7,18 @@ error[E13001]: feature is not supported in specified edition
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
 error[E13001]: feature is not supported in specified edition
-  ┌─ tests/move_check/feature_gate/macro_definition.move:2:38
+  ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:2:38
   │
 2 │     public macro fun do($f: || ()) { $f() }
   │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │
+  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+
+error[E13001]: feature is not supported in specified edition
+  ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:4:24
+  │
+4 │     public fun t() { do!(|| q() ) }
+  │                        ^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.move
@@ -1,0 +1,5 @@
+module a::m {
+    public macro fun do($f: || ()) { $f() }
+    public fun q() { }
+    public fun t() { do!(|| q() ) }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:4:17
   │
 4 │         let _ = |x| x;
-  │                 ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                 ^^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
@@ -2,7 +2,9 @@ error[E04029]: invalid function call
   ┌─ tests/move_check/naming/var_as_fun_invalid.move:4:9
   │
 4 │         var();
-  │         ^^^ Unexpected invocation of parameter or local 'var'. Non-syntax variables cannot be invoked as functions.
+  │         ^^^ Unexpected invocation of parameter or local 'var'. Non-syntax variables cannot be invoked as functions
+  │
+  = Only macro syntax variables, e.g. '$var', may be invoked as functions.
 
 error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/var_as_fun_invalid.move:4:9

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
@@ -1,0 +1,14 @@
+error[E04029]: invalid function call
+  ┌─ tests/move_check/naming/var_as_fun_invalid.move:4:9
+  │
+4 │         var();
+  │         ^^^ Unexpected invocation of parameter or local 'var'. Non-syntax variables cannot be invoked as functions.
+
+error[E13001]: feature is not supported in specified edition
+  ┌─ tests/move_check/naming/var_as_fun_invalid.move:4:9
+  │
+4 │         var();
+  │         ^^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │
+  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.move
@@ -1,0 +1,6 @@
+module a::test_panic {
+    public fun test_panic() {
+        let var = 0;
+        var();
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
   │
 3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │               ^^^^^^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 


### PR DESCRIPTION
## Description 

This fixes a bug in how var calls were being resolved across naming into typing, when the variable was not a valid macro call target. 

This also adds a `lambda` feature gate to make error reporting a bit nicer in these cases.

## Test plan 

New tests cover the crash/bug and ensure it doesn't occur now.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
