### PR TITLE
Add Rust types for denylist v2

### DIFF
--- a/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
@@ -1,43 +1,36 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::authority::authority_tests::send_and_confirm_transaction_;
 use crate::authority::move_integration_tests::build_and_try_publish_test_package;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
-use sui_types::crypto::get_account_key_pair;
+use crate::authority::AuthorityState;
+use move_core_types::ident_str;
+use move_core_types::language_storage::{StructTag, TypeTag};
+use std::sync::Arc;
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::base_types::{dbg_addr, ObjectID, SuiAddress};
+use sui_types::crypto::{get_account_key_pair, AccountKeyPair};
 use sui_types::deny_list_v1::{CoinDenyCap, RegulatedCoinMetadata};
-use sui_types::effects::TransactionEffectsAPI;
+use sui_types::deny_list_v2::{
+    check_address_denied_by_coin, get_per_type_coin_deny_list_v2, DenyCapV2,
+};
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::object::Object;
-use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_PUBLISH;
+use sui_types::transaction::{CallArg, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH};
+use sui_types::{SUI_DENY_LIST_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID};
 
 // Test that a regulated coin can be created and all the necessary objects are created with the right types.
 // Make sure that these types can be converted to Rust types.
 #[tokio::test]
 async fn test_regulated_coin_v1_creation() {
-    let (sender, keypair) = get_account_key_pair();
-    let gas_object = Object::with_owner_for_testing(sender);
-    let gas_object_id = gas_object.id();
-    let authority = TestAuthorityBuilder::new()
-        .with_starting_objects(&[gas_object])
-        .build()
-        .await;
-    let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let (_, effects) = build_and_try_publish_test_package(
-        &authority,
-        &sender,
-        &keypair,
-        &gas_object_id,
-        "coin_deny_list_v1",
-        TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
-        rgp,
-        false,
-    )
-    .await;
+    let env = new_authority_and_publish("coin_deny_list_v1").await;
 
     let mut deny_cap_object = None;
     let mut metadata_object = None;
     let mut regulated_metadata_object = None;
-    for (oref, _owner) in effects.created() {
-        let object = authority.get_object(&oref.0).await.unwrap().unwrap();
+    for (oref, _owner) in env.publish_effects.created() {
+        let object = env.authority.get_object(&oref.0).await.unwrap().unwrap();
         if object.is_package() {
             continue;
         }
@@ -75,4 +68,170 @@ async fn test_regulated_coin_v1_creation() {
         regulated_metadata.coin_metadata_object.bytes,
         metadata_object.id()
     );
+}
+
+// Test that a v2 regulated coin can be created and all the necessary objects are created with the right types.
+// Also test that we could create the deny list config for the coin and all types can be loaded in Rust.
+#[ignore]
+#[tokio::test]
+async fn test_regulated_coin_v2_types() {
+    let env = new_authority_and_publish("coin_deny_list_v2").await;
+
+    let mut deny_cap_object = None;
+    let mut metadata_object = None;
+    let mut regulated_metadata_object = None;
+    let mut package_id = None;
+    for (oref, _owner) in env.publish_effects.created() {
+        let object = env.authority.get_object(&oref.0).await.unwrap().unwrap();
+        if object.is_package() {
+            package_id = Some(object.id());
+            continue;
+        }
+        let t = object.type_().unwrap();
+        if t.is_coin_deny_cap_v2() {
+            assert!(deny_cap_object.is_none());
+            deny_cap_object = Some(object);
+        } else if t.is_regulated_coin_metadata() {
+            assert!(regulated_metadata_object.is_none());
+            regulated_metadata_object = Some(object);
+        } else if t.is_coin_metadata() {
+            assert!(metadata_object.is_none());
+            metadata_object = Some(object);
+        }
+    }
+    let package_id = package_id.unwrap();
+    // Check that publishing the package created
+    // the metadata, deny cap, and regulated metadata.
+    // Check that all their fields are consistent.
+    let metadata_object = metadata_object.unwrap();
+    let deny_cap_object = deny_cap_object.unwrap();
+    let deny_cap: DenyCapV2 = deny_cap_object.to_rust().unwrap();
+    assert_eq!(deny_cap.id.id.bytes, deny_cap_object.id());
+    assert!(deny_cap.allow_global_pause);
+
+    let regulated_metadata_object = regulated_metadata_object.unwrap();
+    let regulated_metadata: RegulatedCoinMetadata = regulated_metadata_object.to_rust().unwrap();
+    assert_eq!(
+        regulated_metadata.id.id.bytes,
+        regulated_metadata_object.id()
+    );
+    assert_eq!(
+        regulated_metadata.deny_cap_object.bytes,
+        deny_cap_object.id()
+    );
+    assert_eq!(
+        regulated_metadata.coin_metadata_object.bytes,
+        metadata_object.id()
+    );
+
+    let deny_list_object_init_version = env
+        .authority
+        .get_object(&SUI_DENY_LIST_OBJECT_ID)
+        .await
+        .unwrap()
+        .unwrap()
+        .version();
+    let regulated_coin_type = TypeTag::Struct(Box::new(StructTag {
+        address: package_id.into(),
+        module: ident_str!("regulated_coin").to_owned(),
+        name: ident_str!("REGULATED_COIN").to_owned(),
+        type_params: vec![],
+    }));
+    let deny_address = dbg_addr(2);
+    let tx = TestTransactionBuilder::new(
+        env.sender,
+        env.authority
+            .get_object(&env.gas_object_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .compute_object_reference(),
+        env.authority.reference_gas_price_for_testing().unwrap(),
+    )
+    .move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        "coin",
+        "deny_list_v2_add",
+        vec![
+            CallArg::Object(ObjectArg::SharedObject {
+                id: SUI_DENY_LIST_OBJECT_ID,
+                initial_shared_version: deny_list_object_init_version,
+                mutable: true,
+            }),
+            CallArg::Object(ObjectArg::ImmOrOwnedObject(
+                deny_cap_object.compute_object_reference(),
+            )),
+            CallArg::Pure(bcs::to_bytes(&deny_address).unwrap()),
+        ],
+    )
+    .with_type_args(vec![regulated_coin_type.clone()])
+    .build_and_sign(&env.keypair);
+    send_and_confirm_transaction_(&env.authority, None, tx, true)
+        .await
+        .unwrap();
+    let coin_deny_config = get_per_type_coin_deny_list_v2(
+        regulated_coin_type.to_canonical_string(false),
+        &env.authority.get_object_store(),
+    )
+    .unwrap();
+    // Updates from the current epoch will not be read.
+    assert!(!check_address_denied_by_coin(
+        &coin_deny_config,
+        deny_address,
+        &env.authority.get_object_store(),
+        0,
+    ));
+    // If we change the current epoch to be 1, the change from epoch 0
+    // would be considered as from previous epoch, and hence will be
+    // used.
+    assert!(check_address_denied_by_coin(
+        &coin_deny_config,
+        deny_address,
+        &env.authority.get_object_store(),
+        1,
+    ));
+    // Check a different address, and it should not be denied.
+    assert!(!check_address_denied_by_coin(
+        &coin_deny_config,
+        dbg_addr(3),
+        &env.authority.get_object_store(),
+        1,
+    ));
+}
+
+struct TestEnv {
+    authority: Arc<AuthorityState>,
+    sender: SuiAddress,
+    keypair: AccountKeyPair,
+    gas_object_id: ObjectID,
+    publish_effects: TransactionEffects,
+}
+
+async fn new_authority_and_publish(path: &str) -> TestEnv {
+    let (sender, keypair) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_id = gas_object.id();
+    let authority = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let (_, effects) = build_and_try_publish_test_package(
+        &authority,
+        &sender,
+        &keypair,
+        &gas_object_id,
+        path,
+        TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
+        rgp,
+        false,
+    )
+    .await;
+    TestEnv {
+        authority,
+        sender,
+        keypair,
+        gas_object_id,
+        publish_effects: effects.into_data(),
+    }
 }

--- a/crates/sui-core/src/unit_tests/data/coin_deny_list_v2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/coin_deny_list_v2/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coin_deny_list_v2"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+coin_deny_list_v2 = "0x0"

--- a/crates/sui-core/src/unit_tests/data/coin_deny_list_v2/sources/regulated_coin.move
+++ b/crates/sui-core/src/unit_tests/data/coin_deny_list_v2/sources/regulated_coin.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module coin_deny_list_v2::regulated_coin {
+    use std::option;
+    use sui::coin::{Self, DenyCapV2};
+    use sui::deny_list::DenyList;
+    use sui::object::UID;
+    use sui::transfer;
+    use sui::tx_context;
+    use sui::tx_context::TxContext;
+
+    public struct REGULATED_COIN has drop {}
+
+    public struct Wallet has key {
+        id: UID,
+    }
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            true,
+            ctx
+        );
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -326,6 +326,12 @@ impl MoveObjectType {
             && self.name().as_str() == "DenyCap"
     }
 
+    pub fn is_coin_deny_cap_v2(&self) -> bool {
+        self.address() == SUI_FRAMEWORK_ADDRESS
+            && self.module().as_str() == "coin"
+            && self.name().as_str() == "DenyCapV2"
+    }
+
     pub fn is_dynamic_field(&self) -> bool {
         match &self.0 {
             MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {

--- a/crates/sui-types/src/deny_list_v2.rs
+++ b/crates/sui-types/src/deny_list_v2.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::base_types::{EpochId, SuiAddress};
+use crate::deny_list_v1::{get_deny_list_root_object, DENY_LIST_COIN_TYPE_INDEX, DENY_LIST_MODULE};
+use crate::dynamic_field::get_dynamic_field_from_store;
+use crate::id::UID;
+use crate::storage::ObjectStore;
+use crate::{MoveTypeTagTrait, SUI_FRAMEWORK_PACKAGE_ID};
+use move_core_types::ident_str;
+use move_core_types::language_storage::{StructTag, TypeTag};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Rust representation of the Move type 0x2::config::Config.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Config {
+    id: UID,
+}
+
+/// Rust representation of the Move type 0x2::config::Setting.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct Setting<V: Copy> {
+    id: UID,
+    data: Option<SettingData<V>>,
+}
+
+/// Rust representation of the Move type 0x2::config::SettingData.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct SettingData<V: Copy> {
+    newer_value_epoch: u64,
+    newer_value: V,
+    older_value_opt: Option<V>,
+}
+
+/// Rust representation of the Move type 0x2::coin::DenyCapV2.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DenyCapV2 {
+    pub id: UID,
+    pub allow_global_pause: bool,
+}
+
+/// Rust representation of the Move type 0x2::deny_list::ConfigKey.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct ConfigKey {
+    per_type_index: u64,
+    per_type_key: Vec<u8>,
+}
+
+impl MoveTypeTagTrait for ConfigKey {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Struct(Box::new(StructTag {
+            address: SUI_FRAMEWORK_PACKAGE_ID.into(),
+            module: DENY_LIST_MODULE.to_owned(),
+            name: ident_str!("ConfigKey").to_owned(),
+            type_params: vec![],
+        }))
+    }
+}
+
+/// Rust representation of the Move type 0x2::deny_list::AddressKey.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct AddressKey(SuiAddress);
+
+impl MoveTypeTagTrait for AddressKey {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Struct(Box::new(StructTag {
+            address: SUI_FRAMEWORK_PACKAGE_ID.into(),
+            module: DENY_LIST_MODULE.to_owned(),
+            name: ident_str!("AddressKey").to_owned(),
+            type_params: vec![],
+        }))
+    }
+}
+
+pub fn get_per_type_coin_deny_list_v2(
+    coin_type: String,
+    object_store: &dyn ObjectStore,
+) -> Option<Config> {
+    let deny_list_root =
+        get_deny_list_root_object(object_store).expect("Deny list root object not found");
+    let config: Config = get_dynamic_field_from_store(
+        object_store,
+        deny_list_root.id(),
+        &ConfigKey {
+            per_type_index: DENY_LIST_COIN_TYPE_INDEX,
+            per_type_key: coin_type.as_bytes().to_vec(),
+        },
+    )
+    .ok()?;
+    Some(config)
+}
+
+pub fn check_address_denied_by_coin(
+    coin_deny_config: &Config,
+    address: SuiAddress,
+    object_store: &dyn ObjectStore,
+    cur_epoch: EpochId,
+) -> bool {
+    let address_key = AddressKey(address);
+    read_config_setting(object_store, coin_deny_config, address_key, cur_epoch).unwrap_or(false)
+}
+
+fn read_config_setting<K, V>(
+    object_store: &dyn ObjectStore,
+    config: &Config,
+    setting_name: K,
+    cur_epoch: EpochId,
+) -> Option<V>
+where
+    K: MoveTypeTagTrait + Serialize + DeserializeOwned + fmt::Debug,
+    V: Copy + Serialize + DeserializeOwned,
+{
+    let setting: Setting<V> = {
+        match get_dynamic_field_from_store(object_store, *config.id.object_id(), &setting_name) {
+            Ok(setting) => setting,
+            Err(_) => return None,
+        }
+    };
+    let Some(setting_data) = setting.data else {
+        return None;
+    };
+    if setting_data.newer_value_epoch < cur_epoch {
+        Some(setting_data.newer_value)
+    } else {
+        setting_data.older_value_opt
+    }
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -37,6 +37,7 @@ pub mod collection_types;
 pub mod committee;
 pub mod crypto;
 pub mod deny_list_v1;
+pub mod deny_list_v2;
 pub mod digests;
 pub mod display;
 pub mod dynamic_field;


### PR DESCRIPTION
## Description 

This is based on the upcoming implementation in https://github.com/tnowacki/sui/tree/config/crates/sui-framework/packages/sui-framework/sources
This PR doesn't introduce any functional changes yet.
It only adds the basic types for denylist v2, as well as the functions to load the config setting data.
Added a test that passes with the new Move code.
We can merge this early.
Test can be enabled once we have the Move code in.

## Test plan 

Added a basic test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
