### PR TITLE
[sui-move] Unbreak build

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::manage_package::resolve_lock_file_path;
 use clap::Parser;
 use move_cli::base;
-use move_package::source_package::layout::SourcePackageLayout;
 use move_package::BuildConfig as MoveBuildConfig;
 use serde_json::json;
 use std::{fs, path::PathBuf};
@@ -96,17 +96,4 @@ impl Build {
 
         Ok(())
     }
-}
-
-/// Resolve Move.lock file path in package directory (where Move.toml is).
-pub fn resolve_lock_file_path(
-    mut build_config: MoveBuildConfig,
-    package_path: Option<PathBuf>,
-) -> Result<MoveBuildConfig, anyhow::Error> {
-    if build_config.lock_file.is_none() {
-        let package_root = base::reroot_path(package_path)?;
-        let lock_file_path = package_root.join(SourcePackageLayout::Lock.path());
-        build_config.lock_file = Some(lock_file_path);
-    }
-    Ok(build_config)
 }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -33,7 +33,7 @@ use url::Url;
 use move_core_types::account_address::AccountAddress;
 use move_package::{BuildConfig as MoveBuildConfig, LintFlag};
 use move_symbol_pool::Symbol;
-use sui_move::build::resolve_lock_file_path;
+use sui_move::manage_package::resolve_lock_file_path;
 use sui_move_build::{BuildConfig, SuiPackageHooks};
 use sui_sdk::rpc_types::{SuiTransactionBlockEffects, TransactionFilter};
 use sui_sdk::types::base_types::ObjectID;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -32,7 +32,7 @@ use move_package::BuildConfig as MoveBuildConfig;
 use prometheus::Registry;
 use serde::Serialize;
 use serde_json::{json, Value};
-use sui_move::build::resolve_lock_file_path;
+use sui_move::manage_package::resolve_lock_file_path;
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 


### PR DESCRIPTION
## Description 

Rust doesn't like importing from modules called `build` (I think due to `build.rs`). This moves the offending function to `manage_package`.

## Test plan 

CI + ran repro locally.

