### PR TITLE
[test] Move coin deny list tests to authority tests

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -188,6 +188,10 @@ mod gas_tests;
 #[path = "unit_tests/batch_verification_tests.rs"]
 mod batch_verification_tests;
 
+#[cfg(test)]
+#[path = "unit_tests/coin_deny_list_tests.rs"]
+mod coin_deny_list_tests;
+
 #[cfg(any(test, feature = "test-utils"))]
 pub mod authority_test_utils;
 

--- a/crates/sui-core/src/unit_tests/data/coin_deny_list_v1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/coin_deny_list_v1/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coin_deny_list_v1"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+coin_deny_list_v1 = "0x0"

--- a/crates/sui-core/src/unit_tests/data/coin_deny_list_v1/sources/regulated_coin.move
+++ b/crates/sui-core/src/unit_tests/data/coin_deny_list_v1/sources/regulated_coin.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module move_test_code::regulated_coin {
+module coin_deny_list_v1::regulated_coin {
     use std::option;
     use sui::coin;
     use sui::object::UID;


### PR DESCRIPTION
## Description 

The coin deny list v1 tests can be run in a single authority, without a cluster.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
