### PR TITLE
[move-ide] Optimized dependency graph construction

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1106,7 +1106,7 @@ fn has_precompiled_deps(
     pkg_path: &Path,
     pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecompiledPkgDeps>>>,
 ) -> bool {
-    let mut pkg_deps = pkg_dependencies.lock().unwrap();
+    let pkg_deps = pkg_dependencies.lock().unwrap();
     pkg_deps.contains_key(pkg_path)
 }
 

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1102,6 +1102,14 @@ impl Symbols {
     }
 }
 
+fn has_precompiled_deps(
+    pkg_path: &Path,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecompiledPkgDeps>>>,
+) -> bool {
+    let mut pkg_deps = pkg_dependencies.lock().unwrap();
+    pkg_deps.contains_key(pkg_path)
+}
+
 /// Main driver to get symbols for the whole package. Returned symbols is an option as only the
 /// correctly computed symbols should be a replacement for the old set - if symbols are not
 /// actually (re)computed and the diagnostics are returned, the old symbolic information should
@@ -1117,6 +1125,7 @@ pub fn get_symbols(
         install_dir: Some(tempdir().unwrap().path().to_path_buf()),
         default_flavor: Some(Flavor::Sui),
         lint_flag: lint.into(),
+        skip_fetch_latest_git_deps: has_precompiled_deps(pkg_path, pkg_dependencies.clone()),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Description 

We should not check for if the (remote) dependencies are up-to-date on each compilation as this is quite costly (seconds) and can massively slowdown some features (e.g., auto-completion). For IDE use case it should be sufficient to check dependency freshness on the first compilation only.

## Test plan 

Verified that time to finish auto-completion request when remote deps are used went down from ~2s to miliseconds
