### PR TITLE
Fix CoinWithBalance example in intents.mdx

### DIFF
--- a/sdk/docs/pages/typescript/transaction-building/intents.mdx
+++ b/sdk/docs/pages/typescript/transaction-building/intents.mdx
@@ -23,18 +23,30 @@ MergeCoins commands to the transaction:
 
 ```typescript
 import { coinWithBalance, Transaction } from '@mysten/sui/transactions';
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { suiClient } from "./client"
+
+const keypair = new Ed25519Keypair();
 
 const tx = new Transaction();
 
 tx.transferObjects(
 	[
 		// Create a SUI coin (balance is in MIST)
-		coinWithBalance({ balance: 100 }),
+		coinWithBalance({ balance: 100n }),
 		// Create a coin of another type
-		coinWithBalance({ balance: 100, type: '0x123::foo:Bar' }),
+		coinWithBalance({ balance: 100n, type: '0x123::foo:Bar' }),
 	],
 	recipient,
 );
+
+tx.setSender(keypair.toSuiAddress());
+
+const { digest } = await suiClient.signAndExecuteTransaction({
+      transaction: tx,
+      signer: keypair,
+});
+
 ```
 
 Splitting the gas coin also causes problems for sponsored transactions. When sponsoring


### PR DESCRIPTION
## Description 

- Fix type error with parameter of `balance` (only accept bigint)
- Update flow of build and execute transaction with `coinWithBalance` in docu exmaple
    - Must `setSender` before build transaction

## Test plan 

No test plan 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
