### PR TITLE
[move-ide] Added support for enums

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -82,6 +82,7 @@ Move source file (a file with a `.move` file extension) and:
 - Place your cursor on a delimiter, such as `<`, `(`, or `{`, and its corresponding delimiter --
   `>`, `)`, or `}` -- will be highlighted.
 - As you type, the editor will offer completion suggestions, in particular:
+  - struct field name and method name suggestions following `.` being typed
   - code snippets to complete `init` function and object type definitions
 - If the opened Move source file is located within a buildable project (a `Move.toml` file can be
   found in one of its parent directories), the following advanced features will also be available:

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -597,7 +597,7 @@ impl TypingAnalysisContext<'_> {
                 ty.clone(),
                 false,
                 false,
-                guard_loc.clone(),
+                guard_loc,
             );
         });
 

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -129,12 +129,12 @@ impl TypingAnalysisContext<'_> {
         if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
             // a module will not be present if a constant belongs to an implicit module
             self.use_defs.insert(
-                mod_name_start.line as u32,
+                mod_name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
                     mod_name.loc().file_hash(),
-                    mod_name_start.into(),
+                    mod_name_start,
                     mod_defs.name_loc,
                     &mod_name.value(),
                     None,
@@ -150,12 +150,12 @@ impl TypingAnalysisContext<'_> {
             let const_info = self.def_info.get(&const_def.name_loc).unwrap();
             let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, const_info);
             self.use_defs.insert(
-                name_start.line as u32,
+                name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
                     use_pos.file_hash(),
-                    name_start.into(),
+                    name_start,
                     const_def.name_loc,
                     &use_name,
                     ident_type_def_loc,
@@ -194,12 +194,12 @@ impl TypingAnalysisContext<'_> {
         // enter self-definition for def name
         let ident_type_def_loc = type_def_loc(self.mod_outer_defs, &def_type);
         self.use_defs.insert(
-            name_start.line as u32,
+            name_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
                 loc.file_hash(),
-                name_start.into(),
+                name_start,
                 *loc,
                 name,
                 ident_type_def_loc,
@@ -222,12 +222,12 @@ impl TypingAnalysisContext<'_> {
         if let Some(local_def) = self.expression_scope.get(use_name) {
             let ident_type_def_loc = type_def_loc(self.mod_outer_defs, &local_def.def_type);
             self.use_defs.insert(
-                name_start.line as u32,
+                name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
                     use_pos.file_hash(),
-                    name_start.into(),
+                    name_start,
                     local_def.def_loc,
                     use_name,
                     ident_type_def_loc,
@@ -256,12 +256,12 @@ impl TypingAnalysisContext<'_> {
         if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
             // a module will not be present if a function belongs to an implicit module
             self.use_defs.insert(
-                mod_name_start.line as u32,
+                mod_name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
                     mod_name.loc().file_hash(),
-                    mod_name_start.into(),
+                    mod_name_start,
                     mod_defs.name_loc,
                     &mod_name.value(),
                     None,
@@ -305,12 +305,12 @@ impl TypingAnalysisContext<'_> {
         if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
             // a module will not be present if a struct belongs to an implicit module
             self.use_defs.insert(
-                mod_name_start.line as u32,
+                mod_name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
                     mod_name.loc().file_hash(),
-                    mod_name_start.into(),
+                    mod_name_start,
                     mod_defs.name_loc,
                     &mod_name.value(),
                     None,
@@ -977,7 +977,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                     true
                 }
                 TE::Constant(mod_ident, name) => {
-                    visitor.add_const_use_def(mod_ident, &name);
+                    visitor.add_const_use_def(mod_ident, name);
                     true
                 }
                 TE::ModuleCall(mod_call) => {
@@ -1120,12 +1120,12 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                 };
                 let ident_type_def_loc = type_def_loc(self.mod_outer_defs, ty);
                 self.use_defs.insert(
-                    name_start.line as u32,
+                    name_start.line,
                     UseDef::new(
                         self.references,
                         self.alias_lengths,
                         use_pos.file_hash(),
-                        name_start.into(),
+                        name_start,
                         *def_loc,
                         &use_name,
                         ident_type_def_loc,

--- a/external-crates/move/crates/move-analyzer/src/analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/analyzer.rs
@@ -44,7 +44,7 @@ pub fn run() {
     );
 
     let (connection, io_threads) = Connection::stdio();
-    let symbols = Arc::new(Mutex::new(symbols::empty_symbols()));
+    let symbols_map = Arc::new(Mutex::new(BTreeMap::new()));
     let pkg_deps = Arc::new(Mutex::new(
         BTreeMap::<PathBuf, symbols::PrecompiledPkgDeps>::new(),
     ));
@@ -135,7 +135,7 @@ pub fn run() {
 
     let symbolicator_runner = symbols::SymbolicatorRunner::new(
         ide_files_root.clone(),
-        symbols.clone(),
+        symbols_map.clone(),
         pkg_deps.clone(),
         diag_sender,
         lint,
@@ -154,15 +154,15 @@ pub fn run() {
                 p.as_path(),
                 lint,
             ) {
-                let mut old_symbols = symbols.lock().unwrap();
-                (*old_symbols).merge(new_symbols);
+                let mut old_symbols_map = symbols_map.lock().unwrap();
+                old_symbols_map.insert(p, new_symbols);
             }
         }
     }
 
     let context = Context {
         connection,
-        symbols: symbols.clone(),
+        symbols: symbols_map.clone(),
         inlay_type_hints: initialize_params
             .initialization_options
             .as_ref()
@@ -292,22 +292,22 @@ fn on_request(
             on_completion_request(context, request, ide_files_root.clone(), pkg_dependencies)
         }
         lsp_types::request::GotoDefinition::METHOD => {
-            symbols::on_go_to_def_request(context, request, &context.symbols.lock().unwrap());
+            symbols::on_go_to_def_request(context, request);
         }
         lsp_types::request::GotoTypeDefinition::METHOD => {
-            symbols::on_go_to_type_def_request(context, request, &context.symbols.lock().unwrap());
+            symbols::on_go_to_type_def_request(context, request);
         }
         lsp_types::request::References::METHOD => {
-            symbols::on_references_request(context, request, &context.symbols.lock().unwrap());
+            symbols::on_references_request(context, request);
         }
         lsp_types::request::HoverRequest::METHOD => {
-            symbols::on_hover_request(context, request, &context.symbols.lock().unwrap());
+            symbols::on_hover_request(context, request);
         }
         lsp_types::request::DocumentSymbolRequest::METHOD => {
-            symbols::on_document_symbol_request(context, request, &context.symbols.lock().unwrap());
+            symbols::on_document_symbol_request(context, request);
         }
         lsp_types::request::InlayHintRequest::METHOD => {
-            inlay_hints::on_inlay_hint_request(context, request, &context.symbols.lock().unwrap());
+            inlay_hints::on_inlay_hint_request(context, request);
         }
         lsp_types::request::Shutdown::METHOD => {
             eprintln!("Shutdown request received");

--- a/external-crates/move/crates/move-analyzer/src/compiler_info.rs
+++ b/external-crates/move/crates/move-analyzer/src/compiler_info.rs
@@ -12,6 +12,9 @@ pub struct CompilerInfo {
     pub macro_info: BTreeMap<Loc, CI::MacroCallInfo>,
     pub expanded_lambdas: BTreeSet<Loc>,
     pub autocomplete_info: BTreeMap<FileHash, BTreeMap<Loc, CI::AutocompleteInfo>>,
+    /// Locations of binders in enum variants that are expanded from an ellipsis (and should
+    /// not be displayed in any way by the IDE)
+    pub ellipsis_binders: BTreeSet<Loc>,
 }
 
 impl CompilerInfo {
@@ -54,7 +57,7 @@ impl CompilerInfo {
                     // TODO: Not much to do with this yet.
                 }
                 CI::IDEAnnotation::EllipsisMatchEntries(_) => {
-                    // TODO: Not much to do with this yet.
+                    self.ellipsis_binders.insert(loc);
                 }
             }
         }

--- a/external-crates/move/crates/move-analyzer/src/compiler_info.rs
+++ b/external-crates/move/crates/move-analyzer/src/compiler_info.rs
@@ -89,14 +89,11 @@ impl CompilerInfo {
         })
     }
 
-    pub fn inside_guard(&self, fhash: FileHash, loc: &Loc) -> bool {
+    pub fn inside_guard(&self, fhash: FileHash, loc: &Loc, gloc: &Loc) -> bool {
         self.guards
             .get(&fhash)
-            .and_then(|guard_locs| {
-                guard_locs
-                    .iter()
-                    .find_map(|gloc| if gloc.contains(loc) { Some(()) } else { None })
-            })
+            .and_then(|guard_locs| guard_locs.get(gloc))
             .is_some()
+            && gloc.contains(loc)
     }
 }

--- a/external-crates/move/crates/move-analyzer/src/compiler_info.rs
+++ b/external-crates/move/crates/move-analyzer/src/compiler_info.rs
@@ -15,6 +15,8 @@ pub struct CompilerInfo {
     /// Locations of binders in enum variants that are expanded from an ellipsis (and should
     /// not be displayed in any way by the IDE)
     pub ellipsis_binders: BTreeSet<Loc>,
+    /// Locations of guard expressions
+    pub guards: BTreeMap<FileHash, BTreeSet<Loc>>,
 }
 
 impl CompilerInfo {
@@ -85,5 +87,16 @@ impl CompilerInfo {
                 }
             })
         })
+    }
+
+    pub fn inside_guard(&self, fhash: FileHash, loc: &Loc) -> bool {
+        self.guards
+            .get(&fhash)
+            .and_then(|guard_locs| {
+                guard_locs
+                    .iter()
+                    .find_map(|gloc| if gloc.contains(loc) { Some(()) } else { None })
+            })
+            .is_some()
     }
 }

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -544,7 +544,7 @@ pub fn on_completion_request(
             }
         }
         None => {
-            eprintln!("failed completion for {:?} (package root not foune)", path);
+            eprintln!("failed completion for {:?} (package root not found)", path);
             vec![]
         }
     };

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -512,6 +512,7 @@ pub fn on_completion_request(
     ide_files_root: VfsPath,
     pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecompiledPkgDeps>>>,
 ) {
+    let symbols_map = &context.symbols.lock().unwrap();
     eprintln!("handling completion request");
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
         .expect("could not deserialize completion request");
@@ -533,10 +534,19 @@ pub fn on_completion_request(
                 LintLevel::None,
             ) {
                 Ok((Some(symbols), _)) => completion_items(pos, &path, &symbols),
-                _ => completion_items(pos, &path, &context.symbols.lock().unwrap()),
+                _ => {
+                    if let Some(symbols) = symbols_map.get(&pkg_path) {
+                        completion_items(pos, &path, symbols)
+                    } else {
+                        vec![]
+                    }
+                }
             }
         }
-        None => completion_items(pos, &path, &context.symbols.lock().unwrap()),
+        None => {
+            eprintln!("failed completion for {:?} (package root not foune)", path);
+            vec![]
+        }
     };
 
     let result = serde_json::to_value(items).expect("could not serialize completion response");

--- a/external-crates/move/crates/move-analyzer/src/context.rs
+++ b/external-crates/move/crates/move-analyzer/src/context.rs
@@ -4,14 +4,18 @@
 
 use crate::symbols::Symbols;
 use lsp_server::Connection;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeMap,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 /// The context within which the language server is running.
 pub struct Context {
     /// The connection with the language server's client.
     pub connection: Connection,
     /// Symbolication information
-    pub symbols: Arc<Mutex<Symbols>>,
+    pub symbols: Arc<Mutex<BTreeMap<PathBuf, Symbols>>>,
     /// Are inlay type hints enabled?
     pub inlay_type_hints: bool,
 }

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use lsp_server::Request;
 use lsp_types::{
-    InlayHint, InlayHintKind, InlayHintLabel, InlayHintLabelPart, InlayHintParams,
-    InlayHintTooltip, Position,
+    InlayHint, InlayHintKind, InlayHintLabel, InlayHintLabelPart, InlayHintParams, InlayHintTooltip,
 };
 
 use move_compiler::{naming::ast as N, shared::Identifier};
