### PR TITLE
[GraphQL] Add a mutation payload size

### DIFF
--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -3523,7 +3523,18 @@ type ServiceConfig {
 	"""
 	requestTimeoutMs: Int!
 	"""
-	Maximum length of a query payload string.
+	The maximum bytes allowed for the `txBytes` and `signatures` fields of the GraphQL mutation
+	`executeTransactionBlock` node, or for the `txBytes` of a `dryRunTransactionBlock`.
+	
+	It is the value of the maximum transaction bytes (including the signatures) allowed by the
+	protocol, plus the Base64 overhead (roughly 1/3 of the original string).
+	"""
+	maxTransactionPayloadSize: Int!
+	"""
+	The maximum bytes allowed for the JSON object in the request body of a GraphQL query, for
+	the read part of the query.
+	In case of mutations or dryRunTransactionBlocks the txBytes and signatures are not
+	included in this limit.
 	"""
 	maxQueryPayloadSize: Int!
 	"""

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -60,14 +60,14 @@ pub struct ConnectionConfig {
 #[GraphQLConfig]
 #[derive(Default)]
 pub struct ServiceConfig {
-    pub(crate) versions: Versions,
-    pub(crate) limits: Limits,
-    pub(crate) disabled_features: BTreeSet<FunctionalGroup>,
-    pub(crate) experiments: Experiments,
-    pub(crate) name_service: NameServiceConfig,
-    pub(crate) background_tasks: BackgroundTasksConfig,
-    pub(crate) zklogin: ZkLoginConfig,
-    pub(crate) move_registry: MoveRegistryConfig,
+    pub versions: Versions,
+    pub limits: Limits,
+    pub disabled_features: BTreeSet<FunctionalGroup>,
+    pub experiments: Experiments,
+    pub name_service: NameServiceConfig,
+    pub background_tasks: BackgroundTasksConfig,
+    pub zklogin: ZkLoginConfig,
+    pub move_registry: MoveRegistryConfig,
 }
 
 #[GraphQLConfig]
@@ -129,7 +129,7 @@ pub struct BackgroundTasksConfig {
 
 #[GraphQLConfig]
 #[derive(Clone)]
-pub(crate) struct MoveRegistryConfig {
+pub struct MoveRegistryConfig {
     pub(crate) external_api_url: Option<String>,
     pub(crate) resolution_type: ResolutionType,
     pub(crate) page_limit: u16,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -83,7 +83,12 @@ pub struct Limits {
     pub max_query_nodes: u32,
     /// Maximum number of output nodes allowed in the response.
     pub max_output_nodes: u32,
-    /// Maximum size (in bytes) of a GraphQL request.
+    /// Maximum size in bytes allowed for the `txBytes` and `signatures` fields of a GraphQL
+    /// mutation request in the `executeTransactionBlock` node, and for the `txBytes` of a
+    /// `dryRunTransactionBlock` node.
+    pub max_tx_payload_size: u32,
+    /// Maximum size in bytes of the JSON payload of a GraphQL read request (excluding
+    /// `max_tx_payload_size`).
     pub max_query_payload_size: u32,
     /// Queries whose EXPLAIN cost are more than this will be logged. Given in the units used by the
     /// database (where 1.0 is roughly the cost of a sequential page access).
@@ -292,7 +297,19 @@ impl ServiceConfig {
         self.limits.request_timeout_ms
     }
 
-    /// Maximum length of a query payload string.
+    /// The maximum bytes allowed for the `txBytes` and `signatures` fields of the GraphQL mutation
+    /// `executeTransactionBlock` node, or for the `txBytes` of a `dryRunTransactionBlock`.
+    ///
+    /// It is the value of the maximum transaction bytes (including the signatures) allowed by the
+    /// protocol, plus the Base64 overhead (roughly 1/3 of the original string).
+    async fn max_transaction_payload_size(&self) -> u32 {
+        self.limits.max_tx_payload_size
+    }
+
+    /// The maximum bytes allowed for the JSON object in the request body of a GraphQL query, for
+    /// the read part of the query.
+    /// In case of mutations or dryRunTransactionBlocks the txBytes and signatures are not
+    /// included in this limit.
     async fn max_query_payload_size(&self) -> u32 {
         self.limits.max_query_payload_size
     }
@@ -551,6 +568,11 @@ impl Default for Limits {
             // for the `TransactionBlockFilter`.
             max_transaction_ids: 1000,
             max_scan_limit: 100_000_000,
+            // This value is set to be the size of the max transaction bytes allowed + base64
+            // overhead (roughly 1/3 of the original string). This is rounded up.
+            //
+            // <https://github.com/MystenLabs/sui/blob/4b934f87acae862cecbcbefb3da34cabb79805aa/crates/sui-protocol-config/src/lib.rs#L1578>
+            max_tx_payload_size: (128u32 * 1024u32 * 4u32).div_ceil(3),
         }
     }
 }
@@ -617,6 +639,7 @@ mod tests {
                 max-query-depth = 100
                 max-query-nodes = 300
                 max-output-nodes = 200000
+                max-mutation-payload-size = 174763
                 max-query-payload-size = 2000
                 max-db-query-cost = 50
                 default-page-size = 20
@@ -638,6 +661,7 @@ mod tests {
                 max_query_depth: 100,
                 max_query_nodes: 300,
                 max_output_nodes: 200000,
+                max_tx_payload_size: 174763,
                 max_query_payload_size: 2000,
                 max_db_query_cost: 50,
                 default_page_size: 20,
@@ -703,6 +727,7 @@ mod tests {
                 max-query-depth = 42
                 max-query-nodes = 320
                 max-output-nodes = 200000
+                max-tx-payload-size = 181017
                 max-query-payload-size = 200
                 max-db-query-cost = 20
                 default-page-size = 10
@@ -727,6 +752,7 @@ mod tests {
                 max_query_depth: 42,
                 max_query_nodes: 320,
                 max_output_nodes: 200000,
+                max_tx_payload_size: 181017,
                 max_query_payload_size: 200,
                 max_db_query_cost: 20,
                 default_page_size: 10,

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -128,7 +128,7 @@ impl<'a> LimitsTraversal<'a> {
             self.check_tx_payload(op)?;
         }
 
-        // Next, with the tranaction payloads accounted for, ensure the remaining query is within
+        // Next, with the transaction payloads accounted for, ensure the remaining query is within
         // the size limit.
         let limits = self.reporter.limits;
         let tx_payload_size = (limits.max_tx_payload_size - self.tx_payload_budget) as u64;
@@ -607,10 +607,10 @@ impl<'a> Reporter<'a> {
         self.graphql_error(
             code::BAD_USER_INPUT,
             format!(
-                "{message}. Requests must spend {max_tx_payload} bytes or fewer on transaction \
-                payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and \
-                the rest of the request (the query part) must be {max_query_payload} bytes or \
-                fewer.",
+                "{message}. Requests are limited to {max_tx_payload} bytes or fewer on \
+                 transaction payloads (all inputs to executeTransactionBlock or \
+                 dryRunTransactionBlock) and the rest of the request (the query part) must be \
+                 {max_query_payload} bytes or fewer.",
                 max_tx_payload = self.limits.max_tx_payload_size,
                 max_query_payload = self.limits.max_query_payload_size,
             ),

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -11,21 +11,28 @@ use async_graphql::parser::types::{
     DocumentOperations, ExecutableDocument, Field, FragmentDefinition, OperationDefinition,
     Selection,
 };
-use async_graphql::{value, Name, Positioned, Response, ServerError, ServerResult, Variables};
+use async_graphql::{value, Name, Pos, Positioned, Response, ServerError, ServerResult, Variables};
+use async_graphql_value::Value as GqlValue;
 use async_graphql_value::{ConstValue, Value};
 use async_trait::async_trait;
 use axum::http::HeaderName;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use sui_graphql_rpc_headers::LIMITS_HEADER;
-use tracing::info;
+use tracing::{error, info};
 use uuid::Uuid;
 
 pub(crate) const CONNECTION_FIELDS: [&str; 2] = ["edges", "nodes"];
+const DRY_RUN_TX_BLOCK: &str = "dryRunTransactionBlock";
+const EXECUTE_TX_BLOCK: &str = "executeTransactionBlock";
+
+/// The size of the query payload in bytes, as it comes from the request header: `Content-Length`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PayloadSize(pub u64);
 
 /// Extension factory for adding checks that the query is within configurable limits.
 pub(crate) struct QueryLimitsChecker;
@@ -45,16 +52,28 @@ struct LimitsTraversal<'a> {
     fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
     variables: &'a Variables,
 
-    // Relevant limits from the service configuration
-    default_page_size: u32,
-    max_input_nodes: u32,
-    max_output_nodes: u32,
-    max_depth: u32,
+    /// Creates and trace errors
+    reporter: &'a Reporter<'a>,
+
+    /// Raw size of the request
+    payload_size: u64,
+
+    /// Variables that are used in transaction executions and dry-runs. If these variables are used
+    /// multiple times, the size of their contents should not be double counted.
+    tx_variables_used: HashSet<&'a Name>,
 
     // Remaining budget for the traversal
+    tx_payload_budget: u32,
     input_budget: u32,
     output_budget: u32,
     depth_seen: u32,
+}
+
+/// Builds error messages and reports them to tracing.
+struct Reporter<'a> {
+    limits: &'a Limits,
+    query_id: &'a Uuid,
+    session_id: &'a SocketAddr,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -76,44 +95,72 @@ impl ShowUsage {
 
 impl<'a> LimitsTraversal<'a> {
     fn new(
-        limits: &Limits,
+        PayloadSize(payload_size): PayloadSize,
+        reporter: &'a Reporter<'a>,
         fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
         variables: &'a Variables,
     ) -> Self {
         Self {
             fragments,
             variables,
-            default_page_size: limits.default_page_size,
-            max_input_nodes: limits.max_query_nodes,
-            max_output_nodes: limits.max_output_nodes,
-            max_depth: limits.max_query_depth,
-            input_budget: limits.max_query_nodes,
-            output_budget: limits.max_output_nodes,
+            payload_size,
+            reporter,
+            tx_variables_used: HashSet::new(),
+            tx_payload_budget: reporter.limits.max_tx_payload_size,
+            input_budget: reporter.limits.max_query_nodes,
+            output_budget: reporter.limits.max_output_nodes,
             depth_seen: 0,
         }
     }
 
     /// Main entrypoint for checking all limits.
-    fn check_document(&mut self, doc: &ExecutableDocument) -> ServerResult<()> {
+    fn check_document(&mut self, doc: &'a ExecutableDocument) -> ServerResult<()> {
+        // First, check the size of the query inputs. This is done using a non-recursive algorithm in
+        // case the input has too many nodes or is too deep. This allows subsequent checks to be
+        // implemented recursively.
         for (_name, op) in doc.operations.iter() {
             self.check_input_limits(op)?;
+        }
+
+        // Then gather inputs to transaction execution and dry-run nodes, and make sure these are
+        // within budget, cumulatively.
+        for (_name, op) in doc.operations.iter() {
+            self.check_tx_payload(op)?;
+        }
+
+        // Next, with the tranaction payloads accounted for, ensure the remaining query is within
+        // the size limit.
+        let limits = self.reporter.limits;
+        let tx_payload_size = (limits.max_tx_payload_size - self.tx_payload_budget) as u64;
+        let query_payload_size = self.payload_size - tx_payload_size;
+        if query_payload_size > limits.max_query_payload_size as u64 {
+            let message = format!("Query part too large: {query_payload_size} bytes");
+            return Err(self.reporter.payload_size_error(&message));
+        }
+
+        // Finally, run output node estimation, to check that the output won't contain too many
+        // nodes, in the worst case.
+        for (_name, op) in doc.operations.iter() {
             self.check_output_limits(op)?;
         }
+
         Ok(())
     }
 
     /// Test that the operation meets input limits (number of nodes and depth).
     fn check_input_limits(&mut self, op: &Positioned<OperationDefinition>) -> ServerResult<()> {
+        let limits = self.reporter.limits;
+
         let mut next_level = vec![];
         let mut curr_level = vec![];
-        let mut depth_budget = self.max_depth;
+        let mut depth_budget = limits.max_query_depth;
 
         next_level.extend(&op.node.selection_set.node.items);
         while let Some(next) = next_level.first() {
             if depth_budget == 0 {
-                return Err(graphql_error_at_pos(
+                return Err(self.reporter.graphql_error_at_pos(
                     code::BAD_USER_INPUT,
-                    format!("Query nesting is over {}", self.max_depth),
+                    format!("Query nesting is over {}", limits.max_query_depth),
                     next.pos,
                 ));
             } else {
@@ -124,9 +171,9 @@ impl<'a> LimitsTraversal<'a> {
 
             for selection in curr_level.drain(..) {
                 if self.input_budget == 0 {
-                    return Err(graphql_error_at_pos(
+                    return Err(self.reporter.graphql_error_at_pos(
                         code::BAD_USER_INPUT,
-                        format!("Query has over {} nodes", self.max_input_nodes),
+                        format!("Query has over {} nodes", limits.max_query_nodes),
                         selection.pos,
                     ));
                 } else {
@@ -144,13 +191,10 @@ impl<'a> LimitsTraversal<'a> {
 
                     Selection::FragmentSpread(fs) => {
                         let name = &fs.node.fragment_name.node;
-                        let def = self.fragments.get(name).ok_or_else(|| {
-                            graphql_error_at_pos(
-                                code::INTERNAL_SERVER_ERROR,
-                                format!("Fragment {name} referred to but not found in document"),
-                                fs.pos,
-                            )
-                        })?;
+                        let def = self
+                            .fragments
+                            .get(name)
+                            .ok_or_else(|| self.reporter.fragment_not_found_error(name, fs.pos))?;
 
                         next_level.extend(&def.node.selection_set.node.items);
                     }
@@ -158,7 +202,175 @@ impl<'a> LimitsTraversal<'a> {
             }
         }
 
-        self.depth_seen = self.depth_seen.max(self.max_depth - depth_budget);
+        self.depth_seen = self.depth_seen.max(limits.max_query_depth - depth_budget);
+        Ok(())
+    }
+
+    /// Test that inputs to `executeTransactionBlock` and `dryRunTransactionBlock` take up less
+    /// space than the service's transaction payload limit, cumulatively.
+    ///
+    /// This check must be done after the input limit check, because it relies on the query depth
+    /// being bounded to protect it from recursing too deeply.
+    fn check_tx_payload(&mut self, op: &'a Positioned<OperationDefinition>) -> ServerResult<()> {
+        for item in &op.node.selection_set.node.items {
+            self.traverse_selection_for_tx_payload(item)?;
+        }
+        Ok(())
+    }
+
+    /// Look for `executeTransactionBlock` and `dryRunTransactionBlock` nodes among the
+    /// query selections, and check their argument sizes are under the service limits.
+    fn traverse_selection_for_tx_payload(
+        &mut self,
+        item: &'a Positioned<Selection>,
+    ) -> ServerResult<()> {
+        match &item.node {
+            Selection::Field(f) => {
+                let name = &f.node.name.node;
+                if name == DRY_RUN_TX_BLOCK || name == EXECUTE_TX_BLOCK {
+                    for (_name, value) in &f.node.arguments {
+                        self.check_tx_arg(value)?;
+                    }
+                }
+            }
+
+            Selection::InlineFragment(f) => {
+                for selection in &f.node.selection_set.node.items {
+                    self.traverse_selection_for_tx_payload(selection)?;
+                }
+            }
+
+            Selection::FragmentSpread(fs) => {
+                let name = &fs.node.fragment_name.node;
+                let def = self
+                    .fragments
+                    .get(name)
+                    .ok_or_else(|| self.reporter.fragment_not_found_error(name, fs.pos))?;
+
+                for selection in &def.node.selection_set.node.items {
+                    self.traverse_selection_for_tx_payload(selection)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Deduct the size of the transaction argument's `value` from the transaction payload budget.
+    /// This operation resolves variables and deducts their size from the budget as well, as long
+    /// as they have not already been encountered in some previous transaction payload.
+    ///
+    /// Fails if there is insufficient remaining budget.
+    fn check_tx_arg(&mut self, value: &'a Positioned<Value>) -> ServerResult<()> {
+        use GqlValue as V;
+
+        let mut stack = vec![&value.node];
+        while let Some(value) = stack.pop() {
+            match value {
+                V::Variable(name) => self.check_tx_var(name)?,
+
+                V::String(s) => {
+                    // Pay for the string, plus the quotes around it.
+                    let debit = s.len() + 2;
+                    if debit > self.tx_payload_budget as usize {
+                        return Err(self.tx_payload_size_error());
+                    } else {
+                        // SAFETY: We know that debit <= self.tx_payload_budget, which is a u32, so
+                        // the cast and subtraction are both safe.
+                        self.tx_payload_budget -= debit as u32;
+                    }
+                }
+
+                V::List(vs) => {
+                    // Pay for the opening and closing brackets and every comma up-front so that
+                    // deeply nested lists are not free.
+                    let debit = vs.len().saturating_sub(1) + 2;
+                    if debit > self.tx_payload_budget as usize {
+                        return Err(self.tx_payload_size_error());
+                    } else {
+                        // SAFETY: We know that debit <= self.tx_payload_budget, which is a u32, so
+                        // the cast and subtraction are both safe.
+                        self.tx_payload_budget -= debit as u32;
+                        stack.extend(vs)
+                    }
+                }
+
+                V::Null
+                | V::Number(_)
+                | V::Boolean(_)
+                | V::Binary(_)
+                | V::Enum(_)
+                | V::Object(_) => {
+                    // Transaction payloads cannot be any of these types, so this request is
+                    // destined to fail. Ignore these values for now, so that it can fail later on
+                    // with a more legible error message.
+                    //
+                    // From a limits perspective, it is safe to ignore these values here, because
+                    // they will still be counted as part of the query payload (and so are still
+                    // subject to a limit).
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Deduct the size of the value that variable `name` resolve to from the transaction payload
+    /// budget, if it has not already been encountered in a previous transaction payload.
+    ///
+    /// Fails if there is insufficient remaining budget.
+    fn check_tx_var(&mut self, name: &'a Name) -> ServerResult<()> {
+        use ConstValue as CV;
+
+        // Already used in a transaction, don't double count.
+        if !self.tx_variables_used.insert(name) {
+            return Ok(());
+        }
+
+        // Can't find the variable, so it can't count towards the transaction payload.
+        let Some(value) = self.variables.get(name) else {
+            return Ok(());
+        };
+
+        let mut stack = vec![value];
+        while let Some(value) = stack.pop() {
+            match &value {
+                CV::String(s) => {
+                    // Pay for the string, plus the quotes around it.
+                    let debit = s.len() + 2;
+                    if debit > self.tx_payload_budget as usize {
+                        return Err(self.tx_payload_size_error());
+                    } else {
+                        // SAFETY: We know that debit <= self.tx_payload_budget, which is a u32, so
+                        // the cast and subtraction are both safe.
+                        self.tx_payload_budget -= debit as u32;
+                    }
+                }
+
+                CV::List(vs) => {
+                    // Pay for the opening and closing brackets and every comma up-front so that
+                    // deeply nested lists are not free.
+                    let debit = vs.len().saturating_sub(1) + 2;
+                    if debit > self.tx_payload_budget as usize {
+                        return Err(self.tx_payload_size_error());
+                    } else {
+                        // SAFETY: We know that debit <= self.tx_payload_budget, which is a u32, so
+                        // the cast and subtraction are both safe.
+                        self.tx_payload_budget -= debit as u32;
+                        stack.extend(vs)
+                    }
+                }
+
+                CV::Null
+                | CV::Number(_)
+                | CV::Boolean(_)
+                | CV::Binary(_)
+                | CV::Enum(_)
+                | CV::Object(_) => {
+                    // As in `check_tx_arg`, these are safe to ignore.
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -221,22 +433,19 @@ impl<'a> LimitsTraversal<'a> {
 
             // Just recurse through fragments, because they are inlined into their "call site".
             Selection::InlineFragment(f) => {
-                for selection in f.node.selection_set.node.items.iter() {
+                for selection in &f.node.selection_set.node.items {
                     self.traverse_selection_for_output(selection, multiplicity, page_size)?;
                 }
             }
 
             Selection::FragmentSpread(fs) => {
                 let name = &fs.node.fragment_name.node;
-                let def = self.fragments.get(name).ok_or_else(|| {
-                    graphql_error_at_pos(
-                        code::INTERNAL_SERVER_ERROR,
-                        format!("Fragment {name} referred to but not found in document"),
-                        fs.pos,
-                    )
-                })?;
+                let def = self
+                    .fragments
+                    .get(name)
+                    .ok_or_else(|| self.reporter.fragment_not_found_error(name, fs.pos))?;
 
-                for selection in def.node.selection_set.node.items.iter() {
+                for selection in &def.node.selection_set.node.items {
                     self.traverse_selection_for_output(selection, multiplicity, page_size)?;
                 }
             }
@@ -258,7 +467,7 @@ impl<'a> LimitsTraversal<'a> {
         let page_size = match (self.resolve_u64(first), self.resolve_u64(last)) {
             (Some(f), Some(l)) => f.max(l),
             (Some(p), _) | (_, Some(p)) => p,
-            (None, None) => self.default_page_size as u64,
+            (None, None) => self.reporter.limits.default_page_size as u64,
         };
 
         Ok(Some(
@@ -330,27 +539,112 @@ impl<'a> LimitsTraversal<'a> {
         .as_u64()
     }
 
+    /// Error returned if transaction payloads exceed limit. Also sets the transaction payload
+    /// budget to zero to indicate it has been spent (This is done to prevent future checks for
+    /// smaller arguments from succeeding even though a previous larger argument has already
+    /// failed).
+    fn tx_payload_size_error(&mut self) -> ServerError {
+        self.tx_payload_budget = 0;
+        self.reporter
+            .payload_size_error("Transaction payload too large")
+    }
+
     /// Error returned if output node estimate exceeds limit. Also sets the output budget to zero,
     /// to indicate that it has been spent (This is done because unlike other budgets, the output
     /// budget is not decremented one unit at a time, so we can have hit the limit previously but
     /// still have budget left over).
     fn output_node_error(&mut self) -> ServerError {
         self.output_budget = 0;
-        graphql_error(
-            code::BAD_USER_INPUT,
-            format!("Estimated output nodes exceeds {}", self.max_output_nodes),
-        )
+        self.reporter.output_node_error()
     }
 
     /// Finish the traversal and report its usage.
     fn finish(self, query_payload: u32) -> Usage {
+        let limits = self.reporter.limits;
         Usage {
-            input_nodes: self.max_input_nodes - self.input_budget,
-            output_nodes: self.max_output_nodes - self.output_budget,
+            input_nodes: limits.max_query_nodes - self.input_budget,
+            output_nodes: limits.max_output_nodes - self.output_budget,
             depth: self.depth_seen,
             variables: self.variables.len() as u32,
             fragments: self.fragments.len() as u32,
             query_payload,
+        }
+    }
+}
+
+impl<'a> Reporter<'a> {
+    fn new(ctx: &'a ExtensionContext<'a>) -> Self {
+        let cfg: &ServiceConfig = ctx.data_unchecked();
+        Self {
+            limits: &cfg.limits,
+            query_id: ctx.data_unchecked(),
+            session_id: ctx.data_unchecked(),
+        }
+    }
+
+    /// Error returned if a fragment is referred to but not found in the document.
+    fn fragment_not_found_error(&self, name: &Name, pos: Pos) -> ServerError {
+        self.graphql_error_at_pos(
+            code::BAD_USER_INPUT,
+            format!("Fragment {name} referred to but not found in document"),
+            pos,
+        )
+    }
+
+    /// Error returned if output node estimate exceeds limit.
+    fn output_node_error(&self) -> ServerError {
+        self.graphql_error(
+            code::BAD_USER_INPUT,
+            format!(
+                "Estimated output nodes exceeds {}",
+                self.limits.max_output_nodes
+            ),
+        )
+    }
+
+    /// Error returned if the payload size exceeds the limit.
+    fn payload_size_error(&self, message: &str) -> ServerError {
+        self.graphql_error(
+            code::BAD_USER_INPUT,
+            format!(
+                "{message}. Requests must spend {max_tx_payload} bytes or fewer on transaction \
+                payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and \
+                the rest of the request (the query part) must be {max_query_payload} bytes or \
+                fewer.",
+                max_tx_payload = self.limits.max_tx_payload_size,
+                max_query_payload = self.limits.max_query_payload_size,
+            ),
+        )
+    }
+
+    /// Build a GraphQL Server Error and also log it.
+    fn graphql_error(&self, code: &str, message: String) -> ServerError {
+        self.log_error(code, &message);
+        graphql_error(code, message)
+    }
+
+    /// Like `graphql_error` but for an error at a specific position in the query.
+    fn graphql_error_at_pos(&self, code: &str, message: String, pos: Pos) -> ServerError {
+        self.log_error(code, &message);
+        graphql_error_at_pos(code, message, pos)
+    }
+
+    /// Log an error (used before returning an error response.
+    fn log_error(&self, error_code: &str, message: &str) {
+        if error_code == code::INTERNAL_SERVER_ERROR {
+            error!(
+                query_id = %self.query_id,
+                session_id = %self.session_id,
+                error_code,
+                "Internal error while checking limits: {message}",
+            );
+        } else {
+            info!(
+                query_id = %self.query_id,
+                session_id = %self.session_id,
+                error_code,
+                "Limits error: {message}",
+            );
         }
     }
 }
@@ -405,32 +699,19 @@ impl Extension for QueryLimitsCheckerExt {
         variables: &Variables,
         next: NextParseQuery<'_>,
     ) -> ServerResult<ExecutableDocument> {
-        let query_id: &Uuid = ctx.data_unchecked();
-        let session_id: &SocketAddr = ctx.data_unchecked();
         let metrics: &Metrics = ctx.data_unchecked();
-        let cfg: &ServiceConfig = ctx.data_unchecked();
+        let payload_size: &PayloadSize = ctx.data_unchecked();
+        let reporter = Reporter::new(ctx);
+
         let instant = Instant::now();
 
-        if query.len() > cfg.limits.max_query_payload_size as usize {
-            metrics
-                .request_metrics
-                .query_payload_too_large_size
-                .observe(query.len() as f64);
-            info!(
-                query_id = %query_id,
-                session_id = %session_id,
-                error_code = code::BAD_USER_INPUT,
-                "Query payload is too large: {}",
-                query.len()
-            );
+        // Make sure the request meets a basic size limit before trying to parse it.
+        let max_payload_size = reporter.limits.max_query_payload_size as u64
+            + reporter.limits.max_tx_payload_size as u64;
 
-            return Err(graphql_error(
-                code::BAD_USER_INPUT,
-                format!(
-                    "Query payload is too large. The maximum allowed is {} bytes",
-                    cfg.limits.max_query_payload_size
-                ),
-            ));
+        if payload_size.0 > max_payload_size {
+            let message = format!("Overall request too large: {} bytes", payload_size.0);
+            return Err(reporter.payload_size_error(&message));
         }
 
         // Document layout of the query
@@ -449,7 +730,9 @@ impl Extension for QueryLimitsCheckerExt {
             }
         }
 
-        let mut traversal = LimitsTraversal::new(&cfg.limits, &doc.fragments, variables);
+        let mut traversal =
+            LimitsTraversal::new(*payload_size, &reporter, &doc.fragments, variables);
+
         let res = traversal.check_document(&doc);
         let usage = traversal.finish(query.len() as u32);
         metrics.query_validation_latency(instant.elapsed());

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -13,7 +13,7 @@ use serde_json as json;
 #[derive(Enum, Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
 #[graphql(name = "Feature")]
-pub(crate) enum FunctionalGroup {
+pub enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
     Analytics,
 

--- a/crates/sui-graphql-rpc/src/metrics.rs
+++ b/crates/sui-graphql-rpc/src/metrics.rs
@@ -65,8 +65,6 @@ pub(crate) struct RequestMetrics {
     pub output_nodes: Histogram,
     /// The query depth
     pub query_depth: Histogram,
-    /// The size (in bytes) of the payload that is higher than the maximum
-    pub query_payload_too_large_size: Histogram,
     /// The size (in bytes) of the payload
     pub query_payload_size: Histogram,
     /// The time it takes to validate the query
@@ -202,13 +200,6 @@ impl RequestMetrics {
                 "Depth of the query",
                 QUERY_DEPTH_BUCKETS.to_vec(),
                 registry
-            )
-            .unwrap(),
-            query_payload_too_large_size: register_histogram_with_registry!(
-                "query_payload_too_large_size",
-                "Query payload size (bytes), that was rejected due to being larger than maximum",
-                QUERY_PAYLOAD_SIZE_BUCKETS.to_vec(),
-                registry,
             )
             .unwrap(),
             query_payload_size: register_histogram_with_registry!(

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -1153,9 +1153,10 @@ pub mod tests {
                 .into()
             )
             .await,
-            "Query part too large: 354 bytes. Requests must spend 400 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 10 bytes or fewer."
+            "Query part too large: 354 bytes. Requests are limited to 400 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 10 \
+             bytes or fewer."
         );
     }
 
@@ -1179,9 +1180,10 @@ pub mod tests {
                 .into()
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 400 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 400 \
+             bytes or fewer."
         );
     }
 
@@ -1206,9 +1208,10 @@ pub mod tests {
                 .into(),
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 400 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 400 bytes \
+             or fewer."
         );
     }
 
@@ -1233,7 +1236,7 @@ pub mod tests {
                 .into(),
             )
             .await,
-            "Overall request too large: 380 bytes. Requests must spend 10 bytes or fewer on \
+            "Overall request too large: 380 bytes. Requests are limited to 10 bytes or fewer on \
              transaction payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) \
              and the rest of the request (the query part) must be 10 bytes or fewer."
         );
@@ -1264,9 +1267,10 @@ pub mod tests {
                 })))
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer."
         );
     }
 
@@ -1295,9 +1299,10 @@ pub mod tests {
                 })))
             )
             .await,
-            "Query part too large: 409 bytes. Requests must spend 500 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 10 bytes or fewer."
+            "Query part too large: 409 bytes. Requests are limited to 500 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 10 bytes \
+             or fewer."
         );
     }
 
@@ -1326,9 +1331,10 @@ pub mod tests {
                 }))),
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 400 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 400 \
+             bytes or fewer."
         );
     }
 
@@ -1357,9 +1363,10 @@ pub mod tests {
                 }))),
             )
             .await,
-            "Query part too large: 398 bytes. Requests must spend 400 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 10 bytes or fewer."
+            "Query part too large: 398 bytes. Requests are limited to 400 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 10 bytes \
+             or fewer."
         );
     }
 
@@ -1410,9 +1417,10 @@ pub mod tests {
                 .into()
             )
             .await,
-            "Transaction payload too large. Requests must spend 30 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 800 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 30 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 800 \
+             bytes or fewer."
         );
     }
 
@@ -1466,9 +1474,10 @@ pub mod tests {
                 .into()
             )
             .await,
-            "Transaction payload too large. Requests must spend 20 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 800 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 20 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 800 \
+             bytes or fewer."
         );
     }
 
@@ -1518,9 +1527,10 @@ pub mod tests {
                 .into(),
             )
             .await,
-            "Transaction payload too large. Requests must spend 30 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer.",
+            "Transaction payload too large. Requests are limited to 30 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer.",
         )
     }
 
@@ -1551,9 +1561,10 @@ pub mod tests {
                 })))
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer."
         );
     }
 
@@ -1784,9 +1795,10 @@ pub mod tests {
                 .into()
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer."
         );
     }
 
@@ -1812,9 +1824,10 @@ pub mod tests {
                 .into()
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer."
         );
     }
 
