### PR TITLE
[move-ide] Embed move-analyzer within Sui CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11703,6 +11703,7 @@ dependencies = [
  "jemalloc-ctl",
  "json_to_table",
  "miette",
+ "move-analyzer",
  "move-binary-format",
  "move-bytecode-verifier-meter",
  "move-command-line-common",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -74,6 +74,7 @@ shell-words.workspace = true
 tempfile.workspace = true
 telemetry-subscribers.workspace = true
 
+move-analyzer.workspace = true
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -175,7 +175,7 @@ pub enum SuiCommand {
     },
 
     /// Invoke Sui's move-analyzer via CLI
-    #[clap(name = "analyzer")]
+    #[clap(name = "analyzer", hide = true)]
     Analyzer,
 }
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -10,6 +10,7 @@ use crate::validator_commands::SuiValidatorCommand;
 use anyhow::{anyhow, bail};
 use clap::*;
 use fastcrypto::traits::KeyPair;
+use move_analyzer::analyzer;
 use move_package::BuildConfig;
 use rand::rngs::OsRng;
 use std::io::{stderr, stdout, Write};
@@ -172,6 +173,10 @@ pub enum SuiCommand {
         #[clap(subcommand)]
         fire_drill: FireDrill,
     },
+
+    /// Invoke Sui's move-analyzer via CLI
+    #[clap(name = "analyzer")]
+    Analyzer,
 }
 
 impl SuiCommand {
@@ -416,6 +421,10 @@ impl SuiCommand {
                 Ok(())
             }
             SuiCommand::FireDrill { fire_drill } => run_fire_drill(fire_drill).await,
+            SuiCommand::Analyzer => {
+                analyzer::run();
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
## Description 

The `move-analyzer` binary was recently moved to `crates` to support its versioning according to the same scheme as the `sui` binary. The goal is to distribute `move-analyzer` in two ways:
- embed it with VSCode extension for those that just want to use the IDE and don't want or (yet) need Sui CLI
- via Sui CLI (so that each time CLI is updated, `move-analyzer` binary is updated as well)

Out of these two options, the newer one (according to the version number) will be chosen to be used by the VSCode extension.

This PR embeds `move-analyzer` within Sui CLI so that it can be distributed via brew and chocolatey. The difference in binary size is rather small 110MB vs 108MB on a Mac

