### PR TITLE
[move][move-ide] Colon/Alias Autocompletion

### DIFF
--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -284,7 +284,7 @@ pub enum ModuleAccess_ {
     ModuleAccess(ModuleIdent, Name),
     Variant(Spanned<(ModuleIdent, Name)>, Name),
 }
-pub type ModuleAccess = Spanned<ModuleAccess_>;
+tpub type ModuleAccess = Spanned<ModuleAccess_>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -371,6 +371,8 @@ pub struct NamePath {
 pub enum NameAccessChain_ {
     Single(PathEntry),
     Path(NamePath),
+    GlobalAutocomplete(),
+    PathAutocomplete(NamePath),
 }
 pub type NameAccessChain = Spanned<NameAccessChain_>;
 


### PR DESCRIPTION
## Description 

This records autocomplete information for alias resolution positions.

## Test plan 

Updated test expectations

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
