### PR TITLE
move: support automated address management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13187,6 +13187,7 @@ dependencies = [
  "move-package",
  "move-symbol-pool",
  "serde-reflection",
+ "sui-package-management",
  "sui-protocol-config",
  "sui-types",
  "sui-verifier-latest",
@@ -13444,8 +13445,10 @@ version = "1.29.0"
 dependencies = [
  "anyhow",
  "move-package",
+ "move-symbol-pool",
  "sui-json-rpc-types",
  "sui-sdk 1.29.0",
+ "sui-types",
  "tracing",
 ]
 

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -301,11 +301,11 @@ async fn test_custom_property_check_unpublished_dependencies() {
         .resolution_graph_for_package(&path, &mut std::io::sink())
         .expect("Could not build resolution graph.");
 
-    let SuiError::ModulePublishFailure { error } =
-        check_unpublished_dependencies(&gather_published_ids(&resolution_graph).1.unpublished)
-            .err()
-            .unwrap()
-    else {
+    let SuiError::ModulePublishFailure { error } = check_unpublished_dependencies(
+        &gather_published_ids(&resolution_graph, None).1.unpublished,
+    )
+    .err()
+    .unwrap() else {
         panic!("Expected ModulePublishFailure")
     };
 

--- a/crates/sui-e2e-tests/tests/snapshot_tests.rs
+++ b/crates/sui-e2e-tests/tests/snapshot_tests.rs
@@ -41,11 +41,9 @@ async fn run_one(
                     }
                 }
             }
-            SuiCommand::Move {
-                package_path: _,
-                build_config: _,
-                cmd: _,
-            } => unimplemented!("Supporting Move publish and upgrade commands"),
+            SuiCommand::Move { .. } => {
+                unimplemented!("Supporting Move publish and upgrade commands")
+            }
             _ => panic!("Command {:?} not supported by RPC snapshot tests", cli_cmd),
         }
     }

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -157,6 +157,7 @@ fn build_packages_with_move_config(
         config: config.clone(),
         run_bytecode_verifier: true,
         print_diags_to_stderr: false,
+        chain_id: None, // Framework pkg addr is agnostic to chain, resolves from Move.toml
     }
     .build(stdlib_path)
     .unwrap();
@@ -164,6 +165,7 @@ fn build_packages_with_move_config(
         config: config.clone(),
         run_bytecode_verifier: true,
         print_diags_to_stderr: false,
+        chain_id: None, // Framework pkg addr is agnostic to chain, resolves from Move.toml
     }
     .build(sui_framework_path)
     .unwrap();
@@ -171,6 +173,7 @@ fn build_packages_with_move_config(
         config: config.clone(),
         run_bytecode_verifier: true,
         print_diags_to_stderr: false,
+        chain_id: None, // Framework pkg addr is agnostic to chain, resolves from Move.toml
     }
     .build(sui_system_path)
     .unwrap();
@@ -178,6 +181,7 @@ fn build_packages_with_move_config(
         config: config.clone(),
         run_bytecode_verifier: true,
         print_diags_to_stderr: false,
+        chain_id: None, // Framework pkg addr is agnostic to chain, resolves from Move.toml
     }
     .build(deepbook_path)
     .unwrap();
@@ -185,6 +189,7 @@ fn build_packages_with_move_config(
         config,
         run_bytecode_verifier: true,
         print_diags_to_stderr: false,
+        chain_id: None, // Framework pkg addr is agnostic to chain, resolves from Move.toml
     }
     .build(bridge_path)
     .unwrap();

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -18,6 +18,7 @@ sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "su
 serde-reflection.workspace = true
 sui-types.workspace = true
 sui-protocol-config.workspace = true
+sui-package-management.workspace = true
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -41,6 +41,7 @@ use move_package::{
 };
 use move_symbol_pool::Symbol;
 use serde_reflection::Registry;
