### PR TITLE
Move deposit amount restriction to utils

### DIFF
--- a/bridge/evm/contracts/SuiBridge.sol
+++ b/bridge/evm/contracts/SuiBridge.sol
@@ -167,8 +167,6 @@ contract SuiBridge is ISuiBridge, CommitteeUpgradeable, PausableUpgradeable {
             amountTransfered
         );
 
-        require(suiAdjustedAmount > 0, "SuiBridge: Invalid amount provided");
-
         emit TokensDeposited(
             config.chainID(),
             nonces[BridgeUtils.TOKEN_TRANSFER],

--- a/bridge/evm/contracts/utils/BridgeUtils.sol
+++ b/bridge/evm/contracts/utils/BridgeUtils.sol
@@ -142,6 +142,9 @@ library BridgeUtils {
         // Ensure the converted amount fits within uint64
         require(amount <= type(uint64).max, "BridgeUtils: Amount too large for uint64");
 
+        // Ensure the converted amount is greater than 0
+        require(amount > 0, "BridgeUtils: Insufficient amount provided");
+
         return uint64(amount);
     }
 

--- a/bridge/evm/test/SuiBridgeTest.t.sol
+++ b/bridge/evm/test/SuiBridgeTest.t.sol
@@ -548,10 +548,15 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
         reentrantAttack.attack();
     }
 
-    function testSuiBridgeInvalidDecimalConversion() public {
+    function testSuiBridgeInvalidERC20DecimalConversion() public {
         IERC20(wETH).approve(address(bridge), 10 ether);
-        vm.expectRevert(bytes("SuiBridge: Invalid amount provided"));
+        vm.expectRevert(bytes("BridgeUtils: Insufficient amount provided"));
         bridge.bridgeERC20(BridgeUtils.ETH, 1, abi.encode("suiAddress"), 0);
+    }
+
+    function testSuiBridgeInvalidEthDecimalConversion() public {
+        vm.expectRevert(bytes("BridgeUtils: Insufficient amount provided"));
+        bridge.bridgeETH{value: 1}(abi.encode("suiAddress"), 0);
     }
 
     // An e2e token transfer regression test covering message ser/de and signature verification


### PR DESCRIPTION
## Description 

Currently only the depositERC20 checks that the conversion is greater than 0. Moving the requirement to the conversion function itself to capture both ERC20 and ETH deposits

## Test plan 

Added unit test coverage to account for both depositEth and depositERC20