### PR TITLE
remove resource handling from transaction data cache

### DIFF
--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -55,8 +55,6 @@ pub fn get_gas_status(cost_table: &CostTable, gas_budget: Option<u64>) -> Result
 }
 
 pub(crate) fn explain_publish_changeset(changeset: &ChangeSet) {
-    // publish effects should contain no resources
-    assert!(changeset.resources().next().is_none());
     // total bytes written across all accounts
     let mut total_bytes_written = 0;
     for (addr, name, blob_op) in changeset.modules() {

--- a/external-crates/move/crates/move-core-types/src/effects.rs
+++ b/external-crates/move/crates/move-core-types/src/effects.rs
@@ -5,7 +5,7 @@
 use crate::{
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{ModuleId, StructTag},
+    language_storage::ModuleId,
 };
 use anyhow::{bail, Result};
 use std::collections::btree_map::{self, BTreeMap};
@@ -59,7 +59,6 @@ impl<T> Op<T> {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AccountChangeSet {
     modules: BTreeMap<Identifier, Op<Vec<u8>>>,
-    resources: BTreeMap<StructTag, Op<Vec<u8>>>,
 }
 
 /// This implements an algorithm to squash two change sets together by merging pairs of operations
@@ -112,17 +111,13 @@ where
 }
 
 impl AccountChangeSet {
-    pub fn from_modules_resources(
-        modules: BTreeMap<Identifier, Op<Vec<u8>>>,
-        resources: BTreeMap<StructTag, Op<Vec<u8>>>,
-    ) -> Self {
-        Self { modules, resources }
+    pub fn from_modules(modules: BTreeMap<Identifier, Op<Vec<u8>>>) -> Self {
+        Self { modules }
     }
 
     pub fn new() -> Self {
         Self {
             modules: BTreeMap::new(),
-            resources: BTreeMap::new(),
         }
     }
 
@@ -139,30 +134,8 @@ impl AccountChangeSet {
         Ok(())
     }
 
-    pub fn add_resource_op(&mut self, struct_tag: StructTag, op: Op<Vec<u8>>) -> Result<()> {
-        use btree_map::Entry::*;
-
-        match self.resources.entry(struct_tag) {
-            Occupied(entry) => bail!("Resource {} already exists", entry.key()),
-            Vacant(entry) => {
-                entry.insert(op);
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn into_inner(
-        self,
-    ) -> (
-        BTreeMap<Identifier, Op<Vec<u8>>>,
-        BTreeMap<StructTag, Op<Vec<u8>>>,
-    ) {
-        (self.modules, self.resources)
-    }
-
-    pub fn into_resources(self) -> BTreeMap<StructTag, Op<Vec<u8>>> {
-        self.resources
+    pub fn into_inner(self) -> BTreeMap<Identifier, Op<Vec<u8>>> {
+        self.modules
     }
 
     pub fn into_modules(self) -> BTreeMap<Identifier, Op<Vec<u8>>> {
@@ -173,17 +146,12 @@ impl AccountChangeSet {
         &self.modules
     }
 
-    pub fn resources(&self) -> &BTreeMap<StructTag, Op<Vec<u8>>> {
-        &self.resources
-    }
-
     pub fn is_empty(&self) -> bool {
-        self.modules.is_empty() && self.resources.is_empty()
+        self.modules.is_empty()
     }
 
     pub fn squash(&mut self, other: Self) -> Result<()> {
-        squash(&mut self.modules, other.modules)?;
-        squash(&mut self.resources, other.resources)
+        squash(&mut self.modules, other.modules)
     }
 }
 
@@ -247,16 +215,6 @@ impl ChangeSet {
         account.add_module_op(module_id.name().to_owned(), op)
     }
 
-    pub fn add_resource_op(
-        &mut self,
-        addr: AccountAddress,
-        struct_tag: StructTag,
-        op: Op<Vec<u8>>,
-    ) -> Result<()> {
-        let account = self.get_or_insert_account_changeset(addr);
-        account.add_resource_op(struct_tag, op)
-    }
-
     pub fn squash(&mut self, other: Self) -> Result<()> {
         for (addr, other_account_changeset) in other.accounts {
             match self.accounts.entry(addr) {
@@ -287,16 +245,6 @@ impl ChangeSet {
                 .modules
                 .iter()
                 .map(move |(module_name, op)| (addr, module_name, op.as_ref().map(|v| v.as_ref())))
-        })
-    }
-
-    pub fn resources(&self) -> impl Iterator<Item = (AccountAddress, &StructTag, Op<&[u8]>)> {
-        self.accounts.iter().flat_map(|(addr, account)| {
-            let addr = *addr;
-            account
-                .resources
-                .iter()
-                .map(move |(struct_tag, op)| (addr, struct_tag, op.as_ref().map(|v| v.as_ref())))
         })
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
@@ -2,35 +2,25 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::Loader;
-
 use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Op},
-    gas_algebra::NumBytes,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, TypeTag},
+    language_storage::ModuleId,
     resolver::MoveResolver,
-    runtime_value::MoveTypeLayout,
     vm_status::StatusCode,
 };
-use move_vm_types::{
-    data_store::DataStore,
-    loaded_data::runtime_types::Type,
-    values::{GlobalValue, Value},
-};
+use move_vm_types::data_store::DataStore;
 use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
-    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
     module_map: BTreeMap<Identifier, Vec<u8>>,
 }
 
 impl AccountDataCache {
     fn new() -> Self {
         Self {
-            data_map: BTreeMap::new(),
             module_map: BTreeMap::new(),
         }
     }
@@ -39,100 +29,47 @@ impl AccountDataCache {
 /// Transaction data cache. Keep updates within a transaction so they can all be published at
 /// once when the transaction succeeds.
 ///
-/// It also provides an implementation for the opcodes that refer to storage and gives the
-/// proper guarantees of reference lifetime.
-///
-/// Dirty objects are serialized and returned in make_write_set.
-///
-/// It is a responsibility of the client to publish changes once the transaction is executed.
-///
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'l, S> {
+pub(crate) struct TransactionDataCache<S> {
     remote: S,
-    loader: &'l Loader,
-    account_map: BTreeMap<AccountAddress, AccountDataCache>,
+    module_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
-impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
+impl<S: MoveResolver> TransactionDataCache<S> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: S, loader: &'l Loader) -> Self {
+    pub(crate) fn new(remote: S) -> Self {
         TransactionDataCache {
             remote,
-            loader,
-            account_map: BTreeMap::new(),
+            module_map: BTreeMap::new(),
         }
     }
 
-    /// Make a write set from the updated (dirty, deleted) global resources along with
-    /// published modules.
-    ///
-    /// Gives all proper guarantees on lifetime of global data as well.
     pub(crate) fn into_effects(mut self) -> (PartialVMResult<ChangeSet>, S) {
         (self.impl_into_effects(), self.remote)
     }
+
     fn impl_into_effects(&mut self) -> PartialVMResult<ChangeSet> {
         let mut change_set = ChangeSet::new();
-        for (addr, account_data_cache) in std::mem::take(&mut self.account_map).into_iter() {
+        for (addr, account_data_cache) in std::mem::take(&mut self.module_map).into_iter() {
             let mut modules = BTreeMap::new();
             for (module_name, module_blob) in account_data_cache.module_map {
                 modules.insert(module_name, Op::New(module_blob));
             }
 
-            let mut resources = BTreeMap::new();
-            for (ty, (layout, gv)) in account_data_cache.data_map {
-                let op = match gv.into_effect() {
-                    Some(op) => op,
-                    None => continue,
-                };
-
-                let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                    TypeTag::Struct(struct_tag) => *struct_tag,
-                    _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
-                };
-
-                match op {
-                    Op::New(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::New(resource_blob));
-                    }
-                    Op::Modify(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::Modify(resource_blob));
-                    }
-                    Op::Delete => {
-                        resources.insert(struct_tag, Op::Delete);
-                    }
-                }
-            }
-            if !modules.is_empty() || !resources.is_empty() {
+            if !modules.is_empty() {
                 change_set
                     .add_account_changeset(
                         addr,
-                        AccountChangeSet::from_modules_resources(modules, resources),
+                        AccountChangeSet::from_modules(modules),
                     )
                     .expect("accounts should be unique");
             }
         }
 
         Ok(change_set)
-    }
-
-    pub(crate) fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        // The sender's account will always be mutated.
-        let mut total_mutated_accounts: u64 = 1;
-        for (addr, entry) in self.account_map.iter() {
-            if addr != sender && entry.data_map.values().any(|(_, v)| v.is_mutated()) {
-                total_mutated_accounts += 1;
-            }
-        }
-        total_mutated_accounts
     }
 
     pub(crate) fn get_remote_resolver(&self) -> &S {
@@ -145,76 +82,7 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
 }
 
 // `DataStore` implementation for the `TransactionDataCache`
-impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
-    // Retrieve data from the local cache or loads it from the remote cache into the local cache.
-    // All operations on the global data are based on this API and they all load the data
-    // into the cache.
-    fn load_resource(
-        &mut self,
-        addr: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-        let account_cache = self
-            .account_map
-            .entry(addr)
-            .or_insert_with(AccountDataCache::new);
-
-        let mut load_res = None;
-        if !account_cache.data_map.contains_key(ty) {
-            let ty_tag = match self.loader.type_to_type_tag(ty)? {
-                TypeTag::Struct(s_tag) => s_tag,
-                _ =>
-                // non-struct top-level value; can't happen
-                {
-                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
-                }
-            };
-            // TODO(Gas): Shall we charge for this?
-            let ty_layout = self.loader.type_to_type_layout(ty)?;
-
-            let gv = match self.remote.get_resource(&addr, &ty_tag) {
-                Ok(Some(blob)) => {
-                    load_res = Some(Some(NumBytes::new(blob.len() as u64)));
-                    let val = match Value::simple_deserialize(&blob, &ty_layout) {
-                        Some(val) => val,
-                        None => {
-                            let msg =
-                                format!("Failed to deserialize resource {} at {}!", ty_tag, addr);
-                            return Err(PartialVMError::new(
-                                StatusCode::FAILED_TO_DESERIALIZE_RESOURCE,
-                            )
-                            .with_message(msg));
-                        }
-                    };
-
-                    GlobalValue::cached(val)?
-                }
-                Ok(None) => {
-                    load_res = Some(None);
-                    GlobalValue::none()
-                }
-                Err(err) => {
-                    let msg = format!("Unexpected storage error: {:?}", err);
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg),
-                    );
-                }
-            };
-
-            account_cache.data_map.insert(ty.clone(), (ty_layout, gv));
-        }
-
-        Ok((
-            account_cache
-                .data_map
-                .get_mut(ty)
-                .map(|(_ty_layout, gv)| gv)
-                .expect("global value must exist"),
-            load_res,
-        ))
-    }
-
+impl<S: MoveResolver> DataStore for TransactionDataCache<S> {
     fn link_context(&self) -> AccountAddress {
         self.remote.link_context()
     }
@@ -241,7 +109,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
     }
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
-        if let Some(account_cache) = self.account_map.get(module_id.address()) {
+        if let Some(account_cache) = self.module_map.get(module_id.address()) {
             if let Some(blob) = account_cache.module_map.get(module_id.name()) {
                 return Ok(blob.clone());
             }
@@ -264,7 +132,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
 
     fn publish_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) -> VMResult<()> {
         let account_cache = self
-            .account_map
+            .module_map
             .entry(*module_id.address())
             .or_insert_with(AccountDataCache::new);
 

--- a/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
@@ -80,7 +80,7 @@ impl MoveVM {
             .loader()
             .load_module(
                 module_id,
-                &TransactionDataCache::new(remote, self.runtime.loader()),
+                &TransactionDataCache::new(remote),
             )
             .map(|(compiled, _)| compiled)
     }

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -61,7 +61,7 @@ impl VMRuntime {
     ) -> Session<'r, '_, S> {
         Session {
             runtime: self,
-            data_cache: TransactionDataCache::new(remote, &self.loader),
+            data_cache: TransactionDataCache::new(remote),
             native_extensions,
         }
     }

--- a/external-crates/move/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/session.rs
@@ -28,7 +28,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'l, S>,
+    pub(crate) data_cache: TransactionDataCache<S>,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
@@ -162,10 +162,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     ) -> VMResult<()> {
         self.runtime
             .publish_module_bundle(modules, sender, &mut self.data_cache, gas_meter)
-    }
-
-    pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        self.data_cache.num_mutated_accounts(sender)
     }
 
     /// Finish up the session and produce the side effects.

--- a/external-crates/move/crates/move-vm-test-utils/src/storage.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/storage.rs
@@ -164,7 +164,7 @@ where
 
 impl InMemoryAccountStorage {
     fn apply(&mut self, account_changeset: AccountChangeSet) -> Result<()> {
-        let (modules, _resources) = account_changeset.into_inner();
+        let modules = account_changeset.into_inner();
         apply_changes(&mut self.modules, modules)?;
         Ok(())
     }

--- a/external-crates/move/crates/move-vm-types/src/data_store.rs
+++ b/external-crates/move/crates/move-vm-types/src/data_store.rs
@@ -2,10 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{loaded_data::runtime_types::Type, values::GlobalValue};
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
-    account_address::AccountAddress, gas_algebra::NumBytes, identifier::IdentStr,
+    account_address::AccountAddress, identifier::IdentStr,
     language_storage::ModuleId,
 };
 
@@ -16,18 +15,6 @@ use move_core_types::{
 /// an in memory cache for a given transaction and the atomic transactional changes
 /// proper of a script execution (transaction).
 pub trait DataStore {
-    // ---
-    // StateStore operations
-    // ---
-
-    /// Try to load a resource from remote storage and create a corresponding GlobalValue
-    /// that is owned by the data store.
-    fn load_resource(
-        &mut self,
-        addr: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)>;
-
     /// The link context identifies the mapping from runtime `ModuleId`s to the `ModuleId`s in
     /// storage that they are loaded from as returned by `relocate`.  Implementors of `DataStore`
     /// are required to keep the link context stable for the duration of

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/data_cache.rs
@@ -2,35 +2,25 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::Loader;
-
 use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Op},
-    gas_algebra::NumBytes,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, TypeTag},
+    language_storage::ModuleId,
     resolver::MoveResolver,
-    runtime_value::MoveTypeLayout,
     vm_status::StatusCode,
 };
-use move_vm_types::{
-    data_store::DataStore,
-    loaded_data::runtime_types::Type,
-    values::{GlobalValue, Value},
-};
+use move_vm_types::data_store::DataStore;
 use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
-    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
     module_map: BTreeMap<Identifier, Vec<u8>>,
 }
 
 impl AccountDataCache {
     fn new() -> Self {
         Self {
-            data_map: BTreeMap::new(),
             module_map: BTreeMap::new(),
         }
     }
@@ -39,100 +29,46 @@ impl AccountDataCache {
 /// Transaction data cache. Keep updates within a transaction so they can all be published at
 /// once when the transaction succeeds.
 ///
-/// It also provides an implementation for the opcodes that refer to storage and gives the
-/// proper guarantees of reference lifetime.
-///
-/// Dirty objects are serialized and returned in make_write_set.
-///
-/// It is a responsibility of the client to publish changes once the transaction is executed.
-///
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'l, S> {
+pub(crate) struct TransactionDataCache<S> {
     remote: S,
-    loader: &'l Loader,
-    account_map: BTreeMap<AccountAddress, AccountDataCache>,
+    module_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
-impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
+impl<S: MoveResolver> TransactionDataCache<S> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: S, loader: &'l Loader) -> Self {
+    pub(crate) fn new(remote: S) -> Self {
         TransactionDataCache {
             remote,
-            loader,
-            account_map: BTreeMap::new(),
+            module_map: BTreeMap::new(),
         }
     }
 
-    /// Make a write set from the updated (dirty, deleted) global resources along with
-    /// published modules.
-    ///
-    /// Gives all proper guarantees on lifetime of global data as well.
     pub(crate) fn into_effects(mut self) -> (PartialVMResult<ChangeSet>, S) {
         (self.impl_into_effects(), self.remote)
     }
+
     fn impl_into_effects(&mut self) -> PartialVMResult<ChangeSet> {
         let mut change_set = ChangeSet::new();
-        for (addr, account_data_cache) in std::mem::take(&mut self.account_map).into_iter() {
+        for (addr, account_data_cache) in std::mem::take(&mut self.module_map).into_iter() {
             let mut modules = BTreeMap::new();
             for (module_name, module_blob) in account_data_cache.module_map {
                 modules.insert(module_name, Op::New(module_blob));
             }
-
-            let mut resources = BTreeMap::new();
-            for (ty, (layout, gv)) in account_data_cache.data_map {
-                let op = match gv.into_effect() {
-                    Some(op) => op,
-                    None => continue,
-                };
-
-                let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                    TypeTag::Struct(struct_tag) => *struct_tag,
-                    _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
-                };
-
-                match op {
-                    Op::New(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::New(resource_blob));
-                    }
-                    Op::Modify(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::Modify(resource_blob));
-                    }
-                    Op::Delete => {
-                        resources.insert(struct_tag, Op::Delete);
-                    }
-                }
-            }
-            if !modules.is_empty() || !resources.is_empty() {
+            if !modules.is_empty() {
                 change_set
                     .add_account_changeset(
                         addr,
-                        AccountChangeSet::from_modules_resources(modules, resources),
+                        AccountChangeSet::from_modules(modules),
                     )
                     .expect("accounts should be unique");
             }
         }
 
         Ok(change_set)
-    }
-
-    pub(crate) fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        // The sender's account will always be mutated.
-        let mut total_mutated_accounts: u64 = 1;
-        for (addr, entry) in self.account_map.iter() {
-            if addr != sender && entry.data_map.values().any(|(_, v)| v.is_mutated()) {
-                total_mutated_accounts += 1;
-            }
-        }
-        total_mutated_accounts
     }
 
     pub(crate) fn get_remote_resolver(&self) -> &S {
@@ -145,76 +81,7 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
 }
 
 // `DataStore` implementation for the `TransactionDataCache`
-impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
-    // Retrieve data from the local cache or loads it from the remote cache into the local cache.
-    // All operations on the global data are based on this API and they all load the data
-    // into the cache.
-    fn load_resource(
-        &mut self,
-        addr: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-        let account_cache = self
-            .account_map
-            .entry(addr)
-            .or_insert_with(AccountDataCache::new);
-
-        let mut load_res = None;
-        if !account_cache.data_map.contains_key(ty) {
-            let ty_tag = match self.loader.type_to_type_tag(ty)? {
-                TypeTag::Struct(s_tag) => s_tag,
-                _ =>
-                // non-struct top-level value; can't happen
-                {
-                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
-                }
-            };
-            // TODO(Gas): Shall we charge for this?
-            let ty_layout = self.loader.type_to_type_layout(ty)?;
-
-            let gv = match self.remote.get_resource(&addr, &ty_tag) {
-                Ok(Some(blob)) => {
-                    load_res = Some(Some(NumBytes::new(blob.len() as u64)));
-                    let val = match Value::simple_deserialize(&blob, &ty_layout) {
-                        Some(val) => val,
-                        None => {
-                            let msg =
-                                format!("Failed to deserialize resource {} at {}!", ty_tag, addr);
-                            return Err(PartialVMError::new(
-                                StatusCode::FAILED_TO_DESERIALIZE_RESOURCE,
-                            )
-                            .with_message(msg));
-                        }
-                    };
-
-                    GlobalValue::cached(val)?
-                }
-                Ok(None) => {
-                    load_res = Some(None);
-                    GlobalValue::none()
-                }
-                Err(err) => {
-                    let msg = format!("Unexpected storage error: {:?}", err);
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg),
-                    );
-                }
-            };
-
-            account_cache.data_map.insert(ty.clone(), (ty_layout, gv));
-        }
-
-        Ok((
-            account_cache
-                .data_map
-                .get_mut(ty)
-                .map(|(_ty_layout, gv)| gv)
-                .expect("global value must exist"),
-            load_res,
-        ))
-    }
-
+impl<S: MoveResolver> DataStore for TransactionDataCache<S> {
     fn link_context(&self) -> AccountAddress {
         self.remote.link_context()
     }
@@ -241,7 +108,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
     }
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
-        if let Some(account_cache) = self.account_map.get(module_id.address()) {
+        if let Some(account_cache) = self.module_map.get(module_id.address()) {
             if let Some(blob) = account_cache.module_map.get(module_id.name()) {
                 return Ok(blob.clone());
             }
@@ -264,7 +131,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
 
     fn publish_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) -> VMResult<()> {
         let account_cache = self
-            .account_map
+            .module_map
             .entry(*module_id.address())
             .or_insert_with(AccountDataCache::new);
 

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/move_vm.rs
@@ -80,7 +80,7 @@ impl MoveVM {
             .loader()
             .load_module(
                 module_id,
-                &TransactionDataCache::new(remote, self.runtime.loader()),
+                &TransactionDataCache::new(remote),
             )
             .map(|(compiled, _)| compiled)
     }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/runtime.rs
@@ -61,7 +61,7 @@ impl VMRuntime {
     ) -> Session<'r, '_, S> {
         Session {
             runtime: self,
-            data_cache: TransactionDataCache::new(remote, &self.loader),
+            data_cache: TransactionDataCache::new(remote),
             native_extensions,
         }
     }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/session.rs
@@ -28,7 +28,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'l, S>,
+    pub(crate) data_cache: TransactionDataCache<S>,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
@@ -152,10 +152,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     ) -> VMResult<()> {
         self.runtime
             .publish_module_bundle(modules, sender, &mut self.data_cache, gas_meter)
-    }
-
-    pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        self.data_cache.num_mutated_accounts(sender)
     }
 
     /// Finish up the session and produce the side effects.

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/data_cache.rs
@@ -2,35 +2,25 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::Loader;
-
 use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Op},
-    gas_algebra::NumBytes,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, TypeTag},
+    language_storage::ModuleId,
     resolver::MoveResolver,
