### PR TITLE
[sui replay] migrate off using sui_getLoadedChildObjects json rpc api

### DIFF
--- a/crates/sui-replay/src/data_fetcher.rs
+++ b/crates/sui-replay/src/data_fetcher.rs
@@ -30,7 +30,6 @@ use sui_types::object::Object;
 use sui_types::transaction::SenderSignedData;
 use sui_types::transaction::TransactionDataAPI;
 use sui_types::transaction::{EndOfEpochTransactionKind, TransactionKind};
-use tracing::error;
 
 /// This trait defines the interfaces for fetching data from some local or remote store
 #[async_trait]
@@ -85,6 +84,12 @@ pub(crate) trait DataFetcher {
     ) -> Result<Vec<SuiEvent>, ReplayEngineError>;
 
     async fn get_chain_id(&self) -> Result<String, ReplayEngineError>;
+
+    async fn get_child_object(
+        &self,
+        object_id: &ObjectID,
+        version_upper_bound: VersionNumber,
+    ) -> Result<Object, ReplayEngineError>;
 }
 
 #[derive(Clone)]
@@ -221,6 +226,16 @@ impl DataFetcher for Fetchers {
         match self {
             Fetchers::Remote(q) => q.get_chain_id().await,
             Fetchers::NodeStateDump(q) => q.get_chain_id().await,
+        }
+    }
+    async fn get_child_object(
+        &self,
+        object_id: &ObjectID,
+        version_upper_bound: VersionNumber,
+    ) -> Result<Object, ReplayEngineError> {
+        match self {
+            Fetchers::Remote(q) => q.get_child_object(object_id, version_upper_bound).await,
+            Fetchers::NodeStateDump(q) => q.get_child_object(object_id, version_upper_bound).await,
         }
     }
 }
@@ -378,6 +393,20 @@ impl DataFetcher for RemoteFetcher {
             })
     }
 
