### PR TITLE
do not run evm tests except for sol changes

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -103,7 +103,7 @@ jobs:
   bridge-evm:
     name: bridge-evm-tests
     needs: diff
-    if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
+    if: needs.diff.outputs.isSolidity == 'true'
     runs-on: [ ubuntu-ghcloud ]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1


### PR DESCRIPTION
## Description 

there is no need to run evm tests for Rust changes: if Rust change becomes incompatible with solidity code, the Rust e2e tests will fail.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
