### PR TITLE
[move-ide] Added support for intelligent dot auto-completion

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -59,7 +59,7 @@ pub struct TypingAnalysisContext<'a> {
     /// Current expression scope, for use when traversing expressions and recording usage.
     pub expression_scope: OrdMap<Symbol, LocalDef>,
     /// IDE Annotation Information from the Compiler
-    pub compiler_info: CompilerInfo,
+    pub compiler_info: &'a mut CompilerInfo,
 }
 
 impl TypingAnalysisContext<'_> {

--- a/external-crates/move/crates/move-analyzer/src/compiler_info.rs
+++ b/external-crates/move/crates/move-analyzer/src/compiler_info.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use move_command_line_common::files::FileHash;
 use move_compiler::shared::ide as CI;
 use move_ir_types::location::Loc;
 
@@ -10,7 +11,7 @@ use move_ir_types::location::Loc;
 pub struct CompilerInfo {
     pub macro_info: BTreeMap<Loc, CI::MacroCallInfo>,
     pub expanded_lambdas: BTreeSet<Loc>,
-    pub autocomplete_info: BTreeMap<Loc, CI::AutocompleteInfo>,
+    pub autocomplete_info: BTreeMap<FileHash, BTreeMap<Loc, CI::AutocompleteInfo>>,
 }
 
 impl CompilerInfo {
@@ -40,7 +41,12 @@ impl CompilerInfo {
                 CI::IDEAnnotation::AutocompleteInfo(info) => {
                     // TODO: what if we find two autocomplete info sets? Intersection may be better
                     // than union, as it's likely in a lambda body.
-                    if let Some(_old) = self.autocomplete_info.insert(loc, *info) {
+                    if let Some(_old) = self
+                        .autocomplete_info
+                        .entry(loc.file_hash())
+                        .or_default()
+                        .insert(loc, *info)
+                    {
                         eprintln!("Repeated autocomplete info");
                     }
                 }
@@ -59,7 +65,19 @@ impl CompilerInfo {
         self.expanded_lambdas.contains(loc)
     }
 
-    pub fn get_autocomplete_info(&mut self, loc: &Loc) -> Option<&CI::AutocompleteInfo> {
-        self.autocomplete_info.get(loc)
+    pub fn get_autocomplete_info(
+        &self,
+        fhash: FileHash,
+        loc: &Loc,
+    ) -> Option<&CI::AutocompleteInfo> {
+        self.autocomplete_info.get(&fhash).and_then(|a| {
+            a.iter().find_map(|(aloc, ainfo)| {
+                if aloc.contains(loc) {
+                    Some(ainfo)
+                } else {
+                    None
+                }
+            })
+        })
     }
 }

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -233,25 +233,27 @@ fn dot(symbols: &Symbols, use_fpath: &Path, position: &Position) -> Vec<Completi
     let Some(info) = symbols.compiler_info.get_autocomplete_info(fhash, &loc) else {
         return completions;
     };
-    for (mident, name) in &info.methods {
+    for ((mident, fname), mname) in &info.methods {
         let init_completion = CompletionItem {
-            label: format!("{}::{}", mod_ident_to_ide_string(&mident.value), name),
+            label: format!("{}::{}", mod_ident_to_ide_string(&mident.value), mname),
             kind: Some(CompletionItemKind::METHOD),
-            insert_text: Some(name.to_string()),
+            insert_text: Some(fname.to_string()),
             insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
             ..Default::default()
         };
         completions.push(init_completion);
     }
-    for name in &info.fields {
-        let init_completion = CompletionItem {
-            label: name.to_string(),
-            kind: Some(CompletionItemKind::FIELD),
-            insert_text: Some(name.to_string()),
-            insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
-            ..Default::default()
-        };
-        completions.push(init_completion);
+    if let Some((_, _, fields)) = &info.fields {
+        for name in fields {
+            let init_completion = CompletionItem {
+                label: name.to_string(),
+                kind: Some(CompletionItemKind::FIELD),
+                insert_text: Some(name.to_string()),
+                insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+                ..Default::default()
+            };
+            completions.push(init_completion);
+        }
     }
     completions
 }

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -626,11 +626,7 @@ fn validate_item(
     );
     if item.label_details.is_none() {
         if detail.is_some() || description.is_some() {
-            assert!(
-                false,
-                "item {} at {} has no label details:  {:#?}",
-                idx, loc, item
-            );
+            panic!("item {} at {} has no label details:  {:#?}", idx, loc, item);
         }
     } else {
         assert!(

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -26,7 +26,7 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request, symbols: &Sym
     let mut hints: Vec<InlayHint> = vec![];
 
     if context.inlay_type_hints {
-        if let Some(file_defs) = symbols.file_mods().get(&fpath) {
+        if let Some(file_defs) = symbols.file_mods.get(&fpath) {
             for mod_defs in file_defs {
                 for untyped_def_loc in mod_defs.untyped_defs() {
                     if let Some(DefInfo::Local(n, t, _, _)) = symbols.def_info(untyped_def_loc) {
@@ -94,7 +94,7 @@ fn additional_hint_info(sp!(_, t): &N::Type, symbols: &Symbols) -> Option<InlayH
     };
 
     let Some(mod_defs) = symbols
-        .file_mods()
+        .file_mods
         .values()
         .flatten()
         .find(|m| m.ident() == &mod_ident.value)

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -41,7 +41,7 @@ pub fn on_inlay_hint_request(context: &Context, request: &Request, symbols: &Sym
                             command: None,
                         };
                         let type_label = InlayHintLabelPart {
-                            value: type_to_ide_string(t),
+                            value: type_to_ide_string(t, /* verbose */ true),
                             tooltip: None,
                             location: None,
                             command: None,

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -378,9 +378,15 @@ pub struct Symbols {
     /// A mapping from file hashes to file names
     file_name_mapping: BTreeMap<FileHash, PathBuf>,
     /// A mapping from filePath to ModuleDefs
-    file_mods: BTreeMap<PathBuf, BTreeSet<ModuleDefs>>,
+    pub file_mods: BTreeMap<PathBuf, BTreeSet<ModuleDefs>>,
     /// Additional information about definitions
     def_info: BTreeMap<DefLoc, DefInfo>,
+    /// A mapping from file names to file content (used to obtain source file locations)
+    pub files: SimpleFiles<Symbol, String>,
+    /// A mapping from file hashes to file IDs (used to obtain source file locations)
+    pub file_id_mapping: HashMap<FileHash, usize>,
+    /// IDE Annotation Information from the Compiler
+    pub compiler_info: CompilerInfo,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -754,7 +760,7 @@ fn ast_value_to_ide_string(sp!(_, val): &Value) -> String {
     }
 }
 
-fn mod_ident_to_ide_string(mod_ident: &E::ModuleIdent_) -> String {
+pub fn mod_ident_to_ide_string(mod_ident: &E::ModuleIdent_) -> String {
     use E::Address as A;
     match mod_ident.address {
         A::Numerical {
@@ -1076,10 +1082,6 @@ impl Symbols {
         self.def_info.extend(other.def_info);
     }
 
-    pub fn file_mods(&self) -> &BTreeMap<PathBuf, BTreeSet<ModuleDefs>> {
-        &self.file_mods
-    }
-
     pub fn line_uses(&self, use_fpath: &Path, use_line: u32) -> BTreeSet<UseDef> {
         let Some(file_symbols) = self.file_use_defs.get(use_fpath) else {
             return BTreeSet::new();
@@ -1099,6 +1101,13 @@ impl Symbols {
             return None;
         };
         mod_defs.iter().find(|d| d.ident == mod_ident)
+    }
+
+    pub fn file_hash(&self, path: &Path) -> Option<FileHash> {
+        let Some(mod_defs) = self.file_mods.get(path) else {
+            return None;
+        };
+        Some(mod_defs.first().unwrap().fhash)
     }
 }
 
@@ -1388,6 +1397,7 @@ pub fn get_symbols(
         );
     }
 
+    let mut compiler_info = compiler_info.unwrap();
     let mut typing_symbolicator = typing_analysis::TypingAnalysisContext {
         mod_outer_defs: &mod_outer_defs,
         files: &files,
@@ -1397,7 +1407,7 @@ pub fn get_symbols(
         use_defs: UseDefMap::new(),
         alias_lengths: &BTreeMap::new(),
         traverse_only: false,
-        compiler_info: compiler_info.unwrap(),
+        compiler_info: &mut compiler_info,
         type_params: BTreeMap::new(),
         expression_scope: OrdMap::new(),
     };
@@ -1433,6 +1443,9 @@ pub fn get_symbols(
         file_name_mapping,
         file_mods,
         def_info,
+        files,
+        file_id_mapping,
+        compiler_info,
     };
 
     eprintln!("get_symbols load complete");
@@ -1612,6 +1625,9 @@ pub fn empty_symbols() -> Symbols {
         file_name_mapping: BTreeMap::new(),
         file_mods: BTreeMap::new(),
         def_info: BTreeMap::new(),
+        files: SimpleFiles::new(),
+        file_id_mapping: HashMap::new(),
+        compiler_info: CompilerInfo::new(),
     }
 }
 

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -434,7 +434,7 @@ impl fmt::Display for DefInfo {
                 //
                 // It also seems like a reasonable idea to be able to tune user experience in the
                 // IDE independently on how compiler error messages are generated.
-                write!(f, "{}", type_to_ide_string(t))
+                write!(f, "{}", type_to_ide_string(t, /* verbose */ true))
             }
             Self::Function(
                 mod_ident,
@@ -444,14 +444,11 @@ impl fmt::Display for DefInfo {
                 type_args,
                 arg_names,
                 arg_types,
-                ret,
+                ret_type,
                 _,
             ) => {
-                let type_args_str = type_args_to_ide_string(type_args);
-                let ret_str = match ret {
-                    sp!(_, Type_::Unit) => "".to_string(),
-                    _ => format!(": {}", type_to_ide_string(ret)),
-                };
+                let type_args_str = type_args_to_ide_string(type_args, /* verbose */ true);
+                let ret_type_str = ret_type_to_ide_str(ret_type, /* verbose */ true);
                 write!(
                     f,
                     "{}{}fun {}::{}{}({}){}",
@@ -460,8 +457,11 @@ impl fmt::Display for DefInfo {
                     mod_ident_to_ide_string(mod_ident),
                     name,
                     type_args_str,
-                    typed_id_list_to_ide_string(arg_names, arg_types, false),
-                    ret_str,
+                    typed_id_list_to_ide_string(
+                        arg_names, arg_types, /* separate_lines */ false,
+                        /* verbose */ true
+                    ),
+                    ret_type_str,
                 )
             }
             Self::Struct(
@@ -474,7 +474,8 @@ impl fmt::Display for DefInfo {
                 field_types,
                 _,
             ) => {
-                let type_args_str = struct_type_args_to_ide_string(type_args);
+                let type_args_str =
+                    struct_type_args_to_ide_string(type_args, /* verbose */ true);
                 let abilities_str = if abilities.is_empty() {
                     "".to_string()
                 } else {
@@ -508,7 +509,12 @@ impl fmt::Display for DefInfo {
                         name,
                         type_args_str,
                         abilities_str,
-                        typed_id_list_to_ide_string(field_names, field_types, true),
+                        typed_id_list_to_ide_string(
+                            field_names,
+                            field_types,
+                            /* separate_lines */ true,
+                            /* verbose */ true
+                        ),
                     )
                 }
             }
@@ -519,15 +525,27 @@ impl fmt::Display for DefInfo {
                     mod_ident,
                     struct_name,
                     name,
-                    type_to_ide_string(t)
+                    type_to_ide_string(t, /* verbose */ true)
                 )
             }
             Self::Local(name, t, is_decl, is_mut) => {
                 let mut_str = if *is_mut { "mut " } else { "" };
                 if *is_decl {
-                    write!(f, "let {}{}: {}", mut_str, name, type_to_ide_string(t))
+                    write!(
+                        f,
+                        "let {}{}: {}",
+                        mut_str,
+                        name,
+                        type_to_ide_string(t, /* verbose */ true)
+                    )
                 } else {
-                    write!(f, "{}{}: {}", mut_str, name, type_to_ide_string(t))
+                    write!(
+                        f,
+                        "{}{}: {}",
+                        mut_str,
+                        name,
+                        type_to_ide_string(t, /* verbose */ true)
+                    )
                 }
             }
             Self::Const(mod_ident, name, t, value, _) => {
@@ -537,7 +555,7 @@ impl fmt::Display for DefInfo {
                         "const {}::{}: {} = {}",
                         mod_ident,
                         name,
-                        type_to_ide_string(t),
+                        type_to_ide_string(t, /* verbose */ true),
                         v
                     )
                 } else {
@@ -546,7 +564,7 @@ impl fmt::Display for DefInfo {
                         "const {}::{}: {}",
                         mod_ident,
                         name,
-                        type_to_ide_string(t)
+                        type_to_ide_string(t, /* verbose */ true)
                     )
                 }
             }
@@ -564,77 +582,86 @@ fn visibility_to_ide_string(visibility: &Visibility) -> String {
     visibility_str
 }
 
-fn type_args_to_ide_string(type_args: &Vec<Type>) -> String {
+pub fn type_args_to_ide_string(type_args: &[Type], verbose: bool) -> String {
     let mut type_args_str = "".to_string();
     if !type_args.is_empty() {
         type_args_str.push('<');
-        type_args_str.push_str(&type_list_to_ide_string(type_args));
+        type_args_str.push_str(&type_list_to_ide_string(type_args, verbose));
         type_args_str.push('>');
     }
     type_args_str
 }
 
-fn struct_type_args_to_ide_string(type_args: &Vec<(Type, bool)>) -> String {
+fn struct_type_args_to_ide_string(type_args: &[(Type, bool)], verbose: bool) -> String {
     let mut type_args_str = "".to_string();
     if !type_args.is_empty() {
         type_args_str.push('<');
-        type_args_str.push_str(&struct_type_list_to_ide_string(type_args));
+        type_args_str.push_str(&struct_type_list_to_ide_string(type_args, verbose));
         type_args_str.push('>');
     }
     type_args_str
 }
 
-fn typed_id_list_to_ide_string(names: &[Symbol], types: &[Type], separate_lines: bool) -> String {
+fn typed_id_list_to_ide_string(
+    names: &[Symbol],
+    types: &[Type],
+    separate_lines: bool,
+    verbose: bool,
+) -> String {
     names
         .iter()
         .zip(types.iter())
         .map(|(n, t)| {
             if separate_lines {
-                format!("\t{}: {}", n, type_to_ide_string(t))
+                format!("\t{}: {}", n, type_to_ide_string(t, verbose))
             } else {
-                format!("{}: {}", n, type_to_ide_string(t))
+                format!("{}: {}", n, type_to_ide_string(t, verbose))
             }
         })
         .collect::<Vec<_>>()
         .join(if separate_lines { ",\n" } else { ", " })
 }
 
-pub fn type_to_ide_string(sp!(_, t): &Type) -> String {
+pub fn type_to_ide_string(sp!(_, t): &Type, verbose: bool) -> String {
     match t {
         Type_::Unit => "()".to_string(),
-        Type_::Ref(m, r) => format!("&{}{}", if *m { "mut " } else { "" }, type_to_ide_string(r)),
+        Type_::Ref(m, r) => format!(
+            "&{}{}",
+            if *m { "mut " } else { "" },
+            type_to_ide_string(r, verbose)
+        ),
         Type_::Param(tp) => {
             format!("{}", tp.user_specified_name)
         }
         Type_::Apply(_, sp!(_, type_name), ss) => match type_name {
             TypeName_::Multiple(_) => {
-                format!("({})", type_list_to_ide_string(ss))
+                format!("({})", type_list_to_ide_string(ss, verbose))
             }
             TypeName_::Builtin(name) => {
                 if ss.is_empty() {
                     format!("{}", name)
                 } else {
-                    format!("{}<{}>", name, type_list_to_ide_string(ss))
+                    format!("{}<{}>", name, type_list_to_ide_string(ss, verbose))
                 }
             }
             TypeName_::ModuleType(sp!(_, module_ident), struct_name) => {
-                format!(
-                    "{}::{}{}",
-                    module_ident,
-                    struct_name,
-                    if ss.is_empty() {
-                        "".to_string()
-                    } else {
-                        format!("<{}>", type_list_to_ide_string(ss))
-                    }
-                )
+                let type_args = if ss.is_empty() {
+                    "".to_string()
+                } else {
+                    format!("<{}>", type_list_to_ide_string(ss, verbose))
+                };
+                if verbose {
+                    format!("{}::{}{}", module_ident, struct_name, type_args,)
+                } else {
+                    struct_name.to_string()
+                }
             }
         },
         Type_::Fun(args, ret) => {
             format!(
                 "|{}| -> {}",
-                type_list_to_ide_string(args),
-                type_to_ide_string(ret)
+                type_list_to_ide_string(args, verbose),
+                type_to_ide_string(ret, verbose)
             )
         }
         Type_::Anything => "_".to_string(),
@@ -643,28 +670,34 @@ pub fn type_to_ide_string(sp!(_, t): &Type) -> String {
     }
 }
 
-fn type_list_to_ide_string(types: &[Type]) -> String {
+pub fn type_list_to_ide_string(types: &[Type], verbose: bool) -> String {
     types
         .iter()
-        .map(type_to_ide_string)
+        .map(|t| type_to_ide_string(t, verbose))
         .collect::<Vec<_>>()
         .join(", ")
 }
 
-fn struct_type_list_to_ide_string(types: &[(Type, bool)]) -> String {
+fn struct_type_list_to_ide_string(types: &[(Type, bool)], verbose: bool) -> String {
     types
         .iter()
         .map(|(t, phantom)| {
             if *phantom {
-                format!("phantom {}", type_to_ide_string(t))
+                format!("phantom {}", type_to_ide_string(t, verbose))
             } else {
-                type_to_ide_string(t)
+                type_to_ide_string(t, verbose)
             }
         })
         .collect::<Vec<_>>()
         .join(", ")
 }
 
+pub fn ret_type_to_ide_str(ret_type: &Type, verbose: bool) -> String {
+    match ret_type {
+        sp!(_, Type_::Unit) => "".to_string(),
+        _ => format!(": {}", type_to_ide_string(ret_type, verbose)),
+    }
+}
 /// Conversions of constant values to strings is currently best-effort which is why this function
 /// returns an Option (in the worst case we will display constant name and type but no value).
 fn const_val_to_ide_string(exp: &Exp) -> Option<String> {

--- a/external-crates/move/crates/move-analyzer/src/utils.rs
+++ b/external-crates/move/crates/move-analyzer/src/utils.rs
@@ -31,6 +31,22 @@ pub fn get_loc(
     }
 }
 
+/// Converts a position (line/column) to byte index in the file.
+pub fn get_byte_idx(
+    pos: Position,
+    fhash: FileHash,
+    files: &SimpleFiles<Symbol, String>,
+    file_id_mapping: &HashMap<FileHash, usize>,
+) -> Option<ByteIndex> {
+    let Some(file_id) = file_id_mapping.get(&fhash) else {
+        return None;
+    };
+    let Ok(line_range) = files.line_range(*file_id, pos.line as usize) else {
+        return None;
+    };
+    Some(line_range.start as u32 + pos.character)
+}
+
 /// Convert a move_compiler Position into an lsp_types position
 pub fn to_lsp_position(pos: move_compiler::diagnostics::Position) -> Position {
     Position {

--- a/external-crates/move/crates/move-analyzer/tests/completion/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/completion/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Completion"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+Completion = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/completion/sources/dot.move
+++ b/external-crates/move/crates/move-analyzer/tests/completion/sources/dot.move
@@ -1,0 +1,31 @@
+module Completion::dot {
+    public struct SomeStruct has drop {
+        some_field: u64,
+    }
+
+    public fun foo(_s: SomeStruct) {
+    }
+
+    public fun bar<T>(s: SomeStruct, _param1: u64, _param2: T): SomeStruct {
+        s
+    }
+
+    public fun simple() {
+        let s = SomeStruct { some_field: 42 };
+        s.;
+    }
+
+    public fun aliased() {
+        use fun bar as SomeStruct.bak;
+        let s = SomeStruct { some_field: 42 };
+        s.;
+    }
+
+    public fun shadowed() {
+        use fun bar as SomeStruct.foo;
+        let s = SomeStruct { some_field: 42 };
+        s.;
+    }
+
+
+}

--- a/external-crates/move/crates/move-compiler/src/shared/ide.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/ide.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, fmt};
+use std::fmt;
 
 use crate::{
     debug_display, diag, diagnostics::Diagnostic, expansion::ast as E, naming::ast as N,
@@ -54,15 +54,9 @@ pub struct AutocompleteMethod {
 }
 
 #[derive(Debug, Clone)]
-pub struct AutocompleteFields {
-    pub enclosing_type: N::Type,
-    pub names: BTreeSet<Symbol>,
-}
-
-#[derive(Debug, Clone)]
 pub struct AutocompleteInfo {
     /// Methods that are valid auto-completes
-    pub methods: BTreeSet<AutocompleteMethod>,
+    pub methods: Vec<AutocompleteMethod>,
     /// Fields that are valid auto-completes (e.g., for a struct) along with their types
     pub fields: Vec<(Symbol, N::Type)>,
 }

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -524,7 +524,11 @@ pub fn ide_annotation(context: &mut Context, annotation: &mut IDEAnnotation) {
             }
         }
         IDEAnnotation::ExpandedLambda => (),
-        IDEAnnotation::AutocompleteInfo(_) => (),
+        IDEAnnotation::AutocompleteInfo(info) => {
+            for (_, t) in info.fields.iter_mut() {
+                type_(context, t);
+            }
+        }
         IDEAnnotation::MissingMatchArms(_) => (),
     }
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_fun_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_fun_autocomplete.ide.exp
@@ -1,0 +1,12 @@
+note[I15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/use_fun_autocomplete.move:11:11
+   │
+11 │         s.bak(); // autocompletion to `bak` and `foo`
+   │           ^^^ Autocompletes to: '0x42::m1::bak', '0x42::m1::foo', '0x42::m1::test1', or '0x42::m1::test2'
+
+note[I15001]: IDE autocomplete
+   ┌─ tests/move_2024/ide_mode/use_fun_autocomplete.move:16:11
+   │
+16 │         s.bar(); // auto-completion to only one (shadowed) `bar`
+   │           ^^^ Autocompletes to: '0x42::m1::bar', '0x42::m1::test1', or '0x42::m1::test2'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_fun_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_fun_autocomplete.move
@@ -1,0 +1,19 @@
+module 0x42::m1 {
+    public struct S {} has drop;
+
+    public fun foo(_s: S) {}
+
+    public fun bar(_s: S) {}
+
+
+    public fun test1(s: S) {
+        use fun bar as S.bak;
+        s.bak(); // autocompletion to `bak` and `foo`
+    }
+
+    public fun test2(s: S) {
+        use fun foo as S.bar;
+        s.bar(); // auto-completion to only one (shadowed) `bar`
+    }
+
+}


### PR DESCRIPTION
## Description 

This PR stands on the shoulders of previously done compiler-side work and simply adds the IDE-side of things to support intelligent auto-completion.

Works for dot completion without valid identifier following the dot:

![image](https://github.com/MystenLabs/sui/assets/1724397/5de46118-e79a-4bb8-aa88-8204d7d5d0b9)

It also works for dot completion when the following identifier is already (partially) typed:

![image](https://github.com/MystenLabs/sui/assets/1724397/6d3e11c7-5523-4171-9671-4f4da14703ec)

Note that additional information (in addition to just name to be completed is available): target function (for methods) as well as the target function signature/type (for methods/fields)

Field completions are inserted "as is" (just the field name) but method completions are inserted as snippets listing parameter names for a given method. The following screenshot shows the effect of accepting the auto-completion suggestion from the screenshot directly above (`param` has been inserted automatically and did not have to be typed by the programmer; if more params were available, their names would be inserted as well and the programmer can move to the next one by pressing TAB):

![image](https://github.com/MystenLabs/sui/assets/1724397/8232cd6e-7593-49d2-a98d-58b217dbd241)

This PR also adds missing auto-completion info in the compiler (method names in addition to target function names) as well additional info (a struct containing fields provided to auto-completion query)

## Test plan 

Correctness of auto-completion items being provided to the IDE is already tested on the compiler side, and a new test there was added. 

Still, added an IDE test for things that are IDE-specific that cannot be tested on the compiler-side. We are considering building a more powerful testing framework for IDE unit tests, but for not (considering compiler-side testing), this added test will hopefully suffice.
