### PR TITLE
Enforce non-zero bridge amount

### DIFF
--- a/bridge/evm/contracts/utils/BridgeUtils.sol
+++ b/bridge/evm/contracts/utils/BridgeUtils.sol
@@ -128,6 +128,8 @@ library BridgeUtils {
         returns (uint64)
     {
         if (erc20Decimal == suiDecimal) {
+            // ensure provided amount is greater than 0
+            require(amount > 0, "BridgeUtils: Insufficient amount provided");
             // Ensure converted amount fits within uint64
             require(amount <= type(uint64).max, "BridgeUtils: Amount too large for uint64");
             return uint64(amount);

--- a/bridge/evm/test/SuiBridgeTest.t.sol
+++ b/bridge/evm/test/SuiBridgeTest.t.sol
@@ -617,6 +617,23 @@ contract SuiBridgeTest is BridgeBaseTest, ISuiBridge {
         );
     }
 
+    function testSuiBridgeInvalidERC20Transfer() public {
+        vm.expectRevert(bytes("BridgeUtils: Insufficient amount provided"));
+        bridge.bridgeERC20(
+            BridgeUtils.USDC,
+            0,
+            hex"06bb77410cd326430fa2036c8282dbb54a6f8640cea16ef5eff32d638718b3e4",
+            0
+        );
+    }
+
+    function testSuiBridgeInvalidETHTransfer() public {
+        vm.expectRevert(bytes("BridgeUtils: Insufficient amount provided"));
+        bridge.bridgeETH{value: 0}(
+            hex"06bb77410cd326430fa2036c8282dbb54a6f8640cea16ef5eff32d638718b3e4", 0
+        );
+    }
+
     // An e2e token transfer regression test covering message ser/de and signature verification
     function testTransferSuiToEthRegressionTest() public {
         address[] memory _committee = new address[](4);


### PR DESCRIPTION
## Description 

We want to disable bridging of zero amounts provided. 

## Test plan 

Added two unit tests for both ERC20 and Native ETH bridging 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
