### PR TITLE
[json rpc] deprecate indexes

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2067,7 +2067,6 @@ impl AuthorityState {
                 digest,
                 timestamp_ms,
                 tx_coins,
-                &inner_temporary_store.loaded_runtime_objects,
             )
             .await
     }
@@ -3531,15 +3530,6 @@ impl AuthorityState {
                 error: "extended object indexing is not enabled on this server".into(),
             }),
         }
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    pub fn loaded_child_object_versions(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
-        self.get_indexes()?
-            .loaded_child_object_versions(transaction_digest)
     }
 
     pub async fn get_transactions_for_tests(

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -24,8 +24,6 @@ use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::digests::{ChainIdentifier, TransactionDigest};
 use sui_types::sui_serde::BigInt;
 
-use sui_json_rpc_types::SuiLoadedChildObjectsResponse;
-
 #[derive(Clone)]
 pub(crate) struct ReadApi<T: R2D2Connection + 'static> {
     inner: IndexerReader<T>,
@@ -267,16 +265,6 @@ impl<T: R2D2Connection + 'static> ReadApiServer for ReadApi<T> {
             .get_transaction_events_in_blocking_task(transaction_digest)
             .await
             .map_err(Into::into)
-    }
-
-    async fn get_loaded_child_objects(
-        &self,
-        _digest: TransactionDigest,
-    ) -> RpcResult<SuiLoadedChildObjectsResponse> {
-        Err(jsonrpsee::types::error::CallError::Custom(
-            jsonrpsee::types::error::ErrorCode::MethodNotFound.into(),
-        )
-        .into())
     }
 
     async fn get_protocol_config(

--- a/crates/sui-json-rpc-api/src/read.rs
+++ b/crates/sui-json-rpc-api/src/read.rs
@@ -4,12 +4,12 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 
+use sui_json_rpc_types::ProtocolConfigResponse;
 use sui_json_rpc_types::{
     Checkpoint, CheckpointId, CheckpointPage, SuiEvent, SuiGetPastObjectRequest,
     SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
-use sui_json_rpc_types::{ProtocolConfigResponse, SuiLoadedChildObjectsResponse};
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::sui_serde::BigInt;
@@ -99,12 +99,6 @@ pub trait ReadApi {
         /// options for specifying the content to be returned
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiPastObjectResponse>>;
-
-    #[method(name = "getLoadedChildObjects")]
-    async fn get_loaded_child_objects(
-        &self,
-        digest: TransactionDigest,
-    ) -> RpcResult<SuiLoadedChildObjectsResponse>;
 
     /// Return a checkpoint
     #[method(name = "getCheckpoint")]

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -2322,40 +2322,6 @@ pub enum SuiObjectArg {
     },
 }
 
-#[serde_as]
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "LoadedChildObject", rename_all = "camelCase")]
-pub struct SuiLoadedChildObject {
-    object_id: ObjectID,
-    #[schemars(with = "AsSequenceNumber")]
-    #[serde_as(as = "AsSequenceNumber")]
-    sequence_number: SequenceNumber,
-}
-
-impl SuiLoadedChildObject {
-    pub fn new(object_id: ObjectID, sequence_number: SequenceNumber) -> Self {
-        Self {
-            object_id,
-            sequence_number,
-        }
-    }
-
-    pub fn object_id(&self) -> ObjectID {
-        self.object_id
-    }
-
-    pub fn sequence_number(&self) -> SequenceNumber {
-        self.sequence_number
-    }
-}
-
-#[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Default)]
-#[serde(rename_all = "camelCase", rename = "LoadedChildObjectsResponse")]
-pub struct SuiLoadedChildObjectsResponse {
-    pub loaded_child_objects: Vec<SuiLoadedChildObject>,
-}
-
 #[derive(Clone)]
 pub struct EffectsWithInput {
     pub effects: SuiTransactionBlockEffects,

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -235,11 +235,6 @@ pub trait StateRead: Send + Sync {
 
     fn get_latest_checkpoint_sequence_number(&self) -> StateReadResult<CheckpointSequenceNumber>;
 
-    fn loaded_child_object_versions(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> StateReadResult<Option<Vec<(ObjectID, SequenceNumber)>>>;
-
     fn get_chain_identifier(&self) -> StateReadResult<ChainIdentifier>;
 }
 
@@ -564,13 +559,6 @@ impl StateRead for AuthorityState {
 
     fn get_latest_checkpoint_sequence_number(&self) -> StateReadResult<CheckpointSequenceNumber> {
         Ok(self.get_latest_checkpoint_sequence_number()?)
-    }
-
-    fn loaded_child_object_versions(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> StateReadResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
-        Ok(self.loaded_child_object_versions(transaction_digest)?)
     }
 
     fn get_chain_identifier(&self) -> StateReadResult<ChainIdentifier> {

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -30,7 +30,6 @@ use sui_json_rpc_types::{
     SuiTransactionBlock, SuiTransactionBlockEvents, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
-use sui_json_rpc_types::{SuiLoadedChildObject, SuiLoadedChildObjectsResponse};
 use sui_open_rpc::Module;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_storage::key_value_store::TransactionKeyValueStore;
@@ -1010,32 +1009,6 @@ impl ReadApiServer for ReadApi {
             self.get_checkpoints(cursor, limit.map(|l| *l as usize), descending_order)
                 .await
                 .map_err(Error::from)
-        })
-    }
-
-    #[instrument(skip(self))]
-    async fn get_loaded_child_objects(
-        &self,
-        digest: TransactionDigest,
-    ) -> RpcResult<SuiLoadedChildObjectsResponse> {
-        with_tracing!(async move {
-            Ok(SuiLoadedChildObjectsResponse {
-                loaded_child_objects: match self
-                    .state
-                    .loaded_child_object_versions(&digest)
-                    .map_err(|e| {
-                        error!(
-                            "Failed to get loaded child objects at {digest:?} with error: {e:?}"
-                        );
-                        Error::StateReadError(e)
-                    })? {
-                    Some(v) => v
-                        .into_iter()
-                        .map(|q| SuiLoadedChildObject::new(q.0, q.1))
-                        .collect::<Vec<_>>(),
-                    None => vec![],
-                },
-            })
         })
     }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -833,72 +833,6 @@
       ]
     },
     {
-      "name": "sui_getLoadedChildObjects",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "params": [
-        {
-          "name": "digest",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          }
-        }
-      ],
-      "result": {
-        "name": "SuiLoadedChildObjectsResponse",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/LoadedChildObjectsResponse"
-        }
-      },
-      "examples": [
-        {
-          "name": "Gets loaded child objects associated with the transaction the request provides.",
-          "params": [
-            {
-              "name": "digest",
-              "value": "6hpz6Qxv6t5VkNT5rcBKQS2Jootr6WHuSuRMLmmN13Jg"
-            }
-          ],
-          "result": {
-            "name": "Result",
-            "value": {
-              "loadedChildObjects": [
-                {
-                  "objectId": "0xb6a23efeb7298cf0a8d0b837b78749c2cfc711c42036cc6b76211639f3606a53",
-                  "sequenceNumber": "2462820"
-                },
-                {
-                  "objectId": "0xf61f3a566963b3eac49fe3bb57d304a454ed2f4859b44f4e49180047d5fa0a82",
-                  "sequenceNumber": "2462820"
-                },
-                {
-                  "objectId": "0xd55c32b09995a0ae1eedfee9c7b1354e805ed10ee3d0800105867da4655eca6d",
-                  "sequenceNumber": "2164186"
-                },
-                {
-                  "objectId": "0x258bfd1ad92af329a07781ee71e60065e00f2de961630d3505f8905a0f4d42c6",
-                  "sequenceNumber": "3350147"
-                },
-                {
-                  "objectId": "0xa78a6ba2b28f68a3299ec3417bbabc6717dcc95b9e341bc3aba1654bdbad707d",
-                  "sequenceNumber": "3560717"
-                },
-                {
-                  "objectId": "0xcd773bd6309363447ef3fe58a960de92aa9377b3482580ee8d5bdc5b824808df",
-                  "sequenceNumber": "3560717"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
       "name": "sui_getMoveFunctionArgTypes",
       "tags": [
         {
@@ -945,7 +879,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x007efb0f94f1e64d2e8090c619a39299d87ee8070b5f56bb10bafa0e2261d819"
+              "value": "0x9c4eb6769ca8b6a23efeb7298cf0a8d0b837b78749c2cfc711c42036cc6b7621"
             },
             {
               "name": "module",
@@ -1025,7 +959,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0xb2582f82ab308bf9c96dfb22ec7345db1b5f14fdb2b9538efb160d31842e3a17"
+              "value": "0x1639f3606a53f61f3a566963b3eac49fe3bb57d304a454ed2f4859b44f4e4918"
             },
             {
               "name": "module_name",
@@ -1097,7 +1031,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x16dc6797cf787c839a07edc03e633842109123618df6438d21a48040e6bb568c"
+              "value": "0x800105867da4655eca6d9eb1258bfd1ad92af329a07781ee71e60065e00f2de9"
             },
             {
               "name": "module_name",
@@ -1108,7 +1042,7 @@
             "name": "Result",
             "value": {
               "fileFormatVersion": 6,
-              "address": "0x43cc4c24010dafad05b12619b275649741cc9060d87664c26a3f9a509228c21b",
+              "address": "0x0047d5fa0a823e7d0ff4d55c32b09995a0ae1eedfee9c7b1354e805ed10ee3d0",
               "name": "module",
               "friends": [],
               "structs": {},
@@ -1151,14 +1085,14 @@
           "params": [
             {
               "name": "package",
-              "value": "0xece356d10d89e75f565b0934851ba8d5bc59462a46078b90f1f508a1e4fd4eed"
+              "value": "0xc95b9e341bc3aba1654bdbad707dcd773bd6309363447ef3fe58a960de92aa93"
             }
           ],
           "result": {
             "name": "Result",
             "value": {
               "fileFormatVersion": 6,
-              "address": "0xafc13246bd847c60448160e0358cac4a11345594d02890c986dbf328d28d21ac",
+              "address": "0x61630d3505f8905a0f4d42c6ff39a78a6ba2b28f68a3299ec3417bbabc6717dc",
               "name": "module",
               "friends": [],
               "structs": {},
@@ -1212,7 +1146,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x46c25c211cb35c05d801c769b78770474957b37379c527753c5c8ab783f697e7"
+              "value": "0x77b3482580ee8d5bdc5b824808df54bfec4fc817622e5add0e48f749f01def98"
             },
             {
               "name": "module_name",
@@ -2220,11 +2154,11 @@
             {
               "name": "object_ids",
               "value": [
-                "0xb61439368cd75ebe63d633af32ffb4a022d18b95b4eaa9fd3b22b43f6b2c8e92",
-                "0x6ea7bed8f6c3d80f2a595c2305e12dd6d07c3fbbd3ebef7dbcc7b02346cdf056",
-                "0x75da5e934f672d3da3e003d989075efaecc79b5cd5df0df2a168259b7115a41c",
-                "0x38554a9ff7b4f6b59f9426c321c8013afed093481dd4ef1267c67a8e9a0d074f",
-                "0xe74d1b250d5df2cb5170782a8a438fbf681eded4d1e0a2cd7dfb27e784493fb1"
+                "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e",
+                "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134",
+                "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656",
+                "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685",
+                "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6"
               ]
             },
             {
@@ -2245,14 +2179,14 @@
             "value": [
               {
                 "data": {
-                  "objectId": "0xb61439368cd75ebe63d633af32ffb4a022d18b95b4eaa9fd3b22b43f6b2c8e92",
+                  "objectId": "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e",
                   "version": "1",
-                  "digest": "6D2MGzZN1DnALrbg6y9nQWwuipCa6fJERLXAwNGuGtKQ",
+                  "digest": "AibMqH69gKT5t7rVTsDZFy2X5iHtoNDobKaZ62mg3FCU",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x090bd6d16522a6fd4fa83ec70a5f197ad656da104dde1de9880be827a1a753e5"
+                    "AddressOwner": "0xe8070b5f56bb10bafa0e2261d819b2582f82ab308bf9c96dfb22ec7345db1b5f"
                   },
-                  "previousTransaction": "CQN1aMpZRYrVHByFfPFceCXzv5kT7bNM4Uzoe2jbZvM",
+                  "previousTransaction": "2QwXW3qzMEZPAyyP9VHtXbC2tp7iomypQc5XnkyPsu5d",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2261,7 +2195,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0xb61439368cd75ebe63d633af32ffb4a022d18b95b4eaa9fd3b22b43f6b2c8e92"
+                        "id": "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e"
                       }
                     }
                   }
@@ -2269,14 +2203,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x6ea7bed8f6c3d80f2a595c2305e12dd6d07c3fbbd3ebef7dbcc7b02346cdf056",
+                  "objectId": "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134",
                   "version": "1",
-                  "digest": "HCvnds5SSF8Tn2kANyZDeAJuKa7bY6mf1ykzD8nQY42b",
+                  "digest": "D5W76mT1A3tqCmE1Z5MdV5obNzesMXLfLKpRDHSp1fyz",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x74452cc61f316af5d5d7c02b94b02324268500a65bf5fdccb50582333b61721e"
+                    "AddressOwner": "0x5594d02890c986dbf328d28d21acece356d10d89e75f565b0934851ba8d5bc59"
                   },
-                  "previousTransaction": "86PvfkkGKweeE3TRmQDL9azrkyU9yqiVcRpWMNsqcWTK",
+                  "previousTransaction": "5itvhMFvtJcV6fY2VY4x7F9Ex18q2N4Rr5WU4FXTJsFU",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2285,7 +2219,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x6ea7bed8f6c3d80f2a595c2305e12dd6d07c3fbbd3ebef7dbcc7b02346cdf056"
+                        "id": "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134"
                       }
                     }
                   }
@@ -2293,14 +2227,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x75da5e934f672d3da3e003d989075efaecc79b5cd5df0df2a168259b7115a41c",
+                  "objectId": "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656",
                   "version": "1",
-                  "digest": "7AVTCGjWUFNAZYmcxtKQvAWbyzbFVn9cbr1fMvngbs9S",
+                  "digest": "H2o2pWgceQgTtYrMacR4xnCi4vqGiuozDA6k2rBc4m3q",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0xcc0a372b6fd0026e0c63043492ce4d0c19a63e7f360c51d035a6470f09c8d237"
+                    "AddressOwner": "0xda104dde1de9880be827a1a753e502ebcdfec53f33e745e3f021366b7bc47c2b"
                   },
-                  "previousTransaction": "2YMeG7z6fPbqT6Sk7K4DQ7qqd2zBC1zAn2SuEXq4wJgY",
+                  "previousTransaction": "8rsTRNPs13DZvD2xneZEtf2nAAipep6uHXPXWVXfzDBr",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2309,7 +2243,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x75da5e934f672d3da3e003d989075efaecc79b5cd5df0df2a168259b7115a41c"
+                        "id": "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656"
                       }
                     }
                   }
@@ -2317,14 +2251,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x38554a9ff7b4f6b59f9426c321c8013afed093481dd4ef1267c67a8e9a0d074f",
+                  "objectId": "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685",
                   "version": "1",
-                  "digest": "DumsSGokTELtJXW54HKCRLjFKBeHkaySUZ86DDo8QwvR",
+                  "digest": "3ovR1s3bZt6AN1AQ7QhGUfX9BSwgjJPvL6XaczgeSKXU",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec315724962ee4193c"
+                    "AddressOwner": "0x00a65bf5fdccb50582333b61721e6963a25f25ac8ead5916a83f49a7b372eae7"
                   },
-                  "previousTransaction": "ARhjuTpfA6H8EM8bpBuJ5vFGALmMrMcbSZDiTTF8nxCp",
+                  "previousTransaction": "3w6ars2tmgBST4ozGxPWzSpEGyn4AdxMBv3K9sdkCWfR",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2333,7 +2267,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x38554a9ff7b4f6b59f9426c321c8013afed093481dd4ef1267c67a8e9a0d074f"
+                        "id": "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685"
                       }
                     }
                   }
@@ -2341,14 +2275,14 @@
               },
               {
                 "data": {
-                  "objectId": "0xe74d1b250d5df2cb5170782a8a438fbf681eded4d1e0a2cd7dfb27e784493fb1",
+                  "objectId": "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6",
                   "version": "1",
-                  "digest": "94nQ4Tz4nyqcVJmbLMUShkucx3eVfhLXGTCR4d1KP6gL",
+                  "digest": "25QdFqrh9FgxhGQyAxZsNEakYmHezqmU3FMPud7JGRB5",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0xdccde7893a3ac5c67cd2c4e27540b52ee828096b2aa5fe50a7effd8c23976147"
+                    "AddressOwner": "0x3e7f360c51d035a6470f09c8d23716e4085025b89d176840d61dde92a452a72f"
                   },
-                  "previousTransaction": "3rqeFGm86S2ZKWXPF2HHP8zdpRRqb7WZLDkquE2KHetA",
+                  "previousTransaction": "BE9GoMd7Mr8fGte3EdsXxUMwYjcErW71n6Gsm4iPvDmv",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2357,7 +2291,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0xe74d1b250d5df2cb5170782a8a438fbf681eded4d1e0a2cd7dfb27e784493fb1"
+                        "id": "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6"
                       }
                     }
                   }
