### PR TITLE
Add ca-certificates to sui-tools Dockerfile

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -33,7 +33,7 @@ FROM debian:bullseye-slim AS runtime
 WORKDIR "$WORKDIR/sui"
 
 # sui-tool needs libpq at runtime
-RUN apt-get update && apt-get install -y libpq5 libpq-dev
+RUN apt-get update && apt-get install -y libpq5 libpq-dev ca-certificates
 
 COPY --from=builder /sui/target/release/sui-node /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin


### PR DESCRIPTION
The `sui-bridge` binary is unable to make upstream TLS requests without the root CA bundle

## Description 

Add the ca-certificates package in the sui-tools Dockerfile package list.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
