### PR TITLE
[Metrics] add bounded and unbounded mpsc channel wrappers

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -346,15 +346,13 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use consensus_config::{local_committee_and_keys, Parameters};
+    use mysten_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::Mutex;
     use prometheus::Registry;
     use rstest::rstest;
     use sui_protocol_config::ProtocolConfig;
     use tempfile::TempDir;
-    use tokio::{
-        sync::{broadcast, mpsc::unbounded_channel},
-        time::sleep,
-    };
+    use tokio::{sync::broadcast, time::sleep};
     use typed_store::DBMetrics;
 
     use super::*;
@@ -471,7 +469,7 @@ mod tests {
         let protocol_keypair = keypairs[own_index].1.clone();
         let network_keypair = keypairs[own_index].0.clone();
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_consumer = CommitConsumer::new(sender, 0, 0);
 
         let authority = ConsensusAuthority::start(
@@ -582,7 +580,7 @@ mod tests {
             let protocol_keypair = keypairs[index].1.clone();
             let network_keypair = keypairs[index].0.clone();
 
-            let (sender, receiver) = unbounded_channel();
+            let (sender, receiver) = unbounded_channel("consensus_output");
             let commit_consumer = CommitConsumer::new(sender, 0, 0);
 
             async move {

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -13,8 +13,8 @@ use bytes::Bytes;
 use consensus_config::{AuthorityIndex, DefaultHashFunction, DIGEST_LENGTH};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction as _};
+use mysten_metrics::monitored_mpsc::UnboundedSender;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     block::{BlockAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock},

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -3,8 +3,8 @@
 
 use std::{sync::Arc, time::Duration};
 
+use mysten_metrics::monitored_mpsc::UnboundedSender;
 use parking_lot::RwLock;
-use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     block::{BlockAPI, VerifiedBlock},
@@ -188,8 +188,8 @@ impl CommitObserver {
 
 #[cfg(test)]
 mod tests {
+    use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver};
     use parking_lot::RwLock;
-    use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
     use super::*;
     use crate::{
@@ -213,7 +213,7 @@ mod tests {
         )));
         let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
-        let (sender, mut receiver) = unbounded_channel();
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
 
         let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
@@ -317,7 +317,7 @@ mod tests {
         )));
         let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
-        let (sender, mut receiver) = unbounded_channel();
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
 
         let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
@@ -465,7 +465,7 @@ mod tests {
         )));
         let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
-        let (sender, mut receiver) = unbounded_channel();
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
 
         let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -721,11 +721,9 @@ mod test {
     use std::{collections::BTreeSet, time::Duration};
 
     use consensus_config::{local_committee_and_keys, AuthorityIndex, Parameters, Stake};
+    use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver};
     use sui_protocol_config::ProtocolConfig;