@@ -2413,9 +2347,9 @@
             {
               "name": "digests",
               "value": [
-                "61GhydW9kTXNU6LXktceLKM5svzLcDwW1eRU2UdQ9wov",
-                "4TU9wToRuiYvPZZAtMzq3gfQEBuv91Nt5pkgWbVL8mR9",
-                "HiWguwCqK3mWzhv5Qefb6pfhKdocWZo7gbToHED5Pzp7"
+                "CKzxe1mN72xVrq5BadAzVu1Lk61AYzuRSEQ3zWK2zbGs",
+                "2jinTmZQ8aModigpcbYcKELwRrTcqosbMmqsiEopvMy9",
+                "BCyCzV64UgrX5vr2kdtzhrojLwaZ9gasnhVV8TQeY1EA"
               ]
             },
             {
@@ -2435,7 +2369,7 @@
             "name": "Result",
             "value": [
               {
-                "digest": "61GhydW9kTXNU6LXktceLKM5svzLcDwW1eRU2UdQ9wov",
+                "digest": "CKzxe1mN72xVrq5BadAzVu1Lk61AYzuRSEQ3zWK2zbGs",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2445,14 +2379,14 @@
                         {
                           "type": "pure",
                           "valueType": "address",
-                          "value": "0x0ad2c31e8c3681aa4f7d35488cf6bf1135d2fc8703690e085797c3e4f846a282"
+                          "value": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157"
                         },
                         {
                           "type": "object",
                           "objectType": "immOrOwnedObject",
-                          "objectId": "0x754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e232fac1a70e20e",
+                          "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
                           "version": "2",
-                          "digest": "21hjAvY5LZAy2dc72b3nPgJTsbmtRYaTfqMn2a2sdnkB"
+                          "digest": "3gmeyj5oEdE8A4PvjWsDSHchC6tb6YQj18gnD7xnDqGz"
                         }
                       ],
                       "transactions": [
@@ -2470,25 +2404,25 @@
                         }
                       ]
                     },
-                    "sender": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13",
+                    "sender": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2",
                     "gasData": {
                       "payment": [
                         {
-                          "objectId": "0x146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601bbdabf2828ee",
+                          "objectId": "0x9585d5591521bfd12dec3a372efd539108ba807a0dabed6e5da0f174efc3f58e",
                           "version": 2,
-                          "digest": "BYX5uiUfQkTJrNSnH3mj8Cs8mz1ppQKWBXi4y3Xi6y8D"
+                          "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
                         }
                       ],
-                      "owner": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13",
+                      "owner": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2",
                       "price": "10",
                       "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "AFj3Uat/4CHwGMzZZgO6PXosHI9nErbfC8uFgiuvowKZKdMd1UVHez5YjNabMgZ98bC+I9C2Hud4/EjoXsamYAI34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ=="
+                    "AAjABbK1jtt2/3ixW3D0YWrDscRT5oevWGf1yJD4KNqudiehykWXtHx7aipTKNx+5dbpTtEwPLI2dTB0CyORlg+nSicGHWn+0mf3oSb/LUa5i+dDAEb1qsgy7LkQ8hbr+w=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgCtLDHow2gapPfTVIjPa/ETXS/IcDaQ4IV5fD5PhGooIBAHVJRuGB4A9DQaU7Xole+Ow8c9I3igoRgl4jL6wacOIOAgAAAAAAAAAgDwm8uJB3PRHBq9cXZ7H2eoBAJneIID85dyL8J2rqpzwBAQEBAQABAAAKP1esHudBRjvJd0QFDxr01XDYuNDyA7Z9Cc2C/bIeEwEUb7EwO9YOtL6pvUU+UGkLQjJB8OLpvqvWAbvavygo7gIAAAAAAAAAIJyn5CJ6Yc/4Uf75+2oIrkRMlvmBAnXWr5c8DQItueIaCj9XrB7nQUY7yXdEBQ8a9NVw2LjQ8gO2fQnNgv2yHhMKAAAAAAAAAKCGAQAAAAAAAAFhAFj3Uat/4CHwGMzZZgO6PXosHI9nErbfC8uFgiuvowKZKdMd1UVHez5YjNabMgZ98bC+I9C2Hud4/EjoXsamYAI34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ==",
+                "rawTransaction": "AQAAAAAAAgAgeo6aDQdPkP3bQs2Sj3S5hsb1Oac089fJp1qcsifsMVcBACSWLuQZPIwNL7KLvg60ul/IeixtGnwSyUVIcsXqBtXhAgAAAAAAAAAgJ+eEST+x3M3niTo6xcZ80sTidUC1LugoCWsqpf5Qp+8BAQEBAQABAABXb44f3FFOjPLgRToLKa3hSbMwBMVt6rVCgjmUKu+ewgGVhdVZFSG/0S3sOjcu/VORCLqAeg2r7W5doPF078P1jgIAAAAAAAAAIP8RnpL1eudNGyUNXfLLUXB4KopDj79oHt7U0eCizX37V2+OH9xRTozy4EU6Cymt4UmzMATFbeq1QoI5lCrvnsIKAAAAAAAAAKCGAQAAAAAAAAFhAAjABbK1jtt2/3ixW3D0YWrDscRT5oevWGf1yJD4KNqudiehykWXtHx7aipTKNx+5dbpTtEwPLI2dTB0CyORlg+nSicGHWn+0mf3oSb/LUa5i+dDAEb1qsgy7LkQ8hbr+w==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2501,57 +2435,57 @@
                     "storageRebate": "10",
                     "nonRefundableStorageFee": "0"
                   },
-                  "transactionDigest": "CVLsRJgJKde8RVNLtkZCBGWxEmCninDQaBb5V4tz9sZ8",
+                  "transactionDigest": "2SY11dmdTQv6JLD2wqcsMiJNqXbXUkn87Rzw5NHib8Mf",
                   "mutated": [
                     {
                       "owner": {
-                        "AddressOwner": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13"
+                        "AddressOwner": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2"
                       },
                       "reference": {
-                        "objectId": "0x146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601bbdabf2828ee",
+                        "objectId": "0x9585d5591521bfd12dec3a372efd539108ba807a0dabed6e5da0f174efc3f58e",
                         "version": 2,
-                        "digest": "BYX5uiUfQkTJrNSnH3mj8Cs8mz1ppQKWBXi4y3Xi6y8D"
+                        "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
                       }
                     },
                     {
                       "owner": {
-                        "AddressOwner": "0x0ad2c31e8c3681aa4f7d35488cf6bf1135d2fc8703690e085797c3e4f846a282"
+                        "AddressOwner": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157"
                       },
                       "reference": {
-                        "objectId": "0x754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e232fac1a70e20e",
+                        "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
                         "version": 2,
-                        "digest": "21hjAvY5LZAy2dc72b3nPgJTsbmtRYaTfqMn2a2sdnkB"
+                        "digest": "3gmeyj5oEdE8A4PvjWsDSHchC6tb6YQj18gnD7xnDqGz"
                       }
                     }
                   ],
                   "gasObject": {
                     "owner": {
-                      "ObjectOwner": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13"
+                      "ObjectOwner": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2"
                     },
                     "reference": {
-                      "objectId": "0x146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601bbdabf2828ee",
+                      "objectId": "0x9585d5591521bfd12dec3a372efd539108ba807a0dabed6e5da0f174efc3f58e",
                       "version": 2,
-                      "digest": "BYX5uiUfQkTJrNSnH3mj8Cs8mz1ppQKWBXi4y3Xi6y8D"
+                      "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
                     }
                   },
-                  "eventsDigest": "Hwdei4TM2C5h2gpRiUQfS8roKsKgTUzx883qTuy7ASdt"
+                  "eventsDigest": "DkaTtjSfULiQ7FT48kzuS7yKj2JUAWGgjDBXddqn1z9o"
                 },
                 "objectChanges": [
                   {
                     "type": "transferred",
-                    "sender": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13",
+                    "sender": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2",
                     "recipient": {
-                      "AddressOwner": "0x0ad2c31e8c3681aa4f7d35488cf6bf1135d2fc8703690e085797c3e4f846a282"
+                      "AddressOwner": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157"
                     },
                     "objectType": "0x2::example::Object",
-                    "objectId": "0x754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e232fac1a70e20e",
+                    "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
                     "version": "2",
-                    "digest": "zbXdxaWUbmKnKQfLLwiCVYe2nQyreC7JoKHrk8vY9aA"
+                    "digest": "J4k64LwycebB7TQhKrPaZ954yCK64rwbDJMSrSUW4Ba4"
                   }
                 ]
               },
               {
-                "digest": "4TU9wToRuiYvPZZAtMzq3gfQEBuv91Nt5pkgWbVL8mR9",
+                "digest": "2jinTmZQ8aModigpcbYcKELwRrTcqosbMmqsiEopvMy9",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2561,14 +2495,14 @@
                         {
                           "type": "pure",
                           "valueType": "address",
-                          "value": "0x2e84e81f871c47c3149e27b12500da884afdf5c30b19c017a0d10388c28ddd59"
+                          "value": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23"
                         },
                         {
                           "type": "object",
                           "objectType": "immOrOwnedObject",
-                          "objectId": "0x77a58e206acd19639c875a4fbecf3342b825c8384300ac7e3badc820a75b5742",
+                          "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
                           "version": "2",
-                          "digest": "6ozDx8La5rgu5zSoxaMseRjcX169ZBEjSyQeD2RGoa44"
+                          "digest": "HyJbrm9Th6ox4oU9vrrRzgZSaCu1n3omMJ1fAcHswvvo"
                         }
                       ],
                       "transactions": [
@@ -2586,25 +2520,25 @@
                         }
                       ]
                     },
-                    "sender": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6",
+                    "sender": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e",
                     "gasData": {
                       "payment": [
                         {
-                          "objectId": "0x24b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5cd8024b4b39a7",
+                          "objectId": "0xbbdabf2828ee9ca7e4227a61cff851fef9fb6a08ae444c96f9810275d6af973c",
                           "version": 2,
-                          "digest": "J9ifwZ2hbL5Tg7fbbta3CXybtaabdaN8BmKudP7R8sBU"
+                          "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
                         }
                       ],
-                      "owner": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6",
+                      "owner": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e",
                       "price": "10",
                       "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "ABBKl/c5PQ8vYVTfmqIhpmKaw5h87g3803RmvzBsvCs+7W4+X7UaGhrNMuHa1mgxEIaujlBa/b6tPZaZxuhfmwWhtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg=="
+                    "AFumlgf6FRg/Hav9rJrEtmSzVW1iHCGixLA/lxj4ojn5ati0aXW8NnOwYe97d68oG1vjFfmid20XrO69XUh6eQULoJG5hufQ9rzjXn1UVSbD7HyPVZykOZAICGCiqQMgGw=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgLoToH4ccR8MUniexJQDaiEr99cMLGcAXoNEDiMKN3VkBAHeljiBqzRljnIdaT77PM0K4Jcg4QwCsfjutyCCnW1dCAgAAAAAAAAAgVlPau21sld3X01pC0x86m+u7aD22booGcGhVRnLhN7UBAQEBAQABAAACjWNudIYpke1SHcycbLerhgtEnj9Pe4UgtYIyW82k9gEkuSCqmwBQk7gg3yTvi0NxVJn0//TgVsDNXNgCS0s5pwIAAAAAAAAAIP7ScTSwc9qGOEVBETllGTeeiIyDq68OYAUEeeRW/wE/Ao1jbnSGKZHtUh3MnGy3q4YLRJ4/T3uFILWCMlvNpPYKAAAAAAAAAKCGAQAAAAAAAAFhABBKl/c5PQ8vYVTfmqIhpmKaw5h87g3803RmvzBsvCs+7W4+X7UaGhrNMuHa1mgxEIaujlBa/b6tPZaZxuhfmwWhtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg==",
+                "rawTransaction": "AQAAAAAAAgAgw+T4RqKCdUlG4YHgD0NBpTteiV747Dxz0jeKChGCXiMBAC+sGnDiDhRvsTA71g60vqm9RT5QaQtCMkHw4um+q9YBAgAAAAAAAAAg/Cdq6qc8DsEltgkKJ7uvql/DLnVzYS0husigmreRU3QBAQEBAQABAACZS5BgMqgrDZ9IAw10wJJkfZImaxOmMEnmAnRowZlmbgG72r8oKO6cp+QiemHP+FH++ftqCK5ETJb5gQJ11q+XPAIAAAAAAAAAIA0CLbniGg8JvLiQdz0RwavXF2ex9nqAQCZ3iCA/OXcimUuQYDKoKw2fSAMNdMCSZH2SJmsTpjBJ5gJ0aMGZZm4KAAAAAAAAAKCGAQAAAAAAAAFhAFumlgf6FRg/Hav9rJrEtmSzVW1iHCGixLA/lxj4ojn5ati0aXW8NnOwYe97d68oG1vjFfmid20XrO69XUh6eQULoJG5hufQ9rzjXn1UVSbD7HyPVZykOZAICGCiqQMgGw==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2617,57 +2551,57 @@
                     "storageRebate": "10",
                     "nonRefundableStorageFee": "0"
                   },
-                  "transactionDigest": "6gAPDZyrAYmnm5zGDhc3LF3Ae2PT6ABP6xSC1dfRRoXp",
+                  "transactionDigest": "69bh3Q9RhRgMFKwmQn8LYE8vYujFTpYyUSVBht3oYkm6",
                   "mutated": [
                     {
                       "owner": {
-                        "AddressOwner": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6"
+                        "AddressOwner": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e"
                       },
                       "reference": {
-                        "objectId": "0x24b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5cd8024b4b39a7",
+                        "objectId": "0xbbdabf2828ee9ca7e4227a61cff851fef9fb6a08ae444c96f9810275d6af973c",
                         "version": 2,
-                        "digest": "J9ifwZ2hbL5Tg7fbbta3CXybtaabdaN8BmKudP7R8sBU"
+                        "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
                       }
                     },
                     {
                       "owner": {
-                        "AddressOwner": "0x2e84e81f871c47c3149e27b12500da884afdf5c30b19c017a0d10388c28ddd59"
+                        "AddressOwner": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23"
                       },
                       "reference": {
-                        "objectId": "0x77a58e206acd19639c875a4fbecf3342b825c8384300ac7e3badc820a75b5742",
+                        "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
                         "version": 2,
-                        "digest": "6ozDx8La5rgu5zSoxaMseRjcX169ZBEjSyQeD2RGoa44"
+                        "digest": "HyJbrm9Th6ox4oU9vrrRzgZSaCu1n3omMJ1fAcHswvvo"
                       }
                     }
                   ],
                   "gasObject": {
                     "owner": {
-                      "ObjectOwner": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6"
+                      "ObjectOwner": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e"
                     },
                     "reference": {
-                      "objectId": "0x24b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5cd8024b4b39a7",
+                      "objectId": "0xbbdabf2828ee9ca7e4227a61cff851fef9fb6a08ae444c96f9810275d6af973c",
                       "version": 2,
-                      "digest": "J9ifwZ2hbL5Tg7fbbta3CXybtaabdaN8BmKudP7R8sBU"
+                      "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
                     }
                   },
-                  "eventsDigest": "8ju2GtaGc2UB3vFu9Pmjwze8LcUh37izem5NsGcstgtx"
+                  "eventsDigest": "4Vh6HmG6PwdbZbMiMwj9YnKvsMnP3gfhLmAd288eujv4"
                 },
                 "objectChanges": [
                   {
                     "type": "transferred",
-                    "sender": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6",
+                    "sender": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e",
                     "recipient": {
-                      "AddressOwner": "0x2e84e81f871c47c3149e27b12500da884afdf5c30b19c017a0d10388c28ddd59"
+                      "AddressOwner": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23"
                     },
                     "objectType": "0x2::example::Object",
-                    "objectId": "0x77a58e206acd19639c875a4fbecf3342b825c8384300ac7e3badc820a75b5742",
+                    "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
                     "version": "2",
-                    "digest": "kLukTF3HAHvTW17s8ZHtVKZyWf4bSJb7SjZ5HuNeELk"
+                    "digest": "CHia3BiES8mt5kqMYhzBpjAeLRpjcsMNDMFakBAdcVAg"
                   }
                 ]
               },
               {
-                "digest": "HiWguwCqK3mWzhv5Qefb6pfhKdocWZo7gbToHED5Pzp7",
+                "digest": "BCyCzV64UgrX5vr2kdtzhrojLwaZ9gasnhVV8TQeY1EA",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2677,14 +2611,14 @@
                         {
                           "type": "pure",
                           "valueType": "address",
-                          "value": "0xdcc85bada4a729d650f7762226432129780927838b06db0346808ffb0676099d"
+                          "value": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad"
                         },
                         {
                           "type": "object",
                           "objectType": "immOrOwnedObject",
-                          "objectId": "0xe0408b31759f57b69c52e09410a66f9a23c34be9913b6697a5e83e02e2a0fc74",
+                          "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
                           "version": "2",
-                          "digest": "GP1ZYjdAR42yCiTAvnQgqPtc5bG9i7BzetfWeAo6ewgN"
+                          "digest": "6jsxetsBSZJ5ozgZuDmHXJzn9ZBp8emivfYHe6tnHg7C"
                         }
                       ],
                       "transactions": [
@@ -2702,25 +2636,25 @@
                         }
                       ]
                     },