+use sui_package_management::{resolve_published_id, PublishedAtError};
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::{
     base_types::ObjectID,
@@ -74,6 +75,9 @@ pub struct BuildConfig {
     pub run_bytecode_verifier: bool,
     /// If true, print build diagnostics to stderr--no printing if false
     pub print_diags_to_stderr: bool,
+    /// The chain ID that compilation is with respect to (e.g., required to resolve
+    /// published dependency IDs from the `Move.lock`).
+    pub chain_id: Option<String>,
 }
 
 impl BuildConfig {
@@ -157,11 +161,13 @@ impl BuildConfig {
     pub fn build(self, path: &Path) -> SuiResult<CompiledPackage> {
         let print_diags_to_stderr = self.print_diags_to_stderr;
         let run_bytecode_verifier = self.run_bytecode_verifier;
+        let chain_id = self.chain_id.clone();
         let resolution_graph = self.resolution_graph(path)?;
         build_from_resolution_graph(
             resolution_graph,
             run_bytecode_verifier,
             print_diags_to_stderr,
+            chain_id,
         )
     }
 
@@ -220,8 +226,9 @@ pub fn build_from_resolution_graph(
     resolution_graph: ResolvedGraph,
     run_bytecode_verifier: bool,
     print_diags_to_stderr: bool,
+    chain_id: Option<String>,
 ) -> SuiResult<CompiledPackage> {
-    let (published_at, dependency_ids) = gather_published_ids(&resolution_graph);
+    let (published_at, dependency_ids) = gather_published_ids(&resolution_graph, chain_id);
 
     let result = if print_diags_to_stderr {
         BuildConfig::compile_package(resolution_graph, &mut std::io::stderr())
@@ -569,6 +576,7 @@ impl Default for BuildConfig {
             config,
             run_bytecode_verifier: true,
             print_diags_to_stderr: false,
+            chain_id: None,
         }
     }
 }
@@ -631,12 +639,9 @@ pub struct PackageDependencies {
     pub unpublished: BTreeSet<Symbol>,
     /// Set of dependencies with invalid `published-at` addresses.
     pub invalid: BTreeMap<Symbol, String>,
-}
-
-#[derive(Debug, Clone)]
-pub enum PublishedAtError {
-    Invalid(String),
-    NotPresent,
+    /// Set of dependencies that have conflicting `published-at` addresses. The key refers to
+    /// the package, and the tuple refers to the address in the (Move.lock, Move.toml) respectively.
+    pub conflicting: BTreeMap<Symbol, (String, String)>,
 }
 
 /// Partition packages in `resolution_graph` into one of four groups:
@@ -646,16 +651,18 @@ pub enum PublishedAtError {
 /// - The names of packages that have a `published-at` field that isn't filled with a valid address.
 pub fn gather_published_ids(
     resolution_graph: &ResolvedGraph,
+    chain_id: Option<String>,
 ) -> (Result<ObjectID, PublishedAtError>, PackageDependencies) {
     let root = resolution_graph.root_package();
 
     let mut published = BTreeMap::new();
     let mut unpublished = BTreeSet::new();
     let mut invalid = BTreeMap::new();
+    let mut conflicting = BTreeMap::new();
     let mut published_at = Err(PublishedAtError::NotPresent);
 
     for (name, package) in &resolution_graph.package_table {
-        let property = published_at_property(package);
+        let property = resolve_published_id(package, chain_id.clone());
         if name == &root {
             // Separate out the root package as a special case
             published_at = property;
@@ -672,6 +679,12 @@ pub fn gather_published_ids(
             Err(PublishedAtError::Invalid(value)) => {
                 invalid.insert(*name, value);
             }
+            Err(PublishedAtError::Conflict {
+                id_lock,
+                id_manifest,
+            }) => {
+                conflicting.insert(*name, (id_lock, id_manifest));
+            }
         };
     }
 
@@ -681,6 +694,7 @@ pub fn gather_published_ids(
             published,
             unpublished,
             invalid,
+            conflicting,
         },
     )
 }

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -59,6 +59,7 @@ impl Build {
             config,
             run_bytecode_verifier: true,
             print_diags_to_stderr: true,
+            chain_id: None,
         }
         .build(rerooted_path)?;
         if dump_bytecode_as_base64 {

--- a/crates/sui-package-management/Cargo.toml
+++ b/crates/sui-package-management/Cargo.toml
@@ -15,5 +15,7 @@ tracing.workspace = true
 
 sui-json-rpc-types.workspace = true
 sui-sdk.workspace = true
+sui-types.workspace = true
 
 move-package.workspace = true
+move-symbol-pool.workspace = true

--- a/crates/sui-package-management/src/lib.rs
+++ b/crates/sui-package-management/src/lib.rs
@@ -2,15 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Context};
+use std::fs::File;
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use move_package::lock_file::{self, LockFile};
+use move_package::{
+    lock_file::{self, schema::ManagedPackage, LockFile},
+    resolution::resolution_graph::Package,
+    source_package::layout::SourcePackageLayout,
+};
+use move_symbol_pool::Symbol;
 use sui_json_rpc_types::{get_new_package_obj_from_response, SuiTransactionBlockResponse};
 use sui_sdk::wallet_context::WalletContext;
+use sui_types::base_types::ObjectID;
+
+const PUBLISHED_AT_MANIFEST_FIELD: &str = "published-at";
 
 pub enum LockCommand {
     Publish,
     Upgrade,
+}
+
+#[derive(Debug, Clone)]
+pub enum PublishedAtError {
+    Invalid(String),
+    NotPresent,
+    Conflict {
+        id_lock: String,
+        id_manifest: String,
+    },
 }
 
 /// Update the `Move.lock` file with automated address management info.
@@ -72,4 +92,67 @@ pub async fn update_lock_file(
     }?;
     lock.commit(lock_file)?;
     Ok(())
+}
+
+/// Find the published on-chain ID in the `Move.lock` or `Move.toml` file.
+/// A chain ID of `None` means that we will only try to resolve a published ID from the Move.toml.
+/// The published ID is resolved from the `Move.toml` if the Move.lock does not exist.
+/// Else, we resolve from the `Move.lock`, where addresses are automatically
+/// managed. If conflicting IDs are found in the `Move.lock` vs. `Move.toml`, a
+/// "Conflict" error message returns.
+pub fn resolve_published_id(
+    package: &Package,
+    chain_id: Option<String>,
+) -> Result<ObjectID, PublishedAtError> {
+    // Look up a valid `published-at` in the `Move.toml` first, which we'll
+    // return if the Move.lock does not manage addresses.
+    let published_id_in_manifest = match published_at_property(package) {
+        Ok(v) => Some(v),
+        Err(PublishedAtError::NotPresent) => None,
+        Err(e) => return Err(e), // An existing but invalid `published-at` in `Move.toml` should fail early.
+    };
+
+    let lock = package.package_path.join(SourcePackageLayout::Lock.path());
+    let Ok(mut lock_file) = File::open(lock.clone()) else {
+        return match published_id_in_manifest {
+            Some(v) => {
+                ObjectID::from_str(v.as_str()).map_err(|_| PublishedAtError::Invalid(v.to_owned()))
+            }
+            None => Err(PublishedAtError::NotPresent),
+        };
+    };
+    let managed_packages = ManagedPackage::read(&mut lock_file).ok();
+    // Find the environment and ManagedPackage data for this chain_id.
+    let env_for_chain_id = managed_packages
+        .and_then(|m| {
+            let chain_id = chain_id.as_ref()?;
+            m.into_iter().find(|(_, v)| v.chain_id == *chain_id)
+        })
+        .map(|(k, v)| (k, v.latest_published_id));
+
+    let package_id = match (env_for_chain_id, published_id_in_manifest) {
+        (Some((_env, id_lock)), Some(id_manifest)) if id_lock != id_manifest => {
+            return Err(PublishedAtError::Conflict {
+                id_lock,
+                id_manifest,
+            })
+        }
+        (Some((_, id_lock)), _) => id_lock,
+        (None, Some(id_manifest)) => id_manifest, /* No info in Move.lock: Fall back to manifest */
+        _ => return Err(PublishedAtError::NotPresent), /* Neither in Move.toml nor Move.lock */
+    };
+    ObjectID::from_str(package_id.as_str())
+        .map_err(|_| PublishedAtError::Invalid(package_id.to_owned()))
+}
+
+fn published_at_property(package: &Package) -> Result<String, PublishedAtError> {
+    let Some(value) = package
+        .source_package
+        .package
+        .custom_properties
+        .get(&Symbol::from(PUBLISHED_AT_MANIFEST_FIELD))
+    else {
+        return Err(PublishedAtError::NotPresent);
+    };
+    Ok(value.to_string())
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -49,9 +49,9 @@ use sui_json_rpc_types::{
 use sui_keys::keystore::AccountKeystore;
 use sui_move_build::{
     build_from_resolution_graph, check_invalid_dependencies, check_unpublished_dependencies,
-    gather_published_ids, BuildConfig, CompiledPackage, PackageDependencies, PublishedAtError,
+    gather_published_ids, BuildConfig, CompiledPackage, PackageDependencies,
 };
-use sui_package_management::LockCommand;
+use sui_package_management::{LockCommand, PublishedAtError};
 use sui_replay::ReplayToolCommand;
 use sui_sdk::{
     apis::ReadApi,
@@ -867,6 +867,11 @@ impl SuiClientCommands {
                         .map_err(|e| SuiError::ModulePublishFailure {
                             error: format!("Failed to canonicalize package path: {}", e),
                         })?;
+                let env_alias = context
+                    .config
+                    .get_active_env()
+                    .map(|e| e.alias.clone())
+                    .ok();
                 let (package_id, compiled_modules, dependencies, package_digest, upgrade_policy) =
                     upgrade_package(
                         client.read_api(),
@@ -875,6 +880,7 @@ impl SuiClientCommands {
                         upgrade_capability,
                         with_unpublished_dependencies,
                         skip_dependency_verification,
+                        env_alias,
                     )
                     .await?;
                 let tx_kind = client
@@ -1023,7 +1029,7 @@ impl SuiClientCommands {
 
                     (_, package_path) => {
                         let package_path = package_path.unwrap_or_else(|| PathBuf::from("."));
-                        let package = compile_package_simple(build_config, &package_path)?;
+                        let package = compile_package_simple(build_config, &package_path, None)?;
                         let name = package
                             .package
                             .compiled_package_info
@@ -1558,10 +1564,17 @@ impl SuiClientCommands {
                 }
 
                 let build_config = resolve_lock_file_path(build_config, Some(&package_path))?;
+                let chain_id = context
+                    .get_client()
+                    .await?
+                    .read_api()
+                    .get_chain_identifier()
+                    .await?;
                 let compiled_package = BuildConfig {
                     config: build_config,
                     run_bytecode_verifier: true,
                     print_diags_to_stderr: true,
+                    chain_id: Some(chain_id),
                 }
                 .build(&package_path)?;
 
@@ -1601,15 +1614,22 @@ impl SuiClientCommands {
 fn compile_package_simple(
     build_config: MoveBuildConfig,
     package_path: &Path,
+    chain_id: Option<String>,
 ) -> Result<CompiledPackage, anyhow::Error> {
     let config = BuildConfig {
         config: resolve_lock_file_path(build_config, Some(package_path))?,
         run_bytecode_verifier: false,
         print_diags_to_stderr: false,
+        chain_id: chain_id.clone(),
     };
     let resolution_graph = config.resolution_graph(package_path)?;
 
-    Ok(build_from_resolution_graph(resolution_graph, false, false)?)
+    Ok(build_from_resolution_graph(
+        resolution_graph,
+        false,
+        false,
+        chain_id,
+    )?)
 }
 
 pub(crate) async fn upgrade_package(
@@ -1619,6 +1639,7 @@ pub(crate) async fn upgrade_package(
     upgrade_capability: ObjectID,
     with_unpublished_dependencies: bool,
     skip_dependency_verification: bool,
+    env_alias: Option<String>,
 ) -> Result<(ObjectID, Vec<Vec<u8>>, PackageDependencies, [u8; 32], u8), anyhow::Error> {
     let (dependencies, compiled_modules, compiled_package, package_id) = compile_package(
         read_api,
@@ -1631,12 +1652,28 @@ pub(crate) async fn upgrade_package(
 
     let package_id = package_id.map_err(|e| match e {
         PublishedAtError::NotPresent => {
-            anyhow!("No 'published-at' field in manifest for package to be upgraded.")
+            anyhow!("No 'published-at' field in Move.toml or 'published-id' in Move.lock for package to be upgraded.")
         }
         PublishedAtError::Invalid(v) => anyhow!(
-            "Invalid 'published-at' field in manifest of package to be upgraded. \
+            "Invalid 'published-at' field in Move.toml or 'published-id' in Move.lock of package to be upgraded. \
                          Expected an on-chain address, but found: {v:?}"
         ),
+        PublishedAtError::Conflict {
+            id_lock,
+            id_manifest,
+        } => {
+            let env_alias = format!("(currently {})", env_alias.unwrap_or_default());
+            anyhow!(
+                "Conflicting published package address: `Move.toml` contains published-at address \
+                 {id_manifest} but `Move.lock` file contains published-at address {id_lock}. \
+                 You may want to:
+
+                 - delete the published-at address in the `Move.toml` if the `Move.lock` address is correct; OR
+                 - update the `Move.lock` address using the `sui manage-package` command to be the same as the `Move.toml`; OR
+                 - check that your `sui active-env` {env_alias} corresponds to the chain on which the package is published (i.e., devnet, testnet, mainnet); OR
+                 - contact the maintainer if this package is a dependency and request resolving the conflict."
+            )
+        }
     })?;
 
     let resp = read_api
@@ -1691,13 +1728,16 @@ pub(crate) async fn compile_package(
     let config = resolve_lock_file_path(build_config, Some(package_path))?;
     let run_bytecode_verifier = true;
     let print_diags_to_stderr = true;
+    let chain_id = read_api.get_chain_identifier().await.ok();
     let config = BuildConfig {
         config,
         run_bytecode_verifier,
         print_diags_to_stderr,
+        chain_id,
     };
     let resolution_graph = config.resolution_graph(package_path)?;
-    let (package_id, dependencies) = gather_published_ids(&resolution_graph);
+    let chain_id = read_api.get_chain_identifier().await.ok();
+    let (package_id, dependencies) = gather_published_ids(&resolution_graph, chain_id.clone());
     check_invalid_dependencies(&dependencies.invalid)?;
     if !with_unpublished_dependencies {
         check_unpublished_dependencies(&dependencies.unpublished)?;
@@ -1706,6 +1746,7 @@ pub(crate) async fn compile_package(
         resolution_graph,
         run_bytecode_verifier,
         print_diags_to_stderr,
+        chain_id,
     )?;
     let protocol_config = read_api.get_protocol_config(None).await?;
 

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -974,6 +974,7 @@ impl<'a> PTBBuilder<'a> {
                         ObjectID::from_address(upgrade_cap_id.into_inner()),
                         false, /* with_unpublished_dependencies */
                         false, /* skip_dependency_verification */
+                        None,
                     )
                     .await
                     .map_err(|e| err!(path_loc, "{e}"))?;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -1857,20 +1857,12 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
 
     assert!(effects.status.is_ok());
     assert_eq!(effects.gas_object().object_id(), gas_obj_id);
-    let package = effects
-        .created()
-        .iter()
-        .find(|refe| matches!(refe.owner, Owner::Immutable))
-        .unwrap();
-
     let cap = effects
         .created()
         .iter()
         .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
         .unwrap();
 
-    // Hacky for now: we need to add the correct `published-at` field to the Move toml file.
-    // In the future once we have automated address management replace this logic!
     let tmp_dir = tempfile::tempdir().unwrap();
     fs_extra::dir::copy(
         &package_path,
@@ -1880,28 +1872,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
     .unwrap();
     let mut upgrade_pkg_path = tmp_dir.path().to_path_buf();
     upgrade_pkg_path.extend(["dummy_modules_upgrade", "Move.toml"]);
-    let mut move_toml = std::fs::File::options()
-        .read(true)
-        .write(true)
-        .open(&upgrade_pkg_path)
-        .unwrap();
     upgrade_pkg_path.pop();
-
-    let mut buf = String::new();
-    move_toml.read_to_string(&mut buf).unwrap();
-
-    // Add a `published-at = "0x<package_object_id>"` to the Move manifest.
-    let mut lines: Vec<String> = buf.split('\n').map(|x| x.to_string()).collect();
-    let idx = lines.iter().position(|s| s == "[package]").unwrap();
-    lines.insert(
-        idx + 1,
-        format!(
-            "published-at = \"{}\"",
-            package.reference.object_id.to_hex_uncompressed()
-        ),
-    );
-    let new = lines.join("\n");
-    move_toml.write_at(new.as_bytes(), 0).unwrap();
 
     // Create a new build config for the upgrade. Initialize its lock file
     // to the package we published.
@@ -1965,6 +1936,127 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
         expect_upgrade_version.value(),
         localnet.version.parse::<u64>().unwrap(),
     );
+    Ok(())
+}
+
+#[sim_test]
+async fn test_package_management_on_upgrade_command_conflict() -> Result<(), anyhow::Error> {
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    // Provide path to well formed package sources
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("dummy_modules_upgrade");
+    let build_config_publish = BuildConfig::new_for_testing().config;
+    let resp = SuiClientCommands::Publish {
+        package_path: package_path.clone(),
+        build_config: build_config_publish.clone(),
+        opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(publish_response) = resp else {
+        unreachable!("Invalid response");
+    };
+
+    let SuiTransactionBlockEffects::V1(effects) = publish_response.clone().effects.unwrap();
+
+    assert!(effects.status.is_ok());
+    assert_eq!(effects.gas_object().object_id(), gas_obj_id);
+    let package = effects
+        .created()
+        .iter()
+        .find(|refe| matches!(refe.owner, Owner::Immutable))
+        .unwrap();
+
+    let cap = effects
+        .created()
+        .iter()
+        .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
+        .unwrap();
+
+    // Set up a temporary working directory  for upgrading.
+    let tmp_dir = tempfile::tempdir().unwrap();
+    fs_extra::dir::copy(
+        &package_path,
+        tmp_dir.path(),
+        &fs_extra::dir::CopyOptions::default(),
+    )
+    .unwrap();
+    let mut upgrade_pkg_path = tmp_dir.path().to_path_buf();
+    upgrade_pkg_path.extend(["dummy_modules_upgrade", "Move.toml"]);
+    let mut move_toml = std::fs::File::options()
+        .read(true)
+        .write(true)
+        .open(&upgrade_pkg_path)
+        .unwrap();
+    upgrade_pkg_path.pop();
+    let mut buf = String::new();
+    move_toml.read_to_string(&mut buf).unwrap();
+    let mut lines: Vec<String> = buf.split('\n').map(|x| x.to_string()).collect();
+    let idx = lines.iter().position(|s| s == "[package]").unwrap();
+    // Purposely add a conflicting `published-at` address to the Move manifest.
+    lines.insert(idx + 1, "published-at = \"0xbad\"".to_string());
+    let new = lines.join("\n");
+    move_toml.write_at(new.as_bytes(), 0).unwrap();
+
+    // Create a new build config for the upgrade. Initialize its lock file to the package we published.
+    let build_config_upgrade = BuildConfig::new_for_testing().config;
+    let mut upgrade_lock_file_path = upgrade_pkg_path.clone();
+    upgrade_lock_file_path.push("Move.lock");
+    let publish_lock_file_path = build_config_publish.lock_file.unwrap();
+    std::fs::copy(
+        publish_lock_file_path.clone(),
+        upgrade_lock_file_path.clone(),
+    )?;
+
+    // Now run the upgrade
+    let upgrade_response = SuiClientCommands::Upgrade {
+        package_path: upgrade_pkg_path,
+        upgrade_capability: cap.reference.object_id,
+        build_config: build_config_upgrade.clone(),
+        opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+    }
+    .execute(context)
+    .await;
+
+    let err_string = upgrade_response.unwrap_err().to_string();
+    let err_string = err_string.replace(&package.object_id().to_string(), "<elided-for-test>");
+
+    let expect = expect![[r#"
+        Conflicting published package address: `Move.toml` contains published-at address 0xbad but `Move.lock` file contains published-at address <elided-for-test>. You may want to:
+
+                         - delete the published-at address in the `Move.toml` if the `Move.lock` address is correct; OR
+                         - update the `Move.lock` address using the `sui manage-package` command to be the same as the `Move.toml`; OR
+                         - check that your `sui active-env` (currently localnet) corresponds to the chain on which the package is published (i.e., devnet, testnet, mainnet); OR
+                         - contact the maintainer if this package is a dependency and request resolving the conflict."#]];
+    expect.assert_eq(&err_string);
     Ok(())
 }
 

--- a/sdk/typescript/test/e2e/multisig.test.ts
+++ b/sdk/typescript/test/e2e/multisig.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { tmpdir } from 'os';
+import path from 'path';
 import { fromB64 } from '@mysten/bcs';
 import { describe, expect, it } from 'vitest';
 
@@ -43,7 +45,8 @@ describe('MultiSig with zklogin signature', () => {
 			],
 		});
 		let multisigAddr = multiSigPublicKey.toSuiAddress();
-		let toolbox = await setupWithFundedAddress(kp, multisigAddr);
+		const configPath = path.join(tmpdir(), 'client.yaml');
+		let toolbox = await setupWithFundedAddress(kp, multisigAddr, configPath);
 
 		// construct a transfer from the multisig address.
 		const tx = new Transaction();


### PR DESCRIPTION
## Description 

This PR adds automated address management support for `sui client publish` and `sui client upgrade`. The `chain_id` is resolved early in sui commands and propagated down where published ID resolution is needed.

High-level:

- If a package contains a `Move.lock` that contains info to support a package upgrade, then that is used, and a user does not have to (nor should they) maintain a `published-at` address in their `Move.toml`.

- If a package does _not_ have any `Move.lock` information to support a package upgrade, we will still fallback to `Move.toml` as we do today. Nothing changes.

- If a package has both a `Move.lock` and `Move.toml`, then the `Move.lock` will be used (the user is free to delete `published-at` in their `Move.toml`). Caveat: If a published address is in both of these files, they must be the same (we will raise a `Conflict` error message otherwise).
 
- Note: docs to follow and merge at the same time as this PR, particularly [this section on upgrades](https://docs.sui.io/concepts/sui-move-concepts/packages/upgrade#example)

- Note after this PR it is still required to set `[addresses]` to `0x0` in `Move.toml`. This requirement will be removed subsequently (which also requires setting to `0x0` still). I didn't want to meddle with that logic all at once.

## Test plan 

How did you test the new or updated feature?

We cover three cases:

- Upgrade with `Move.toml` only (existing package upgrade test)
- Upgrade with `Move.lock` only (extension of existing package management test)
- Upgrade with `Move.lock` and `Move.toml` with conflicting addresses error condition (new test)

- Existing e2e tests pass (and SDK tests now resolve chain ID for publish commands)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Running `sui client publish` or `sui client upgrade` will now cause package addresses to be tracked in the `Move.lock` file. This removes the need to manually record or edit `published-at` addresses in the `Move.toml` file going forward. See docs PR https://github.com/MystenLabs/sui/pull/18433 for full details.
- [ ] Rust SDK: 
