### PR TITLE
[bridge]  support rank validators by voting power when requesting signatures

### DIFF
--- a/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
+++ b/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
@@ -14,9 +14,10 @@ use crate::types::{
 };
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_common::authority_aggregation::quorum_map_then_reduce_with_timeout;
+use sui_common::authority_aggregation::quorum_map_then_reduce_with_timeout_and_prefs;
 use sui_common::authority_aggregation::ReduceOutput;
 use sui_types::base_types::ConciseableName;
 use sui_types::committee::StakeUnit;
@@ -168,9 +169,25 @@ async fn request_sign_bridge_action_into_certification(
     clients: Arc<BTreeMap<BridgeAuthorityPublicKeyBytes, Arc<BridgeClient>>>,
     state: GetSigsState,
 ) -> BridgeResult<VerifiedCertifiedBridgeAction> {
-    let (result, _) = quorum_map_then_reduce_with_timeout(
+    // `preferences` is used as a trick here to influence the order of validators to be requested
+    // if `Some(_)`, then we will request validators in the order of the voting power
+    // if `None`, we still refer to voting power, but they are shuffled by randomness
+    // Because ethereum gas price is not negligible, when the signatures are to be verified on ethereum,
+    // we pass in `Some` to make sure the validators with higher voting power are requested first
+    // to save gas cost.
+    let preference = if matches!(action, BridgeAction::SuiToEthBridgeAction(_)) {
+        Some(BTreeSet::new())
+    } else if matches!(action, BridgeAction::EthToSuiBridgeAction(_))
+        || action.chain_id().is_sui_chain()
+    {
+        None
+    } else {
+        Some(BTreeSet::new())
+    };
+    let (result, _) = quorum_map_then_reduce_with_timeout_and_prefs(
         committee,
         clients,
+        preference.as_ref(),
         state,
         |_name, client| {
             Box::pin(async move { client.request_sign_bridge_action(action.clone()).await })

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -98,7 +98,7 @@ where
 
     /// Get the mutable bridge object arg on chain.
     // We retry a few times in case of errors. If it fails eventually, we panic.
-    // In generaly it's safe to call in the beginning of the program.
+    // In general it's safe to call in the beginning of the program.
     // After the first call, the result is cached since the value should never change.
     pub async fn get_mutable_bridge_object_arg_must_succeed(&self) -> ObjectArg {
         static ARG: OnceCell<ObjectArg> = OnceCell::const_new();

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -119,9 +119,9 @@ impl CommitteeTrait<BridgeAuthorityPublicKeyBytes> for BridgeCommittee {
     // Note: blocklisted members are always excluded.
     fn shuffle_by_stake_with_rng(
         &self,
-        // `preferences` is used as a flag here to influence the order of validators to be requested
-        //  if `Some(_)`, then we will request validators in the order of the voting power
-        //  if `None`, we still refer to voting power, but they are shuffled by randomness.
+        // `preferences` is used as a *flag* here to influence the order of validators to be requested.
+        //  * if `Some(_)`, then we will request validators in the order of the voting power
+        //  * if `None`, we still refer to voting power, but they are shuffled by randomness.
         //  to save gas cost.
         preferences: Option<&BTreeSet<BridgeAuthorityPublicKeyBytes>>,
         // only attempt from these authorities.

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4475,6 +4475,13 @@ impl AuthorityState {
             info!("bridge not enabled");
             return None;
         }
+        if !epoch_store
+            .protocol_config()
+            .should_try_to_finalize_bridge_committee()
+        {
+            info!("should not try to finalize bridge committee yet");
+            return None;
+        }
         // Only create this transaction if bridge exists
         if !epoch_store.bridge_exists() {
             return None;

--- a/crates/sui-json-rpc-types/src/sui_protocol.rs
+++ b/crates/sui-json-rpc-types/src/sui_protocol.rs
@@ -35,6 +35,11 @@ pub enum SuiProtocolConfigValue {
         #[serde_as(as = "DisplayFromStr")]
         f64,
     ),
+    Bool(
+        #[schemars(with = "String")]
+        #[serde_as(as = "DisplayFromStr")]
+        bool,
+    ),
 }
 
 impl From<ProtocolConfigValue> for SuiProtocolConfigValue {
@@ -44,6 +49,7 @@ impl From<ProtocolConfigValue> for SuiProtocolConfigValue {
             ProtocolConfigValue::u32(y) => SuiProtocolConfigValue::U32(y),
             ProtocolConfigValue::u64(x) => SuiProtocolConfigValue::U64(x),
             ProtocolConfigValue::f64(z) => SuiProtocolConfigValue::F64(z),
+            ProtocolConfigValue::bool(z) => SuiProtocolConfigValue::Bool(z),
         }
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1403,6 +1403,7 @@
                 "bls12381_bls12381_min_sig_verify_msg_cost_per_byte": {
                   "u64": "2"
                 },
+                "bridge_should_try_to_finalize_committee": null,
                 "buffer_stake_for_protocol_upgrade_bps": {
                   "u64": "5000"
                 },
@@ -7958,6 +7959,18 @@
             ],
             "properties": {
               "f64": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "bool"
+            ],
+            "properties": {
+              "bool": {
                 "type": "string"
               }
             },

--- a/crates/sui-rest-api/src/system.rs
+++ b/crates/sui-rest-api/src/system.rs
@@ -627,6 +627,7 @@ impl From<ProtocolConfig> for ProtocolConfigResponse {
                         ProtocolConfigValue::u32(y) => y.to_string(),
                         ProtocolConfigValue::u64(z) => z.to_string(),
                         ProtocolConfigValue::f64(f) => f.to_string(),
+                        ProtocolConfigValue::bool(b) => b.to_string(),
                     };
                     (k, v)
                 })

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -449,10 +449,22 @@ impl EndOfEpochTransactionKind {
                     ));
                 }
             }
-            Self::BridgeStateCreate(_) | Self::BridgeCommitteeInit(_) => {
+            Self::BridgeStateCreate(_) => {
                 if !config.enable_bridge() {
                     return Err(UserInputError::Unsupported(
                         "bridge not enabled".to_string(),
+                    ));
+                }
+            }
+            Self::BridgeCommitteeInit(_) => {
+                if !config.enable_bridge() {
+                    return Err(UserInputError::Unsupported(
+                        "bridge not enabled".to_string(),
+                    ));
+                }
+                if !config.should_try_to_finalize_bridge_committee() {
+                    return Err(UserInputError::Unsupported(
+                        "should not try to finalize committee yet".to_string(),
                     ));
                 }
             }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -673,6 +673,7 @@ mod checked {
                         }
                         EndOfEpochTransactionKind::BridgeCommitteeInit(bridge_shared_version) => {
                             assert!(protocol_config.enable_bridge());
+                            assert!(protocol_config.should_try_to_finalize_bridge_committee());
                             builder = setup_bridge_committee_update(builder, bridge_shared_version)
                         }
                     }


### PR DESCRIPTION
## Description 

In this PR we introduce a way to order validators to request signatures according to their voting power. This is useful for signatures to be verified on ethereum because the # of signatures do impact the gas cost there significantly.


## Test plan 

deploying on a testnet bridge node to test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
