### PR TITLE
[GraphQL] Bump graphql prod version to 2024.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12649,7 +12649,7 @@ dependencies = [
 
 [[package]]
 name = "sui-graphql-rpc"
-version = "2024.4.1"
+version = "2024.4.2"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -97,13 +97,13 @@ task 15 'run-graphql'. lines 63-68:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
-    "x-sui-rpc-version": "2024.4.1-testing-no-sha",
+    "x-sui-rpc-version": "2024.4.2-testing-no-sha",
     "access-control-allow-origin": "*",
     "vary": "origin",
     "vary": "access-control-request-method",
     "vary": "access-control-request-headers",
 }
-Service version: 2024.4.1-testing-no-sha
+Service version: 2024.4.2-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-graphql-rpc"
-version = "2024.4.1"
+version = "2024.4.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
## Description 

After the `v2024.4.1` release, this PR bumps up the version for the prod service.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
