### PR TITLE
[GraphQL][cherry-pick] Fix missing setting the query string (#18238)

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -47,6 +47,8 @@ impl Extension for TimeoutExt {
         next: NextParseQuery<'_>,
     ) -> ServerResult<ExecutableDocument> {
         let document = next.run(ctx, query, variables).await?;
+        *self.query.lock().unwrap() = Some(ctx.stringify_execute_doc(&document, variables));
+
         let is_mutation = document
             .operations
             .iter()


### PR DESCRIPTION
## Description 

A previous PR messed up the logging of queries that time out. This fixes it.

## Test plan 

Locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
