### PR TITLE
[2/n][gql-performance] update committer and store-writer for new tx indices

### DIFF
--- a/crates/sui-graphql-rpc/src/server/compatibility_check.rs
+++ b/crates/sui-graphql-rpc/src/server/compatibility_check.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::check_table;
+use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::error::Error;
+use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
+use sui_indexer::models::checkpoints::StoredCheckpoint;
+use sui_indexer::models::display::StoredDisplay;
+use sui_indexer::models::epoch::QueryableEpochInfo;
+use sui_indexer::models::events::StoredEvent;
+use sui_indexer::models::objects::{StoredHistoryObject, StoredObjectSnapshot};
+use sui_indexer::models::packages::StoredPackage;
+use sui_indexer::models::transactions::StoredTransaction;
+use sui_indexer::models::tx_indices::{
+    StoredTxChangedObject, StoredTxDigest, StoredTxFun, StoredTxInputObject, StoredTxRecipients,
+    StoredTxSenders,
+};
+use sui_indexer::schema::tx_digests;
+use sui_indexer::schema::{
+    checkpoints, display, epochs, events, objects_history, objects_snapshot, packages,
+    transactions, tx_calls_fun, tx_changed_objects, tx_input_objects, tx_recipients, tx_senders,
+};
+
+#[macro_export]
+macro_rules! check_table {
+    ($conn:expr, $table:path, $type:ty) => {{
+        let result: Result<Option<$type>, _> = $conn
+            .first(move || $table.select(<$type>::as_select()))
+            .optional();
+        result.is_ok()
+    }};
+}
+
+#[macro_export]
+macro_rules! generate_check_all_tables {
+    ($(($table:ident, $type:ty)),* $(,)?) => {
+        pub(crate) async fn check_all_tables(db: &Db) -> Result<bool, Error> {
+            use futures::future::join_all;
+
+            let futures = vec![
+                $(
+                    db.execute(|conn| {
+                        Ok::<_, diesel::result::Error>(check_table!(conn, $table::dsl::$table, $type))
+                    })
+                ),*
+            ];
+
+            let results = join_all(futures).await;
+            if results.into_iter().all(|res| res.unwrap_or(false)) {
+                Ok(true)
+            } else {
+                Err(Error::Internal(
+                    "One or more tables are missing expected columns".into(),
+                ))
+            }
+        }
+    };
+}
+
+generate_check_all_tables!(
+    (checkpoints, StoredCheckpoint),
+    (display, StoredDisplay),
+    (epochs, QueryableEpochInfo),
+    (events, StoredEvent),
+    (objects_history, StoredHistoryObject),
+    (objects_snapshot, StoredObjectSnapshot),
+    (packages, StoredPackage),
+    (transactions, StoredTransaction),
+    (tx_calls_fun, StoredTxFun),
+    (tx_changed_objects, StoredTxChangedObject),
+    (tx_digests, StoredTxDigest),
+    (tx_input_objects, StoredTxInputObject),
+    (tx_recipients, StoredTxRecipients),
+    (tx_senders, StoredTxSenders),
+);

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -414,7 +414,7 @@ where
                 object_changes,
                 balance_change,
                 events,
-                transaction_kind,
+                transaction_kind: transaction_kind.clone(),
                 successful_tx_num: if fx.status().is_ok() {
                     tx.kind().tx_count() as u64
                 } else {
@@ -442,8 +442,8 @@ where
             // Payers
             let payers = vec![tx.gas_owner()];
 
-            // Senders
-            let senders = vec![tx.sender()];
+            // Sender
+            let sender = tx.sender();
 
             // Recipients
             let recipients = fx
@@ -469,10 +469,11 @@ where
                 checkpoint_sequence_number: *checkpoint_seq,
                 input_objects,
                 changed_objects,
-                senders,
+                sender,
                 payers,
                 recipients,
                 move_calls,
+                tx_kind: transaction_kind,
             });
         }
         Ok((db_transactions, db_events, db_indices, db_displays))

--- a/crates/sui-indexer/src/models/tx_indices.rs
+++ b/crates/sui-indexer/src/models/tx_indices.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     schema::{
-        tx_calls_fun, tx_changed_objects, tx_digests, tx_input_objects, tx_recipients, tx_senders,
+        tx_calls_fun, tx_calls_mod, tx_calls_pkg, tx_changed_objects, tx_digests, tx_input_objects,
+        tx_kinds, tx_recipients, tx_senders,
     },
     types::TxIndex,
 };