-    runtime_value::MoveTypeLayout,
     vm_status::StatusCode,
 };
-use move_vm_types::{
-    data_store::DataStore,
-    loaded_data::runtime_types::Type,
-    values::{GlobalValue, Value},
-};
+use move_vm_types::data_store::DataStore;
 use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
-    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
     module_map: BTreeMap<Identifier, Vec<u8>>,
 }
 
 impl AccountDataCache {
     fn new() -> Self {
         Self {
-            data_map: BTreeMap::new(),
             module_map: BTreeMap::new(),
         }
     }
@@ -39,100 +29,46 @@ impl AccountDataCache {
 /// Transaction data cache. Keep updates within a transaction so they can all be published at
 /// once when the transaction succeeds.
 ///
-/// It also provides an implementation for the opcodes that refer to storage and gives the
-/// proper guarantees of reference lifetime.
-///
-/// Dirty objects are serialized and returned in make_write_set.
-///
-/// It is a responsibility of the client to publish changes once the transaction is executed.
-///
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'l, S> {
+pub(crate) struct TransactionDataCache<S> {
     remote: S,
-    loader: &'l Loader,
-    account_map: BTreeMap<AccountAddress, AccountDataCache>,
+    module_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
-impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
+impl<S: MoveResolver> TransactionDataCache<S> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: S, loader: &'l Loader) -> Self {
+    pub(crate) fn new(remote: S) -> Self {
         TransactionDataCache {
             remote,
-            loader,
-            account_map: BTreeMap::new(),
+            module_map: BTreeMap::new(),
         }
     }
 
-    /// Make a write set from the updated (dirty, deleted) global resources along with
-    /// published modules.
-    ///
-    /// Gives all proper guarantees on lifetime of global data as well.
     pub(crate) fn into_effects(mut self) -> (PartialVMResult<ChangeSet>, S) {
         (self.impl_into_effects(), self.remote)
     }
+
     fn impl_into_effects(&mut self) -> PartialVMResult<ChangeSet> {
         let mut change_set = ChangeSet::new();
-        for (addr, account_data_cache) in std::mem::take(&mut self.account_map).into_iter() {
+        for (addr, account_data_cache) in std::mem::take(&mut self.module_map).into_iter() {
             let mut modules = BTreeMap::new();
             for (module_name, module_blob) in account_data_cache.module_map {
                 modules.insert(module_name, Op::New(module_blob));
             }
-
-            let mut resources = BTreeMap::new();
-            for (ty, (layout, gv)) in account_data_cache.data_map {
-                let op = match gv.into_effect() {
-                    Some(op) => op,
-                    None => continue,
-                };
-
-                let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                    TypeTag::Struct(struct_tag) => *struct_tag,
-                    _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
-                };
-
-                match op {
-                    Op::New(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::New(resource_blob));
-                    }
-                    Op::Modify(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::Modify(resource_blob));
-                    }
-                    Op::Delete => {
-                        resources.insert(struct_tag, Op::Delete);
-                    }
-                }
-            }
-            if !modules.is_empty() || !resources.is_empty() {
+            if !modules.is_empty() {
                 change_set
                     .add_account_changeset(
                         addr,
-                        AccountChangeSet::from_modules_resources(modules, resources),
+                        AccountChangeSet::from_modules(modules),
                     )
                     .expect("accounts should be unique");
             }
         }
 
         Ok(change_set)
-    }
-
-    pub(crate) fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        // The sender's account will always be mutated.
-        let mut total_mutated_accounts: u64 = 1;
-        for (addr, entry) in self.account_map.iter() {
-            if addr != sender && entry.data_map.values().any(|(_, v)| v.is_mutated()) {
-                total_mutated_accounts += 1;
-            }
-        }
-        total_mutated_accounts
     }
 
     pub(crate) fn get_remote_resolver(&self) -> &S {
@@ -145,76 +81,7 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
 }
 
 // `DataStore` implementation for the `TransactionDataCache`
-impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
-    // Retrieve data from the local cache or loads it from the remote cache into the local cache.
-    // All operations on the global data are based on this API and they all load the data
-    // into the cache.
-    fn load_resource(
-        &mut self,
-        addr: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-        let account_cache = self
-            .account_map
-            .entry(addr)
-            .or_insert_with(AccountDataCache::new);
-
-        let mut load_res = None;
-        if !account_cache.data_map.contains_key(ty) {
-            let ty_tag = match self.loader.type_to_type_tag(ty)? {
-                TypeTag::Struct(s_tag) => s_tag,
-                _ =>
-                // non-struct top-level value; can't happen
-                {
-                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
-                }
-            };
-            // TODO(Gas): Shall we charge for this?
-            let ty_layout = self.loader.type_to_type_layout(ty)?;
-
-            let gv = match self.remote.get_resource(&addr, &ty_tag) {
-                Ok(Some(blob)) => {
-                    load_res = Some(Some(NumBytes::new(blob.len() as u64)));
-                    let val = match Value::simple_deserialize(&blob, &ty_layout) {
-                        Some(val) => val,
-                        None => {
-                            let msg =
-                                format!("Failed to deserialize resource {} at {}!", ty_tag, addr);
-                            return Err(PartialVMError::new(
-                                StatusCode::FAILED_TO_DESERIALIZE_RESOURCE,
-                            )
-                            .with_message(msg));
-                        }
-                    };
-
-                    GlobalValue::cached(val)?
-                }
-                Ok(None) => {
-                    load_res = Some(None);
-                    GlobalValue::none()
-                }
-                Err(err) => {
-                    let msg = format!("Unexpected storage error: {:?}", err);
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg),
-                    );
-                }
-            };
-
-            account_cache.data_map.insert(ty.clone(), (ty_layout, gv));
-        }
-
-        Ok((
-            account_cache
-                .data_map
-                .get_mut(ty)
-                .map(|(_ty_layout, gv)| gv)
-                .expect("global value must exist"),
-            load_res,
-        ))
-    }
-
+impl<S: MoveResolver> DataStore for TransactionDataCache<S> {
     fn link_context(&self) -> AccountAddress {
         self.remote.link_context()
     }
@@ -241,7 +108,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
     }
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
-        if let Some(account_cache) = self.account_map.get(module_id.address()) {
+        if let Some(account_cache) = self.module_map.get(module_id.address()) {
             if let Some(blob) = account_cache.module_map.get(module_id.name()) {
                 return Ok(blob.clone());
             }
@@ -264,7 +131,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
 
     fn publish_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) -> VMResult<()> {
         let account_cache = self
-            .account_map
+            .module_map
             .entry(*module_id.address())
             .or_insert_with(AccountDataCache::new);
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/move_vm.rs
@@ -80,7 +80,7 @@ impl MoveVM {
             .loader()
             .load_module(
                 module_id,
-                &TransactionDataCache::new(remote, self.runtime.loader()),
+                &TransactionDataCache::new(remote),
             )
             .map(|(compiled, _)| compiled)
     }

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -62,7 +62,7 @@ impl VMRuntime {
     ) -> Session<'r, '_, S> {
         Session {
             runtime: self,
-            data_cache: TransactionDataCache::new(remote, &self.loader),
+            data_cache: TransactionDataCache::new(remote),
             native_extensions,
         }
     }

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
@@ -28,7 +28,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'l, S>,
+    pub(crate) data_cache: TransactionDataCache<S>,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
@@ -162,10 +162,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     ) -> VMResult<()> {
         self.runtime
             .publish_module_bundle(modules, sender, &mut self.data_cache, gas_meter)
-    }
-
-    pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        self.data_cache.num_mutated_accounts(sender)
     }
 
     /// Finish up the session and produce the side effects.

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/data_cache.rs
@@ -2,35 +2,25 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::Loader;
-
 use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Op},
