### PR TITLE
Add k1 test functions

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
@@ -16,6 +16,21 @@ module sui::ecdsa_k1 {
     const EInvalidPubKey: u64 = 2;
 
     #[allow(unused_const)]
+    #[test_only]
+    /// Error if the private key is invalid.
+    const EInvalidPrivKey: u64 = 3;
+
+    #[allow(unused_const)]
+    #[test_only]
+    /// Error if the public key is invalid.
+    const EInvalidHashFunction: u64 = 4;
+
+    #[allow(unused_const)]
+    #[test_only]
+    /// Error if the public key is invalid.
+    const EInvalidSeed: u64 = 5;
+
+    #[allow(unused_const)]
     /// Hash function name that are valid for ecrecover and secp256k1_verify.
     const KECCAK256: u8 = 0;
     #[allow(unused_const)]
@@ -60,7 +75,6 @@ module sui::ecdsa_k1 {
     public native fun secp256k1_sign(private_key: &vector<u8>, msg: &vector<u8>, hash: u8): vector<u8>;
 
     #[test_only]
-    #[allow(unused_field)]
     public struct KeyPair has drop {
         private_key: vector<u8>,
         public_key: vector<u8>,

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
@@ -22,12 +22,12 @@ module sui::ecdsa_k1 {
 
     #[allow(unused_const)]
     #[test_only]
-    /// Error if the public key is invalid.
+    /// Error if the given hash function does not exist.
     const EInvalidHashFunction: u64 = 4;
 
     #[allow(unused_const)]
     #[test_only]
-    /// Error if the public key is invalid.
+    /// Error if the seed is invalid.
     const EInvalidSeed: u64 = 5;
 
     #[allow(unused_const)]

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
@@ -58,4 +58,27 @@ module sui::ecdsa_k1 {
     /// Return the 64-bytes signature in form (r, s) that is signed using Secp256k1.
     /// This should ONLY be used in tests, because it will reveal the private key onchain.
     public native fun secp256k1_sign(private_key: &vector<u8>, msg: &vector<u8>, hash: u8): vector<u8>;
+
+    #[test_only]
+    #[allow(unused_field)]
+    public struct KeyPair has drop {
+        private_key: vector<u8>,
+        public_key: vector<u8>,
+    }
+
+    #[test_only]
+    public fun private_key(self: &KeyPair): &vector<u8> {
+        &self.private_key
+    }
+
+    #[test_only]
+    public fun public_key(self: &KeyPair): &vector<u8> {
+        &self.public_key
+    }
+
+    #[test_only]
+    /// @param seed: A 32-bytes seed that is used to generate the keypair.
+    ///
+    /// Returns a Secp256k1 keypair deterministically generated from the seed.
+    public native fun secp256k1_keypair_from_seed(seed: &vector<u8>): KeyPair;
 }

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
@@ -69,10 +69,13 @@ module sui::ecdsa_k1 {
     /// @param private_key: A 32-bytes private key that is used to sign the message.
     /// @param msg: The message to sign, this is raw message without hashing.
     /// @param hash: The hash function used to hash the message when signing.
+    /// @param recoverable: A boolean flag to indicate if the produced signature should be recoverable.
     ///
-    /// Return the 64-bytes signature in form (r, s) that is signed using Secp256k1.
+    /// Return the signature in form (r, s) that is signed using Secp256k1.
+    /// If `recoverable` is true, the signature will be in form (r, s, v) where v is the recovery id.
+    ///
     /// This should ONLY be used in tests, because it will reveal the private key onchain.
-    public native fun secp256k1_sign(private_key: &vector<u8>, msg: &vector<u8>, hash: u8): vector<u8>;
+    public native fun secp256k1_sign(private_key: &vector<u8>, msg: &vector<u8>, hash: u8, recoverable: bool): vector<u8>;
 
     #[test_only]
     public struct KeyPair has drop {

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/ecdsa_k1.move
@@ -49,4 +49,13 @@ module sui::ecdsa_k1 {
     ///
     /// If the signature is valid to the pubkey and hashed message, return true. Else false.
     public native fun secp256k1_verify(signature: &vector<u8>, public_key: &vector<u8>, msg: &vector<u8>, hash: u8): bool;
+
+    #[test_only]
+    /// @param private_key: A 32-bytes private key that is used to sign the message.
+    /// @param msg: The message to sign, this is raw message without hashing.
+    /// @param hash: The hash function used to hash the message when signing.
+    ///
+    /// Return the 64-bytes signature in form (r, s) that is signed using Secp256k1.
+    /// This should ONLY be used in tests, because it will reveal the private key onchain.
+    public native fun secp256k1_sign(private_key: &vector<u8>, msg: &vector<u8>, hash: u8): vector<u8>;
 }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
@@ -131,4 +131,23 @@ module sui::ecdsa_k1_tests {
 
         addr
     }
+
+    #[test]
+    fun test_sign() {
+        let msg = b"Hello, world!";
+        let pk = x"02337cca2171fdbfcfd657fa59881f46269f1e590b5ffab6023686c7ad2ecc2c1c";
+        let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e69316";
+
+        // Test with Keccak256 hash
+        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 0);
+        assert!(ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 0));
+
+        // Test with SHA256 hash
+        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 1);
+        assert!(ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 1));
+
+        // Verification should fail with another message
+        let other_msg = b"Farewell, world!";
+        assert!(!ecdsa_k1::secp256k1_verify(&sig, &pk, &other_msg, 0));
+    }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
@@ -150,4 +150,14 @@ module sui::ecdsa_k1_tests {
         let other_msg = b"Farewell, world!";
         assert!(!ecdsa_k1::secp256k1_verify(&sig, &pk, &other_msg, 0));
     }
+
+    #[test]
+    fun test_generate_keypair() {
+        let seed = b"Some random seed, 32 bytes long.";
+        let kp = ecdsa_k1::secp256k1_keypair_from_seed(&seed);
+
+        let msg = b"Hello, world!";
+        let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 0);
+        assert!(ecdsa_k1::secp256k1_verify(&sig, kp.public_key(), &msg, 0));
+    }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
@@ -139,12 +139,12 @@ module sui::ecdsa_k1_tests {
         let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e69316";
 
         // Test with Keccak256 hash
-        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 0);
+        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 0, false);
         assert!(ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 0));
         assert!(sig == x"7e4237ebfbc36613e166bfc5f6229360a9c1949242da97ca04867e4de57b2df30c8340bcb320328cf46d71bda51fcb519e3ce53b348eec62de852e350edbd886");
 
         // Test with SHA256 hash
