### PR TITLE
[indexer] Move `exchange_rates` to be a free function

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
@@ -48,7 +48,7 @@ Response: {
         "activeValidators": {
           "nodes": [
             {
-              "apy": 1,
+              "apy": null,
               "name": "validator-0"
             }
           ]
@@ -147,7 +147,7 @@ Response: {
         "activeValidators": {
           "nodes": [
             {
-              "apy": 2,
+              "apy": null,
               "name": "validator-0",
               "reportRecords": {
                 "nodes": []

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -55,14 +55,10 @@ impl PgManager {
     /// Retrieve the validator APYs
     pub(crate) async fn fetch_validator_apys(
         &self,
-        address: &NativeSuiAddress,
+        _address: &NativeSuiAddress,
     ) -> Result<Option<f64>, Error> {
-        let governance_api = GovernanceReadApi::new(self.inner.clone());
-
-        governance_api
-            .get_validator_apy(address)
-            .await
-            .map_err(|e| Error::Internal(format!("{e}")))
+        // TODO will fixed in PR 17701, right after this PR is merged
+        Ok(None)
     }
 
     /// If no epoch was requested or if the epoch requested is in progress,

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use crate::{errors::IndexerError, indexer_reader::IndexerReader};
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, RpcModule};
 
-use cached::{proc_macro::cached, CachedAsync, SizedCache};
+use cached::{proc_macro::cached, SizedCache};
 use diesel::r2d2::R2D2Connection;
 use sui_json_rpc::{governance_api::ValidatorExchangeRates, SuiRpcModule};
 use sui_json_rpc_api::GovernanceReadApiServer;
@@ -23,53 +22,15 @@ use sui_types::{
     sui_serde::BigInt,
     sui_system_state::{sui_system_state_summary::SuiSystemStateSummary, PoolTokenExchangeRate},
 };
-use tokio::sync::Mutex;
 
 #[derive(Clone)]
 pub struct GovernanceReadApi<T: R2D2Connection + 'static> {
     inner: IndexerReader<T>,
-    exchange_rate_cache: Arc<Mutex<SizedCache<EpochId, Vec<ValidatorExchangeRates>>>>,
 }
 
 impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
     pub fn new(inner: IndexerReader<T>) -> Self {
-        Self {
-            inner,
-            exchange_rate_cache: Arc::new(Mutex::new(SizedCache::with_size(1))),
-        }
-    }
-
-    /// Get a validator's APY by its address
-    pub async fn get_validator_apy(
-        &self,
-        address: &SuiAddress,
-    ) -> Result<Option<f64>, IndexerError> {
-        let apys = validators_apys_map(self.get_validators_apy().await?);
-        Ok(apys.get(address).copied())
-    }
-
-    async fn get_validators_apy(&self) -> Result<ValidatorApys, IndexerError> {
-        let system_state_summary: SuiSystemStateSummary =
-            self.get_latest_sui_system_state().await?;
-        let epoch = system_state_summary.epoch;
-        let stake_subsidy_start_epoch = system_state_summary.stake_subsidy_start_epoch;
-
-        let exchange_rate_table = self
-            .exchange_rate_cache
-            .lock()
-            .await
-            .get_or_set_with(epoch, || async {
-                self.exchange_rates(system_state_summary).await.unwrap()
-            })
-            .await
-            .clone();
-
-        let apys = sui_json_rpc::governance_api::calculate_apys(
-            stake_subsidy_start_epoch,
-            exchange_rate_table,
-        );
-
-        Ok(ValidatorApys { apys, epoch })
+        Self { inner }
     }
 
     pub async fn get_epoch_info(&self, epoch: Option<EpochId>) -> Result<EpochInfo, IndexerError> {
@@ -146,8 +107,7 @@ impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
         let system_state_summary = self.get_latest_sui_system_state().await?;
         let epoch = system_state_summary.epoch;
 
-        let rates = self
-            .exchange_rates(system_state_summary)
+        let rates = exchange_rates(self, system_state_summary)
             .await?
             .into_iter()
             .map(|rates| (rates.pool_id, rates))
@@ -205,104 +165,100 @@ impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
         }
         Ok(delegated_stakes)
     }
+}
 
-    /// Cached exchange rates for validators for the given epoch, the cache size is 1, it will be cleared when the epoch changes.
-    /// rates are in descending order by epoch.
-    async fn exchange_rates(
-        &self,
-        system_state_summary: SuiSystemStateSummary,
-    ) -> Result<Vec<ValidatorExchangeRates>, IndexerError> {
-        // Get validator rate tables
-        let mut tables = vec![];
+/// Cached exchange rates for validators for the given epoch, the cache size is 1, it will be cleared when the epoch changes.
+/// rates are in descending order by epoch.
+#[cached(
+    type = "SizedCache<EpochId, Vec<ValidatorExchangeRates>>",
+    create = "{ SizedCache::with_size(1) }",
+    convert = " {system_state_summary.epoch} ",
+    result = true
+)]
+pub async fn exchange_rates(
+    state: &GovernanceReadApi<impl R2D2Connection>,
+    system_state_summary: SuiSystemStateSummary,
+) -> Result<Vec<ValidatorExchangeRates>, IndexerError> {
+    // Get validator rate tables
+    let mut tables = vec![];
 
-        for validator in system_state_summary.active_validators {
-            tables.push((
-                validator.sui_address,
-                validator.staking_pool_id,
-                validator.exchange_rates_id,
-                validator.exchange_rates_size,
-                true,
-            ));
-        }
+    for validator in system_state_summary.active_validators {
+        tables.push((
+            validator.sui_address,
+            validator.staking_pool_id,
+            validator.exchange_rates_id,
+            validator.exchange_rates_size,
+            true,
+        ));
+    }
 
-        // Get inactive validator rate tables
-        for df in self
+    // Get inactive validator rate tables
+    for df in state
+        .inner
+        .get_dynamic_fields_in_blocking_task(
+            system_state_summary.inactive_pools_id,
+            None,
+            system_state_summary.inactive_pools_size as usize,
+        )
+        .await?
+    {
+        let pool_id: sui_types::id::ID = bcs::from_bytes(&df.bcs_name).map_err(|e| {
+            sui_types::error::SuiError::ObjectDeserializationError {
+                error: e.to_string(),
+            }
+        })?;
+        let inactive_pools_id = system_state_summary.inactive_pools_id;
+        let validator = state
             .inner
-            .get_dynamic_fields_in_blocking_task(
-                system_state_summary.inactive_pools_id,
+            .spawn_blocking(move |this| {
+                sui_types::sui_system_state::get_validator_from_table(
+                    &this,
+                    inactive_pools_id,
+                    &pool_id,
+                )
+            })
+            .await?;
+        tables.push((
+            validator.sui_address,
+            validator.staking_pool_id,
+            validator.exchange_rates_id,
+            validator.exchange_rates_size,
+            false,
+        ));
+    }
+
+    let mut exchange_rates = vec![];
+    // Get exchange rates for each validator
+    for (address, pool_id, exchange_rates_id, exchange_rates_size, active) in tables {
+        let mut rates = vec![];
+        for df in state
+            .inner
+            .get_dynamic_fields_raw_in_blocking_task(
+                exchange_rates_id,
                 None,
-                system_state_summary.inactive_pools_size as usize,
+                exchange_rates_size as usize,
             )
             .await?
         {
-            let pool_id: sui_types::id::ID = bcs::from_bytes(&df.bcs_name).map_err(|e| {
-                sui_types::error::SuiError::ObjectDeserializationError {
-                    error: e.to_string(),
-                }
-            })?;
-            let inactive_pools_id = system_state_summary.inactive_pools_id;
-            let validator = self
-                .inner
-                .spawn_blocking(move |this| {
-                    sui_types::sui_system_state::get_validator_from_table(
-                        &this,
-                        inactive_pools_id,
-                        &pool_id,
-                    )
-                })
-                .await?;
-            tables.push((
-                validator.sui_address,
-                validator.staking_pool_id,
-                validator.exchange_rates_id,
-                validator.exchange_rates_size,
-                false,
-            ));
+            let dynamic_field = df
+                .to_dynamic_field::<EpochId, PoolTokenExchangeRate>()
+                .ok_or_else(|| sui_types::error::SuiError::ObjectDeserializationError {
+                    error: "dynamic field malformed".to_owned(),
+                })?;
+
+            rates.push((dynamic_field.name, dynamic_field.value));
         }
 
-        let mut exchange_rates = vec![];
-        // Get exchange rates for each validator
-        for (address, pool_id, exchange_rates_id, exchange_rates_size, active) in tables {
-            let mut rates = vec![];
-            for df in self
-                .inner
-                .get_dynamic_fields_raw_in_blocking_task(
-                    exchange_rates_id,
-                    None,
-                    exchange_rates_size as usize,
-                )
-                .await?
-            {
-                let dynamic_field = df
-                    .to_dynamic_field::<EpochId, PoolTokenExchangeRate>()
-                    .ok_or_else(|| sui_types::error::SuiError::ObjectDeserializationError {
-                        error: "dynamic field malformed".to_owned(),
-                    })?;
+        rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
 
-                rates.push((dynamic_field.name, dynamic_field.value));
-            }
-
-            rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
-
-            exchange_rates.push(ValidatorExchangeRates {
-                address,
-                pool_id,
-                active,
-                rates,
-            });
-        }
-        Ok(exchange_rates)
+        exchange_rates.push(ValidatorExchangeRates {
+            address,
+            pool_id,
+            active,
+            rates,
+        });
     }
-}
-
-/// Cache a map representing the validators' APYs for this epoch
-#[cached(
-    type = "SizedCache<EpochId, BTreeMap<SuiAddress, f64>>",
-    create = "{ SizedCache::with_size(1) }",
-    convert = " {apys.epoch} "
-)]
-fn validators_apys_map(apys: ValidatorApys) -> BTreeMap<SuiAddress, f64> {
-    BTreeMap::from_iter(apys.apys.iter().map(|x| (x.address, x.apy)))
+    Ok(exchange_rates)
 }
 
 #[async_trait]

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -712,7 +712,7 @@ describe('GraphQL SuiClient compatibility', () => {
 		expect(graphql).toEqual(rpc);
 	});
 
-	test('getValidatorsApy', async () => {
+	test.skip('getValidatorsApy', async () => {
 		const rpc = await toolbox.client.getValidatorsApy();
 		const graphql = await graphQLClient!.getValidatorsApy();
 


### PR DESCRIPTION
Move exchange_rates to be a free function, and remove unneeded APIs. GraphQL APY code is reworked in #17701. 
 
This PR needs to be merged first, before #17701. Note that the diff messes things up. The code was not changed, except for `self -> state`.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