-    use tokio::{
-        sync::mpsc::{unbounded_channel, UnboundedReceiver},
-        time::sleep,
-    };
+    use tokio::time::sleep;
 
     use super::*;
     use crate::{
@@ -782,7 +780,7 @@ mod test {
             dag_state.clone(),
         ));
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -898,7 +896,7 @@ mod test {
             dag_state.clone(),
         ));
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -993,7 +991,7 @@ mod test {
             dag_state.clone(),
         ));
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -1101,7 +1099,7 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (sender, _receiver) = unbounded_channel();
+        let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
@@ -1646,7 +1644,7 @@ mod test {
             // Need at least one subscriber to the block broadcast channel.
             let block_receiver = signal_receivers.block_broadcast_receiver();
 
-            let (commit_sender, commit_receiver) = unbounded_channel();
+            let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
             let commit_observer = CommitObserver::new(
                 context.clone(),
                 CommitConsumer::new(commit_sender.clone(), 0, 0),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -54,20 +54,17 @@ const SIZE_BUCKETS: &[f64] = &[
 
 pub(crate) struct Metrics {
     pub(crate) node_metrics: NodeMetrics,
-    pub(crate) channel_metrics: ChannelMetrics,
     pub(crate) network_metrics: NetworkMetrics,
     pub(crate) quinn_connection_metrics: QuinnConnectionMetrics,
 }
 
 pub(crate) fn initialise_metrics(registry: Registry) -> Arc<Metrics> {
     let node_metrics = NodeMetrics::new(&registry);
-    let channel_metrics = ChannelMetrics::new(&registry);
     let network_metrics = NetworkMetrics::new(&registry);
     let quinn_connection_metrics = QuinnConnectionMetrics::new(&registry);
 
     Arc::new(Metrics {
         node_metrics,
-        channel_metrics,
         network_metrics,
         quinn_connection_metrics,
     })
@@ -444,44 +441,6 @@ impl NodeMetrics {
                 "Total node uptime",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
-        }
-    }
-}
-
-pub(crate) struct ChannelMetrics {
-    /// occupancy of the channel from TransactionClient to TransactionConsumer
-    pub(crate) tx_transactions_submit: IntGauge,
-    /// total received on channel from TransactionClient to TransactionConsumer
-    pub(crate) tx_transactions_submit_total: IntCounter,
-    /// occupancy of the CoreThread commands channel
-    pub(crate) core_thread: IntGauge,
-    /// total received on the CoreThread commands channel
-    pub(crate) core_thread_total: IntCounter,
-}
-
-impl ChannelMetrics {
-    pub(crate) fn new(registry: &Registry) -> Self {
-        Self {
-            tx_transactions_submit: register_int_gauge_with_registry!(
-                "tx_transactions_submit",
-                "occupancy of the channel from the `TransactionClient` to the `TransactionConsumer`",
-                registry
-            ).unwrap(),
-            tx_transactions_submit_total: register_int_counter_with_registry!(
-                "tx_transactions_submit_total",
-                "total received on channel from the `TransactionClient` to the `TransactionConsumer`",
-                registry
-            ).unwrap(),
-            core_thread: register_int_gauge_with_registry!(
-                "core_thread",
-                "occupancy of the `CoreThread` commands channel",
-                registry
-            ).unwrap(),
-            core_thread_total: register_int_counter_with_registry!(
-                "core_thread_total",
-                "total received on the `CoreThread` commands channel",
-                registry
             ).unwrap(),
         }
     }

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -157,7 +157,7 @@ pub enum ClientError {
 
 impl TransactionClient {
     pub(crate) fn new(context: Arc<Context>) -> (Self, Receiver<TransactionsGuard>) {
-        let (sender, receiver) = channel("consensus_transactions", MAX_PENDING_TRANSACTIONS);
+        let (sender, receiver) = channel("consensus_input", MAX_PENDING_TRANSACTIONS);
 
         (
             Self {

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -3,8 +3,7 @@
 
 use std::sync::Arc;
 
-use mysten_metrics::metered_channel;
-use mysten_metrics::metered_channel::channel_with_total;
+use mysten_metrics::monitored_mpsc::{channel, Receiver, Sender};
 use sui_protocol_config::ProtocolConfig;
 use tap::tap::TapFallible;
 use thiserror::Error;
@@ -35,7 +34,7 @@ pub(crate) struct TransactionsGuard {
 /// The transactions are submitted to a channel which is shared between the TransactionConsumer and the TransactionClient
 /// and are pulled every time the `next` method is called.
 pub(crate) struct TransactionConsumer {
-    tx_receiver: metered_channel::Receiver<TransactionsGuard>,
+    tx_receiver: Receiver<TransactionsGuard>,
     max_consumed_bytes_per_request: u64,
     max_consumed_transactions_per_request: u64,
     pending_transactions: Option<TransactionsGuard>,
@@ -43,7 +42,7 @@ pub(crate) struct TransactionConsumer {
 
 impl TransactionConsumer {
     pub(crate) fn new(
-        tx_receiver: metered_channel::Receiver<TransactionsGuard>,
+        tx_receiver: Receiver<TransactionsGuard>,
         context: Arc<Context>,
         max_consumed_transactions_per_request: Option<u64>,
     ) -> Self {
@@ -143,7 +142,7 @@ impl TransactionConsumer {
 
 #[derive(Clone)]
 pub struct TransactionClient {
-    sender: metered_channel::Sender<TransactionsGuard>,
+    sender: Sender<TransactionsGuard>,
     max_transaction_size: u64,
 }
 
@@ -157,14 +156,8 @@ pub enum ClientError {
 }
 
 impl TransactionClient {
-    pub(crate) fn new(
-        context: Arc<Context>,
-    ) -> (Self, metered_channel::Receiver<TransactionsGuard>) {
-        let (sender, receiver) = channel_with_total(
-            MAX_PENDING_TRANSACTIONS,
-            &context.metrics.channel_metrics.tx_transactions_submit,
-            &context.metrics.channel_metrics.tx_transactions_submit_total,
-        );
+    pub(crate) fn new(context: Arc<Context>) -> (Self, Receiver<TransactionsGuard>) {
+        let (sender, receiver) = channel("consensus_transactions", MAX_PENDING_TRANSACTIONS);
 
         (
             Self {

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 mod guards;
 pub mod histogram;
 pub mod metered_channel;
+pub mod monitored_mpsc;
 pub use guards::*;
 
 pub const TX_TYPE_SINGLE_WRITER_TX: &str = "single_writer";
@@ -30,7 +31,9 @@ pub const TX_TYPE_SHARED_OBJ_TX: &str = "shared_object";
 pub struct Metrics {
     pub tasks: IntGaugeVec,
     pub futures: IntGaugeVec,
-    pub channels: IntGaugeVec,
+    pub channel_inflight: IntGaugeVec,
+    pub channel_sent: IntGaugeVec,
+    pub channel_received: IntGaugeVec,
     pub scope_iterations: IntGaugeVec,
     pub scope_duration_ns: IntGaugeVec,
     pub scope_entrance: IntGaugeVec,
@@ -53,9 +56,23 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
-            channels: register_int_gauge_vec_with_registry!(
-                "monitored_channels",
-                "Size of channels.",
+            channel_inflight: register_int_gauge_vec_with_registry!(
+                "monitored_channel_inflight",
+                "Inflight items in channels.",
+                &["name"],
+                registry,
+            )
+            .unwrap(),
+            channel_sent: register_int_gauge_vec_with_registry!(
+                "monitored_channel_sent",
+                "Sent items in channels.",
+                &["name"],
+                registry,
+            )
+            .unwrap(),
+            channel_received: register_int_gauge_vec_with_registry!(
+                "monitored_channel_received",
+                "Received items in channels.",
                 &["name"],
                 registry,
             )

--- a/crates/mysten-metrics/src/metered_channel.rs
+++ b/crates/mysten-metrics/src/metered_channel.rs
@@ -167,7 +167,9 @@ impl<'a, T> Permit<'a, T> {
 impl<'a, T> Drop for Permit<'a, T> {
     fn drop(&mut self) {
         // in the case the permit is dropped without sending, we still want to decrease the occupancy of the channel
-        self.gauge_ref.dec()
+        if self.permit.is_some() {
+            self.gauge_ref.dec();
+        }
     }
 }
 

--- a/crates/mysten-metrics/src/metered_channel.rs
+++ b/crates/mysten-metrics/src/metered_channel.rs
@@ -320,6 +320,7 @@ impl<T> From<Receiver<T>> for ReceiverStream<T> {
 ////////////////////////////////////////////////////////////////
 
 /// Similar to `mpsc::channel`, `channel` creates a pair of `Sender` and `Receiver`
+/// Deprecated: use `monitored_mpsc::channel` instead.
 #[track_caller]
 pub fn channel<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
     gauge.set(0);
@@ -337,6 +338,7 @@ pub fn channel<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
     )
 }
 
+/// Deprecated: use `monitored_mpsc::channel` instead.
 #[track_caller]
 pub fn channel_with_total<T>(
     size: usize,

--- a/crates/mysten-metrics/src/monitored_mpsc.rs
+++ b/crates/mysten-metrics/src/monitored_mpsc.rs
@@ -50,15 +50,14 @@ impl<T> Sender<T> {
     pub fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
         self.inner
             .try_send(message)
-            // remove this unsightly hack once https://github.com/rust-lang/rust/issues/91345 is resolved
-            .map(|val| {
+            // TODO: switch to inspect() once the repo upgrades to Rust 1.76 or higher.
+            .map(|_| {
                 if let Some(inflight) = &self.inflight {
                     inflight.inc();
                 }
                 if let Some(sent) = &self.sent {
                     sent.inc();
                 }
-                val
             })
     }
 

--- a/crates/mysten-metrics/src/monitored_mpsc.rs
+++ b/crates/mysten-metrics/src/monitored_mpsc.rs
@@ -1,0 +1,252 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides wrappers to tokio mpsc channels, with metrics on total items sent, received and inflight.
+
+use std::task::{Context, Poll};
+
+use futures::{Future, TryFutureExt as _};
+use prometheus::IntGauge;
+use tap::Tap;
+use tokio::sync::mpsc::{
+    self,
+    error::{SendError, TryRecvError, TrySendError},
+};
+
+use crate::get_metrics;
+
+/// Wraps an [`mpsc::Sender`] with gauges counting the sent and inflight items.
+#[derive(Clone, Debug)]
+pub struct Sender<T> {
+    inner: mpsc::Sender<T>,
+    inflight: IntGauge,
+    sent: IntGauge,
+}
+
+impl<T> Sender<T> {
+    /// Sends a value, waiting until there is capacity.
+    /// Increments the gauge in case of a successful `send`.
+    pub async fn send(&self, value: T) -> Result<(), SendError<T>> {
+        self.inner
+            .send(value)
+            .inspect_ok(|_| {
+                self.inflight.inc();
+                self.sent.inc();
+            })
+            .await
+    }
+
+    /// Completes when the receiver has dropped.
+    pub async fn closed(&self) {
+        self.inner.closed().await
+    }
+
+    /// Attempts to immediately send a message on this `Sender`
+    /// Increments the gauge in case of a successful `try_send`.
+    pub fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
+        self.inner
+            .try_send(message)
+            // remove this unsightly hack once https://github.com/rust-lang/rust/issues/91345 is resolved
+            .map(|val| {
+                self.inflight.inc();
+                self.sent.inc();
+                val
+            })
+    }
+
+    // TODO: facade [`send_timeout`](tokio::mpsc::Sender::send_timeout) under the tokio feature flag "time"
+    // TODO: facade [`blocking_send`](tokio::mpsc::Sender::blocking_send) under the tokio feature flag "sync"
+
+    /// Checks if the channel has been closed. This happens when the
+    /// [`Receiver`] is dropped, or when the [`Receiver::close`] method is
+    /// called.
+    pub fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Waits for channel capacity. Once capacity to send one message is
+    /// available, it is reserved for the caller.
+    /// Increments the gauge in case of a successful `reserve`.
+    pub async fn reserve(&self) -> Result<Permit<'_, T>, SendError<()>> {
+        self.inner.reserve().await.map(|permit| {
+            self.inflight.inc();
+            Permit::new(permit, &self.inflight)
+        })
+    }
+
+    /// Tries to acquire a slot in the channel without waiting for the slot to become
+    /// available.
+    /// Increments the gauge in case of a successful `try_reserve`.
+    pub fn try_reserve(&self) -> Result<Permit<'_, T>, TrySendError<()>> {
+        self.inner.try_reserve().map(|val| {
+            self.inflight.inc();
+            Permit::new(val, &self.inflight)
+        })
+    }
+
+    // TODO: consider exposing the _owned methods
+
+    // Note: not exposing `same_channel`, as it is hard to implement with callers able to
+    // break the coupling between channel and gauge using `gauge`.
+
+    /// Returns the current capacity of the channel.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    // We're voluntarily not putting WeakSender under a facade.
+
+    /// Returns a reference to the underlying inflight gauge.
+    pub fn inflight(&self) -> &IntGauge {
+        &self.inflight
+    }
+
+    pub fn downgrade(&self) -> WeakSender<T> {
+        let sender = self.inner.downgrade();
+        WeakSender {
+            inner: sender,
+            inflight: self.inflight.clone(),
+            sent: self.sent.clone(),
+        }
+    }
+}
+
+/// A newtype for an `mpsc::Permit` which allows us to inject gauge accounting
+/// in the case the permit is dropped w/o sending
+pub struct Permit<'a, T> {
+    permit: Option<mpsc::Permit<'a, T>>,
+    inflight_ref: &'a IntGauge,
+}
+
+impl<'a, T> Permit<'a, T> {
+    pub fn new(permit: mpsc::Permit<'a, T>, inflight_ref: &'a IntGauge) -> Permit<'a, T> {
+        Permit {
+            permit: Some(permit),
+            inflight_ref,
+        }
+    }
+
+    pub fn send(mut self, value: T) {
+        let sender = self.permit.take().expect("Permit invariant violated!");
+        sender.send(value);
+        // skip the drop logic, see https://github.com/tokio-rs/tokio/blob/a66884a2fb80d1180451706f3c3e006a3fdcb036/tokio/src/sync/mpsc/bounded.rs#L1155-L1163
+        std::mem::forget(self);
+    }
+}
+
+impl<'a, T> Drop for Permit<'a, T> {
+    fn drop(&mut self) {
+        // in the case the permit is dropped without sending, we still want to decrease the occupancy of the channel
+        self.inflight_ref.dec()
+    }
+}
+
+#[async_trait::async_trait]
+pub trait WithPermit<T> {
+    async fn with_permit<F: Future + Send>(&self, f: F) -> Option<(Permit<T>, F::Output)>
+    where
+        T: 'static;
+}
+
+#[async_trait::async_trait]
+impl<T: Send> WithPermit<T> for Sender<T> {
+    async fn with_permit<F: Future + Send>(&self, f: F) -> Option<(Permit<T>, F::Output)> {
+        let permit = self.reserve().await.ok()?;
+        Some((permit, f.await))
+    }
+}
+
+/// Wraps an [`mpsc::WeakSender`] with gauges counting the sent and inflight items.
+#[derive(Clone, Debug)]
+pub struct WeakSender<T> {
+    inner: mpsc::WeakSender<T>,
+    inflight: IntGauge,
+    sent: IntGauge,
+}
+
+impl<T> WeakSender<T> {
+    pub fn upgrade(&self) -> Option<Sender<T>> {
+        self.inner.upgrade().map(|s| Sender {
+            inner: s,
+            inflight: self.inflight.clone(),
+            sent: self.sent.clone(),
+        })
+    }
+}
+
+/// Wraps an [`mpsc::Receiver`] with gauges counting the inflight and received items.
+#[derive(Debug)]
+pub struct Receiver<T> {
+    inner: mpsc::Receiver<T>,
+    inflight: IntGauge,
+    received: IntGauge,
+}
+
+impl<T> Receiver<T> {
+    /// Receives the next value for this receiver.
+    /// Decrements the gauge in case of a successful `recv`.
+    pub async fn recv(&mut self) -> Option<T> {
+        self.inner.recv().await.tap(|opt| {
+            if opt.is_some() {
+                self.inflight.dec();
+                self.received.inc();
+            }
+        })
+    }
+
+    /// Attempts to receive the next value for this receiver.
+    /// Decrements the gauge in case of a successful `try_recv`.
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        self.inner.try_recv().map(|val| {
+            self.inflight.dec();
+            self.received.inc();
+            val
+        })
+    }
+
+    pub fn blocking_recv(&mut self) -> Option<T> {
+        self.inner.blocking_recv().map(|val| {
+            self.inflight.dec();
+            self.received.inc();
+            val
+        })
+    }
+
+    /// Closes the receiving half of a channel without dropping it.
+    pub fn close(&mut self) {
+        self.inner.close()
+    }
+
+    /// Polls to receive the next message on this channel.
+    /// Decrements the gauge in case of a successful `poll_recv`.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        match self.inner.poll_recv(cx) {
+            res @ Poll::Ready(Some(_)) => {
+                self.inflight.dec();
+                self.received.inc();
+                res
+            }
+            s => s,
+        }
+    }
+}
+
+impl<T> Unpin for Receiver<T> {}
+
+/// Wraps `mpsc::channel` to create a pair of `Sender` and `Receiver`
+pub fn channel<T>(name: &str, size: usize) -> (Sender<T>, Receiver<T>) {
+    let metrics = get_metrics().expect("Metrics uninitialized");
+    let (sender, receiver) = mpsc::channel(size);
+    (
+        Sender {
+            inner: sender,
+            inflight: metrics.channel_inflight.with_label_values(&[name]),
+            sent: metrics.channel_sent.with_label_values(&[name]),
+        },
+        Receiver {
+            inner: receiver,
+            inflight: metrics.channel_inflight.with_label_values(&[name]),
+            received: metrics.channel_received.with_label_values(&[name]),
+        },
+    )
+}

--- a/crates/mysten-metrics/src/monitored_mpsc.rs
+++ b/crates/mysten-metrics/src/monitored_mpsc.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::{
 use crate::get_metrics;
 
 /// Wraps an [`mpsc::Sender`] with gauges counting the sent and inflight items.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Sender<T> {
     inner: mpsc::Sender<T>,
     inflight: IntGauge,
@@ -106,6 +106,17 @@ impl<T> Sender<T> {
     }
 }
 
+// Derive Clone manually to avoid the `T: Clone` bound
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            inflight: self.inflight.clone(),
+            sent: self.sent.clone(),
+        }
+    }
+}
+
 /// A newtype for an `mpsc::Permit` which allows us to inject gauge accounting
 /// in the case the permit is dropped w/o sending
 pub struct Permit<'a, T> {
@@ -152,7 +163,7 @@ impl<T: Send> WithPermit<T> for Sender<T> {
 }
 
 /// Wraps an [`mpsc::WeakSender`] with gauges counting the sent and inflight items.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WeakSender<T> {
     inner: mpsc::WeakSender<T>,
     inflight: IntGauge,
@@ -166,6 +177,17 @@ impl<T> WeakSender<T> {
             inflight: self.inflight.clone(),
             sent: self.sent.clone(),
         })
+    }
+}
+
+// Derive Clone manually to avoid the `T: Clone` bound
+impl<T> Clone for WeakSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            inflight: self.inflight.clone(),
+            sent: self.sent.clone(),
+        }
     }
 }
 
@@ -247,7 +269,7 @@ pub fn channel<T>(name: &str, size: usize) -> (Sender<T>, Receiver<T>) {
 }
 
 /// Wraps an [`mpsc::UnboundedSender`] with gauges counting the sent and inflight items.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct UnboundedSender<T> {
     inner: mpsc::UnboundedSender<T>,
     inflight: IntGauge,
@@ -291,8 +313,19 @@ impl<T> UnboundedSender<T> {
     }
 }
 
+// Derive Clone manually to avoid the `T: Clone` bound
+impl<T> Clone for UnboundedSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            inflight: self.inflight.clone(),
+            sent: self.sent.clone(),
+        }
+    }
+}
+
 /// Wraps an [`mpsc::WeakUnboundedSender`] with gauges counting the sent and inflight items.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WeakUnboundedSender<T> {
     inner: mpsc::WeakUnboundedSender<T>,
     inflight: IntGauge,
@@ -306,6 +339,17 @@ impl<T> WeakUnboundedSender<T> {
             inflight: self.inflight.clone(),
             sent: self.sent.clone(),
         })
+    }
+}
+
+// Derive Clone manually to avoid the `T: Clone` bound
+impl<T> Clone for WeakUnboundedSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            inflight: self.inflight.clone(),
+            sent: self.sent.clone(),
+        }
     }
 }
 