@@ -1843,9 +1856,10 @@ pub mod tests {
                 .into(),
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer."
         );
     }
 
@@ -1872,9 +1886,10 @@ pub mod tests {
                 .into(),
             )
             .await,
-            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
-             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
-             rest of the request (the query part) must be 500 bytes or fewer."
+            "Transaction payload too large. Requests are limited to 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 500 \
+             bytes or fewer."
         );
     }
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -27,7 +27,7 @@ use crate::{
     extensions::{
         feature_gate::FeatureGate,
         logger::Logger,
-        query_limits_checker::{QueryLimitsChecker, ShowUsage},
+        query_limits_checker::{PayloadSize, QueryLimitsChecker, ShowUsage},
         timeout::Timeout,
     },
     server::version::{check_version_middleware, set_version_middleware},
@@ -47,6 +47,8 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post, MethodRouter, Route};
 use axum::Extension;
 use axum::Router;
+use axum_extra::headers::ContentLength;
+use axum_extra::TypedHeader;
 use chrono::Utc;
 use http::{HeaderValue, Method, Request};
 use mysten_metrics::spawn_monitored_task;
@@ -523,6 +525,7 @@ pub fn export_schema() -> String {
 /// if set in the request headers, and the watermark as set by the background task.
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    TypedHeader(ContentLength(content_length)): TypedHeader<ContentLength>,
     schema: Extension<SuiGraphQLSchema>,
     Extension(watermark_lock): Extension<WatermarkLock>,
     Extension(chain_identifier_lock): Extension<ChainIdentifierLock>,
@@ -530,14 +533,16 @@ async fn graphql_handler(
     req: GraphQLRequest,
 ) -> (axum::http::Extensions, GraphQLResponse) {
     let mut req = req.into_inner();
+
+    req.data.insert(PayloadSize(content_length));
     req.data.insert(Uuid::new_v4());
     if headers.contains_key(ShowUsage::name()) {
         req.data.insert(ShowUsage)
     }
+
     // Capture the IP address of the client
     // Note: if a load balancer is used it must be configured to forward the client IP address
     req.data.insert(addr);
-
     req.data.insert(Watermark::new(watermark_lock).await);
     req.data.insert(chain_identifier_lock.read().await);
 
@@ -681,8 +686,9 @@ pub mod tests {
     };
     use async_graphql::{
         extensions::{Extension, ExtensionContext, NextExecute},
-        Response,
+        Request, Response, Variables,
     };
+    use serde_json::json;
     use std::sync::Arc;
     use std::time::Duration;
     use sui_sdk::{wallet_context::WalletContext, SuiClient};
@@ -881,6 +887,7 @@ pub mod tests {
             };
 
             let schema = prep_schema(None, Some(service_config))
+                .context_data(PayloadSize(100))
                 .extension(QueryLimitsChecker)
                 .build_schema();
             schema.execute(query).await
@@ -933,6 +940,7 @@ pub mod tests {
             };
 
             let schema = prep_schema(None, Some(service_config))
+                .context_data(PayloadSize(100))
                 .extension(QueryLimitsChecker)
                 .build_schema();
             schema.execute(query).await
@@ -1044,7 +1052,7 @@ pub mod tests {
     }
 
     pub async fn test_query_complexity_metrics_impl() {
-        let server_builder = prep_schema(None, None);
+        let server_builder = prep_schema(None, None).context_data(PayloadSize(100));
         let metrics = server_builder.state.metrics.clone();
         let schema = server_builder
             .extension(QueryLimitsChecker) // QueryLimitsChecker is where we actually set the metrics
@@ -1092,5 +1100,781 @@ pub mod tests {
         let url_with_param = format!("{}?max_checkpoint_lag_ms=1", url);
         let resp = reqwest::get(&url_with_param).await.unwrap();
         assert_eq!(resp.status(), reqwest::StatusCode::GATEWAY_TIMEOUT);
+    }
+
+    /// Execute a GraphQL request with `limits` in place, expecting an error to be returned.
+    /// Returns the list of errors returned.
+    async fn execute_for_error(limits: Limits, request: Request) -> String {
+        let service_config = ServiceConfig {
+            limits,
+            ..Default::default()
+        };
+
+        let schema = prep_schema(None, Some(service_config))
+            .context_data(PayloadSize(
+                // Payload size is usually set per request, and it is the size of the raw HTTP
+                // request, which includes the query, variables, and surrounding JSON. Simulate for
+                // testing purposes by serializing the request back into JSON and baking its length
+                // as context data into the schema.
+                serde_json::to_string(&request).unwrap().len() as u64,
+            ))
+            .extension(QueryLimitsChecker)
+            .build_schema();
+
+        let errs: Vec<_> = schema
+            .execute(request)
+            .await
+            .into_result()
+            .unwrap_err()
+            .into_iter()
+            .map(|e| e.message)
+            .collect();
+
+        errs.join("\n")
+    }
+
+    pub async fn test_payload_read_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 400,
+                    max_query_payload_size: 10,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        executeTransactionBlock(txBytes: "AAA", signatures: ["BBB"]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await,
+            "Query part too large: 354 bytes. Requests must spend 400 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 10 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_mutation_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 400,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        executeTransactionBlock(txBytes: "AAABBBCCC", signatures: ["BBB"]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 400 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_dry_run_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 400,
+                    ..Default::default()
+                },
+                r#"
+                    query {
+                        dryRunTransactionBlock(txBytes: "AAABBBCCC") {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                "#
+                .into(),
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 400 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_total_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 10,
+                    ..Default::default()
+                },
+                r#"
+                    query {
+                        dryRunTransactionBlock(txByte: "AAABBB") {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                "#
+                .into(),
+            )
+            .await,
+            "Overall request too large: 380 bytes. Requests must spend 10 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) \
+             and the rest of the request (the query part) must be 10 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_using_vars_mutation_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                Request::new(
+                    r#"
+                    mutation ($tx: String!, $sigs: [String!]!) {
+                        executeTransactionBlock(txBytes: $tx, signatures: $sigs) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                    "#
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAABBBCCC",
+                    "sigs": ["BBB"]
+                })))
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_using_vars_read_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 500,
+                    max_query_payload_size: 10,
+                    ..Default::default()
+                },
+                Request::new(
+                    r#"
+                    mutation ($tx: String!, $sigs: [String!]!) {
+                        executeTransactionBlock(txBytes: $tx, signatures: $sigs) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                    "#
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAA",
+                    "sigs": ["BBB"]
+                })))
+            )
+            .await,
+            "Query part too large: 409 bytes. Requests must spend 500 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 10 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_using_vars_dry_run_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 400,
+                    ..Default::default()
+                },
+                Request::new(
+                    r#"
+                    query ($tx: String!) {
+                        dryRunTransactionBlock(txBytes: $tx) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                    "#
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAABBBCCC"
+                }))),
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 400 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_using_vars_dry_run_read_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 400,
+                    max_query_payload_size: 10,
+                    ..Default::default()
+                },
+                Request::new(
+                    r#"
+                    query ($tx: String!) {
+                        dryRunTransactionBlock(txBytes: $tx) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                    "#
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAABBBCCC"
+                }))),
+            )
+            .await,
+            "Query part too large: 398 bytes. Requests must spend 400 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 10 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_multiple_execution_exceeded_impl() {
+        // First check that the limit is large enough to hold one transaction's parameters (by
+        // checking that we hit the read limit).
+        let err = execute_for_error(
+            Limits {
+                max_tx_payload_size: 30,
+                max_query_payload_size: 320,
+                ..Default::default()
+            },
+            r#"
+                mutation {
+                    executeTransactionBlock(txBytes: "AAABBBCCC", signatures: ["DDD"]) {
+                        effects {
+                            status
+                        }
+                    }
+                }
+            "#
+            .into(),
+        )
+        .await;
+        assert!(err.starts_with("Query part too large"), "{err}");
+
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 30,
+                    max_query_payload_size: 800,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        e0: executeTransactionBlock(txBytes: "AAABBBCCC", signatures: ["DDD"]) {
+                            effects {
+                                status
+                            }
+                        }
+                        e1: executeTransactionBlock(txBytes: "EEEFFFGGG", signatures: ["HHH"]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 30 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 800 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_multiple_dry_run_exceeded_impl() {
+        // First check that tx limit is large enough to hold one transaction's parameters (by
+        // checking that we hit the read limit).
+        let err = execute_for_error(
+            Limits {
+                max_tx_payload_size: 20,
+                max_query_payload_size: 330,
+                ..Default::default()
+            },
+            r#"
+                query {
+                    dryRunTransactionBlock(txBytes: "AAABBBCCC") {
+                       error
+                       transaction {
+                           digest
+                       }
+                    }
+                }
+            "#
+            .into(),
+        )
+        .await;
+        assert!(err.starts_with("Query part too large"), "{err}");
+
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 20,
+                    max_query_payload_size: 800,
+                    ..Default::default()
+                },
+                r#"
+                    query {
+                        d0: dryRunTransactionBlock(txBytes: "AAABBBCCC") {
+                           error
+                           transaction {
+                               digest
+                           }
+                        }
+                        d1: dryRunTransactionBlock(txBytes: "DDDEEEFFF") {
+                           error
+                           transaction {
+                               digest
+                           }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 20 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 800 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_execution_multiple_sigs_exceeded_impl() {
+        // First check that the limit is large enough to hold a transaction with a single signature
+        // (by checking that we hite the read limit).
+        let err = execute_for_error(
+            Limits {
+                max_tx_payload_size: 30,
+                max_query_payload_size: 320,
+                ..Default::default()
+            },
+            r#"
+                mutation {
+                    executeTransactionBlock(txBytes: "AAA", signatures: ["BBB"]) {
+                        effects {
+                            status
+                        }
+                    }
+                }
+            "#
+            .into(),
+        )
+        .await;
+
+        assert!(err.starts_with("Query part too large"), "{err}");
+
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 30,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        executeTransactionBlock(
+                            txBytes: "AAA",
+                            signatures: ["BBB", "CCC", "DDD", "EEE", "FFF"]
+                        ) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                "#
+                .into(),
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 30 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer.",
+        )
+    }
+
+    pub async fn test_payload_sig_var_execution_exceeded_impl() {
+        // Variables can show up in the sub-structure of a GraphQL value as well, and we need to
+        // count those as well.
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                Request::new(
+                    r#"
+                    mutation ($tx: String!, $sig: String!) {
+                        executeTransactionBlock(txBytes: $tx, signatures: [$sig]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                    "#
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAA",
+                    "sig": "BBB"
+                })))
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer."
+        );
+    }
+
+    /// Check if the error indicates that the request passed the overall size check and the
+    /// transaction payload check.
+    fn passed_tx_checks(err: &str) -> bool {
+        !err.starts_with("Overall request too large")
+            && !err.starts_with("Transaction payload too large")
+    }
+
+    pub async fn test_payload_reusing_vars_execution_impl() {
+        // Test that when variables are re-used as execution params, the size of the variable is
+        // only counted once.
+
+        // First, check that `eror_passed_tx_checks` is working, by submitting a request that will
+        // fail the initial payload check.
+        assert!(!passed_tx_checks(
+            &execute_for_error(
+                Limits {
+                    max_tx_payload_size: 1,
+                    max_query_payload_size: 1,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        executeTransactionBlock(txBytes: "AAA", signatures: ["BBB"]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await
+        ));
+
+        let limits = Limits {
+            max_tx_payload_size: 20,
+            max_query_payload_size: 1000,
+            ..Default::default()
+        };
+
+        // Then check that a request that uses the variable once passes the transaction limit
+        // check.
+        assert!(passed_tx_checks(
+            &execute_for_error(
+                limits.clone(),
+                Request::new(
+                    r#"
+                    mutation ($sig: String!) {
+                        executeTransactionBlock(txBytes: "AAABBBCCC", signatures: [$sig]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "sig": "BBB"
+                })))
+            )
+            .await
+        ));
+
+        // Then check that a request that introduces an extra signature, but without re-using the
+        // variable fails the transaction limit.
+        assert!(!passed_tx_checks(
+            &execute_for_error(
+                limits.clone(),
+                Request::new(
+                    r#"
+                    mutation ($sig: String!) {
+                        executeTransactionBlock(txBytes: "AAABBBCCC", signatures: [$sig, "BBB"]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "sig": "BBB"
+                })))
+            )
+            .await
+        ));
+
+        // And then when that use is replaced by re-using the variable, we should be under the
+        // transaction payload limit again.
+        assert!(passed_tx_checks(
+            &execute_for_error(
+                limits,
+                Request::new(
+                    r#"
+                    mutation ($sig: String!) {
+                        executeTransactionBlock(txBytes: "AAABBBCCC", signatures: [$sig, $sig]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "sig": "BBB"
+                })))
+            )
+            .await
+        ));
+    }
+
+    pub async fn test_payload_reusing_vars_dry_run_impl() {
+        // Like `test_payload_reusing_vars_execution` but the variable is used in a dry-run.
+
+        let limits = Limits {
+            max_tx_payload_size: 20,
+            max_query_payload_size: 1000,
+            ..Default::default()
+        };
+
+        // A single dry-run is under the limit.
+        assert!(passed_tx_checks(
+            &execute_for_error(
+                limits.clone(),
+                Request::new(
+                    r#"
+                    query ($tx: String!) {
+                        dryRunTransactionBlock(txBytes: $tx) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAABBBCCC"
+                })))
+            )
+            .await
+        ));
+
+        // Duplicating the dry-run causes us to hit the limit.
+        assert!(!passed_tx_checks(
+            &execute_for_error(
+                limits.clone(),
+                Request::new(
+                    r#"
+                    query ($tx: String!) {
+                        d0: dryRunTransactionBlock(txBytes: $tx) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+
+                        d1: dryRunTransactionBlock(txBytes: "AAABBBCCC") {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAABBBCCC"
+                })))
+            )
+            .await
+        ));
+
+        // And by re-using the variable, we are under the transaction limit again.
+        assert!(passed_tx_checks(
+            &execute_for_error(
+                limits,
+                Request::new(
+                    r#"
+                    query ($tx: String!) {
+                        d0: dryRunTransactionBlock(txBytes: $tx) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+
+                        d1: dryRunTransactionBlock(txBytes: $tx) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "tx": "AAABBBCCC"
+                })))
+            )
+            .await
+        ));
+    }
+
+    pub async fn test_payload_named_fragment_execution_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        ...Tx
+                    }
+
+                    fragment Tx on Mutation {
+                        executeTransactionBlock(txBytes: "AAABBBCCC", signatures: ["BBB"]) {
+                            effects {
+                                status
+                            }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_inline_fragment_execution_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                r#"
+                    mutation {
+                        ... on Mutation {
+                            executeTransactionBlock(txBytes: "AAABBBCCC", signatures: ["BBB"]) {
+                                effects {
+                                    status
+                                }
+                            }
+                        }
+                    }
+                "#
+                .into()
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_named_fragment_dry_run_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                r#"
+                    query {
+                        ...DryRun
+                    }
+
+                    fragment DryRun on Query {
+                        dryRunTransactionBlock(txBytes: "AAABBBCCC") {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                "#
+                .into(),
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer."
+        );
+    }
+
+    pub async fn test_payload_inline_fragment_dry_run_exceeded_impl() {
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 10,
+                    max_query_payload_size: 500,
+                    ..Default::default()
+                },
+                r#"
+                    query {
+                        ... on Query {
+                            dryRunTransactionBlock(txBytes: "AAABBBCCC") {
+                                error
+                                transaction {
+                                    digest
+                                }
+                            }
+                        }
+                    }
+                "#
+                .into(),
+            )
+            .await,
+            "Transaction payload too large. Requests must spend 10 bytes or fewer on transaction \
+             payloads (all inputs to executeTransactionBlock or dryRunTransactionBlock) and the \
+             rest of the request (the query part) must be 500 bytes or fewer."
+        );
     }
 }

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -961,4 +961,181 @@ mod tests {
         test_health_check_impl().await;
         cluster.cleanup_resources().await
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_total_exceeded() {
+        test_payload_total_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_read_exceeded() {
+        test_payload_read_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_mutation_exceeded() {
+        test_payload_mutation_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_dry_run_exceeded() {
+        test_payload_dry_run_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_using_vars_mutation_exceeded() {
+        test_payload_using_vars_mutation_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_using_vars_read_exceeded() {
+        test_payload_using_vars_read_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_using_vars_dry_run_read_exceeded() {
+        test_payload_using_vars_dry_run_read_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_using_vars_dry_run_exceeded() {
+        test_payload_using_vars_dry_run_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_multiple_execution_exceeded() {
+        test_payload_multiple_execution_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_multiple_dry_run_exceeded() {
+        test_payload_multiple_dry_run_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_execution_multiple_sigs_exceeded() {
+        test_payload_execution_multiple_sigs_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_sig_var_execution_exceeded() {
+        test_payload_sig_var_execution_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_reusing_vars_execution() {
+        test_payload_reusing_vars_execution_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_reusing_vars_dry_run() {
+        test_payload_reusing_vars_dry_run_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_named_fragment_execution_exceeded() {
+        test_payload_named_fragment_execution_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_inline_fragment_execution_exceeded() {
+        test_payload_inline_fragment_execution_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_named_fragment_dry_run_exceeded() {
+        test_payload_named_fragment_dry_run_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_inline_fragment_dry_run_exceeded() {
+        test_payload_inline_fragment_dry_run_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_payload_using_vars_mutation_passes() {
+        let _guard = telemetry_subscribers::TelemetryConfig::new()
+            .with_env()
+            .init();
+        let cluster = sui_graphql_rpc::test_infra::cluster::start_cluster(
+            ConnectionConfig::ci_integration_test_cfg(),
+            None,
+            ServiceConfig {
+                limits: Some(Limits {
+                    max_query_payload_size: 5000,
+                    max_tx_payload_size: 6000,
+                    ..Default::default()
+                }),
+                ..ServiceConfig::test_defaults()
+            },
+        )
+        .await;
+        let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
+
+        let recipient = addresses[1];
+        let tx = cluster
+            .validator_fullnode_handle
+            .test_transaction_builder()
+            .await
+            .transfer_sui(Some(1_000), recipient)
+            .build();
+        let signed_tx = cluster
+            .validator_fullnode_handle
+            .wallet
+            .sign_transaction(&tx);
+        let (tx_bytes, sigs) = signed_tx.to_tx_bytes_and_signatures();
+        let tx_bytes = tx_bytes.encoded();
+        let sigs = sigs.iter().map(|sig| sig.encoded()).collect::<Vec<_>>();
+
+        let mutation = r#"{
+            executeTransactionBlock(txBytes: $tx,  signatures: $sigs) {
+                effects {
+                    transactionBlock { digest }
+                    status
+                }
+                errors
+            }
+        }"#;
+
+        let variables = vec![
+            GraphqlQueryVariable {
+                name: "tx".to_string(),
+                ty: "String!".to_string(),
+                value: json!(tx_bytes),
+            },
+            GraphqlQueryVariable {
+                name: "sigs".to_string(),
+                ty: "[String!]!".to_string(),
+                value: json!(sigs),
+            },
+        ];
+
+        let res = cluster
+            .graphql_client
+            .execute_mutation_to_graphql(mutation.to_string(), variables)
+            .await
+            .unwrap();
+
+        assert!(res.errors().is_empty());
+        cluster.cleanup_resources().await
+    }
 }

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -14,6 +14,7 @@ mod tests {
     use sui_graphql_rpc::client::simple_client::GraphqlQueryVariable;
     use sui_graphql_rpc::client::ClientError;
     use sui_graphql_rpc::config::ConnectionConfig;
+    use sui_graphql_rpc::config::Limits;
     use sui_graphql_rpc::config::ServiceConfig;
     use sui_graphql_rpc::test_infra::cluster::start_cluster;
     use sui_graphql_rpc::test_infra::cluster::ExecutorCluster;
@@ -1080,25 +1081,31 @@ mod tests {
             ConnectionConfig::ci_integration_test_cfg(),
             None,
             ServiceConfig {
-                limits: Some(Limits {
+                limits: Limits {
                     max_query_payload_size: 5000,
                     max_tx_payload_size: 6000,
                     ..Default::default()
-                }),
+                },
                 ..ServiceConfig::test_defaults()
             },
         )
         .await;
-        let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
+        let addresses = cluster
+            .network
+            .validator_fullnode_handle
+            .wallet
+            .get_addresses();
 
         let recipient = addresses[1];
         let tx = cluster
+            .network
             .validator_fullnode_handle
             .test_transaction_builder()
             .await
             .transfer_sui(Some(1_000), recipient)
             .build();
         let signed_tx = cluster
+            .network
             .validator_fullnode_handle
             .wallet
             .sign_transaction(&tx);

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3527,7 +3527,18 @@ type ServiceConfig {
 	"""
 	requestTimeoutMs: Int!
 	"""
-	Maximum length of a query payload string.
+	The maximum bytes allowed for the `txBytes` and `signatures` fields of the GraphQL mutation
+	`executeTransactionBlock` node, or for the `txBytes` of a `dryRunTransactionBlock`.
+	
+	It is the value of the maximum transaction bytes (including the signatures) allowed by the
+	protocol, plus the Base64 overhead (roughly 1/3 of the original string).
+	"""
+	maxTransactionPayloadSize: Int!
+	"""
+	The maximum bytes allowed for the JSON object in the request body of a GraphQL query, for
+	the read part of the query.
+	In case of mutations or dryRunTransactionBlocks the txBytes and signatures are not
+	included in this limit.
 	"""
 	maxQueryPayloadSize: Int!
 	"""


### PR DESCRIPTION
## Description 

The mutation payload can be a lot higher than a query payload, due to the possibility of passing a large transaction data (e.g., publishing a package). This PR adds a different check for when a mutation is requested, and adds a `max_tx_payload_size` variable that holds the max bytes that can be sent through a GraphQL mutation request. 
The total sum of `txBytes + signatures` of all GraphQL mutation or `txBytes` in a `dryRunTransactionBlock` query have to be below the `max_tx_payload_size`.  

The `max_tx_payload_size` is computed based on the `protocol_version -> max_tx_bytes` and a Base64 overhead as follows:
`max_tx_bytes * 4 / 3`

## Test plan
Added several tests.
`cd crates/sui-graphql-rpc`
`cargo nextest run --features pg_integration -- test_query test_mutation test_dry_run_transaction test_transaction_dry_run`


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: 
Added a `max_tx_payload_size` variable to protect against large transaction queries. The sum of `txBytes + signatures` in all GraphQL mutation `executeTransactionBlock` nodes or `txBytes` in `dryRunTransactionBlock` nodes from a query have to be below the `max_tx_payload_size`.
The `max_tx_payload_size` is computed based on the `protocol_version -> max_tx_bytes` and a Base64 overhead as follows:
`max_tx_bytes * 4 / 3`
Added also a check that the overall query size is not larger than `max_tx_payload_size` + `max_query_payload_size`, where `max_query_payload_size` is the `read` part of the query.
- [ ] CLI: 
- [ ] Rust SDK: 