### PR TITLE
[pick #18261][GraphQL] Ensure single source of truth for compatibility check

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -79,12 +79,7 @@ impl Server {
 
         // Compatibility check
         info!("Starting compatibility check");
-        let result = check_all_tables(&self.db_reader).await?;
-
-        if !result {
-            return Err(Error::Internal("Compatibility check failed".to_string()));
-        }
-
+        check_all_tables(&self.db_reader).await?;
         info!("Compatibility check passed");
 
         // A handle that spawns a background task to periodically update the `Watermark`, which

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -272,23 +272,30 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    checkpoints,
-    display,
-    epochs,
-    events,
-    events_partition_0,
-    objects,
-    objects_history,
-    objects_history_partition_0,
-    objects_snapshot,
-    packages,
-    transactions,
-    transactions_partition_0,
-    tx_calls,
-    tx_changed_objects,
-    tx_digests,
-    tx_input_objects,
-    tx_recipients,
-    tx_senders,
-);
+#[macro_export]
+macro_rules! for_all_tables {
+    ($action:path) => {
+        $action!(
+            checkpoints,
+            epochs,
+            events,
+            events_partition_0,
+            objects,
+            objects_history,
+            objects_history_partition_0,
+            objects_snapshot,
+            packages,
+            transactions,
+            transactions_partition_0,
+            tx_calls,
+            tx_changed_objects,
+            tx_digests,
+            tx_input_objects,
+            tx_recipients,
+            tx_senders
+        );
+    };
+}
+pub use for_all_tables;
+
+for_all_tables!(diesel::allow_tables_to_appear_in_same_query);


### PR DESCRIPTION
## Description

Increase the likelihood that when a schema change is made on the indexer side, the compatibility check on the GraphQL side is also updated, by removing the duplication of table names from both places:

Now, the compatibility check relies on a macro --
`sui_indexer::for_all_tables` to enumerate tables. This is more likely to be updated when a new table is added because it's also used by the indexer to ensure all the tables can appear in queries next to each other.

This PR also changes the nature of the query used for the compatibility check: It no longer relies on knowing about a model type to select fields for, because such a type may have columns missing. Instead it fetches all the columns for the table, but then discards them.

## Test plan

Run the service against a compatible DB -- it should spin up. Then add a field to the local schema, re-run, and it will panic on start-up.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: