### PR TITLE
[rocksdb] add a deprecate attribute

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -76,6 +76,9 @@ pub struct NodeConfig {
     #[serde(default = "default_enable_index_processing")]
     pub enable_index_processing: bool,
 
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub remove_deprecated_tables: bool,
+
     #[serde(default)]
     /// Determines the jsonrpc server type as either:
     /// - 'websocket' for a websocket based service (deprecated)

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -275,6 +275,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 epoch_store
                     .protocol_config()
                     .max_move_identifier_len_as_option(),
+                false,
             )))
         };
         let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -536,6 +536,7 @@ impl SuiNode {
                 epoch_store
                     .protocol_config()
                     .max_move_identifier_len_as_option(),
+                config.remove_deprecated_tables,
             )))
         } else {
             None

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -197,6 +197,7 @@ impl ValidatorConfigBuilder {
                 .to_socket_addr()
                 .unwrap(),
             consensus_config: Some(consensus_config),
+            remove_deprecated_tables: false,
             enable_index_processing: default_enable_index_processing(),
             genesis: sui_config::node::Genesis::new(genesis),
             grpc_load_shed: None,
@@ -464,6 +465,7 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(local_ip_utils::get_available_port(&localhost)),
             json_rpc_address: self.json_rpc_address.unwrap_or(json_rpc_address),
             consensus_config: None,
+            remove_deprecated_tables: false,
             enable_index_processing: default_enable_index_processing(),
             genesis: self.genesis.unwrap_or(sui_config::node::Genesis::new(
                 network_config.genesis.clone(),


### PR DESCRIPTION
The PR adds a new attribute `[deprecated]` that is used to drop the corresponding column family and eventually reclaim the space. 
During restart, the marked cf will be dropped. Space will be gradually reclaimed during the compaction process. Eventually, references to deprecated column families could be removed from the codebase.
The feature is hidden behind the temporary `remove_deprecated_tables` configuration flag.
Making it optional extends transition period and allows certain node operators to serve deprecated JSON RPC APIs for a bit longer