@@ -33,6 +34,7 @@ pub struct StoredTxSenders {
 pub struct StoredTxRecipients {
     pub tx_sequence_number: i64,
     pub recipient: Vec<u8>,
+    pub sender: Vec<u8>,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -40,6 +42,7 @@ pub struct StoredTxRecipients {
 pub struct StoredTxInputObject {
     pub tx_sequence_number: i64,
     pub object_id: Vec<u8>,
+    pub sender: Vec<u8>,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -47,21 +50,47 @@ pub struct StoredTxInputObject {
 pub struct StoredTxChangedObject {
     pub tx_sequence_number: i64,
     pub object_id: Vec<u8>,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = tx_calls_pkg)]
+pub struct StoredTxPkg {
+    pub tx_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = tx_calls_mod)]
+pub struct StoredTxMod {
+    pub tx_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub module: String,
+    pub sender: Vec<u8>,
 }
 
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = tx_calls_fun)]
-pub struct StoredTxCalls {
+pub struct StoredTxFun {
     pub tx_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
     pub func: String,
+    pub sender: Vec<u8>,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
 #[diesel(table_name = tx_digests)]
 pub struct StoredTxDigest {
     pub tx_digest: Vec<u8>,
+    pub tx_sequence_number: i64,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = tx_kinds)]
+pub struct StoredTxKind {
+    pub tx_kind: i16,
     pub tx_sequence_number: i64,
 }
 
@@ -74,24 +103,24 @@ impl TxIndex {
         Vec<StoredTxRecipients>,
         Vec<StoredTxInputObject>,
         Vec<StoredTxChangedObject>,
-        Vec<StoredTxCalls>,
+        Vec<StoredTxPkg>,
+        Vec<StoredTxMod>,
+        Vec<StoredTxFun>,
         Vec<StoredTxDigest>,
+        Vec<StoredTxKind>,
     ) {
         let tx_sequence_number = self.tx_sequence_number as i64;
-        let tx_senders = self
-            .senders
-            .iter()
-            .map(|s| StoredTxSenders {
-                tx_sequence_number,
-                sender: s.to_vec(),
-            })
-            .collect();
+        let tx_sender = StoredTxSenders {
+            tx_sequence_number,
+            sender: self.sender.to_vec(),
+        };
         let tx_recipients = self
             .recipients
             .iter()
             .map(|s| StoredTxRecipients {
                 tx_sequence_number,
                 recipient: s.to_vec(),
+                sender: self.sender.to_vec(),
             })
             .collect();
         let tx_input_objects = self
@@ -100,6 +129,7 @@ impl TxIndex {
             .map(|o| StoredTxInputObject {
                 tx_sequence_number,
                 object_id: bcs::to_bytes(&o).unwrap(),
+                sender: self.sender.to_vec(),
             })
             .collect();
         let tx_changed_objects = self
@@ -108,30 +138,74 @@ impl TxIndex {
             .map(|o| StoredTxChangedObject {
                 tx_sequence_number,
                 object_id: bcs::to_bytes(&o).unwrap(),
+                sender: self.sender.to_vec(),
             })
             .collect();
-        let tx_calls = self
+
+        let mut packages = Vec::new();
+        let mut packages_modules = Vec::new();
+        let mut packages_modules_funcs = Vec::new();
+
+        for (pkg, pkg_mod, pkg_mod_func) in self
             .move_calls
             .iter()
-            .map(|(p, m, f)| StoredTxCalls {
+            .map(|(p, m, f)| (*p, (*p, m.clone()), (*p, m.clone(), f.clone())))
+        {
+            packages.push(pkg);
+            packages_modules.push(pkg_mod);
+            packages_modules_funcs.push(pkg_mod_func);
+        }
+
+        let tx_pkgs = packages
+            .iter()
+            .map(|p| StoredTxPkg {
+                tx_sequence_number,
+                package: p.to_vec(),
+                sender: self.sender.to_vec(),
+            })
+            .collect();
+
+        let tx_mods = packages_modules
+            .iter()
+            .map(|(p, m)| StoredTxMod {
+                tx_sequence_number,
+                package: p.to_vec(),
+                module: m.to_string(),
+                sender: self.sender.to_vec(),
+            })
+            .collect();
+
+        let tx_calls = packages_modules_funcs
+            .iter()
+            .map(|(p, m, f)| StoredTxFun {
                 tx_sequence_number,
                 package: p.to_vec(),
                 module: m.to_string(),
                 func: f.to_string(),
+                sender: self.sender.to_vec(),
             })
             .collect();
+
         let stored_tx_digest = StoredTxDigest {
             tx_digest: self.transaction_digest.into_inner().to_vec(),
             tx_sequence_number,
         };
 
+        let tx_kind = StoredTxKind {
+            tx_kind: self.tx_kind as i16,
+            tx_sequence_number,
+        };
+
         (
-            tx_senders,
+            vec![tx_sender],
             tx_recipients,
             tx_input_objects,
             tx_changed_objects,
+            tx_pkgs,
+            tx_mods,
             tx_calls,
             vec![stored_tx_digest],
+            vec![tx_kind],
         )
     }
 }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -38,10 +38,11 @@ use crate::models::objects::{
 };
 use crate::models::packages::StoredPackage;
 use crate::models::transactions::StoredTransaction;
+use crate::schema::tx_kinds;
 use crate::schema::{
     checkpoints, display, epochs, events, objects, objects_history, objects_snapshot,
-    objects_version, packages, transactions, tx_calls_fun, tx_changed_objects, tx_digests,
-    tx_input_objects, tx_recipients, tx_senders,
+    objects_version, packages, transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg,
+    tx_changed_objects, tx_digests, tx_input_objects, tx_recipients, tx_senders,
 };
 use crate::types::{IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex};
 use crate::{
@@ -684,9 +685,12 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
             .checkpoint_db_commit_latency_tx_indices_chunks
             .start_timer();
         let len = indices.len();
-        let (senders, recipients, input_objects, changed_objects, calls, digests) =
+        let (senders, recipients, input_objects, changed_objects, pkgs, mods, funs, digests, kinds) =
             indices.into_iter().map(|i| i.split()).fold(
                 (
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
                     Vec::new(),
                     Vec::new(),
                     Vec::new(),
@@ -699,23 +703,32 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                     mut tx_recipients,
                     mut tx_input_objects,
                     mut tx_changed_objects,
-                    mut tx_calls,
+                    mut tx_pkgs,
+                    mut tx_mods,
+                    mut tx_funs,
                     mut tx_digests,
+                    mut tx_kinds,
                 ),
                  index| {
                     tx_senders.extend(index.0);
                     tx_recipients.extend(index.1);
                     tx_input_objects.extend(index.2);
                     tx_changed_objects.extend(index.3);
-                    tx_calls.extend(index.4);
-                    tx_digests.extend(index.5);
+                    tx_pkgs.extend(index.4);
+                    tx_mods.extend(index.5);
+                    tx_funs.extend(index.6);
+                    tx_digests.extend(index.7);
+                    tx_kinds.extend(index.8);
                     (
                         tx_senders,
                         tx_recipients,
                         tx_input_objects,
                         tx_changed_objects,
-                        tx_calls,
+                        tx_pkgs,
+                        tx_mods,
+                        tx_funs,
                         tx_digests,
+                        tx_kinds,
                     )
                 },
             );
@@ -804,13 +817,61 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                 tracing::error!("Failed to persist tx_changed_objects with error: {}", e);
             })
         }));
+
         futures.push(self.spawn_blocking_task(move |this| {
             let now = Instant::now();
-            let calls_len = calls.len();
+            let rows_len = pkgs.len();
             transactional_blocking_with_retry!(
                 &this.blocking_cp,
                 |conn| {
-                    for chunk in calls.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                    for chunk in pkgs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                        insert_or_ignore_into!(tx_calls_pkg::table, chunk, conn);
+                    }
+                    Ok::<(), IndexerError>(())
+                },
+                PG_DB_COMMIT_SLEEP_DURATION
+            )
+            .tap_ok(|_| {
+                let elapsed = now.elapsed().as_secs_f64();
+                info!(
+                    elapsed,
+                    "Persisted {} rows to tx_calls_pkg tables", rows_len
+                );
+            })
+            .tap_err(|e| {
+                tracing::error!("Failed to persist tx_calls_pkg with error: {}", e);
+            })
+        }));
+
+        futures.push(self.spawn_blocking_task(move |this| {
+            let now = Instant::now();
+            let rows_len = mods.len();
+            transactional_blocking_with_retry!(
+                &this.blocking_cp,
+                |conn| {
+                    for chunk in mods.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                        insert_or_ignore_into!(tx_calls_mod::table, chunk, conn);
+                    }
+                    Ok::<(), IndexerError>(())
+                },
+                PG_DB_COMMIT_SLEEP_DURATION
+            )
+            .tap_ok(|_| {
+                let elapsed = now.elapsed().as_secs_f64();
+                info!(elapsed, "Persisted {} rows to tx_calls_mod table", rows_len);
+            })
+            .tap_err(|e| {
+                tracing::error!("Failed to persist tx_calls_mod with error: {}", e);
+            })
+        }));
+
+        futures.push(self.spawn_blocking_task(move |this| {
+            let now = Instant::now();
+            let rows_len = funs.len();
+            transactional_blocking_with_retry!(
+                &this.blocking_cp,
+                |conn| {
+                    for chunk in funs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
                         insert_or_ignore_into!(tx_calls_fun::table, chunk, conn);
                     }
                     Ok::<(), IndexerError>(())
@@ -819,12 +880,13 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
             )
             .tap_ok(|_| {
                 let elapsed = now.elapsed().as_secs_f64();
-                info!(elapsed, "Persisted {} rows to tx_calls tables", calls_len);
+                info!(elapsed, "Persisted {} rows to tx_calls_fun table", rows_len);
             })
             .tap_err(|e| {
-                tracing::error!("Failed to persist tx_calls with error: {}", e);
+                tracing::error!("Failed to persist tx_calls_fun with error: {}", e);
             })
         }));
