### PR TITLE
[Consensus 2.0] Recover from amnesia - part 2

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -350,6 +350,7 @@ where
 mod tests {
     #![allow(non_snake_case)]
 
+    use std::sync::Mutex;
     use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
     use consensus_config::{local_committee_and_keys, Parameters};
@@ -496,6 +497,160 @@ mod tests {
     }
 
     // TODO: create a fixture
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_amnesia_success(
+        #[values(ConsensusNetwork::Anemo, ConsensusNetwork::Tonic)] network_type: ConsensusNetwork,
+    ) {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(&db_registry);
+
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1, 1, 1, 1]);
+        let mut output_receivers = vec![];
+        let mut authorities = vec![];
+
+        for (index, _authority_info) in committee.authorities() {
+            let (authority, receiver) = make_authority(
+                index,
+                &TempDir::new().unwrap(),
+                committee.clone(),
+                keypairs.clone(),
+                network_type,
+            )
+            .await;
+            output_receivers.push(receiver);
+            authorities.push(authority);
+        }
+
+        const NUM_TRANSACTIONS: u8 = 15;
+        let mut submitted_transactions = BTreeSet::<Vec<u8>>::new();
+        for i in 0..NUM_TRANSACTIONS {
+            let txn = vec![i; 16];
+            submitted_transactions.insert(txn.clone());
+            authorities[i as usize % authorities.len()]
+                .transaction_client()
+                .submit(vec![txn])
+                .await
+                .unwrap();
+        }
+
+        for receiver in &mut output_receivers {
+            let mut expected_transactions = submitted_transactions.clone();
+            loop {
+                let committed_subdag =
+                    tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+                        .await
+                        .unwrap()
+                        .unwrap();
+                for b in committed_subdag.blocks {
+                    for txn in b.transactions().iter().map(|t| t.data().to_vec()) {
+                        assert!(
+                            expected_transactions.remove(&txn),
+                            "Transaction not submitted or already seen: {:?}",
+                            txn
+                        );
+                    }
+                }
+                assert_eq!(committed_subdag.reputation_scores_desc, vec![]);
+                if expected_transactions.is_empty() {
+                    break;
+                }
+            }
+        }
+
+        // Stop authority 1.
+        let index = committee.to_authority_index(1).unwrap();
+        authorities.remove(index.value()).stop().await;
+        sleep(Duration::from_secs(5)).await;
+
+        // now create a new directory to simulate amnesia. The node will start having participated previously
+        // to consensus but now will attempt to synchronize the last own block and recover from there.
+        let (authority, receiver) = make_authority(
+            index,
+            &TempDir::new().unwrap(),
+            committee.clone(),
+            keypairs,
+            network_type,
+        )
+        .await;
+        output_receivers[index] = receiver;
+        authorities.insert(index.value(), authority);
+        sleep(Duration::from_secs(5)).await;
+
+        // Stop all authorities and exit.
+        for authority in authorities {
+            authority.stop().await;
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_amnesia_failure(
+        #[values(ConsensusNetwork::Anemo, ConsensusNetwork::Tonic)] network_type: ConsensusNetwork,
+    ) {
+        telemetry_subscribers::init_for_testing();
+
+        let occurred_panic = Arc::new(Mutex::new(None));
+        let occurred_panic_cloned = occurred_panic.clone();
+
+        let default_panic_handler = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic| {
+            let mut l = occurred_panic_cloned.lock().unwrap();
+            *l = Some(panic.to_string());
+            default_panic_handler(panic);
+        }));
+
+        let db_registry = Registry::new();
+        DBMetrics::init(&db_registry);
+
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1, 1, 1, 1]);
+        let mut output_receivers = vec![];
+        let mut authorities = vec![];
+
+        for (index, _authority_info) in committee.authorities() {
+            let (authority, receiver) = make_authority(
+                index,
+                &TempDir::new().unwrap(),
+                committee.clone(),
+                keypairs.clone(),
+                network_type,
+            )
+            .await;
+            output_receivers.push(receiver);
+            authorities.push(authority);
+        }
+
+        // Let the network run for a few seconds
+        sleep(Duration::from_secs(5)).await;
+
+        // Stop all authorities
+        while let Some(authority) = authorities.pop() {
+            authority.stop().await;
+        }
+
+        sleep(Duration::from_secs(2)).await;
+
+        let index = AuthorityIndex::new_for_test(0);
+        let (_authority, _receiver) = make_authority(
+            index,
+            &TempDir::new().unwrap(),
+            committee,
+            keypairs,
+            network_type,
+        )
+        .await;
+        sleep(Duration::from_secs(5)).await;
+
+        // Now reset the panic hook
+        let _default_panic_handler = std::panic::take_hook();
+
+        let panic_info = occurred_panic.lock().unwrap().take().unwrap();
+        assert!(panic_info.contains(
+            "No peer has returned any acceptable result, can not safely update min round"
+        ));
+    }
+
     async fn make_authority(
         index: AuthorityIndex,
         db_dir: &TempDir,
@@ -511,6 +666,7 @@ mod tests {
             dag_state_cached_rounds: 5,
             commit_sync_parallel_fetches: 3,
             commit_sync_batch_size: 3,
+            sync_last_proposed_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -51,6 +51,14 @@ pub(crate) enum ConsensusError {
         block_ref: BlockRef,
     },
 
+    #[error(
+        "Unexpected block {block_ref} returned while fetching last own block from peer {index}"
+    )]
+    UnexpectedLastOwnBlock {
+        index: AuthorityIndex,
+        block_ref: BlockRef,
+    },
+
     #[error("Too many blocks have been returned from authority {0} when requesting to fetch missing blocks")]
     TooManyFetchedBlocksReturned(AuthorityIndex),
 

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -132,7 +132,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_committed_authority_round: IntGaugeVec,
     pub(crate) last_committed_leader_round: IntGauge,
     pub(crate) last_commit_index: IntGauge,
