### PR TITLE
[gql] Compatibility check on graphql service startup (#18118)

### DIFF
--- a/crates/sui-graphql-rpc/src/raw_query.rs
+++ b/crates/sui-graphql-rpc/src/raw_query.rs
@@ -189,7 +189,7 @@ macro_rules! query {
     // Matches the case where no subqueries are provided. A `RawQuery` is constructed from the given
     // select clause.
     ($select:expr) => {
-        RawQuery::new($select, vec![])
+        $crate::raw_query::RawQuery::new($select, vec![])
     };
 
     // Expects a select clause and one or more subqueries. The select clause should contain curly

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::compatibility_check::check_all_tables;
-use super::exchange_rates_task::TriggerExchangeRatesTask;
 use super::system_package_task::SystemPackageTask;
 use super::watermark_task::{Watermark, WatermarkLock, WatermarkTask};
 use crate::config::{

--- a/crates/sui-graphql-rpc/src/server/compatibility_check.rs
+++ b/crates/sui-graphql-rpc/src/server/compatibility_check.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::check_table;
+use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::error::Error;
+use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
+use sui_indexer::models::checkpoints::StoredCheckpoint;
+use sui_indexer::models::display::StoredDisplay;
+use sui_indexer::models::epoch::QueryableEpochInfo;
+use sui_indexer::models::events::StoredEvent;
+use sui_indexer::models::objects::{StoredHistoryObject, StoredObjectSnapshot};
+use sui_indexer::models::packages::StoredPackage;
+use sui_indexer::models::transactions::StoredTransaction;
+use sui_indexer::models::tx_indices::{
+    StoredTxCalls, StoredTxChangedObject, StoredTxDigest, StoredTxInputObject, StoredTxRecipients,
+    StoredTxSenders,
+};
+use sui_indexer::schema::tx_digests;
+use sui_indexer::schema::{
+    checkpoints, display, epochs, events, objects_history, objects_snapshot, packages,
+    transactions, tx_calls, tx_changed_objects, tx_input_objects, tx_recipients, tx_senders,
+};
+
+#[macro_export]
+macro_rules! check_table {
+    ($conn:expr, $table:path, $type:ty) => {{
+        let result: Result<Option<$type>, _> = $conn
+            .first(move || $table.select(<$type>::as_select()))
+            .optional();
+        result.is_ok()
+    }};
+}
+
+#[macro_export]
+macro_rules! generate_check_all_tables {
+    ($(($table:ident, $type:ty)),* $(,)?) => {
+        pub(crate) async fn check_all_tables(db: &Db) -> Result<bool, Error> {
+            use futures::future::join_all;
+
+            let futures = vec![
+                $(
+                    db.execute(|conn| {
+                        Ok::<_, diesel::result::Error>(check_table!(conn, $table::dsl::$table, $type))
+                    })
+                ),*
+            ];
+
+            let results = join_all(futures).await;
+            if results.into_iter().all(|res| res.unwrap_or(false)) {
+                Ok(true)
+            } else {
+                Err(Error::Internal(
+                    "One or more tables are missing expected columns".into(),
+                ))
+            }
+        }
+    };
+}
+
+generate_check_all_tables!(
+    (checkpoints, StoredCheckpoint),
+    (display, StoredDisplay),
+    (epochs, QueryableEpochInfo),
+    (events, StoredEvent),
+    (objects_history, StoredHistoryObject),
+    (objects_snapshot, StoredObjectSnapshot),
+    (packages, StoredPackage),
+    (transactions, StoredTransaction),
+    (tx_calls, StoredTxCalls),
+    (tx_changed_objects, StoredTxChangedObject),
+    (tx_digests, StoredTxDigest),
+    (tx_input_objects, StoredTxInputObject),
+    (tx_recipients, StoredTxRecipients),
+    (tx_senders, StoredTxSenders),
+);

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -4,6 +4,7 @@
 pub mod graphiql_server;
 
 pub mod builder;
+pub(crate) mod compatibility_check;
 pub(crate) mod system_package_task;
 pub mod version;
 pub(crate) mod watermark_task;

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -12,7 +12,7 @@ use crate::errors::IndexerError;
 use crate::schema::checkpoints;
 use crate::types::IndexedCheckpoint;
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = checkpoints)]
 pub struct StoredCheckpoint {
     pub sequence_number: i64,

--- a/crates/sui-indexer/src/models/display.rs
+++ b/crates/sui-indexer/src/models/display.rs
@@ -6,7 +6,7 @@ use sui_types::display::DisplayVersionUpdatedEvent;
 
 use crate::schema::display;
 
-#[derive(Queryable, Insertable, Debug, Clone)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone)]
 #[diesel(table_name = display)]
 pub struct StoredDisplay {
     pub object_type: String,

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -20,7 +20,7 @@ use crate::errors::IndexerError;
 use crate::schema::events;
 use crate::types::IndexedEvent;
 
-#[derive(Queryable, QueryableByName, Insertable, Debug, Clone)]
+#[derive(Queryable, QueryableByName, Selectable, Insertable, Debug, Clone)]
 #[diesel(table_name = events)]
 pub struct StoredEvent {
     #[diesel(sql_type = diesel::sql_types::BigInt)]

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -68,7 +68,7 @@ pub struct StoredObject {
     pub df_object_id: Option<Vec<u8>>,
 }
 
-#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects_snapshot, primary_key(object_id))]
 pub struct StoredObjectSnapshot {
     pub object_id: Vec<u8>,
@@ -79,6 +79,9 @@ pub struct StoredObjectSnapshot {
     pub owner_type: Option<i16>,
     pub owner_id: Option<Vec<u8>>,
     pub object_type: Option<String>,
+    pub object_type_package: Option<Vec<u8>>,
+    pub object_type_module: Option<String>,
+    pub object_type_name: Option<String>,
     pub serialized_object: Option<Vec<u8>>,
     pub coin_type: Option<String>,
     pub coin_balance: Option<i64>,
@@ -97,6 +100,9 @@ impl From<StoredObject> for StoredObjectSnapshot {
             object_digest: Some(o.object_digest),
             checkpoint_sequence_number: o.checkpoint_sequence_number,
             owner_type: Some(o.owner_type),
+            object_type_package: o.object_type_package,
+            object_type_module: o.object_type_module,
+            object_type_name: o.object_type_name,
             owner_id: o.owner_id,
             object_type: o.object_type,
             serialized_object: Some(o.serialized_object),
@@ -121,6 +127,9 @@ impl From<StoredDeletedObject> for StoredObjectSnapshot {
             owner_type: None,
             owner_id: None,
             object_type: None,
+            object_type_package: None,
+            object_type_module: None,
+            object_type_name: None,
             serialized_object: None,
             coin_type: None,
             coin_balance: None,
@@ -132,7 +141,7 @@ impl From<StoredDeletedObject> for StoredObjectSnapshot {
     }
 }
 
-#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects_history, primary_key(object_id, object_version, checkpoint_sequence_number))]
 pub struct StoredHistoryObject {
     pub object_id: Vec<u8>,

--- a/crates/sui-indexer/src/models/packages.rs
+++ b/crates/sui-indexer/src/models/packages.rs
@@ -6,7 +6,7 @@ use crate::types::IndexedPackage;
 
 use diesel::prelude::*;
 
-#[derive(Queryable, Insertable, Clone, Debug, Identifiable)]
+#[derive(Queryable, Insertable, Selectable, Clone, Debug, Identifiable)]
 #[diesel(table_name = packages, primary_key(package_id))]
 pub struct StoredPackage {
     pub package_id: Vec<u8>,

--- a/crates/sui-indexer/src/models/tx_indices.rs
+++ b/crates/sui-indexer/src/models/tx_indices.rs
@@ -21,7 +21,7 @@ pub struct TxDigest {
     pub transaction_digest: Vec<u8>,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_senders)]
 pub struct StoredTxSenders {
     pub cp_sequence_number: i64,
@@ -29,7 +29,7 @@ pub struct StoredTxSenders {
     pub sender: Vec<u8>,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_recipients)]
 pub struct StoredTxRecipients {
     pub cp_sequence_number: i64,
@@ -37,7 +37,7 @@ pub struct StoredTxRecipients {
     pub recipient: Vec<u8>,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_input_objects)]
 pub struct StoredTxInputObject {
     pub cp_sequence_number: i64,
@@ -45,7 +45,7 @@ pub struct StoredTxInputObject {
     pub object_id: Vec<u8>,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_changed_objects)]
 pub struct StoredTxChangedObject {
     pub cp_sequence_number: i64,
@@ -53,7 +53,7 @@ pub struct StoredTxChangedObject {
     pub object_id: Vec<u8>,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_calls)]
 pub struct StoredTxCalls {
     pub cp_sequence_number: i64,
@@ -63,7 +63,7 @@ pub struct StoredTxCalls {
     pub func: String,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_digests)]
 pub struct StoredTxDigest {
     pub tx_digest: Vec<u8>,


### PR DESCRIPTION
Add a compatibility check on server start `server.run` that goes through each table in the schema and makes a simple `select * from table limit 1`

I've added `Selectable` as a macro to the Rust structs that correspond to the data we'd select from each table, so we can use it in the macro

How did you test the new or updated feature?

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