+
         futures.push(self.spawn_blocking_task(move |this| {
             let now = Instant::now();
             let calls_len = digests.len();
@@ -849,6 +911,33 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
             })
             .tap_err(|e| {
                 tracing::error!("Failed to persist tx_digests with error: {}", e);
+            })
+        }));
+
+        futures.push(self.spawn_blocking_task(move |this| {
+            let now = Instant::now();
+            let rows_len = kinds.len();
+            transactional_blocking_with_retry!(
+                &this.blocking_cp,
+                |conn| {
+                    for chunk in kinds.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                        diesel::insert_into(tx_kinds::table)
+                            .values(chunk)
+                            .on_conflict_do_nothing()
+                            .execute(conn)
+                            .map_err(IndexerError::from)
+                            .context("Failed to write tx_digests chunk to PostgresDB")?;
+                    }
+                    Ok::<(), IndexerError>(())
+                },
+                Duration::from_secs(60)
+            )
+            .tap_ok(|_| {
+                let elapsed = now.elapsed().as_secs_f64();
+                info!(elapsed, "Persisted {} rows to tx_kinds tables", rows_len);
+            })
+            .tap_err(|e| {
+                tracing::error!("Failed to persist tx_kinds with error: {}", e);
             })
         }));
 

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -356,12 +356,13 @@ pub struct IndexedTransaction {
 #[derive(Debug, Clone)]
 pub struct TxIndex {
     pub tx_sequence_number: u64,
+    pub tx_kind: TransactionKind,
     pub transaction_digest: TransactionDigest,
     pub checkpoint_sequence_number: u64,
     pub input_objects: Vec<ObjectID>,
     pub changed_objects: Vec<ObjectID>,
     pub payers: Vec<SuiAddress>,
-    pub senders: Vec<SuiAddress>,
+    pub sender: SuiAddress,
     pub recipients: Vec<SuiAddress>,
     pub move_calls: Vec<(ObjectID, String, String)>,
 }


### PR DESCRIPTION
## Description 

update the TxIndex.senders to a single .sender, since we only index a single sender today. Update the Rust structs that correspond to tx lookup tables, and then update how we index data to these tables. Namely, we drop `cp_sequence_number` and denormalize `sender` as a column on all the lookup tables.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
