### PR TITLE
Run framework verification on its own VM

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1381,6 +1381,7 @@
                 "enable_poseidon": false,
                 "enable_vdf": false,
                 "end_of_epoch_transaction_supported": false,
+                "fresh_vm_on_framework_upgrade": false,
                 "hardened_otw_check": false,
                 "include_consensus_digest_in_prologue": false,
                 "loaded_child_object_format": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -133,6 +133,7 @@ const MAX_PROTOCOL_VERSION: u64 = 49;
 // Version 48: Use tonic networking for Mysticeti.
 //             Resolve Move abort locations to the package id instead of the runtime module ID.
 //             Enable random beacon in testnet.
+//             Use new VM when verifying framework packages.
 // Version 49: Enable Move enums on devnet.
 //             Enable VDF in devnet
 //             Run Mysticeti consensus by default.
@@ -463,6 +464,10 @@ struct FeatureFlags {
     // The purpose of doing this is to enable replaying transaction without transaction effects.
     #[serde(skip_serializing_if = "is_false")]
     record_consensus_determined_version_assignments_in_prologue: bool,
+
+    // Run verification of framework upgrades using a new/fresh VM.
+    #[serde(skip_serializing_if = "is_false")]
+    fresh_vm_on_framework_upgrade: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1375,6 +1380,10 @@ impl ProtocolConfig {
 
     pub fn enable_vdf(&self) -> bool {
         self.feature_flags.enable_vdf
+    }
+
+    pub fn fresh_vm_on_framework_upgrade(&self) -> bool {
+        self.feature_flags.fresh_vm_on_framework_upgrade
     }
 }
 
@@ -2309,6 +2318,9 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.consensus_choice = ConsensusChoice::Mysticeti;
                     }
+
+                    // Run Move verification on framework upgrades in its own VM
+                    cfg.feature_flags.fresh_vm_on_framework_upgrade = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_49.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_49.snap
@@ -48,6 +48,7 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
+  fresh_vm_on_framework_upgrade: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -268,3 +269,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_49.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_49.snap
@@ -52,6 +52,7 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
+  fresh_vm_on_framework_upgrade: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -275,3 +276,4 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_49.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_49.snap
@@ -56,6 +56,7 @@ feature_flags:
   mysticeti_use_committed_subdag_digest: true
   enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -283,3 +284,4 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -26,10 +26,12 @@ mod checked {
     use sui_types::{BRIDGE_ADDRESS, SUI_BRIDGE_OBJECT_ID, SUI_RANDOMNESS_STATE_OBJECT_ID};
     use tracing::{info, instrument, trace, warn};
 
+    use crate::adapter::new_move_vm;
     use crate::programmable_transactions;
     use crate::type_layout_resolver::TypeLayoutResolver;
     use crate::{gas_charger::GasCharger, temporary_store::TemporaryStore};
     use move_core_types::ident_str;
+    use sui_move_natives::all_natives;
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::authenticator_state::{
         AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME, AUTHENTICATOR_STATE_EXPIRE_JWKS_FUNCTION_NAME,
@@ -903,6 +905,45 @@ mod checked {
             }
         }
 
+        if protocol_config.fresh_vm_on_framework_upgrade() {
+            let new_vm = new_move_vm(
+                all_natives(/* silent */ true),
+                protocol_config,
+                /* enable_profiler */ None,
+            )
+            .expect("Failed to create new MoveVM");
+            process_system_packages(
+                change_epoch,
+                temporary_store,
+                tx_ctx,
+                &new_vm,
+                gas_charger,
+                protocol_config,
+                metrics,
+            );
+        } else {
+            process_system_packages(
+                change_epoch,
+                temporary_store,
+                tx_ctx,
+                move_vm,
+                gas_charger,
+                protocol_config,
+                metrics,
+            );
+        }
+        Ok(())
+    }
+
+    fn process_system_packages(
+        change_epoch: ChangeEpoch,
+        temporary_store: &mut TemporaryStore<'_>,
+        tx_ctx: &mut TxContext,
+        move_vm: &MoveVM,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) {
         let binary_config = to_binary_config(protocol_config);
         for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
             let deserialized_modules: Vec<_> = modules
@@ -955,8 +996,6 @@ mod checked {
                 temporary_store.upgrade_system_package(new_package);
             }
         }
-
-        Ok(())
     }
 
     /// Perform metadata updates in preparation for the transactions in the upcoming checkpoint:


### PR DESCRIPTION
## Description 

Gated by a protocol version we run upgrades of framework in its own VM.
That is to avoid loader cache issues when verification of a VM can use packages that are loaded already and as such incompatible with the new upgrade.
This solution should solve the vast majority of problems related to changes in framework code.
Next steps:
- forbid new `init` in framework modules (verifier check)
- make a easy to use framework to push `init` style code on the epoch after the framework upgrade. That is in line with what has been done for all new systems we exposed in the framework (e.g. random beacon and bridge)

## Test plan 

Existing tests and about to run multi-epochs replay

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
