### PR TITLE
[DB] disable write stalling and stopping due to pending compaction bytes for index cfs

### DIFF
--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -237,31 +237,33 @@ pub struct IndexStore {
 
 // These functions are used to initialize the DB tables
 fn transactions_order_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn transactions_seq_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn transactions_from_addr_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn transactions_to_addr_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn transactions_by_move_function_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn timestamps_table_default_config() -> DBOptions {
-    default_db_options().optimize_for_point_lookup(64)
+    default_db_options()
+        .optimize_for_point_lookup(64)
+        .disable_write_throttling()
 }
 fn owner_index_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn dynamic_field_index_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn index_table_default_config() -> DBOptions {
-    default_db_options()
+    default_db_options().disable_write_throttling()
 }
 fn coin_index_table_default_config() -> DBOptions {
     default_db_options()
@@ -269,6 +271,7 @@ fn coin_index_table_default_config() -> DBOptions {
         .optimize_for_read(
             read_size_from_env(ENV_VAR_COIN_INDEX_BLOCK_CACHE_SIZE_MB).unwrap_or(5 * 1024),
         )
+        .disable_write_throttling()
 }
 
 impl IndexStore {

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2439,7 +2439,15 @@ pub fn default_db_options() -> DBOptions {
         read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
     );
 
+    // Num threads for compaction and flush.
     opt.increase_parallelism(4);
+
+    // Disable write stalling and stopping based on pending compaction bytes.
+    // Throttling writes in Sui does not reduce the incoming data throughput most of the time,
+    // especially on the larger column families that do not get deleted per epoch.
+    opt.set_soft_pending_compaction_bytes_limit(0);
+    opt.set_hard_pending_compaction_bytes_limit(0);
+
     opt.set_enable_pipelined_write(true);
 
     opt.set_block_based_table_factory(&get_block_options(128));

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2385,10 +2385,10 @@ impl DBOptions {
         self
     }
 
-    // Optimize tables receiving significant deletions.
-    // TODO: revisit when intra-epoch pruning is enabled.
-    pub fn optimize_for_pruning(mut self) -> DBOptions {
-        self.options.set_min_write_buffer_number_to_merge(2);
+    // Disables write stalling and stopping based on pending compaction bytes.
+    pub fn disable_write_throttling(mut self) -> DBOptions {
+        self.options.set_soft_pending_compaction_bytes_limit(0);
+        self.options.set_hard_pending_compaction_bytes_limit(0);
         self
     }
 }
@@ -2441,12 +2441,6 @@ pub fn default_db_options() -> DBOptions {
 
     // Num threads for compaction and flush.
     opt.increase_parallelism(4);
-
-    // Disable write stalling and stopping based on pending compaction bytes.
-    // Throttling writes in Sui does not reduce the incoming data throughput most of the time,
-    // especially on the larger column families that do not get deleted per epoch.
-    opt.set_soft_pending_compaction_bytes_limit(0);
-    opt.set_hard_pending_compaction_bytes_limit(0);
 
     opt.set_enable_pipelined_write(true);
 


### PR DESCRIPTION
## Description 

Index db cfs can become large and require compactions. Write throttling based on compaction bytes can happen after initial ingestion of data, and is hard to investigate. Disable write throttling for index cfs.

## Test plan 

Deploy to private testnet.


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