-    gas_algebra::NumBytes,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, TypeTag},
+    language_storage::ModuleId,
     resolver::MoveResolver,
-    runtime_value::MoveTypeLayout,
     vm_status::StatusCode,
 };
-use move_vm_types::{
-    data_store::DataStore,
-    loaded_data::runtime_types::Type,
-    values::{GlobalValue, Value},
-};
+use move_vm_types::data_store::DataStore;
 use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
-    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
     module_map: BTreeMap<Identifier, Vec<u8>>,
 }
 
 impl AccountDataCache {
     fn new() -> Self {
         Self {
-            data_map: BTreeMap::new(),
             module_map: BTreeMap::new(),
         }
     }
@@ -39,100 +29,46 @@ impl AccountDataCache {
 /// Transaction data cache. Keep updates within a transaction so they can all be published at
 /// once when the transaction succeeds.
 ///
-/// It also provides an implementation for the opcodes that refer to storage and gives the
-/// proper guarantees of reference lifetime.
-///
-/// Dirty objects are serialized and returned in make_write_set.
-///
-/// It is a responsibility of the client to publish changes once the transaction is executed.
-///
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'l, S> {
+pub(crate) struct TransactionDataCache<S> {
     remote: S,
-    loader: &'l Loader,
-    account_map: BTreeMap<AccountAddress, AccountDataCache>,
+    module_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
-impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
+impl<S: MoveResolver> TransactionDataCache<S> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: S, loader: &'l Loader) -> Self {
+    pub(crate) fn new(remote: S) -> Self {
         TransactionDataCache {
             remote,
-            loader,
-            account_map: BTreeMap::new(),
+            module_map: BTreeMap::new(),
         }
     }
 
-    /// Make a write set from the updated (dirty, deleted) global resources along with
-    /// published modules.
-    ///
-    /// Gives all proper guarantees on lifetime of global data as well.
     pub(crate) fn into_effects(mut self) -> (PartialVMResult<ChangeSet>, S) {
         (self.impl_into_effects(), self.remote)
     }
+
     fn impl_into_effects(&mut self) -> PartialVMResult<ChangeSet> {
         let mut change_set = ChangeSet::new();
-        for (addr, account_data_cache) in std::mem::take(&mut self.account_map).into_iter() {
+        for (addr, account_data_cache) in std::mem::take(&mut self.module_map).into_iter() {
             let mut modules = BTreeMap::new();
             for (module_name, module_blob) in account_data_cache.module_map {
                 modules.insert(module_name, Op::New(module_blob));
             }
-
-            let mut resources = BTreeMap::new();
-            for (ty, (layout, gv)) in account_data_cache.data_map {
-                let op = match gv.into_effect() {
-                    Some(op) => op,
-                    None => continue,
-                };
-
-                let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                    TypeTag::Struct(struct_tag) => *struct_tag,
-                    _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
-                };
-
-                match op {
-                    Op::New(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::New(resource_blob));
-                    }
-                    Op::Modify(val) => {
-                        let resource_blob = val
-                            .simple_serialize(&layout)
-                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Op::Modify(resource_blob));
-                    }
-                    Op::Delete => {
-                        resources.insert(struct_tag, Op::Delete);
-                    }
-                }
-            }
-            if !modules.is_empty() || !resources.is_empty() {
+            if !modules.is_empty() {
                 change_set
                     .add_account_changeset(
                         addr,
-                        AccountChangeSet::from_modules_resources(modules, resources),
+                        AccountChangeSet::from_modules(modules),
                     )
                     .expect("accounts should be unique");
             }
         }
 
         Ok(change_set)
-    }
-
-    pub(crate) fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        // The sender's account will always be mutated.
-        let mut total_mutated_accounts: u64 = 1;
-        for (addr, entry) in self.account_map.iter() {
-            if addr != sender && entry.data_map.values().any(|(_, v)| v.is_mutated()) {
-                total_mutated_accounts += 1;
-            }
-        }
-        total_mutated_accounts
     }
 
     pub(crate) fn get_remote_resolver(&self) -> &S {
@@ -145,76 +81,7 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
 }
 
 // `DataStore` implementation for the `TransactionDataCache`
-impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
-    // Retrieve data from the local cache or loads it from the remote cache into the local cache.
-    // All operations on the global data are based on this API and they all load the data
-    // into the cache.
-    fn load_resource(
-        &mut self,
-        addr: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-        let account_cache = self
-            .account_map
-            .entry(addr)
-            .or_insert_with(AccountDataCache::new);
-
-        let mut load_res = None;
-        if !account_cache.data_map.contains_key(ty) {
-            let ty_tag = match self.loader.type_to_type_tag(ty)? {
-                TypeTag::Struct(s_tag) => s_tag,
-                _ =>
-                // non-struct top-level value; can't happen
-                {
-                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))
-                }
-            };
-            // TODO(Gas): Shall we charge for this?
-            let ty_layout = self.loader.type_to_type_layout(ty)?;
-
-            let gv = match self.remote.get_resource(&addr, &ty_tag) {
-                Ok(Some(blob)) => {
-                    load_res = Some(Some(NumBytes::new(blob.len() as u64)));
-                    let val = match Value::simple_deserialize(&blob, &ty_layout) {
-                        Some(val) => val,
-                        None => {
-                            let msg =
-                                format!("Failed to deserialize resource {} at {}!", ty_tag, addr);
-                            return Err(PartialVMError::new(
-                                StatusCode::FAILED_TO_DESERIALIZE_RESOURCE,
-                            )
-                            .with_message(msg));
-                        }
-                    };
-
-                    GlobalValue::cached(val)?
-                }
-                Ok(None) => {
-                    load_res = Some(None);
-                    GlobalValue::none()
-                }
-                Err(err) => {
-                    let msg = format!("Unexpected storage error: {:?}", err);
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg),
-                    );
-                }
-            };
-
-            account_cache.data_map.insert(ty.clone(), (ty_layout, gv));
-        }
-
-        Ok((
-            account_cache
-                .data_map
-                .get_mut(ty)
-                .map(|(_ty_layout, gv)| gv)
-                .expect("global value must exist"),
-            load_res,
-        ))
-    }
-
+impl<S: MoveResolver> DataStore for TransactionDataCache<S> {
     fn link_context(&self) -> AccountAddress {
         self.remote.link_context()
     }
@@ -241,7 +108,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
     }
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
-        if let Some(account_cache) = self.account_map.get(module_id.address()) {
+        if let Some(account_cache) = self.module_map.get(module_id.address()) {
             if let Some(blob) = account_cache.module_map.get(module_id.name()) {
                 return Ok(blob.clone());
             }
@@ -264,7 +131,7 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
 
     fn publish_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) -> VMResult<()> {
         let account_cache = self
-            .account_map
+            .module_map
             .entry(*module_id.address())
             .or_insert_with(AccountDataCache::new);
 

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/move_vm.rs
@@ -80,7 +80,7 @@ impl MoveVM {
             .loader()
             .load_module(
                 module_id,
-                &TransactionDataCache::new(remote, self.runtime.loader()),
+                &TransactionDataCache::new(remote),
             )
             .map(|(compiled, _)| compiled)
     }

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/runtime.rs
@@ -61,7 +61,7 @@ impl VMRuntime {
     ) -> Session<'r, '_, S> {
         Session {
             runtime: self,
-            data_cache: TransactionDataCache::new(remote, &self.loader),
+            data_cache: TransactionDataCache::new(remote),
             native_extensions,
         }
     }

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/session.rs
@@ -28,7 +28,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'l, S>,
+    pub(crate) data_cache: TransactionDataCache<S>,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
@@ -162,10 +162,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     ) -> VMResult<()> {
         self.runtime
             .publish_module_bundle(modules, sender, &mut self.data_cache, gas_meter)
-    }
-
-    pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
-        self.data_cache.num_mutated_accounts(sender)
     }
 
     /// Finish up the session and produce the side effects.

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -21,7 +21,6 @@ mod checked {
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
         CompiledModule,
     };
