### PR TITLE
[consensus] Disable multi leader per round in universal committer

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -34,9 +34,6 @@ use crate::{
     },
 };
 
-// TODO: Move to protocol config once initial value is finalized.
-const NUM_LEADERS_PER_ROUND: usize = 1;
-
 // Maximum number of commit votes to include in a block.
 // TODO: Move to protocol config, and verify in BlockVerifier.
 const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
@@ -92,12 +89,16 @@ impl Core {
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
         let last_decided_leader = dag_state.read().last_commit_leader();
+        let number_of_leaders = context
+            .protocol_config
+            .mysticeti_num_leaders_per_round()
+            .unwrap_or(1);
         let committer = UniversalCommitterBuilder::new(
             context.clone(),
             leader_schedule.clone(),
             dag_state.clone(),
         )
-        .with_number_of_leaders(NUM_LEADERS_PER_ROUND)
+        .with_number_of_leaders(number_of_leaders)
         .with_pipeline(true)
         .build();
 
@@ -1532,6 +1533,133 @@ mod test {
                 0
             );
             let expected_reputation_scores = ReputationScores::new(CommitRange::default(), vec![]);
+            assert_eq!(
+                core.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .reputation_scores,
+                expected_reputation_scores
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_commit_on_leader_schedule_change_boundary_without_multileader() {
+        parameterized_test_commit_on_leader_schedule_change_boundary(Some(1)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_commit_on_leader_schedule_change_boundary_with_multileader() {
+        parameterized_test_commit_on_leader_schedule_change_boundary(None).await;
+    }
+
+    async fn parameterized_test_commit_on_leader_schedule_change_boundary(
+        num_leaders_per_round: Option<usize>,
+    ) {
+        telemetry_subscribers::init_for_testing();
+        let default_params = Parameters::default();
+
+        let (mut context, _) = Context::new_for_test(6);
+        context
+            .protocol_config
+            .set_mysticeti_num_leaders_per_round(num_leaders_per_round);
+        // create the cores and their signals for all the authorities
+        let mut cores = create_cores(context, vec![1, 1, 1, 1, 1, 1]);
+
+        // Now iterate over a few rounds and ensure the corresponding signals are created while network advances
+        let mut last_round_blocks = Vec::new();
+        for round in 1..=63 {
+            let mut this_round_blocks = Vec::new();
+
+            // Wait for min round delay to allow blocks to be proposed.
+            sleep(default_params.min_round_delay).await;
+
+            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
+                // add the blocks from last round
+                // this will trigger a block creation for the round and a signal should be emitted
+                core.add_blocks(last_round_blocks.clone()).unwrap();
+
+                // A "new round" signal should be received given that all the blocks of previous round have been processed
+                let new_round = receive(
+                    Duration::from_secs(1),
+                    signal_receivers.new_round_receiver(),
+                )
+                .await;
+                assert_eq!(new_round, round);
+
+                // Check that a new block has been proposed.
+                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(block.round(), round);
+                assert_eq!(block.author(), core.context.own_index);
+
+                // append the new block to this round blocks
+                this_round_blocks.push(core.last_proposed_block().clone());
+
+                let block = core.last_proposed_block();
+
+                // ensure that produced block is referring to the blocks of last_round
+                assert_eq!(block.ancestors().len(), core.context.committee.size());
+                for ancestor in block.ancestors() {
+                    if block.round() > 1 {
+                        // don't bother with round 1 block which just contains the genesis blocks.
+                        assert!(
+                            last_round_blocks
+                                .iter()
+                                .any(|block| block.reference() == *ancestor),
+                            "Reference from previous round should be added"
+                        );
+                    }
+                }
+            }
+
+            last_round_blocks = this_round_blocks;
+        }
+
+        for (core, _, _, _, store) in cores {
+            // Check commits have been persisted to store
+            let last_commit = store
+                .read_last_commit()
+                .unwrap()
+                .expect("last commit should be set");
+            // There are 61 leader rounds with rounds completed up to and including
+            // round 63. Round 63 blocks will only include their own blocks, so there
+            // should only be 60 commits.
+            // However on a leader schedule change boundary its is possible for a
+            // new leader to get selected for the same round if the leader elected
+            // gets swapped allowing for multiple leaders to be committed at a round.
+            // Meaning with multi leader per round explicitly set to 1 we will have 60,
+            // otherwise 61.
+            // NOTE: We used 61 leader rounds to specifically trigger the scenario
+            // where the leader schedule boundary occured AND we had a swap to a new
+            // leader for the same round
+            let expected_commit_count = match num_leaders_per_round {
+                Some(1) => 60,
+                _ => 61,
+            };
+            assert_eq!(last_commit.index(), expected_commit_count);
+            let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
+            assert_eq!(all_stored_commits.len(), expected_commit_count as usize);
+            assert_eq!(
+                core.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .bad_nodes
+                    .len(),
+                1
+            );
+            assert_eq!(
+                core.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .good_nodes
+                    .len(),
+                1
+            );
+            let expected_reputation_scores =
+                ReputationScores::new((51..=60).into(), vec![8, 8, 9, 8, 8, 8]);
             assert_eq!(
                 core.leader_schedule
                     .leader_swap_table

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -429,7 +429,7 @@ impl Core {
         self.last_proposed_block = verified_block.clone();
 
         // Now acknowledge the transactions for their inclusion to block
-        ack_transactions();
+        ack_transactions(verified_block.reference());
 
         info!("Created block {:?}", verified_block);
 

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -175,6 +175,7 @@ impl TransactionClient {
     /// Submits a list of transactions to be sequenced. The method returns when all the transactions have been successfully included
     /// to next proposed blocks.
     pub async fn submit(&self, transactions: Vec<Vec<u8>>) -> Result<BlockRef, ClientError> {
+        // TODO: Support returning the block refs for transactions that span multiple blocks
         let included_in_block = self.submit_no_wait(transactions).await?;
         included_in_block
             .await

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -44,18 +44,19 @@ impl UniversalCommitter {
         // Try to decide as many leaders as possible, starting with the highest round.
         let mut leaders = VecDeque::new();
 
-        let last_round = if self
+        let last_round = match self
             .context
             .protocol_config
-            .mysticeti_disable_multi_leader_per_round_in_committer()
+            .mysticeti_num_leaders_per_round()
         {
-            // Ensure that we don't commit any leaders from the same round as last_decided
-            // until we have full support for multi-leader per round.
-            // This can happen when we are on a leader schedule boundary and the leader
-            // elected for the round changes with the new schedule.
-            last_decided.round + 1
-        } else {
-            last_decided.round
+            Some(1) => {
+                // Ensure that we don't commit any leaders from the same round as last_decided
+                // until we have full support for multi-leader per round.
+                // This can happen when we are on a leader schedule boundary and the leader
+                // elected for the round changes with the new schedule.
+                last_decided.round + 1
+            }
+            _ => last_decided.round,
         };
 
         // try to commit a leader up to the highest_accepted_round - 2. There is no

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -43,11 +43,26 @@ impl UniversalCommitter {
 
         // Try to decide as many leaders as possible, starting with the highest round.
         let mut leaders = VecDeque::new();
+
+        let last_round = if self
+            .context
+            .protocol_config
+            .mysticeti_disable_multi_leader_per_round_in_committer()
+        {
+            // Ensure that we don't commit any leaders from the same round as last_decided
+            // until we have full support for multi-leader per round.
+            // This can happen when we are on a leader schedule boundary and the leader
+            // elected for the round changes with the new schedule.
+            last_decided.round + 1
+        } else {
+            last_decided.round
+        };
+
         // try to commit a leader up to the highest_accepted_round - 2. There is no
         // reason to try and iterate on higher rounds as in order to make a direct
         // decision for a leader at round R we need blocks from round R+2 to figure
         // out that enough certificates and support exist to commit a leader.
-        'outer: for round in (last_decided.round..=highest_accepted_round.saturating_sub(2)).rev() {
+        'outer: for round in (last_round..=highest_accepted_round.saturating_sub(2)).rev() {
             for committer in self.committers.iter().rev() {
                 // Skip committers that don't have a leader for this round.
                 let Some(slot) = committer.elect_leader(round) else {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -996,16 +996,6 @@ mod tests {
             last_consensus_stats_1.stats.get_num_user_transactions(0),
             num_transactions as u64
         );
-
-        // WHEN processing the same output multiple times
-        // THEN the consensus stats do not update
-        for _ in 0..2 {
-            consensus_handler
-                .handle_consensus_output(consensus_output.clone())
-                .await;
-            let last_consensus_stats_2 = consensus_handler.last_consensus_stats.clone();
-            assert_eq!(last_consensus_stats_1, last_consensus_stats_2);
-        }
     }
 
     #[test]

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -233,17 +233,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         let round = consensus_output.leader_round();
 
-        assert!(round >= last_committed_round);
-        if last_committed_round == round {
-            // we can receive the same commit twice after restart
-            // It is critical that the writes done by this function are atomic - otherwise we can
-            // lose the later parts of a commit if we restart midway through processing it.
-            info!(
-                "Ignoring consensus output for round {} as it is already committed",
-                round
-            );
-            return;
-        }
+        assert!(round > last_committed_round);
 
         /* (serialized, transaction, output_cert) */
         let mut transactions = vec![];

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -145,7 +145,7 @@ const MAX_PROTOCOL_VERSION: u64 = 50;
 //             New Move stdlib integer modules
 //             Enable checkpoint batching in testnet.
 //             Prepose consensus commit prologue in checkpoints.
-//             Disable multi-leader per round in Mysticeti universal committer.
+//             Set number of leaders per round for Mysticeti commits.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -498,9 +498,9 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     prepend_prologue_tx_in_consensus_commit_in_checkpoints: bool,
 
-    // Disable multi-leader per round in Mysticeti universal committer.
-    #[serde(skip_serializing_if = "is_false")]
-    mysticeti_disable_multi_leader_per_round_in_committer: bool,
+    // Set number of leaders per round for Mysticeti commits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mysticeti_num_leaders_per_round: Option<usize>,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1430,9 +1430,8 @@ impl ProtocolConfig {
         self.feature_flags.fresh_vm_on_framework_upgrade
     }
 
-    pub fn mysticeti_disable_multi_leader_per_round_in_committer(&self) -> bool {
-        self.feature_flags
-            .mysticeti_disable_multi_leader_per_round_in_committer
+    pub fn mysticeti_num_leaders_per_round(&self) -> Option<usize> {
+        self.feature_flags.mysticeti_num_leaders_per_round
     }
 }
 
@@ -2388,8 +2387,7 @@ impl ProtocolConfig {
                             .prepend_prologue_tx_in_consensus_commit_in_checkpoints = true;
                     }
 
-                    cfg.feature_flags
-                        .mysticeti_disable_multi_leader_per_round_in_committer = true;
+                    cfg.feature_flags.mysticeti_num_leaders_per_round = Some(1);
                 }
                 // Use this template when making changes:
                 //
@@ -2560,8 +2558,13 @@ impl ProtocolConfig {
     pub fn set_mysticeti_leader_scoring_and_schedule(&mut self, val: bool) {
         self.feature_flags.mysticeti_leader_scoring_and_schedule = val;
     }
+
     pub fn set_min_checkpoint_interval_ms(&mut self, val: u64) {
         self.min_checkpoint_interval_ms = Some(val);
+    }
+
+    pub fn set_mysticeti_num_leaders_per_round(&mut self, val: Option<usize>) {
+        self.feature_flags.mysticeti_num_leaders_per_round = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
@@ -49,6 +49,7 @@ feature_flags:
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
   fresh_vm_on_framework_upgrade: true
+  mysticeti_disable_multi_leader_per_round_in_committer: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
@@ -49,7 +49,7 @@ feature_flags:
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
   fresh_vm_on_framework_upgrade: true
-  mysticeti_disable_multi_leader_per_round_in_committer: true
+  mysticeti_num_leaders_per_round: 1
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
+assertion_line: 2657
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 50
@@ -53,6 +54,7 @@ feature_flags:
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
   fresh_vm_on_framework_upgrade: true
+  mysticeti_disable_multi_leader_per_round_in_committer: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
-assertion_line: 2657
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 50
@@ -54,7 +53,7 @@ feature_flags:
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
   fresh_vm_on_framework_upgrade: true
-  mysticeti_disable_multi_leader_per_round_in_committer: true
+  mysticeti_num_leaders_per_round: 1
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
@@ -58,6 +58,7 @@ feature_flags:
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_disable_multi_leader_per_round_in_committer: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
@@ -58,7 +58,7 @@ feature_flags:
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
-  mysticeti_disable_multi_leader_per_round_in_committer: true
+  mysticeti_num_leaders_per_round: 1
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -12,6 +12,7 @@ import argparse
 parser = argparse.ArgumentParser(description='Run the simulator with different seeds')
 parser.add_argument('binary', type=str, help='Name of simulator binary, or full path to binary')
 parser.add_argument('--test', type=str, help='Name of the test to run', required=True)
+parser.add_argument('--exact', action='store_true', help='Use exact matching for test name', default=False)
 parser.add_argument('--num-seeds', type=int, help='Number of seeds to run', default=200)
 parser.add_argument(
     '--seed-start',
@@ -94,7 +95,7 @@ if __name__ == "__main__":
 
     for i in range(1, args.num_seeds + 1):
         next_seed = args.seed_start + i
-        commands.append(("%s --exact %s" % (binary, args.test), {
+        commands.append(("%s %s %s" % (binary, '--exact' if args.exact else '', args.test), {
           "MSIM_TEST_SEED": "%d" % next_seed,
           "RUST_LOG": "off",
         }))

--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -41,7 +41,7 @@ def run_command(command, env_vars):
         else:
           print("-- seed passed %s" % env_vars["MSIM_TEST_SEED"])
 
-        return 0
+        return exit_code
     except subprocess.CalledProcessError as e:
         print(f"Command '{e.cmd}' failed with exit code {e.returncode} for seed: " + env_vars["MSIM_TEST_SEED"])
         return e.returncode
@@ -55,12 +55,17 @@ def main(commands):
             future = executor.submit(run_command, cmd, env_vars)
             future_to_command[future] = cmd
 
+        all_passed = True
         for future in concurrent.futures.as_completed(future_to_command):
             cmd = future_to_command[future]
             exit_code = future.result()
             if exit_code != 0:
+                all_passed = False
                 print(f"Command '{cmd}' failed with exit code {exit_code}")
                 sys.exit(1)
+
+        if all_passed:
+            print("\033[92mAll tests passed successfully!\033[0m")
 
 if __name__ == "__main__":
     repo_root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()


### PR DESCRIPTION
## Description 

On the boundaries of Leader Schedule change it is possible to elect a new leader for the same round resulting in multiple commits for the same round. This was unintended output from consensus as we have set the parameters to only commit 1 leader per round. Sui also only expects one commit per round, because of this the second commit of the same round is ignored by consensus handler. This led to an error in simtests where the `EndOfPublish` transaction was part of this ignored commit and we could not form a quorum to close the epoch without this node. 

Changes
-  Explicitly set number of leaders per round to 1 for Mysticeti commits. I wanted to try and maintain this but it would be a much more intrusive change and we will probably have to do a larger refactor to fully support it anyways, so better off doing the cleaner mitigation for now. 
- Pass back the block that the transaction was included in as part of the tx acknowledgment and include that in the logging to help with debugging future issues.
- Also a minor change to print if all tests pass during simtest seed-search 

## Test plan 

```
❯ scripts/simtest/seed-search.py simtest --test test_reconfig_with_committee_change_basic --num-seeds 1000
    Updating git repository `https://github.com/MystenLabs/mysten-sim.git`
   Compiling consensus-core v0.1.0 (/Users/arunkoshy/Documents/GitHub/sui/consensus/core)
   ...
   All tests passed successfully!
  Killing child processes
  [1]    391 killed     scripts/simtest/seed-search.py simtest --test  --num-seeds 1000
```

---

## Release notes

- [X] Protocol: Version 50 - Explicitly set number of leaders per round to 1 for Mysticeti commits
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
