### PR TITLE
[sui-json-rpc-types] Add back `read_dynamic_field_value` to SuiMoveStruct

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -501,6 +501,14 @@ impl SuiMoveStruct {
             }
         }
     }
+
+    pub fn field_value(&self, field_name: &str) -> Option<SuiMoveValue> {
+        match self {
+            SuiMoveStruct::WithFields(fields) => fields.get(field_name).cloned(),
+            SuiMoveStruct::WithTypes { type_: _, fields } => fields.get(field_name).cloned(),
+            _ => None,
+        }
+    }
 }
 
 impl Display for SuiMoveStruct {


### PR DESCRIPTION


## Description 

Got removed in the enums PR for some reason, so adding it back in.

## Test plan 

CI

