### PR TITLE
[bridge] use protocol parameter to determine when to finalize bridge committee `bridge_should_try_to_finalize_committee` 

### DIFF
--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -98,7 +98,7 @@ where
 
     /// Get the mutable bridge object arg on chain.
     // We retry a few times in case of errors. If it fails eventually, we panic.
-    // In generaly it's safe to call in the beginning of the program.
+    // In general it's safe to call in the beginning of the program.
     // After the first call, the result is cached since the value should never change.
     pub async fn get_mutable_bridge_object_arg_must_succeed(&self) -> ObjectArg {
         static ARG: OnceCell<ObjectArg> = OnceCell::const_new();

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4475,6 +4475,13 @@ impl AuthorityState {
             info!("bridge not enabled");
             return None;
         }
+        if !epoch_store
+            .protocol_config()
+            .should_try_to_finalize_bridge_committee()
+        {
+            info!("should not try to finalize bridge committee yet");
+            return None;
+        }
         // Only create this transaction if bridge exists
         if !epoch_store.bridge_exists() {
             return None;

--- a/crates/sui-json-rpc-types/src/sui_protocol.rs
+++ b/crates/sui-json-rpc-types/src/sui_protocol.rs
@@ -35,6 +35,11 @@ pub enum SuiProtocolConfigValue {
         #[serde_as(as = "DisplayFromStr")]
         f64,
     ),
+    Bool(
+        #[schemars(with = "String")]
+        #[serde_as(as = "DisplayFromStr")]
+        bool,
+    ),
 }
 
 impl From<ProtocolConfigValue> for SuiProtocolConfigValue {
@@ -44,6 +49,7 @@ impl From<ProtocolConfigValue> for SuiProtocolConfigValue {
             ProtocolConfigValue::u32(y) => SuiProtocolConfigValue::U32(y),
             ProtocolConfigValue::u64(x) => SuiProtocolConfigValue::U64(x),
             ProtocolConfigValue::f64(z) => SuiProtocolConfigValue::F64(z),
+            ProtocolConfigValue::bool(z) => SuiProtocolConfigValue::Bool(z),
         }
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1403,6 +1403,7 @@
                 "bls12381_bls12381_min_sig_verify_msg_cost_per_byte": {
                   "u64": "2"
                 },
+                "bridge_should_try_to_finalize_committee": null,
                 "buffer_stake_for_protocol_upgrade_bps": {
                   "u64": "5000"
                 },
@@ -7958,6 +7959,18 @@
             ],
             "properties": {
               "f64": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "bool"
+            ],
+            "properties": {
+              "bool": {
                 "type": "string"
               }
             },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -159,6 +159,7 @@ const MAX_PROTOCOL_VERSION: u64 = 53;
 //             Enable enums on testnet.
 //             Add support for passkey in devnet.
 //             Enable deny list v2 on testnet and mainnet.
+// Version 54: Add feature flag to decide whether to attempt to finalize bridge committee
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1188,6 +1189,11 @@ pub struct ProtocolConfig {
 
     /// The max number of transactions that can be included in a single Soft Bundle.
     max_soft_bundle_size: Option<u64>,
+
+    /// Whether to try to form bridge committee
+    // Note: this is not a feature flag because we want to distinguish between
+    // `None` and `Some(false)`, as committee was already finalized on Testnet.
+    bridge_should_try_to_finalize_committee: Option<bool>,
 }
 
 // feature flags
@@ -1373,6 +1379,14 @@ impl ProtocolConfig {
             assert!(self.feature_flags.end_of_epoch_transaction_supported);
         }
         ret
+    }
+
+    pub fn should_try_to_finalize_bridge_committee(&self) -> bool {
+        if !self.enable_bridge() {
+            return false;
+        }
+        // In the older protocol version, always try to finalize the committee.
+        self.bridge_should_try_to_finalize_committee.unwrap_or(true)
     }
 
     pub fn enable_effects_v2(&self) -> bool {
@@ -1953,6 +1967,8 @@ impl ProtocolConfig {
             checkpoint_summary_version_specific_data: None,
 
             max_soft_bundle_size: None,
+
+            bridge_should_try_to_finalize_committee: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -2498,6 +2514,10 @@ impl ProtocolConfig {
                         cfg.feature_flags.passkey_auth = true;
                     }
                     cfg.feature_flags.enable_coin_deny_list_v2 = true;
+                }
+                54 => {
+                    // Do not allow bridge committee to finalize on mainnet.
+                    cfg.bridge_should_try_to_finalize_committee = Some(chain != Chain::Mainnet);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-rest-api/src/system.rs
+++ b/crates/sui-rest-api/src/system.rs
@@ -627,6 +627,7 @@ impl From<ProtocolConfig> for ProtocolConfigResponse {
                         ProtocolConfigValue::u32(y) => y.to_string(),
                         ProtocolConfigValue::u64(z) => z.to_string(),
                         ProtocolConfigValue::f64(f) => f.to_string(),
+                        ProtocolConfigValue::bool(b) => b.to_string(),
                     };
                     (k, v)
                 })

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -449,10 +449,22 @@ impl EndOfEpochTransactionKind {
                     ));
                 }
             }
-            Self::BridgeStateCreate(_) | Self::BridgeCommitteeInit(_) => {
+            Self::BridgeStateCreate(_) => {
                 if !config.enable_bridge() {
                     return Err(UserInputError::Unsupported(
                         "bridge not enabled".to_string(),
+                    ));
+                }
+            }
+            Self::BridgeCommitteeInit(_) => {
+                if !config.enable_bridge() {
+                    return Err(UserInputError::Unsupported(
+                        "bridge not enabled".to_string(),
+                    ));
+                }
+                if !config.should_try_to_finalize_bridge_committee() {
+                    return Err(UserInputError::Unsupported(
+                        "should not try to finalize committee yet".to_string(),
                     ));
                 }
             }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -673,6 +673,7 @@ mod checked {
                         }
                         EndOfEpochTransactionKind::BridgeCommitteeInit(bridge_shared_version) => {
                             assert!(protocol_config.enable_bridge());
+                            assert!(protocol_config.should_try_to_finalize_bridge_committee());
                             builder = setup_bridge_committee_update(builder, bridge_shared_version)
                         }
                     }


### PR DESCRIPTION
## Description 

Updated: we decided to introduce a protocol parameter to determine when bridge committee happens. This gives us more flexibility to include validators. As a result, we don't need the original change of threshold any more. Together with the new parameter, the old default value 7500 still acts as the minimal voting power threshold


------------------

Old description:


Previously the 75% minimal stake is too low to include most validators. This PR changes it to 90%.

I have two commits in this PR:
* the first commit sets the value by distinguish chain id - if it's testnet, then use 7500, otherwise 9000. This is safe because on mainnet we haven't enabled registration yet.
* the second commit uses a different approach with protocol config. Basically it adds a `minimal_threshold_for_bridge_committee` field and is set to 90% after the added version. In this way we don't need to differentiate chain ids. It's safe for testnet because this value won't be needed post committee initialization.

I like the 2nd commit better because the code is cleaner.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
