### PR TITLE
Update executors.mdx - replace txb with tx1 & tx2

### DIFF
--- a/sdk/docs/pages/typescript/executors.mdx
+++ b/sdk/docs/pages/typescript/executors.mdx
@@ -37,10 +37,10 @@ const executor = new SerialTransactionExecutor({
 });
 
 const tx1 = new Transaction();
-const [coin1] = tx1.splitCoins(txb.gas, [1]);
+const [coin1] = tx1.splitCoins(tx1.gas, [1]);
 tx1.transferObjects([coin1], address1);
 const tx2 = new Transaction();
-const [coin2] = tx1.splitCoins(txb.gas, [1]);
+const [coin2] = tx1.splitCoins(tx2.gas, [1]);
 tx1.transferObjects([coin2], address2);
 
 const [{ digest: digest1 }, { digest: digest2 }] = await Promise.all([
@@ -102,10 +102,10 @@ const executor = new ParallelTransactionExecutor({
 });
 
 const tx1 = new Transaction();
-const [coin1] = tx1.splitCoins(txb.gas, [1]);
+const [coin1] = tx1.splitCoins(tx1.gas, [1]);
 tx1.transferObjects([coin1], address1);
 const tx2 = new Transaction();
-const [coin2] = tx1.splitCoins(txb.gas, [1]);
+const [coin2] = tx1.splitCoins(tx2.gas, [1]);
 tx1.transferObjects([coin2], address2);
 
 const [{ digest: digest1 }, { digest: digest2 }] = await Promise.all([


### PR DESCRIPTION
txb is nowhere defined so the correct statements should include tx1 and tx2.

## Description 

Fixed typos.