### PR TITLE
Fix shared counter workload config creation

### DIFF
--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -100,9 +100,11 @@ impl SharedCounterWorkloadBuilder {
         let max_ops = target_qps * in_flight_ratio;
         let shared_counter_ratio =
             1.0 - (std::cmp::min(shared_counter_hotness_factor, 100) as f32 / 100.0);
-        let num_shared_counters =
-            num_shared_counters.unwrap_or((max_ops as f32 * shared_counter_ratio) as u64);
-        if num_shared_counters == 0 || num_workers == 0 {
+        let num_shared_counters = num_shared_counters.unwrap_or(std::cmp::max(
+            1,
+            (max_ops as f32 * shared_counter_ratio) as u64,
+        ));
+        if max_ops == 0 || num_shared_counters == 0 || num_workers == 0 {
             None
         } else {
             let workload_params = WorkloadParams {

--- a/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
@@ -142,8 +142,8 @@ impl SharedCounterDeletionWorkloadBuilder {
         let max_ops = target_qps * in_flight_ratio;
         let shared_counter_ratio =
             1.0 - (std::cmp::min(shared_counter_hotness_factor, 100) as f32 / 100.0);
-        let num_shared_counters = (max_ops as f32 * shared_counter_ratio) as u64;
-        if num_shared_counters == 0 || num_workers == 0 {
+        let num_shared_counters = std::cmp::max(1, (max_ops as f32 * shared_counter_ratio) as u64);
+        if max_ops == 0 || num_shared_counters == 0 || num_workers == 0 {
             None
         } else {
             let workload_params = WorkloadParams {

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -156,6 +156,7 @@ impl WorkloadConfiguration {
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Option<WorkloadBuilderInfo>> {
         let total_weight = shared_counter_weight
+            + shared_deletion_weight
             + transfer_object_weight
             + delegation_weight
             + batch_payment_weight


### PR DESCRIPTION
## Description 

In shared counter workload, when `shared_counter_hotness_factor == 100`, currently no shared counter is created due to the calculation, even though the option doc specifies that when hotness factor is 100, we need to create 1 shared counter and all requests is targeting that counter.

```
        // total_shared_counters = max(1, qps * (1.0 - hotness/100.0))
        shared_counter_hotness_factor: Vec<u32>,
```

This PR also adds shared deletion workload weight in the total weight calculation in create_workload_builders.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