+    async fn get_child_object(
+        &self,
+        object_id: &ObjectID,
+        version_upper_bound: VersionNumber,
+    ) -> Result<Object, ReplayEngineError> {
+        let response = self
+            .rpc_client
+            .read_api()
+            .try_get_object_before_version(*object_id, version_upper_bound)
+            .await
+            .map_err(|q| ReplayEngineError::SuiRpcError { err: q.to_string() })?;
+        convert_past_obj_response(response)
+    }
+
     async fn multi_get_latest(
         &self,
         objects: &[ObjectID],
@@ -441,29 +470,9 @@ impl DataFetcher for RemoteFetcher {
 
     async fn get_loaded_child_objects(
         &self,
-        tx_digest: &TransactionDigest,
+        _: &TransactionDigest,
     ) -> Result<Vec<(ObjectID, SequenceNumber)>, ReplayEngineError> {
-        let loaded_child_objs = match self
-            .rpc_client
-            .read_api()
-            .get_loaded_child_objects(*tx_digest)
-            .await
-        {
-            Ok(objs) => objs,
-            Err(e) => {
-                error!("Error getting dynamic fields loaded objects: {}. This RPC server might not support this feature yet", e);
-                return Err(ReplayEngineError::UnableToGetDynamicFieldLoadedObjects {
-                    rpc_err: e.to_string(),
-                });
-            }
-        };
-
-        // Fetch the refs
-        Ok(loaded_child_objs
-            .loaded_child_objects
-            .iter()
-            .map(|obj| (obj.object_id(), obj.sequence_number()))
-            .collect::<Vec<_>>())
+        Ok(vec![])
     }
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, ReplayEngineError> {
@@ -805,5 +814,13 @@ impl DataFetcher for NodeStateDumpFetcher {
 
     async fn get_chain_id(&self) -> Result<String, ReplayEngineError> {
         unimplemented!("get_chain_id for state dump is not implemented")
+    }
+
+    async fn get_child_object(
+        &self,
+        _object_id: &ObjectID,
+        _version_upper_bound: VersionNumber,
+    ) -> Result<Object, ReplayEngineError> {
+        unimplemented!("get child object is not implemented for state dump");
     }
 }

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -90,8 +90,6 @@ pub enum ReplayToolCommand {
         tx_digest: String,
         #[arg(long, short)]
         show_effects: bool,
-        #[arg(long, short)]
-        diag: bool,
         /// Optional version of the executor to use, if not specified defaults to the one originally used for the transaction.
         #[arg(long, short, allow_hyphen_values = true)]
         executor_version: Option<i64>,
@@ -206,11 +204,8 @@ pub async fn execute_replay_command(
             let contents = std::fs::read_to_string(path)?;
             let sandbox_state: ExecutionSandboxState = serde_json::from_str(&contents)?;
             info!("Executing tx: {}", sandbox_state.transaction_info.tx_digest);
-            let sandbox_state = LocalExec::certificate_execute_with_sandbox_state(
-                &sandbox_state,
-                &sandbox_state.pre_exec_diag,
-            )
-            .await?;
+            let sandbox_state =
+                LocalExec::certificate_execute_with_sandbox_state(&sandbox_state).await?;
             sandbox_state.check_effects()?;
             info!("Execution finished successfully. Local and on-chain effects match.");
             None
@@ -330,12 +325,10 @@ pub async fn execute_replay_command(
                     let contents = std::fs::read_to_string(file).unwrap();
                     let sandbox_state: ExecutionSandboxState =
                         serde_json::from_str(&contents).unwrap();
-                    let sandbox_state = LocalExec::certificate_execute_with_sandbox_state(
-                        &sandbox_state,
-                        &sandbox_state.pre_exec_diag,
-                    )
-                    .await
-                    .unwrap();
+                    let sandbox_state =
+                        LocalExec::certificate_execute_with_sandbox_state(&sandbox_state)
+                            .await
+                            .unwrap();
                     sandbox_state.check_effects().unwrap();
                 }
             });
@@ -372,7 +365,6 @@ pub async fn execute_replay_command(
         ReplayToolCommand::ReplayTransaction {
             tx_digest,
             show_effects,
-            diag,
             executor_version,
             protocol_version,
         } => {
@@ -389,9 +381,6 @@ pub async fn execute_replay_command(
             )
             .await?;
 
-            if diag {
-                println!("{:#?}", sandbox_state.pre_exec_diag);
-            }
             if show_effects {
                 println!("{}", sandbox_state.local_exec_effects);
             }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -76,8 +76,6 @@ pub struct ExecutionSandboxState {
     /// Status from executing this locally in `execute_transaction_to_effects`
     #[serde(skip)]
     pub local_exec_status: Option<Result<(), ExecutionError>>,
-    /// Pre exec diag info
-    pub pre_exec_diag: DiagInfo,
 }
 
 impl ExecutionSandboxState {
@@ -140,7 +138,7 @@ pub struct Storage {
     /// They might not be the latest object currently but they are the latest objects
     /// for the TX at the time it was run
     /// This store cannot be shared between runners
-    pub live_objects_store: BTreeMap<ObjectID, Object>,
+    pub live_objects_store: Arc<Mutex<BTreeMap<ObjectID, Object>>>,
 
     /// Package cache and object version cache can be shared between runners
     /// Non system packages are immutable so we can cache these
@@ -153,7 +151,12 @@ pub struct Storage {
 impl std::fmt::Display for Storage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Live object store")?;
-        for (id, obj) in self.live_objects_store.iter() {
+        for (id, obj) in self
+            .live_objects_store
+            .lock()
+            .expect("Unable to lock")
+            .iter()
+        {
             writeln!(f, "{}: {:?}", id, obj.compute_object_reference())?;
         }
         writeln!(f, "Package cache")?;
@@ -177,7 +180,7 @@ impl std::fmt::Display for Storage {
 impl Storage {
     pub fn default() -> Self {
         Self {
-            live_objects_store: BTreeMap::new(),
+            live_objects_store: Arc::new(Mutex::new(BTreeMap::new())),
             package_cache: Arc::new(Mutex::new(BTreeMap::new())),
             object_version_cache: Arc::new(Mutex::new(BTreeMap::new())),
         }
@@ -185,6 +188,8 @@ impl Storage {
 
     pub fn all_objects(&self) -> Vec<Object> {
         self.live_objects_store
+            .lock()
+            .expect("Unable to lock")
             .values()
             .cloned()
             .chain(
@@ -224,7 +229,6 @@ pub struct LocalExec {
     // Used for fetching data from the network or remote store
     pub fetcher: Fetchers,
 
-    pub diag: DiagInfo,
     // One can optionally override the executor version
     // -1 implies use latest version
     pub executor_version: Option<i64>,
@@ -377,7 +381,6 @@ impl LocalExec {
             // TODO: make these configurable
             num_retries_for_timeout: RPC_TIMEOUT_ERR_NUM_RETRIES,
             sleep_period_for_timeout: RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD,
-            diag: Default::default(),
             executor_version: None,
             protocol_version: None,
             enable_profiler: None,
@@ -420,7 +423,6 @@ impl LocalExec {
             // TODO: make these configurable
             num_retries_for_timeout: RPC_TIMEOUT_ERR_NUM_RETRIES,
             sleep_period_for_timeout: RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD,
-            diag: Default::default(),
             executor_version: None,
             protocol_version: None,
             enable_profiler: None,
@@ -436,7 +438,11 @@ impl LocalExec {
         // Backfill the store
         for obj in objs.iter() {
             let o_ref = obj.compute_object_reference();
-            self.storage.live_objects_store.insert(o_ref.0, obj.clone());
+            self.storage
+                .live_objects_store
+                .lock()
+                .expect("Can't lock")
+                .insert(o_ref.0, obj.clone());
             self.storage
                 .object_version_cache
                 .lock()
@@ -558,6 +564,59 @@ impl LocalExec {
             Ok(v) => Ok(Some(v)),
             Err(ReplayEngineError::ObjectNotExist { id }) => {
                 error!("Could not find object {id} on RPC server. It might have been pruned, deleted, or never existed.");
+                Ok(None)
+            }
+            Err(ReplayEngineError::ObjectDeleted {
+                id,
+                version,
+                digest,
+            }) => {
+                error!("Object {id} {version} {digest} was deleted on RPC server.");
+                Ok(None)
+            }
+            Err(err) => Err(ReplayEngineError::SuiRpcError {
+                err: err.to_string(),
+            }),
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    pub fn download_child_object(
+        &self,
+        object_id: &ObjectID,
+        version_upper_bound: VersionNumber,
+    ) -> Result<Option<Object>, ReplayEngineError> {
+        let local_object = self
+            .storage
+            .live_objects_store
+            .lock()
+            .expect("Can't lock")
+            .get(object_id)
+            .cloned();
+        if local_object.is_some() {
+            return Ok(local_object);
+        }
+        let response = block_on({
+            self.fetcher
+                .get_child_object(object_id, version_upper_bound)
+        });
+        match response {
+            Ok(object) => {
+                let obj_ref = object.compute_object_reference();
+                self.storage
+                    .live_objects_store
+                    .lock()
+                    .expect("Can't lock")
+                    .insert(*object_id, object.clone());
+                self.storage
+                    .object_version_cache
+                    .lock()
+                    .expect("Can't lock")
+                    .insert((obj_ref.0, obj_ref.1), object.clone());
+                Ok(Some(object))
+            }
+            Err(ReplayEngineError::ObjectNotExist { id }) => {
+                error!("Could not find child object {id} on RPC server. It might have been pruned, deleted, or never existed.");
                 Ok(None)
             }
             Err(ReplayEngineError::ObjectDeleted {
@@ -734,7 +793,6 @@ impl LocalExec {
             local_exec_temporary_store: Some(inner_store),
             local_exec_effects: effects,
             local_exec_status: Some(result),
-            pre_exec_diag: self.diag.clone(),
         })
     }
 
@@ -822,7 +880,6 @@ impl LocalExec {
     /// However if the state in invalid, the behavior is undefined.
     pub async fn certificate_execute_with_sandbox_state(
         pre_run_sandbox: &ExecutionSandboxState,
-        pre_exec_diag: &DiagInfo,
     ) -> Result<ExecutionSandboxState, ReplayEngineError> {
         // These cannot be changed and are inherited from the sandbox state
         let executed_epoch = pre_run_sandbox.transaction_info.executed_epoch;
@@ -881,7 +938,6 @@ impl LocalExec {
             local_exec_temporary_store: None, // We dont capture it for cert exec run
             local_exec_effects: effects,
             local_exec_status: Some(exec_res),
-            pre_exec_diag: pre_exec_diag.clone(),
         })
     }
 
@@ -896,7 +952,7 @@ impl LocalExec {
         let pre_run_sandbox = self
             .execution_engine_execute_impl(tx_digest, expensive_safety_check_config)
             .await?;
-        Self::certificate_execute_with_sandbox_state(&pre_run_sandbox, &self.diag).await
+        Self::certificate_execute_with_sandbox_state(&pre_run_sandbox).await
     }
 
     /// Must be called after `init_for_execution`
@@ -982,7 +1038,13 @@ impl LocalExec {
             //     !self.system_package_ids().contains(obj_id),
             //     "All system packages should be downloaded already"
             // );
-        } else if let Some(obj) = self.storage.live_objects_store.get(obj_id) {
+        } else if let Some(obj) = self
+            .storage
+            .live_objects_store
+            .lock()
+            .expect("Can't lock")
+            .get(obj_id)
+        {
             return Ok(Some(obj.clone()));
         }
 
@@ -1550,7 +1612,13 @@ impl LocalExec {
                     mutable: _,
                 } if !deleted_shared_info_map.contains_key(id) => {
                     // We already downloaded
-                    if let Some(o) = self.storage.live_objects_store.get(id) {
+                    if let Some(o) = self
+                        .storage
+                        .live_objects_store
+                        .lock()
+                        .expect("Can't lock")
+                        .get(id)
+                    {
                         shared_inputs.push(o.clone());
                         Ok(())
                     } else {
@@ -1622,6 +1690,8 @@ impl LocalExec {
                         *kind,
                         self.storage
                             .live_objects_store
+                            .lock()
+                            .expect("Can't lock")
                             .get(id)
                             .unwrap()
                             .clone()
@@ -1675,7 +1745,6 @@ impl LocalExec {
         // Prep the object runtime for dynamic fields
         // Download the child objects accessed at the version right before the execution of this TX
         let loaded_child_refs = self.fetch_loaded_child_refs(&tx_info.tx_digest).await?;
-        self.diag.loaded_child_objects = loaded_child_refs.clone();
         self.multi_download_and_store(&loaded_child_refs).await?;
         tokio::task::yield_now().await;
 
@@ -1723,10 +1792,11 @@ impl ChildObjectResolver for LocalExec {
             child: &ObjectID,
             child_version_upper_bound: SequenceNumber,
         ) -> SuiResult<Option<Object>> {
-            let child_object = match self_.get_object(child)? {
-                None => return Ok(None),
-                Some(o) => o,
-            };
+            let child_object =
+                match self_.download_child_object(child, child_version_upper_bound)? {
+                    None => return Ok(None),
+                    Some(o) => o,
+                };
             let child_version = child_object.version();
             if child_object.version() > child_version_upper_bound {
                 return Err(SuiError::Unknown(format!(
@@ -1810,7 +1880,13 @@ impl ParentSync for LocalExec {
         object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
         fn inner(self_: &LocalExec, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
-            if let Some(v) = self_.storage.live_objects_store.get(&object_id) {
+            if let Some(v) = self_
+                .storage
+                .live_objects_store
+                .lock()
+                .expect("Can't lock")
+                .get(&object_id)
+            {
                 return Ok(Some(v.compute_object_reference()));
             }
             Ok(None)
@@ -1920,7 +1996,13 @@ impl ObjectStore for LocalExec {
         &self,
         object_id: &ObjectID,
     ) -> sui_types::storage::error::Result<Option<Object>> {
-        let res = self.storage.live_objects_store.get(object_id).cloned();
+        let res = self
+            .storage
+            .live_objects_store
+            .lock()
+            .expect("Can't lock")
+            .get(object_id)
+            .cloned();
         self.exec_store_events
             .lock()
             .expect("Unable to lock events list")
@@ -1941,6 +2023,8 @@ impl ObjectStore for LocalExec {
         let res = self
             .storage
             .live_objects_store
+            .lock()
+            .expect("Can't lock")
             .get(object_id)
             .and_then(|obj| {
                 if obj.version() == version {

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -67,11 +67,6 @@ fn unspecified_chain() -> Chain {
     Chain::Unknown
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct DiagInfo {
-    pub loaded_child_objects: Vec<(ObjectID, VersionNumber)>,
-}
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error, Clone)]
 pub enum ReplayEngineError {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -704,6 +704,18 @@ impl ReadApi {
     ) -> SuiRpcResult<ProtocolConfigResponse> {
         Ok(self.api.http.get_protocol_config(version).await?)
     }
+
+    pub async fn try_get_object_before_version(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> SuiRpcResult<SuiPastObjectResponse> {
+        Ok(self
+            .api
+            .http
+            .try_get_object_before_version(object_id, version)
+            .await?)
+    }
 }
 
 /// Coin Read API provides the functionality needed to get information from the Sui network regarding the coins owned by an address.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -697,7 +697,6 @@ impl SuiClientCommands {
                 let cmd = ReplayToolCommand::ReplayTransaction {
                     tx_digest,
                     show_effects: true,
-                    diag: false,
                     executor_version,
                     protocol_version,
                 };


### PR DESCRIPTION
The PR removes usage of the sui_getLoadedChildObjects API for the remote mode of the replay tool. 
It's required to drop the corresponding index from index_db.

The change is verified by deploying the dynamic field smart contract to devnet, modifying the underlying child object several times, and replaying the corresponding transactions:
```sui-tool replay --rpc https://fullnode.devnet.sui.io:443 tx -t F5xtZeoHH8Dk6cSMbN1CEz7GiYmC4HGjYuBN2La5wr3R```