### PR TITLE
[json rpc] add tryGetObjectBeforeVersion endpoint

### DIFF
--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -187,6 +187,17 @@ impl<T: R2D2Connection + 'static> ReadApiServer for ReadApi<T> {
         .into())
     }
 
+    async fn try_get_object_before_version(
+        &self,
+        _: ObjectID,
+        _: SequenceNumber,
+    ) -> RpcResult<SuiPastObjectResponse> {
+        Err(jsonrpsee::types::error::CallError::Custom(
+            jsonrpsee::types::error::ErrorCode::MethodNotFound.into(),
+        )
+        .into())
+    }
+
     async fn try_multi_get_past_objects(
         &self,
         _past_objects: Vec<SuiGetPastObjectRequest>,

--- a/crates/sui-json-rpc-api/src/read.rs
+++ b/crates/sui-json-rpc-api/src/read.rs
@@ -77,6 +77,19 @@ pub trait ReadApi {
     /// Note there is no software-level guarantee/SLA that objects with past versions
     /// can be retrieved by this API, even if the object and version exists/existed.
     /// The result may vary across nodes depending on their pruning policies.
+    /// Returns the latest object information with a version less than or equal to the given version
+    #[method(name = "tryGetObjectBeforeVersion", deprecated = "true")]
+    async fn try_get_object_before_version(
+        &self,
+        /// the ID of the queried object
+        object_id: ObjectID,
+        /// the version of the queried object
+        version: SequenceNumber,
+    ) -> RpcResult<SuiPastObjectResponse>;
+
+    /// Note there is no software-level guarantee/SLA that objects with past versions
+    /// can be retrieved by this API, even if the object and version exists/existed.
+    /// The result may vary across nodes depending on their pruning policies.
     /// Return the object information for a specified version
     #[method(name = "tryMultiGetPastObjects")]
     async fn try_multi_get_past_objects(

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -52,10 +52,10 @@ use sui_types::transaction::TransactionDataAPI;
 
 use crate::authority_state::{StateRead, StateReadError, StateReadResult};
 use crate::error::{Error, RpcInterimResult, SuiRpcInputError};
-use crate::with_tracing;
 use crate::{
     get_balance_changes_from_effect, get_object_changes, ObjectProviderCache, SuiRpcModule,
 };
+use crate::{with_tracing, ObjectProvider};
 
 const MAX_DISPLAY_NESTED_LEVEL: usize = 10;
 
@@ -636,6 +636,27 @@ impl ReadApiServer for ReadApi {
                 }),
             }
         })
+    }
+
+    #[instrument(skip(self))]
+    async fn try_get_object_before_version(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> RpcResult<SuiPastObjectResponse> {
+        let version = self
+            .state
+            .find_object_lt_or_eq_version(&object_id, &version)
+            .await
+            .map_err(Error::from)?
+            .map(|obj| obj.version())
+            .unwrap_or_default();
+        self.try_get_past_object(
+            object_id,
+            version,
+            Some(SuiObjectDataOptions::bcs_lossless()),
+        )
+        .await
     }
 
     #[instrument(skip(self))]


### PR DESCRIPTION
we need this endpoint to migrate sui replay tool away from using `loaded_child_object_versions_endpoint` and eventually reclaim the disk space on FNs