### PR TITLE
Prune erroneously lingering pending randomness rounds from `AuthorityPerEpochStore` tables on startup

### DIFF
--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -39,7 +39,7 @@ use crate::consensus_adapter::ConsensusAdapter;
 type PkG = bls12381::G2Element;
 type EncG = bls12381::G2Element;
 
-const SINGLETON_KEY: u64 = 0;
+pub const SINGLETON_KEY: u64 = 0;
 
 // State machine for randomness DKG and generation.
 //


### PR DESCRIPTION
The underlying race issue causing these not to be removed properly will be fixed in a future change.