-    pub(crate) last_own_block_round: IntGauge,
+    pub(crate) last_known_own_block_round: IntGauge,
     pub(crate) commit_round_advancement_interval: Histogram,
     pub(crate) last_decided_leader_round: IntGauge,
     pub(crate) leader_timeout_total: IntCounterVec,
@@ -322,8 +322,8 @@ impl NodeMetrics {
                 &["authority", "type"],
                 registry,
             ).unwrap(),
-            last_own_block_round: register_int_gauge_with_registry!(
-                "last_own_block_round",
+            last_known_own_block_round: register_int_gauge_with_registry!(
+                "last_known_own_block_round",
                 "The highest round of our own block as this has been synced from peers during an amnesia recovery",
                 registry,
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -132,6 +132,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_committed_authority_round: IntGaugeVec,
     pub(crate) last_committed_leader_round: IntGauge,
     pub(crate) last_commit_index: IntGauge,
+    pub(crate) last_own_block_round: IntGauge,
     pub(crate) commit_round_advancement_interval: Histogram,
     pub(crate) last_decided_leader_round: IntGauge,
     pub(crate) leader_timeout_total: IntCounterVec,
@@ -319,6 +320,11 @@ impl NodeMetrics {
                 "synchronizer_fetched_blocks_by_authority",
                 "Number of fetched blocks per block author via the synchronizer",
                 &["authority", "type"],
+                registry,
+            ).unwrap(),
+            last_own_block_round: register_int_gauge_with_registry!(
+                "last_own_block_round",
+                "The highest round of our own block as this has been synced from peers during an amnesia recovery",
                 registry,
             ).unwrap(),
             // TODO: add a short status label.

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -19,6 +19,8 @@ use parking_lot::{Mutex, RwLock};
 #[cfg(not(test))]
 use rand::{prelude::SliceRandom, rngs::ThreadRng};
 use sui_macros::fail_point_async;
+#[cfg(test)]
+use tokio::task::JoinError;
 use tokio::{
     sync::{mpsc::error::TrySendError, oneshot},
     task::JoinSet,
@@ -161,12 +163,13 @@ enum Command {
         peer_index: AuthorityIndex,
         result: oneshot::Sender<Result<(), ConsensusError>>,
     },
+    FetchOwnLastBlock,
     KickOffScheduler,
 }
 
 pub(crate) struct SynchronizerHandle {
     commands_sender: Sender<Command>,
-    tasks: Mutex<JoinSet<()>>,
+    tasks: tokio::sync::Mutex<JoinSet<()>>,
 }
 
 impl SynchronizerHandle {
@@ -190,8 +193,18 @@ impl SynchronizerHandle {
     }
 
     pub(crate) async fn stop(&self) {
-        let mut tasks = self.tasks.lock();
+        let mut tasks = self.tasks.lock().await;
         tasks.abort_all();
+    }
+
+    #[cfg(test)]
+    async fn stop_and_wait_on(&self) -> Result<(), JoinError> {
+        let mut tasks = self.tasks.lock().await;
+        tasks.abort_all();
+        while let Some(result) = tasks.join_next().await {
+            result?
+        }
+        Ok(())
     }
 }
 
@@ -212,6 +225,10 @@ impl SynchronizerHandle {
 ///    missing blocks that were not ancestors of a received block via the "block send" path.
 ///    The scheduler operates on either a fixed periodic basis or is triggered immediately
 ///    after explicit fetches described in (1), ensuring continued block retrieval if gaps persist.
+///
+/// Additionally to the above, the synchronizer can synchronize and fetch the last own proposed block
+/// from the network peers as best effort approach to recover node from amnesia and avoid making the
+/// node equivocate.
 pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> {
     context: Arc<Context>,
     commands_receiver: Receiver<Command>,
@@ -220,6 +237,7 @@ pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThread
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     dag_state: Arc<RwLock<DagState>>,
     fetch_blocks_scheduler_task: JoinSet<()>,
+    fetch_own_last_block_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
     inflight_blocks_map: Arc<InflightBlocksMap>,
@@ -270,6 +288,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         let commands_sender_clone = commands_sender.clone();
 
+        if context.parameters.is_sync_last_proposed_block_enabled() {
+            commands_sender
+                .try_send(Command::FetchOwnLastBlock)
+                .expect("Failed to sync our last block");
+        }
+
         // Spawn the task to listen to the requests & periodic runs
         tasks.spawn(monitored_future!(async move {
             let mut s = Self {
@@ -278,6 +302,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 fetch_block_senders,
                 core_dispatcher,
                 fetch_blocks_scheduler_task: JoinSet::new(),
+                fetch_own_last_block_task: JoinSet::new(),
                 network_client,
                 block_verifier,
                 inflight_blocks_map,
@@ -290,7 +315,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         Arc::new(SynchronizerHandle {
             commands_sender,
-            tasks: Mutex::new(tasks),
+            tasks: tokio::sync::Mutex::new(tasks),
         })
     }
 
@@ -340,7 +365,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 });
 
                             result.send(r).ok();
-                        },
+                        }
+                        Command::FetchOwnLastBlock => {
+                            if self.fetch_own_last_block_task.is_empty() {
+                                self.start_fetch_own_last_block_task();
+                            }
+                        }
                         Command::KickOffScheduler => {
                             // just reset the scheduler timeout timer to run immediately if not already running.
                             // If the scheduler is already running then just reduce the remaining time to run.
@@ -356,6 +386,19 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             }
                         }
                     }
+                },
+                Some(result) = self.fetch_own_last_block_task.join_next(), if !self.fetch_own_last_block_task.is_empty() => {
+                    match result {
+                        Ok(()) => {},
+                        Err(e) => {
+                            if e.is_cancelled() {
+                            } else if e.is_panic() {
+                                std::panic::resume_unwind(e.into_panic());
+                            } else {
+                                panic!("fetch our last block task failed: {e}");
+                            }
+                        },
+                    };
                 },
                 Some(result) = self.fetch_blocks_scheduler_task.join_next(), if !self.fetch_blocks_scheduler_task.is_empty() => {
                     match result {
@@ -654,6 +697,111 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         (resp, blocks_guard, retries, peer, highest_rounds)
     }
 
+    fn start_fetch_own_last_block_task(&mut self) {
+        const FETCH_OWN_BLOCK_RETRY_DELAY: Duration = Duration::from_millis(1_000);
+
+        let context = self.context.clone();
+        let network_client = self.network_client.clone();
+        let block_verifier = self.block_verifier.clone();
+        let core_dispatcher = self.core_dispatcher.clone();
+
+        self.fetch_own_last_block_task
+            .spawn(monitored_future!(async move {
+                let _scope = monitored_scope("FetchOwnLastBlockTask");
+
+                // Ask all the other peers about our last block
+                let mut results = FuturesUnordered::new();
+
+                let fetch_own_block = |authority_index: AuthorityIndex, fetch_own_block_delay: Duration| {
+                    let network_client_cloned = network_client.clone();
+                    let context_cloned = context.clone();
+                    async move {
+                        sleep(fetch_own_block_delay).await;
+                        let r = network_client_cloned.fetch_latest_blocks(authority_index, vec![context_cloned.own_index], FETCH_REQUEST_TIMEOUT).await;
+                        (r, authority_index)
+                    }
+                };
+
+                for (authority_index, _authority) in context.committee.authorities() {
+                    if authority_index != context.own_index {
+                        results.push(fetch_own_block(authority_index, Duration::from_millis(0)));
+                    }
+                }
+
+                // Gather the results but wait to timeout as well
+                let timer = sleep_until(Instant::now() + context.parameters.sync_last_proposed_block_timeout);
+
+                tokio::pin!(timer);
+
+                // Get the highest of all the results
+                let mut total_stake = 0;
+                let mut highest_round = 0;
+                'main_loop: loop {
+                    tokio::select! {
+                        Some((result, authority_index)) = results.next() => {
+                            match result {
+                                Ok(result) => {
+                                    let mut blocks = Vec::new();
+                                    for serialized_block in result {
+                                        let Ok(signed_block) = bcs::from_bytes(&serialized_block) else {
+                                            warn!("Malformed block received from peer {authority_index} while fetching own last block, skipping.");
+                                            continue 'main_loop;
+                                        };
+
+                                        if let Err(e) = block_verifier.verify(&signed_block) {
+                                            context
+                                                .metrics
+                                                .node_metrics
+                                                .invalid_blocks
+                                                .with_label_values(&[&signed_block.author().to_string(), "synchronizer_own_block"])
+                                                .inc();
+                                            warn!("Invalid block received from {}: {}", authority_index, e);
+                                            continue 'main_loop;
+                                        }
+
+                                        let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
+                                        if verified_block.author() != context.own_index {
+                                            continue 'main_loop;
+                                        }
+                                        blocks.push(verified_block);
+                                    }
+
+                                    let max_round = blocks.into_iter().map(|b|b.round()).max().unwrap_or(0);
+                                    highest_round = highest_round.max(max_round);
+
+                                    total_stake += context.committee.stake(authority_index);
+
+                                    if results.is_empty() {
+                                        break;
+                                    }
+                                },
+                                Err(err) => {
+                                    warn!("Error {err} while fetching our own block from peer {authority_index}. Will retry.");
+                                    results.push(fetch_own_block(authority_index, FETCH_OWN_BLOCK_RETRY_DELAY));
+                                }
+                            }
+                        },
+                        () = &mut timer => {
+                            info!("Timeout while trying to sync our own last block from peers");
+                            break;
+                        }
+                    }
+                }
+
+                // Update the Core with the highest detected round
+                if total_stake == 0 {
+                    panic!("No peer has returned any acceptable result, can not safely update min round");
+                }
+
+                context.metrics.node_metrics.last_own_block_round.set(highest_round as i64);
+
+                info!("{} out of {} total stake returned acceptable results for our own last block with highest round {}", total_stake, context.committee.total_stake(), highest_round);
+                if let Err(err) = core_dispatcher.set_min_propose_round(highest_round).await {
+                    warn!("Error received while calling dispatcher, probably dispatcher is shutting down, will now exit: {err:?}");
+                }
+            }));
+    }
+
     async fn start_fetch_missing_blocks_task(&mut self) -> ConsensusResult<()> {
         let (commit_lagging, last_commit_index, quorum_commit_index) = self.is_commit_lagging();
         if commit_lagging {
@@ -847,9 +995,9 @@ mod tests {
 
     use async_trait::async_trait;
     use bytes::Bytes;
-    use consensus_config::AuthorityIndex;
+    use consensus_config::{AuthorityIndex, Parameters};
     use parking_lot::RwLock;
-    use tokio::time::sleep;
+    use tokio::{sync::Mutex, time::sleep};
 
     use crate::authority_service::COMMIT_LAG_MULTIPLIER;
     use crate::commit::{CommitVote, TrustedCommit};
@@ -873,8 +1021,9 @@ mod tests {
     // TODO: create a complete Mock for thread dispatcher to be used from several tests
     #[derive(Default)]
     struct MockCoreThreadDispatcher {
-        add_blocks: tokio::sync::Mutex<Vec<VerifiedBlock>>,
-        missing_blocks: tokio::sync::Mutex<BTreeSet<BlockRef>>,
+        add_blocks: Mutex<Vec<VerifiedBlock>>,
+        missing_blocks: Mutex<BTreeSet<BlockRef>>,
+        min_proposed_round_calls: Mutex<Vec<Round>>,
     }
 
     impl MockCoreThreadDispatcher {
@@ -886,6 +1035,11 @@ mod tests {
         async fn stub_missing_blocks(&self, block_refs: BTreeSet<BlockRef>) {
             let mut lock = self.missing_blocks.lock().await;
             lock.extend(block_refs);
+        }
+
+        async fn get_min_propose_round_calls(&self) -> Vec<Round> {
+            let lock = self.min_proposed_round_calls.lock().await;
+            lock.clone()
         }
     }
 
@@ -901,7 +1055,7 @@ mod tests {
         }
 
         async fn new_block(&self, _round: Round, _force: bool) -> Result<(), CoreError> {
-            todo!()
+            Ok(())
         }
 
         async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
@@ -915,17 +1069,23 @@ mod tests {
             todo!()
         }
 
-        fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
-            todo!()
+        fn set_last_known_proposed_round(&self, round: Round) -> Result<(), CoreError> {
+            let mut lock = self.min_proposed_round_calls.lock().await;
+            lock.push(round);
+            Ok(())
         }
     }
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
     type FetchRequestResponse = (Vec<VerifiedBlock>, Option<Duration>);
+    type FetchLatestBlockKey = (AuthorityIndex, Vec<AuthorityIndex>);
+    type FetchLatestBlockResponse = (Vec<VerifiedBlock>, Option<Duration>);
 
     #[derive(Default)]
     struct MockNetworkClient {
-        fetch_blocks_requests: tokio::sync::Mutex<BTreeMap<FetchRequestKey, FetchRequestResponse>>,
+        fetch_blocks_requests: Mutex<BTreeMap<FetchRequestKey, FetchRequestResponse>>,
+        fetch_latest_blocks_requests:
+            Mutex<BTreeMap<FetchLatestBlockKey, FetchLatestBlockResponse>>,
     }
 
     impl MockNetworkClient {
@@ -941,6 +1101,17 @@ mod tests {
                 .map(|block| block.reference())
                 .collect::<Vec<_>>();
             lock.insert((block_refs, peer), (blocks, latency));
+        }
+
+        async fn stub_fetch_latest_blocks(
+            &self,
+            blocks: Vec<VerifiedBlock>,
+            peer: AuthorityIndex,
+            authorities: Vec<AuthorityIndex>,
+            latency: Option<Duration>,
+        ) {
+            let mut lock = self.fetch_latest_blocks_requests.lock().await;
+            lock.insert((peer, authorities), (blocks, latency));
         }
     }
 
@@ -1004,11 +1175,28 @@ mod tests {
 
         async fn fetch_latest_blocks(
             &self,
-            _peer: AuthorityIndex,
-            _authorities: Vec<AuthorityIndex>,
+            peer: AuthorityIndex,
+            authorities: Vec<AuthorityIndex>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
-            todo!()
+            let mut lock = self.fetch_latest_blocks_requests.lock().await;
+            let response = lock
+                .remove(&(peer, authorities))
+                .expect("Unexpected fetch blocks request made");
+
+            let serialised = response
+                .0
+                .into_iter()
+                .map(|block| block.serialized().clone())
+                .collect::<Vec<_>>();
+
+            if let Some(latency) = response.1 {
+                sleep(latency).await;
+            }
+
+            drop(lock);
+
+            Ok(serialised)
         }
     }
 
@@ -1354,5 +1542,84 @@ mod tests {
         // THEN the missing blocks should now be fetched and added to core
         let added_blocks = core_dispatcher.get_add_blocks().await;
         assert_eq!(added_blocks, expected_blocks);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn synchronizer_fetch_own_last_block() {
+        // GIVEN
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context.with_parameters(Parameters {
+            sync_last_proposed_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        }));
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let network_client = Arc::new(MockNetworkClient::default());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let our_index = AuthorityIndex::new_for_test(0);
+
+        // Create some test blocks
+        let mut expected_blocks = (9..=10)
+            .map(|round| VerifiedBlock::new_for_test(TestBlock::new(round, 0).build()))
+            .collect::<Vec<_>>();
+
+        // Now set different latest blocks for the peers
+        // For peer 1 we give the block of round 10 (highest)
+        network_client
+            .stub_fetch_latest_blocks(
+                vec![expected_blocks.pop().unwrap()],
+                AuthorityIndex::new_for_test(1),
+                vec![our_index],
+                None,
+            )
+            .await;
+
+        // For peer 2 we give the block of round 9
+        network_client
+            .stub_fetch_latest_blocks(
+                vec![expected_blocks.pop().unwrap()],
+                AuthorityIndex::new_for_test(2),
+                vec![our_index],
+                None,
+            )
+            .await;
+
+        // For peer 3 we don't give any block - and it should return an empty vector
+        network_client
+            .stub_fetch_latest_blocks(
+                vec![],
+                AuthorityIndex::new_for_test(3),
+                vec![our_index],
+                None,
+            )
+            .await;
+
+        // WHEN start the synchronizer and wait for a couple of seconds
+        let handle = Synchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor,
+            block_verifier,
+            dag_state,
+        );
+
+        // Wait at least for the timeout time
+        sleep(context.parameters.sync_last_proposed_block_timeout * 2).await;
+
+        // Assert that core has been called to set the min propose round
+        assert_eq!(
+            core_dispatcher.get_last_own_proposed_round().await,
+            vec![10]
+        );
+
+        // Ensure that no panic occurred
+        if let Err(err) = handle.stop().await {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
     }
 }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -796,7 +796,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 context.metrics.node_metrics.last_own_block_round.set(highest_round as i64);
 
                 info!("{} out of {} total stake returned acceptable results for our own last block with highest round {}", total_stake, context.committee.total_stake(), highest_round);
-                if let Err(err) = core_dispatcher.set_min_propose_round(highest_round).await {
+                if let Err(err) = core_dispatcher.set_last_known_proposed_round(highest_round) {
                     warn!("Error received while calling dispatcher, probably dispatcher is shutting down, will now exit: {err:?}");
                 }
             }));
@@ -1023,7 +1023,7 @@ mod tests {
     struct MockCoreThreadDispatcher {
         add_blocks: Mutex<Vec<VerifiedBlock>>,
         missing_blocks: Mutex<BTreeSet<BlockRef>>,
-        min_proposed_round_calls: Mutex<Vec<Round>>,
+        last_known_proposed_round: parking_lot::Mutex<Vec<Round>>,
     }
 
     impl MockCoreThreadDispatcher {
@@ -1037,8 +1037,8 @@ mod tests {
             lock.extend(block_refs);
         }
 
-        async fn get_min_propose_round_calls(&self) -> Vec<Round> {
-            let lock = self.min_proposed_round_calls.lock().await;
+        async fn get_last_own_proposed_round(&self) -> Vec<Round> {
+            let lock = self.last_known_proposed_round.lock();
             lock.clone()
         }
     }
@@ -1070,7 +1070,7 @@ mod tests {
         }
 
         fn set_last_known_proposed_round(&self, round: Round) -> Result<(), CoreError> {
-            let mut lock = self.min_proposed_round_calls.lock().await;
+            let mut lock = self.last_known_proposed_round.lock();
             lock.push(round);
             Ok(())
         }


### PR DESCRIPTION
## Description 

The second part of the recovering from amnesia feature. This PR is implementing the logic to fetch the last own block from the peer network in the synchronizer. It is also adding several tests to confirm the behaviour correctness.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
