### PR TITLE
[move] Fix and add interactive disassembler

### DIFF
--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -22,6 +22,9 @@ pub struct Disassemble {
     /// Whether to display the disassembly in raw Debug format
     #[clap(long = "Xdebug")]
     debug: bool,
+
+    #[clap(short = 'i', long = "interactive")]
+    interactive: bool,
 }
 
 impl Disassemble {
@@ -40,7 +43,7 @@ impl Disassemble {
                 .expect("Cannot convert module name to string")
                 .to_owned();
             move_cli::base::disassemble::Disassemble {
-                interactive: false,
+                interactive: self.interactive,
                 package_name: None,
                 module_or_script_name: module_name,
                 debug: self.debug,

--- a/external-crates/move/crates/move-bytecode-viewer/src/bytecode_viewer.rs
+++ b/external-crates/move/crates/move-bytecode-viewer/src/bytecode_viewer.rs
@@ -47,7 +47,10 @@ impl<'a> BytecodeViewer<'a> {
 
     fn build_mapping(&mut self) {
         let regex = Regex::new(r"^(\d+):.*").unwrap();
-        let fun_regex = Regex::new(r"^public\s+([a-zA-Z_]+)\(").unwrap();
+        let fun_regex =
+            Regex::new(r"^(?:public(?:\(\w+\))?|native|entry)?\s*(\w+)\s*(?:<.*>)?\s*\(.*\).*\{")
+                .unwrap();
+
         let mut current_fun = None;
         let mut current_fdef_idx = None;
         let mut line_map = HashMap::new();


### PR DESCRIPTION
## Description 

Fixes the interactive disassembler, and adds the flag for it to `sui move disassemble` (with the `-i` flag). See screencast for what this looks like.


https://github.com/MystenLabs/sui/assets/2895723/50a75eb1-3d84-4c00-a30b-ab051c2ca169



## Test plan 

👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Adds new `-i` flag to `sui move disassemble` that creates an interactive disassembled bytecode-to-source explorer.
- [ ] Rust SDK: 
