### PR TITLE
[bridge] return public metadata upon ping

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -5,6 +5,7 @@ use crate::abi::EthBridgeCommittee;
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::events::*;
+use crate::server::BridgeNodePublicMetadata;
 use crate::types::BridgeAction;
 use crate::utils::get_eth_signer_client;
 use crate::utils::EthSigner;
@@ -720,9 +721,13 @@ pub(crate) async fn start_bridge_cluster(
         // Spawn bridge node in memory
         let config_clone = config.clone();
         handles.push(
-            run_bridge_node(config_clone, Registry::new())
-                .await
-                .unwrap(),
+            run_bridge_node(
+                config_clone,
+                BridgeNodePublicMetadata::empty_for_testing(),
+                Registry::new(),
+            )
+            .await
+            .unwrap(),
         );
     }
     handles

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 };
 use sui_bridge::config::BridgeNodeConfig;
 use sui_bridge::node::run_bridge_node;
+use sui_bridge::server::BridgeNodePublicMetadata;
 use sui_config::Config;
 use tracing::info;
 
@@ -42,5 +43,8 @@ async fn main() -> anyhow::Result<()> {
         .with_env()
         .with_prom_registry(&prometheus_registry)
         .init();
-    Ok(run_bridge_node(config, prometheus_registry).await?.await?)
+    let metadata = BridgeNodePublicMetadata::new(VERSION.into());
+    Ok(run_bridge_node(config, metadata, prometheus_registry)
+        .await?
+        .await?)
 }

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -9,7 +9,7 @@ use crate::{
     events::init_all_struct_tags,
     metrics::BridgeMetrics,
     orchestrator::BridgeOrchestrator,
-    server::{handler::BridgeRequestHandler, run_server},
+    server::{handler::BridgeRequestHandler, run_server, BridgeNodePublicMetadata},
     storage::BridgeOrchestratorTables,
     sui_syncer::SuiSyncer,
 };
@@ -30,6 +30,7 @@ use tracing::info;
 
 pub async fn run_bridge_node(
     config: BridgeNodeConfig,
+    metadata: BridgeNodePublicMetadata,
     prometheus_registry: prometheus::Registry,
 ) -> anyhow::Result<JoinHandle<()>> {
     init_all_struct_tags();
@@ -57,6 +58,7 @@ pub async fn run_bridge_node(
             server_config.approved_governance_actions,
         ),
         metrics,
+        Arc::new(metadata),
     ))
 }
 
@@ -386,7 +388,13 @@ mod tests {
             db_path: None,
         };
         // Spawn bridge node in memory
-        let _handle = run_bridge_node(config, Registry::new()).await.unwrap();
+        let _handle = run_bridge_node(
+            config,
+            BridgeNodePublicMetadata::empty_for_testing(),
+            Registry::new(),
+        )
+        .await
+        .unwrap();
 
         let server_url = format!("http://127.0.0.1:{}", server_listen_port);
         // Now we expect to see the server to be up and running.
@@ -443,7 +451,13 @@ mod tests {
             db_path: Some(db_path),
         };
         // Spawn bridge node in memory
-        let _handle = run_bridge_node(config, Registry::new()).await.unwrap();
+        let _handle = run_bridge_node(
+            config,
+            BridgeNodePublicMetadata::empty_for_testing(),
+            Registry::new(),
+        )
+        .await
+        .unwrap();
 
         let server_url = format!("http://127.0.0.1:{}", server_listen_port);
         // Now we expect to see the server to be up and running.
@@ -511,7 +525,13 @@ mod tests {
             db_path: Some(db_path),
         };
         // Spawn bridge node in memory
-        let _handle = run_bridge_node(config, Registry::new()).await.unwrap();
+        let _handle = run_bridge_node(
+            config,
+            BridgeNodePublicMetadata::empty_for_testing(),
+            Registry::new(),
+        )
+        .await
+        .unwrap();
 
         let server_url = format!("http://127.0.0.1:{}", server_listen_port);
         // Now we expect to see the server to be up and running.

--- a/crates/sui-bridge/src/server/mock_handler.rs
+++ b/crates/sui-bridge/src/server/mock_handler.rs
@@ -14,6 +14,7 @@ use crate::crypto::BridgeAuthoritySignInfo;
 use crate::error::BridgeError;
 use crate::error::BridgeResult;
 use crate::metrics::BridgeMetrics;
+use crate::server::BridgeNodePublicMetadata;
 use crate::types::SignedBridgeAction;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
@@ -136,6 +137,7 @@ pub fn run_mock_server(
         make_router(
             Arc::new(mock_handler),
             Arc::new(BridgeMetrics::new_for_testing()),
+            Arc::new(BridgeNodePublicMetadata::empty_for_testing()),
         )
         .into_make_service(),
     );

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -37,7 +37,9 @@ pub(crate) mod mock_handler;
 
 pub const APPLICATION_JSON: &str = "application/json";
 
-// Important: the paths need to match the ones in bridge_client.rs
+pub const PING_PATH: &str = "/ping";
+
+// Important: for BridgeActions, the paths need to match the ones in bridge_client.rs
 pub const ETH_TO_SUI_TX_PATH: &str = "/sign/bridge_tx/eth/sui/:tx_hash/:event_index";
 pub const SUI_TO_ETH_TX_PATH: &str = "/sign/bridge_tx/sui/eth/:tx_digest/:event_index";
 pub const COMMITTEE_BLOCKLIST_UPDATE_PATH: &str =
