### PR TITLE
[sui-types] Add Serde alias in type origin table to preserve backwards compatibility

### DIFF
--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -17,6 +17,7 @@ use sui_types::execution_status::{
     TypeArgumentError,
 };
 use sui_types::messages_grpc::ObjectInfoRequestKind;
+use sui_types::move_package::TypeOrigin;
 use sui_types::{
     base_types::MoveObjectType_,
     crypto::Signer,
@@ -145,6 +146,13 @@ fn get_registry() -> Result<Registry> {
 
     let ccd = CheckpointDigest::random();
     tracer.trace_value(&mut samples, &ccd)?;
+
+    let tot = TypeOrigin {
+        module_name: "module_name".to_string(),
+        datatype_name: "datatype_name".to_string(),
+        package: ObjectID::random(),
+    };
+    tracer.trace_value(&mut samples, &tot)?;
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<Owner>(&samples)?;

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -66,6 +66,8 @@ pub type FnInfoMap = BTreeMap<FnInfoKey, FnInfo>;
 )]
 pub struct TypeOrigin {
     pub module_name: String,
+    // `struct_name` alias to support backwards compatibility with the old name
+    #[serde(alias = "struct_name")]
     pub datatype_name: String,
     pub package: ObjectID,
 }


### PR DESCRIPTION
## Description 

Adds an alias for the old name of the field in the type origin table to preserve backwards compatibility with a rename for enums.

## Test plan 

Verified transaction replay worked (was previously failing off of `main`).