-    use move_core_types::gas_algebra::NumBytes;
     use move_core_types::resolver::ModuleResolver;
     use move_core_types::vm_status::StatusCode;
     use move_core_types::{
@@ -36,7 +35,6 @@ mod checked {
     };
     use move_vm_types::data_store::DataStore;
     use move_vm_types::loaded_data::runtime_types::Type;
-    use move_vm_types::values::GlobalValue;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
@@ -1532,19 +1530,6 @@ mod checked {
                     )
                 }
             }
-        }
-
-        //
-        // TODO: later we will clean up the interface with the runtime and the functions below
-        //       will likely be exposed via extensions
-        //
-
-        fn load_resource(
-            &mut self,
-            _addr: AccountAddress,
-            _ty: &Type,
-        ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-            panic!("load_resource should never be called for LinkageView")
         }
 
         fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -679,13 +679,8 @@ mod checked {
             }
 
             let (res, linkage) = session.finish_with_extensions();
-            let (change_set, mut native_context_extensions) =
+            let (_, mut native_context_extensions) =
                 res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-            // Sui Move programs should never touch global state, so resources should be empty
-            assert_invariant!(
-                change_set.resources().next().is_none(),
-                "Change set must be empty"
-            );
             let object_runtime: ObjectRuntime = native_context_extensions.remove();
             let new_ids = object_runtime.new_ids().clone();
             // tell the object runtime what input objects were taken and which were transferred

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -20,7 +20,6 @@ mod checked {
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
         CompiledModule,
     };
