### PR TITLE
[StateAccumulator] Introduce StateAccumulatorV2

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -90,6 +90,29 @@ mod test {
         test_simulated_load(test_cluster, 60).await;
     }
 
+    // Ensure that with half the committee enabling v2 and half not,
+    // we still arrive at the same root state hash (we do not split brain
+    // fork).
+    #[sim_test(config = "test_config()")]
+    async fn test_simulated_load_with_accumulator_v2_partial_upgrade() {
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        let test_cluster = init_test_cluster_builder(4, 1000)
+            .with_authority_overload_config(AuthorityOverloadConfig {
+                // Disable system overload checks for the test - during tests with crashes,
+                // it is possible for overload protection to trigger due to validators
+                // having queued certs which are missing dependencies.
+                check_system_overload_at_execution: false,
+                check_system_overload_at_signing: false,
+                ..Default::default()
+            })
+            .with_submit_delay_step_override_millis(3000)
+            .with_state_accumulator_v2_enabled_callback(Arc::new(|idx| idx % 2 == 0))
+            .build()
+            .await
+            .into();
+        test_simulated_load(test_cluster, 60).await;
+    }
+
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_with_reconfig_and_correlated_crashes() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -183,7 +183,7 @@ pub struct NodeConfig {
     #[serde(default)]
     pub execution_cache: ExecutionCacheConfig,
 
-    #[serde(default)]
+    #[serde(default = "bool_true")]
     pub state_accumulator_v2: bool,
 }
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -182,6 +182,9 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub execution_cache: ExecutionCacheConfig,
+
+    #[serde(default)]
+    pub state_accumulator_v2: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -88,7 +88,7 @@ pub async fn execute_certificate_with_execution_error(
     // for testing and regression detection.
     // We must do this before sending to consensus, otherwise consensus may already
     // lead to transaction execution and state change.
-    let state_acc = StateAccumulator::new(authority.get_accumulator_store().clone());
+    let state_acc = StateAccumulator::new(authority.get_accumulator_store().clone(), &epoch_store);
     let include_wrapped_tombstone = !authority
         .epoch_store_for_testing()
         .protocol_config()

--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -47,19 +47,23 @@ pub enum EpochFlag {
     PerEpochFinalizedTransactions,
     ObjectLockSplitTables,
     WritebackCacheEnabled,
+    StateAccumulatorV2Enabled,
 }
 
 impl EpochFlag {
     pub fn default_flags_for_new_epoch(config: &NodeConfig) -> Vec<Self> {
-        Self::default_flags_impl(&config.execution_cache)
+        Self::default_flags_impl(&config.execution_cache, config.state_accumulator_v2)
     }
 
     /// For situations in which there is no config available (e.g. setting up a downloaded snapshot).
     pub fn default_for_no_config() -> Vec<Self> {
-        Self::default_flags_impl(&Default::default())
+        Self::default_flags_impl(&Default::default(), false)
     }
 
-    fn default_flags_impl(cache_config: &ExecutionCacheConfig) -> Vec<Self> {
+    fn default_flags_impl(
+        cache_config: &ExecutionCacheConfig,
+        enable_state_accumulator_v2: bool,
+    ) -> Vec<Self> {
         let mut new_flags = vec![
             EpochFlag::InMemoryCheckpointRoots,
             EpochFlag::PerEpochFinalizedTransactions,
@@ -71,6 +75,10 @@ impl EpochFlag {
             ExecutionCacheConfigType::WritebackCache
         ) {
             new_flags.push(EpochFlag::WritebackCacheEnabled);
+        }
+
+        if enable_state_accumulator_v2 {
+            new_flags.push(EpochFlag::StateAccumulatorV2Enabled);
         }
 
         new_flags
@@ -85,6 +93,7 @@ impl fmt::Display for EpochFlag {
             EpochFlag::PerEpochFinalizedTransactions => write!(f, "PerEpochFinalizedTransactions"),
             EpochFlag::ObjectLockSplitTables => write!(f, "ObjectLockSplitTables"),
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
+            EpochFlag::StateAccumulatorV2Enabled => write!(f, "StateAccumulatorV2Enabled"),
         }
     }
 }

--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -57,7 +57,7 @@ impl EpochFlag {
 
     /// For situations in which there is no config available (e.g. setting up a downloaded snapshot).
     pub fn default_for_no_config() -> Vec<Self> {
-        Self::default_flags_impl(&Default::default(), false)
+        Self::default_flags_impl(&Default::default(), true)
     }
 
     fn default_flags_impl(

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -390,8 +390,9 @@ async fn init_executor_test(
 
     let (checkpoint_sender, _): (Sender<VerifiedCheckpoint>, Receiver<VerifiedCheckpoint>) =
         broadcast::channel(buffer_size);
+    let epoch_store = state.epoch_store_for_testing();
 
-    let accumulator = StateAccumulator::new(state.get_accumulator_store().clone());
+    let accumulator = StateAccumulator::new(state.get_accumulator_store().clone(), &epoch_store);
     let accumulator = Arc::new(accumulator);
 
     let executor = CheckpointExecutor::new_for_tests(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1266,17 +1266,17 @@ impl CheckpointBuilder {
 
                 // This must happen after the call to augment_epoch_last_checkpoint,
                 // otherwise we will not capture the change_epoch tx
-                self.accumulator.accumulate_checkpoint(
-                    effects.clone(),
-                    sequence_number,
-                    self.epoch_store.clone(),
-                )?;
+                self.accumulator
+                    .accumulate_final_checkpoint(
+                        effects.clone(),
+                        sequence_number,
+                        self.epoch_store.clone(),
+                    )
+                    .await?;
 
                 let root_state_digest = self
                     .accumulator
-                    .digest_epoch(&epoch, sequence_number, self.epoch_store.clone())
-                    .in_monitored_scope("CheckpointBuilder::digest_epoch")
-                    .await?;
+                    .digest_epoch(self.epoch_store.clone(), sequence_number)?;
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
@@ -2203,10 +2203,11 @@ mod tests {
 
         let ckpt_dir = tempfile::tempdir().unwrap();
         let checkpoint_store = CheckpointStore::new(ckpt_dir.path());
-
-        let accumulator = StateAccumulator::new(state.get_accumulator_store().clone());
-
         let epoch_store = state.epoch_store_for_testing();
+
+        let accumulator =
+            StateAccumulator::new(state.get_accumulator_store().clone(), &epoch_store);
+
         let (checkpoint_service, _exit) = CheckpointService::spawn(
             state.clone(),
             checkpoint_store,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1266,17 +1266,18 @@ impl CheckpointBuilder {
 
                 // This must happen after the call to augment_epoch_last_checkpoint,
                 // otherwise we will not capture the change_epoch tx
+                let acc = self.accumulator.accumulate_checkpoint(
+                    effects.clone(),
+                    sequence_number,
+                    self.epoch_store.clone(),
+                )?;
                 self.accumulator
-                    .accumulate_final_checkpoint(
-                        effects.clone(),
-                        sequence_number,
-                        self.epoch_store.clone(),
-                    )
+                    .accumulate_running_root(&self.epoch_store, sequence_number, Some(acc))
                     .await?;
-
                 let root_state_digest = self
                     .accumulator
-                    .digest_epoch(self.epoch_store.clone(), sequence_number)?;
+                    .digest_epoch(self.epoch_store.clone(), sequence_number)
+                    .await?;
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -695,8 +695,8 @@ impl StateAccumulatorV2 {
                 });
 
                 running_root.union(&checkpoint_acc);
-                *highest_accumulated = checkpoint_seq_num;
                 epoch_store.insert_running_root_accumulator(&checkpoint_seq_num, running_root)?;
+                *highest_accumulated = checkpoint_seq_num;
                 debug!(
                     "Accumulated checkpoint {} to running root accumulator",
                     checkpoint_seq_num,
@@ -717,8 +717,8 @@ impl StateAccumulatorV2 {
                     .expect("Failed to get checkpoint accumulator from disk")
                     .expect("Expected checkpoint accumulator to exist")
             });
-            *guard = Some((checkpoint_seq_num, checkpoint_acc.clone()));
             epoch_store.insert_running_root_accumulator(&checkpoint_seq_num, &checkpoint_acc)?;
+            *guard = Some((checkpoint_seq_num, checkpoint_acc));
             debug!(
                 "Accumulated checkpoint {} to running root accumulator",
                 checkpoint_seq_num,

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -80,7 +80,7 @@ pub async fn send_and_confirm_transaction(
     //
     // We also check the incremental effects of the transaction on the live object set against StateAccumulator
     // for testing and regression detection
-    let state_acc = StateAccumulator::new(authority.get_accumulator_store().clone());
+    let state_acc = StateAccumulator::new(authority.get_accumulator_store().clone(), &epoch_store);
     let include_wrapped_tombstone = !authority
         .epoch_store_for_testing()
         .protocol_config()

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -69,10 +69,9 @@ async fn send_transactions(
 
 pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<CheckpointService> {
     let (output, _result) = mpsc::channel::<(CheckpointContents, CheckpointSummary)>(10);
-    let accumulator = StateAccumulator::new(state.get_accumulator_store().clone());
-    let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
-
     let epoch_store = state.epoch_store_for_testing();
+    let accumulator = StateAccumulator::new(state.get_accumulator_store().clone(), &epoch_store);
+    let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
 
     let (checkpoint_service, _) = CheckpointService::spawn(
         state.clone(),

--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -43,7 +43,7 @@ async fn basic_checkpoints_integration_test() {
 }
 
 #[sim_test]
-async fn checkpoint_split_brain_test() {
+async fn test_checkpoint_split_brain() {
     #[cfg(msim)]
     {
         // this test intentionally halts the network by causing a fork, so we cannot panic on

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -696,6 +696,7 @@ impl SuiNode {
 
         let accumulator = Arc::new(StateAccumulator::new(
             cache_traits.accumulator_store.clone(),
+            &epoch_store,
         ));
 
         let authority_names_to_peer_ids = epoch_store

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -280,6 +280,7 @@ impl SingleValidator {
             validator.clone(),
             Arc::new(StateAccumulator::new(
                 validator.get_accumulator_store().clone(),
+                self.get_epoch_store(),
             )),
         );
         (checkpoint_executor, ckpt_sender)

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -51,6 +51,14 @@ pub enum ProtocolVersionsConfig {
     PerValidator(SupportedProtocolVersionsCallback),
 }
 
+pub type StateAccumulatorV2EnabledCallback = Arc<dyn Fn(usize) -> bool + Send + Sync + 'static>;
+
+#[derive(Clone)]
+pub enum StateAccumulatorV2EnabledConfig {
+    Global(bool),
+    PerValidator(StateAccumulatorV2EnabledCallback),
+}
+
 pub struct ConfigBuilder<R = OsRng> {
     rng: Option<R>,
     config_directory: PathBuf,
@@ -67,6 +75,7 @@ pub struct ConfigBuilder<R = OsRng> {
     firewall_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
+    state_accumulator_v2_enabled_config: Option<StateAccumulatorV2EnabledConfig>,
 }
 
 impl ConfigBuilder {
@@ -87,6 +96,7 @@ impl ConfigBuilder {
             firewall_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
+            state_accumulator_v2_enabled_config: None,
         }
     }
 
@@ -204,6 +214,29 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_state_accumulator_v2_enabled(mut self, enabled: bool) -> Self {
+        self.state_accumulator_v2_enabled_config =
+            Some(StateAccumulatorV2EnabledConfig::Global(enabled));
+        self
+    }
+
+    pub fn with_state_accumulator_v2_enabled_callback(
+        mut self,
+        func: StateAccumulatorV2EnabledCallback,
+    ) -> Self {
+        self.state_accumulator_v2_enabled_config =
+            Some(StateAccumulatorV2EnabledConfig::PerValidator(func));
+        self
+    }
+
+    pub fn with_state_accumulator_v2_enabled_config(
+        mut self,
+        c: StateAccumulatorV2EnabledConfig,
+    ) -> Self {
+        self.state_accumulator_v2_enabled_config = Some(c);
+        self
+    }
+
     pub fn with_authority_overload_config(mut self, c: AuthorityOverloadConfig) -> Self {
         self.authority_overload_config = Some(c);
         self
@@ -249,6 +282,7 @@ impl<R> ConfigBuilder<R> {
             firewall_config: self.firewall_config,
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
+            state_accumulator_v2_enabled_config: self.state_accumulator_v2_enabled_config,
         }
     }
 
@@ -428,6 +462,14 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         }
                     };
                     builder = builder.with_supported_protocol_versions(supported_versions);
+                }
+                if let Some(acc_v2_config) = &self.state_accumulator_v2_enabled_config {
+                    let state_accumulator_v2_enabled: bool = match acc_v2_config {
+                        StateAccumulatorV2EnabledConfig::Global(enabled) => *enabled,
+                        StateAccumulatorV2EnabledConfig::PerValidator(func) => func(idx),
+                    };
+                    builder =
+                        builder.with_state_accumulator_v2_enabled(state_accumulator_v2_enabled);
                 }
                 if let Some(num_unpruned_validators) = self.num_unpruned_validators {
                     if idx < num_unpruned_validators {

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -228,6 +228,7 @@ impl ValidatorConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
             execution_cache: ExecutionCacheConfig::default(),
+            state_accumulator_v2: true,
         }
     }
 
@@ -496,6 +497,7 @@ impl FullnodeConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.fw_config,
             execution_cache: ExecutionCacheConfig::default(),
+            state_accumulator_v2: true,
         }
     }
 }

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -41,11 +41,15 @@ pub struct ValidatorConfigBuilder {
     firewall_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
+    state_accumulator_v2: bool,
 }
 
 impl ValidatorConfigBuilder {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            state_accumulator_v2: true,
+            ..Default::default()
+        }
     }
 
     pub fn with_config_directory(mut self, config_directory: PathBuf) -> Self {
@@ -103,6 +107,11 @@ impl ValidatorConfigBuilder {
         submit_delay_step_override_millis: u64,
     ) -> Self {
         self.submit_delay_step_override_millis = Some(submit_delay_step_override_millis);
+        self
+    }
+
+    pub fn with_state_accumulator_v2_enabled(mut self, enabled: bool) -> Self {
+        self.state_accumulator_v2 = enabled;
         self
     }
 
@@ -228,7 +237,7 @@ impl ValidatorConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
             execution_cache: ExecutionCacheConfig::default(),
-            state_accumulator_v2: true,
+            state_accumulator_v2: self.state_accumulator_v2,
         }
     }
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -138,6 +138,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -273,6 +274,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -408,6 +410,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -543,6 +546,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -678,6 +682,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -813,6 +818,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -948,6 +954,7 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
+    state-accumulator-v2: true
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -23,7 +23,8 @@ use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
 use sui_swarm_config::genesis_config::{AccountConfig, GenesisConfig, ValidatorGenesisConfig};
 use sui_swarm_config::network_config::NetworkConfig;
 use sui_swarm_config::network_config_builder::{
-    CommitteeConfig, ConfigBuilder, ProtocolVersionsConfig, SupportedProtocolVersionsCallback,
+    CommitteeConfig, ConfigBuilder, ProtocolVersionsConfig, StateAccumulatorV2EnabledConfig,
+    SupportedProtocolVersionsCallback,
 };
 use sui_swarm_config::node_config_builder::FullnodeConfigBuilder;
 use sui_types::base_types::AuthorityName;
@@ -55,6 +56,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_fw_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
+    state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig,
 }
 
 impl SwarmBuilder {
@@ -82,6 +84,7 @@ impl SwarmBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
+            state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig::Global(true),
         }
     }
 }
@@ -111,6 +114,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_fw_config: self.fullnode_fw_config,
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
+            state_accumulator_v2_enabled_config: self.state_accumulator_v2_enabled_config,
         }
     }
 
@@ -216,6 +220,14 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_supported_protocol_versions_config(mut self, c: ProtocolVersionsConfig) -> Self {
         self.supported_protocol_versions_config = c;
+        self
+    }
+
+    pub fn with_state_accumulator_v2_enabled_config(
+        mut self,
+        c: StateAccumulatorV2EnabledConfig,
+    ) -> Self {
+        self.state_accumulator_v2_enabled_config = c;
         self
     }
 
@@ -335,6 +347,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 .with_objects(self.additional_objects)
                 .with_supported_protocol_versions_config(
                     self.supported_protocol_versions_config.clone(),
+                )
+                .with_state_accumulator_v2_enabled_config(
+                    self.state_accumulator_v2_enabled_config.clone(),
                 )
                 .build()
         });

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -48,7 +48,8 @@ use sui_swarm_config::genesis_config::{
 };
 use sui_swarm_config::network_config::NetworkConfig;
 use sui_swarm_config::network_config_builder::{
-    ProtocolVersionsConfig, SupportedProtocolVersionsCallback,
+    ProtocolVersionsConfig, StateAccumulatorV2EnabledCallback, StateAccumulatorV2EnabledConfig,
+    SupportedProtocolVersionsCallback,
 };
 use sui_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder};
 use sui_test_transaction_builder::TestTransactionBuilder;
@@ -892,6 +893,7 @@ pub struct TestClusterBuilder {
 
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
+    validator_state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig,
 }
 
 impl TestClusterBuilder {
@@ -918,6 +920,9 @@ impl TestClusterBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
+            validator_state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig::Global(
+                true,
+            ),
         }
     }
 
@@ -1037,6 +1042,15 @@ impl TestClusterBuilder {
     ) -> Self {
         self.validator_supported_protocol_versions_config =
             ProtocolVersionsConfig::PerValidator(func);
+        self
+    }
+
+    pub fn with_state_accumulator_v2_enabled_callback(
+        mut self,
+        func: StateAccumulatorV2EnabledCallback,
+    ) -> Self {
+        self.validator_state_accumulator_v2_enabled_config =
+            StateAccumulatorV2EnabledConfig::PerValidator(func);
         self
     }
 
@@ -1353,6 +1367,9 @@ impl TestClusterBuilder {
             .with_db_checkpoint_config(self.db_checkpoint_config_validators.clone())
             .with_supported_protocol_versions_config(
                 self.validator_supported_protocol_versions_config.clone(),
+            )
+            .with_state_accumulator_v2_enabled_config(
+                self.validator_state_accumulator_v2_enabled_config.clone(),
             )
             .with_fullnode_count(1)
             .with_fullnode_supported_protocol_versions_config(


### PR DESCRIPTION
## Description 

With Mysticeti moving our checkpoint rate to 12 checkpoints per second, we now have to handle state accumulation for ~1 million new checkpoints per epoch. This requires that we rethink a few design decisions in state accumulator. 

This PR introduces V2 (enabled by default), which aims to make state accumulation more efficient across a couple of levels:

1. Make end of epoch accumulation faster by amortizing the cost of unioning all checkpoint accumulators in the epoch. i.e. rather than unioning ~1M accumulators (one per checkpoint) at end of epoch, sequentially accumulate each checkpoint into the running root state hash, and finalize the running root as the root state hash at end of epoch.
2. Avoid needing to read all 1 million accumulators from disk at end of epoch by enforcing that the running root is written sequentially (although we continue to accumulate individual checkpoints concurrently), thus allowing us to only await the last checkpoint accumulator on disk. To enforce sequential accumulation, we update the running root in checkpoint executor during the sequential checkpoint processing.

Old behavior is preserved as a safety measure, but will remove once we've done a couple reconfigurations against it and we see that snapshot restore workflows are still stable

## Test plan 

Ran for 100+ seeds and did not find failures (with V2 enabled across all simtests)
```
./scripts/simtest/seed-search.py simtest --test test_simulated_load_reconfig_with_crashes_and_delays
```

Also the following to test root state hash equivalence between V1 and V2
```
cargo simtest test_simulated_load_with_accumulator_v2_partial_upgrade
```


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
