### PR TITLE
Deprecate old epoch flags and delete dead code

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -774,13 +774,6 @@ impl AuthorityPerEpochStore {
             info!("authenticator_state disabled");
         }
 
-        let is_validator = committee.authority_index(&name).is_some();
-        if is_validator {
-            assert!(epoch_start_configuration
-                .flags()
-                .contains(&EpochFlag::InMemoryCheckpointRoots));
-        }
-
         let mut jwk_aggregator = JwkAggregator::new(committee.clone());
 
         for ((authority, id, jwk), _) in tables.pending_jwks.unbounded_iter().seek_to_first() {
@@ -1424,17 +1417,6 @@ impl AuthorityPerEpochStore {
             .multi_get(digests)?
             .into_iter()
             .collect())
-    }
-
-    pub fn per_epoch_finalized_txns_enabled(&self) -> bool {
-        self.epoch_start_configuration
-            .flags()
-            .contains(&EpochFlag::PerEpochFinalizedTransactions)
-    }
-
-    pub fn object_lock_split_tables_enabled(&self) -> bool {
-        self.epoch_start_configuration
-            .object_lock_split_tables_enabled()
     }
 
     // For each id in objects_to_init, return the next version for that id as recorded in the

--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -43,9 +43,13 @@ pub trait EpochStartConfigTrait {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum EpochFlag {
-    InMemoryCheckpointRoots,
-    PerEpochFinalizedTransactions,
-    ObjectLockSplitTables,
+    // The deprecated flags have all been in production for long enough that
+    // we can have deleted the old code paths they were guarding.
+    // We retain them here in order not to break deserialization.
+    _InMemoryCheckpointRootsDeprecated,
+    _PerEpochFinalizedTransactionsDeprecated,
+    _ObjectLockSplitTablesDeprecated,
+
     WritebackCacheEnabled,
     StateAccumulatorV2Enabled,
 }
@@ -64,11 +68,7 @@ impl EpochFlag {
         cache_config: &ExecutionCacheConfig,
         enable_state_accumulator_v2: bool,
     ) -> Vec<Self> {
-        let mut new_flags = vec![
-            EpochFlag::InMemoryCheckpointRoots,
-            EpochFlag::PerEpochFinalizedTransactions,
-            EpochFlag::ObjectLockSplitTables,
-        ];
+        let mut new_flags = vec![];
 
         if matches!(
             choose_execution_cache(cache_config),
@@ -89,9 +89,15 @@ impl fmt::Display for EpochFlag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Important - implementation should return low cardinality values because this is used as metric key
         match self {
-            EpochFlag::InMemoryCheckpointRoots => write!(f, "InMemoryCheckpointRoots"),
-            EpochFlag::PerEpochFinalizedTransactions => write!(f, "PerEpochFinalizedTransactions"),
-            EpochFlag::ObjectLockSplitTables => write!(f, "ObjectLockSplitTables"),
+            EpochFlag::_InMemoryCheckpointRootsDeprecated => {
+                write!(f, "InMemoryCheckpointRoots (DEPRECATED)")
+            }
+            EpochFlag::_PerEpochFinalizedTransactionsDeprecated => {
+                write!(f, "PerEpochFinalizedTransactions (DEPRECATED)")
+            }
+            EpochFlag::_ObjectLockSplitTablesDeprecated => {
+                write!(f, "ObjectLockSplitTables (DEPRECATED)")
+            }
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
             EpochFlag::StateAccumulatorV2Enabled => write!(f, "StateAccumulatorV2Enabled"),
         }
@@ -168,10 +174,6 @@ impl EpochStartConfiguration {
 
     pub fn epoch_start_timestamp_ms(&self) -> CheckpointTimestamp {
         self.epoch_start_state().epoch_start_timestamp_ms()
-    }
-
-    pub fn object_lock_split_tables_enabled(&self) -> bool {
-        self.flags().contains(&EpochFlag::ObjectLockSplitTables)
     }
 }
 

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -1311,9 +1311,8 @@ async fn finalize_checkpoint(
     data_ingestion_dir: Option<PathBuf>,
 ) -> SuiResult<Accumulator> {
     debug!("finalizing checkpoint");
-    if epoch_store.per_epoch_finalized_txns_enabled() {
-        epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
-    }
+    epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
+
     // TODO remove once we no longer need to support this table for read RPC
     state
         .get_checkpoint_cache()

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -6,10 +6,9 @@ use rand::rngs::OsRng;
 use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-use sui_core::authority::epoch_start_configuration::EpochFlag;
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
-use sui_macros::{register_fail_point_arg, sim_test};
+use sui_macros::sim_test;
 use sui_node::SuiNodeHandle;
 use sui_protocol_config::ProtocolConfig;
 use sui_swarm_config::genesis_config::{ValidatorGenesisConfig, ValidatorGenesisConfigBuilder};
@@ -301,21 +300,6 @@ async fn do_test_passive_reconfig() {
 // Test for syncing a node to an authority that already has many txes.
 #[sim_test]
 async fn test_expired_locks() {
-    do_test_lock_table_upgrade().await
-}
-
-#[sim_test]
-async fn test_expired_locks_with_lock_table_upgrade() {
-    register_fail_point_arg("initial_epoch_flags", || {
-        Some(vec![
-            EpochFlag::InMemoryCheckpointRoots,
-            EpochFlag::PerEpochFinalizedTransactions,
-        ])
-    });
-    do_test_lock_table_upgrade().await
-}
-
-async fn do_test_lock_table_upgrade() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)
         .build()


### PR DESCRIPTION
All of these flags have been released for months, so the old code should not be needed anywhere at this point.
