### PR TITLE
Set max_deferral_rounds_for_congestion_control to 10

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2388,6 +2388,9 @@ impl ProtocolConfig {
                     }
 
                     cfg.feature_flags.mysticeti_num_leaders_per_round = Some(1);
+
+                    // Set max transaction deferral to 10 consensus rounds.
+                    cfg.max_deferral_rounds_for_congestion_control = Some(10);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
@@ -270,4 +270,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
-
+max_deferral_rounds_for_congestion_control: 10

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
@@ -277,6 +277,6 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
@@ -286,5 +286,6 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1


### PR DESCRIPTION
## Description 

Deferred txn due to congestion will be cancelled after 10 consensus commit rounds.

Note that this setting has no effect if congestion control is not on.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
