### PR TITLE
[formal-snapshots] skiplist checkpoint sync and verification

### DIFF
--- a/crates/sui-archival/src/reader.rs
+++ b/crates/sui-archival/src/reader.rs
@@ -263,9 +263,9 @@ impl ArchiveReader {
             .await
     }
 
-    /// Load checkpoints+txns+effects from archive into the input store `S` for the given
-    /// checkpoint range. Summaries are downloaded out of order and inserted without verification
-    pub async fn read_summaries<S>(
+    /// Load checkpoints from archive into the input store `S` for the given checkpoint
+    /// range. Summaries are downloaded out of order and inserted without verification
+    pub async fn read_summaries_with_range<S>(
         &self,
         store: S,
         checkpoint_range: Range<CheckpointSequenceNumber>,
@@ -275,8 +275,9 @@ impl ArchiveReader {
     where
         S: WriteStore + Clone,
     {
-        let (summary_files, start_index, end_index) =
-            self.get_summary_files(checkpoint_range.clone()).await?;
+        let (summary_files, start_index, end_index) = self
+            .get_summary_files_for_range(checkpoint_range.clone())
+            .await?;
         let remote_object_store = self.remote_object_store.clone();
         let stream = futures::stream::iter(summary_files.iter())
             .enumerate()
@@ -355,6 +356,52 @@ impl ArchiveReader {
                 })
                 .await
         }
+    }
+
+    /// Load given list of checkpoints from archive into the input store `S`.
+    /// Summaries are downloaded out of order and inserted without verification
+    pub async fn read_summaries_with_skiplist<S>(
+        &self,
+        store: S,
+        skiplist: Vec<CheckpointSequenceNumber>,
+        checkpoint_counter: Arc<AtomicU64>,
+    ) -> Result<()>
+    where
+        S: WriteStore + Clone,
+    {
+        let summary_files = self.get_summary_files_for_list(skiplist.clone()).await?;
+        let remote_object_store = self.remote_object_store.clone();
+        let stream = futures::stream::iter(summary_files.iter())
+            .map(|summary_metadata| {
+                let remote_object_store = remote_object_store.clone();
+                async move {
+                    let summary_data =
+                        get(&remote_object_store, &summary_metadata.file_path()).await?;
+                    Ok::<Bytes, anyhow::Error>(summary_data)
+                }
+            })
+            .boxed();
+
+        stream
+            .buffer_unordered(self.concurrency)
+            .try_for_each(|summary_data| {
+                let result: Result<(), anyhow::Error> =
+                    make_iterator::<CertifiedCheckpointSummary, Reader<Bytes>>(
+                        SUMMARY_FILE_MAGIC,
+                        summary_data.reader(),
+                    )
+                    .and_then(|summary_iter| {
+                        summary_iter
+                            .filter(|s| skiplist.contains(&s.sequence_number))
+                            .try_for_each(|summary| {
+                                Self::insert_certified_checkpoint(&store, summary)?;
+                                checkpoint_counter.fetch_add(1, Ordering::Relaxed);
+                                Ok::<(), anyhow::Error>(())
+                            })
+                    });
+                futures::future::ready(result)
+            })
+            .await
     }
 
     /// Load checkpoints+txns+effects from archive into the input store `S` for the given
@@ -568,7 +615,7 @@ impl ArchiveReader {
             .map_err(|e| anyhow!("Failed to get verified checkpoint: {:?}", e))
     }
 
-    async fn get_summary_files(
+    async fn get_summary_files_for_range(
         &self,
         checkpoint_range: Range<CheckpointSequenceNumber>,
     ) -> Result<(Vec<FileMetadata>, usize, usize)> {
@@ -608,6 +655,52 @@ impl ArchiveReader {
         };
 
         Ok((summary_files, start_index, end_index))
+    }
+
+    async fn get_summary_files_for_list(
+        &self,
+        checkpoints: Vec<CheckpointSequenceNumber>,
+    ) -> Result<Vec<FileMetadata>> {
+        assert!(!checkpoints.is_empty());
+        let manifest = self.manifest.lock().await.clone();
+        let latest_available_checkpoint = manifest
+            .next_checkpoint_seq_num()
+            .checked_sub(1)
+            .context("Checkpoint seq num underflow")?;
+
+        let mut ordered_checkpoints = checkpoints;
+        ordered_checkpoints.sort();
+        if *ordered_checkpoints.first().unwrap() > latest_available_checkpoint {
+            return Err(anyhow!(
+                "Latest available checkpoint is: {}",
+                latest_available_checkpoint
+            ));
+        }
+
+        let summary_files: Vec<FileMetadata> = self
+            .verify_manifest(manifest)
+            .await?
+            .iter()
+            .map(|(s, _)| s.clone())
+            .collect();
+
+        let mut summaries_filtered = vec![];
+        for checkpoint in ordered_checkpoints.iter() {
+            let index = summary_files
+                .binary_search_by(|s| {
+                    if checkpoint < &s.checkpoint_seq_range.start {
+                        std::cmp::Ordering::Greater
+                    } else if checkpoint >= &s.checkpoint_seq_range.end {
+                        std::cmp::Ordering::Less
+                    } else {
+                        std::cmp::Ordering::Equal
+                    }
+                })
+                .expect("Archive does not contain checkpoint {checkpoint}");
+            summaries_filtered.push(summary_files[index].clone());
+        }
+
+        Ok(summaries_filtered)
     }
 
     fn spawn_manifest_sync_task<S: ObjectStoreGetExt + Clone>(

--- a/crates/sui-snapshot/src/lib.rs
+++ b/crates/sui-snapshot/src/lib.rs
@@ -260,10 +260,10 @@ pub async fn setup_db_state(
     checkpoint_store.update_highest_executed_checkpoint(&last_checkpoint)?;
 
     if verify {
-        eprintln!(
+        m.println(
             "Beginning DB live object state verification. This may take a while, \
-            and currently does not provide progress updates..."
-        );
+            and currently does not provide progress updates...",
+        )?;
         let simplified_unwrap_then_delete = match (chain, epoch) {
             (Chain::Mainnet, ep) if ep >= 87 => true,
             (Chain::Mainnet, ep) if ep < 87 => false,
@@ -274,7 +274,7 @@ pub async fn setup_db_state(
         let include_tombstones = !simplified_unwrap_then_delete;
         let iter = perpetual_db.iter_live_object_set(include_tombstones);
         let local_digest = ECMHLiveObjectSetDigest::from(
-            accumulate_live_object_iter(Box::new(iter), m, num_live_objects).digest(),
+            accumulate_live_object_iter(Box::new(iter), m.clone(), num_live_objects).digest(),
         );
         assert_eq!(
             root_digest, local_digest,
@@ -282,7 +282,7 @@ pub async fn setup_db_state(
                 local root state hash {} after restoring db from formal snapshot",
             epoch, root_digest.digest, local_digest.digest,
         );
-        eprintln!("DB live object state verification completed successfully!");
+        m.println("DB live object state verification completed successfully!")?;
     }
 
     Ok(())

--- a/crates/sui-snapshot/src/lib.rs
+++ b/crates/sui-snapshot/src/lib.rs
@@ -260,10 +260,6 @@ pub async fn setup_db_state(
     checkpoint_store.update_highest_executed_checkpoint(&last_checkpoint)?;
 
     if verify {
-        m.println(
-            "Beginning DB live object state verification. This may take a while, \
-            and currently does not provide progress updates...",
-        )?;
         let simplified_unwrap_then_delete = match (chain, epoch) {
             (Chain::Mainnet, ep) if ep >= 87 => true,
             (Chain::Mainnet, ep) if ep < 87 => false,
@@ -274,7 +270,9 @@ pub async fn setup_db_state(
         let include_tombstones = !simplified_unwrap_then_delete;
         let iter = perpetual_db.iter_live_object_set(include_tombstones);
         let local_digest = ECMHLiveObjectSetDigest::from(
-            accumulate_live_object_iter(Box::new(iter), m.clone(), num_live_objects).digest(),
+            accumulate_live_object_iter(Box::new(iter), m.clone(), num_live_objects)
+                .await
+                .digest(),
         );
         assert_eq!(
             root_digest, local_digest,
@@ -282,29 +280,28 @@ pub async fn setup_db_state(
                 local root state hash {} after restoring db from formal snapshot",
             epoch, root_digest.digest, local_digest.digest,
         );
-        m.println("DB live object state verification completed successfully!")?;
+        println!("DB live object state verification completed successfully!");
     }
 
     Ok(())
 }
 
-pub fn accumulate_live_object_iter(
+pub async fn accumulate_live_object_iter(
     iter: Box<dyn Iterator<Item = LiveObject> + '_>,
     m: MultiProgress,
     num_live_objects: u64,
 ) -> Accumulator {
     // Monitor progress of live object accumulation
     let accum_progress_bar = m.add(ProgressBar::new(num_live_objects).with_style(
-        ProgressStyle::with_template(
-            "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files accumulated from db ({msg})",
-        ).unwrap(),
+        ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
     ));
     let accum_counter = Arc::new(AtomicU64::new(0));
     let cloned_accum_counter = accum_counter.clone();
-    tokio::spawn(async move {
+    let cloned_progress_bar = accum_progress_bar.clone();
+    let handle = tokio::spawn(async move {
         let a_instant = Instant::now();
         loop {
-            if accum_progress_bar.is_finished() {
+            if cloned_progress_bar.is_finished() {
                 break;
             }
             let num_accumulated = cloned_accum_counter.load(Ordering::Relaxed);
@@ -313,9 +310,9 @@ pub fn accumulate_live_object_iter(
                 "Accumulated more objects (at least {num_accumulated}) than expected ({num_live_objects})"
             );
             let accumulations_per_sec = num_accumulated as f64 / a_instant.elapsed().as_secs_f64();
-            accum_progress_bar.set_position(num_accumulated);
-            accum_progress_bar.set_message(format!(
-                "live obj accumulations per sec: {}",
+            cloned_progress_bar.set_position(num_accumulated);
+            cloned_progress_bar.set_message(format!(
+                "DB live obj accumulations per sec: {}",
                 accumulations_per_sec
             ));
             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -338,5 +335,9 @@ pub fn accumulate_live_object_iter(
         }
         accum_counter.fetch_add(1, Ordering::Relaxed);
     }
+    accum_progress_bar.finish_with_message("DB live object accumulation completed");
+    handle
+        .await
+        .expect("Failed to join live object accumulation progress monitor");
     acc
 }

--- a/crates/sui-snapshot/src/reader.rs
+++ b/crates/sui-snapshot/src/reader.rs
@@ -138,7 +138,7 @@ impl StateSnapshotReaderV1 {
         let progress_bar = m.add(
             ProgressBar::new(files.len() as u64).with_style(
                 ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} .ref files done\n({msg})",
+                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} .ref files done ({msg})",
                 )
                 .unwrap(),
             ),
@@ -351,7 +351,7 @@ impl StateSnapshotReaderV1 {
         let obj_progress_bar = self.m.add(
             ProgressBar::new(input_files.len() as u64).with_style(
                 ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} .obj files done\n({msg})",
+                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} .obj files done ({msg})",
                 )
                 .unwrap(),
             ),

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -365,6 +365,10 @@ pub enum ToolCommand {
         /// and output will be reduced to necessary status information.
         #[clap(long = "verbose")]
         verbose: bool,
+
+        /// If true, only download and verify end of epoch checkpoints.
+        #[clap(long = "with-skiplist")]
+        with_skiplist: bool,
     },
 
     #[clap(name = "replay")]
@@ -709,6 +713,7 @@ impl ToolCommand {
                 no_sign_request,
                 latest,
                 verbose,
+                with_skiplist,
             } => {
                 if !verbose {
                     tracing_handle
@@ -917,6 +922,7 @@ impl ToolCommand {
                     num_parallel_downloads,
                     network,
                     verify,
+                    with_skiplist,
                 )
                 .await?;
             }

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -366,9 +366,12 @@ pub enum ToolCommand {
         #[clap(long = "verbose")]
         verbose: bool,
 
-        /// If true, only download and verify end of epoch checkpoints.
-        #[clap(long = "with-skiplist")]
-        with_skiplist: bool,
+        /// If provided, all checkpoint summaries from genesis to the end of the target epoch
+        /// will be downloaded and (if --verify is provided) full checkpoint chain verification
+        /// will be performed. If omitted, only end of epoch checkpoint summaries will be
+        /// downloaded, and (if --verify is provided) will be verified via committee signature.
+        #[clap(long = "all-checkpoints")]
+        all_checkpoints: bool,
     },
 
     #[clap(name = "replay")]
@@ -713,7 +716,7 @@ impl ToolCommand {
                 no_sign_request,
                 latest,
                 verbose,
-                with_skiplist,
+                all_checkpoints,
             } => {
                 if !verbose {
                     tracing_handle
@@ -922,7 +925,7 @@ impl ToolCommand {
                     num_parallel_downloads,
                     network,
                     verify,
-                    with_skiplist,
+                    all_checkpoints,
                 )
                 .await?;
             }


### PR DESCRIPTION
## Description 

Checkpoint summary sync and verification now dominates the critical path for formal snapshot restore. Mysticeti is magnifying this due to the increased checkpointing rate. 

This PR aims to fix this by removing the requirement that we download and verify all checkpoints. 

If `--all-checkpoints` flag is provided, behavior is as it was before. If not, we simply download all end of epoch checkpoints, check signatures, and omit the step where we verify checkpoint chain continuity. The security argument for why this is ok is that the validators in the committee had to verify chain continuity, and a quorum of them signed against the given checkpoint digest. Signature verification confirms that the contents have not been altered, and the digest matching confirms that the chain was checked for consistency against this digest by the committee.

In general this will lead to a 2x speed increase (moreso when comparing post-mysticeti)

Note that if the flag is not provided, we use the old behavior, sacrificing longer restore times for more hardened security.

## Test plan 

Run with strict verification

```
target/release/sui-tool download-formal-snapshot --network mainnet --latest --path /opt/sui/db/authorities_db/full_node_db --genesis /opt/sui/mainnet/config/genesis.blob --no-sign-request --verify strict
Beginning formal snapshot restore to end of epoch 427, network: Mainnet, verification mode: Strict                                                                                        [00:06:42] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 468 out of 468 .ref files done (ref files download complete)
[00:01:03] █████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 428/428 (Checkpoint summary sync is complete)
[00:00:00] █████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 428/428 (Checkpoint summary verification is complete)
[00:00:41] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 468 out of 468 ref files checksummed (Checksumming complete)
[00:02:19] ████████████████████████████████████████████████████████████████████████████████████████████████████ 468 out of 468 ref files accumulated from snapshot (Accumulation complete)
[00:33:12] ████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 468 out of 468 .obj files done (Objects download complete)
[00:00:00] ███████████████████████████████████████████████████████████████████████████████████████████████████ Verifying snapshot contents against root state hash (Verification complete)
[00:40:42] ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 266867624/266867624 (DB live object accumulation completed)DB live object state verification completed successfully!
Successfully restored state from snapshot at end of epoch 427
```

Run with full summary sync and verification (old default)
```
target/release/sui-tool download-formal-snapshot --network mainnet --latest --path /opt/sui/db/authorities_db/full_node_db --genesis /opt/sui/mainnet/config/genesis.blob --no-sign-request --all-checkpoints
Formal snapshot state verification completed successfully!
[00:00:41] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 465 out of 465 ref files checksummed (Checksumming complete)
[00:02:23] ████████████████████████████████████████████████████████████████████████████████████████████████████ 465 out of 465 ref files accumulated from snapshot (Accumulation complete)
[00:29:15] ████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 465 out of 465 .obj files done
(Objects download complete)
[00:40:33] ████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 36549181/36549181(Checkpoint summary verification is complete)
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