-        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 1);
+        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 1, false);
         assert!(ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 1));
         assert!(sig == x"e5847245b38548547f613aaea3421ad47f5b95a222366fb9f9b8c57568feb19c7077fc31e7d83e00acc1347d08c3e1ad50a4eeb6ab044f25c861ddc7be5b8f9f");
 
@@ -154,13 +154,32 @@ module sui::ecdsa_k1_tests {
     }
 
     #[test]
+    fun test_sign_recoverable() {
+        let msg = b"Hello, world!";
+        let pk = x"02337cca2171fdbfcfd657fa59881f46269f1e590b5ffab6023686c7ad2ecc2c1c";
+        let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e69316";
+
+        // Test with Keccak256 hash
+        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 0, true);
+        assert!(pk == ecdsa_k1::secp256k1_ecrecover(&sig, &msg, 0));
+
+        // Test with SHA256 hash
+        let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 1, true);
+        assert!(pk == ecdsa_k1::secp256k1_ecrecover(&sig, &msg, 1));
+
+        // Recoveres pk should not be the same with another message
+        let other_msg = b"Farewell, world!";
+        assert!(pk != ecdsa_k1::secp256k1_ecrecover(&sig, &other_msg, 0));
+    }
+
+    #[test]
     #[expected_failure(abort_code = ecdsa_k1::EInvalidHashFunction)]
     fun test_sign_invalid_hash() {
         let msg = b"Hello, world!";
         let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e69316";
 
         // Invalid hash function
-        ecdsa_k1::secp256k1_sign(&sk, &msg, 2);
+        ecdsa_k1::secp256k1_sign(&sk, &msg, 2, false);
     }
 
     #[test]
@@ -171,7 +190,7 @@ module sui::ecdsa_k1_tests {
         // Invalid (too short) private key
         let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e693";
 
-        ecdsa_k1::secp256k1_sign(&sk, &msg, 0);
+        ecdsa_k1::secp256k1_sign(&sk, &msg, 0, false);
     }
 
     #[test]
@@ -181,10 +200,10 @@ module sui::ecdsa_k1_tests {
 
         let msg = b"Hello, world!";
 
-        let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 0);
+        let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 0, false);
         assert!(ecdsa_k1::secp256k1_verify(&sig, kp.public_key(), &msg, 0));
 
-        let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 1);
+        let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 1, false);
         assert!(ecdsa_k1::secp256k1_verify(&sig, kp.public_key(), &msg, 1));
     }
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
@@ -141,14 +141,37 @@ module sui::ecdsa_k1_tests {
         // Test with Keccak256 hash
         let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 0);
         assert!(ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 0));
+        assert!(sig == x"7e4237ebfbc36613e166bfc5f6229360a9c1949242da97ca04867e4de57b2df30c8340bcb320328cf46d71bda51fcb519e3ce53b348eec62de852e350edbd886");
 
         // Test with SHA256 hash
         let sig = ecdsa_k1::secp256k1_sign(&sk, &msg, 1);
         assert!(ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 1));
+        assert!(sig == x"e5847245b38548547f613aaea3421ad47f5b95a222366fb9f9b8c57568feb19c7077fc31e7d83e00acc1347d08c3e1ad50a4eeb6ab044f25c861ddc7be5b8f9f");
 
         // Verification should fail with another message
         let other_msg = b"Farewell, world!";
         assert!(!ecdsa_k1::secp256k1_verify(&sig, &pk, &other_msg, 0));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ecdsa_k1::EInvalidHashFunction)]
+    fun test_sign_invalid_hash() {
+        let msg = b"Hello, world!";
+        let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e69316";
+
+        // Invalid hash function
+        ecdsa_k1::secp256k1_sign(&sk, &msg, 2);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ecdsa_k1::EInvalidPrivKey)]
+    fun test_sign_invalid_private_key() {
+        let msg = b"Hello, world!";
+
+        // Invalid (too short) private key
+        let sk = x"42258dcda14cf111c602b8971b8cc843e91e46ca905151c02744a6b017e693";
+
+        ecdsa_k1::secp256k1_sign(&sk, &msg, 0);
     }
 
     #[test]
@@ -157,7 +180,19 @@ module sui::ecdsa_k1_tests {
         let kp = ecdsa_k1::secp256k1_keypair_from_seed(&seed);
 
         let msg = b"Hello, world!";
+
         let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 0);
         assert!(ecdsa_k1::secp256k1_verify(&sig, kp.public_key(), &msg, 0));
+
+        let sig = ecdsa_k1::secp256k1_sign(kp.private_key(), &msg, 1);
+        assert!(ecdsa_k1::secp256k1_verify(&sig, kp.public_key(), &msg, 1));
     }
+
+    #[test]
+    #[expected_failure(abort_code = ecdsa_k1::EInvalidSeed)]
+    fun test_generate_keypair_invalid_seed() {
+        let seed = b"Seed is not 32 bytes long";
+        ecdsa_k1::secp256k1_keypair_from_seed(&seed);
+    }
+
 }

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -29,8 +29,9 @@ use sui_types::crypto::KeypairTraits;
 pub const FAIL_TO_RECOVER_PUBKEY: u64 = 0;
 pub const INVALID_SIGNATURE: u64 = 1;
 pub const INVALID_PUBKEY: u64 = 2;
