### PR TITLE
[indexer] move objects snapshot processing into its own pipeline

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -26,6 +26,7 @@ use test_cluster::TestClusterBuilder;
 use tokio::join;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 const VALIDATOR_COUNT: usize = 7;
 const EPOCH_DURATION_MS: u64 = 15000;
@@ -236,6 +237,11 @@ async fn wait_for_graphql_checkpoint_catchup(
     checkpoint: u64,
     base_timeout: Duration,
 ) {
+    info!(
+        "Waiting for graphql to catchup to checkpoint {}, base time out is {}",
+        checkpoint,
+        base_timeout.as_secs()
+    );
     let query = r#"
     {
         availableRange {
@@ -256,7 +262,7 @@ async fn wait_for_graphql_checkpoint_catchup(
                 .response_body_json();
 
             let current_checkpoint = resp["data"]["availableRange"]["last"].get("sequenceNumber");
-
+            info!("Current checkpoint: {:?}", current_checkpoint);
             // Indexer has not picked up any checkpoints yet
             let Some(current_checkpoint) = current_checkpoint else {
                 tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -9,7 +9,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use tracing::{error, info};
 
-use sui_rest_api::Client;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::metrics::IndexerMetrics;
@@ -18,12 +17,10 @@ use crate::types::IndexerResult;
 
 use super::{CheckpointDataToCommit, EpochToCommit};
 
-const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
-const OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG: u64 = 900;
+pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
 
 pub async fn start_tx_checkpoint_commit_task<S>(
     state: S,
-    client: Client,
     metrics: IndexerMetrics,
     tx_indexing_receiver: mysten_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
     commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
@@ -45,16 +42,6 @@ where
     let mut stream = mysten_metrics::metered_channel::ReceiverStream::new(tx_indexing_receiver)
         .ready_chunks(checkpoint_commit_batch_size);
 
-    let mut object_snapshot_backfill_mode = true;
-    let latest_object_snapshot_seq = state
-        .get_latest_object_snapshot_checkpoint_sequence_number()
-        .await?;
-    let latest_cp_seq = state.get_latest_checkpoint_sequence_number().await?;
-    if latest_object_snapshot_seq != latest_cp_seq {
-        info!("Flipping object_snapshot_backfill_mode to false because objects_snapshot is behind already!");
-        object_snapshot_backfill_mode = false;
-    }
-
     let mut unprocessed = HashMap::new();
     let mut batch = vec![];
 
@@ -62,21 +49,6 @@ where
         if cancel.is_cancelled() {
             break;
         }
-
-        let mut latest_fn_cp_res = client.get_latest_checkpoint().await;
-        while latest_fn_cp_res.is_err() {
-            error!("Failed to get latest checkpoint from the network");
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            latest_fn_cp_res = client.get_latest_checkpoint().await;
-        }
-        // unwrap is safe here because we checked that latest_fn_cp_res is Ok above
-        let latest_fn_cp = latest_fn_cp_res.unwrap().sequence_number;
-        // unwrap is safe b/c we checked for empty batch above
-        let latest_committed_cp = indexed_checkpoint_batch
-            .last()
-            .unwrap()
-            .checkpoint
-            .sequence_number;
 
         // split the batch into smaller batches per epoch to handle partitioning
         for checkpoint in indexed_checkpoint_batch {
@@ -87,35 +59,13 @@ where
             batch.push(checkpoint);
             next_checkpoint_sequence_number += 1;
             if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
-                commit_checkpoints(
-                    &state,
-                    batch,
-                    epoch,
-                    &metrics,
-                    &commit_notifier,
-                    object_snapshot_backfill_mode,
-                )
-                .await;
+                commit_checkpoints(&state, batch, epoch, &metrics, &commit_notifier).await;
                 batch = vec![];
             }
         }
         if !batch.is_empty() && unprocessed.is_empty() {
-            commit_checkpoints(
-                &state,
-                batch,
-                None,
-                &metrics,
-                &commit_notifier,
-                object_snapshot_backfill_mode,
-            )
-            .await;
+            commit_checkpoints(&state, batch, None, &metrics, &commit_notifier).await;
             batch = vec![];
-        }
-        // this is a one-way flip in case indexer falls behind again, so that the objects snapshot
-        // table will not be populated by both committer and async snapshot processor at the same time.
-        if latest_committed_cp + OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG > latest_fn_cp {
-            info!("Flipping object_snapshot_backfill_mode to false because objects_snapshot is close to up-to-date.");
-            object_snapshot_backfill_mode = false;
         }
     }
     Ok(())
@@ -132,7 +82,6 @@ async fn commit_checkpoints<S>(
     epoch: Option<EpochToCommit>,
     metrics: &IndexerMetrics,
     commit_notifier: &watch::Sender<Option<CheckpointSequenceNumber>>,
-    object_snapshot_backfill_mode: bool,
 ) where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
@@ -189,9 +138,6 @@ async fn commit_checkpoints<S>(
             state.persist_objects(object_changes_batch.clone()),
             state.persist_object_history(object_history_changes_batch.clone()),
         ];
-        if object_snapshot_backfill_mode {
-            persist_tasks.push(state.backfill_objects_snapshot(object_changes_batch));
-        }
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));
         }
@@ -250,11 +196,6 @@ async fn commit_checkpoints<S>(
         .total_tx_checkpoint_committed
         .inc_by(checkpoint_num as u64);
     metrics.total_transaction_committed.inc_by(tx_count as u64);
-    if object_snapshot_backfill_mode {
-        metrics
-            .latest_object_snapshot_sequence_number
-            .set(last_checkpoint_seq as i64);
-    }
     metrics
         .transaction_per_checkpoint
         .observe(tx_count as f64 / (last_checkpoint_seq - first_checkpoint_seq + 1) as f64);

--- a/crates/sui-indexer/src/handlers/objects_snapshot_processor.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_processor.rs
@@ -1,23 +1,53 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_trait::async_trait;
+use diesel::r2d2::R2D2Connection;
+use futures::StreamExt;
+use mysten_metrics::get_metrics;
+use mysten_metrics::metered_channel::{Receiver, Sender};
+use mysten_metrics::spawn_monitored_task;
+use prometheus::Registry;
+use sui_data_ingestion_core::DataIngestionMetrics;
+use sui_data_ingestion_core::IndexerExecutor;
+use sui_data_ingestion_core::ReaderOptions;
+use sui_data_ingestion_core::ShimProgressStore;
+use sui_data_ingestion_core::Worker;
+use sui_data_ingestion_core::WorkerPool;
+use sui_package_resolver::Resolver;
+use sui_rest_api::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use sui_rest_api::Client;
-
+use crate::store::package_resolver::IndexerStorePackageResolver;
+use crate::store::package_resolver::InterimPackageResolver;
 use crate::types::IndexerResult;
+use crate::IndexerConfig;
 use crate::{metrics::IndexerMetrics, store::IndexerStore};
+use std::sync::{Arc, Mutex};
+use sui_package_resolver::PackageStoreWithLruCache;
+
+use super::checkpoint_handler::CheckpointHandler;
+use super::tx_processor::IndexingPackageBuffer;
+use super::TransactionObjectChangesToCommit;
 
 const OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG: usize = 900;
 const OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG: usize = 300;
 
-pub struct ObjectsSnapshotProcessor<S> {
-    pub client: Client,
+pub struct ObjectsSnapshotProcessor<S, T: R2D2Connection + 'static> {
     pub store: S,
+    package_buffer: Arc<Mutex<IndexingPackageBuffer>>,
+    package_resolver: Arc<Resolver<PackageStoreWithLruCache<InterimPackageResolver<T>>>>,
+    pub indexed_obj_sender: Sender<CheckpointObjectChanges>,
     metrics: IndexerMetrics,
-    pub config: SnapshotLagConfig,
-    cancel: CancellationToken,
+}
+
+pub struct CheckpointObjectChanges {
+    pub checkpoint_sequence_number: u64,
+    pub object_changes: TransactionObjectChangesToCommit,
 }
 
 #[derive(Clone)]
@@ -62,105 +92,220 @@ impl Default for SnapshotLagConfig {
     }
 }
 
-// NOTE: "handler"
-impl<S> ObjectsSnapshotProcessor<S>
+#[async_trait]
+impl<S, T> Worker for ObjectsSnapshotProcessor<S, T>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
+    T: R2D2Connection + 'static,
 {
-    pub fn new_with_config(
-        client: Client,
+    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> anyhow::Result<()> {
+        let checkpoint_sequence_number = checkpoint.checkpoint_summary.sequence_number;
+        // Index the object changes and send them to the committer.
+        let object_changes: TransactionObjectChangesToCommit =
+            CheckpointHandler::<S, T>::index_objects(
+                checkpoint,
+                &self.metrics,
+                self.package_resolver.clone(),
+            )
+            .await?;
+        self.indexed_obj_sender
+            .send(CheckpointObjectChanges {
+                checkpoint_sequence_number,
+                object_changes,
+            })
+            .await?;
+        Ok(())
+    }
+
+    fn preprocess_hook(&self, checkpoint: CheckpointData) -> anyhow::Result<()> {
+        let package_objects = CheckpointHandler::<S, T>::get_package_objects(&[checkpoint]);
+        self.package_buffer
+            .lock()
+            .unwrap()
+            .insert_packages(package_objects);
+        Ok(())
+    }
+}
+
+// Start both the ingestion pipeline and committer for objects snapshot table.
+pub async fn start_objects_snapshot_processor<S, T>(
+    store: S,
+    metrics: IndexerMetrics,
+    config: IndexerConfig,
+    snapshot_config: SnapshotLagConfig,
+    reader_options: ReaderOptions,
+    cancel: CancellationToken,
+) -> IndexerResult<()>
+where
+    S: IndexerStore + Clone + Sync + Send + 'static,
+    T: R2D2Connection + 'static,
+{
+    info!("Starting object snapshot processor...");
+
+    let watermark = store
+        .get_latest_object_snapshot_checkpoint_sequence_number()
+        .await
+        .expect("Failed to get latest snapshot checkpoint sequence number from DB")
+        .map(|seq| seq + 1)
+        .unwrap_or_default();
+    let download_queue_size = std::env::var("DOWNLOAD_QUEUE_SIZE")
+        .unwrap_or_else(|_| crate::indexer::DOWNLOAD_QUEUE_SIZE.to_string())
+        .parse::<usize>()
+        .expect("Invalid DOWNLOAD_QUEUE_SIZE");
+
+    // Set up exit sender and receiver. Sender signals the ingestion executor to exit when
+    // the cancel token is triggered.
+    let (exit_sender, exit_receiver) = oneshot::channel();
+    let cancel_clone = cancel.clone();
+    spawn_monitored_task!(async move {
+        cancel_clone.cancelled().await;
+        let _ = exit_sender.send(());
+    });
+
+    // Commit notifier to to signal the package buffer that a checkpoint has been committed.
+    let (commit_notifier, commit_receiver) = watch::channel(None);
+
+    let global_metrics = get_metrics().unwrap();
+    // Channel for actually communicating indexed object changes between the ingestion pipeline and the committer.
+    let (indexed_obj_sender, indexed_obj_receiver) = mysten_metrics::metered_channel::channel(
+        // TODO: placeholder for now
+        1800,
+        &global_metrics
+            .channel_inflight
+            .with_label_values(&["obj_indexing_for_snapshot"]),
+    );
+
+    // Start an ingestion pipeline with the objects snapshot processor as a worker.
+    let worker = ObjectsSnapshotProcessor::<S, T>::new(
+        store.clone(),
+        indexed_obj_sender,
+        commit_receiver,
+        metrics.clone(),
+    );
+    let mut executor = IndexerExecutor::new(
+        ShimProgressStore(watermark),
+        1,
+        DataIngestionMetrics::new(&Registry::new()),
+    );
+    let worker_pool = WorkerPool::new(
+        worker,
+        "objects_snapshot_worker".to_string(),
+        download_queue_size,
+    );
+
+    executor.register(worker_pool).await?;
+
+    spawn_monitored_task!(async move {
+        info!("Starting data ingestion executor for processing objects snapshot...");
+        let _ = executor
+            .run(
+                config
+                    .data_ingestion_path
+                    .clone()
+                    .unwrap_or(tempfile::tempdir().unwrap().into_path()),
+                config.remote_store_url.clone(),
+                vec![],
+                reader_options,
+                exit_receiver,
+            )
+            .await;
+    });
+
+    // Now start the task that will commit the indexed object changes to the store.
+    spawn_monitored_task!(ObjectsSnapshotProcessor::<S, T>::commit_objects_snapshot(
+        store,
+        watermark,
+        indexed_obj_receiver,
+        commit_notifier,
+        metrics,
+        snapshot_config,
+        cancel,
+    ));
+    Ok(())
+}
+
+impl<S, T> ObjectsSnapshotProcessor<S, T>
+where
+    S: IndexerStore + Clone + Sync + Send + 'static,
+    T: R2D2Connection + 'static,
+{
+    pub fn new(
         store: S,
+        indexed_obj_sender: Sender<CheckpointObjectChanges>,
+        commit_receiver: watch::Receiver<Option<CheckpointSequenceNumber>>,
         metrics: IndexerMetrics,
-        config: SnapshotLagConfig,
-        cancel: CancellationToken,
-    ) -> ObjectsSnapshotProcessor<S> {
+    ) -> ObjectsSnapshotProcessor<S, T> {
+        // Start the package buffer used for buffering packages before they are written to the db.
+        // We include a commit receiver which will be paged when a checkpoint has been processed and
+        // the corresponding package data can be deleted from the buffer.
+        let package_buffer = IndexingPackageBuffer::start(commit_receiver);
+        let pg_blocking_cp = CheckpointHandler::pg_blocking_cp(store.clone()).unwrap();
+        let package_db_resolver = IndexerStorePackageResolver::new(pg_blocking_cp);
+        let in_mem_package_resolver = InterimPackageResolver::new(
+            package_db_resolver,
+            package_buffer.clone(),
+            metrics.clone(),
+        );
+        let cached_package_resolver = PackageStoreWithLruCache::new(in_mem_package_resolver);
+        let package_resolver = Arc::new(Resolver::new(cached_package_resolver));
+
         Self {
-            client,
             store,
+            indexed_obj_sender,
+            package_resolver,
+            package_buffer,
             metrics,
-            config,
-            cancel,
         }
     }
 
-    // The `objects_snapshot` table maintains a delayed snapshot of the `objects` table,
-    // controlled by `object_snapshot_max_checkpoint_lag` (max lag) and
-    // `object_snapshot_min_checkpoint_lag` (min lag). For instance, with a max lag of 900
-    // and a min lag of 300 checkpoints, the `objects_snapshot` table will lag behind the
-    // `objects` table by 300 to 900 checkpoints. The snapshot is updated when the lag
-    // exceeds the max lag threshold, and updates continue until the lag is reduced to
-    // the min lag threshold. Then, we have a consistent read range between
-    // `latest_snapshot_cp` and `latest_cp` based on `objects_snapshot` and `objects_history`,
-    // where the size of this range varies between the min and max lag values.
-    pub async fn start(&self) -> IndexerResult<()> {
-        info!("Starting object snapshot processor...");
-        let latest_snapshot_cp = self
-            .store
-            .get_latest_object_snapshot_checkpoint_sequence_number()
-            .await?
-            .unwrap_or_default();
-        let latest_indexer_cp = self
-            .store
-            .get_latest_checkpoint_sequence_number()
-            .await?
-            .unwrap_or_default();
-        // make sure cp 0 is handled
-        let mut start_cp = if latest_snapshot_cp == 0 {
-            0
-        } else {
-            latest_snapshot_cp + 1
-        };
-        // with MAX and MIN, the CSR range will vary from MIN cps to MAX cps
-        let snapshot_window =
-            self.config.snapshot_max_lag as u64 - self.config.snapshot_min_lag as u64;
-        let mut latest_fn_cp = self.client.get_latest_checkpoint().await?.sequence_number;
+    // Receives object changes from the ingestion pipeline and commits them to the store,
+    // keeping the appropriate amount of checkpoint lag behind the rest of the indexer.
+    pub async fn commit_objects_snapshot(
+        store: S,
+        watermark: CheckpointSequenceNumber,
+        indexed_obj_receiver: Receiver<CheckpointObjectChanges>,
+        commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
+        metrics: IndexerMetrics,
+        config: SnapshotLagConfig,
+        cancel: CancellationToken,
+    ) -> IndexerResult<()> {
+        let batch_size = config.snapshot_max_lag - config.snapshot_min_lag;
+        let mut stream = mysten_metrics::metered_channel::ReceiverStream::new(indexed_obj_receiver)
+            .ready_chunks(batch_size);
 
-        // While the below is true, we are in backfill mode, and so `ObjectsSnapshotProcessor` will
-        // no-op. Once we exit the loop, this task will then be responsible for updating the
-        // `objects_snapshot` table.
-        if latest_snapshot_cp == latest_indexer_cp {
-            while latest_fn_cp > start_cp + self.config.snapshot_max_lag as u64 {
-                tokio::select! {
-                    _ = self.cancel.cancelled() => {
-                        info!("Shutdown signal received, terminating object snapshot processor");
-                        return Ok(());
-                    }
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(self.config.sleep_duration)) => {
-                        info!("Objects snapshot is in backfill mode, objects snapshot processor is sleeping for {} seconds", self.config.sleep_duration);
-                        latest_fn_cp = self.client.get_latest_checkpoint().await?.sequence_number;
-                        start_cp = self
-                            .store
-                            .get_latest_object_snapshot_checkpoint_sequence_number()
-                            .await?
-                            .unwrap_or_default();
-                    }
-                }
-            }
-        }
+        let mut start_cp = watermark;
 
-        info!("Objects snapshot processor starts updating objects_snapshot periodically...");
+        info!("Starting objects snapshot committer...");
         loop {
             tokio::select! {
-                _ = self.cancel.cancelled() => {
+                _ = cancel.cancelled() => {
                     info!("Shutdown signal received, terminating object snapshot processor");
                     return Ok(());
                 }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(self.config.sleep_duration)) => {
-                    let latest_cp = self
-                        .store
+                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                    let latest_indexer_cp = store
                         .get_latest_checkpoint_sequence_number()
                         .await?
                         .unwrap_or_default();
 
-                    if latest_cp > start_cp + self.config.snapshot_max_lag as u64 {
-                        info!("Objects snapshot processor is updating objects snapshot table from {} to {}", start_cp, start_cp + snapshot_window);
-                        self.store
-                            .update_objects_snapshot(start_cp, start_cp + snapshot_window)
-                            .await?;
-                        start_cp += snapshot_window;
-                        self.metrics
-                            .latest_object_snapshot_sequence_number
-                            .set(start_cp as i64);
+                    // We update the snapshot table when it falls behind the rest of the indexer by more than the max_lag.
+                    while latest_indexer_cp > start_cp + config.snapshot_max_lag as u64 {
+                        // Stream the next 600 checkpoints of object changes to be committed to the store.
+                        if let Some(object_changes_batch) = stream.next().await {
+                            let first_checkpoint_seq = object_changes_batch.first().as_ref().unwrap().checkpoint_sequence_number;
+                            let last_checkpoint_seq = object_changes_batch.last().as_ref().unwrap().checkpoint_sequence_number;
+                            info!("Objects snapshot processor is updating objects snapshot table from {} to {}", first_checkpoint_seq, last_checkpoint_seq);
+
+                            let changes_to_commit = object_changes_batch.into_iter().map(|obj| obj.object_changes).collect();
+                            store.backfill_objects_snapshot(changes_to_commit).await.expect("Failed to backfill objects snapshot");
+                            start_cp = last_checkpoint_seq + 1;
+
+                            // Tells the package buffer that this checkpoint has been processed and the corresponding package data can be deleted.
+                            commit_notifier.send(Some(last_checkpoint_seq)).expect("Commit watcher should not be closed");
+                            metrics
+                                .latest_object_snapshot_sequence_number
+                                .set(last_checkpoint_seq as i64);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description 

This PR separates indexing and committing of objects snapshot table into its own pipeline, that can run independently from the rest of the indexer easily. 

## Test plan 

Tested locally against devnet fullnode.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
