### PR TITLE
[move][move-ide][move-compiler] Swap `FilesSourceText` to `MappedFiles` in most places

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -18,7 +18,8 @@ use move_binary_format::{
 use move_bytecode_utils::{layout::SerdeLayoutBuilder, module_cache::GetModule};
 use move_compiler::{
     compiled_unit::AnnotatedCompiledModule,
-    diagnostics::{report_diagnostics_to_buffer, report_warnings, Diagnostics, FilesSourceText},
+    diagnostics::{report_diagnostics_to_buffer, report_warnings, Diagnostics},
+    shared::files::MappedFiles,
     editions::Edition,
     linters::LINT_WARNING_PREFIX,
 };
@@ -184,7 +185,7 @@ impl BuildConfig {
 
 /// There may be additional information that needs to be displayed after diagnostics are reported
 /// (optionally report diagnostics themselves if files argument is provided).
-pub fn decorate_warnings(warning_diags: Diagnostics, files: Option<&FilesSourceText>) {
+pub fn decorate_warnings(warning_diags: Diagnostics, files: Option<&MappedFiles>) {
     let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX);
     let (filtered_diags_num, unique) =
         warning_diags.filtered_source_diags_with_prefix(LINT_WARNING_PREFIX);

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -19,9 +19,9 @@ use move_bytecode_utils::{layout::SerdeLayoutBuilder, module_cache::GetModule};
 use move_compiler::{
     compiled_unit::AnnotatedCompiledModule,
     diagnostics::{report_diagnostics_to_buffer, report_warnings, Diagnostics},
-    shared::files::MappedFiles,
     editions::Edition,
     linters::LINT_WARNING_PREFIX,
+    shared::files::MappedFiles,
 };
 use move_core_types::{
     account_address::AccountAddress,

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -8,7 +8,7 @@ use crate::{
         expansion_mod_ident_to_map_key, type_def_loc, DefInfo, DefLoc, LocalDef, ModuleDefs,
         UseDef, UseDefMap, UseLoc,
     },
-    utils::{get_start_position_opt, ignored_function},
+    utils::{ignored_function, loc_start_to_lsp_position_opt},
 };
 
 use move_compiler::{
@@ -62,13 +62,13 @@ impl TypingAnalysisContext<'_> {
     /// Returns the `lsp_types::Position` start for a location, but may fail if we didn't see the
     /// definition already.
     fn lsp_start_position_opt(&self, loc: &Loc) -> Option<lsp_types::Position> {
-        get_start_position_opt(loc, self.files)
+        loc_start_to_lsp_position_opt(self.files, loc)
     }
 
     /// Returns the `lsp_types::Position` start for a location, but may fail if we didn't see the
     /// definition already. This should only be used on things we already indexed.
     fn lsp_start_position(&self, loc: &Loc) -> lsp_types::Position {
-        get_start_position_opt(loc, self.files).unwrap()
+        loc_start_to_lsp_position_opt(self.files, loc).unwrap()
     }
 
     fn reset_for_module_member(&mut self) {

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -8,16 +8,15 @@ use crate::{
         expansion_mod_ident_to_map_key, type_def_loc, DefInfo, DefLoc, LocalDef, ModuleDefs,
         UseDef, UseDefMap, UseLoc,
     },
-    utils::{get_start_position_opt, ignored_function, to_lsp_position},
+    utils::{get_start_position_opt, ignored_function},
 };
 
-use move_command_line_common::files::FileHash;
 use move_compiler::{
-    diagnostics::{self as diag, PositionInfo},
+    diagnostics as diag,
     expansion::ast::{self as E, ModuleIdent},
     naming::ast as N,
     parser::ast as P,
-    shared::{ide::MacroCallInfo, Identifier, Name},
+    shared::{files::MappedFiles, ide::MacroCallInfo, Identifier, Name},
     typing::{
         ast as T,
         visitor::{LValueKind, TypingVisitorContext},
@@ -26,10 +25,9 @@ use move_compiler::{
 use move_ir_types::location::{sp, Loc};
 use move_symbol_pool::Symbol;
 
-use codespan_reporting::files::SimpleFiles;
 use im::OrdMap;
 use lsp_types::Position;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Data used during anlysis over typed AST
 pub struct TypingAnalysisContext<'a> {
@@ -37,10 +35,8 @@ pub struct TypingAnalysisContext<'a> {
     /// string so that we can access it regardless of the ModuleIdent representation
     /// (e.g., in the parsing AST or in the typing AST)
     pub mod_outer_defs: &'a BTreeMap<String, ModuleDefs>,
-    /// A mapping from file names to file content (used to obtain source file locations)
-    pub files: &'a SimpleFiles<Symbol, String>,
-    /// A mapping from file hashes to file IDs (used to obtain source file locations)
-    pub file_id_mapping: &'a HashMap<FileHash, usize>,
+    /// Mapped file information for translating locations into positions
+    pub files: &'a MappedFiles,
     pub references: &'a mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
     /// Additional information about definitions
     pub def_info: &'a mut BTreeMap<DefLoc, DefInfo>,
@@ -66,13 +62,13 @@ impl TypingAnalysisContext<'_> {
     /// Returns the `lsp_types::Position` start for a location, but may fail if we didn't see the
     /// definition already.
     fn lsp_start_position_opt(&self, loc: &Loc) -> Option<lsp_types::Position> {
-        get_start_position_opt(loc, self.files(), self.file_mapping())
+        get_start_position_opt(loc, self.files)
     }
 
     /// Returns the `lsp_types::Position` start for a location, but may fail if we didn't see the
     /// definition already. This should only be used on things we already indexed.
     fn lsp_start_position(&self, loc: &Loc) -> lsp_types::Position {
-        to_lsp_position(self.start_position(loc))
+        get_start_position_opt(loc, self.files).unwrap()
     }
 
     fn reset_for_module_member(&mut self) {
@@ -289,8 +285,7 @@ impl TypingAnalysisContext<'_> {
         let result = add_fun_use_def(
             fun_def_name,
             self.mod_outer_defs,
-            self.files(),
-            self.file_mapping(),
+            self.files,
             mod_ident_str,
             mod_defs,
             use_name,
@@ -345,8 +340,7 @@ impl TypingAnalysisContext<'_> {
         let mut refs = std::mem::take(self.references);
         add_struct_use_def(
             self.mod_outer_defs,
-            self.files(),
-            self.file_mapping(),
+            self.files,
             mod_ident_str,
             mod_defs,
             &use_name.value(),
@@ -607,7 +601,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
         }
         let loc = function_name.loc();
         // first, enter self-definition for function name (unwrap safe - done when inserting def)
-        let name_start = to_lsp_position(self.start_position(&loc));
+        let name_start = self.lsp_start_position(&loc);
         let fun_info = self
             .def_info
             .get(&DefLoc::new(loc.file_hash(), name_start))
@@ -913,17 +907,5 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                 self.add_fun_use_def(&module_ident, &fun_def_name, &fun_def_name, &fun_def_loc);
             }
         }
-    }
-}
-
-impl diag::PositionInfo for TypingAnalysisContext<'_> {
-    type FileContents = String;
-
-    fn files(&self) -> &SimpleFiles<Symbol, Self::FileContents> {
-        self.files
-    }
-
-    fn file_mapping(&self) -> &HashMap<FileHash, move_compiler::diagnostics::FileId> {
-        self.file_id_mapping
     }
 }

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -27,7 +27,7 @@ use move_compiler::{
         keywords::{BUILTINS, CONTEXTUAL_KEYWORDS, KEYWORDS, PRIMITIVE_TYPES},
         lexer::{Lexer, Tok},
     },
-    shared::{ide::AutocompleteMethod, Identifier},
+    shared::{Identifier, ide::AutocompleteMethod},
 };
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
@@ -285,7 +285,7 @@ fn dot(symbols: &Symbols, use_fpath: &Path, position: &Position) -> Vec<Completi
         return completions;
     };
     let Some(byte_idx) =
-        utils::get_byte_idx(*position, fhash, &symbols.files, &symbols.file_id_mapping)
+        utils::lsp_position_to_byte_index(&symbols.files, fhash, position)
     else {
         return completions;
     };
@@ -547,17 +547,17 @@ fn completion_items(pos: Position, path: &Path, symbols: &Symbols) -> Vec<Comple
     let Some(fhash) = symbols.file_hash(path) else {
         return items;
     };
-    let Some(file_id) = symbols.file_id_mapping.get(&fhash) else {
+    let Some(file_id) = symbols.files.file_mapping().get(&fhash) else {
         return items;
     };
-    let Ok(file) = symbols.files.get(*file_id) else {
+    let Ok(file) = symbols.files.files().get(*file_id) else {
         return items;
     };
 
     let buffer = file.source().clone();
     if !buffer.is_empty() {
         let mut only_custom_items = false;
-        let cursor = get_cursor_token(buffer.as_str(), &pos);
+        let cursor = get_cursor_token(&buffer, &pos);
         match cursor {
             Some(Tok::Colon) => {
                 items.extend_from_slice(&primitive_types());
@@ -585,7 +585,7 @@ fn completion_items(pos: Position, path: &Path, symbols: &Symbols) -> Vec<Comple
                 // offer them context-specific autocompletion items as well as
                 // Move's keywords, operators, and builtins.
                 let (custom_items, custom) =
-                    context_specific_no_trigger(symbols, path, buffer.as_str(), &pos);
+                    context_specific_no_trigger(symbols, path, &buffer, &pos);
                 only_custom_items = custom;
                 items.extend_from_slice(&custom_items);
                 if !only_custom_items {
@@ -595,7 +595,7 @@ fn completion_items(pos: Position, path: &Path, symbols: &Symbols) -> Vec<Comple
             }
         }
         if !only_custom_items {
-            let identifiers = identifiers(buffer.as_str(), symbols, path);
+            let identifiers = identifiers(&buffer, symbols, path);
             items.extend_from_slice(&identifiers);
         }
     } else {
@@ -682,8 +682,8 @@ fn completion_dot_test() {
         character: 10,
     };
     let items = completion_items(pos, &cpath, &symbols);
-    let loc = format!("{:?} (line: {}, col: {}", cpath, pos.line, pos.character);
-    assert!(items.len() == 3, "wrong number of items at {}", loc.clone());
+    let loc = format!("{:?} (line: {}, col: {})", cpath, pos.line, pos.character);
+    assert!(items.len() == 3, "wrong number of items at {} (3 vs {})", loc.clone(), items.len());
     validate_item(
         loc.clone(),
         &items,

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -27,7 +27,7 @@ use move_compiler::{
         keywords::{BUILTINS, CONTEXTUAL_KEYWORDS, KEYWORDS, PRIMITIVE_TYPES},
         lexer::{Lexer, Tok},
     },
-    shared::{Identifier, ide::AutocompleteMethod},
+    shared::{ide::AutocompleteMethod, Identifier},
 };
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
@@ -284,9 +284,7 @@ fn dot(symbols: &Symbols, use_fpath: &Path, position: &Position) -> Vec<Completi
     let Some(fhash) = symbols.file_hash(use_fpath) else {
         return completions;
     };
-    let Some(byte_idx) =
-        utils::lsp_position_to_byte_index(&symbols.files, fhash, position)
-    else {
+    let Some(byte_idx) = utils::lsp_position_to_byte_index(&symbols.files, fhash, position) else {
         return completions;
     };
     let loc = Loc::new(fhash, byte_idx, byte_idx);
@@ -683,7 +681,12 @@ fn completion_dot_test() {
     };
     let items = completion_items(pos, &cpath, &symbols);
     let loc = format!("{:?} (line: {}, col: {})", cpath, pos.line, pos.character);
-    assert!(items.len() == 3, "wrong number of items at {} (3 vs {})", loc.clone(), items.len());
+    assert!(
+        items.len() == 3,
+        "wrong number of items at {} (3 vs {})",
+        loc.clone(),
+        items.len()
+    );
     validate_item(
         loc.clone(),
         &items,

--- a/external-crates/move/crates/move-analyzer/src/diagnostics.rs
+++ b/external-crates/move/crates/move-analyzer/src/diagnostics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils::get_loc;
+use crate::utils::{loc_end_to_lsp_position_opt, loc_start_to_lsp_position_opt};
 use codespan_reporting::diagnostic::Severity;
 use lsp_types::{Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location, Range};
 use move_command_line_common::files::FileHash;
@@ -24,8 +24,8 @@ pub fn lsp_diagnostics(
     let mut lsp_diagnostics = BTreeMap::new();
     for (s, _, (loc, msg), labels, _) in diagnostics {
         let fpath = files.file_path(&loc.file_hash());
-        if let Some(start) = get_loc(&loc.file_hash(), loc.start(), files) {
-            if let Some(end) = get_loc(&loc.file_hash(), loc.end(), files) {
+        if let Some(start) = loc_start_to_lsp_position_opt(files, loc) {
+            if let Some(end) = loc_end_to_lsp_position_opt(files, loc) {
                 let range = Range::new(start, end);
                 let related_info_opt = if labels.is_empty() {
                     None
@@ -34,8 +34,8 @@ pub fn lsp_diagnostics(
                         labels
                             .iter()
                             .filter_map(|(lloc, lmsg)| {
-                                let lstart = get_loc(&lloc.file_hash(), lloc.start(), files)?;
-                                let lend = get_loc(&lloc.file_hash(), lloc.end(), files)?;
+                                let lstart = loc_start_to_lsp_position_opt(files, lloc)?;
+                                let lend = loc_end_to_lsp_position_opt(files, lloc)?;
                                 let lpath = files.file_path(&lloc.file_hash());
                                 let lpos = Location::new(
                                     Url::from_file_path(lpath).unwrap(),

--- a/external-crates/move/crates/move-analyzer/src/utils.rs
+++ b/external-crates/move/crates/move-analyzer/src/utils.rs
@@ -62,7 +62,9 @@ pub fn lsp_position_to_byte_index(
     file_hash: FileHash,
     pos: &Position,
 ) -> Option<ByteIndex> {
-    files.line_char_offset_to_loc_opt(file_hash, pos.line, pos.character).map(|loc| loc.start())
+    files
+        .line_char_offset_to_loc_opt(file_hash, pos.line, pos.character)
+        .map(|loc| loc.start())
 }
 
 /// Some functions defined in a module need to be ignored.

--- a/external-crates/move/crates/move-analyzer/src/utils.rs
+++ b/external-crates/move/crates/move-analyzer/src/utils.rs
@@ -56,6 +56,15 @@ pub fn lsp_position_to_loc(
     files.line_char_offset_to_loc_opt(file_hash, line_offset, char_offset)
 }
 
+/// Converts a position (line/column) to byte index in the file.
+pub fn lsp_position_to_byte_index(
+    files: &MappedFiles,
+    file_hash: FileHash,
+    pos: &Position,
+) -> Option<ByteIndex> {
+    files.line_char_offset_to_loc_opt(file_hash, pos.line, pos.character).map(|loc| loc.start())
+}
+
 /// Some functions defined in a module need to be ignored.
 pub fn ignored_function(name: Symbol) -> bool {
     // In test mode (that's how IDE compiles Move source files),

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -172,7 +172,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
         let (mut compiler, cfgir) = compiler.into_ast();
         let compilation_env = compiler.compilation_env();
         let built_test_plan = construct_test_plan(compilation_env, Some(root_package), &cfgir);
-        let mapped_files = compilation_env.file_mapping().clone();
+        let mapped_files = compilation_env.mapped_files().clone();
 
         let compilation_result = compiler.at_cfgir(cfgir).build();
         let (units, warnings) =

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -13,7 +13,10 @@ use move_binary_format::{
 };
 use move_bytecode_utils::Modules;
 use move_command_line_common::files::{FileHash, MOVE_COMPILED_EXTENSION};
-use move_compiler::diagnostics::{self, report_diagnostics, Diagnostic, Diagnostics, FileName};
+use move_compiler::{
+    diagnostics::{self, report_diagnostics, Diagnostic, Diagnostics},
+    shared::files::FileName,
+};
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Op},
@@ -267,7 +270,7 @@ pub(crate) fn explain_publish_error(
                     }
                 }
             }
-            report_diagnostics(&files, diags)
+            report_diagnostics(&files.into(), diags)
         }
         status_code => {
             println!("Publishing failed with unexpected error {:?}", status_code)

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -17,6 +17,7 @@ use crate::{
     expansion, hlir, interface_generator, naming,
     parser::{self, comments::*, *},
     shared::{
+        files::{FilesSourceText, MappedFiles},
         CompilationEnv, Flags, IndexedPhysicalPackagePath, IndexedVfsPackagePath, NamedAddressMap,
         NamedAddressMaps, NumericalAddress, PackageConfig, PackagePaths, SaveFlag, SaveHook,
     },
@@ -97,8 +98,7 @@ enum PassResult {
 
 #[derive(Clone)]
 pub struct FullyCompiledProgram {
-    // TODO don't store this...
-    pub files: FilesSourceText,
+    pub files: MappedFiles,
     pub parser: parser::ast::Program,
     pub expansion: expansion::ast::Program,
     pub naming: naming::ast::Program,
@@ -310,7 +310,7 @@ impl Compiler {
     pub fn run<const TARGET: Pass>(
         self,
     ) -> anyhow::Result<(
-        FilesSourceText,
+        MappedFiles,
         Result<(CommentMap, SteppedCompiler<TARGET>), (Pass, Diagnostics)>,
     )> {
         let Self {
@@ -384,30 +384,29 @@ impl Compiler {
             compilation_env.add_custom_known_filters(prefix, filters)?;
         }
 
-        let (mut source_text, pprog, comments) =
+        let (source_text, pprog, comments) =
             parse_program(&mut compilation_env, maps, targets, deps)?;
 
-        source_text.iter_mut().for_each(|(_, (path, _))| {
+        for (fhash, (fname, contents)) in &source_text {
             // TODO better support for bytecode interface file paths
-            *path = vfs_to_original_path.get(path).copied().unwrap_or(*path)
-        });
+            let path = vfs_to_original_path.get(fname).copied().unwrap_or(*fname);
 
-        for (fhash, (fname, contents)) in source_text.iter() {
-            compilation_env.add_source_file(*fhash, *fname, contents.clone())
+            compilation_env.add_source_file(*fhash, path, contents.clone())
         }
+        let mapped_files = compilation_env.mapped_files().clone();
 
         let res: Result<_, (Pass, Diagnostics)> =
             SteppedCompiler::new_at_parser(compilation_env, pre_compiled_lib, pprog)
                 .run::<TARGET>()
                 .map(|compiler| (comments, compiler));
 
-        Ok((source_text, res))
+        Ok((mapped_files, res))
     }
 
     pub fn generate_migration_patch(
         mut self,
         root_module: &Symbol,
-    ) -> anyhow::Result<(FilesSourceText, Result<Option<Migration>, Diagnostics>)> {
+    ) -> anyhow::Result<(MappedFiles, Result<Option<Migration>, Diagnostics>)> {
         self.package_configs.get_mut(root_module).unwrap().edition = Edition::E2024_MIGRATION;
         let (files, res) = self.run::<PASS_COMPILATION>()?;
         if let Err((pass, mut diags)) = res {
@@ -433,12 +432,12 @@ impl Compiler {
         }
     }
 
-    pub fn check(self) -> anyhow::Result<(FilesSourceText, Result<(), Diagnostics>)> {
+    pub fn check(self) -> anyhow::Result<(MappedFiles, Result<(), Diagnostics>)> {
         let (files, res) = self.run::<PASS_COMPILATION>()?;
         Ok((files, res.map(|_| ()).map_err(|(_pass, diags)| diags)))
     }
 
-    pub fn check_and_report(self) -> anyhow::Result<FilesSourceText> {
+    pub fn check_and_report(self) -> anyhow::Result<MappedFiles> {
         let (files, res) = self.check()?;
         unwrap_or_report_diagnostics(&files, res);
         Ok(files)
@@ -447,7 +446,7 @@ impl Compiler {
     pub fn build(
         self,
     ) -> anyhow::Result<(
-        FilesSourceText,
+        MappedFiles,
         Result<(Vec<AnnotatedCompiledUnit>, Diagnostics), Diagnostics>,
     )> {
         let (files, res) = self.run::<PASS_COMPILATION>()?;
@@ -458,7 +457,7 @@ impl Compiler {
         ))
     }
 
-    pub fn build_and_report(self) -> anyhow::Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)> {
+    pub fn build_and_report(self) -> anyhow::Result<(MappedFiles, Vec<AnnotatedCompiledUnit>)> {
         let (files, units_res) = self.build()?;
         let (units, warnings) = unwrap_or_report_diagnostics(&files, units_res);
         report_warnings(&files, warnings);
@@ -500,6 +499,9 @@ impl<const P: Pass> SteppedCompiler<P> {
 
     pub fn compilation_env(&mut self) -> &mut CompilationEnv {
         &mut self.compilation_env
+    }
+    pub fn compilation_env_ref(&self) -> &CompilationEnv {
+        &self.compilation_env
     }
 }
 
@@ -573,14 +575,14 @@ macro_rules! ast_stepped_compilers {
                     Ok(units)
                 }
 
-                pub fn check_and_report(self, files: &FilesSourceText)  {
+                pub fn check_and_report(self, files: &MappedFiles)  {
                     let errors_result = self.check().map_err(|(_, diags)| diags);
                     unwrap_or_report_diagnostics(&files, errors_result);
                 }
 
                 pub fn build_and_report(
                     self,
-                    files: &FilesSourceText,
+                    files: &MappedFiles,
                 ) -> Vec<AnnotatedCompiledUnit> {
                     let units_result = self.build().map_err(|(_, diags)| diags);
                     let (units, warnings) = unwrap_or_report_diagnostics(&files, units_result);
@@ -628,7 +630,7 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
     interface_files_dir_opt: Option<String>,
     flags: Flags,
     vfs_root: Option<VfsPath>,
-) -> anyhow::Result<Result<FullyCompiledProgram, (FilesSourceText, Diagnostics)>> {
+) -> anyhow::Result<Result<FullyCompiledProgram, (MappedFiles, Diagnostics)>> {
     let hook = SaveHook::new([
         SaveFlag::Parser,
         SaveFlag::Expansion,
@@ -701,14 +703,14 @@ pub fn sanity_check_compiled_units(
 ) {
     let ice_errors = compiled_unit::verify_units(compiled_units);
     if !ice_errors.is_empty() {
-        report_diagnostics(&files, ice_errors)
+        report_diagnostics(&files.into(), ice_errors)
     }
 }
 
 /// Given a file map and a set of compiled programs, saves the compiled programs to disk
 pub fn output_compiled_units(
     emit_source_maps: bool,
-    files: FilesSourceText,
+    files: MappedFiles,
     compiled_units: Vec<AnnotatedCompiledUnit>,
     out_dir: &str,
 ) -> anyhow::Result<()> {

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -12,18 +12,14 @@ mod token_set;
 pub(crate) mod verification_attribute_filter;
 
 use crate::{
-    diagnostics::FilesSourceText,
     parser::{self, ast::PackageDefinition, syntax::parse_file_string},
-    shared::{CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
+    shared::{files::MappedFiles, CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
 };
 use anyhow::anyhow;
 use comments::*;
 use move_command_line_common::files::FileHash;
 use move_symbol_pool::Symbol;
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 use vfs::VfsPath;
 
 /// Parses program's targets and dependencies, both of which are read from different virtual file
@@ -33,13 +29,13 @@ pub(crate) fn parse_program(
     named_address_maps: NamedAddressMaps,
     mut targets: Vec<IndexedVfsPackagePath>,
     mut deps: Vec<IndexedVfsPackagePath>,
-) -> anyhow::Result<(FilesSourceText, parser::ast::Program, CommentMap)> {
+) -> anyhow::Result<(MappedFiles, parser::ast::Program, CommentMap)> {
     // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
     // deterministic
     targets.sort_by(|p1, p2| p1.path.as_str().cmp(p2.path.as_str()));
     deps.sort_by(|p1, p2| p1.path.as_str().cmp(p2.path.as_str()));
     ensure_targets_deps_dont_intersect(compilation_env, &targets, &mut deps)?;
-    let mut files: FilesSourceText = HashMap::new();
+    let mut files: MappedFiles = MappedFiles::empty();
     let mut source_definitions = Vec::new();
     let mut source_comments = CommentMap::new();
     let mut lib_definitions = Vec::new();
@@ -118,7 +114,7 @@ fn ensure_targets_deps_dont_intersect(
 fn parse_file(
     path: &VfsPath,
     compilation_env: &mut CompilationEnv,
-    files: &mut FilesSourceText,
+    files: &mut MappedFiles,
     package: Option<Symbol>,
 ) -> anyhow::Result<(
     Vec<parser::ast::Definition>,
@@ -132,7 +128,7 @@ fn parse_file(
     let source_str = Arc::from(source_buffer);
     if let Err(ds) = verify_string(file_hash, &source_str) {
         compilation_env.add_diags(ds);
-        files.insert(file_hash, (fname, source_str));
+        files.add(file_hash, fname, source_str);
         return Ok((vec![], MatchedFileCommentMap::new(), file_hash));
     }
     let (defs, comments) = match parse_file_string(compilation_env, file_hash, &source_str, package)
@@ -143,6 +139,6 @@ fn parse_file(
             (vec![], MatchedFileCommentMap::new())
         }
     };
-    files.insert(file_hash, (fname, source_str));
+    files.add(file_hash, fname, source_str);
     Ok((defs, comments, file_hash))
 }

--- a/external-crates/move/crates/move-compiler/src/shared/files.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/files.rs
@@ -239,7 +239,24 @@ impl MappedFiles {
         Some(posn)
     }
 
-    /// Given a line number in the file return the `Loc` for the line.
+    /// Given a line number and character number (both 0-indexed) in the file return the `Loc` for
+    /// the line. Note that the end byte is exclusive in the resultant `Loc`.
+    pub fn line_char_offset_to_loc_opt(
+        &self,
+        file_hash: FileHash,
+        line_offset: u32,
+        char_offset: u32,
+    ) -> Option<Loc> {
+        let file_id = self.file_mapping().get(&file_hash)?;
+        let line_range = self
+            .files()
+            .line_range(*file_id, (line_offset + 1) as usize)
+            .ok()?;
+        let offset = line_range.start as u32 + char_offset;
+        Some(Loc::new(file_hash, offset, offset + 1))
+    }
+
+    /// Given a line number (1-indexed) in the file return the `Loc` for the line.
     pub fn line_to_loc_opt(&self, file_hash: &FileHash, line_number: usize) -> Option<Loc> {
         let file_id = self.file_mapping().get(file_hash)?;
         let line_range = self.files().line_range(*file_id, line_number).ok()?;

--- a/external-crates/move/crates/move-compiler/src/shared/files.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/files.rs
@@ -1,0 +1,192 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use codespan_reporting::files::{Files, SimpleFiles};
+use move_command_line_common::files::FileHash;
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
+
+//**************************************************************************************************
+// Types
+//**************************************************************************************************
+
+pub type FileId = usize;
+pub type FileName = Symbol;
+
+pub type FilesSourceText = HashMap<FileHash, (FileName, Arc<str>)>;
+
+/// A mapping from file ids to file contents along with the mapping of filehash to fileID.
+pub struct MappedFiles {
+    pub files: SimpleFiles<Symbol, Arc<str>>,
+    pub file_mapping: HashMap<FileHash, FileId>,
+}
+
+/// A file, and the line:column start, and line:column end that corresponds to a `Loc`
+#[allow(dead_code)]
+pub struct FilePosition {
+    pub file_id: FileId,
+    pub start: Position,
+    pub end: Position,
+}
+
+/// A position holds the byte offset along with the line and column location in a file.
+/// Both are zero-indexed.
+pub struct Position {
+    pub line: usize,
+    pub column: usize,
+    pub byte: usize,
+}
+
+/// A file, and the usize start and usize end that corresponds to a `Loc`
+pub struct FileByteSpan {
+    pub file_id: FileId,
+    pub byte_span: ByteSpan,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ByteSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+//**************************************************************************************************
+// Traits and Impls
+//**************************************************************************************************
+
+impl MappedFiles {
+    pub fn new(files: FilesSourceText) -> Self {
+        let mut simple_files = SimpleFiles::new();
+        let mut file_mapping = HashMap::new();
+        for (fhash, (fname, source)) in files {
+            let id = simple_files.add(fname, source);
+            file_mapping.insert(fhash, id);
+        }
+        Self {
+            files: simple_files,
+            file_mapping,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            files: SimpleFiles::new(),
+            file_mapping: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, fhash: FileHash, fname: FileName, source: Arc<str>) {
+        let id = self.files.add(fname, source);
+        self.file_mapping.insert(fhash, id);
+    }
+
+    pub fn files(&self) -> &SimpleFiles<Symbol, Arc<str>> {
+        &self.files
+    }
+
+    pub fn file_mapping(&self) -> &HashMap<FileHash, FileId> {
+        &self.file_mapping
+    }
+
+    pub fn filename(&self, fhash: &FileHash) -> &str {
+        let file_id = self.file_mapping().get(fhash).unwrap();
+        self.files().get(*file_id).unwrap().name()
+    }
+
+    pub fn file_hash_to_file_id(&self, fhash: &FileHash) -> Option<FileId> {
+        self.file_mapping().get(fhash).copied()
+    }
+
+    /// Like `start_position_opt`, but may panic
+    pub fn start_position(&self, loc: &Loc) -> Position {
+        self.position(loc).start
+    }
+
+    /// Like `end_position_opt`, but may panic
+    pub fn end_position(&self, loc: &Loc) -> Position {
+        self.position(loc).end
+    }
+
+    /// Like `position_opt`, but may panic
+    pub fn position(&self, loc: &Loc) -> FilePosition {
+        self.position_opt(loc).unwrap()
+    }
+
+    /// Like `byte_span_opt`, but may panic
+    pub fn byte_span(&self, loc: &Loc) -> FileByteSpan {
+        self.byte_span_opt(loc).unwrap()
+    }
+
+    pub fn start_position_opt(&self, loc: &Loc) -> Option<Position> {
+        self.position_opt(loc).map(|posn| posn.start)
+    }
+
+    pub fn end_position_opt(&self, loc: &Loc) -> Option<Position> {
+        self.position_opt(loc).map(|posn| posn.end)
+    }
+
+    pub fn position_opt(&self, loc: &Loc) -> Option<FilePosition> {
+        let start_loc = loc.start() as usize;
+        let end_loc = loc.end() as usize;
+        let file_id = *self.file_mapping().get(&loc.file_hash())?;
+        let start_file_loc = self.files().location(file_id, start_loc).ok()?;
+        let end_file_loc = self.files().location(file_id, end_loc).ok()?;
+        let posn = FilePosition {
+            file_id,
+            start: Position {
+                line: start_file_loc.line_number - 1,
+                column: start_file_loc.column_number - 1,
+                byte: start_loc,
+            },
+            end: Position {
+                line: end_file_loc.line_number - 1,
+                column: end_file_loc.column_number - 1,
+                byte: end_loc,
+            },
+        };
+        Some(posn)
+    }
+
+    pub fn byte_span_opt(&self, loc: &Loc) -> Option<FileByteSpan> {
+        let start = loc.start() as usize;
+        let end = loc.end() as usize;
+        let file_id = *self.file_mapping().get(&loc.file_hash())?;
+        let posn = FileByteSpan {
+            byte_span: ByteSpan { start, end },
+            file_id,
+        };
+        Some(posn)
+    }
+
+    /// Given a line number in the file return the `Loc` for the line.
+    fn line_to_loc_opt(&self, file_hash: &FileHash, line_number: usize) -> Option<Loc> {
+        let file_id = self.file_mapping().get(file_hash)?;
+        let line_range = self.files().line_range(*file_id, line_number).ok()?;
+        Some(Loc::new(
+            *file_hash,
+            line_range.start as u32,
+            line_range.end as u32,
+        ))
+    }
+
+    /// Given a location `Loc` return a new loc only for source with leading and trailing
+    /// whitespace removed.
+    fn trimmed_loc_opt(&self, loc: &Loc) -> Option<Loc> {
+        let source_str = self.source_of_loc_opt(loc)?;
+        let trimmed_front = source_str.trim_start();
+        let new_start = loc.start() as usize + (source_str.len() - trimmed_front.len());
+        let trimmed_back = trimmed_front.trim_end();
+        let new_end = (loc.end() as usize).saturating_sub(trimmed_front.len() - trimmed_back.len());
+        Some(Loc::new(loc.file_hash(), new_start as u32, new_end as u32))
+    }
+
+    /// Given a location `Loc` return the source for the location. This include any leading and
+    /// trailing whitespace.
+    fn source_of_loc_opt(&self, loc: &Loc) -> Option<&str> {
+        let file_id = *self.file_mapping().get(&loc.file_hash())?;
+        Some(&self.files().source(file_id).ok()?[loc.usize_range()])
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/shared/files.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/files.rs
@@ -114,7 +114,7 @@ impl MappedFiles {
         }
     }
 
-    pub fn append(&mut self, other: Self) {
+    pub fn extend(&mut self, other: Self) {
         for (file_hash, file_id) in other.file_mapping {
             let Ok(file) = other.files.get(file_id) else {
                 debug_assert!(false, "Found a file without a file entry");
@@ -250,7 +250,7 @@ impl MappedFiles {
         let file_id = self.file_mapping().get(&file_hash)?;
         let line_range = self
             .files()
-            .line_range(*file_id, (line_offset + 1) as usize)
+            .line_range(*file_id, line_offset as usize)
             .ok()?;
         let offset = line_range.start as u32 + char_offset;
         Some(Loc::new(file_hash, offset, offset + 1))

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     command_line as cli,
     diagnostics::{
         codes::{Category, Declarations, DiagnosticsID, Severity, WarningFilter},
-        Diagnostic, Diagnostics, DiagnosticsFormat, FileName, MappedFiles, WarningFilters,
+        Diagnostic, Diagnostics, DiagnosticsFormat, WarningFilters,
     },
     editions::{
         check_feature_or_error as edition_check_feature, feature_edition_error_msg, Edition,
@@ -20,7 +20,10 @@ use crate::{
     hlir::ast as H,
     naming::ast as N,
     parser::ast as P,
-    shared::ide::{IDEAnnotation, IDEInfo},
+    shared::{
+        files::{FileName, MappedFiles},
+        ide::{IDEAnnotation, IDEInfo},
+    },
     sui_mode,
     typing::{
         ast as T,
@@ -46,6 +49,7 @@ use std::{
 use vfs::{VfsError, VfsPath};
 
 pub mod ast_debug;
+pub mod files;
 pub mod ide;
 pub mod known_attributes;
 pub mod matching;
@@ -388,7 +392,7 @@ impl CompilationEnv {
         self.mapped_files.add(file_hash, file_name, source_text)
     }
 
-    pub fn file_mapping(&self) -> &MappedFiles {
+    pub fn mapped_files(&self) -> &MappedFiles {
         &self.mapped_files
     }
 

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -7,7 +7,6 @@ use crate::{
     cfgir::{ast as G, translate::move_value_from_value_},
     compiled_unit::*,
     diag,
-    diagnostics::PositionInfo,
     expansion::ast::{
         AbilitySet, Address, Attributes, ModuleIdent, ModuleIdent_, Mutability, TargetKind,
     },
@@ -1062,9 +1061,9 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
         } => {
             let line_no = context
                 .env
-                .file_mapping()
+                .mapped_files()
                 .start_position(&line_number_loc)
-                .line;
+                .user_line();
 
             // Clamp line number to u16::MAX -- so if the line number exceeds u16::MAX, we don't
             // record the line number essentially.

--- a/external-crates/move/crates/move-compiler/src/unit_test/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    compiled_unit::NamedCompiledModule, diagnostics::MappedFiles, shared::NumericalAddress,
+    compiled_unit::NamedCompiledModule, shared::files::MappedFiles, shared::NumericalAddress,
 };
 use move_core_types::{
     account_address::AccountAddress,

--- a/external-crates/move/crates/move-ir-types/src/location.rs
+++ b/external-crates/move/crates/move-ir-types/src/location.rs
@@ -72,7 +72,7 @@ impl Loc {
 
     /// Indicates this this location contains the provided location
     pub fn contains(&self, other: &Loc) -> bool {
-        self.file_hash == other.file_hash && self.start <= other.start && other.end <=  self.end
+        self.file_hash == other.file_hash && self.start <= other.start && other.end <= self.end
     }
 
     /// Indicates this this location overlaps the provided location

--- a/external-crates/move/crates/move-model/src/lib.rs
+++ b/external-crates/move/crates/move-model/src/lib.rs
@@ -36,7 +36,7 @@ use move_symbol_pool::Symbol as MoveSymbol;
 use crate::{
     ast::ModuleName,
     builder::model_builder::ModelBuilder,
-    model::{FunId, FunctionData, GlobalEnv, Loc, ModuleData, ModuleId, DatatypeId},
+    model::{DatatypeId, FunId, FunctionData, GlobalEnv, Loc, ModuleData, ModuleId},
     options::ModelBuilderOptions,
 };
 
@@ -155,7 +155,7 @@ pub fn run_model_builder_with_options_and_compilation_flags<
             .iter()
             .map(|(symbol, addr)| (env.symbol_pool().make(symbol.as_str()), *addr))
             .collect();
-        env.add_source(fhash, Rc::new(aliases), fname.as_str(), fsrc, is_dep);
+        env.add_source(fhash, Rc::new(aliases), fname.as_str(), &fsrc, is_dep);
     }
 
     // If a move file does not contain any definition, it will not appear in `parsed_prog`. Add them explicitly.
@@ -167,7 +167,7 @@ pub fn run_model_builder_with_options_and_compilation_flags<
                 *fhash,
                 Rc::new(BTreeMap::new()),
                 fname.as_str(),
-                fsrc,
+                &fsrc,
                 is_dep,
             );
         }

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -14,11 +14,9 @@ use crate::{
 use anyhow::Result;
 use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
-    diagnostics::{
-        report_diagnostics_to_buffer_with_env_color, report_warnings, FilesSourceText, Migration,
-    },
+    diagnostics::{report_diagnostics_to_buffer_with_env_color, report_warnings, Migration},
     editions::Edition,
-    shared::PackagePaths,
+    shared::{files::MappedFiles, PackagePaths},
     Compiler,
 };
 use move_symbol_pool::Symbol;
@@ -212,7 +210,7 @@ impl BuildPlan {
         compiler_driver: impl FnMut(
             Compiler,
         )
-            -> anyhow::Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)>,
+            -> anyhow::Result<(MappedFiles, Vec<AnnotatedCompiledUnit>)>,
     ) -> Result<CompiledPackage> {
         let dependencies = self.compute_dependencies();
         self.compile_with_driver_and_deps(dependencies, writer, compiler_driver)
@@ -225,7 +223,7 @@ impl BuildPlan {
         mut compiler_driver: impl FnMut(
             Compiler,
         )
-            -> anyhow::Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)>,
+            -> anyhow::Result<(MappedFiles, Vec<AnnotatedCompiledUnit>)>,
     ) -> Result<CompiledPackage> {
         let CompilationDependencies {
             root_package,

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -23,10 +23,9 @@ use move_command_line_common::files::{
 };
 use move_compiler::{
     compiled_unit::{AnnotatedCompiledUnit, CompiledUnit, NamedCompiledModule},
-    diagnostics::FilesSourceText,
     editions::Flavor,
     linters,
-    shared::{NamedAddressMap, NumericalAddress, PackageConfig, PackagePaths},
+    shared::{files::MappedFiles, NamedAddressMap, NumericalAddress, PackageConfig, PackagePaths},
     sui_mode::{self},
     Compiler,
 };
@@ -532,7 +531,7 @@ impl CompiledPackage {
         resolved_package: Package,
         transitive_dependencies: Vec<DependencyInfo>,
         resolution_graph: &ResolvedGraph,
-        compiler_driver: impl FnMut(Compiler) -> Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)>,
+        compiler_driver: impl FnMut(Compiler) -> Result<(MappedFiles, Vec<AnnotatedCompiledUnit>)>,
     ) -> Result<CompiledPackage> {
         let BuildResult {
             root_package_name,
@@ -552,7 +551,13 @@ impl CompiledPackage {
         let mut root_compiled_units = vec![];
         let mut deps_compiled_units = vec![];
         for annot_unit in all_compiled_units {
-            let source_path = PathBuf::from(file_map[&annot_unit.loc().file_hash()].0.as_str());
+            let source_path = PathBuf::from(
+                file_map
+                    .get(&annot_unit.loc().file_hash())
+                    .unwrap()
+                    .0
+                    .as_str(),
+            );
             let package_name = annot_unit.named_module.package_name.unwrap();
             let unit = CompiledUnitWithSource {
                 unit: annot_unit.into_compiled_unit(),

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -23,9 +23,9 @@ use move_command_line_common::{
 };
 use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
-    diagnostics::{Diagnostics, FilesSourceText, WarningFilters},
+    diagnostics::{Diagnostics, WarningFilters},
     editions::{Edition, Flavor},
-    shared::{NumericalAddress, PackageConfig},
+    shared::{files::MappedFiles, NumericalAddress, PackageConfig},
     FullyCompiledProgram,
 };
 use move_core_types::{
@@ -618,14 +618,16 @@ pub fn compile_source_units(
     state: &CompiledState,
     file_name: impl AsRef<Path>,
 ) -> Result<(Vec<AnnotatedCompiledUnit>, Option<String>)> {
-    fn rendered_diags(files: &FilesSourceText, diags: Diagnostics) -> Option<String> {
+    fn rendered_diags(files: &MappedFiles, diags: Diagnostics) -> Option<String> {
         if diags.is_empty() {
             return None;
         }
 
         let ansi_color = read_bool_env_var(move_command_line_common::testing::PRETTY);
         let error_buffer =
-            move_compiler::diagnostics::report_diagnostics_to_buffer(files, diags, ansi_color);
+            move_compiler::diagnostics::report_diagnostics_to_buffer_with_mapped_files(
+                files, diags, ansi_color,
+            );
         Some(String::from_utf8(error_buffer).unwrap())
     }
 
@@ -656,14 +658,8 @@ pub fn compile_source_units(
     match units_or_diags {
         Err((_pass, diags)) => {
             if let Some(pcd) = state.pre_compiled_deps.clone() {
-                for (file_name, text) in &pcd.files {
-                    // TODO This is bad. Rethink this when errors are redone
-                    if !files.contains_key(file_name) {
-                        files.insert(*file_name, text.clone());
-                    }
-                }
+                files.append(pcd.files.clone());
             }
-
             Err(anyhow!(rendered_diags(&files, diags).unwrap()))
         }
         Ok((units, warnings)) => Ok((units, rendered_diags(&files, warnings))),

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -658,7 +658,7 @@ pub fn compile_source_units(
     match units_or_diags {
         Err((_pass, diags)) => {
             if let Some(pcd) = state.pre_compiled_deps.clone() {
-                files.append(pcd.files.clone());
+                files.extend(pcd.files.clone());
             }
             Err(anyhow!(rendered_diags(&files, diags).unwrap()))
         }

--- a/external-crates/move/crates/move-unit-test/src/lib.rs
+++ b/external-crates/move/crates/move-unit-test/src/lib.rs
@@ -172,7 +172,7 @@ impl UnitTestingConfig {
         let (mut compiler, cfgir) = compiler.into_ast();
         let compilation_env = compiler.compilation_env();
         let test_plan = unit_test::plan_builder::construct_test_plan(compilation_env, None, &cfgir);
-        let mapped_files = compilation_env.file_mapping().clone();
+        let mapped_files = compilation_env.mapped_files().clone();
 
         let compilation_result = compiler.at_cfgir(cfgir).build();
         let (units, warnings) =

--- a/external-crates/move/crates/move-unit-test/src/test_reporter.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_reporter.rs
@@ -7,7 +7,7 @@ use colored::{control, Colorize};
 use move_binary_format::errors::{ExecutionState, Location, VMError};
 use move_command_line_common::error_bitset::ErrorBitset;
 use move_compiler::{
-    diagnostics::{self, Diagnostic, Diagnostics, PositionInfo},
+    diagnostics::{self, Diagnostic, Diagnostics},
     unit_test::{ModuleTestPlan, MoveErrorType, TestPlan},
 };
 use move_core_types::{
@@ -226,11 +226,14 @@ impl TestFailure {
                 let fn_name = named_module.module.identifier_at(fn_id_idx).as_str();
                 let file_name = test_plan.mapped_files.filename(&loc.file_hash());
                 let formatted_line = {
+                    // Adjust lines by 1 to report 1-indexed
                     let position = test_plan.mapped_files.position(&loc);
-                    if position.start.line == position.end.line {
-                        format!("{}", position.start.line)
+                    let start_line = position.start.user_line();
+                    let end_line = position.end.user_line();
+                    if start_line == end_line {
+                        format!("{}", start_line)
                     } else {
-                        format!("{}-{}", position.start.line, position.end.line)
+                        format!("{}-{}", start_line, end_line)
                     }
                 };
                 buf.push_str(

--- a/external-crates/move/crates/move-unit-test/src/test_reporter.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_reporter.rs
@@ -582,7 +582,7 @@ impl TestResults {
                             "│ {}",
                             format!(
                                 "This test uses randomly generated inputs. Rerun with `{}` to recreate this test failure.\n",
-                                format!("test {} --seed {}", 
+                                format!("test {} --seed {}",
                                     test_name,
                                     seed
                                 ).bright_red().bold()


### PR DESCRIPTION
## Description 

This swaps out `FilesSourceText` for `MappedFiles` whenever possible, along with the following changes: 

- The internal implementation of `MappedFiles` is a little more complicated to support some `move-analyzer` behaviors.
- `MappedFiles` now lives in `move-compiler/shared/files.rs` to reflect it being standalone from the diagnostics.
- This also updates the `move-analyzer` to start using the `MappedFiles` instead of maintaining a separate file state.
- The `Position` form had its fields reverted to non-`pub` with getters to better-clarify the value being returned.

## Test plan 

All tests still run.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