-                    "sender": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82",
+                    "sender": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563",
                     "gasData": {
                       "payment": [
                         {
-                          "objectId": "0x7057ba0901e4d9b1e04de75ea2699a4413215612581eba57ebe7e594b809ccce",
+                          "objectId": "0xd8024b4b39a7fed27134b073da8638454111396519379e888c83abaf0e600504",
                           "version": 2,
-                          "digest": "Gtv38WbTUCw2KoAv9S5db8oTXn8ZdgkX7gGCrfU3Zvms"
+                          "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
                         }
                       ],
-                      "owner": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82",
+                      "owner": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563",
                       "price": "10",
                       "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "APXV3tMi3dDUyb0PGKcI4/2kDw7W++XWyRWZTLK4jZKo/V0qseed7rngZsrNg6fgmXIbJlHBxvzK50I4K208TwnWnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw=="
+                    "ALp3VT1YKzOOGLARJCrDqBbMScEPcFq2vWNJ68Zzr3+v5sEK+44cfPlQfMY0UZWyhA86viiG8yd4eLWmnzzU2gXBLYrHKlE7PwRVuJjmBwbiSpqS0m/j+PFnALfPM5bN1Q=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAg3MhbraSnKdZQ93YiJkMhKXgJJ4OLBtsDRoCP+wZ2CZ0BAOBAizF1n1e2nFLglBCmb5ojw0vpkTtml6XoPgLioPx0AgAAAAAAAAAg5IK3WMI5kDnbvt1dskOF6TTWgrL9ZzRGkavQ78dxlBsBAQEBAQABAACzD91z21LE6wZ1S9tQ/sPqDhmnhR8jg9dk/LPW63+MggFwV7oJAeTZseBN516iaZpEEyFWElgeulfr5+WUuAnMzgIAAAAAAAAAIOwr5NrG/2lF1Js+zAQ9BJYR9s/RC8pNUX6UUq1Uhtaesw/dc9tSxOsGdUvbUP7D6g4Zp4UfI4PXZPyz1ut/jIIKAAAAAAAAAKCGAQAAAAAAAAFhAPXV3tMi3dDUyb0PGKcI4/2kDw7W++XWyRWZTLK4jZKo/V0qseed7rngZsrNg6fgmXIbJlHBxvzK50I4K208TwnWnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw==",
+                "rawTransaction": "AQAAAAAAAgAgA4jCjd1Zd6WOIGrNGWOch1pPvs8zQrglyDhDAKx+O60BAMggp1tXQiS5IKqbAFCTuCDfJO+LQ3FUmfT/9OBWwM1cAgAAAAAAAAAgVUZy4Te1Cxp8iyTYMxDI9sRo5v6QbaCnpymsaNySaNMBAQEBAQABAAC2w22ZKjtQ86z448mg+5CerL/CSer2ZhatZxJAnS7lYwHYAktLOaf+0nE0sHPahjhFQRE5ZRk3noiMg6uvDmAFBAIAAAAAAAAAIHnkVv8BP1ZT2rttbJXd19NaQtMfOpvru2g9tm6KBnBotsNtmSo7UPOs+OPJoPuQnqy/wknq9mYWrWcSQJ0u5WMKAAAAAAAAAKCGAQAAAAAAAAFhALp3VT1YKzOOGLARJCrDqBbMScEPcFq2vWNJ68Zzr3+v5sEK+44cfPlQfMY0UZWyhA86viiG8yd4eLWmnzzU2gXBLYrHKlE7PwRVuJjmBwbiSpqS0m/j+PFnALfPM5bN1Q==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2733,52 +2667,52 @@
                     "storageRebate": "10",
                     "nonRefundableStorageFee": "0"
                   },
-                  "transactionDigest": "F2iA4tJuSYJhXArnKAhrUJVAvNdTuvA8VMj9zXj6PNDe",
+                  "transactionDigest": "DzJWHtFNHttaBdpECZGDMF7tcx5NYZfNfCk5NsaaRgmn",
                   "mutated": [
                     {
                       "owner": {
-                        "AddressOwner": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82"
+                        "AddressOwner": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563"
                       },
                       "reference": {
-                        "objectId": "0x7057ba0901e4d9b1e04de75ea2699a4413215612581eba57ebe7e594b809ccce",
+                        "objectId": "0xd8024b4b39a7fed27134b073da8638454111396519379e888c83abaf0e600504",
                         "version": 2,
-                        "digest": "Gtv38WbTUCw2KoAv9S5db8oTXn8ZdgkX7gGCrfU3Zvms"
+                        "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
                       }
                     },
                     {
                       "owner": {
-                        "AddressOwner": "0xdcc85bada4a729d650f7762226432129780927838b06db0346808ffb0676099d"
+                        "AddressOwner": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad"
                       },
                       "reference": {
-                        "objectId": "0xe0408b31759f57b69c52e09410a66f9a23c34be9913b6697a5e83e02e2a0fc74",
+                        "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
                         "version": 2,
-                        "digest": "GP1ZYjdAR42yCiTAvnQgqPtc5bG9i7BzetfWeAo6ewgN"
+                        "digest": "6jsxetsBSZJ5ozgZuDmHXJzn9ZBp8emivfYHe6tnHg7C"
                       }
                     }
                   ],
                   "gasObject": {
                     "owner": {
-                      "ObjectOwner": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82"
+                      "ObjectOwner": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563"
                     },
                     "reference": {
-                      "objectId": "0x7057ba0901e4d9b1e04de75ea2699a4413215612581eba57ebe7e594b809ccce",
+                      "objectId": "0xd8024b4b39a7fed27134b073da8638454111396519379e888c83abaf0e600504",
                       "version": 2,
-                      "digest": "Gtv38WbTUCw2KoAv9S5db8oTXn8ZdgkX7gGCrfU3Zvms"
+                      "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
                     }
                   },
-                  "eventsDigest": "HQh9RPyW3hh7X3GYRXPvAQ2k7VmYWKKrZ5cMcvPypu3v"
+                  "eventsDigest": "Bbh3U8fCxVzdX6uZUNWRzZrUktcUfWcydhWCMyWJSPpt"
                 },
                 "objectChanges": [
                   {
                     "type": "transferred",
-                    "sender": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82",
+                    "sender": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563",
                     "recipient": {
-                      "AddressOwner": "0xdcc85bada4a729d650f7762226432129780927838b06db0346808ffb0676099d"
+                      "AddressOwner": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad"
                     },
                     "objectType": "0x2::example::Object",
-                    "objectId": "0xe0408b31759f57b69c52e09410a66f9a23c34be9913b6697a5e83e02e2a0fc74",
+                    "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
                     "version": "2",
-                    "digest": "Azr7oPHAo6LZ9iPfHYjguY2BoVTZ9zwVArvUEJSwXKWW"
+                    "digest": "HaFQHEJugXDGh95A9Ye1tp7GikbuAQNiEanrQuVLvpfz"
                   }
                 ]
               }
@@ -2929,11 +2863,11 @@
               "name": "past_objects",
               "value": [
                 {
-                  "objectId": "0x5056aa3325512c8af40b9f5fd7065c83ded900657eac70a7979c2541646fa449",
+                  "objectId": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27",
                   "version": "4"
                 },
                 {
-                  "objectId": "0xe81109dc075f537067726d63dd5287100e177404a969989215da2abfbfc098cf",
+                  "objectId": "0x47866ff92885a3c21a7703f564721c198308aa0c71b771ada6b96c16fc9c0fa7",
                   "version": "12"
                 }
               ]
@@ -2957,14 +2891,14 @@
               {
                 "status": "VersionFound",
                 "details": {
-                  "objectId": "0x5056aa3325512c8af40b9f5fd7065c83ded900657eac70a7979c2541646fa449",
+                  "objectId": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27",
                   "version": "4",
-                  "digest": "F34PCnEHm5GAP5ksDKPSdRMKz49JiqrvLUTZsiojqJS2",
+                  "digest": "CE9bNT96Sa2BxQQH2id4PRxTgW5TW7zm6VVhDeRNBegW",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0xfde53941b2a08a8bf752c20979842732ac019f52835282744318d6d84f3c52b3"
+                    "AddressOwner": "0x54b3c61936f77fcfdaa213c2f7b4fb1b51ef9f3ed66000c0e45697dbee095479"
                   },
-                  "previousTransaction": "EMLrFqmDkZtFvidxKy1T8bwAiHnUiLqramE58kSUcAf8",
+                  "previousTransaction": "hvBGBXvKVhC7XYgVPujuiLjxASR6UGAkSFrCRtVxX1F",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2973,7 +2907,7 @@
                     "fields": {
                       "balance": "10000",
                       "id": {
-                        "id": "0x5056aa3325512c8af40b9f5fd7065c83ded900657eac70a7979c2541646fa449"
+                        "id": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27"
                       }
                     }
                   }
@@ -2982,14 +2916,14 @@
               {
                 "status": "VersionFound",
                 "details": {
-                  "objectId": "0xe81109dc075f537067726d63dd5287100e177404a969989215da2abfbfc098cf",
+                  "objectId": "0x47866ff92885a3c21a7703f564721c198308aa0c71b771ada6b96c16fc9c0fa7",
                   "version": "12",
-                  "digest": "FvrqyqH5yA85sziA2NoPGJ8N23kmTxeXQh4HyJAbB7c2",
+                  "digest": "3pRSYsCdrDkfMDwecvKZ1zgSEpwUo52VcLE95iK9ap1N",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x13090a95287cde98d711fc27217b81e08d494bdb70c3b42f0fe27be8eb500568"
+                    "AddressOwner": "0x998aaf3d11da24c49e014d4ccb1d7d0cd09d3cc1679290f1df2803b32b76ba03"
                   },
-                  "previousTransaction": "6XEirxRenmgbeg4tviP43bAKsosqgySXwoBxGEWQVTii",
+                  "previousTransaction": "B5z4YkAgTi78fdxMbxG3fv2V4YBkhpc8PRCPz8MzLtbf",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2998,7 +2932,7 @@
                     "fields": {
                       "balance": "20000",
                       "id": {
-                        "id": "0x5056aa3325512c8af40b9f5fd7065c83ded900657eac70a7979c2541646fa449"
+                        "id": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27"
                       }
                     }
                   }
