### PR TITLE
[SDK] Support multi signer when using `multiSigPublicKey.getSigner()`, now only support a single signer.

### DIFF
--- a/sdk/typescript/src/multisig/publickey.ts
+++ b/sdk/typescript/src/multisig/publickey.ts
@@ -179,7 +179,11 @@ export class MultiSigPublicKey extends PublicKey {
 		return this.multisigPublicKey.threshold;
 	}
 
-	getSigner(...signers: Signer[]) {
+	getSigner(signer: Signer) {
+		return new MultiSigSigner(this, [signer]);
+	}
+
+	getSigners(...signers: Signer[]) {
 		return new MultiSigSigner(this, signers);
 	}
 

--- a/sdk/typescript/src/multisig/publickey.ts
+++ b/sdk/typescript/src/multisig/publickey.ts
@@ -179,7 +179,7 @@ export class MultiSigPublicKey extends PublicKey {
 		return this.multisigPublicKey.threshold;
 	}
 
-	getSigner(...signers: [signer: Signer]) {
+	getSigner(...signers: Signer[]) {
 		return new MultiSigSigner(this, signers);
 	}
 


### PR DESCRIPTION
[SDK] Support multi signer when using `multiSigPublicKey.getSigner()`, now only support a single signer.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
- [x] Typescript SDK:  