-pub const INVALID_PRIVKEY_OR_HASH: u64 = 3;
-pub const INVALID_SEED: u64 = 4;
+pub const INVALID_PRIVKEY: u64 = 3;
+pub const INVALID_HASH: u64 = 4;
+pub const INVALID_SEED: u64 = 5;
 
 pub const KECCAK256: u8 = 0;
 pub const SHA256: u8 = 1;
@@ -314,7 +315,7 @@ pub fn secp256k1_sign(
 
     let sk = match <Secp256k1PrivateKey as ToFromBytes>::from_bytes(&private_key_bytes_ref) {
         Ok(sk) => sk,
-        Err(_) => return Ok(NativeResult::err(cost, INVALID_PRIVKEY_OR_HASH)),
+        Err(_) => return Ok(NativeResult::err(cost, INVALID_PRIVKEY)),
     };
 
     let kp = Secp256k1KeyPair::from(sk);
@@ -322,7 +323,7 @@ pub fn secp256k1_sign(
     let signature = match hash {
         KECCAK256 => kp.sign_with_hash::<Keccak256>(&msg_ref),
         SHA256 => kp.sign_with_hash::<Sha256>(&msg_ref),
-        _ => return Ok(NativeResult::err(cost, INVALID_PRIVKEY_OR_HASH)),
+        _ => return Ok(NativeResult::err(cost, INVALID_HASH)),
     };
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -370,8 +370,8 @@ pub fn secp256k1_keypair_from_seed(
 
     let kp = Secp256k1KeyPair::generate(&mut StdRng::from_seed(seed_array));
 
-    let sk_bytes = kp.private().as_bytes().to_vec();
     let pk_bytes = kp.public().as_bytes().to_vec();
+    let sk_bytes = kp.private().as_bytes().to_vec();
 
     Ok(NativeResult::ok(
         cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -315,15 +315,6 @@ pub fn secp256k1_sign(
     // we don't need to charge any gas.
     let cost = 0.into();
 
-    // Load the cost parameters from the protocol config
-    let (ecdsa_k1_secp256k1_sign_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
-        (
-            cost_table.ecdsa_k1_secp256k1_sign_cost_params.clone(),
-            cost_table.crypto_invalid_arguments_cost,
-        )
-    };
-
     let hash = pop_arg!(args, u8);
     let msg = pop_arg!(args, VectorRef);
     let private_key_bytes = pop_arg!(args, VectorRef);

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -3,6 +3,7 @@
 use crate::NativesCostTable;
 use fastcrypto::secp256k1::Secp256k1KeyPair;
 use fastcrypto::secp256k1::Secp256k1PrivateKey;
+use fastcrypto::traits::RecoverableSigner;
 use fastcrypto::{
     error::FastCryptoError,
     hash::{Keccak256, Sha256},
@@ -25,7 +26,6 @@ use rand::SeedableRng;
 use smallvec::smallvec;
 use std::collections::VecDeque;
 use sui_types::crypto::KeypairTraits;
-use fastcrypto::traits::RecoverableSigner;
 
 pub const FAIL_TO_RECOVER_PUBKEY: u64 = 0;
 pub const INVALID_SIGNATURE: u64 = 1;
@@ -332,9 +332,15 @@ pub fn secp256k1_sign(
     let kp = Secp256k1KeyPair::from(sk);
 
     let signature = match (hash, recoverable) {
-        (KECCAK256, true) => kp.sign_recoverable_with_hash::<Keccak256>(&msg_ref).as_bytes().to_vec(),
+        (KECCAK256, true) => kp
+            .sign_recoverable_with_hash::<Keccak256>(&msg_ref)
+            .as_bytes()
+            .to_vec(),
         (KECCAK256, false) => kp.sign_with_hash::<Keccak256>(&msg_ref).as_bytes().to_vec(),
-        (SHA256, true) => kp.sign_recoverable_with_hash::<Sha256>(&msg_ref).as_bytes().to_vec(),
+        (SHA256, true) => kp
+            .sign_recoverable_with_hash::<Sha256>(&msg_ref)
+            .as_bytes()
+            .to_vec(),
         (SHA256, false) => kp.sign_with_hash::<Sha256>(&msg_ref).as_bytes().to_vec(),
         _ => return Ok(NativeResult::err(cost, INVALID_HASH_FUNCTION)),
     };

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -30,7 +30,7 @@ pub const FAIL_TO_RECOVER_PUBKEY: u64 = 0;
 pub const INVALID_SIGNATURE: u64 = 1;
 pub const INVALID_PUBKEY: u64 = 2;
 pub const INVALID_PRIVKEY: u64 = 3;
-pub const INVALID_HASH: u64 = 4;
+pub const INVALID_HASH_FUNCTION: u64 = 4;
 pub const INVALID_SEED: u64 = 5;
 
 pub const KECCAK256: u8 = 0;
@@ -324,7 +324,7 @@ pub fn secp256k1_sign(
     let signature = match hash {
         KECCAK256 => kp.sign_with_hash::<Keccak256>(&msg_ref),
         SHA256 => kp.sign_with_hash::<Sha256>(&msg_ref),
-        _ => return Ok(NativeResult::err(cost, INVALID_HASH)),
+        _ => return Ok(NativeResult::err(cost, INVALID_HASH_FUNCTION)),
     };
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -303,7 +303,8 @@ pub fn secp256k1_sign(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 3);
 
-    // This function is only used for testing, so we don't need to charge gas
+    // The corresponding Move function, sui::ecdsa_k1::secp256k1_sign, is only used for testing, so
+    // we don't need to charge any gas.
     let cost = 0.into();
 
     let hash = pop_arg!(args, u8);
@@ -340,7 +341,8 @@ pub fn secp256k1_keypair_from_seed(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    // This function is only used for testing, so we don't need to charge gas
+    // The corresponding Move function, sui::ecdsa_k1::secp256k1_keypair_from_seed, is only used for
+    // testing, so we don't need to charge any gas.
     let cost = 0.into();
 
     let seed = pop_arg!(args, VectorRef);

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -370,8 +370,8 @@ pub fn secp256k1_keypair_from_seed(
 
     let kp = Secp256k1KeyPair::generate(&mut StdRng::from_seed(seed_array));
 
-    let pk_bytes = kp.public().as_bytes().to_vec();
     let sk_bytes = kp.private().as_bytes().to_vec();
+    let pk_bytes = kp.public().as_bytes().to_vec();
 
     Ok(NativeResult::ok(
         cost,

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -910,6 +910,11 @@ pub fn all_natives(silent: bool) -> NativeFunctionTable {
             "secp256k1_sign",
             make_native!(ecdsa_k1::secp256k1_sign),
         ),
+        (
+            "ecdsa_k1",
+            "secp256k1_keypair_from_seed",
+            make_native!(ecdsa_k1::secp256k1_keypair_from_seed),
+        ),
     ];
     let sui_framework_natives_iter =
         sui_framework_natives

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -905,6 +905,11 @@ pub fn all_natives(silent: bool) -> NativeFunctionTable {
             "hash_to_input_internal",
             make_native!(vdf::hash_to_input_internal),
         ),
+        (
+            "ecdsa_k1",
+            "secp256k1_sign",
+            make_native!(ecdsa_k1::secp256k1_sign),
+        ),
     ];
     let sui_framework_natives_iter =
         sui_framework_natives


### PR DESCRIPTION
## Description 

Adds test functions to generate keypairs and create ECDSA signatures over Secp256k1

## Test plan 

Unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
