### PR TITLE
[GraphQL] Ensure single source of truth for compatibility check

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -80,12 +80,7 @@ impl Server {
 
         // Compatibility check
         info!("Starting compatibility check");
-        let result = check_all_tables(&self.db_reader).await?;
-
-        if !result {
-            return Err(Error::Internal("Compatibility check failed".to_string()));
-        }
-
+        check_all_tables(&self.db_reader).await?;
         info!("Compatibility check passed");
 
         // A handle that spawns a background task to periodically update the `Watermark`, which

--- a/crates/sui-graphql-rpc/src/server/compatibility_check.rs
+++ b/crates/sui-graphql-rpc/src/server/compatibility_check.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::data::{Db, DbConnection, QueryExecutor, DieselConn, DieselBackend};
+use crate::data::{Db, DbConnection, DieselBackend, DieselConn, QueryExecutor};
 use crate::error::Error;
-use diesel::query_builder::{QueryId, Query, QueryFragment, AstPass};
+use diesel::query_builder::{AstPass, Query, QueryFragment, QueryId};
 use diesel::sql_types::Bool;
-use diesel::{QueryDsl, RunQueryDsl, QueryResult};
+use diesel::{QueryDsl, QueryResult, RunQueryDsl};
 
 /// Generates a function: `check_all_tables` that runs a query against every table this GraphQL
 /// service is aware of, to test for schema compatibility. Each query is of the form:

--- a/crates/sui-graphql-rpc/src/server/compatibility_check.rs
+++ b/crates/sui-graphql-rpc/src/server/compatibility_check.rs
@@ -1,54 +1,39 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::check_table;
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::{Db, DbConnection, QueryExecutor, DieselConn, DieselBackend};
 use crate::error::Error;
-use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
-use sui_indexer::models::checkpoints::StoredCheckpoint;
-use sui_indexer::models::display::StoredDisplay;
-use sui_indexer::models::epoch::QueryableEpochInfo;
-use sui_indexer::models::events::StoredEvent;
-use sui_indexer::models::objects::{StoredHistoryObject, StoredObjectSnapshot};
-use sui_indexer::models::packages::StoredPackage;
-use sui_indexer::models::transactions::StoredTransaction;
-use sui_indexer::models::tx_indices::{
-    StoredTxCalls, StoredTxChangedObject, StoredTxDigest, StoredTxInputObject, StoredTxRecipients,
-    StoredTxSenders,
-};
-use sui_indexer::schema::tx_digests;
-use sui_indexer::schema::{
-    checkpoints, display, epochs, events, objects_history, objects_snapshot, packages,
-    transactions, tx_calls, tx_changed_objects, tx_input_objects, tx_recipients, tx_senders,
-};
+use diesel::query_builder::{QueryId, Query, QueryFragment, AstPass};
+use diesel::sql_types::Bool;
+use diesel::{QueryDsl, RunQueryDsl, QueryResult};
 
-#[macro_export]
-macro_rules! check_table {
-    ($conn:expr, $table:path, $type:ty) => {{
-        let result: Result<Option<$type>, _> = $conn
-            .first(move || $table.select(<$type>::as_select()))
-            .optional();
-        result.is_ok()
-    }};
-}
-
-#[macro_export]
-macro_rules! generate_check_all_tables {
-    ($(($table:ident, $type:ty)),* $(,)?) => {
-        pub(crate) async fn check_all_tables(db: &Db) -> Result<bool, Error> {
+/// Generates a function: `check_all_tables` that runs a query against every table this GraphQL
+/// service is aware of, to test for schema compatibility. Each query is of the form:
+///
+///   SELECT TRUE FROM (...) q WHERE FALSE
+///
+/// where `...` is a query selecting all of the fields from the given table. The query is expected
+/// to return no results, but will complain if it relies on a column that doesn't exist.
+macro_rules! generate_compatibility_check {
+    ($($table:ident),*) => {
+        pub(crate) async fn check_all_tables(db: &Db) -> Result<(), Error> {
             use futures::future::join_all;
+            use sui_indexer::schema::*;
 
             let futures = vec![
                 $(
-                    db.execute(|conn| {
-                        Ok::<_, diesel::result::Error>(check_table!(conn, $table::dsl::$table, $type))
-                    })
+                    db.execute(|conn| Ok::<_, diesel::result::Error>(
+                        conn.results::<_, bool>(move || Check {
+                            query: $table::table.select($table::all_columns)
+                        })
+                        .is_ok()
+                    ))
                 ),*
             ];
 
             let results = join_all(futures).await;
             if results.into_iter().all(|res| res.unwrap_or(false)) {
-                Ok(true)
+                Ok(())
             } else {
                 Err(Error::Internal(
                     "One or more tables are missing expected columns".into(),
@@ -58,19 +43,24 @@ macro_rules! generate_check_all_tables {
     };
 }
 
-generate_check_all_tables!(
-    (checkpoints, StoredCheckpoint),
-    (display, StoredDisplay),
-    (epochs, QueryableEpochInfo),
-    (events, StoredEvent),
-    (objects_history, StoredHistoryObject),
-    (objects_snapshot, StoredObjectSnapshot),
-    (packages, StoredPackage),
-    (transactions, StoredTransaction),
-    (tx_calls, StoredTxCalls),
-    (tx_changed_objects, StoredTxChangedObject),
-    (tx_digests, StoredTxDigest),
-    (tx_input_objects, StoredTxInputObject),
-    (tx_recipients, StoredTxRecipients),
-    (tx_senders, StoredTxSenders),
-);
+sui_indexer::for_all_tables!(generate_compatibility_check);
+
+#[derive(Debug, Clone, Copy, QueryId)]
+struct Check<Q> {
+    query: Q,
+}
+
+impl<Q: Query> Query for Check<Q> {
+    type SqlType = Bool;
+}
+
+impl<Q> RunQueryDsl<DieselConn> for Check<Q> {}
+
+impl<Q: QueryFragment<DieselBackend>> QueryFragment<DieselBackend> for Check<Q> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DieselBackend>) -> QueryResult<()> {
+        out.push_sql("SELECT TRUE FROM (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(") q WHERE FALSE");
+        Ok(())
+    }
+}

--- a/crates/sui-indexer/src/schema/mod.rs
+++ b/crates/sui-indexer/src/schema/mod.rs
@@ -64,3 +64,11 @@ pub use inner::tx_digests;
 pub use inner::tx_input_objects;
 pub use inner::tx_recipients;
 pub use inner::tx_senders;
+
+// Postgres only tables
+#[cfg(feature = "postgres-feature")]
+pub use crate::schema::pg::events_partition_0;
+#[cfg(feature = "postgres-feature")]
+pub use crate::schema::pg::objects_history_partition_0;
+#[cfg(feature = "postgres-feature")]
+pub use crate::schema::pg::transactions_partition_0;

--- a/crates/sui-indexer/src/schema/mysql.rs
+++ b/crates/sui-indexer/src/schema/mysql.rs
@@ -215,20 +215,27 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    checkpoints,
-    display,
-    epochs,
-    events,
-    objects,
-    objects_history,
-    objects_snapshot,
-    packages,
-    transactions,
-    tx_calls,
-    tx_changed_objects,
-    tx_digests,
-    tx_input_objects,
-    tx_recipients,
-    tx_senders,
-);
+#[macro_export]
+macro_rules! for_all_tables {
+    ($action:path) => {
+        $action!(
+            checkpoints,
+            epochs,
+            events,
+            objects,
+            objects_history,
+            objects_snapshot,
+            packages,
+            transactions,
+            tx_calls,
+            tx_changed_objects,
+            tx_digests,
+            tx_input_objects,
+            tx_recipients,
+            tx_senders
+        );
+    }
+}
+pub use for_all_tables;
+
+for_all_tables!(diesel::allow_tables_to_appear_in_same_query);

--- a/crates/sui-indexer/src/schema/mysql.rs
+++ b/crates/sui-indexer/src/schema/mysql.rs
@@ -234,7 +234,7 @@ macro_rules! for_all_tables {
             tx_recipients,
             tx_senders
         );
-    }
+    };
 }
 pub use for_all_tables;
 

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -272,23 +272,30 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    checkpoints,
-    display,
-    epochs,
-    events,
-    events_partition_0,
-    objects,
-    objects_history,
-    objects_history_partition_0,
-    objects_snapshot,
-    packages,
-    transactions,
-    transactions_partition_0,
-    tx_calls,
-    tx_changed_objects,
-    tx_digests,
-    tx_input_objects,
-    tx_recipients,
-    tx_senders,
-);
+#[macro_export]
+macro_rules! for_all_tables {
+    ($action:path) => {
+        $action!(
+            checkpoints,
+            epochs,
+            events,
+            events_partition_0,
+            objects,
+            objects_history,
+            objects_history_partition_0,
+            objects_snapshot,
+            packages,
+            transactions,
+            transactions_partition_0,
+            tx_calls,
+            tx_changed_objects,
+            tx_digests,
+            tx_input_objects,
+            tx_recipients,
+            tx_senders
+        );
+    }
+}
+pub use for_all_tables;
+
+for_all_tables!(diesel::allow_tables_to_appear_in_same_query);

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -294,7 +294,7 @@ macro_rules! for_all_tables {
             tx_recipients,
             tx_senders
         );
-    }
+    };
 }
 pub use for_all_tables;
 


### PR DESCRIPTION
## Description

Increase the likelihood that when a schema change is made on the indexer side, the compatibility check on the GraphQL side is also updated, by removing the duplication of table names from both places:

Now, the compatibility check relies on a macro --
`sui_indexer::for_all_tables` to enumerate tables. This is more likely to be updated when a new table is added because it's also used by the indexer to ensure all the tables can appear in queries next to each other.

This PR also changes the nature of the query used for the compatibility check: It no longer relies on knowing about a model type to select fields for, because such a type may have columns missing. Instead it fetches all the columns for the table, but then discards them.

## Test plan

Run the service against a compatible DB -- it should spin up. Then add a field to the local schema, re-run, and it will panic on start-up.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
