### PR TITLE
[move] enable event introspection in tests

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/event.move
+++ b/crates/sui-framework/packages/sui-framework/sources/event.move
@@ -36,7 +36,6 @@ module sui::event {
     /// phantom parameters, eg `emit(MyEvent<phantom T>)`.
     public native fun emit<T: copy + drop>(event: T);
 
-/* uncomment me after next release
     #[test_only]
     /// Get the total number of events emitted during execution so far
     public native fun num_events(): u32;
@@ -45,5 +44,4 @@ module sui::event {
     /// Get all events of type `T` emitted during execution.
     /// Can only be used in testing,
     public native fun events_by_type<T: copy + drop>(): vector<T>;
-*/
 }

--- a/crates/sui-framework/packages/sui-framework/tests/event_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/event_tests.move
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-/* uncomment me after next release
+
 #[test_only]
 module sui::event_tests {
     use sui::event;
@@ -56,4 +56,4 @@ module sui::event_tests {
         assert_eq(event::events_by_type<S1>()[1], e3);
         assert_eq(event::num_events(), 4);
     }
-}*/
+}

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -1019,11 +1019,13 @@ module sui::test_scenario_tests {
         abort 42
     }
 
-/* uncomment me after next release
     public struct E1(u64) has copy, drop;
 
     #[test]
     fun test_events() {
+        use sui::event;
+        use sui::test_utils::assert_eq;
+
         // calling test_scenario::end should dump events emitted during previous txes
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
@@ -1047,5 +1049,4 @@ module sui::test_scenario_tests {
         assert_eq(effects.num_user_events(), 1);
         assert_eq(event::num_events(), 0);
     }
-*/
 }


### PR DESCRIPTION
Follow up on https://github.com/MystenLabs/sui/commit/9c9ffd088cc00d5775100971be96198ced0dfb26 now that the native functions are live