@@ -371,6 +415,7 @@ impl<T> Unpin for UnboundedReceiver<T> {}
 /// Wraps an [`mpsc::UnboundedChannel`] to create a pair of `UnboundedSender` and `UnboundedReceiver`
 pub fn unbounded_channel<T>(name: &str) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
     let metrics = get_metrics().expect("Metrics uninitialized");
+    #[allow(clippy::disallowed_methods)]
     let (sender, receiver) = mpsc::unbounded_channel();
     (
         UnboundedSender {

--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -129,7 +129,7 @@ where
             CHANNEL_SIZE,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["executor_signing_queue"]),
         );
 
@@ -137,7 +137,7 @@ where
             CHANNEL_SIZE,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["executor_execution_queue"]),
         );
         let execution_tx_clone = execution_tx.clone();

--- a/crates/sui-bridge/src/eth_syncer.rs
+++ b/crates/sui-bridge/src/eth_syncer.rs
@@ -54,7 +54,7 @@ where
             ETH_EVENTS_CHANNEL_SIZE,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["eth_events_queue"]),
         );
         let last_finalized_block = self.eth_client.get_last_finalized_block_id().await?;

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -397,7 +397,7 @@ mod tests {
             100,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["unit_test_eth_events_queue"]),
         );
 
@@ -405,7 +405,7 @@ mod tests {
             100,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["unit_test_sui_events_queue"]),
         );
 
