### PR TITLE
[CI] Tries to separate GitHub issues + external PRs monitor into two workflows

### DIFF
--- a/.github/workflows/github-external-pr-monitor.yml
+++ b/.github/workflows/github-external-pr-monitor.yml
@@ -1,20 +1,18 @@
-name: GitHub Issues Monitor
-
+name: "GitHub external PRs Monitor"
 on:
-  issues:
-    types: [opened]
+- pull_request_target
 
-jobs: 
-  notify-issues:
-    name: Dispatch workflow to notify slack channel on issues
-    if: github.event_name == 'issues'
+jobs:
+  notify-prs:
+    name: Dispatch workflow to notify slack channel on PRs
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch github-issues-external-prs-monitor in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0
         with: 
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           event-type: github-issues-external-prs-monitor
-          client-payload: '{"author": "${{github.event.issue.user.login}}", "event_name": "issue", "issue_number": "${{github.event.issue.number}}"}'
+          client-payload: '{"author": "${{github.event.pull_request.user.login}}", "event_name": "pull_request", "pull_request_number": "${{github.event.pull_request.number}}"}'
 


### PR DESCRIPTION
## Description 

Splits the GitHub issues + external PRs monitor into two workflows. The issues part works fine, but the pull request from external PRs does not work :( so following the `labeler` workflow, maybe this will work.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
