### PR TITLE
Improve sampling of consensus submission latency

### DIFF
--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -418,7 +418,7 @@ impl ConsensusAdapter {
         let (position, positions_moved, preceding_disconnected) =
             self.submission_position(committee, tx_digest);
 
-        const MAX_LATENCY: Duration = Duration::from_secs(15);
+        const MAX_LATENCY: Duration = Duration::from_secs(10);
         const DEFAULT_LATENCY: Duration = Duration::from_secs(3); // > p50 consensus latency with global deployment
         let latency = self.latency_observer.latency().unwrap_or(DEFAULT_LATENCY);
         self.metrics
@@ -1100,7 +1100,7 @@ impl<'a> Drop for InflightDropGuard<'a> {
         // Only sample latency after consensus quorum is up. Otherwise, the wait for consensus
         // quorum at the beginning of an epoch can be distort the sampled latencies.
         // Technically there are more system transaction types that can be included in samples
-        // after the first consensus commit, but using the types above should be enough.
+        // after the first consensus commit, but this set of types should be enough.
         if self.position == Some(0) {
             // Transaction types below require quorum existed in the current epoch.
             let sampled = matches!(

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -66,7 +66,9 @@ const SEQUENCING_CERTIFICATE_LATENCY_SEC_BUCKETS: &[f64] = &[
     20., 25., 30., 60.,
 ];
 
-const SEQUENCING_CERTIFICATE_POSITION_BUCKETS: &[f64] = &[0., 1., 2., 3., 5., 10.];
+const SEQUENCING_CERTIFICATE_POSITION_BUCKETS: &[f64] = &[
+    0., 1., 2., 3., 5., 10., 15., 20., 25., 30., 50., 100., 150., 200.,
+];
 
 pub struct ConsensusAdapterMetrics {
     // Certificate sequencing metrics
@@ -416,7 +418,7 @@ impl ConsensusAdapter {
         let (position, positions_moved, preceding_disconnected) =
             self.submission_position(committee, tx_digest);
 
-        const MAX_LATENCY: Duration = Duration::from_secs(5 * 60);
+        const MAX_LATENCY: Duration = Duration::from_secs(15);
         const DEFAULT_LATENCY: Duration = Duration::from_secs(3); // > p50 consensus latency with global deployment
         let latency = self.latency_observer.latency().unwrap_or(DEFAULT_LATENCY);
         self.metrics
@@ -719,7 +721,7 @@ impl ConsensusAdapter {
         let (await_submit, position, positions_moved, preceding_disconnected) =
             self.await_submit_delay(epoch_store.committee(), &transactions[..]);
 
-        let mut guard = InflightDropGuard::acquire(&self, tx_type.to_string());
+        let mut guard = InflightDropGuard::acquire(&self, tx_type);
         let processed_waiter = tokio::select! {
             // We need to wait for some delay until we submit transaction to the consensus
             _ = await_submit => Some(processed_waiter),
@@ -1022,11 +1024,11 @@ struct InflightDropGuard<'a> {
     position: Option<usize>,
     positions_moved: Option<usize>,
     preceding_disconnected: Option<usize>,
-    tx_type: String,
+    tx_type: &'static str,
 }
 
 impl<'a> InflightDropGuard<'a> {
-    pub fn acquire(adapter: &'a ConsensusAdapter, tx_type: String) -> Self {
+    pub fn acquire(adapter: &'a ConsensusAdapter, tx_type: &'static str) -> Self {
         let inflight = adapter
             .num_inflight_transactions
             .fetch_add(1, Ordering::SeqCst);
@@ -1061,7 +1063,7 @@ impl<'a> Drop for InflightDropGuard<'a> {
         self.adapter
             .metrics
             .sequencing_certificate_inflight
-            .with_label_values(&[&self.tx_type])
+            .with_label_values(&[self.tx_type])
             .set(inflight as i64);
 
         let position = if let Some(position) = self.position {
@@ -1089,14 +1091,26 @@ impl<'a> Drop for InflightDropGuard<'a> {
         };
 
         let latency = self.start.elapsed();
-        if self.position == Some(0) {
-            self.adapter.latency_observer.report(latency);
-        }
         self.adapter
             .metrics
             .sequencing_certificate_latency
-            .with_label_values(&[&position, &self.tx_type])
+            .with_label_values(&[&position, self.tx_type])
             .observe(latency.as_secs_f64());
+
+        // Only sample latency after consensus quorum is up. Otherwise, the wait for consensus
+        // quorum at the beginning of an epoch can be distort the sampled latencies.
+        // Technically there are more system transaction types that can be included in samples
+        // after the first consensus commit, but using the types above should be enough.
+        if self.position == Some(0) {
+            // Transaction types below require quorum existed in the current epoch.
+            let sampled = matches!(
+                self.tx_type,
+                "shared_certificate" | "owned_certificate" | "checkpoint_signature" | "soft_bundle"
+            );
+            if sampled {
+                self.adapter.latency_observer.report(latency);
+            }
+        }
     }
 }
 

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -424,14 +424,16 @@ mod tests {
             .build()
             .await;
 
-        // Creates a simple case to see if authority state overload_info can be updated
-        // correctly by check_authority_overload.
+        // Initialize latency reporter.
         for _ in 0..1000 {
             state
                 .metrics
                 .execution_queueing_latency
                 .report(Duration::from_secs(20));
         }
+
+        // Creates a simple case to see if authority state overload_info can be updated
+        // correctly by check_authority_overload.
         let authority = Arc::downgrade(&state);
         assert!(check_authority_overload(&authority, &config));
         assert!(state.overload_info.is_overload.load(Ordering::Relaxed));

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -426,10 +426,12 @@ mod tests {
 
         // Creates a simple case to see if authority state overload_info can be updated
         // correctly by check_authority_overload.
-        state
-            .metrics
-            .execution_queueing_latency
-            .report(Duration::from_secs(20));
+        for _ in 0..1000 {
+            state
+                .metrics
+                .execution_queueing_latency
+                .report(Duration::from_secs(20));
+        }
         let authority = Arc::downgrade(&state);
         assert!(check_authority_overload(&authority, &config));
         assert!(state.overload_info.is_overload.load(Ordering::Relaxed));


### PR DESCRIPTION
## Description 

1. Do not report latency from sampler until enough samples are taken. This avoids issues with wildly off latency estimates at the start of an epoch.
2. Reduce max submission delay step to 10s, which is still significantly larger than consensus latency.
3. Do not report latency from system transactions that do no require quorum to have formed. These transactions can distort the latency estimate, their submission attempts start before a consensus quorum has formed.
4. Increase expected latency samples to 128.

## Test plan 

CI
Private testnet

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