-    use move_core_types::gas_algebra::NumBytes;
     use move_core_types::resolver::ModuleResolver;
     use move_core_types::vm_status::StatusCode;
     use move_core_types::{
@@ -35,7 +34,6 @@ mod checked {
     };
     use move_vm_types::data_store::DataStore;
     use move_vm_types::loaded_data::runtime_types::Type;
-    use move_vm_types::values::GlobalValue;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
@@ -1442,19 +1440,6 @@ mod checked {
                     )
                 }
             }
-        }
-
-        //
-        // TODO: later we will clean up the interface with the runtime and the functions below
-        //       will likely be exposed via extensions
-        //
-
-        fn load_resource(
-            &mut self,
-            _addr: AccountAddress,
-            _ty: &Type,
-        ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-            panic!("load_resource should never be called for LinkageView")
         }
 
         fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -21,7 +21,6 @@ mod checked {
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
         CompiledModule,
     };
-    use move_core_types::gas_algebra::NumBytes;
     use move_core_types::resolver::ModuleResolver;
     use move_core_types::vm_status::StatusCode;
     use move_core_types::{
@@ -36,7 +35,6 @@ mod checked {
     };
     use move_vm_types::data_store::DataStore;
     use move_vm_types::loaded_data::runtime_types::Type;
-    use move_vm_types::values::GlobalValue;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
@@ -1498,19 +1496,6 @@ mod checked {
                     )
                 }
             }
-        }
-
-        //
-        // TODO: later we will clean up the interface with the runtime and the functions below
-        //       will likely be exposed via extensions
-        //
-
-        fn load_resource(
-            &mut self,
-            _addr: AccountAddress,
-            _ty: &Type,
-        ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
-            panic!("load_resource should never be called for LinkageView")
         }
 
         fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {


### PR DESCRIPTION
## Description 

Remove code related to resources from the transaction data cache to simplify code on our way to session removal and trait simplification in the Move VM.
One step at the time to avoid making a massive and too confusing PR.
This way we get more clarity on what is needed.
It slightly cleans up things in the adapter as well

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
