### PR TITLE
[test] Allow AuthorityState to reconfigure in single validator tests

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -958,6 +958,29 @@ impl AuthorityPerEpochStore {
         )
     }
 
+    pub fn new_at_next_epoch_for_testing(
+        &self,
+        backing_package_store: Arc<dyn BackingPackageStore + Send + Sync>,
+        object_store: Arc<dyn ObjectStore + Send + Sync>,
+        expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
+    ) -> Arc<Self> {
+        let next_epoch = self.epoch() + 1;
+        let next_committee = Committee::new(
+            next_epoch,
+            self.committee.voting_rights.iter().cloned().collect(),
+        );
+        self.new_at_next_epoch(
+            self.name,
+            next_committee,
+            self.epoch_start_configuration
+                .new_at_next_epoch_for_testing(),
+            backing_package_store,
+            object_store,
+            expensive_safety_check_config,
+            self.chain_identifier,
+        )
+    }
+
     pub fn committee(&self) -> &Arc<Committee> {
         &self.committee
     }

--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -138,6 +138,26 @@ impl EpochStartConfiguration {
         }))
     }
 
+    pub fn new_at_next_epoch_for_testing(&self) -> Self {
+        // We only need to implement this function for the latest version.
+        // When a new version is introduced, this function should be updated.
+        match self {
+            Self::V6(config) => {
+                Self::V6(EpochStartConfigurationV6 {
+                    system_state: config.system_state.new_at_next_epoch_for_testing(),
+                    epoch_digest: config.epoch_digest,
+                    flags: config.flags.clone(),
+                    authenticator_obj_initial_shared_version: config.authenticator_obj_initial_shared_version,
+                    randomness_obj_initial_shared_version: config.randomness_obj_initial_shared_version,
+                    coin_deny_list_obj_initial_shared_version: config.coin_deny_list_obj_initial_shared_version,
+                    bridge_obj_initial_shared_version: config.bridge_obj_initial_shared_version,
+                    bridge_committee_initiated: config.bridge_committee_initiated,
+                })
+            }
+            _ => panic!("This function is only implemented for the latest version of EpochStartConfiguration"),
+        }
+    }
+
     pub fn epoch_data(&self) -> EpochData {
         EpochData::new(
             self.epoch_start_state().epoch(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -6151,3 +6151,11 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
         panic!("First scheduled transaction must be a ConsensusCommitPrologueV3 transaction.");
     }
 }
+
+#[tokio::test]
+async fn test_single_authority_reconfigure() {
+    let state = TestAuthorityBuilder::new().build().await;
+    assert_eq!(state.epoch_store_for_testing().epoch(), 0);
+    state.reconfigure_for_testing().await;
+    assert_eq!(state.epoch_store_for_testing().epoch(), 1);
+}

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -74,6 +74,21 @@ impl EpochStartSystemState {
     pub fn new_for_testing_with_epoch(epoch: EpochId) -> Self {
         Self::V1(EpochStartSystemStateV1::new_for_testing_with_epoch(epoch))
     }
+
+    pub fn new_at_next_epoch_for_testing(&self) -> Self {
+        // Only need to support the latest version for testing.
+        match self {
+            Self::V1(state) => Self::V1(EpochStartSystemStateV1 {
+                epoch: state.epoch + 1,
+                protocol_version: state.protocol_version,
+                reference_gas_price: state.reference_gas_price,
+                safe_mode: state.safe_mode,
+                epoch_start_timestamp_ms: state.epoch_start_timestamp_ms,
+                epoch_duration_ms: state.epoch_duration_ms,
+                active_validators: state.active_validators.clone(),
+            }),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -298,7 +313,7 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct EpochStartValidatorInfoV1 {
     pub sui_address: SuiAddress,
     pub protocol_pubkey: narwhal_crypto::PublicKey,


### PR DESCRIPTION
## Description 

Add an API to AuthorityState to allow for epoch change during a single validator test.
This will unblock the per-epoch-immutable config Move transactional tests.

## Test plan 

Added a smoke test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