@@ -448,7 +448,7 @@ mod tests {
                     100,
                     &mysten_metrics::get_metrics()
                         .unwrap()
-                        .channels
+                        .channel_inflight
                         .with_label_values(&["unit_test_mock_executor"]),
                 );
 

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -218,21 +218,21 @@ impl BridgeRequestHandler {
             1000,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["server_sui_action_signing_queue"]),
         );
         let (eth_signer_tx, eth_rx) = mysten_metrics::metered_channel::channel(
             1000,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["server_eth_action_signing_queue"]),
         );
         let (governance_signer_tx, governance_rx) = mysten_metrics::metered_channel::channel(
             1000,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["server_governance_action_signing_queue"]),
         );
         let signer = Arc::new(signer);

--- a/crates/sui-bridge/src/sui_syncer.rs
+++ b/crates/sui-bridge/src/sui_syncer.rs
@@ -53,13 +53,16 @@ where
             SUI_EVENTS_CHANNEL_SIZE,
             &mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&["sui_events_queue"]),
         );
 
         let mut task_handles = vec![];
         for (module, cursor) in self.cursors {
-            let events_rx_clone = events_tx.clone();
+            let events_rx_clone: mysten_metrics::metered_channel::Sender<(
+                Identifier,
+                Vec<SuiEvent>,
+            )> = events_tx.clone();
             let sui_client_clone = self.sui_client.clone();
             task_handles.push(spawn_logged_monitored_task!(
                 Self::run_event_listening_task(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -11,7 +11,7 @@ use std::{
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use lru::LruCache;
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
 use narwhal_config::Committee;
 use narwhal_executor::{ExecutionIndices, ExecutionState};
 use narwhal_types::ConsensusOutput;
@@ -501,7 +501,7 @@ pub struct MysticetiConsensusHandler {
 impl MysticetiConsensusHandler {
     pub fn new(
         mut consensus_handler: ConsensusHandler<CheckpointService>,
-        mut receiver: tokio::sync::mpsc::UnboundedReceiver<consensus_core::CommittedSubDag>,
+        mut receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
     ) -> Self {
         let handle = spawn_monitored_task!(async move {
             while let Some(consensus_output) = receiver.recv().await {

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use consensus_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use consensus_core::{CommitConsumer, CommitIndex, ConsensusAuthority, Round};
 use fastcrypto::ed25519;
-use mysten_metrics::{RegistryID, RegistryService};
+use mysten_metrics::{monitored_mpsc::unbounded_channel, RegistryID, RegistryService};
 use narwhal_executor::ExecutionState;
 use prometheus::Registry;
 use sui_config::NodeConfig;
@@ -15,7 +15,7 @@ use sui_protocol_config::ConsensusNetwork;
 use sui_types::{
     committee::EpochId, sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
 };
-use tokio::sync::{mpsc::unbounded_channel, Mutex};
+use tokio::sync::Mutex;
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
@@ -133,7 +133,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         // TODO: that should be replaced by a metered channel. We can discuss if unbounded approach
         // is the one we want to go with.
         #[allow(clippy::disallowed_methods)]
-        let (commit_sender, commit_receiver) = unbounded_channel();
+        let (commit_sender, commit_receiver) = unbounded_channel("committed_subdag");
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();
         let consumer = CommitConsumer::new(

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -130,9 +130,6 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         let registry = Registry::new_custom(Some("consensus".to_string()), None).unwrap();
 
-        // TODO: that should be replaced by a metered channel. We can discuss if unbounded approach
-        // is the one we want to go with.
-        #[allow(clippy::disallowed_methods)]
         let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -133,7 +133,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         // TODO: that should be replaced by a metered channel. We can discuss if unbounded approach
         // is the one we want to go with.
         #[allow(clippy::disallowed_methods)]
-        let (commit_sender, commit_receiver) = unbounded_channel("committed_subdag");
+        let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();
         let consumer = CommitConsumer::new(

--- a/crates/sui-core/src/streamer.rs
+++ b/crates/sui-core/src/streamer.rs
@@ -39,14 +39,16 @@ where
     ) -> Self {
         let channel_label = format!("streamer_{}", metrics_label);
         let gauge = if let Some(metrics) = mysten_metrics::get_metrics() {
-            metrics.channels.with_label_values(&[&channel_label])
+            metrics
+                .channel_inflight
+                .with_label_values(&[&channel_label])
         } else {
             // We call init_metrics very early when starting a node. Therefore when this happens,
             // it's probably in a test.
             mysten_metrics::init_metrics(&Registry::default());
             mysten_metrics::get_metrics()
                 .unwrap()
-                .channels
+                .channel_inflight
                 .with_label_values(&[&channel_label])
         };
 

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -81,7 +81,7 @@ where
         mysten_metrics::metered_channel::channel(
             checkpoint_queue_size,
             &global_metrics
-                .channels
+                .channel_inflight
                 .with_label_values(&["checkpoint_indexing"]),
         );
 


### PR DESCRIPTION
## Description 

Majority of the implementation is adapted from the existing metered bounded channel. The main advantage of the new implementation is that it eliminates the need to create separate metrics for each channel.

Channels in `consensus-core` are migrated to the new monitored channel wrappers. This adds monitoring for unbounded channels.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
