### PR TITLE
Fix typo in StashedOnly function: correct curentWallet to currentWallet

### DIFF
--- a/sdk/docs/pages/zksend/dapp.mdx
+++ b/sdk/docs/pages/zksend/dapp.mdx
@@ -64,8 +64,8 @@ import { useCurrentWallet } from '@mysten/dapp-kit';
 import { STASHED_WALLET_NAME } from '@mysten/zksend';
 
 function StashedOnly() {
-	const { curentWallet } = useCurrentWallet();
-	const walletIsStashedWallet = curentWallet?.name === STASHED_WALLET_NAME;
+	const { currentWallet } = useCurrentWallet();
+	const walletIsStashedWallet = currentWallet?.name === STASHED_WALLET_NAME;
 
 	// rest of component logic...
 }


### PR DESCRIPTION
## Description 

This pull request fixes a typo in the `StashedOnly` function. The variable `curentWallet` has been corrected to `currentWallet`.


## Test plan 



- Verified that the function StashedOnly works correctly with the updated variable name.
- Ensured that there are no errors or warnings after the change.
- Manually tested the functionality to confirm that it behaves as expected with the correct variable name.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
- [x] TypeScript SDK:
  - Fixed a typo in the `StashedOnly` function: corrected `curentWallet` to `currentWallet`.
