### PR TITLE
[consensus] Add Randomized Commit Tests

### DIFF
--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Instant;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
     sync::Arc,
+    time::Instant,
 };
 
 use itertools::Itertools as _;
@@ -374,18 +374,18 @@ impl BlockManager {
             .set(max_round.into());
     }
 
+    /// Checks if block manager is empty.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.suspended_blocks.is_empty()
+            && self.missing_ancestors.is_empty()
+            && self.missing_blocks.is_empty()
+    }
+
     /// Returns all the suspended blocks whose causal history we miss hence we can't accept them yet.
     #[cfg(test)]
     fn suspended_blocks(&self) -> Vec<BlockRef> {
         self.suspended_blocks.keys().cloned().collect()
-    }
-
-    /// Checks if block manager is empty.
-    #[cfg(test)]
-    fn is_empty(&self) -> bool {
-        self.suspended_blocks.is_empty()
-            && self.missing_ancestors.is_empty()
-            && self.missing_blocks.is_empty()
     }
 }
 
@@ -408,7 +408,6 @@ mod tests {
     use parking_lot::RwLock;
     use rand::{prelude::StdRng, seq::SliceRandom, SeedableRng};
 
-    use crate::test_dag_builder::DagBuilder;
     use crate::{
         block::{BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
         block_manager::BlockManager,
@@ -417,6 +416,7 @@ mod tests {
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
         storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
     };
 
     #[tokio::test]

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-use std::time::SystemTime;
+use std::{sync::Arc, time::SystemTime};
 
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 #[cfg(test)]
@@ -12,10 +11,9 @@ use sui_protocol_config::ProtocolConfig;
 use tempfile::TempDir;
 use tokio::time::Instant;
 
-use crate::block::BlockTimestampMs;
 #[cfg(test)]
 use crate::metrics::test_metrics;
-use crate::metrics::Metrics;
+use crate::{block::BlockTimestampMs, metrics::Metrics};
 
 /// Context contains per-epoch configuration and metrics shared by all components
 /// of this authority.

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -743,7 +743,7 @@ impl CoreSignalsReceivers {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use std::{collections::BTreeSet, time::Duration};
 
     use consensus_config::{local_committee_and_keys, AuthorityIndex, Parameters, Stake};
@@ -1226,25 +1226,32 @@ mod test {
         for round in 1..=3 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, _signal_receivers, _, _, _) in cores.iter_mut() {
-                wait_blocks(&last_round_blocks, &core.context).await;
+            for core_fixture in cores.iter_mut() {
+                wait_blocks(&last_round_blocks, &core_fixture.core.context).await;
 
-                core.add_blocks(last_round_blocks.clone()).unwrap();
+                core_fixture
+                    .core
+                    .add_blocks(last_round_blocks.clone())
+                    .unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
                 if let Some(r) = last_round_blocks.first().map(|b| b.round()) {
                     assert_eq!(round - 1, r);
-                    if core.last_proposed_round() == r {
+                    if core_fixture.core.last_proposed_round() == r {
                         // Force propose new block regardless of min round delay.
-                        core.try_propose(true).unwrap().unwrap_or_else(|| {
-                            panic!("Block should have been proposed for round {}", round)
-                        });
+                        core_fixture
+                            .core
+                            .try_propose(true)
+                            .unwrap()
+                            .unwrap_or_else(|| {
+                                panic!("Block should have been proposed for round {}", round)
+                            });
                     }
                 }
 
-                assert_eq!(core.last_proposed_round(), round);
+                assert_eq!(core_fixture.core.last_proposed_round(), round);
 
-                this_round_blocks.push(core.last_proposed_block.clone());
+                this_round_blocks.push(core_fixture.core.last_proposed_block.clone());
             }
 
             last_round_blocks = this_round_blocks;
@@ -1252,28 +1259,35 @@ mod test {
 
         // Try to create the blocks for round 4 by calling the try_propose() method. No block should be created as the
         // leader - authority 3 - hasn't proposed any block.
-        for (core, _, _, _, _) in cores.iter_mut() {
-            wait_blocks(&last_round_blocks, &core.context).await;
+        for core_fixture in cores.iter_mut() {
+            wait_blocks(&last_round_blocks, &core_fixture.core.context).await;
 
-            core.add_blocks(last_round_blocks.clone()).unwrap();
-            assert!(core.try_propose(false).unwrap().is_none());
+            core_fixture
+                .core
+                .add_blocks(last_round_blocks.clone())
+                .unwrap();
+            assert!(core_fixture.core.try_propose(false).unwrap().is_none());
         }
 
         // Now try to create the blocks for round 4 via the leader timeout method which should
         // ignore any leader checks or min round delay.
-        for (core, _, _, _, store) in cores.iter_mut() {
-            assert!(core.new_block(4, true).unwrap().is_some());
-            assert_eq!(core.last_proposed_round(), 4);
+        for core_fixture in cores.iter_mut() {
+            assert!(core_fixture.core.new_block(4, true).unwrap().is_some());
+            assert_eq!(core_fixture.core.last_proposed_round(), 4);
 
             // Check commits have been persisted to store
-            let last_commit = store
+            let last_commit = core_fixture
+                .store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
             // There are 1 leader rounds with rounds completed up to and including
             // round 4
             assert_eq!(last_commit.index(), 1);
-            let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+            let all_stored_commits = core_fixture
+                .store
+                .scan_commits((0..=CommitIndex::MAX).into())
+                .unwrap();
             assert_eq!(all_stored_commits.len(), 1);
         }
     }
@@ -1357,34 +1371,43 @@ mod test {
             // Wait for min round delay to allow blocks to be proposed.
             sleep(default_params.min_round_delay).await;
 
-            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
+            for core_fixture in &mut cores {
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be emitted
-                core.add_blocks(last_round_blocks.clone()).unwrap();
+                core_fixture
+                    .core
+                    .add_blocks(last_round_blocks.clone())
+                    .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
                     Duration::from_secs(1),
-                    signal_receivers.new_round_receiver(),
+                    core_fixture.signal_receivers.new_round_receiver(),
                 )
                 .await;
                 assert_eq!(new_round, round);
 
                 // Check that a new block has been proposed.
-                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let block = tokio::time::timeout(
+                    Duration::from_secs(1),
+                    core_fixture.block_receiver.recv(),
+                )
+                .await
+                .unwrap()
+                .unwrap();
                 assert_eq!(block.round(), round);
-                assert_eq!(block.author(), core.context.own_index);
+                assert_eq!(block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core.last_proposed_block().clone());
+                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
 
-                let block = core.last_proposed_block();
+                let block = core_fixture.core.last_proposed_block();
 
                 // ensure that produced block is referring to the blocks of last_round
-                assert_eq!(block.ancestors().len(), core.context.committee.size());
+                assert_eq!(
+                    block.ancestors().len(),
+                    core_fixture.core.context.committee.size()
+                );
                 for ancestor in block.ancestors() {
                     if block.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
@@ -1401,9 +1424,10 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
 
-        for (core, _, _, _, store) in cores {
+        for core_fixture in cores {
             // Check commits have been persisted to store
-            let last_commit = store
+            let last_commit = core_fixture
+                .store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
@@ -1411,10 +1435,15 @@ mod test {
             // round 29. Round 30 blocks will only include their own blocks, so the
             // 28th leader will not be committed.
             assert_eq!(last_commit.index(), 27);
-            let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+            let all_stored_commits = core_fixture
+                .store
+                .scan_commits((0..=CommitIndex::MAX).into())
+                .unwrap();
             assert_eq!(all_stored_commits.len(), 27);
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .bad_nodes
@@ -1422,7 +1451,9 @@ mod test {
                 1
             );
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .good_nodes
@@ -1432,7 +1463,9 @@ mod test {
             let expected_reputation_scores =
                 ReputationScores::new((11..=20).into(), vec![9, 8, 8, 8]);
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .reputation_scores,
@@ -1458,36 +1491,45 @@ mod test {
         for round in 1..=30 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
+            for core_fixture in &mut cores {
                 // Wait for min round delay to allow blocks to be proposed.
                 sleep(default_params.min_round_delay).await;
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be emitted
-                core.add_blocks(last_round_blocks.clone()).unwrap();
+                core_fixture
+                    .core
+                    .add_blocks(last_round_blocks.clone())
+                    .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
                     Duration::from_secs(1),
-                    signal_receivers.new_round_receiver(),
+                    core_fixture.signal_receivers.new_round_receiver(),
                 )
                 .await;
                 assert_eq!(new_round, round);
 
                 // Check that a new block has been proposed.
-                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let block = tokio::time::timeout(
+                    Duration::from_secs(1),
+                    core_fixture.block_receiver.recv(),
+                )
+                .await
+                .unwrap()
+                .unwrap();
                 assert_eq!(block.round(), round);
-                assert_eq!(block.author(), core.context.own_index);
+                assert_eq!(block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core.last_proposed_block().clone());
+                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
 
-                let block = core.last_proposed_block();
+                let block = core_fixture.core.last_proposed_block();
 
                 // ensure that produced block is referring to the blocks of last_round
-                assert_eq!(block.ancestors().len(), core.context.committee.size());
+                assert_eq!(
+                    block.ancestors().len(),
+                    core_fixture.core.context.committee.size()
+                );
                 for ancestor in block.ancestors() {
                     if block.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
@@ -1504,9 +1546,10 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
 
-        for (core, _, _, _, store) in cores {
+        for core_fixture in cores {
             // Check commits have been persisted to store
-            let last_commit = store
+            let last_commit = core_fixture
+                .store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
@@ -1514,10 +1557,15 @@ mod test {
             // round 29. Round 30 blocks will only include their own blocks, so the
             // 28th leader will not be committed.
             assert_eq!(last_commit.index(), 27);
-            let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+            let all_stored_commits = core_fixture
+                .store
+                .scan_commits((0..=CommitIndex::MAX).into())
+                .unwrap();
             assert_eq!(all_stored_commits.len(), 27);
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .bad_nodes
@@ -1525,7 +1573,9 @@ mod test {
                 0
             );
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .good_nodes
@@ -1534,7 +1584,9 @@ mod test {
             );
             let expected_reputation_scores = ReputationScores::new(CommitRange::default(), vec![]);
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .reputation_scores,
@@ -1574,34 +1626,43 @@ mod test {
             // Wait for min round delay to allow blocks to be proposed.
             sleep(default_params.min_round_delay).await;
 
-            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
+            for core_fixture in &mut cores {
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be emitted
-                core.add_blocks(last_round_blocks.clone()).unwrap();
+                core_fixture
+                    .core
+                    .add_blocks(last_round_blocks.clone())
+                    .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
                     Duration::from_secs(1),
-                    signal_receivers.new_round_receiver(),
+                    core_fixture.signal_receivers.new_round_receiver(),
                 )
                 .await;
                 assert_eq!(new_round, round);
 
                 // Check that a new block has been proposed.
-                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let block = tokio::time::timeout(
+                    Duration::from_secs(1),
+                    core_fixture.block_receiver.recv(),
+                )
+                .await
+                .unwrap()
+                .unwrap();
                 assert_eq!(block.round(), round);
-                assert_eq!(block.author(), core.context.own_index);
+                assert_eq!(block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core.last_proposed_block().clone());
+                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
 
-                let block = core.last_proposed_block();
+                let block = core_fixture.core.last_proposed_block();
 
                 // ensure that produced block is referring to the blocks of last_round
-                assert_eq!(block.ancestors().len(), core.context.committee.size());
+                assert_eq!(
+                    block.ancestors().len(),
+                    core_fixture.core.context.committee.size()
+                );
                 for ancestor in block.ancestors() {
                     if block.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
@@ -1618,9 +1679,10 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
 
-        for (core, _, _, _, store) in cores {
+        for core_fixture in cores {
             // Check commits have been persisted to store
-            let last_commit = store
+            let last_commit = core_fixture
+                .store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
@@ -1640,10 +1702,15 @@ mod test {
                 _ => 61,
             };
             assert_eq!(last_commit.index(), expected_commit_count);
-            let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+            let all_stored_commits = core_fixture
+                .store
+                .scan_commits((0..=CommitIndex::MAX).into())
+                .unwrap();
             assert_eq!(all_stored_commits.len(), expected_commit_count as usize);
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .bad_nodes
@@ -1651,7 +1718,9 @@ mod test {
                 1
             );
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .good_nodes
@@ -1661,7 +1730,9 @@ mod test {
             let expected_reputation_scores =
                 ReputationScores::new((51..=60).into(), vec![8, 8, 9, 8, 8, 8]);
             assert_eq!(
-                core.leader_schedule
+                core_fixture
+                    .core
+                    .leader_schedule
                     .leader_swap_table
                     .read()
                     .reputation_scores,
@@ -1687,34 +1758,43 @@ mod test {
             // Wait for min round delay to allow blocks to be proposed.
             sleep(default_params.min_round_delay).await;
 
-            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
+            for core_fixture in &mut cores {
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be emitted
-                core.add_blocks(last_round_blocks.clone()).unwrap();
+                core_fixture
+                    .core
+                    .add_blocks(last_round_blocks.clone())
+                    .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
                     Duration::from_secs(1),
-                    signal_receivers.new_round_receiver(),
+                    core_fixture.signal_receivers.new_round_receiver(),
                 )
                 .await;
                 assert_eq!(new_round, round);
 
                 // Check that a new block has been proposed.
-                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let block = tokio::time::timeout(
+                    Duration::from_secs(1),
+                    core_fixture.block_receiver.recv(),
+                )
+                .await
+                .unwrap()
+                .unwrap();
                 assert_eq!(block.round(), round);
-                assert_eq!(block.author(), core.context.own_index);
+                assert_eq!(block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core.last_proposed_block().clone());
+                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
 
-                let block = core.last_proposed_block();
+                let block = core_fixture.core.last_proposed_block();
 
                 // ensure that produced block is referring to the blocks of last_round
-                assert_eq!(block.ancestors().len(), core.context.committee.size());
+                assert_eq!(
+                    block.ancestors().len(),
+                    core_fixture.core.context.committee.size()
+                );
                 for ancestor in block.ancestors() {
                     if block.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
@@ -1731,9 +1811,10 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
 
-        for (_, _, _, _, store) in cores {
+        for core_fixture in cores {
             // Check commits have been persisted to store
-            let last_commit = store
+            let last_commit = core_fixture
+                .store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
@@ -1741,7 +1822,10 @@ mod test {
             // round 9. Round 10 blocks will only include their own blocks, so the
             // 8th leader will not be committed.
             assert_eq!(last_commit.index(), 7);
-            let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+            let all_stored_commits = core_fixture
+                .store
+                .scan_commits((0..=CommitIndex::MAX).into())
+                .unwrap();
             assert_eq!(all_stored_commits.len(), 7);
         }
     }
@@ -1763,17 +1847,20 @@ mod test {
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, _, _, _, _) in &mut cores {
+            for core_fixture in &mut cores {
                 // do not produce any block for authority 3
-                if core.context.own_index == excluded_authority {
+                if core_fixture.core.context.own_index == excluded_authority {
                     continue;
                 }
 
                 // try to propose to ensure that we are covering the case where we miss the leader authority 3
-                core.add_blocks(last_round_blocks.clone()).unwrap();
-                core.new_block(round, true).unwrap();
+                core_fixture
+                    .core
+                    .add_blocks(last_round_blocks.clone())
+                    .unwrap();
+                core_fixture.core.new_block(round, true).unwrap();
 
-                let block = core.last_proposed_block();
+                let block = core_fixture.core.last_proposed_block();
                 assert_eq!(block.round(), round);
 
                 // append the new block to this round blocks
@@ -1787,15 +1874,15 @@ mod test {
         // Now send all the produced blocks to core of authority 3. It should produce a new block. If no compression would
         // be applied the we should expect all the previous blocks to be referenced from round 0..=10. However, since compression
         // is applied only the last round's (10) blocks should be referenced + the authority's block of round 0.
-        let (core, _, _, _, store) = &mut cores[excluded_authority];
+        let core_fixture = &mut cores[excluded_authority];
         // Wait for min round delay to allow blocks to be proposed.
         sleep(default_params.min_round_delay).await;
         // add blocks to trigger proposal.
-        core.add_blocks(all_blocks).unwrap();
+        core_fixture.core.add_blocks(all_blocks).unwrap();
 
         // Assert that a block has been created for round 11 and it references to blocks of round 10 for the other peers, and
         // to round 1 for its own block (created after recovery).
-        let block = core.last_proposed_block();
+        let block = core_fixture.core.last_proposed_block();
         assert_eq!(block.round(), 11);
         assert_eq!(block.ancestors().len(), 4);
         for block_ref in block.ancestors() {
@@ -1807,7 +1894,8 @@ mod test {
         }
 
         // Check commits have been persisted to store
-        let last_commit = store
+        let last_commit = core_fixture
+            .store
             .read_last_commit()
             .unwrap()
             .expect("last commit should be set");
@@ -1815,31 +1903,50 @@ mod test {
         // round 10. However because there were no blocks produced for authority 3
         // 2 leader rounds will be skipped.
         assert_eq!(last_commit.index(), 6);
-        let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+        let all_stored_commits = core_fixture
+            .store
+            .scan_commits((0..=CommitIndex::MAX).into())
+            .unwrap();
         assert_eq!(all_stored_commits.len(), 6);
     }
 
     /// Creates cores for the specified number of authorities for their corresponding stakes. The method returns the
     /// cores and their respective signal receivers are returned in `AuthorityIndex` order asc.
-    // TODO: return a test fixture instead.
-    fn create_cores(
-        context: Context,
-        authorities: Vec<Stake>,
-    ) -> Vec<(
-        Core,
-        CoreSignalsReceivers,
-        broadcast::Receiver<VerifiedBlock>,
-        UnboundedReceiver<CommittedSubDag>,
-        Arc<impl Store>,
-    )> {
+    pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<CoreTextFixture> {
         let mut cores = Vec::new();
 
         for index in 0..authorities.len() {
+            let own_index = AuthorityIndex::new_for_test(index as u32);
+            let core = CoreTextFixture::new(context.clone(), authorities.clone(), own_index);
+            cores.push(core);
+        }
+        cores
+    }
+
+    pub(crate) async fn receive<T: Copy>(timeout: Duration, mut receiver: watch::Receiver<T>) -> T {
+        tokio::time::timeout(timeout, receiver.changed())
+            .await
+            .expect("Timeout while waiting to read from receiver")
+            .expect("Signal receive channel shouldn't be closed");
+        *receiver.borrow_and_update()
+    }
+
+    pub(crate) struct CoreTextFixture {
+        pub core: Core,
+        pub signal_receivers: CoreSignalsReceivers,
+        pub block_receiver: broadcast::Receiver<VerifiedBlock>,
+        #[allow(unused)]
+        pub commit_receiver: UnboundedReceiver<CommittedSubDag>,
+        pub store: Arc<MemStore>,
+    }
+
+    impl CoreTextFixture {
+        fn new(context: Context, authorities: Vec<Stake>, own_index: AuthorityIndex) -> Self {
             let (committee, mut signers) = local_committee_and_keys(0, authorities.clone());
             let mut context = context.clone();
             context = context
                 .with_committee(committee)
-                .with_authority_index(AuthorityIndex::new_for_test(index as u32));
+                .with_authority_index(own_index);
             context
                 .protocol_config
                 .set_consensus_bad_nodes_stake_threshold_for_testing(33);
@@ -1872,7 +1979,7 @@ mod test {
                 leader_schedule.clone(),
             );
 
-            let block_signer = signers.remove(index).1;
+            let block_signer = signers.remove(own_index.value()).1;
 
             let core = Core::new(
                 context,
@@ -1886,22 +1993,13 @@ mod test {
                 dag_state,
             );
 
-            cores.push((
+            Self {
                 core,
                 signal_receivers,
                 block_receiver,
                 commit_receiver,
                 store,
-            ));
+            }
         }
-        cores
-    }
-
-    async fn receive<T: Copy>(timeout: Duration, mut receiver: watch::Receiver<T>) -> T {
-        tokio::time::timeout(timeout, receiver.changed())
-            .await
-            .expect("Timeout while waiting to read from receiver")
-            .expect("Signal receive channel shouldn't be closed");
-        *receiver.borrow_and_update()
     }
 }

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -42,3 +42,7 @@ pub use authority_node::ConsensusAuthority;
 pub use block::{BlockAPI, Round};
 pub use commit::{CommitConsumer, CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use transaction::{TransactionClient, TransactionVerifier, ValidationError};
+
+#[cfg(test)]
+#[path = "tests/randomized_tests.rs"]
+mod randomized_tests;

--- a/consensus/core/src/tests/randomized_tests.rs
+++ b/consensus/core/src/tests/randomized_tests.rs
@@ -1,0 +1,233 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{env, sync::Arc};
+
+use consensus_config::AuthorityIndex;
+use parking_lot::RwLock;
+use rand::{prelude::SliceRandom, rngs::StdRng, Rng, SeedableRng};
+
+use crate::{
+    block::{BlockAPI, Slot},
+    block_manager::BlockManager,
+    block_verifier::NoopBlockVerifier,
+    commit::{DecidedLeader, DEFAULT_WAVE_LENGTH},
+    context::Context,
+    dag_state::DagState,
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
+    storage::mem_store::MemStore,
+    test_dag::create_random_dag,
+    universal_committer::{
+        universal_committer_builder::UniversalCommitterBuilder, UniversalCommitter,
+    },
+};
+
+/// Test builds a randomized dag with the following conditions:
+/// - Links to 2f+1 minimum ancestors
+/// - Links to leader of previous round.
+///
+/// Should result in a direct commit for every round.
+#[test]
+fn test_randomized_dag_all_direct_commit() {
+    let random_test_setup = random_test_setup();
+    let authority = authority_setup(random_test_setup.num_authorities);
+
+    let pipeline = random_test_setup.num_waves % DEFAULT_WAVE_LENGTH as usize;
+    let wave_number =
+        authority.committer.committers[pipeline].wave_number(random_test_setup.num_waves as u32);
+    let num_rounds = authority.committer.committers[pipeline].decision_round(wave_number);
+    let include_leader_percentage = 100;
+    let dag_builder = create_random_dag(
+        random_test_setup.seed,
+        include_leader_percentage,
+        num_rounds,
+        authority.context.clone(),
+    );
+
+    dag_builder.persist_all_blocks(authority.dag_state.clone());
+
+    tracing::info!(
+        "Running test with committee size {} & {} completed waves in the DAG...",
+        random_test_setup.num_authorities,
+        random_test_setup.num_waves
+    );
+
+    let last_decided = Slot::new_for_test(0, 0);
+    let sequence = authority.committer.try_decide(last_decided);
+    tracing::debug!("Commit sequence: {sequence:#?}");
+
+    assert_eq!(sequence.len(), random_test_setup.num_waves);
+    for (i, leader_block) in sequence.iter().enumerate() {
+        // First sequenced leader should be in round 1.
+        let leader_round = i as u32 + 1;
+        if let DecidedLeader::Commit(ref block) = leader_block {
+            assert_eq!(block.round(), leader_round);
+            assert_eq!(
+                block.author(),
+                authority.committer.get_leaders(leader_round)[0]
+            );
+        } else {
+            panic!("Expected a committed leader")
+        };
+    }
+}
+
+/// Test builds a randomized dag with the following conditions:
+/// - Links to 2f+1 minimum ancestors
+/// - Links to leader of previous round 50% of the time.
+///
+/// Blocks will randomly be fed through BlockManager and after each accepted
+/// block we will try_decide() and if there is a committed sequence we will update
+/// last_decided and continue. We do this from the perspective of two different
+/// authorities who receive the blocks in different orders and ensure the resulting
+/// sequence is the same for both authorities. The resulting sequence will include
+/// Commit & Skip decisions and potentially will stop before coming to a decision
+/// on all waves as we may have an Undecided leader somewhere early in the sequence.
+#[test]
+fn test_randomized_dag_and_decision_sequence() {
+    let mut random_test_setup = random_test_setup();
+
+    // Setup for Authority 1
+    let mut authority_1 = authority_setup(random_test_setup.num_authorities);
+
+    let pipeline = random_test_setup.num_waves % DEFAULT_WAVE_LENGTH as usize;
+    let wave_number =
+        authority_1.committer.committers[pipeline].wave_number(random_test_setup.num_waves as u32);
+    let num_rounds = authority_1.committer.committers[pipeline].decision_round(wave_number);
+    let include_leader_percentage = 50;
+    let dag_builder = create_random_dag(
+        random_test_setup.seed,
+        include_leader_percentage,
+        num_rounds,
+        authority_1.context.clone(),
+    );
+
+    tracing::info!(
+        "Running test with committee size {} & {} completed waves in the DAG...",
+        random_test_setup.num_authorities,
+        random_test_setup.num_waves
+    );
+
+    let mut all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+    all_blocks.shuffle(&mut random_test_setup.seeded_rng);
+
+    let mut sequenced_leaders_1 = vec![];
+    let mut last_decided = Slot::new_for_test(0, 0);
+    for block in &all_blocks {
+        let _ = authority_1
+            .block_manager
+            .try_accept_blocks(vec![block.clone()]);
+        let sequence = authority_1.committer.try_decide(last_decided);
+
+        if !sequence.is_empty() {
+            sequenced_leaders_1.extend(sequence.clone());
+            let leader_status = sequence.last().unwrap();
+            last_decided = Slot::new(leader_status.round(), leader_status.authority());
+        }
+    }
+
+    assert!(authority_1.block_manager.is_empty());
+
+    // Setup for Authority 2
+    let mut authority_2 = authority_setup(random_test_setup.num_authorities);
+
+    let mut all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+    all_blocks.shuffle(&mut random_test_setup.seeded_rng);
+
+    let mut sequenced_leaders_2 = vec![];
+    let mut last_decided = Slot::new_for_test(0, 0);
+    for block in &all_blocks {
+        let _ = authority_2
+            .block_manager
+            .try_accept_blocks(vec![block.clone()]);
+        let sequence = authority_2.committer.try_decide(last_decided);
+
+        if !sequence.is_empty() {
+            sequenced_leaders_2.extend(sequence.clone());
+            let leader_status = sequence.last().unwrap();
+            last_decided = Slot::new(leader_status.round(), leader_status.authority());
+        }
+    }
+
+    assert!(authority_2.block_manager.is_empty());
+
+    // Ensure despite the difference in when blocks were received eventually after
+    // receiving all blocks both authorities should return the same sequence of blocks.
+    assert_eq!(sequenced_leaders_1, sequenced_leaders_2);
+}
+
+struct AuthorityTestFixture {
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    committer: UniversalCommitter,
+    block_manager: BlockManager,
+}
+
+fn authority_setup(num_authorities: usize) -> AuthorityTestFixture {
+    let context = Arc::new(
+        Context::new_for_test(num_authorities)
+            .0
+            .with_authority_index(AuthorityIndex::new_for_test(1)),
+    );
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        context.clone(),
+        LeaderSwapTable::default(),
+    ));
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+
+    // Create committer with pipelining and only 1 leader per leader round
+    let committer =
+        UniversalCommitterBuilder::new(context.clone(), leader_schedule, dag_state.clone())
+            .with_pipeline(true)
+            .build();
+
+    let block_manager = BlockManager::new(
+        context.clone(),
+        dag_state.clone(),
+        Arc::new(NoopBlockVerifier),
+    );
+
+    AuthorityTestFixture {
+        context,
+        dag_state,
+        committer,
+        block_manager,
+    }
+}
+
+struct RandomTestFixture {
+    seed: u64,
+    seeded_rng: StdRng,
+    num_authorities: usize,
+    num_waves: usize,
+}
+
+fn random_test_setup() -> RandomTestFixture {
+    telemetry_subscribers::init_for_testing();
+    let mut rng = StdRng::from_entropy();
+    let seed = match env::var("DAG_TEST_SEED") {
+        Ok(seed_str) => {
+            if let Ok(seed) = seed_str.parse::<u64>() {
+                seed
+            } else {
+                tracing::warn!("Invalid DAG_TEST_SEED format. Using random seed.");
+                rng.gen_range(0..10000)
+            }
+        }
+        Err(_) => rng.gen_range(0..10000),
+    };
+    tracing::warn!("Using Random Seed: {seed}");
+
+    let mut seeded_rng = StdRng::seed_from_u64(seed);
+    let num_waves = seeded_rng.gen_range(0..100);
+    let num_authorities = seeded_rng.gen_range(4..10);
+    RandomTestFixture {
+        seed,
+        seeded_rng,
+        num_authorities,
+        num_waves,
+    }
+}

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -31,7 +31,7 @@ pub(crate) struct UniversalCommitter {
     /// In memory block store representing the dag state
     dag_state: Arc<RwLock<DagState>>,
     /// The list of committers for multi-leader or pipelining
-    pub committers: Vec<BaseCommitter>,
+    committers: Vec<BaseCommitter>,
 }
 
 impl UniversalCommitter {

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -31,7 +31,7 @@ pub(crate) struct UniversalCommitter {
     /// In memory block store representing the dag state
     dag_state: Arc<RwLock<DagState>>,
     /// The list of committers for multi-leader or pipelining
-    committers: Vec<BaseCommitter>,
+    pub committers: Vec<BaseCommitter>,
 }
 
 impl UniversalCommitter {


### PR DESCRIPTION
The random tests will print out a seed that can be passed in as an env var (`DAG_TEST_SEED`) to repro any failures. Also for now going through block manager so we can randomize how the blocks are received but ideally we can test this flow directly through core once "turning off proposal" is possible in core. Additionally we can follow up this PR with even more randomized dags to simulate crashes, byzantine validators, etc.