### PR TITLE
[indexer] use beginning of epoch system state instead of end of epoch

### DIFF
--- a/crates/sui-indexer/src/models/epoch.rs
+++ b/crates/sui-indexer/src/models/epoch.rs
@@ -66,6 +66,7 @@ impl StoredEpochInfo {
     pub fn from_epoch_beginning_info(e: &IndexedEpochInfo) -> Self {
         Self {
             epoch: e.epoch as i64,
+            system_state: e.system_state.clone(),
             first_checkpoint_id: e.first_checkpoint_id as i64,
             epoch_start_timestamp: e.epoch_start_timestamp as i64,
             reference_gas_price: e.reference_gas_price as i64,
@@ -79,7 +80,6 @@ impl StoredEpochInfo {
     pub fn from_epoch_end_info(e: &IndexedEpochInfo) -> Self {
         Self {
             epoch: e.epoch as i64,
-            system_state: e.system_state.clone(),
             epoch_total_transactions: e.epoch_total_transactions.map(|v| v as i64),
             last_checkpoint_id: e.last_checkpoint_id.map(|v| v as i64),
             epoch_end_timestamp: e.epoch_end_timestamp.map(|v| v as i64),
@@ -105,6 +105,7 @@ impl StoredEpochInfo {
             protocol_version: 0,
             total_stake: 0,
             storage_fund_balance: 0,
+            system_state: vec![],
         }
     }
 }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -897,7 +897,6 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                             // Note: Exclude epoch beginning info except system_state below.
                             // This is to ensure that epoch beginning info columns are not overridden with default values,
                             // because these columns are default values in `last_epoch`.
-                            epochs::system_state.eq(excluded(epochs::system_state)),
                             epochs::epoch_total_transactions
                                 .eq(excluded(epochs::epoch_total_transactions)),
                             epochs::last_checkpoint_id.eq(excluded(epochs::last_checkpoint_id)),
@@ -915,7 +914,6 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                             epochs::epoch_commitments.eq(excluded(epochs::epoch_commitments)),
                         ),
                         |excluded: StoredEpochInfo| (
-                            epochs::system_state.eq(excluded.system_state.clone()),
                             epochs::epoch_total_transactions.eq(excluded.epoch_total_transactions),
                             epochs::last_checkpoint_id.eq(excluded.last_checkpoint_id),
                             epochs::epoch_end_timestamp.eq(excluded.epoch_end_timestamp),

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -152,7 +152,6 @@ impl IndexedEpochInfo {
                 .end_of_epoch_data
                 .as_ref()
                 .map(|e| e.epoch_commitments.clone()),
-            system_state: bcs::to_bytes(system_state_summary).unwrap(),
             // The following felds will not and shall not be upserted
             // into DB. We have them below to make compiler and diesel happy
             first_checkpoint_id: 0,
@@ -161,6 +160,7 @@ impl IndexedEpochInfo {
             protocol_version: 0,
             total_stake: 0,
             storage_fund_balance: 0,
+            system_state: vec![],
         }
     }
 }


### PR DESCRIPTION
## Description 

As titled, making sure that system state info is not overwritten at the end of the epoch.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
