### PR TITLE
[bridge] bridge node check zero transfer value and err

### DIFF
--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -93,20 +93,27 @@ impl EthBridgeEvent {
         self,
         eth_tx_hash: ethers::types::H256,
         eth_event_index: u16,
-    ) -> Option<BridgeAction> {
-        match self {
+    ) -> BridgeResult<Option<BridgeAction>> {
+        Ok(match self {
             EthBridgeEvent::EthSuiBridgeEvents(event) => {
                 match event {
                     EthSuiBridgeEvents::TokensDepositedFilter(event) => {
                         let bridge_event = match EthToSuiTokenBridgeV1::try_from(&event) {
-                            Ok(bridge_event) => bridge_event,
+                            Ok(bridge_event) => {
+                                if bridge_event.sui_adjusted_amount == 0 {
+                                    return Err(BridgeError::ZeroValueBridgeTransfer(format!(
+                                        "Manual intervention is required: {}",
+                                        eth_tx_hash
+                                    )));
+                                }
+                                bridge_event
+                            }
                             // This only happens when solidity code does not align with rust code.
                             // When this happens in production, there is a risk of stuck bridge transfers.
                             // We log error here.
                             // TODO: add metrics and alert
                             Err(e) => {
-                                tracing::error!(?eth_tx_hash, eth_event_index, "Manual intervention is required. Failed to convert TokensDepositedFilter log to EthToSuiTokenBridgeV1. This indicates incorrect parameters or a bug in the code: {:?}. Err: {:?}", event, e);
-                                return None;
+                                return Err(BridgeError::Generic(format!("Manual intervention is required. Failed to convert TokensDepositedFilter log to EthToSuiTokenBridgeV1. This indicates incorrect parameters or a bug in the code: {:?}. Err: {:?}", event, e)));
                             }
                         };
 
@@ -145,7 +152,7 @@ impl EthBridgeEvent {
                 EthCommitteeUpgradeableContractEvents::InitializedFilter(_event) => None,
                 EthCommitteeUpgradeableContractEvents::UpgradedFilter(_event) => None,
             },
-        }
+        })
     }
 }
 
@@ -495,5 +502,44 @@ mod tests {
             ))
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_0_sui_amount_conversion_for_eth_event() {
+        let e = EthBridgeEvent::EthSuiBridgeEvents(EthSuiBridgeEvents::TokensDepositedFilter(
+            TokensDepositedFilter {
+                source_chain_id: BridgeChainId::EthSepolia as u8,
+                nonce: 0,
+                destination_chain_id: BridgeChainId::SuiTestnet as u8,
+                token_id: 2,
+                sui_adjusted_amount: 1,
+                sender_address: EthAddress::random(),
+                recipient_address: ethers::types::Bytes::from(
+                    SuiAddress::random_for_testing_only().to_vec(),
+                ),
+            },
+        ));
+        assert!(e
+            .try_into_bridge_action(TxHash::random(), 0)
+            .unwrap()
+            .is_some());
+
+        let e = EthBridgeEvent::EthSuiBridgeEvents(EthSuiBridgeEvents::TokensDepositedFilter(
+            TokensDepositedFilter {
+                source_chain_id: BridgeChainId::EthSepolia as u8,
+                nonce: 0,
+                destination_chain_id: BridgeChainId::SuiTestnet as u8,
+                token_id: 2,
+                sui_adjusted_amount: 0, // <------------
+                sender_address: EthAddress::random(),
+                recipient_address: ethers::types::Bytes::from(
+                    SuiAddress::random_for_testing_only().to_vec(),
+                ),
+            },
+        ));
+        match e.try_into_bridge_action(TxHash::random(), 0).unwrap_err() {
+            BridgeError::ZeroValueBridgeTransfer(_) => {}
+            e => panic!("Unexpected error: {:?}", e),
+        }
     }
 }

--- a/crates/sui-bridge/src/e2e_tests/complex.rs
+++ b/crates/sui-bridge/src/e2e_tests/complex.rs
@@ -15,7 +15,7 @@ use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_types::bridge::{BridgeChainId, TOKEN_ID_ETH};
 use tracing::info;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn test_sui_bridge_paused() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -61,6 +61,8 @@ pub enum BridgeError {
     ActionIsNotTokenTransferAction,
     // Sui transaction failure due to generic error
     SuiTxFailureGeneric(String),
+    // Zero value bridge transfer should not be allowed
+    ZeroValueBridgeTransfer(String),
     // Storage Error
     StorageError(String),
     // Rest API Error

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -99,7 +99,7 @@ where
         let bridge_event = EthBridgeEvent::try_from_eth_log(&eth_log)
             .ok_or(BridgeError::NoBridgeEventsInTxPosition)?;
         bridge_event
-            .try_into_bridge_action(tx_hash, event_idx)
+            .try_into_bridge_action(tx_hash, event_idx)?
             .ok_or(BridgeError::BridgeEventNotActionable)
     }
 

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -203,10 +203,12 @@ where
                 let bridge_event = opt_bridge_event.unwrap();
                 info!("Observed Eth bridge event: {:?}", bridge_event);
 
-                if let Some(action) =
-                    bridge_event.try_into_bridge_action(log.tx_hash, log.log_index_in_tx)
-                {
-                    actions.push(action);
+                match bridge_event.try_into_bridge_action(log.tx_hash, log.log_index_in_tx) {
+                    Ok(Some(action)) => actions.push(action),
+                    Ok(None) => {}
+                    Err(e) => {
+                        error!(eth_tx_hash=?log.tx_hash, eth_event_index=?log.log_index_in_tx, "Error converting EthBridgeEvent to BridgeAction: {:?}", e);
+                    }
                 }
                 // TODO: handle non Action events
             }


### PR DESCRIPTION
## Description 

The latest solidity code already disallows 0 transfer. After move's update, this should not be reachable in bridge node.


## Test plan 

new unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