@@ -56,13 +58,33 @@ pub const ADD_TOKENS_ON_SUI_PATH: &str =
 pub const ADD_TOKENS_ON_EVM_PATH: &str =
     "/sign/add_tokens_on_evm/:chain_id/:nonce/:native/:token_ids/:token_addresses/:token_sui_decimals/:token_prices";
 
+/// BridgeNode's public metadata that is acceesible via the `/ping` endpoint.
+// Be careful with what to put here, as it is public.
+#[derive(serde::Serialize, Clone)]
+pub struct BridgeNodePublicMetadata {
+    pub version: Option<String>,
+}
+
+impl BridgeNodePublicMetadata {
+    pub fn new(version: String) -> Self {
+        Self {
+            version: Some(version),
+        }
+    }
+
+    pub fn empty_for_testing() -> Self {
+        Self { version: None }
+    }
+}
+
 pub fn run_server(
     socket_address: &SocketAddr,
     handler: BridgeRequestHandler,
     metrics: Arc<BridgeMetrics>,
+    metadata: Arc<BridgeNodePublicMetadata>,
 ) -> tokio::task::JoinHandle<()> {
     let service = axum::Server::bind(socket_address)
-        .serve(make_router(Arc::new(handler), metrics).into_make_service());
+        .serve(make_router(Arc::new(handler), metrics, metadata).into_make_service());
     tokio::spawn(async move {
         service.await.unwrap();
     })
@@ -71,9 +93,11 @@ pub fn run_server(
 pub(crate) fn make_router(
     handler: Arc<impl BridgeRequestHandlerTrait + Sync + Send + 'static>,
     metrics: Arc<BridgeMetrics>,
+    metadata: Arc<BridgeNodePublicMetadata>,
 ) -> Router {
     Router::new()
         .route("/", get(health_check))
+        .route(PING_PATH, get(ping))
         .route(ETH_TO_SUI_TX_PATH, get(handle_eth_tx_hash))
         .route(SUI_TO_ETH_TX_PATH, get(handle_sui_tx_digest))
         .route(
@@ -93,7 +117,7 @@ pub(crate) fn make_router(
         )
         .route(ADD_TOKENS_ON_SUI_PATH, get(handle_add_tokens_on_sui))
         .route(ADD_TOKENS_ON_EVM_PATH, get(handle_add_tokens_on_evm))
-        .with_state((handler, metrics))
+        .with_state((handler, metrics, metadata))
 }
 
 impl axum::response::IntoResponse for BridgeError {
@@ -120,12 +144,23 @@ async fn health_check() -> StatusCode {
     StatusCode::OK
 }
 
+async fn ping(
+    State((_handler, _metrics, metadata)): State<(
+        Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
+        Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
+    )>,
+) -> Result<Json<BridgeNodePublicMetadata>, BridgeError> {
+    Ok(Json(metadata.as_ref().clone()))
+}
+
 #[instrument(level = "error", skip_all, fields(tx_hash_hex=tx_hash_hex, event_idx=event_idx))]
 async fn handle_eth_tx_hash(
     Path((tx_hash_hex, event_idx)): Path<(String, u16)>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -138,9 +173,10 @@ async fn handle_eth_tx_hash(
 #[instrument(level = "error", skip_all, fields(tx_digest_base58=tx_digest_base58, event_idx=event_idx))]
 async fn handle_sui_tx_digest(
     Path((tx_digest_base58, event_idx)): Path<(String, u16)>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -155,9 +191,10 @@ async fn handle_sui_tx_digest(
 #[instrument(level = "error", skip_all, fields(chain_id=chain_id, nonce=nonce, blocklist_type=blocklist_type, keys=keys))]
 async fn handle_update_committee_blocklist_action(
     Path((chain_id, nonce, blocklist_type, keys)): Path<(u8, u64, u8, String)>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -200,9 +237,10 @@ async fn handle_update_committee_blocklist_action(
 #[instrument(level = "error", skip_all, fields(chain_id=chain_id, nonce=nonce, action_type=action_type))]
 async fn handle_emergency_action(
     Path((chain_id, nonce, action_type)): Path<(u8, u64, u8)>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -229,9 +267,10 @@ async fn handle_emergency_action(
 #[instrument(level = "error", skip_all, fields(chain_id=chain_id, nonce=nonce, sending_chain_id=sending_chain_id, new_usd_limit=new_usd_limit))]
 async fn handle_limit_update_action(
     Path((chain_id, nonce, sending_chain_id, new_usd_limit)): Path<(u8, u64, u8, u64)>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -256,9 +295,10 @@ async fn handle_limit_update_action(
 #[instrument(level = "error", skip_all, fields(chain_id=chain_id, nonce=nonce, token_id=token_id, new_usd_price=new_usd_price))]
 async fn handle_asset_price_update_action(
     Path((chain_id, nonce, token_id, new_usd_price)): Path<(u8, u64, u8, u64)>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -286,9 +326,10 @@ async fn handle_evm_contract_upgrade_with_calldata(
         EthAddress,
         String,
     )>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -328,9 +369,10 @@ async fn handle_evm_contract_upgrade(
         EthAddress,
         EthAddress,
     )>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -361,9 +403,10 @@ async fn handle_add_tokens_on_sui(
         String,
         String,
     )>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {
@@ -442,9 +485,10 @@ async fn handle_add_tokens_on_evm(
         String,
         String,
     )>,
-    State((handler, metrics)): State<(
+    State((handler, metrics, _metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
     )>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
     let future = async {


### PR DESCRIPTION
## Description 

This PR added an "/ping" endpoint that returns `BridgeNodePublicMetadata`. `BridgeNodePublicMetadata` is a collection of public info about a node. Now it contains the node version.

## Test plan 

tested the new endpoint locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
