### PR TITLE
[CLI][Easy] Display the estimated gas budget after a dry run info

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2619,7 +2619,6 @@ pub fn estimate_gas_budget_from_gas_cost(
     let gas_usage = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
     let estimated_gas_budget =
         computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 });
-    tracing::info!("Estimated gas budget: {}", estimated_gas_budget);
     estimated_gas_budget
 }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2617,9 +2617,7 @@ pub fn estimate_gas_budget_from_gas_cost(
     let computation_cost_with_overhead = gas_cost_summary.computation_cost + safe_overhead;
 
     let gas_usage = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
-    let estimated_gas_budget =
-        computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 });
-    estimated_gas_budget
+    computation_cost_with_overhead.max(if gas_usage < 0 { 0 } else { gas_usage as u64 })
 }
 
 /// Queries the protocol config for the maximum gas allowed in a transaction.

--- a/crates/sui/src/displays/dry_run_tx_block.rs
+++ b/crates/sui/src/displays/dry_run_tx_block.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::displays::Pretty;
+use crate::{client_commands::estimate_gas_budget_from_gas_cost, displays::Pretty};
 use std::fmt::{Display, Formatter};
 use sui_json_rpc_types::{
-    DryRunTransactionBlockResponse, ObjectChange, SuiTransactionBlockEffectsAPI,
+    DryRunTransactionBlockResponse, ObjectChange, SuiTransactionBlockDataAPI,
+    SuiTransactionBlockEffectsAPI,
 };
 use tabled::{
     builder::Builder as TableBuilder,
@@ -93,6 +94,14 @@ impl<'a> Display for Pretty<'a, DryRunTransactionBlockResponse> {
             f,
             "Dry run completed, execution status: {}",
             response.effects.status()
+        )?;
+        writeln!(
+            f,
+            "Estimated gas cost needed: {} MIST",
+            estimate_gas_budget_from_gas_cost(
+                response.effects.gas_cost_summary(),
+                response.input.gas_data().price
+            )
         )
     }
 }

--- a/crates/sui/src/displays/dry_run_tx_block.rs
+++ b/crates/sui/src/displays/dry_run_tx_block.rs
@@ -97,7 +97,7 @@ impl<'a> Display for Pretty<'a, DryRunTransactionBlockResponse> {
         )?;
         writeln!(
             f,
-            "Estimated gas cost needed: {} MIST",
+            "Estimated gas cost (includes a small buffer): {} MIST",
             estimate_gas_budget_from_gas_cost(
                 response.effects.gas_cost_summary(),
                 response.input.gas_data().price


### PR DESCRIPTION
## Description 

Prints the estimated gas cost after a dry run's execution status.

```
Dry run completed, execution status: success
Estimated gas cost (includes a small buffer): 72216400 MIST
```

## Test plan 

Existing features

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