@@ -3462,7 +3396,7 @@
           "params": [
             {
               "name": "parent_object_id",
-              "value": "0xc8359b6b5e3bfeab524e5edaad3a204b4053745b2d45d1f00cd8d24e5b697607"
+              "value": "0x5ea6f7a348f4a7bd1a9ab069eb7f63865de3075cc5a4e62432f634b50fd2bb2b"
             },
             {
               "name": "name",
@@ -3476,14 +3410,14 @@
             "name": "Result",
             "value": {
               "data": {
-                "objectId": "0xc8359b6b5e3bfeab524e5edaad3a204b4053745b2d45d1f00cd8d24e5b697607",
+                "objectId": "0x5ea6f7a348f4a7bd1a9ab069eb7f63865de3075cc5a4e62432f634b50fd2bb2b",
                 "version": "1",
-                "digest": "2VivvkBoFVwEg8oXq3tK9r3d3ybvMACtk9QwpFnkM6v2",
+                "digest": "FnxePMX8y7AqX5mRL4nCcK4xecSrpHrd85c3sJDmh5uG",
                 "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                 "owner": {
-                  "AddressOwner": "0xc055d5c23e2f6c69e6aacf5b4664b570cb20d4feace07fc863a2eef286c3e95e"
+                  "AddressOwner": "0x013d1eb156edcc1bedc3b1af1be1fe41671856fd3450dc5574abd53c793c9f22"
                 },
-                "previousTransaction": "FJjAr8fdpuQvVZgd9VswXxz9jZcFGEAgKgdi8d6zXE3S",
+                "previousTransaction": "Faiv4yqGR4HjAW8WhMN1NHHNStxXgP3u22dVPyvLad2z",
                 "storageRebate": "100",
                 "content": {
                   "dataType": "moveObject",
@@ -3544,11 +3478,11 @@
           "params": [
             {
               "name": "parent_object_id",
-              "value": "0xe15bb8de6dadd21835dfe44f4973139c15f93ddea0f8c3da994d9ead562ce76e"
+              "value": "0xcfd10bca4d517e9452ad5486d69ee482b758c2399039dbbedd5db24385e934d6"
             },
             {
               "name": "cursor",
-              "value": "0xa9334aeacc435c70ab9635e47a277d8f8dd9d87765d1aadec2db8cc24c312542"
+              "value": "0x3ddea0f8c3da994d9ead562ce76e36fdef6a382da344930c73d1298b0e9644b8"
             },
             {
               "name": "limit",
@@ -3567,9 +3501,9 @@
                   "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
                   "type": "DynamicField",
                   "objectType": "test",
-                  "objectId": "0x36fdef6a382da344930c73d1298b0e9644b85ea6f7a348f4a7bd1a9ab069eb7f",
+                  "objectId": "0x82b2fd67344691abd0efc771941b948ad35360b08e449fbbc28b0641175bf60b",
                   "version": 1,
-                  "digest": "7hWCQjKfZf7oNLpSrhFJZEmYnpmSPzVLwJfFuHmMD9ct"
+                  "digest": "P2fGrUFbsF576cFxXYXrp1PskZHo2XKvbEoxL14qtnr"
                 },
                 {
                   "name": {
@@ -3579,9 +3513,9 @@
                   "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
                   "type": "DynamicField",
                   "objectType": "test",
-                  "objectId": "0xfe41671856fd3450dc5574abd53c793c9f22d8a72d5550df8d2d64a9155d126c",
+                  "objectId": "0x21564fc5a68ace997461b098c1d1f3ccbde241d8fdf562db36bc1423ee10cecb",
                   "version": 1,
-                  "digest": "CxuC9uMcWLk8oMg7QGaJSqUE4hwP6cMUQ94ipiN53jr3"
+                  "digest": "8Nmpatir33R88Xow2td3dpezMm1gsQJD19VThwR1Y8T5"
                 },
                 {
                   "name": {
@@ -3591,12 +3525,12 @@
                   "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
                   "type": "DynamicField",
                   "objectType": "test",
-                  "objectId": "0x1edb2df5ea5d55c96a611371d22799d268270cd4bb4d4f520fe9bbf0cf1cebe3",
+                  "objectId": "0x7e00acf5386662fa062483ba507b1e9e3039750f0a270f2e12441ad7f611a5f7",
                   "version": 1,
-                  "digest": "HJxTwLy4oE1Aoy3PocGfL9oHystQiyssHfmyE8YaPrw4"
+                  "digest": "J2n2gEG8R9P9nMep8mRVLjttxcDXQnWSH9KmrRsnGSg2"
                 }
               ],
-              "nextCursor": "0x8a25d8876ea3c60e345ac3861444136b4a1b0b37a91692359a98496738a58c17",
+              "nextCursor": "0x671832358f25bfacde706e528df4e15bb8de6dadd21835dfe44f4973139c15f9",
               "hasNextPage": true
             }
           }
@@ -3684,7 +3618,7 @@
           "params": [
             {
               "name": "address",
-              "value": "0xa69bb635dcee0f33643b4729ae81730d55e5e26860fac6839ce2d7ed7e6f29d2"
+              "value": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
             },
             {
               "name": "query",
@@ -3695,7 +3629,7 @@
                       "StructType": "0x2::coin::Coin<0x2::sui::SUI>"
                     },
                     {
-                      "AddressOwner": "0xa69bb635dcee0f33643b4729ae81730d55e5e26860fac6839ce2d7ed7e6f29d2"
+                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
                     },
                     {
                       "Version": "13488"
@@ -3715,7 +3649,7 @@
             },
             {
               "name": "cursor",
-              "value": "0x76a1b4c23f2d9a9b6f0d8b2c17beace292b72aea16d6fb49b7d1ae51f33b01ed"
+              "value": "0x8a417a09c971859f8f2b8ec279438a25d8876ea3c60e345ac3861444136b4a1b"
             },
             {
               "name": "limit",
@@ -3728,45 +3662,45 @@
               "data": [
                 {
                   "data": {
-                    "objectId": "0x3d6255ff8223c12b0fd985c49d5777a0d65ad3d707164b2a378eee639ebc2690",
+                    "objectId": "0xd87765d1aadec2db8cc24c312542c8359b6b5e3bfeab524e5edaad3a204b4053",
                     "version": "13488",
-                    "digest": "A6v9pFTLH3PkDSvEGgVjW1JhL7CtcUQKwGmgXK8SQNsc",
+                    "digest": "8qCvxDHh5LtDfF95Ci9G7vvQN2P6y4v55S9xoKBYp7FM",
                     "type": "0x2::coin::Coin<0x2::sui::SUI>",
                     "owner": {
-                      "AddressOwner": "0xa69bb635dcee0f33643b4729ae81730d55e5e26860fac6839ce2d7ed7e6f29d2"
+                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
                     },
-                    "previousTransaction": "AZiaEnge9YnawyLosmuxd8grpoiYasfpvBEjSLFUmJ8m",
+                    "previousTransaction": "kniF9zCBVYevxq3ZmtKxDDJk27N1qEgwkDtPiyeve4Y",
                     "storageRebate": "100"
                   }
                 },
                 {
                   "data": {
-                    "objectId": "0x1a6e30f43933bbf40f5f5b6ce1f44957337dcb28f32e0355326f8c7d932bd54d",
+                    "objectId": "0x26ed170e0427f9416a614d23284116375c16bd317738fd2c7a885362e04923f5",
                     "version": "13488",
-                    "digest": "Fn1HG7LyUcLDps6bhYQkPWXpeUXgisznxRJ2qvn7Q1JN",
+                    "digest": "5Ka3vDaDy9h5UYk3Maz3vssWHrhbcGXQgwg8fL2ygyTi",
                     "type": "0x2::coin::Coin<0x2::sui::SUI>",
                     "owner": {
-                      "AddressOwner": "0xa69bb635dcee0f33643b4729ae81730d55e5e26860fac6839ce2d7ed7e6f29d2"
+                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
                     },
-                    "previousTransaction": "5EZjpdpApGGb48UZtuRgXuTRDBgkFDYaiNUtUNg7788k",
+                    "previousTransaction": "FLSfkL1pVTxv724z5kfPbTq2KsWP1HEKBwZQ57uRZU11",
                     "storageRebate": "100"
                   }
                 },
                 {
                   "data": {
-                    "objectId": "0x28628a24386298faa98850887f64da841b87279efd098d59a66a3d9adc87cce8",
+                    "objectId": "0x2aea16d6fb49b7d1ae51f33b01ed8e1ac66916858610c124bb6fd73bb13e141c",
                     "version": "13488",
-                    "digest": "39aXGAwHaY3CiqWwLiBZ7JRaGSvnpvPbHxMSJAwAUY5i",
+                    "digest": "D3hfhfecVcmRcqNEkxkoFMzbuXvBqWj1JkCNU9zbnYMo",
                     "type": "0x2::coin::Coin<0x2::sui::SUI>",
                     "owner": {
-                      "AddressOwner": "0xa69bb635dcee0f33643b4729ae81730d55e5e26860fac6839ce2d7ed7e6f29d2"
+                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
                     },
-                    "previousTransaction": "CnBDiCrxWcJCCU1LHoda6XwwRaCSRfva8HZzfmR3p8Ag",
+                    "previousTransaction": "GEoTGQuWicnPLM9Rg3vW1Q2y3kvnAgEkbyn8Z3RnAYai",
                     "storageRebate": "100"
                   }
                 }
               ],
-              "nextCursor": "0x28628a24386298faa98850887f64da841b87279efd098d59a66a3d9adc87cce8",
+              "nextCursor": "0x2aea16d6fb49b7d1ae51f33b01ed8e1ac66916858610c124bb6fd73bb13e141c",
               "hasNextPage": true
             }
           }
@@ -3833,18 +3767,18 @@
           "params": [
             {
               "name": "owner",
-              "value": "0xb5387b29a731d26d98108d7abc4902107d7d6a8e0f8fea6fda5488462e58724c"
+              "value": "0x3befb84f03a24386492bd3b05b1fd386172eb450e5059ce7df0ea6d9d6cefcaa"
             }
           ],
           "result": {
             "name": "Result",
             "value": [
               {
-                "validatorAddress": "0x034462b6064a08845e2ae2942fe7c4ee816d754eb2eed23e6c6bb32c89fe1f21",
-                "stakingPool": "0xab588374445e72e0402aea014b295610579963ee67e81398729f87d81d62f399",
+                "validatorAddress": "0x9a95cf69368e31b4dbe8ee9bdb3c0587bbc79d8fc6edf4007e185a962fd906df",
+                "stakingPool": "0xb4eeb46b70f0bebcae832aeef9f7c5db76052ab656e5f81853d0cf701cdbc8eb",
                 "stakes": [
                   {
-                    "stakedSuiId": "0xc041b0f8d0938923ea7e3917608ee62df4376710024f81dd33ab6833482ee803",
+                    "stakedSuiId": "0xf27ab513fc6ef8c344406c78da3d5ad3a5fcc295dc8803c15989a62d33ee8590",
                     "stakeRequestEpoch": "62",
                     "stakeActiveEpoch": "63",
                     "principal": "200000000000",
@@ -3852,7 +3786,7 @@
                     "estimatedReward": "520000000"
                   },
                   {
-                    "stakedSuiId": "0x4e779a48e6ef635c7f856df4905022458bfbd22bbb46f892c42d9ec0ae4de93e",
+                    "stakedSuiId": "0x14cfd5e91c13a481370240e392464c329a203fb9f0a8158aaab9b2a90044b26e",
                     "stakeRequestEpoch": "142",
                     "stakeActiveEpoch": "143",
                     "principal": "200000000000",
@@ -3861,11 +3795,11 @@
                 ]
               },
               {
-                "validatorAddress": "0x02c75973a51c17180798237326a58694a2cf5cd6fa76ed1d18f05f15e3507525",
-                "stakingPool": "0x2ddec4fb83621d55952d9172fcfcb72feae238b3186a7bb26a1ab2c982a0a9b4",
+                "validatorAddress": "0x14cc7fee4100fdcabda6d15c63c4b49c45ae23f2b936495cd38b1a4b04010295",
+                "stakingPool": "0xbaa75ac72e548aeecf2ce8b4e88530651d6e8f93e0fb79b4bc65a512beb5b9f3",
                 "stakes": [
                   {
-                    "stakedSuiId": "0x82aa70f5a010fffc60f20194ef0f597474e8ceaf9ee4582d3a233101e322a22c",
+                    "stakedSuiId": "0x378423de90ed03b694cecf443c72b5387b29a731d26d98108d7abc4902107d7d",
                     "stakeRequestEpoch": "244",
                     "stakeActiveEpoch": "245",
                     "principal": "200000000000",
@@ -3915,19 +3849,19 @@
             {
               "name": "staked_sui_ids",
               "value": [
-                "0xb2a5bea2e681ea5af4e59bd1abb0bb4fcb2747866ff92885a3c21a7703f56472",
-                "0x1c198308aa0c71b771ada6b96c16fc9c0fa754b3c61936f77fcfdaa213c2f7b4"
+                "0x6a8e0f8fea6fda5488462e58724c034462b6064a08845e2ae2942fe7c4ee816d",
+                "0x754eb2eed23e6c6bb32c89fe1f21ab588374445e72e0402aea014b2956105799"
               ]
             }
           ],
           "result": {
             "name": "Result",
             "value": {
-              "validatorAddress": "0xfb1b51ef9f3ed66000c0e45697dbee0954790a7b5c15ad7354f23b968be8bb06",
-              "stakingPool": "0x03d47b901cb7b3177a791cd29bb5304037fea6ced287081357950315a8842c38",
+              "validatorAddress": "0x63ee67e81398729f87d81d62f399c041b0f8d0938923ea7e3917608ee62df437",
+              "stakingPool": "0x6710024f81dd33ab6833482ee8034e779a48e6ef635c7f856df4905022458bfb",
               "stakes": [
                 {
-                  "stakedSuiId": "0xb2a5bea2e681ea5af4e59bd1abb0bb4fcb2747866ff92885a3c21a7703f56472",
+                  "stakedSuiId": "0x6a8e0f8fea6fda5488462e58724c034462b6064a08845e2ae2942fe7c4ee816d",
                   "stakeRequestEpoch": "62",
                   "stakeActiveEpoch": "63",
                   "principal": "200000000000",
@@ -3935,7 +3869,7 @@
                   "estimatedReward": "520000000"
                 },
                 {
-                  "stakedSuiId": "0x1c198308aa0c71b771ada6b96c16fc9c0fa754b3c61936f77fcfdaa213c2f7b4",
+                  "stakedSuiId": "0x754eb2eed23e6c6bb32c89fe1f21ab588374445e72e0402aea014b2956105799",
                   "stakeRequestEpoch": "244",
                   "stakeActiveEpoch": "245",
                   "principal": "200000000000",
@@ -4015,15 +3949,15 @@
             "value": {
               "apys": [
                 {
-                  "address": "0xb7d1cb695b9491893f88a5ae1b9d4f235b3c7e00acf5386662fa062483ba507b",
+                  "address": "0x27838b06db0346808ffb0676099de0408b31759f57b69c52e09410a66f9a23c3",
                   "apy": 0.06
                 },
                 {
-                  "address": "0x1e9e3039750f0a270f2e12441ad7f611a5f7fd0b2c4326c56b1fec231d73038d",
+                  "address": "0x4be9913b6697a5e83e02e2a0fc747057ba0901e4d9b1e04de75ea2699a441321",
                   "apy": 0.02
                 },
                 {
-                  "address": "0xba0f0885b97982f5fcac3ec6f5c8cae16743671832358f25bfacde706e528df4",
+                  "address": "0x5612581eba57ebe7e594b809ccceec2be4dac6ff6945d49b3ecc043d049611f6",
                   "apy": 0.05
                 }
               ],
@@ -4089,7 +4023,7 @@
               "name": "query",
               "value": {
                 "MoveModule": {
-                  "package": "0x30651d6e8f93e0fb79b4bc65a512beb5b9f3378423de90ed03b694cecf443c72",
+                  "package": "0x9c76d5157eaa77c41a7bfda8db98a8e8080f7cb53b7313088ed085c73f866f21",
                   "module": "test"
                 }
               }
@@ -4097,7 +4031,7 @@
             {
               "name": "cursor",
               "value": {
-                "txDigest": "Nb5kW8n655ApSBA19d2K8UVFGtMnJHa1mJQRH1h5N9L",
+                "txDigest": "EnySDWe22mnp35umt47kifqXvvchBqTzAoyoPXaH3rfK",
                 "eventSeq": "1"
               }
             },
@@ -4116,55 +4050,55 @@
               "data": [
                 {
                   "id": {
-                    "txDigest": "8WecQq8Qd79MmrHRXYudNG7e6vjWC9HtGAT4XZFyyWRM",
+                    "txDigest": "FUMhRSj76es8MYeaRYeaBnppk56cuEehKwL2CiU82U7B",
                     "eventSeq": "1"
                   },
-                  "packageId": "0x28f9c59f430eaba84b8bee9b43a30f9cc83fa395759ca37c6e1ffc179184e98a",
+                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
                   "transactionModule": "test",
-                  "sender": "0xc5db76052ab656e5f81853d0cf701cdbc8ebf27ab513fc6ef8c344406c78da3d",
+                  "sender": "0x84bd999f9ff7a1804872957fafa528628a24386298faa98850887f64da841b87",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
                   "bcs": ""
                 },
                 {
                   "id": {
-                    "txDigest": "CNLhn3qWzHhfmmLQTdinbFDd2DuXFPN9z77UUqsC4Z4A",
+                    "txDigest": "CkEYWW2zxTCGBLvUcTARhyX92fu2uc7cnCUXfCiqAypp",
                     "eventSeq": "1"
                   },
-                  "packageId": "0x28f9c59f430eaba84b8bee9b43a30f9cc83fa395759ca37c6e1ffc179184e98a",
+                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
                   "transactionModule": "test",
-                  "sender": "0x5ad3a5fcc295dc8803c15989a62d33ee859014cfd5e91c13a481370240e39246",
+                  "sender": "0x279efd098d59a66a3d9adc87cce81fe9ec69dc8105b2b60140589ec8be44c29f",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
                   "bcs": ""
                 },
                 {
                   "id": {
-                    "txDigest": "FEhceVx5a6mkeZH8dPxthQkEEPkWfjWN3w1e6uTB5rFm",
+                    "txDigest": "Eg3ynETJfTfPKyvJzq3VLG6MngURYHPMjjUJ3Xt1t7tf",
                     "eventSeq": "1"
                   },
-                  "packageId": "0x28f9c59f430eaba84b8bee9b43a30f9cc83fa395759ca37c6e1ffc179184e98a",
+                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
                   "transactionModule": "test",
-                  "sender": "0x4c329a203fb9f0a8158aaab9b2a90044b26e14cc7fee4100fdcabda6d15c63c4",
+                  "sender": "0x289be027d2a94f744b4c59fda7b528f9c59f430eaba84b8bee9b43a30f9cc83f",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
                   "bcs": ""
                 },
                 {
                   "id": {
-                    "txDigest": "Nb5kW8n655ApSBA19d2K8UVFGtMnJHa1mJQRH1h5N9L",
+                    "txDigest": "EnySDWe22mnp35umt47kifqXvvchBqTzAoyoPXaH3rfK",
                     "eventSeq": "1"
                   },
-                  "packageId": "0x28f9c59f430eaba84b8bee9b43a30f9cc83fa395759ca37c6e1ffc179184e98a",
+                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
                   "transactionModule": "test",
-                  "sender": "0xb49c45ae23f2b936495cd38b1a4b04010295baa75ac72e548aeecf2ce8b4e885",
+                  "sender": "0xa395759ca37c6e1ffc179184e98a6f9a2da5d78f6e34b0e5044ed52a6bc0a1bc",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
                   "bcs": ""
                 }
               ],
               "nextCursor": {
-                "txDigest": "Nb5kW8n655ApSBA19d2K8UVFGtMnJHa1mJQRH1h5N9L",
+                "txDigest": "EnySDWe22mnp35umt47kifqXvvchBqTzAoyoPXaH3rfK",
                 "eventSeq": "1"
               },
               "hasNextPage": false
@@ -4306,7 +4240,7 @@
           ],
           "result": {
             "name": "Result",
-            "value": "0x70f2d83f980fe0996a92d351d6749a0a0b47998aaf3d11da24c49e014d4ccb1d"
+            "value": "0xd22bbb46f892c42d9ec0ae4de93e02c75973a51c17180798237326a58694a2cf"
           }
         }
       ]
@@ -4356,11 +4290,11 @@
           "params": [
             {
               "name": "address",
-              "value": "0xb01f2f3f227a90090e6777f19aa10fd9e64e29dd4e8da119481d1a7c3c050dc5"
+              "value": "0x38b3186a7bb26a1ab2c982a0a9b482aa70f5a010fffc60f20194ef0f597474e8"
             },
             {
               "name": "cursor",
-              "value": "0x7d0cd09d3cc1679290f1df2803b32b76ba0395dbb635e3fb7390f04e6567f739"
+              "value": "0x5cd6fa76ed1d18f05f15e35075252ddec4fb83621d55952d9172fcfcb72feae2"
             },
             {
               "name": "limit",
@@ -4373,7 +4307,7 @@
               "data": [
                 "example.sui"
               ],
-              "nextCursor": "0x7d0cd09d3cc1679290f1df2803b32b76ba0395dbb635e3fb7390f04e6567f739",
+              "nextCursor": "0x5cd6fa76ed1d18f05f15e35075252ddec4fb83621d55952d9172fcfcb72feae2",
               "hasNextPage": false
             }
           }
@@ -6643,35 +6577,6 @@
             "additionalProperties": false
           }
         ]
-      },
-      "LoadedChildObject": {
-        "type": "object",
-        "required": [
-          "objectId",
-          "sequenceNumber"
-        ],
-        "properties": {
-          "objectId": {
-            "$ref": "#/components/schemas/ObjectID"
-          },
-          "sequenceNumber": {
-            "$ref": "#/components/schemas/SequenceNumber"
-          }
-        }
-      },
-      "LoadedChildObjectsResponse": {
-        "type": "object",
-        "required": [
-          "loadedChildObjects"
-        ],
-        "properties": {
-          "loadedChildObjects": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LoadedChildObject"
-            }
-          }
-        }
       },
       "MoveCallParams": {
         "type": "object",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -25,9 +25,8 @@ use sui_json_rpc_types::{
     MoveFunctionArgType, ObjectChange, ObjectValueKind::ByImmutableReference,
     ObjectValueKind::ByMutableReference, ObjectValueKind::ByValue, ObjectsPage, OwnedObjectRef,
     Page, ProtocolConfigResponse, RPCTransactionRequestParams, Stake, StakeStatus, SuiCoinMetadata,
-    SuiCommittee, SuiData, SuiEvent, SuiExecutionStatus, SuiGetPastObjectRequest,
-    SuiLoadedChildObject, SuiLoadedChildObjectsResponse, SuiMoveAbility, SuiMoveAbilitySet,
-    SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
+    SuiCommittee, SuiData, SuiEvent, SuiExecutionStatus, SuiGetPastObjectRequest, SuiMoveAbility,
+    SuiMoveAbilitySet, SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
     SuiMoveNormalizedType, SuiMoveVisibility, SuiObjectData, SuiObjectDataFilter,
     SuiObjectDataOptions, SuiObjectRef, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedData,
     SuiPastObjectResponse, SuiTransactionBlock, SuiTransactionBlockData,
@@ -122,7 +121,6 @@ impl RpcExampleProvider {
             self.suix_get_dynamic_fields(),
             self.suix_get_dynamic_field_object(),
             self.suix_get_owned_objects(),
-            self.sui_get_loaded_child_objects(),
             self.sui_get_move_function_arg_types(),
             self.sui_get_normalized_move_function(),
             self.sui_get_normalized_move_module(),
@@ -996,33 +994,6 @@ impl RpcExampleProvider {
             vec![ExamplePairing::new(
                 "Gets total supply for the type of coin provided.",
                 vec![("coin_type", json!(coin))],
-                json!(result),
-            )],
-        )
-    }
-
-    fn sui_get_loaded_child_objects(&mut self) -> Examples {
-        let mut sequence = SequenceNumber::from_u64(self.rng.gen_range(24506..6450624));
-        let seqs = (0..6)
-            .map(|x| {
-                if x % 2 == 0 || x % 3 == 0 {
-                    sequence = SequenceNumber::from_u64(self.rng.gen_range(24506..6450624));
-                }
-
-                SuiLoadedChildObject::new(ObjectID::new(self.rng.gen()), sequence)
-            })
-            .collect::<Vec<_>>();
-        let result = {
-            SuiLoadedChildObjectsResponse {
-                loaded_child_objects: seqs,
-            }
-        };
-
-        Examples::new(
-            "sui_getLoadedChildObjects",
-            vec![ExamplePairing::new(
-                "Gets loaded child objects associated with the transaction the request provides.",
-                vec![("digest", json!(ObjectDigest::new(self.rng.gen())))],
                 json!(result),
             )],
         )

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -19,6 +19,7 @@ use sui_json_rpc_api::{
     CoinReadApiClient, GovernanceReadApiClient, IndexerApiClient, MoveUtilsClient, ReadApiClient,
     WriteApiClient,
 };
+use sui_json_rpc_types::CheckpointPage;
 use sui_json_rpc_types::{
     Balance, Checkpoint, CheckpointId, Coin, CoinPage, DelegatedStake, DevInspectResults,
     DryRunTransactionBlockResponse, DynamicFieldPage, EventFilter, EventPage, ObjectsPage,
@@ -28,7 +29,6 @@ use sui_json_rpc_types::{
     SuiTransactionBlockResponseOptions, SuiTransactionBlockResponseQuery, TransactionBlocksPage,
     TransactionFilter,
 };
-use sui_json_rpc_types::{CheckpointPage, SuiLoadedChildObjectsResponse};
 use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::dynamic_field::DynamicFieldName;
@@ -684,17 +684,6 @@ impl ReadApi {
                 additional_args,
             )
             .await?)
-    }
-
-    /// Return the loaded child objects response for the provided digest, or an error upon failure.
-    ///
-    /// Loaded child objects ([SuiLoadedChildObject](sui_json_rpc_types::SuiLoadedChildObject)) are the non-input objects that the transaction at the digest loaded
-    /// in response to dynamic field accesses.
-    pub async fn get_loaded_child_objects(
-        &self,
-        digest: TransactionDigest,
-    ) -> SuiRpcResult<SuiLoadedChildObjectsResponse> {
-        Ok(self.api.http.get_loaded_child_objects(digest).await?)
     }
 
     /// Return the protocol config, or an error upon failure.


### PR DESCRIPTION
PR marks as deprecated following indexes:
* transactions_by_input_object_id
* transactions_by_mutated_object_id
* loaded_child_object_versions
