### PR TITLE
[move][move-2024] Improve errors when a call might be referring to a missing datatype.

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -779,10 +779,20 @@ impl<'env> Context<'env> {
                 ResolvedCallSubject::Builtin(Box::new(resolved))
             }
             EA::Name(n) => {
+                let possibly_datatype_name = self
+                    .env
+                    .supports_feature(self.current_package, FeatureGate::PositionalFields)
+                    && is_constant_name(&n.value);
                 match self.resolve_local(
                     n.loc,
                     NameResolution::UnboundUnscopedName,
-                    |n| format!("Unbound function '{}' in current scope", n),
+                    |n| {
+                        if possibly_datatype_name {
+                            format!("Unbound datatype or function '{}' in current scope", n)
+                        } else {
+                            format!("Unbound function '{}' in current scope", n)
+                        }
+                    },
                     n,
                 ) {
                     None => {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/unknown_contructor_name.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/unknown_contructor_name.exp
@@ -1,0 +1,6 @@
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_2024/naming/unknown_contructor_name.move:4:13
+  │
+4 │     let _ = X<Y<X>>();
+  │             ^ Unbound datatype or function 'X' in current scope
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/unknown_contructor_name.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/unknown_contructor_name.move
@@ -1,0 +1,5 @@
+module 0x42::m;
+
+public fun t() {
+    let _ = X<Y<X>>();
+}


### PR DESCRIPTION
## Description 

This improves the error for a specific naming miss.

## Test plan 

New test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