@@ -30,7 +29,7 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request, symbols: &Sym
             for mod_defs in file_defs {
                 for untyped_def_loc in mod_defs.untyped_defs() {
                     let start_position = symbols.files.start_position(untyped_def_loc);
-                    if let Some(DefInfo::Local(n, t, _, _)) = symbols.def_info(untyped_def_loc) {
+                    if let Some(DefInfo::Local(_, t, _, _)) = symbols.def_info(untyped_def_loc) {
                         let colon_label = InlayHintLabelPart {
                             value: ": ".to_string(),
                             tooltip: None,

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -107,7 +107,7 @@ fn additional_hint_info(sp!(_, t): &N::Type, symbols: &Symbols) -> Option<InlayH
         return None;
     };
 
-    let Some(struct_def_info) = symbols.def_info(&struct_def.name_start()) else {
+    let Some(struct_def_info) = symbols.def_info(&struct_def.name_loc) else {
         return None;
     };
 

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -11,10 +11,10 @@ use lsp_types::{
 };
 
 use move_compiler::{naming::ast as N, shared::Identifier};
+use std::path::PathBuf;
 
 /// Handles inlay hints request of the language server
 pub fn on_inlay_hint_request(context: &Context, request: &Request) {
-    let symbols_map = &context.symbols.lock().unwrap();
     let parameters = serde_json::from_value::<InlayHintParams>(request.params.clone())
         .expect("could not deserialize inlay hints request");
 
@@ -23,48 +23,7 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request) {
         "inlay_hints_request (types: {}): {:?}",
         context.inlay_type_hints, fpath
     );
-    let mut hints: Vec<InlayHint> = vec![];
-
-    if let Some(symbols) =
-        SymbolicatorRunner::root_dir(&fpath).and_then(|pkg_path| symbols_map.get(&pkg_path))
-    {
-        if context.inlay_type_hints {
-            if let Some(file_defs) = symbols.file_mods.get(&fpath) {
-                for mod_defs in file_defs {
-                    for untyped_def_loc in mod_defs.untyped_defs() {
-                        let start_position = symbols.files.start_position(untyped_def_loc);
-                        if let Some(DefInfo::Local(_, t, _, _, _)) =
-                            symbols.def_info(untyped_def_loc)
-                        {
-                            let colon_label = InlayHintLabelPart {
-                                value: ": ".to_string(),
-                                tooltip: None,
-                                location: None,
-                                command: None,
-                            };
-                            let type_label = InlayHintLabelPart {
-                                value: type_to_ide_string(t, /* verbose */ true),
-                                tooltip: None,
-                                location: None,
-                                command: None,
-                            };
-                            let h = InlayHint {
-                                position: start_position.into(),
-                                label: InlayHintLabel::LabelParts(vec![colon_label, type_label]),
-                                kind: Some(InlayHintKind::TYPE),
-                                text_edits: None,
-                                tooltip: additional_hint_info(t, symbols),
-                                padding_left: None,
-                                padding_right: None,
-                                data: None,
-                            };
-                            hints.push(h);
-                        }
-                    }
-                }
-            };
-        }
-    }
+    let hints = inlay_hints(context, fpath).unwrap_or_default();
 
     let response = lsp_server::Response::new_ok(request.id.clone(), hints);
     if let Err(err) = context
@@ -74,6 +33,45 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request) {
     {
         eprintln!("could not send inlay thing response: {:?}", err);
     }
+}
+
+fn inlay_hints(context: &Context, fpath: PathBuf) -> Option<Vec<InlayHint>> {
+    let symbols_map = &context.symbols.lock().unwrap();
+    let mut hints: Vec<InlayHint> = vec![];
+    let symbols =
+        SymbolicatorRunner::root_dir(&fpath).and_then(|pkg_path| symbols_map.get(&pkg_path))?;
+    let file_defs = symbols.file_mods.get(&fpath)?;
+    for mod_defs in file_defs {
+        for untyped_def_loc in mod_defs.untyped_defs() {
+            let start_position = symbols.files.start_position(untyped_def_loc);
+            if let DefInfo::Local(_, t, _, _, _) = symbols.def_info(untyped_def_loc)? {
+                let colon_label = InlayHintLabelPart {
+                    value: ": ".to_string(),
+                    tooltip: None,
+                    location: None,
+                    command: None,
+                };
+                let type_label = InlayHintLabelPart {
+                    value: type_to_ide_string(t, /* verbose */ true),
+                    tooltip: None,
+                    location: None,
+                    command: None,
+                };
+                let h = InlayHint {
+                    position: start_position.into(),
+                    label: InlayHintLabel::LabelParts(vec![colon_label, type_label]),
+                    kind: Some(InlayHintKind::TYPE),
+                    text_edits: None,
+                    tooltip: additional_hint_info(t, symbols),
+                    padding_left: None,
+                    padding_right: None,
+                    data: None,
+                };
+                hints.push(h);
+            }
+        }
+    }
+    Some(hints)
 }
 
 /// Helper function to compute additional optional info for the hint.
@@ -96,22 +94,15 @@ fn additional_hint_info(sp!(_, t): &N::Type, symbols: &Symbols) -> Option<InlayH
         return None;
     };
 
-    let Some(mod_defs) = symbols
+    let mod_defs = symbols
         .file_mods
         .values()
         .flatten()
-        .find(|m| m.ident() == &mod_ident.value)
-    else {
-        return None;
-    };
+        .find(|m| m.ident() == &mod_ident.value)?;
 
-    let Some(struct_def) = mod_defs.structs().get(&struct_name.value()) else {
-        return None;
-    };
+    let struct_def = mod_defs.structs().get(&struct_name.value())?;
 
-    let Some(struct_def_info) = symbols.def_info(&struct_def.name_loc) else {
-        return None;
-    };
+    let struct_def_info = symbols.def_info(&struct_def.name_loc)?;
 
     Some(InlayHintTooltip::MarkupContent(on_hover_markup(
         struct_def_info,

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -31,10 +31,6 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request, symbols: &Sym
                 for untyped_def_loc in mod_defs.untyped_defs() {
                     let start_position = symbols.files.start_position(untyped_def_loc);
                     if let Some(DefInfo::Local(n, t, _, _)) = symbols.def_info(untyped_def_loc) {
-                        let position = Position {
-                            line: start_position.line_offset() as u32,
-                            character: start_position.column_offset() as u32 + n.len() as u32,
-                        };
                         let colon_label = InlayHintLabelPart {
                             value: ": ".to_string(),
                             tooltip: None,
@@ -48,7 +44,7 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request, symbols: &Sym
                             command: None,
                         };
                         let h = InlayHint {
-                            position,
+                            position: start_position.into(),
                             label: InlayHintLabel::LabelParts(vec![colon_label, type_label]),
                             kind: Some(InlayHintKind::TYPE),
                             text_edits: None,

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -36,7 +36,7 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request) {
 }
 
 fn inlay_hints(context: &Context, fpath: PathBuf) -> Option<Vec<InlayHint>> {
-    let symbols_map = &context.symbols.lock().unwrap();
+    let symbols_map = &context.symbols.lock().ok()?;
     let mut hints: Vec<InlayHint> = vec![];
     let symbols =
         SymbolicatorRunner::root_dir(&fpath).and_then(|pkg_path| symbols_map.get(&pkg_path))?;

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2430,8 +2430,8 @@ impl<'a> ParsingSymbolicator<'a> {
             }
             MP::Name(_, chain) => self.chain_symbols(chain),
             MP::Or(m1, m2) => {
-                self.match_pattern_symbols(m1);
                 self.match_pattern_symbols(m2);
+                self.match_pattern_symbols(m1);
             }
             MP::At(_, m) => self.match_pattern_symbols(m),
             MP::Literal(_) => (),
@@ -3033,17 +3033,11 @@ pub fn maybe_convert_for_guard(
     let DefInfo::Local(name, ty, is_let, is_mut, guard_loc) = def_info else {
         return None;
     };
-    let Some(gloc) = guard_loc else {
-        return None;
-    };
-    let Some(fhash) = symbols.file_hash(use_fpath) else {
-        return None;
-    };
-    let Some(byte_idx) = lsp_position_to_byte_index(&symbols.files, fhash, position) else {
-        return None;
-    };
+    let gloc = (*guard_loc)?;
+    let fhash = symbols.file_hash(use_fpath)?;
+    let byte_idx = lsp_position_to_byte_index(&symbols.files, fhash, position)?;
     let loc = Loc::new(fhash, byte_idx, byte_idx);
-    if symbols.compiler_info.inside_guard(fhash, &loc, gloc) {
+    if symbols.compiler_info.inside_guard(fhash, &loc, &gloc) {
         let new_ty = sp(
             ty.loc,
             Type_::Ref(false, Box::new(sp(ty.loc, ty.value.base_type_()))),

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -59,7 +59,7 @@ use crate::{
     compiler_info::CompilerInfo,
     context::Context,
     diagnostics::{lsp_diagnostics, lsp_empty_diagnostics},
-    utils::loc_start_to_lsp_position_opt,
+    utils::{loc_start_to_lsp_position_opt, lsp_position_to_byte_index},
 };
 
 use anyhow::{anyhow, Result};
@@ -250,6 +250,8 @@ pub enum DefInfo {
         /// Should displayed definition be preceded by `let`?
         bool,
         /// Should displayed definition be preceded by `mut`?
+        bool,
+        /// Is it an enum arm's binder variable definition
         bool,
     ),
     Const(
@@ -591,7 +593,7 @@ impl fmt::Display for DefInfo {
                     type_to_ide_string(t, /* verbose */ true)
                 )
             }
-            Self::Local(name, t, is_decl, is_mut) => {
+            Self::Local(name, t, is_decl, is_mut, _) => {
                 let mut_str = if *is_mut { "mut " } else { "" };
                 if *is_decl {
                     write!(
@@ -925,7 +927,7 @@ impl SymbolicatorRunner {
     /// Create a new runner
     pub fn new(
         ide_files_root: VfsPath,
-        symbols: Arc<Mutex<Symbols>>,
+        symbols_map: Arc<Mutex<BTreeMap<PathBuf, Symbols>>>,
         pkg_deps: Arc<Mutex<BTreeMap<PathBuf, PrecompiledPkgDeps>>>,
         sender: Sender<Result<BTreeMap<PathBuf, Vec<Diagnostic>>>>,
         lint: LintLevel,
@@ -985,25 +987,24 @@ impl SymbolicatorRunner {
                             continue;
                         }
                         eprintln!("symbolication started");
+                        let pkg_path = root_dir.unwrap();
                         match get_symbols(
                             pkg_deps.clone(),
                             ide_files_root.clone(),
-                            root_dir.unwrap().as_path(),
+                            pkg_path.as_path(),
                             lint,
                         ) {
                             Ok((symbols_opt, lsp_diagnostics)) => {
                                 eprintln!("symbolication finished");
                                 if let Some(new_symbols) = symbols_opt {
-                                    // merge the new symbols with the old ones to support a
-                                    // (potentially) new project/package that symbolication information
-                                    // was built for
+                                    // replace symbolication info for a given package
                                     //
                                     // TODO: we may consider "unloading" symbolication information when
                                     // files/directories are being closed but as with other performance
                                     // optimizations (e.g. incrementalizatino of the vfs), let's wait
                                     // until we know we actually need it
-                                    let mut old_symbols = symbols.lock().unwrap();
-                                    (*old_symbols).merge(new_symbols);
+                                    let mut old_symbols_map = symbols_map.lock().unwrap();
+                                    old_symbols_map.insert(pkg_path, new_symbols);
                                 }
                                 // set/reset (previous) diagnostics
                                 if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
@@ -1278,15 +1279,6 @@ impl UseDefMap {
 }
 
 impl Symbols {
-    pub fn merge(&mut self, other: Self) {
-        for (k, v) in other.references {
-            self.references.entry(k).or_default().extend(v);
-        }
-        self.file_use_defs.extend(other.file_use_defs);
-        self.files.extend_with_duplicates(other.files);
-        self.def_info.extend(other.def_info);
-    }
-
     pub fn line_uses(&self, use_fpath: &Path, use_line: u32) -> BTreeSet<UseDef> {
         let Some(file_symbols) = self.file_use_defs.get(use_fpath) else {
             return BTreeSet::new();
@@ -2746,7 +2738,7 @@ pub fn def_info_to_type_def_loc(
         DefInfo::Enum(mod_ident, name, ..) => find_datatype(mod_outer_defs, mod_ident, name),
         DefInfo::Variant(..) => None,
         DefInfo::Field(.., t, _) => type_def_loc(mod_outer_defs, t),
-        DefInfo::Local(_, t, _, _) => type_def_loc(mod_outer_defs, t),
+        DefInfo::Local(_, t, _, _, _) => type_def_loc(mod_outer_defs, t),
         DefInfo::Const(_, _, t, _, _) => type_def_loc(mod_outer_defs, t),
         DefInfo::Module(..) => None,
     }
@@ -2890,7 +2882,8 @@ fn extract_doc_string(
 }
 
 /// Handles go-to-def request of the language server
-pub fn on_go_to_def_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_go_to_def_request(context: &Context, request: &Request) {
+    let symbols_map = &context.symbols.lock().unwrap();
     let parameters = serde_json::from_value::<GotoDefinitionParams>(request.params.clone())
         .expect("could not deserialize go-to-def request");
 
@@ -2906,34 +2899,22 @@ pub fn on_go_to_def_request(context: &Context, request: &Request, symbols: &Symb
 
     on_use_request(
         context,
-        symbols,
+        symbols_map,
         &fpath,
         line,
         col,
         request.id.clone(),
-        |u| {
+        |u, symbols| {
             let loc = def_ide_location(&u.def_loc, symbols);
             Some(serde_json::to_value(loc).unwrap())
         },
     );
 }
 
-pub fn def_ide_location(loc: &Loc, symbols: &Symbols) -> Location {
+pub fn def_ide_location(def_loc: &Loc, symbols: &Symbols) -> Location {
     // TODO: Do we need beginning and end of the definition? Does not seem to make a
     // difference from the IDE perspective as the cursor goes to the beginning anyway (at
     // least in VSCode).
-    let def_loc = if loc.start() as usize > symbols.files.file_size(&loc.file_hash()) {
-        // Locations for enum guard variable definitions are "reverted" (as we need two definitions
-        // to represent different types but they share the same location in the AST). We need to
-        // adjust the "reverted" value for go to def to jump to the right location
-        Loc::new(
-            loc.file_hash(),
-            std::u32::MAX - loc.start(),
-            std::u32::MAX - loc.end(),
-        )
-    } else {
-        *loc
-    };
     let span = symbols.files.position_opt(&def_loc).unwrap();
     let range = Range {
         start: span.start.into(),
@@ -2947,7 +2928,8 @@ pub fn def_ide_location(loc: &Loc, symbols: &Symbols) -> Location {
 }
 
 /// Handles go-to-type-def request of the language server
-pub fn on_go_to_type_def_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_go_to_type_def_request(context: &Context, request: &Request) {
+    let symbols_map = &context.symbols.lock().unwrap();
     let parameters = serde_json::from_value::<GotoTypeDefinitionParams>(request.params.clone())
         .expect("could not deserialize go-to-type-def request");
 
@@ -2963,23 +2945,23 @@ pub fn on_go_to_type_def_request(context: &Context, request: &Request, symbols: 
 
     on_use_request(
         context,
-        symbols,
+        symbols_map,
         &fpath,
         line,
         col,
         request.id.clone(),
-        |u| match u.type_def_loc {
-            Some(def_loc) => {
+        |u, symbols| {
+            u.type_def_loc.map(|def_loc| {
                 let loc = def_ide_location(&def_loc, symbols);
-                Some(serde_json::to_value(loc).unwrap())
-            }
-            None => Some(serde_json::to_value(Option::<lsp_types::Location>::None).unwrap()),
+                serde_json::to_value(loc).unwrap()
+            })
         },
     );
 }
 
 /// Handles go-to-references request of the language server
-pub fn on_references_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_references_request(context: &Context, request: &Request) {
+    let symbols_map = &context.symbols.lock().unwrap();
     let parameters = serde_json::from_value::<ReferenceParams>(request.params.clone())
         .expect("could not deserialize references request");
 
@@ -2996,15 +2978,17 @@ pub fn on_references_request(context: &Context, request: &Request, symbols: &Sym
 
     on_use_request(
         context,
-        symbols,
+        symbols_map,
         &fpath,
         line,
         col,
         request.id.clone(),
-        |u| {
+        |u, symbols| {
             let def_posn = symbols.files.file_start_position_opt(&u.def_loc)?;
-            match symbols.references.get(&u.def_loc) {
-                Some(s) => {
+            symbols
+                .references
+                .get(&u.def_loc)
+                .map(|s| {
                     let mut locs = vec![];
 
                     for ref_loc in s {
@@ -3027,20 +3011,50 @@ pub fn on_references_request(context: &Context, request: &Request, symbols: &Sym
                             });
                         }
                     }
-                    if locs.is_empty() {
-                        Some(serde_json::to_value(Option::<lsp_types::Location>::None).unwrap())
-                    } else {
-                        Some(serde_json::to_value(locs).unwrap())
-                    }
-                }
-                None => Some(serde_json::to_value(Option::<lsp_types::Location>::None).unwrap()),
-            }
+                    locs
+                })
+                .and_then(|locs| Some(serde_json::to_value(locs).unwrap()))
         },
     );
 }
 
+/// Helper function that take a DefInfo, checks if it represents
+/// a enum arm variable defintion, and if need be converts it
+/// to the one that represents an enum guard variable (which
+/// has immutable reference type regarldes of arm variable definition
+/// type).
+pub fn maybe_convert_for_guard(
+    def_info: &DefInfo,
+    use_fpath: &Path,
+    position: &Position,
+    symbols: &Symbols,
+) -> Option<DefInfo> {
+    let DefInfo::Local(name, ty, is_let, is_mut, arm_binder) = def_info else {
+        return None;
+    };
+    if !arm_binder {
+        return None;
+    }
+    let Some(fhash) = symbols.file_hash(use_fpath) else {
+        return None;
+    };
+    let Some(byte_idx) = lsp_position_to_byte_index(&symbols.files, fhash, position) else {
+        return None;
+    };
+    let loc = Loc::new(fhash, byte_idx, byte_idx);
+    if symbols.compiler_info.inside_guard(fhash, &loc) {
+        let new_ty = sp(
+            ty.loc,
+            Type_::Ref(false, Box::new(sp(ty.loc, ty.value.base_type_()))),
+        );
+        return Some(DefInfo::Local(*name, new_ty, *is_let, *is_mut, *arm_binder));
+    }
+    None
+}
+
 /// Handles hover request of the language server
-pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_hover_request(context: &Context, request: &Request) {
+    let symbols_map = &context.symbols.lock().unwrap();
     let parameters = serde_json::from_value::<HoverParams>(request.params.clone())
         .expect("could not deserialize hover request");
 
@@ -3056,18 +3070,21 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
 
     on_use_request(
         context,
-        symbols,
+        symbols_map,
         &fpath,
         line,
         col,
         request.id.clone(),
-        |u| {
+        |u, symbols| {
             let Some(info) = symbols.def_info.get(&u.def_loc) else {
                 return Some(serde_json::to_value(Option::<lsp_types::Location>::None).unwrap());
             };
-
-            // use rust for highlighting in Markdown until there is support for Move
-            let contents = HoverContents::Markup(on_hover_markup(info));
+            let contents =
+                if let Some(guard_info) = maybe_convert_for_guard(info, &fpath, &loc, symbols) {
+                    HoverContents::Markup(on_hover_markup(&guard_info))
+                } else {
+                    HoverContents::Markup(on_hover_markup(info))
+                };
             let range = None;
             Some(serde_json::to_value(Hover { contents, range }).unwrap())
         },
@@ -3075,6 +3092,7 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
 }
 
 pub fn on_hover_markup(info: &DefInfo) -> MarkupContent {
+    // use rust for highlighting in Markdown until there is support for Move
     let value = if let Some(s) = &def_info_doc_string(info) {
         format!("```rust\n{}\n```\n{}", info, s)
     } else {
@@ -3089,32 +3107,37 @@ pub fn on_hover_markup(info: &DefInfo) -> MarkupContent {
 /// Helper function to handle language server queries related to identifier uses
 pub fn on_use_request(
     context: &Context,
-    symbols: &Symbols,
+    symbols_map: &BTreeMap<PathBuf, Symbols>,
     use_fpath: &PathBuf,
     use_line: u32,
     use_col: u32,
     id: RequestId,
-    use_def_action: impl Fn(&UseDef) -> Option<serde_json::Value>,
+    use_def_action: impl Fn(&UseDef, &Symbols) -> Option<serde_json::Value>,
 ) {
     let mut result = None;
 
-    let mut use_def_found = false;
-
-    if let Some(mod_symbols) = symbols.file_use_defs.get(use_fpath) {
-        if let Some(uses) = mod_symbols.get(use_line) {
-            for u in uses {
-                if use_col >= u.col_start && use_col <= u.col_end {
-                    result = use_def_action(&u);
-                    use_def_found = true;
+    if let Some(symbols) =
+        SymbolicatorRunner::root_dir(use_fpath).and_then(|pkg_path| symbols_map.get(&pkg_path))
+    {
+        if let Some(mod_symbols) = symbols.file_use_defs.get(use_fpath) {
+            if let Some(uses) = mod_symbols.get(use_line) {
+                for u in uses {
+                    if use_col >= u.col_start && use_col <= u.col_end {
+                        result = use_def_action(&u, symbols);
+                    }
                 }
             }
         }
     }
-    if !use_def_found {
+    eprintln!(
+        "about to send use response (symbols found: {})",
+        result.is_some()
+    );
+
+    if result.is_none() {
         result = Some(serde_json::to_value(Option::<lsp_types::Location>::None).unwrap());
     }
 
-    eprintln!("about to send use response (symbols found: {use_def_found})");
     // unwrap will succeed based on the logic above which the compiler is unable to figure out
     // without using Option
     let response = lsp_server::Response::new_ok(id, result.unwrap());
@@ -3129,120 +3152,124 @@ pub fn on_use_request(
 
 /// Handles document symbol request of the language server
 #[allow(deprecated)]
-pub fn on_document_symbol_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_document_symbol_request(context: &Context, request: &Request) {
+    let symbols_map = &context.symbols.lock().unwrap();
     let parameters = serde_json::from_value::<DocumentSymbolParams>(request.params.clone())
         .expect("could not deserialize document symbol request");
 
     let fpath = parameters.text_document.uri.to_file_path().unwrap();
     eprintln!("on_document_symbol_request: {:?}", fpath);
 
-    let empty_mods: BTreeSet<ModuleDefs> = BTreeSet::new();
-    let mods = symbols.file_mods.get(&fpath).unwrap_or(&empty_mods);
-
     let mut defs: Vec<DocumentSymbol> = vec![];
-    for mod_def in mods {
-        let name = mod_def.ident.module.clone().to_string();
-        let detail = Some(mod_def.ident.clone().to_string());
-        let kind = SymbolKind::MODULE;
-        let Some(range) = symbols.files.lsp_range_opt(&mod_def.name_loc) else {
-            continue;
-        };
+    if let Some(symbols) =
+        SymbolicatorRunner::root_dir(&fpath).and_then(|pkg_path| symbols_map.get(&pkg_path))
+    {
+        let empty_mods: BTreeSet<ModuleDefs> = BTreeSet::new();
+        let mods = symbols.file_mods.get(&fpath).unwrap_or(&empty_mods);
 
-        let mut children = vec![];
-
-        // handle constants
-        for (sym, const_def) in &mod_def.constants {
-            let Some(const_range) = symbols.files.lsp_range_opt(&const_def.name_loc) else {
-                continue;
-            };
-            children.push(DocumentSymbol {
-                name: sym.clone().to_string(),
-                detail: None,
-                kind: SymbolKind::CONSTANT,
-                range: const_range,
-                selection_range: const_range,
-                children: None,
-                tags: Some(vec![]),
-                deprecated: Some(false),
-            });
-        }
-
-        // handle structs
-        for (sym, struct_def) in &mod_def.structs {
-            let Some(struct_range) = symbols.files.lsp_range_opt(&struct_def.name_loc) else {
+        for mod_def in mods {
+            let name = mod_def.ident.module.clone().to_string();
+            let detail = Some(mod_def.ident.clone().to_string());
+            let kind = SymbolKind::MODULE;
+            let Some(range) = symbols.files.lsp_range_opt(&mod_def.name_loc) else {
                 continue;
             };
 
-            let fields = struct_field_symbols(struct_def, symbols);
-            children.push(DocumentSymbol {
-                name: sym.clone().to_string(),
-                detail: None,
-                kind: SymbolKind::STRUCT,
-                range: struct_range,
-                selection_range: struct_range,
-                children: Some(fields),
-                tags: Some(vec![]),
-                deprecated: Some(false),
-            });
-        }
+            let mut children = vec![];
 
-        // handle enums
-        for (sym, enum_def) in &mod_def.enums {
-            let Some(enum_range) = symbols.files.lsp_range_opt(&enum_def.name_loc) else {
-                continue;
-            };
-
-            let variants = enum_variant_symbols(enum_def, symbols);
-            children.push(DocumentSymbol {
-                name: sym.clone().to_string(),
-                detail: None,
-                kind: SymbolKind::ENUM,
-                range: enum_range,
-                selection_range: enum_range,
-                children: Some(variants),
-                tags: Some(vec![]),
-                deprecated: Some(false),
-            });
-        }
-
-        // handle functions
-        for (sym, func_def) in &mod_def.functions {
-            let MemberDefInfo::Fun { attrs } = &func_def.info else {
-                continue;
-            };
-            let Some(func_range) = symbols.files.lsp_range_opt(&func_def.name_loc) else {
-                continue;
-            };
-
-            let mut detail = None;
-            if !attrs.is_empty() {
-                detail = Some(format!("{:?}", attrs));
+            // handle constants
+            for (sym, const_def) in &mod_def.constants {
+                let Some(const_range) = symbols.files.lsp_range_opt(&const_def.name_loc) else {
+                    continue;
+                };
+                children.push(DocumentSymbol {
+                    name: sym.clone().to_string(),
+                    detail: None,
+                    kind: SymbolKind::CONSTANT,
+                    range: const_range,
+                    selection_range: const_range,
+                    children: None,
+                    tags: Some(vec![]),
+                    deprecated: Some(false),
+                });
             }
 
-            children.push(DocumentSymbol {
-                name: sym.clone().to_string(),
+            // handle structs
+            for (sym, struct_def) in &mod_def.structs {
+                let Some(struct_range) = symbols.files.lsp_range_opt(&struct_def.name_loc) else {
+                    continue;
+                };
+
+                let fields = struct_field_symbols(struct_def, symbols);
+                children.push(DocumentSymbol {
+                    name: sym.clone().to_string(),
+                    detail: None,
+                    kind: SymbolKind::STRUCT,
+                    range: struct_range,
+                    selection_range: struct_range,
+                    children: Some(fields),
+                    tags: Some(vec![]),
+                    deprecated: Some(false),
+                });
+            }
+
+            // handle enums
+            for (sym, enum_def) in &mod_def.enums {
+                let Some(enum_range) = symbols.files.lsp_range_opt(&enum_def.name_loc) else {
+                    continue;
+                };
+
+                let variants = enum_variant_symbols(enum_def, symbols);
+                children.push(DocumentSymbol {
+                    name: sym.clone().to_string(),
+                    detail: None,
+                    kind: SymbolKind::ENUM,
+                    range: enum_range,
+                    selection_range: enum_range,
+                    children: Some(variants),
+                    tags: Some(vec![]),
+                    deprecated: Some(false),
+                });
+            }
+
+            // handle functions
+            for (sym, func_def) in &mod_def.functions {
+                let MemberDefInfo::Fun { attrs } = &func_def.info else {
+                    continue;
+                };
+                let Some(func_range) = symbols.files.lsp_range_opt(&func_def.name_loc) else {
+                    continue;
+                };
+
+                let mut detail = None;
+                if !attrs.is_empty() {
+                    detail = Some(format!("{:?}", attrs));
+                }
+
+                children.push(DocumentSymbol {
+                    name: sym.clone().to_string(),
+                    detail,
+                    kind: SymbolKind::FUNCTION,
+                    range: func_range,
+                    selection_range: func_range,
+                    children: None,
+                    tags: Some(vec![]),
+                    deprecated: Some(false),
+                });
+            }
+
+            defs.push(DocumentSymbol {
+                name,
                 detail,
-                kind: SymbolKind::FUNCTION,
-                range: func_range,
-                selection_range: func_range,
-                children: None,
+                kind,
+                range,
+                selection_range: range,
+                children: Some(children),
                 tags: Some(vec![]),
                 deprecated: Some(false),
             });
         }
-
-        defs.push(DocumentSymbol {
-            name,
-            detail,
-            kind,
-            range,
-            selection_range: range,
-            children: Some(children),
-            tags: Some(vec![]),
-            deprecated: Some(false),
-        });
     }
-
     // unwrap will succeed based on the logic above which the compiler is unable to figure out
     let response = lsp_server::Response::new_ok(request.id.clone(), defs);
     if let Err(err) = context

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2915,7 +2915,7 @@ pub fn def_ide_location(def_loc: &Loc, symbols: &Symbols) -> Location {
     // TODO: Do we need beginning and end of the definition? Does not seem to make a
     // difference from the IDE perspective as the cursor goes to the beginning anyway (at
     // least in VSCode).
-    let span = symbols.files.position_opt(&def_loc).unwrap();
+    let span = symbols.files.position_opt(def_loc).unwrap();
     let range = Range {
         start: span.start.into(),
         end: span.end.into(),
@@ -3013,7 +3013,7 @@ pub fn on_references_request(context: &Context, request: &Request) {
                     }
                     locs
                 })
-                .and_then(|locs| Some(serde_json::to_value(locs).unwrap()))
+                .map(|locs| serde_json::to_value(locs).unwrap())
         },
     );
 }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -901,7 +901,7 @@ fn variant_to_ide_string(variants: &[VariantInfo]) -> String {
         .enumerate()
         .map(|(idx, info)| {
             if idx >= NUM_PRINTED - 1 {
-                format!("\t/* ... */")
+                "\t/* ... */".to_string()
             } else if info.empty {
                 format!("\t{}", info.name)
             } else if info.positional {
@@ -1969,7 +1969,7 @@ fn get_mod_outer_defs(
                     let (defs, types) = field_defs_and_types(
                         *name,
                         name_loc,
-                        &fields,
+                        fields,
                         mod_ident,
                         files,
                         file_id_to_lines,
@@ -3289,7 +3289,7 @@ fn enum_variant_symbols(enum_def: &MemberDef, symbols: &Symbols) -> Vec<Document
     let mut variants: Vec<DocumentSymbol> = vec![];
     if let MemberDefInfo::Enum { variants_info } = &enum_def.info {
         for (name, (loc, _, _)) in variants_info {
-            let Some(variant_range) = symbols.files.lsp_range_opt(&loc) else {
+            let Some(variant_range) = symbols.files.lsp_range_opt(loc) else {
                 continue;
             };
 

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -95,7 +95,7 @@ use move_compiler::{
     editions::{Edition, FeatureGate, Flavor},
     expansion::ast::{self as E, AbilitySet, ModuleIdent, ModuleIdent_, Value, Value_, Visibility},
     linters::LintLevel,
-    naming::ast::{StructFields, Type, TypeName_, Type_},
+    naming::ast::{DatatypeTypeParameter, StructFields, Type, TypeName_, Type_, VariantFields},
     parser::ast::{self as P},
     shared::{
         files::{FileId, MappedFiles},
@@ -148,6 +148,12 @@ pub enum FunType {
     Regular,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct VariantInfo {
+    name: Symbol,
+    empty: bool,
+    positional: bool,
+}
 /// Information about a definition of some identifier
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(clippy::large_enum_variant)]
@@ -185,6 +191,38 @@ pub enum DefInfo {
         Vec<(Type, bool /* phantom */)>,
         /// Abilities
         AbilitySet,
+        /// Field names
+        Vec<Symbol>,
+        /// Field types
+        Vec<Type>,
+        /// Doc string
+        Option<String>,
+    ),
+    Enum(
+        /// Defining module
+        ModuleIdent_,
+        /// Name
+        Symbol,
+        /// Visibility
+        Visibility,
+        /// Type args
+        Vec<(Type, bool /* phantom */)>,
+        /// Abilities
+        AbilitySet,
+        /// Info about variants
+        Vec<VariantInfo>,
+        /// Doc string
+        Option<String>,
+    ),
+    Variant(
+        /// Defining module of the containing enum
+        ModuleIdent_,
+        /// Name of the containing enum
+        Symbol,
+        /// Variant name
+        Symbol,
+        /// Positional fields?
+        bool,
         /// Field names
         Vec<Symbol>,
         /// Field types
@@ -256,26 +294,26 @@ pub struct FieldDef {
     pub loc: Loc,
 }
 
-/// Definition of a struct
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct StructDef {
-    pub name_loc: Loc,
-    pub field_defs: Vec<FieldDef>,
-    /// Does this struct have positional fields?
-    pub positional: bool,
+pub enum MemberDefInfo {
+    Struct {
+        field_defs: Vec<FieldDef>,
+        positional: bool,
+    },
+    Enum {
+        variants_info: BTreeMap<Symbol, (Loc, Vec<FieldDef>, /* positional */ bool)>,
+    },
+    Fun {
+        attrs: Vec<String>,
+    },
+    Const,
 }
 
-impl StructDef {
-    pub fn name_start(&self) -> Loc {
-        self.name_loc
-    }
-}
-
+/// Definition of a module member
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FunctionDef {
-    pub name: Symbol,
+pub struct MemberDef {
     pub name_loc: Loc,
-    pub attrs: Vec<String>,
+    pub info: MemberDefInfo,
 }
 
 /// Definition of a local (or parameter)
@@ -291,12 +329,6 @@ pub struct LocalDef {
     pub def_type: Type,
 }
 
-/// Definition of a constant
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ConstDef {
-    pub name_loc: Loc,
-}
-
 /// Module-level definitions
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ModuleDefs {
@@ -307,11 +339,13 @@ pub struct ModuleDefs {
     /// Module name
     pub ident: ModuleIdent_,
     /// Struct definitions
-    pub structs: BTreeMap<Symbol, StructDef>,
+    pub structs: BTreeMap<Symbol, MemberDef>,
+    /// Enum definitions
+    pub enums: BTreeMap<Symbol, MemberDef>,
     /// Const definitions
-    pub constants: BTreeMap<Symbol, ConstDef>,
+    pub constants: BTreeMap<Symbol, MemberDef>,
     /// Function definitions
-    pub functions: BTreeMap<Symbol, FunctionDef>,
+    pub functions: BTreeMap<Symbol, MemberDef>,
     /// Definitions where the type is not explicitly specified
     pub untyped_defs: BTreeSet<Loc>,
 }
@@ -383,11 +417,11 @@ pub struct SymbolicatorRunner {
 }
 
 impl ModuleDefs {
-    pub fn functions(&self) -> &BTreeMap<Symbol, FunctionDef> {
+    pub fn functions(&self) -> &BTreeMap<Symbol, MemberDef> {
         &self.functions
     }
 
-    pub fn structs(&self) -> &BTreeMap<Symbol, StructDef> {
+    pub fn structs(&self) -> &BTreeMap<Symbol, MemberDef> {
         &self.structs
     }
 
@@ -456,21 +490,8 @@ impl fmt::Display for DefInfo {
                 _,
             ) => {
                 let type_args_str =
-                    struct_type_args_to_ide_string(type_args, /* verbose */ true);
-                let abilities_str = if abilities.is_empty() {
-                    "".to_string()
-                } else {
-                    format!(
-                        " has {}",
-                        abilities
-                            .iter()
-                            .map(|a| format!("{a}"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
-                };
-                // the mod_ident conversions below will ensure that only pkg name (without numerical
-                // address) is displayed which is the same as in source
+                    datatype_type_args_to_ide_string(type_args, /* verbose */ true);
+                let abilities_str = abilities_to_id_string(abilities);
                 if field_names.is_empty() {
                     write!(
                         f,
@@ -499,11 +520,72 @@ impl fmt::Display for DefInfo {
                     )
                 }
             }
+            Self::Enum(mod_ident, name, visibility, type_args, abilities, variants, _) => {
+                let type_args_str =
+                    datatype_type_args_to_ide_string(type_args, /* verbose */ true);
+                let abilities_str = abilities_to_id_string(abilities);
+                if variants.is_empty() {
+                    write!(
+                        f,
+                        "{}enum {}::{}{}{} {{}}",
+                        visibility_to_ide_string(visibility),
+                        mod_ident_to_ide_string(mod_ident),
+                        name,
+                        type_args_str,
+                        abilities_str,
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{}enum {}::{}{}{} {{\n{}\n}}",
+                        visibility_to_ide_string(visibility),
+                        mod_ident_to_ide_string(mod_ident),
+                        name,
+                        type_args_str,
+                        abilities_str,
+                        variant_to_ide_string(variants)
+                    )
+                }
+            }
+            Self::Variant(mod_ident, enum_name, name, positional, field_names, field_types, _) => {
+                if field_types.is_empty() {
+                    write!(
+                        f,
+                        "{}::{}::{}",
+                        mod_ident_to_ide_string(mod_ident),
+                        enum_name,
+                        name
+                    )
+                } else if *positional {
+                    write!(
+                        f,
+                        "{}::{}::{}({})",
+                        mod_ident_to_ide_string(mod_ident),
+                        enum_name,
+                        name,
+                        type_list_to_ide_string(field_types, /* verbose */ true)
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{}::{}::{}{{{}}}",
+                        mod_ident_to_ide_string(mod_ident),
+                        enum_name,
+                        name,
+                        typed_id_list_to_ide_string(
+                            field_names,
+                            field_types,
+                            /* separate_lines */ false,
+                            /* verbose */ true,
+                        ),
+                    )
+                }
+            }
             Self::Field(mod_ident, struct_name, name, t, _) => {
                 write!(
                     f,
                     "{}::{}\n{}: {}",
-                    mod_ident,
+                    mod_ident_to_ide_string(mod_ident),
                     struct_name,
                     name,
                     type_to_ide_string(t, /* verbose */ true)
@@ -573,11 +655,11 @@ pub fn type_args_to_ide_string(type_args: &[Type], verbose: bool) -> String {
     type_args_str
 }
 
-fn struct_type_args_to_ide_string(type_args: &[(Type, bool)], verbose: bool) -> String {
+fn datatype_type_args_to_ide_string(type_args: &[(Type, bool)], verbose: bool) -> String {
     let mut type_args_str = "".to_string();
     if !type_args.is_empty() {
         type_args_str.push('<');
-        type_args_str.push_str(&struct_type_list_to_ide_string(type_args, verbose));
+        type_args_str.push_str(&datatype_type_list_to_ide_string(type_args, verbose));
         type_args_str.push('>');
     }
     type_args_str
@@ -659,7 +741,7 @@ pub fn type_list_to_ide_string(types: &[Type], verbose: bool) -> String {
         .join(", ")
 }
 
-fn struct_type_list_to_ide_string(types: &[(Type, bool)], verbose: bool) -> String {
+fn datatype_type_list_to_ide_string(types: &[(Type, bool)], verbose: bool) -> String {
     types
         .iter()
         .map(|(t, phantom)| {
@@ -793,6 +875,37 @@ fn fun_type_to_ide_string(fun_type: &FunType) -> String {
         FunType::Regular => "",
     }
     .to_string()
+}
+
+fn abilities_to_id_string(abilities: &AbilitySet) -> String {
+    if abilities.is_empty() {
+        "".to_string()
+    } else {
+        format!(
+            " has {}",
+            abilities
+                .iter()
+                .map(|a| format!("{a}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+fn variant_to_ide_string(variants: &[VariantInfo]) -> String {
+    variants
+        .iter()
+        .map(|info| {
+            if info.empty {
+                format!("\t{}", info.name)
+            } else if info.positional {
+                format!("\t{}( /* ... */ )", info.name)
+            } else {
+                format!("\t{}{{ /* ... */ }}", info.name)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",\n")
 }
 
 impl SymbolicatorRunner {
@@ -1720,6 +1833,53 @@ fn ignored_function(name: Symbol) -> bool {
 
 /// Main AST traversal functions
 
+fn field_defs_and_types(
+    datatype_name: Symbol,
+    datatype_loc: Loc,
+    fields: &E::Fields<Type>,
+    mod_ident: &ModuleIdent,
+    files: &MappedFiles,
+    file_id_to_lines: &HashMap<usize, Vec<String>>,
+    def_info: &mut DefMap,
+) -> (Vec<FieldDef>, Vec<Type>) {
+    let mut field_defs = vec![];
+    let mut field_types = vec![];
+    for (floc, fname, (_, t)) in fields {
+        field_defs.push(FieldDef {
+            name: *fname,
+            loc: floc,
+        });
+        let doc_string = extract_doc_string(files, file_id_to_lines, &floc, Some(datatype_loc));
+        def_info.insert(
+            floc,
+            DefInfo::Field(
+                mod_ident.value,
+                datatype_name,
+                *fname,
+                t.clone(),
+                doc_string,
+            ),
+        );
+        field_types.push(t.clone());
+    }
+    (field_defs, field_types)
+}
+
+fn datatype_type_params(data_tparams: &[DatatypeTypeParameter]) -> Vec<(Type, /* phantom */ bool)> {
+    data_tparams
+        .iter()
+        .map(|t| {
+            (
+                sp(
+                    t.param.user_specified_name.loc,
+                    Type_::Param(t.param.clone()),
+                ),
+                t.is_phantom,
+            )
+        })
+        .collect()
+}
+
 /// Get symbols for outer definitions in the module (functions, structs, and consts)
 fn get_mod_outer_defs(
     loc: &Loc,
@@ -1732,6 +1892,7 @@ fn get_mod_outer_defs(
     edition: &Option<Edition>,
 ) -> (ModuleDefs, UseDefMap) {
     let mut structs = BTreeMap::new();
+    let mut enums = BTreeMap::new();
     let mut constants = BTreeMap::new();
     let mut functions = BTreeMap::new();
 
@@ -1743,29 +1904,27 @@ fn get_mod_outer_defs(
         let mut field_types = vec![];
         if let StructFields::Defined(pos_fields, fields) = &def.fields {
             positional = *pos_fields;
-            for (floc, fname, (_, t)) in fields {
-                field_defs.push(FieldDef {
-                    name: *fname,
-                    loc: floc,
-                });
-                let doc_string = extract_doc_string(files, file_id_to_lines, &floc);
-                def_info.insert(
-                    floc,
-                    DefInfo::Field(mod_ident.value, *name, *fname, t.clone(), doc_string),
-                );
-                field_types.push(t.clone());
-            }
+            (field_defs, field_types) = field_defs_and_types(
+                *name,
+                name_loc,
+                fields,
+                mod_ident,
+                files,
+                file_id_to_lines,
+                def_info,
+            );
         };
 
         // process the struct itself
-
         let field_names = field_defs.iter().map(|f| f.name).collect();
         structs.insert(
             *name,
-            StructDef {
+            MemberDef {
                 name_loc,
-                field_defs,
-                positional,
+                info: MemberDefInfo::Struct {
+                    field_defs,
+                    positional,
+                },
             },
         );
         let pub_struct = edition
@@ -1777,25 +1936,14 @@ fn get_mod_outer_defs(
         } else {
             Visibility::Internal
         };
-        let doc_string = extract_doc_string(files, file_id_to_lines, &name_loc);
+        let doc_string = extract_doc_string(files, file_id_to_lines, &name_loc, None);
         def_info.insert(
             name_loc,
             DefInfo::Struct(
                 mod_ident.value,
                 *name,
                 visibility,
-                def.type_parameters
-                    .iter()
-                    .map(|t| {
-                        (
-                            sp(
-                                t.param.user_specified_name.loc,
-                                Type_::Param(t.param.clone()),
-                            ),
-                            t.is_phantom,
-                        )
-                    })
-                    .collect(),
+                datatype_type_params(&def.type_parameters),
                 def.abilities.clone(),
                 field_names,
                 field_types,
@@ -1804,9 +1952,81 @@ fn get_mod_outer_defs(
         );
     }
 
+    for (name_loc, name, def) in &mod_def.enums {
+        // process variants
+        let mut variants_info = BTreeMap::new();
+        let mut def_info_variants = vec![];
+        for (vname_loc, vname, vdef) in &def.variants {
+            let (field_defs, field_types, positional) = match &vdef.fields {
+                VariantFields::Defined(pos_fields, fields) => {
+                    let (defs, types) = field_defs_and_types(
+                        *name,
+                        name_loc,
+                        &fields,
+                        mod_ident,
+                        files,
+                        file_id_to_lines,
+                        def_info,
+                    );
+                    (defs, types, *pos_fields)
+                }
+                VariantFields::Empty => (vec![], vec![], false),
+            };
+            let field_names = field_defs.iter().map(|f| f.name).collect();
+            def_info_variants.push(VariantInfo {
+                name: *vname,
+                empty: field_defs.is_empty(),
+                positional,
+            });
+            variants_info.insert(*vname, (vname_loc, field_defs, positional));
+
+            let vdoc_string =
+                extract_doc_string(files, file_id_to_lines, &vname_loc, Some(name_loc));
+            def_info.insert(
+                vname_loc,
+                DefInfo::Variant(
+                    mod_ident.value,
+                    *name,
+                    *vname,
+                    positional,
+                    field_names,
+                    field_types,
+                    vdoc_string,
+                ),
+            );
+        }
+        // process the enum itself
+        enums.insert(
+            *name,
+            MemberDef {
+                name_loc,
+                info: MemberDefInfo::Enum { variants_info },
+            },
+        );
+        let enum_doc_string = extract_doc_string(files, file_id_to_lines, &name_loc, None);
+        def_info.insert(
+            name_loc,
+            DefInfo::Enum(
+                mod_ident.value,
+                *name,
+                Visibility::Public(Loc::invalid()),
+                datatype_type_params(&def.type_parameters),
+                def.abilities.clone(),
+                def_info_variants,
+                enum_doc_string,
+            ),
+        );
+    }
+
     for (name_loc, name, c) in &mod_def.constants {
-        constants.insert(*name, ConstDef { name_loc });
-        let doc_string = extract_doc_string(files, file_id_to_lines, &name_loc);
+        constants.insert(
+            *name,
+            MemberDef {
+                name_loc,
+                info: MemberDefInfo::Const,
+            },
+        );
+        let doc_string = extract_doc_string(files, file_id_to_lines, &name_loc, None);
         def_info.insert(
             name_loc,
             DefInfo::Const(
@@ -1830,7 +2050,7 @@ fn get_mod_outer_defs(
         } else {
             FunType::Regular
         };
-        let doc_string = extract_doc_string(files, file_id_to_lines, &name_loc);
+        let doc_string = extract_doc_string(files, file_id_to_lines, &name_loc, None);
         let fun_info = DefInfo::Function(
             mod_ident.value,
             fun.visibility,
@@ -1856,15 +2076,16 @@ fn get_mod_outer_defs(
         );
         functions.insert(
             *name,
-            FunctionDef {
-                name: *name,
+            MemberDef {
                 name_loc,
-                attrs: fun
-                    .attributes
-                    .clone()
-                    .iter()
-                    .map(|(_loc, name, _attr)| name.to_string())
-                    .collect(),
+                info: MemberDefInfo::Fun {
+                    attrs: fun
+                        .attributes
+                        .clone()
+                        .iter()
+                        .map(|(_loc, name, _attr)| name.to_string())
+                        .collect(),
+                },
             },
         );
         def_info.insert(name_loc, fun_info);
@@ -1873,13 +2094,13 @@ fn get_mod_outer_defs(
     let mut use_def_map = UseDefMap::new();
 
     let ident = mod_ident.value;
-
-    let doc_comment = extract_doc_string(files, file_id_to_lines, loc);
+    let doc_comment = extract_doc_string(files, file_id_to_lines, loc, None);
     let mod_defs = ModuleDefs {
         fhash,
         ident,
         name_loc: *loc,
         structs,
+        enums,
         constants,
         functions,
         untyped_defs: BTreeSet::new(),
@@ -2104,6 +2325,16 @@ impl<'a> ParsingSymbolicator<'a> {
                     self.exp_symbols(e)
                 }
             }
+            E::Match(e, sp!(_, v)) => {
+                self.exp_symbols(e);
+                v.iter().for_each(|sp!(_, arm)| {
+                    self.match_pattern_symbols(&arm.pattern);
+                    if let Some(g) = &arm.guard {
+                        self.exp_symbols(g);
+                    }
+                    self.exp_symbols(&arm.rhs);
+                })
+            }
             E::While(e1, e2) => {
                 self.exp_symbols(e1);
                 self.exp_symbols(e2);
@@ -2116,7 +2347,8 @@ impl<'a> ParsingSymbolicator<'a> {
                     if let Some(bt) = bto {
                         self.type_symbols(bt);
                     }
-                    v.iter().for_each(|bind| self.bind_symbols(bind, to.is_some()));
+                    v.iter()
+                        .for_each(|bind| self.bind_symbols(bind, to.is_some()));
                 }
                 if let Some(t) = to {
                     self.type_symbols(t);
@@ -2173,9 +2405,36 @@ impl<'a> ParsingSymbolicator<'a> {
             | E::Unit
             | E::Continue(_)
             | E::Spec(_)
-            | E::Match(_, _) // TODO support it
-            | E::UnresolvedError
-            => (),
+            | E::UnresolvedError => (),
+        }
+    }
+
+    fn match_pattern_symbols(&mut self, sp!(_, pattern): &P::MatchPattern) {
+        use P::MatchPattern_ as MP;
+        match pattern {
+            MP::PositionalConstructor(chain, sp!(_, v)) => {
+                self.chain_symbols(chain);
+                v.iter().for_each(|e| {
+                    if let P::Ellipsis::Binder(m) = e {
+                        self.match_pattern_symbols(m);
+                    }
+                })
+            }
+            MP::FieldConstructor(chain, sp!(_, v)) => {
+                self.chain_symbols(chain);
+                v.iter().for_each(|e| {
+                    if let P::Ellipsis::Binder((_, m)) = e {
+                        self.match_pattern_symbols(m);
+                    }
+                })
+            }
+            MP::Name(_, chain) => self.chain_symbols(chain),
+            MP::Or(m1, m2) => {
+                self.match_pattern_symbols(m1);
+                self.match_pattern_symbols(m2);
+            }
+            MP::At(_, m) => self.match_pattern_symbols(m),
+            MP::Literal(_) => (),
         }
     }
 
@@ -2275,7 +2534,8 @@ impl<'a> ParsingSymbolicator<'a> {
         let Some(mod_defs) = self.mod_outer_defs.get(&mod_ident_str) else {
             return;
         };
-        if let Some(mut ud) = add_struct_use_def(
+        if let Some(mut ud) = add_member_use_def(
+            &name.value,
             self.mod_outer_defs,
             self.files,
             mod_defs,
@@ -2303,7 +2563,7 @@ impl<'a> ParsingSymbolicator<'a> {
             }
             return;
         }
-        if let Some(mut ud) = add_fun_use_def(
+        if let Some(mut ud) = add_member_use_def(
             &name.value,
             self.mod_outer_defs,
             self.files,
@@ -2394,102 +2654,71 @@ impl<'a> ParsingSymbolicator<'a> {
     /// Get symbols for a name access chain
     fn chain_symbols(&mut self, sp!(_, chain): &P::NameAccessChain) {
         use P::NameAccessChain_ as NA;
-        // record the length of an identifier representing a potentially
-        // aliased module, struct or function  name in an access chain,
-        let no = match chain {
+        // Record the length of all identifiers representing a potentially
+        // aliased module, struct, enum or function name in an access chain.
+        // We can conservatively record all identifiers as they are only
+        // accessed by-location so those irrelevant will never be queried.
+        match chain {
             NA::Single(entry) => {
                 self.path_entry_symbols(entry);
-                Some(entry.name)
+                if let Some(loc) = loc_start_to_lsp_position_opt(self.files, &entry.name.loc) {
+                    self.alias_lengths.insert(loc, entry.name.value.len());
+                };
             }
             NA::Path(path) => {
                 let P::NamePath { root, entries } = path;
                 self.root_path_entry_symbols(root);
-                entries
-                    .iter()
-                    .for_each(|entry| self.path_entry_symbols(entry));
-                // FIXME: this is a hack that will break when we add enums
-                if entries.len() < 2 {
+                if let Some(root_loc) = loc_start_to_lsp_position_opt(self.files, &root.name.loc) {
                     if let P::LeadingNameAccess_::Name(n) = root.name.value {
-                        Some(n)
-                    } else {
-                        None
+                        self.alias_lengths.insert(root_loc, n.value.len());
                     }
-                } else {
-                    None
-                }
+                };
+                entries.iter().for_each(|entry| {
+                    self.path_entry_symbols(entry);
+                    if let Some(loc) = loc_start_to_lsp_position_opt(self.files, &entry.name.loc) {
+                        self.alias_lengths.insert(loc, entry.name.value.len());
+                    };
+                });
             }
         };
-        let Some(n) = no else {
-            return;
-        };
-        let sp!(pos, name) = n;
-        let Some(loc) = loc_start_to_lsp_position_opt(self.files, &pos) else {
-            return;
-        };
-        self.alias_lengths.insert(loc, name.len());
     }
 }
 
-/// Add use of a function identifier
-pub fn add_fun_use_def(
-    fun_def_name: &Symbol, // may be different from use_name for methods
+/// Add use of a function, method, struct or enum identifier
+pub fn add_member_use_def(
+    member_def_name: &Symbol, // may be different from use_name for methods
     mod_outer_defs: &BTreeMap<String, ModuleDefs>,
     files: &MappedFiles,
     mod_defs: &ModuleDefs,
     use_name: &Symbol,
-    use_pos: &Loc,
+    use_loc: &Loc,
     references: &mut References,
     def_info: &DefMap,
     use_defs: &mut UseDefMap,
     alias_lengths: &BTreeMap<Position, usize>,
 ) -> Option<UseDef> {
-    let Some(name_start) = loc_start_to_lsp_position_opt(files, use_pos) else {
+    let Some(name_file_start) = files.start_position_opt(use_loc) else {
         debug_assert!(false);
         return None;
     };
-    if let Some(func_def) = mod_defs.functions.get(fun_def_name) {
-        let fun_info = def_info.get(&func_def.name_loc).unwrap();
-        let ident_type_def_loc = def_info_to_type_def_loc(mod_outer_defs, fun_info);
-        let ud = UseDef::new(
-            references,
-            alias_lengths,
-            use_pos.file_hash(),
-            name_start,
-            func_def.name_loc,
-            use_name,
-            ident_type_def_loc,
-        );
-        use_defs.insert(name_start.line, ud.clone());
-        return Some(ud);
-    }
-    None
-}
-
-/// Add use of a struct identifier
-pub fn add_struct_use_def(
-    mod_outer_defs: &BTreeMap<String, ModuleDefs>,
-    files: &MappedFiles,
-    mod_defs: &ModuleDefs,
-    use_name: &Symbol,
-    use_pos: &Loc,
-    references: &mut References,
-    def_info: &DefMap,
-    use_defs: &mut UseDefMap,
-    alias_lengths: &BTreeMap<Position, usize>,
-) -> Option<UseDef> {
-    let Some(name_start) = loc_start_to_lsp_position_opt(files, use_pos) else {
-        debug_assert!(false);
-        return None;
+    let name_start = Position {
+        line: name_file_start.line_offset() as u32,
+        character: name_file_start.column_offset() as u32,
     };
-    if let Some(def) = mod_defs.structs.get(use_name) {
-        let struct_info = def_info.get(&def.name_loc).unwrap();
-        let ident_type_def_loc = def_info_to_type_def_loc(mod_outer_defs, struct_info);
+    if let Some(member_def) = mod_defs
+        .functions
+        .get(member_def_name)
+        .or_else(|| mod_defs.structs.get(member_def_name))
+        .or_else(|| mod_defs.enums.get(member_def_name))
+    {
+        let member_info = def_info.get(&member_def.name_loc).unwrap();
+        let ident_type_def_loc = def_info_to_type_def_loc(mod_outer_defs, member_info);
         let ud = UseDef::new(
             references,
             alias_lengths,
-            use_pos.file_hash(),
+            use_loc.file_hash(),
             name_start,
-            def.name_loc,
+            member_def.name_loc,
             use_name,
             ident_type_def_loc,
         );
@@ -2506,7 +2735,9 @@ pub fn def_info_to_type_def_loc(
     match def_info {
         DefInfo::Type(t) => type_def_loc(mod_outer_defs, t),
         DefInfo::Function(..) => None,
-        DefInfo::Struct(mod_ident, name, ..) => find_struct(mod_outer_defs, mod_ident, name),
+        DefInfo::Struct(mod_ident, name, ..) => find_datatype(mod_outer_defs, mod_ident, name),
+        DefInfo::Enum(mod_ident, name, ..) => find_datatype(mod_outer_defs, mod_ident, name),
+        DefInfo::Variant(..) => None,
         DefInfo::Field(.., t, _) => type_def_loc(mod_outer_defs, t),
         DefInfo::Local(_, t, _, _) => type_def_loc(mod_outer_defs, t),
         DefInfo::Const(_, _, t, _, _) => type_def_loc(mod_outer_defs, t),
@@ -2519,6 +2750,8 @@ pub fn def_info_doc_string(def_info: &DefInfo) -> Option<String> {
         DefInfo::Type(_) => None,
         DefInfo::Function(.., s) => s.clone(),
         DefInfo::Struct(.., s) => s.clone(),
+        DefInfo::Enum(.., s) => s.clone(),
+        DefInfo::Variant(.., s) => s.clone(),
         DefInfo::Field(.., s) => s.clone(),
         DefInfo::Local(..) => None,
         DefInfo::Const(.., s) => s.clone(),
@@ -2533,23 +2766,31 @@ pub fn type_def_loc(
     match t {
         Type_::Ref(_, r) => type_def_loc(mod_outer_defs, r),
         Type_::Apply(_, sp!(_, TypeName_::ModuleType(sp!(_, mod_ident), struct_name)), _) => {
-            find_struct(mod_outer_defs, mod_ident, &struct_name.value())
+            find_datatype(mod_outer_defs, mod_ident, &struct_name.value())
         }
         _ => None,
     }
 }
 
-fn find_struct(
+fn find_datatype(
     mod_outer_defs: &BTreeMap<String, ModuleDefs>,
     mod_ident: &ModuleIdent_,
-    struct_name: &Symbol,
+    datatype_name: &Symbol,
 ) -> Option<Loc> {
     let mod_ident_str = expansion_mod_ident_to_map_key(mod_ident);
     let mod_defs = match mod_outer_defs.get(&mod_ident_str) {
         Some(v) => v,
         None => return None,
     };
-    mod_defs.structs.get(struct_name).map(|sdef| sdef.name_loc)
+    mod_defs.structs.get(datatype_name).map_or_else(
+        || {
+            mod_defs
+                .enums
+                .get(datatype_name)
+                .map(|enum_def| enum_def.name_loc)
+        },
+        |struct_def| Some(struct_def.name_loc),
+    )
 }
 
 /// Extracts the docstring (/// or /** ... */) for a given definition by traversing up from the line definition
@@ -2557,11 +2798,32 @@ fn extract_doc_string(
     files: &MappedFiles,
     file_id_to_lines: &HashMap<FileId, Vec<String>>,
     loc: &Loc,
+    outer_def_loc: Option<Loc>,
 ) -> Option<String> {
     let file_hash = loc.file_hash();
     let file_id = files.file_hash_to_file_id(&file_hash)?;
     let start_position = files.start_position_opt(loc)?;
     let file_lines = file_id_to_lines.get(&file_id)?;
+
+    /*
+        if let Some(outer_line) = outer_def_line {
+            if outer_line == name_start.line {
+                // It's a bit of a hack but due to the way we extract doc strings
+                // we should not do it for a definition if this definition is placed
+                // on the same line as another (outer) one as this way we'd pick
+                // doc comment of the outer definition. For example (where field
+                // of the struct would pick up struct's doc comment)
+                //
+                // /// Struct doc comment
+                // public struct Tmp { field: u64 }
+                return None;
+            }
+        }
+
+        let Some(file_id) = file_id_mapping.get(file_hash) else {
+            return None;
+    };
+        */
 
     if start_position.line_offset() == 0 {
         return None;
@@ -2873,8 +3135,7 @@ pub fn on_document_symbol_request(context: &Context, request: &Request, symbols:
         let mut children = vec![];
 
         // handle constants
-        let cloned_const_def = mod_def.constants.clone();
-        for (sym, const_def) in cloned_const_def {
+        for (sym, const_def) in &mod_def.constants {
             let Some(const_range) = symbols.files.lsp_range_opt(&const_def.name_loc) else {
                 continue;
             };
@@ -2891,15 +3152,12 @@ pub fn on_document_symbol_request(context: &Context, request: &Request, symbols:
         }
 
         // handle structs
-        let cloned_struct_def = mod_def.structs.clone();
-        for (sym, struct_def) in cloned_struct_def {
+        for (sym, struct_def) in &mod_def.structs {
             let Some(struct_range) = symbols.files.lsp_range_opt(&struct_def.name_loc) else {
                 continue;
             };
 
-            let mut fields: Vec<DocumentSymbol> = vec![];
-            handle_struct_fields(struct_def, &mut fields, symbols);
-
+            let fields = struct_field_symbols(struct_def, symbols);
             children.push(DocumentSymbol {
                 name: sym.clone().to_string(),
                 detail: None,
@@ -2912,16 +3170,37 @@ pub fn on_document_symbol_request(context: &Context, request: &Request, symbols:
             });
         }
 
+        // handle enums
+        for (sym, enum_def) in &mod_def.enums {
+            let Some(enum_range) = symbols.files.lsp_range_opt(&enum_def.name_loc) else {
+                continue;
+            };
+
+            let variants = enum_variant_symbols(enum_def, symbols);
+            children.push(DocumentSymbol {
+                name: sym.clone().to_string(),
+                detail: None,
+                kind: SymbolKind::ENUM,
+                range: enum_range,
+                selection_range: enum_range,
+                children: Some(variants),
+                tags: Some(vec![]),
+                deprecated: Some(false),
+            });
+        }
+
         // handle functions
-        let cloned_func_def = mod_def.functions.clone();
-        for (sym, func_def) in cloned_func_def {
+        for (sym, func_def) in &mod_def.functions {
+            let MemberDefInfo::Fun { attrs } = &func_def.info else {
+                continue;
+            };
             let Some(func_range) = symbols.files.lsp_range_opt(&func_def.name_loc) else {
                 continue;
             };
 
             let mut detail = None;
-            if !func_def.attrs.is_empty() {
-                detail = Some(format!("{:?}", func_def.attrs));
+            if !attrs.is_empty() {
+                detail = Some(format!("{:?}", attrs));
             }
 
             children.push(DocumentSymbol {
@@ -2959,29 +3238,56 @@ pub fn on_document_symbol_request(context: &Context, request: &Request, symbols:
     }
 }
 
-/// Helper function to handle struct fields
+/// Helper function to generate struct field symbols
 #[allow(deprecated)]
-fn handle_struct_fields(
-    struct_def: StructDef,
-    fields: &mut Vec<DocumentSymbol>,
-    symbols: &Symbols,
-) {
-    let cloned_fileds = struct_def.field_defs;
+fn struct_field_symbols(struct_def: &MemberDef, symbols: &Symbols) -> Vec<DocumentSymbol> {
+    let mut fields: Vec<DocumentSymbol> = vec![];
+    if let MemberDefInfo::Struct {
+        field_defs,
+        positional: _,
+    } = &struct_def.info
+    {
+        for field_def in field_defs {
+            let Some(field_range) = symbols.files.lsp_range_opt(&field_def.loc) else {
+                continue;
+            };
 
-    for field_def in cloned_fileds {
-        let Some(field_range) = symbols.files.lsp_range_opt(&field_def.loc) else {
-            continue;
-        };
-
-        fields.push(DocumentSymbol {
-            name: field_def.name.clone().to_string(),
-            detail: None,
-            kind: SymbolKind::FIELD,
-            range: field_range,
-            selection_range: field_range,
-            children: None,
-            tags: Some(vec![]),
-            deprecated: Some(false),
-        });
+            fields.push(DocumentSymbol {
+                name: field_def.name.clone().to_string(),
+                detail: None,
+                kind: SymbolKind::FIELD,
+                range: field_range,
+                selection_range: field_range,
+                children: None,
+                tags: Some(vec![]),
+                deprecated: Some(false),
+            });
+        }
     }
+    fields
+}
+
+/// Helper function to generate enum variant symbols
+#[allow(deprecated)]
+fn enum_variant_symbols(enum_def: &MemberDef, symbols: &Symbols) -> Vec<DocumentSymbol> {
+    let mut variants: Vec<DocumentSymbol> = vec![];
+    if let MemberDefInfo::Enum { variants_info } = &enum_def.info {
+        for (name, (loc, _, _)) in variants_info {
+            let Some(variant_range) = symbols.files.lsp_range_opt(&loc) else {
+                continue;
+            };
+
+            variants.push(DocumentSymbol {
+                name: name.clone().to_string(),
+                detail: None,
+                kind: SymbolKind::ENUM_MEMBER,
+                range: variant_range,
+                selection_range: variant_range,
+                children: None,
+                tags: Some(vec![]),
+                deprecated: Some(false),
+            });
+        }
+    }
+    variants
 }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -893,10 +893,16 @@ fn abilities_to_id_string(abilities: &AbilitySet) -> String {
 }
 
 fn variant_to_ide_string(variants: &[VariantInfo]) -> String {
-    variants
+    // how many variant lines (including optional ellipsis if there
+    // are too many of them) are printed
+    const NUM_PRINTED: usize = 7;
+    let mut vstrings = variants
         .iter()
-        .map(|info| {
-            if info.empty {
+        .enumerate()
+        .map(|(idx, info)| {
+            if idx >= NUM_PRINTED - 1 {
+                format!("\t/* ... */")
+            } else if info.empty {
                 format!("\t{}", info.name)
             } else if info.positional {
                 format!("\t{}( /* ... */ )", info.name)
@@ -904,8 +910,9 @@ fn variant_to_ide_string(variants: &[VariantInfo]) -> String {
                 format!("\t{}{{ /* ... */ }}", info.name)
             }
         })
-        .collect::<Vec<_>>()
-        .join(",\n")
+        .collect::<Vec<_>>();
+    vstrings.truncate(NUM_PRINTED);
+    vstrings.join(",\n")
 }
 
 impl SymbolicatorRunner {

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -491,7 +491,7 @@ impl fmt::Display for DefInfo {
             ) => {
                 let type_args_str =
                     datatype_type_args_to_ide_string(type_args, /* verbose */ true);
-                let abilities_str = abilities_to_id_string(abilities);
+                let abilities_str = abilities_to_ide_string(abilities);
                 if field_names.is_empty() {
                     write!(
                         f,
@@ -523,7 +523,7 @@ impl fmt::Display for DefInfo {
             Self::Enum(mod_ident, name, visibility, type_args, abilities, variants, _) => {
                 let type_args_str =
                     datatype_type_args_to_ide_string(type_args, /* verbose */ true);
-                let abilities_str = abilities_to_id_string(abilities);
+                let abilities_str = abilities_to_ide_string(abilities);
                 if variants.is_empty() {
                     write!(
                         f,
@@ -877,7 +877,7 @@ fn fun_type_to_ide_string(fun_type: &FunType) -> String {
     .to_string()
 }
 
-fn abilities_to_id_string(abilities: &AbilitySet) -> String {
+fn abilities_to_ide_string(abilities: &AbilitySet) -> String {
     if abilities.is_empty() {
         "".to_string()
     } else {

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2812,9 +2812,9 @@ fn extract_doc_string(
     let start_position = files.start_position_opt(loc)?;
     let file_lines = file_id_to_lines.get(&file_id)?;
 
-    /*
-        if let Some(outer_line) = outer_def_line {
-            if outer_line == name_start.line {
+    if let Some(outer_loc) = outer_def_loc {
+        if let Some(outer_pos) = files.start_position_opt(&outer_loc) {
+            if outer_pos.line_offset() == start_position.line_offset() {
                 // It's a bit of a hack but due to the way we extract doc strings
                 // we should not do it for a definition if this definition is placed
                 // on the same line as another (outer) one as this way we'd pick
@@ -2826,11 +2826,7 @@ fn extract_doc_string(
                 return None;
             }
         }
-
-        let Some(file_id) = file_id_mapping.get(file_hash) else {
-            return None;
-    };
-        */
+    }
 
     if start_position.line_offset() == 0 {
         return None;

--- a/external-crates/move/crates/move-analyzer/tests/enums.exp
+++ b/external-crates/move/crates/move-analyzer/tests/enums.exp
@@ -81,6 +81,31 @@ TypeDef: no info
 On Hover:
 mut_var: &mut u64
 
+== nested_guard.move ========================================================
+-- test 0 -------------------
+use line: 3, use_ndx: 2
+Use: 'nested_var', start: 30, end: 40
+Def: 'nested_var', line: 3, def char: 30
+TypeDef: no info
+On Hover:
+nested_var: bool
+
+-- test 1 -------------------
+use line: 3, use_ndx: 3
+Use: 'nested_var', start: 47, end: 57
+Def: 'nested_var', line: 3, def char: 30
+TypeDef: no info
+On Hover:
+nested_var: &bool
+
+-- test 2 -------------------
+use line: 3, use_ndx: 4
+Use: 'nested_var', start: 62, end: 72
+Def: 'nested_var', line: 3, def char: 30
+TypeDef: no info
+On Hover:
+nested_var: bool
+
 == nested_match.move ========================================================
 -- test 0 -------------------
 use line: 14, use_ndx: 2

--- a/external-crates/move/crates/move-analyzer/tests/enums.exp
+++ b/external-crates/move/crates/move-analyzer/tests/enums.exp
@@ -68,7 +68,7 @@ mut_var: &mut u64
 -- test 2 -------------------
 use line: 4, use_ndx: 1
 Use: 'mut_var', start: 25, end: 32
-Def: 'INVALID DEF IDENT', line: 9, def char: 0
+Def: 'mut_var', line: 4, def char: 12
 TypeDef: no info
 On Hover:
 mut_var: &u64
@@ -487,7 +487,7 @@ s: Enums::variant_match::SomeStruct
 -- test 25 -------------------
 use line: 23, use_ndx: 5
 Use: 'num1', start: 55, end: 59
-Def: 'INVALID DEF IDENT', line: 36, def char: 0
+Def: 'num1', line: 23, def char: 30
 TypeDef: no info
 On Hover:
 num1: &u64
@@ -495,7 +495,7 @@ num1: &u64
 -- test 26 -------------------
 use line: 23, use_ndx: 6
 Use: 's', start: 62, end: 63
-Def: 'INVALID DEF IDENT', line: 36, def char: 0
+Def: 's', line: 23, def char: 46
 TypeDef: 'SomeStruct', line: 2, char: 18
 On Hover:
 s: &Enums::variant_match::SomeStruct
@@ -503,7 +503,7 @@ s: &Enums::variant_match::SomeStruct
 -- test 27 -------------------
 use line: 23, use_ndx: 8
 Use: 'num1', start: 79, end: 83
-Def: 'INVALID DEF IDENT', line: 36, def char: 0
+Def: 'num1', line: 23, def char: 30
 TypeDef: no info
 On Hover:
 num1: &u64

--- a/external-crates/move/crates/move-analyzer/tests/enums.exp
+++ b/external-crates/move/crates/move-analyzer/tests/enums.exp
@@ -1,0 +1,542 @@
+== int_match.move ========================================================
+-- test 0 -------------------
+use line: 4, use_ndx: 0
+Use: 'bound_var', start: 12, end: 21
+Def: 'bound_var', line: 4, def char: 12
+TypeDef: no info
+On Hover:
+bound_var: u64
+
+-- test 1 -------------------
+use line: 4, use_ndx: 1
+Use: 'bound_var', start: 36, end: 45
+Def: 'bound_var', line: 4, def char: 12
+TypeDef: no info
+On Hover:
+bound_var: u64
+
+-- test 2 -------------------
+use line: 5, use_ndx: 0
+Use: 'another_var', start: 12, end: 23
+Def: 'another_var', line: 5, def char: 12
+TypeDef: no info
+On Hover:
+another_var: u64
+
+-- test 3 -------------------
+use line: 5, use_ndx: 1
+Use: 'another_var', start: 27, end: 38
+Def: 'another_var', line: 5, def char: 12
+TypeDef: no info
+On Hover:
+another_var: u64
+
+== long_enum.move ========================================================
+-- test 0 -------------------
+use line: 2, use_ndx: 0
+Use: 'LongEnum', start: 16, end: 24
+Def: 'LongEnum', line: 2, def char: 16
+TypeDef: 'LongEnum', line: 2, char: 16
+On Hover:
+public enum Enums::long_enum::LongEnum {
+	V1,
+	V2,
+	V3,
+	V4,
+	V5,
+	V6,
+	/* ... */
+}
+
+== mut_match.move ========================================================
+-- test 0 -------------------
+use line: 3, use_ndx: 0
+Use: 'mut_param', start: 15, end: 24
+Def: 'mut_param', line: 2, def char: 25
+TypeDef: no info
+On Hover:
+mut_param: &mut u64
+
+-- test 1 -------------------
+use line: 4, use_ndx: 0
+Use: 'mut_var', start: 12, end: 19
+Def: 'mut_var', line: 4, def char: 12
+TypeDef: no info
+On Hover:
+mut_var: &mut u64
+
+-- test 2 -------------------
+use line: 4, use_ndx: 1
+Use: 'mut_var', start: 25, end: 32
+Def: 'INVALID DEF IDENT', line: 9, def char: 0
+TypeDef: no info
+On Hover:
+mut_var: &u64
+
+-- test 3 -------------------
+use line: 4, use_ndx: 2
+Use: 'mut_var', start: 43, end: 50
+Def: 'mut_var', line: 4, def char: 12
+TypeDef: no info
+On Hover:
+mut_var: &mut u64
+
+== nested_match.move ========================================================
+-- test 0 -------------------
+use line: 14, use_ndx: 2
+Use: 'num', start: 40, end: 43
+Def: 'T1', line: 3, def char: 25
+TypeDef: no info
+On Hover:
+Enums::nested_match::OuterEnum
+0: T1
+
+-- test 1 -------------------
+use line: 14, use_ndx: 3
+Use: 'InnerEnum', start: 45, end: 54
+Def: 'InnerEnum', line: 7, def char: 16
+TypeDef: 'InnerEnum', line: 7, char: 16
+On Hover:
+public enum Enums::nested_match::InnerEnum<L, R> has drop {
+	Left( /* ... */ ),
+	Right( /* ... */ )
+}
+
+-- test 2 -------------------
+use line: 14, use_ndx: 4
+Use: 'Left', start: 56, end: 60
+Def: 'Left', line: 8, def char: 8
+TypeDef: no info
+On Hover:
+Enums::nested_match::InnerEnum::Left(L)
+
+-- test 3 -------------------
+use line: 14, use_ndx: 5
+Use: 'inner_num', start: 61, end: 70
+Def: 'L', line: 8, def char: 13
+TypeDef: no info
+On Hover:
+Enums::nested_match::InnerEnum
+0: L
+
+-- test 4 -------------------
+use line: 14, use_ndx: 6
+Use: 'num', start: 76, end: 79
+Def: 'num', line: 14, def char: 40
+TypeDef: no info
+On Hover:
+num: u64
+
+-- test 5 -------------------
+use line: 14, use_ndx: 7
+Use: 'inner_num', start: 82, end: 91
+Def: 'inner_num', line: 14, def char: 61
+TypeDef: no info
+On Hover:
+inner_num: u64
+
+-- test 6 -------------------
+use line: 15, use_ndx: 2
+Use: 'field', start: 37, end: 42
+Def: 'field', line: 4, def char: 22
+TypeDef: no info
+On Hover:
+Enums::nested_match::OuterEnum
+field: T2
+
+-- test 7 -------------------
+use line: 15, use_ndx: 3
+Use: 'InnerEnum', start: 44, end: 53
+Def: 'InnerEnum', line: 7, def char: 16
+TypeDef: 'InnerEnum', line: 7, char: 16
+On Hover:
+public enum Enums::nested_match::InnerEnum<L, R> has drop {
+	Left( /* ... */ ),
+	Right( /* ... */ )
+}
+
+-- test 8 -------------------
+use line: 15, use_ndx: 4
+Use: 'Right', start: 55, end: 60
+Def: 'Right', line: 9, def char: 8
+TypeDef: no info
+On Hover:
+Enums::nested_match::InnerEnum::Right(R)
+
+-- test 9 -------------------
+use line: 15, use_ndx: 5
+Use: 'inner_num', start: 61, end: 70
+Def: 'R', line: 9, def char: 14
+TypeDef: no info
+On Hover:
+Enums::nested_match::InnerEnum
+0: R
+
+-- test 10 -------------------
+use line: 15, use_ndx: 6
+Use: 'inner_num', start: 77, end: 86
+Def: 'inner_num', line: 15, def char: 61
+TypeDef: no info
+On Hover:
+inner_num: u64
+
+== struct_match.move ========================================================
+-- test 0 -------------------
+use line: 12, use_ndx: 0
+Use: 's', start: 15, end: 16
+Def: 's', line: 11, def char: 28
+TypeDef: 'AnotherStruct', line: 6, char: 18
+On Hover:
+s: Enums::struct_match::AnotherStruct
+
+-- test 1 -------------------
+use line: 13, use_ndx: 0
+Use: 'AnotherStruct', start: 12, end: 25
+Def: 'AnotherStruct', line: 6, def char: 18
+TypeDef: 'AnotherStruct', line: 6, char: 18
+On Hover:
+public struct Enums::struct_match::AnotherStruct has drop {
+	another_field: Enums::struct_match::SomeStruct,
+	field: u64
+}
+
+-- test 2 -------------------
+use line: 13, use_ndx: 1
+Use: 'field', start: 28, end: 33
+Def: 'field', line: 7, def char: 8
+TypeDef: no info
+On Hover:
+Enums::struct_match::AnotherStruct
+field: u64
+
+-- test 3 -------------------
+use line: 13, use_ndx: 2
+Use: 'field', start: 43, end: 48
+Def: 'field', line: 13, def char: 28
+TypeDef: no info
+On Hover:
+field: u64
+
+-- test 4 -------------------
+use line: 14, use_ndx: 1
+Use: 'another_field', start: 33, end: 46
+Def: 'another_field', line: 8, def char: 8
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Enums::struct_match::AnotherStruct
+another_field: Enums::struct_match::SomeStruct
+
+-- test 5 -------------------
+use line: 14, use_ndx: 2
+Use: 'SomeStruct', start: 48, end: 58
+Def: 'SomeStruct', line: 2, def char: 18
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+public struct Enums::struct_match::SomeStruct has drop {
+	some_field: u64
+}
+
+-- test 6 -------------------
+use line: 14, use_ndx: 3
+Use: 'some_field', start: 61, end: 71
+Def: 'some_field', line: 3, def char: 8
+TypeDef: no info
+On Hover:
+Enums::struct_match::SomeStruct
+some_field: u64
+
+-- test 7 -------------------
+use line: 14, use_ndx: 4
+Use: 'some_field', start: 79, end: 89
+Def: 'some_field', line: 14, def char: 61
+TypeDef: no info
+On Hover:
+some_field: u64
+
+== variant_match.move ========================================================
+-- test 0 -------------------
+use line: 6, use_ndx: 0
+Use: 'SomeEnum', start: 16, end: 24
+Def: 'SomeEnum', line: 6, def char: 16
+TypeDef: 'SomeEnum', line: 6, char: 16
+On Hover:
+public enum Enums::variant_match::SomeEnum has drop {
+	Empty,
+	NamedFields{ /* ... */ },
+	PositionalFields( /* ... */ )
+}
+
+-- test 1 -------------------
+use line: 7, use_ndx: 0
+Use: 'PositionalFields', start: 8, end: 24
+Def: 'PositionalFields', line: 7, def char: 8
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum::PositionalFields(u64, Enums::variant_match::SomeStruct)
+
+-- test 2 -------------------
+use line: 7, use_ndx: 1
+Use: 'SomeStruct', start: 30, end: 40
+Def: 'SomeStruct', line: 2, def char: 18
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+public struct Enums::variant_match::SomeStruct has drop {
+	some_field: u64
+}
+
+-- test 3 -------------------
+use line: 8, use_ndx: 0
+Use: 'NamedFields', start: 8, end: 19
+Def: 'NamedFields', line: 8, def char: 8
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum::NamedFields{num1: u64, num2: u64, s: Enums::variant_match::SomeStruct}
+
+-- test 4 -------------------
+use line: 8, use_ndx: 1
+Use: 'num1', start: 21, end: 25
+Def: 'num1', line: 8, def char: 21
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum
+num1: u64
+
+-- test 5 -------------------
+use line: 8, use_ndx: 2
+Use: 'num2', start: 32, end: 36
+Def: 'num2', line: 8, def char: 32
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum
+num2: u64
+
+-- test 6 -------------------
+use line: 8, use_ndx: 3
+Use: 's', start: 43, end: 44
+Def: 's', line: 8, def char: 43
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Enums::variant_match::SomeEnum
+s: Enums::variant_match::SomeStruct
+
+-- test 7 -------------------
+use line: 8, use_ndx: 4
+Use: 'SomeStruct', start: 46, end: 56
+Def: 'SomeStruct', line: 2, def char: 18
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+public struct Enums::variant_match::SomeStruct has drop {
+	some_field: u64
+}
+
+-- test 8 -------------------
+use line: 9, use_ndx: 0
+Use: 'Empty', start: 8, end: 13
+Def: 'Empty', line: 9, def char: 8
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum::Empty
+
+-- test 9 -------------------
+use line: 14, use_ndx: 0
+Use: 'e', start: 16, end: 17
+Def: 'e', line: 14, def char: 16
+TypeDef: 'SomeEnum', line: 6, char: 16
+On Hover:
+let mut e: Enums::variant_match::SomeEnum
+
+-- test 10 -------------------
+use line: 14, use_ndx: 1
+Use: 'SE', start: 20, end: 22
+Def: 'SomeEnum', line: 6, def char: 16
+TypeDef: 'SomeEnum', line: 6, char: 16
+On Hover:
+public enum Enums::variant_match::SomeEnum has drop {
+	Empty,
+	NamedFields{ /* ... */ },
+	PositionalFields( /* ... */ )
+}
+
+-- test 11 -------------------
+use line: 14, use_ndx: 3
+Use: 's', start: 45, end: 46
+Def: 'SomeStruct', line: 7, def char: 30
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Enums::variant_match::SomeEnum
+1: Enums::variant_match::SomeStruct
+
+-- test 12 -------------------
+use line: 18, use_ndx: 0
+Use: 'e', start: 20, end: 21
+Def: 'e', line: 14, def char: 16
+TypeDef: 'SomeEnum', line: 6, char: 16
+On Hover:
+let mut e: Enums::variant_match::SomeEnum
+
+-- test 13 -------------------
+use line: 19, use_ndx: 0
+Use: 'SomeEnum', start: 12, end: 20
+Def: 'SomeEnum', line: 6, def char: 16
+TypeDef: 'SomeEnum', line: 6, char: 16
+On Hover:
+public enum Enums::variant_match::SomeEnum has drop {
+	Empty,
+	NamedFields{ /* ... */ },
+	PositionalFields( /* ... */ )
+}
+
+-- test 14 -------------------
+use line: 19, use_ndx: 1
+Use: 'PositionalFields', start: 22, end: 38
+Def: 'PositionalFields', line: 7, def char: 8
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum::PositionalFields(u64, Enums::variant_match::SomeStruct)
+
+-- test 15 -------------------
+use line: 19, use_ndx: 2
+Use: 'num', start: 39, end: 42
+Def: 'u64', line: 7, def char: 25
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum
+0: u64
+
+-- test 16 -------------------
+use line: 19, use_ndx: 3
+Use: 's', start: 44, end: 45
+Def: 'SomeStruct', line: 7, def char: 30
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Enums::variant_match::SomeEnum
+1: Enums::variant_match::SomeStruct
+
+-- test 17 -------------------
+use line: 20, use_ndx: 0
+Use: 'num', start: 17, end: 20
+Def: 'num', line: 19, def char: 39
+TypeDef: no info
+On Hover:
+num: &mut u64
+
+-- test 18 -------------------
+use line: 20, use_ndx: 1
+Use: 's', start: 23, end: 24
+Def: 's', line: 19, def char: 44
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+s: &mut Enums::variant_match::SomeStruct
+
+-- test 19 -------------------
+use line: 20, use_ndx: 2
+Use: 'some_field', start: 25, end: 35
+Def: 'some_field', line: 3, def char: 8
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeStruct
+some_field: u64
+
+-- test 20 -------------------
+use line: 23, use_ndx: 0
+Use: 'SE', start: 12, end: 14
+Def: 'SomeEnum', line: 6, def char: 16
+TypeDef: 'SomeEnum', line: 6, char: 16
+On Hover:
+public enum Enums::variant_match::SomeEnum has drop {
+	Empty,
+	NamedFields{ /* ... */ },
+	PositionalFields( /* ... */ )
+}
+
+-- test 21 -------------------
+use line: 23, use_ndx: 1
+Use: 'NamedFields', start: 16, end: 27
+Def: 'NamedFields', line: 8, def char: 8
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum::NamedFields{num1: u64, num2: u64, s: Enums::variant_match::SomeStruct}
+
+-- test 22 -------------------
+use line: 23, use_ndx: 2
+Use: 'num1', start: 30, end: 34
+Def: 'num1', line: 8, def char: 21
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum
+num1: u64
+
+-- test 23 -------------------
+use line: 23, use_ndx: 3
+Use: 'num2', start: 36, end: 40
+Def: 'num2', line: 8, def char: 32
+TypeDef: no info
+On Hover:
+Enums::variant_match::SomeEnum
+num2: u64
+
+-- test 24 -------------------
+use line: 23, use_ndx: 4
+Use: 's', start: 46, end: 47
+Def: 's', line: 8, def char: 43
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Enums::variant_match::SomeEnum
+s: Enums::variant_match::SomeStruct
+
+-- test 25 -------------------
+use line: 23, use_ndx: 5
+Use: 'num1', start: 55, end: 59
+Def: 'INVALID DEF IDENT', line: 36, def char: 0
+TypeDef: no info
+On Hover:
+num1: &u64
+
+-- test 26 -------------------
+use line: 23, use_ndx: 6
+Use: 's', start: 62, end: 63
+Def: 'INVALID DEF IDENT', line: 36, def char: 0
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+s: &Enums::variant_match::SomeStruct
+
+-- test 27 -------------------
+use line: 23, use_ndx: 8
+Use: 'num1', start: 79, end: 83
+Def: 'INVALID DEF IDENT', line: 36, def char: 0
+TypeDef: no info
+On Hover:
+num1: &u64
+
+-- test 28 -------------------
+use line: 23, use_ndx: 9
+Use: 'local', start: 86, end: 91
+Def: 'local', line: 16, def char: 12
+TypeDef: no info
+On Hover:
+let local: u64
+
+-- test 29 -------------------
+use line: 24, use_ndx: 0
+Use: 's', start: 16, end: 17
+Def: 's', line: 23, def char: 46
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+s: &mut Enums::variant_match::SomeStruct
+
+-- test 30 -------------------
+use line: 24, use_ndx: 2
+Use: 'num1', start: 32, end: 36
+Def: 'num1', line: 23, def char: 30
+TypeDef: no info
+On Hover:
+num1: &mut u64
+
+-- test 31 -------------------
+use line: 24, use_ndx: 3
+Use: 'num2', start: 40, end: 44
+Def: 'num2', line: 23, def char: 36
+TypeDef: no info
+On Hover:
+num2: &mut u64
+

--- a/external-crates/move/crates/move-analyzer/tests/enums.exp
+++ b/external-crates/move/crates/move-analyzer/tests/enums.exp
@@ -9,13 +9,21 @@ bound_var: u64
 
 -- test 1 -------------------
 use line: 4, use_ndx: 1
-Use: 'bound_var', start: 36, end: 45
+Use: 'bound_var', start: 38, end: 47
+Def: 'bound_var', line: 4, def char: 12
+TypeDef: no info
+On Hover:
+bound_var: &u64
+
+-- test 2 -------------------
+use line: 4, use_ndx: 2
+Use: 'bound_var', start: 57, end: 66
 Def: 'bound_var', line: 4, def char: 12
 TypeDef: no info
 On Hover:
 bound_var: u64
 
--- test 2 -------------------
+-- test 3 -------------------
 use line: 5, use_ndx: 0
 Use: 'another_var', start: 12, end: 23
 Def: 'another_var', line: 5, def char: 12
@@ -23,7 +31,7 @@ TypeDef: no info
 On Hover:
 another_var: u64
 
--- test 3 -------------------
+-- test 4 -------------------
 use line: 5, use_ndx: 1
 Use: 'another_var', start: 27, end: 38
 Def: 'another_var', line: 5, def char: 12

--- a/external-crates/move/crates/move-analyzer/tests/enums.ide
+++ b/external-crates/move/crates/move-analyzer/tests/enums.ide
@@ -1,0 +1,384 @@
+// Checks if symbolication enums work correctly.
+{
+  "project": "tests/enums",
+  "file_tests": {
+    // test matching of variants
+    "variant_match.move": [
+      {
+        "UseDefTest": {
+          "use_line": 6,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 7,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 7,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 8,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 8,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 8,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 8,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 8,
+          "use_ndx": 4
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 9,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 18,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 19,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 19,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 19,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 19,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 20,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 20,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 20,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 4
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 5
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 6
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 8
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 23,
+          "use_ndx": 9
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 24,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 24,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 24,
+          "use_ndx": 3
+        }
+      }
+    ],
+    // test matching of structs
+    "struct_match.move": [
+      {
+        "UseDefTest": {
+          "use_line": 12,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 13,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 13,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 13,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 4
+        }
+      }
+    ],  
+    // test matching of ints
+    "int_match.move": [
+      {
+        "UseDefTest": {
+          "use_line": 4,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 4,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 5,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 5,
+          "use_ndx": 1
+        }
+      }
+    ],
+    // test displaying of enum with many variants
+    "long_enum.move": [
+      {
+        "UseDefTest": {
+          "use_line": 2,
+          "use_ndx": 0
+        }
+      }
+    ],
+    // test matching of mutable value (guards should be immutable refs)
+    "mut_match.move": [
+      {
+        "UseDefTest": {
+          "use_line": 3,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 4,
+          "use_ndx": 0
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 4,
+          "use_ndx": 1
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 4,
+          "use_ndx": 2
+        }
+      }            
+    ],
+    // test matching of nested patterns
+    "nested_match.move": [
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 4
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 5
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 6
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 14,
+          "use_ndx": 7
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 15,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 15,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 15,
+          "use_ndx": 4
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 15,
+          "use_ndx": 5
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 15,
+          "use_ndx": 6
+        }
+      }
+    ]
+  }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums.ide
+++ b/external-crates/move/crates/move-analyzer/tests/enums.ide
@@ -264,6 +264,12 @@
       },
       {
         "UseDefTest": {
+          "use_line": 4,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
           "use_line": 5,
           "use_ndx": 0
         }

--- a/external-crates/move/crates/move-analyzer/tests/enums.ide
+++ b/external-crates/move/crates/move-analyzer/tests/enums.ide
@@ -379,6 +379,28 @@
           "use_ndx": 6
         }
       }
+    ],
+    // tests if a nested pattern var is displayed correctly (it's inside outer guard
+    // but should only be displayed as immutable reference when inside inner guard)
+    "nested_guard.move": [
+      {
+        "UseDefTest": {
+          "use_line": 3,
+          "use_ndx": 2
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 3,
+          "use_ndx": 3
+        }
+      },
+      {
+        "UseDefTest": {
+          "use_line": 3,
+          "use_ndx": 4
+        }
+      }
     ]
   }
 }

--- a/external-crates/move/crates/move-analyzer/tests/enums/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/enums/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Enums"
+version = "0.0.1"
+edition = "2024.alpha"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+Enums = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/int_match.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/int_match.move
@@ -2,7 +2,7 @@ module Enums::int_match {
 
     public fun int_match(int_param: u64) {
         match (int_param) {
-            bound_var@ ( 7 | 42) => bound_var,
+            bound_var@ ( 7 | 42) if (*bound_var < 42) => bound_var,
             another_var => another_var + 42,
         };
     }

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/int_match.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/int_match.move
@@ -1,0 +1,9 @@
+module Enums::int_match {
+
+    public fun int_match(int_param: u64) {
+        match (int_param) {
+            bound_var@ ( 7 | 42) => bound_var,
+            another_var => another_var + 42,
+        };
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/long_enum.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/long_enum.move
@@ -1,0 +1,14 @@
+module Enums::long_enum {
+
+    public enum LongEnum {
+        V1,
+        V2,
+        V3,
+        V4,
+        V5,
+        V6,
+        V7,
+        V8,
+        V9,
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/mut_match.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/mut_match.move
@@ -1,0 +1,9 @@
+module Enums::mut_match {
+
+    public fun match_mut(mut_param: &mut u64) {
+        match (mut_param) {
+            mut_var if (*mut_var > 42) => *mut_var = 42,
+            _ => (),
+        }
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/nested_guard.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/nested_guard.move
@@ -1,0 +1,8 @@
+module Enums::nested_guard {
+    public fun nested_guard(x: bool, b: bool): bool {
+        match (x) {
+            x if (match (b) { nested_var if (!*nested_var) => nested_var, z => z }) => x,
+            _ => false
+        }
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/nested_match.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/nested_match.move
@@ -1,0 +1,20 @@
+module Enums::nested_match {
+
+    public enum OuterEnum<T1, T2> has drop {
+        PositionalFields(T1, T2),
+        NamedFields { field: T2 },
+    }
+
+    public enum InnerEnum<L, R> has drop {
+        Left(L),
+        Right(R),
+    }
+
+    public fun nested_match(e: OuterEnum<u64, InnerEnum<u64, u64>>): u64 {
+        match (e) {
+            OuterEnum::PositionalFields(num, InnerEnum::Left(inner_num)) => num + inner_num,
+            OuterEnum::NamedFields { field: InnerEnum::Right(inner_num) } => inner_num,
+            _ => 42,
+        }
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/struct_match.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/struct_match.move
@@ -1,0 +1,19 @@
+module Enums::struct_match {
+
+    public struct SomeStruct has drop {
+        some_field: u64,
+    }
+
+    public struct AnotherStruct has drop {
+        field: u64,
+        another_field: SomeStruct,
+    }
+
+    public fun struct_match(s: AnotherStruct): u64 {
+        match (s) {
+            AnotherStruct { field, .. } => field,
+            AnotherStruct { .. , another_field: SomeStruct { some_field } } => some_field,
+            _ => 42,
+        }
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/enums/sources/variant_match.move
+++ b/external-crates/move/crates/move-analyzer/tests/enums/sources/variant_match.move
@@ -1,0 +1,36 @@
+module Enums::variant_match {
+
+    public struct SomeStruct has drop {
+        some_field: u64,
+    }
+
+    public enum SomeEnum has drop {
+        PositionalFields(u64, SomeStruct),
+        NamedFields{ num1: u64, num2: u64, s: SomeStruct},
+        Empty,
+    }
+
+    public fun variant_match(s: SomeStruct) {
+        use Enums::variant_match::SomeEnum as SE;
+        let mut e = SE::PositionalFields(42, s);
+
+        let local = 42;
+
+        match (&mut e) {
+            SomeEnum::PositionalFields(num, s) => {
+                *num = s.some_field;
+            },
+            SomeEnum::PositionalFields(_, _) => (),
+            SE::NamedFields { num1, num2, mut s } if (*num1 < s.some_field && *num1 < local) => {
+                s.some_field = *num1 + *num2;
+            },
+            SE::NamedFields { num1, .. } if (*num1 < 42) =>  {
+                num1;
+            },
+            SE::NamedFields { num1, num2: _, .. } => {
+                num1;
+            },
+            SE::Empty => ()
+        }
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -102,7 +102,7 @@ impl UseDefTest {
         };
 
         if let Some(guard_def) = maybe_convert_for_guard(
-            &def,
+            def,
             use_file_path,
             &Position::new(*use_line, use_def.col_start()),
             symbols,

--- a/external-crates/move/crates/move-compiler/src/shared/files.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/files.rs
@@ -208,6 +208,12 @@ impl MappedFiles {
             .map(|posn| FilePosition::new(posn.file_hash, posn.end))
     }
 
+    pub fn file_size(&self, fhash: &FileHash) -> usize {
+        let file_id = *self.file_mapping().get(fhash).unwrap();
+        let source = self.files().source(file_id).unwrap();
+        source.len()
+    }
+
     pub fn position_opt(&self, loc: &Loc) -> Option<FilePositionSpan> {
         let start_loc = loc.start() as usize;
         let end_loc = loc.end() as usize;


### PR DESCRIPTION
## Description 

This PR adds enums support to the Move analyzer. 

In this PR, I also sneaked a fix for symbols merging, which was not very robust when multiple packages are built within the same IDE instance. It's much more robust to keep symbols on the per-package basis, even if it's more memory-intensive.

## Test plan 

All existing and newly added tests must pass.

