### PR TITLE
rest-index: parallelize initializing index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12325,6 +12325,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rand 0.8.5",
+ "rayon",
  "reqwest",
  "roaring",
  "rocksdb",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -36,6 +36,7 @@ parking_lot.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 roaring.workspace = true
+rayon.workspace = true
 rocksdb.workspace = true
 reqwest.workspace = true
 scopeguard.workspace = true

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -380,6 +380,23 @@ impl AuthorityPerpetualTables {
         }
     }
 
+    pub fn range_iter_live_object_set(
+        &self,
+        lower_bound: Option<ObjectID>,
+        upper_bound: Option<ObjectID>,
+        include_wrapped_object: bool,
+    ) -> LiveSetIter<'_> {
+        let lower_bound = lower_bound.as_ref().map(ObjectKey::min_for_id);
+        let upper_bound = upper_bound.as_ref().map(ObjectKey::max_for_id);
+
+        LiveSetIter {
+            iter: self.objects.iter_with_bounds(lower_bound, upper_bound),
+            tables: self,
+            prev: None,
+            include_wrapped_object,
+        }
+    }
+
     pub fn checkpoint_db(&self, path: &Path) -> SuiResult {
         // This checkpoints the entire db and not just objects table
         self.objects.checkpoint_db(path).map_err(Into::into)

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -282,15 +282,12 @@ impl<'a> TestAuthorityBuilder<'a> {
         let rest_index = if self.disable_indexer {
             None
         } else {
-            let mut resolver = epoch_store
-                .executor()
-                .type_layout_resolver(Box::new(&cache_traits.backing_package_store));
-
             Some(Arc::new(RestIndexStore::new(
                 path.join("rest_index"),
                 &authority_store,
                 &checkpoint_store,
-                resolver.as_mut(),
+                &epoch_store,
+                &cache_traits.backing_package_store,
             )))
         };
 

--- a/crates/sui-core/src/rest_index.rs
+++ b/crates/sui-core/src/rest_index.rs
@@ -1,16 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::AuthorityStore;
 use crate::checkpoints::CheckpointStore;
-use crate::state_accumulator::AccumulatorStore;
 use move_core_types::language_storage::StructTag;
 use move_core_types::language_storage::TypeTag;
+use rayon::iter::IntoParallelIterator;
+use rayon::iter::ParallelIterator;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Instant;
 use sui_rest_api::CheckpointData;
 use sui_types::base_types::MoveObjectType;
 use sui_types::base_types::ObjectID;
@@ -22,6 +27,7 @@ use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::object::Object;
 use sui_types::object::Owner;
 use sui_types::storage::error::Error as StorageError;
+use sui_types::storage::BackingPackageStore;
 use sui_types::type_resolver::LayoutResolver;
 use tracing::{debug, info};
 use typed_store::rocks::{DBMap, MetricConf};
@@ -200,7 +206,8 @@ impl IndexStoreTables {
         &mut self,
         authority_store: &AuthorityStore,
         checkpoint_store: &CheckpointStore,
-        resolver: &mut dyn LayoutResolver,
+        epoch_store: &AuthorityPerEpochStore,
+        package_store: &Arc<dyn BackingPackageStore + Send + Sync>,
     ) -> Result<(), StorageError> {
         info!("Initializing REST indexes");
 
@@ -213,9 +220,15 @@ impl IndexStoreTables {
                 .get_highest_pruned_checkpoint_seq_number()?
                 .saturating_add(1);
 
-            let mut batch = self.transactions.batch();
+            let checkpoint_range = lowest_available_checkpoint..=highest_executed_checkpint;
 
-            for seq in lowest_available_checkpoint..=highest_executed_checkpint {
+            info!(
+                "Indexing {} checkpoints in range {checkpoint_range:?}",
+                checkpoint_range.size_hint().0
+            );
+            let start_time = Instant::now();
+
+            checkpoint_range.into_par_iter().try_for_each(|seq| {
                 let checkpoint = checkpoint_store
                     .get_checkpoint_by_sequence_number(seq)?
                     .ok_or_else(|| StorageError::missing(format!("missing checkpoint {seq}")))?;
@@ -227,24 +240,102 @@ impl IndexStoreTables {
                     checkpoint: checkpoint.sequence_number,
                 };
 
-                batch.insert_batch(
-                    &self.transactions,
-                    contents.iter().map(|digests| (digests.transaction, info)),
-                )?;
-            }
+                self.transactions
+                    .multi_insert(contents.iter().map(|digests| (digests.transaction, info)))
+                    .map_err(StorageError::from)
+            })?;
 
-            batch.write()?;
+            info!(
+                "Indexing checkpoints took {} seconds",
+                start_time.elapsed().as_secs()
+            );
         }
 
+        let coin_index = Mutex::new(HashMap::new());
+
+        info!("Indexing Live Object Set");
+        let start_time = Instant::now();
+        std::thread::scope(|s| -> Result<(), StorageError> {
+            let mut threads = Vec::new();
+            const BITS: u8 = 5;
+            for index in 0u8..(1 << BITS) {
+                let this = &self;
+                let coin_index = &coin_index;
+                threads.push(s.spawn(move || {
+                    this.live_object_set_index_task(
+                        index,
+                        BITS,
+                        authority_store,
+                        coin_index,
+                        epoch_store,
+                        package_store,
+                    )
+                }));
+            }
+
+            // join threads
+            for thread in threads {
+                thread.join().unwrap()?;
+            }
+
+            Ok(())
+        })?;
+
+        self.coin.multi_insert(coin_index.into_inner().unwrap())?;
+
+        info!(
+            "Indexing Live Object Set took {} seconds",
+            start_time.elapsed().as_secs()
+        );
+
+        self.meta.insert(
+            &(),
+            &MetadataInfo {
+                version: CURRENT_DB_VERSION,
+            },
+        )?;
+
+        info!("Finished initializing REST indexes");
+
+        Ok(())
+    }
+
+    fn live_object_set_index_task(
+        &self,
+        task_id: u8,
+        bits: u8,
+        authority_store: &AuthorityStore,
+        coin_index: &Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
+        epoch_store: &AuthorityPerEpochStore,
+        package_store: &Arc<dyn BackingPackageStore + Send + Sync>,
+    ) -> Result<(), StorageError> {
+        let mut id_bytes = [0; ObjectID::LENGTH];
+        id_bytes[0] = task_id << (8 - bits);
+        let start_id = ObjectID::new(id_bytes);
+
+        id_bytes[0] |= (1 << (8 - bits)) - 1;
+        for element in id_bytes.iter_mut().skip(1) {
+            *element = u8::MAX;
+        }
+        let end_id = ObjectID::new(id_bytes);
+
+        let mut resolver = epoch_store
+            .executor()
+            .type_layout_resolver(Box::new(package_store));
         let mut batch = self.owner.batch();
-
-        let mut coin_index = HashMap::new();
-
-        // Iterate through live object set to initialize object-based indexes
+        let mut object_scanned: u64 = 0;
         for object in authority_store
-            .iter_live_object_set(false)
+            .perpetual_tables
+            .range_iter_live_object_set(Some(start_id), Some(end_id), false)
             .filter_map(LiveObject::to_normal)
         {
+            object_scanned += 1;
+            if object_scanned % 2_000_000 == 0 {
+                info!(
+                    "[Index] Task {}: object scanned: {}",
+                    task_id, object_scanned
+                );
+            }
             match object.owner {
                 // Owner Index
                 Owner::AddressOwner(owner) => {
@@ -255,7 +346,9 @@ impl IndexStoreTables {
 
                 // Dynamic Field Index
                 Owner::ObjectOwner(parent) => {
-                    if let Some(field_info) = try_create_dynamic_field_info(&object, resolver)? {
+                    if let Some(field_info) =
+                        try_create_dynamic_field_info(&object, resolver.as_mut())?
+                    {
                         let field_key = DynamicFieldKey::new(parent, object.id());
 
                         batch.insert_batch(&self.dynamic_field, [(field_key, field_info)])?;
@@ -269,7 +362,7 @@ impl IndexStoreTables {
             if let Some((key, value)) = try_create_coin_index_info(&object) {
                 use std::collections::hash_map::Entry;
 
-                match coin_index.entry(key) {
+                match coin_index.lock().unwrap().entry(key) {
                     Entry::Occupied(o) => {
                         let (key, v) = o.remove_entry();
                         let value = value.merge(v);
@@ -290,18 +383,6 @@ impl IndexStoreTables {
         }
 
         batch.write()?;
-
-        self.coin.multi_insert(coin_index)?;
-
-        self.meta.insert(
-            &(),
-            &MetadataInfo {
-                version: CURRENT_DB_VERSION,
-            },
-        )?;
-
-        info!("Finished initializing REST indexes");
-
         Ok(())
     }
 
@@ -510,7 +591,8 @@ impl RestIndexStore {
         path: PathBuf,
         authority_store: &AuthorityStore,
         checkpoint_store: &CheckpointStore,
-        resolver: &mut dyn LayoutResolver,
+        epoch_store: &AuthorityPerEpochStore,
+        package_store: &Arc<dyn BackingPackageStore + Send + Sync>,
     ) -> Self {
         let tables = {
             let tables = IndexStoreTables::open(&path);
@@ -528,7 +610,12 @@ impl RestIndexStore {
                 };
 
                 tables
-                    .init(authority_store, checkpoint_store, resolver)
+                    .init(
+                        authority_store,
+                        checkpoint_store,
+                        epoch_store,
+                        package_store,
+                    )
                     .expect("unable to initialize rest index from live object set");
                 tables
             } else {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -547,15 +547,12 @@ impl SuiNode {
             && config.enable_experimental_rest_api
             && config.enable_index_processing
         {
-            let mut resolver = epoch_store
-                .executor()
-                .type_layout_resolver(Box::new(&cache_traits.backing_package_store));
-
             Some(Arc::new(RestIndexStore::new(
                 config.db_path().join("rest_index"),
                 &store,
                 &checkpoint_store,
-                resolver.as_mut(),
+                &epoch_store,
+                &cache_traits.backing_package_store,
             )))
         } else {
             None


### PR DESCRIPTION
From a few local tests using epoch 429's formal snapshot, this patch reduced indexing time from ~45 minutes to ~5 minutes.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
