### PR TITLE
Clean up protocol config testing setters

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -726,7 +726,7 @@ impl CoreSignals {
 }
 
 /// Receivers of signals from Core.
-/// Intentially un-clonable. Comonents should only subscribe to channels they need.
+/// Intentionally un-clonable. Comonents should only subscribe to channels they need.
 pub(crate) struct CoreSignalsReceivers {
     rx_block_broadcast: broadcast::Receiver<VerifiedBlock>,
     new_round_receiver: watch::Receiver<Round>,
@@ -994,8 +994,8 @@ mod test {
     async fn test_core_propose_after_genesis() {
         telemetry_subscribers::init_for_testing();
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_consensus_max_transaction_size_bytes(2_000);
-            config.set_consensus_max_transactions_in_block_bytes(2_000);
+            config.set_consensus_max_transaction_size_bytes_for_testing(2_000);
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(2_000);
             config
         });
 
@@ -1279,7 +1279,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_core_set_consumer_availablity() {
+    async fn test_core_set_consumer_availability() {
         telemetry_subscribers::init_for_testing();
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
@@ -1449,7 +1449,7 @@ mod test {
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_mysticeti_leader_scoring_and_schedule(false);
+            .set_mysticeti_leader_scoring_and_schedule_for_testing(false);
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1]);
 
@@ -1562,7 +1562,7 @@ mod test {
         let (mut context, _) = Context::new_for_test(6);
         context
             .protocol_config
-            .set_mysticeti_num_leaders_per_round(num_leaders_per_round);
+            .set_mysticeti_num_leaders_per_round_for_testing(num_leaders_per_round);
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1, 1, 1]);
 
@@ -1633,7 +1633,7 @@ mod test {
             // Meaning with multi leader per round explicitly set to 1 we will have 60,
             // otherwise 61.
             // NOTE: We used 61 leader rounds to specifically trigger the scenario
-            // where the leader schedule boundary occured AND we had a swap to a new
+            // where the leader schedule boundary occurred AND we had a swap to a new
             // leader for the same round
             let expected_commit_count = match num_leaders_per_round {
                 Some(1) => 60,
@@ -1842,7 +1842,7 @@ mod test {
                 .with_authority_index(AuthorityIndex::new_for_test(index as u32));
             context
                 .protocol_config
-                .set_consensus_bad_nodes_stake_threshold(33);
+                .set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
             let context = Arc::new(context);
             let store = Arc::new(MemStore::new());

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -530,7 +530,7 @@ mod tests {
         let mut context = Context::new_for_test(4).0;
         context
             .protocol_config
-            .set_mysticeti_leader_scoring_and_schedule(false);
+            .set_mysticeti_leader_scoring_and_schedule_for_testing(false);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
 
@@ -640,7 +640,7 @@ mod tests {
         let mut context = Context::new_for_test(4).0;
         context
             .protocol_config
-            .set_consensus_bad_nodes_stake_threshold(33);
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
 
@@ -734,7 +734,7 @@ mod tests {
         let mut context = Context::new_for_test(4).0;
         context
             .protocol_config
-            .set_consensus_bad_nodes_stake_threshold(33);
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
 
@@ -763,7 +763,7 @@ mod tests {
         let mut context = Context::new_for_test(4).0;
         context
             .protocol_config
-            .set_consensus_bad_nodes_stake_threshold(33);
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
 
@@ -867,7 +867,7 @@ mod tests {
         let mut context = Context::new_for_test(4).0;
         context
             .protocol_config
-            .set_consensus_bad_nodes_stake_threshold(33);
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -92,7 +92,7 @@ impl TransactionConsumer {
 
             if remaining_txs.is_empty() {
                 // The batch has been fully consumed, register its ack.
-                // In case a batch gets splitted, ack shall only be sent when the last transaction is included in the block.
+                // In case a batch gets split, ack shall only be sent when the last transaction is included in the block.
                 acks.push(t.included_in_block_ack);
                 None
             } else {
@@ -264,8 +264,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_submit_and_consume() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_consensus_max_transaction_size_bytes(2_000); // 2KB
-            config.set_consensus_max_transactions_in_block_bytes(2_000);
+            config.set_consensus_max_transaction_size_bytes_for_testing(2_000); // 2KB
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(2_000);
             config
         });
 
@@ -316,8 +316,8 @@ mod tests {
     #[tokio::test]
     async fn submit_over_max_fetch_size_and_consume() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_consensus_max_transaction_size_bytes(100);
-            config.set_consensus_max_transactions_in_block_bytes(100);
+            config.set_consensus_max_transaction_size_bytes_for_testing(100);
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(100);
             config
         });
 
@@ -384,8 +384,8 @@ mod tests {
     #[tokio::test]
     async fn submit_large_batch_and_ack() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_consensus_max_transaction_size_bytes(100);
-            config.set_consensus_max_transactions_in_block_bytes(100);
+            config.set_consensus_max_transaction_size_bytes_for_testing(100);
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(100);
             config
         });
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -453,15 +453,15 @@ mod test {
         );
 
         let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, mut config| {
-            config.set_per_object_congestion_control_mode(
+            config.set_per_object_congestion_control_mode_for_testing(
                 PerObjectCongestionControlMode::TotalGasBudget,
             );
-            config.set_max_accumulated_txn_cost_per_object_in_checkpoint(
+            config.set_max_accumulated_txn_cost_per_object_in_checkpoint_for_testing(
                 checkpoint_budget_factor
                     * DEFAULT_VALIDATOR_GAS_PRICE
                     * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
             );
-            config.set_max_deferral_rounds_for_congestion_control(max_deferral_rounds);
+            config.set_max_deferral_rounds_for_congestion_control_for_testing(max_deferral_rounds);
             config
         });
 
@@ -700,7 +700,7 @@ mod test {
         let test_cluster = build_test_cluster(6, 20_000).await;
 
         // Network should continue as long as nodes are participating in DKG representing
-        // stake equal to 2f+1 PLUS proprotion of stake represented by the
+        // stake equal to 2f+1 PLUS proportion of stake represented by the
         // `random_beacon_reduction_allowed_delta` ProtocolConfig option.
         // In this case we make sure it still works with 5/6 validators.
         let eligible_nodes: HashSet<_> = test_cluster

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -980,7 +980,7 @@ impl CheckpointBuilder {
                     continue;
                 }
 
-                // Min interval has elasped, we can now coalesce and build a checkpoint.
+                // Min interval has elapsed, we can now coalesce and build a checkpoint.
                 last_height = Some(height);
                 last_timestamp = Some(current_timestamp);
                 debug!(
@@ -2398,7 +2398,7 @@ mod tests {
 
         let mut protocol_config =
             ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_min_checkpoint_interval_ms(100);
+        protocol_config.set_min_checkpoint_interval_ms_for_testing(100);
         let state = TestAuthorityBuilder::new()
             .with_protocol_config(protocol_config)
             .build()

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5778,18 +5778,19 @@ async fn test_consensus_handler_per_object_congestion_control(
     // Create the cluster with controlled per object congestion control.
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-    protocol_config.set_per_object_congestion_control_mode(mode);
+    protocol_config.set_per_object_congestion_control_mode_for_testing(mode);
 
     match mode {
         PerObjectCongestionControlMode::None => unreachable!(),
         PerObjectCongestionControlMode::TotalGasBudget => {
-            protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint(200_000_000);
+            protocol_config
+                .set_max_accumulated_txn_cost_per_object_in_checkpoint_for_testing(200_000_000);
         }
         PerObjectCongestionControlMode::TotalTxCount => {
-            protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint(2);
+            protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint_for_testing(2);
         }
     }
-    protocol_config.set_max_deferral_rounds_for_congestion_control(1000); // Set to a large number so that we don't hit this limit.
+    protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(1000); // Set to a large number so that we don't hit this limit.
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)
@@ -5998,10 +5999,11 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     // Create the cluster with controlled per object congestion control and cancellation.
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-    protocol_config
-        .set_per_object_congestion_control_mode(PerObjectCongestionControlMode::TotalGasBudget);
-    protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint(100_000_000);
-    protocol_config.set_max_deferral_rounds_for_congestion_control(2);
+    protocol_config.set_per_object_congestion_control_mode_for_testing(
+        PerObjectCongestionControlMode::TotalGasBudget,
+    );
+    protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint_for_testing(100_000_000);
+    protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(2);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -51,18 +51,19 @@ impl TestSetup {
 
         let mut protocol_config =
             ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config
-            .set_per_object_congestion_control_mode(PerObjectCongestionControlMode::TotalGasBudget);
+        protocol_config.set_per_object_congestion_control_mode_for_testing(
+            PerObjectCongestionControlMode::TotalGasBudget,
+        );
 
         // Set shared object congestion control such that it only allows 1 transaction to go through.
         let max_accumulated_txn_cost_per_object_in_checkpoint =
             TEST_ONLY_GAS_PRICE * TEST_ONLY_GAS_UNIT;
-        protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint(
+        protocol_config.set_max_accumulated_txn_cost_per_object_in_checkpoint_for_testing(
             max_accumulated_txn_cost_per_object_in_checkpoint,
         );
 
         // Set max deferral rounds to 0 to testr cancellation. All deferred transactions will be cancelled.
-        protocol_config.set_max_deferral_rounds_for_congestion_control(0);
+        protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(0);
 
         let setup_authority_state = TestAuthorityBuilder::new()
             .with_reference_gas_price(TEST_ONLY_GAS_PRICE)
@@ -257,7 +258,7 @@ async fn test_congestion_control_execution_cancellation() {
     telemetry_subscribers::init_for_testing();
 
     // Creates a authority state with 2 shared object and 1 owned object. We use this setup
-    // to intialize two more authority states: one tests cancellation execution, and one tests
+    // to initialize two more authority states: one tests cancellation execution, and one tests
     // executing cancelled transaction from effect.
     let test_setup = TestSetup::new().await;
     let shared_object_1 = test_setup.create_shared_object().await;

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -53,7 +53,7 @@ impl TestRunner {
 
         let mut protocol_config =
             ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_shared_object_deletion(true);
+        protocol_config.set_shared_object_deletion_for_testing(true);
         let authority_state = TestAuthorityBuilder::new()
             .with_protocol_config(protocol_config)
             .build()

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -673,7 +673,7 @@ async fn test_expired_epoch_zklogin_in_multisig() {
 async fn test_max_epoch_too_large_fail_zklogin_in_multisig() {
     use sui_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_zklogin_max_epoch_upper_bound_delta(Some(1));
+        config.set_zklogin_max_epoch_upper_bound_delta_for_testing(Some(1));
         config
     });
 

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -264,7 +264,7 @@ async fn test_passive_reconfig_determinism() {
 async fn do_test_passive_reconfig() {
     telemetry_subscribers::init_for_testing();
     let _commit_root_state_digest = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_commit_root_state_digest_supported(true);
+        config.set_commit_root_state_digest_supported_for_testing(true);
         config
     });
     ProtocolConfig::poison_get_for_min_version();

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -86,8 +86,8 @@ async fn test_zklogin_feature_legacy_address_deny() {
     use sui_protocol_config::ProtocolConfig;
 
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_verify_legacy_zklogin_address(false);
-        config.set_zklogin_max_epoch_upper_bound_delta(None);
+        config.set_verify_legacy_zklogin_address_for_testing(false);
+        config.set_zklogin_max_epoch_upper_bound_delta_for_testing(None);
         config
     });
 
@@ -100,7 +100,7 @@ async fn test_zklogin_feature_legacy_address_deny() {
 #[sim_test]
 async fn test_legacy_zklogin_address_accept() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_verify_legacy_zklogin_address(true);
+        config.set_verify_legacy_zklogin_address_for_testing(true);
         config
     });
     let err = do_zklogin_test(get_legacy_zklogin_user_address(), true)
@@ -137,7 +137,7 @@ async fn zklogin_end_to_end_test() {
 async fn test_max_epoch_too_large_fail_tx() {
     use sui_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_zklogin_max_epoch_upper_bound_delta(Some(1));
+        config.set_zklogin_max_epoch_upper_bound_delta_for_testing(Some(1));
         config
     });
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -260,6 +260,7 @@ impl Chain {
 
 pub struct Error(pub String);
 
+// TODO: There are quite a few non boolean values in the feature flags. We should move them out.
 /// Records on/off feature flags that may vary at each protocol version.
 #[derive(Default, Clone, Serialize, Debug, ProtocolConfigFeatureFlagsGetters)]
 struct FeatureFlags {
@@ -2486,16 +2487,15 @@ impl ProtocolConfig {
     }
 }
 
-// Setters for tests
+// Setters for tests.
+// This is only needed for feature_flags. Please suffix each setter with `_for_testing`.
+// Non-feature_flags should already have test setters defined through macros.
 impl ProtocolConfig {
-    pub fn set_package_upgrades_for_testing(&mut self, val: bool) {
-        self.feature_flags.package_upgrades = val
-    }
     pub fn set_advance_to_highest_supported_protocol_version_for_testing(&mut self, val: bool) {
         self.feature_flags
             .advance_to_highest_supported_protocol_version = val
     }
-    pub fn set_commit_root_state_digest_supported(&mut self, val: bool) {
+    pub fn set_commit_root_state_digest_supported_for_testing(&mut self, val: bool) {
         self.feature_flags.commit_root_state_digest = val
     }
     pub fn set_zklogin_auth_for_testing(&mut self, val: bool) {
@@ -2514,72 +2514,51 @@ impl ProtocolConfig {
         self.feature_flags.accept_zklogin_in_multisig = val
     }
 
-    pub fn set_shared_object_deletion(&mut self, val: bool) {
+    pub fn set_shared_object_deletion_for_testing(&mut self, val: bool) {
         self.feature_flags.shared_object_deletion = val;
     }
 
-    pub fn set_narwhal_new_leader_election_schedule(&mut self, val: bool) {
+    pub fn set_narwhal_new_leader_election_schedule_for_testing(&mut self, val: bool) {
         self.feature_flags.narwhal_new_leader_election_schedule = val;
     }
 
-    pub fn set_consensus_bad_nodes_stake_threshold(&mut self, val: u64) {
-        self.consensus_bad_nodes_stake_threshold = Some(val);
-    }
     pub fn set_receive_object_for_testing(&mut self, val: bool) {
         self.feature_flags.receive_objects = val
     }
-    pub fn set_narwhal_certificate_v2(&mut self, val: bool) {
+    pub fn set_narwhal_certificate_v2_for_testing(&mut self, val: bool) {
         self.feature_flags.narwhal_certificate_v2 = val
     }
-    pub fn set_verify_legacy_zklogin_address(&mut self, val: bool) {
+    pub fn set_verify_legacy_zklogin_address_for_testing(&mut self, val: bool) {
         self.feature_flags.verify_legacy_zklogin_address = val
     }
-    pub fn set_enable_effects_v2(&mut self, val: bool) {
-        self.feature_flags.enable_effects_v2 = val;
-    }
-    pub fn set_consensus_max_transaction_size_bytes(&mut self, val: u64) {
-        self.consensus_max_transaction_size_bytes = Some(val);
-    }
-    pub fn set_consensus_max_transactions_in_block_bytes(&mut self, val: u64) {
-        self.consensus_max_transactions_in_block_bytes = Some(val);
-    }
 
-    pub fn set_per_object_congestion_control_mode(&mut self, val: PerObjectCongestionControlMode) {
+    pub fn set_per_object_congestion_control_mode_for_testing(
+        &mut self,
+        val: PerObjectCongestionControlMode,
+    ) {
         self.feature_flags.per_object_congestion_control_mode = val;
     }
 
-    pub fn set_consensus_choice(&mut self, val: ConsensusChoice) {
+    pub fn set_consensus_choice_for_testing(&mut self, val: ConsensusChoice) {
         self.feature_flags.consensus_choice = val;
     }
 
-    pub fn set_consensus_network(&mut self, val: ConsensusNetwork) {
+    pub fn set_consensus_network_for_testing(&mut self, val: ConsensusNetwork) {
         self.feature_flags.consensus_network = val;
     }
 
-    pub fn set_max_accumulated_txn_cost_per_object_in_checkpoint(&mut self, val: u64) {
-        self.max_accumulated_txn_cost_per_object_in_checkpoint = Some(val);
-    }
-
-    pub fn set_max_deferral_rounds_for_congestion_control(&mut self, val: u64) {
-        self.max_deferral_rounds_for_congestion_control = Some(val);
-    }
-
-    pub fn set_zklogin_max_epoch_upper_bound_delta(&mut self, val: Option<u64>) {
+    pub fn set_zklogin_max_epoch_upper_bound_delta_for_testing(&mut self, val: Option<u64>) {
         self.feature_flags.zklogin_max_epoch_upper_bound_delta = val
     }
     pub fn set_disable_bridge_for_testing(&mut self) {
         self.feature_flags.bridge = false
     }
 
-    pub fn set_mysticeti_leader_scoring_and_schedule(&mut self, val: bool) {
+    pub fn set_mysticeti_leader_scoring_and_schedule_for_testing(&mut self, val: bool) {
         self.feature_flags.mysticeti_leader_scoring_and_schedule = val;
     }
 
-    pub fn set_min_checkpoint_interval_ms(&mut self, val: u64) {
-        self.min_checkpoint_interval_ms = Some(val);
-    }
-
-    pub fn set_mysticeti_num_leaders_per_round(&mut self, val: Option<usize>) {
+    pub fn set_mysticeti_num_leaders_per_round_for_testing(&mut self, val: Option<usize>) {
         self.feature_flags.mysticeti_num_leaders_per_round = val;
     }
 }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -246,7 +246,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
                     ProtocolConfig::get_for_max_version_UNSAFE()
                 };
                 if let Some(enable) = shared_object_deletion {
-                    protocol_config.set_shared_object_deletion(enable);
+                    protocol_config.set_shared_object_deletion_for_testing(enable);
                 }
                 if let Some(mx_tx_gas_override) = max_gas {
                     if simulator {

--- a/narwhal/primary/src/consensus/tests/bullshark_tests.rs
+++ b/narwhal/primary/src/consensus/tests/bullshark_tests.rs
@@ -92,7 +92,7 @@ async fn commit_one_with_leader_schedule_change() {
             description: "When schedule change is enabled, then authority 0 is bad node and swapped with authority 3".to_string(),
             protocol_config: {
                 let mut config: ProtocolConfig = latest_protocol_version();
-                config.set_consensus_bad_nodes_stake_threshold(33);
+                config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
                 config
             },
             rounds: 11,
@@ -237,7 +237,7 @@ async fn not_enough_support_with_leader_schedule_change() {
     certificates.extend(out);
 
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_consensus_bad_nodes_stake_threshold(33);
+    config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let gc_depth = 50;
@@ -357,7 +357,7 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
     certificates.extend(out);
 
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_consensus_bad_nodes_stake_threshold(33);
+    config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let gc_depth = 50;

--- a/narwhal/primary/src/consensus/tests/consensus_tests.rs
+++ b/narwhal/primary/src/consensus/tests/consensus_tests.rs
@@ -45,7 +45,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let committee = fixture.committee();
 
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_consensus_bad_nodes_stake_threshold(33);
+    config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
     // AND make certificates for rounds 1 to 7 (inclusive)
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();

--- a/narwhal/primary/src/consensus/tests/leader_schedule_tests.rs
+++ b/narwhal/primary/src/consensus/tests/leader_schedule_tests.rs
@@ -21,7 +21,7 @@ async fn test_leader_swap_table() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut protocol_config = latest_protocol_version();
-    protocol_config.set_consensus_bad_nodes_stake_threshold(33);
+    protocol_config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
     // the authority ids
     let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
@@ -104,7 +104,7 @@ async fn test_leader_schedule() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let mut protocol_config = latest_protocol_version();
-    protocol_config.set_consensus_bad_nodes_stake_threshold(33);
+    protocol_config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
     // the authority ids
     let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
@@ -205,7 +205,7 @@ async fn test_leader_schedule_from_store() {
 
     // WHEN
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    protocol_config.set_consensus_bad_nodes_stake_threshold(33);
+    protocol_config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
     let schedule = LeaderSchedule::from_store(committee, store, protocol_config);
 
     // THEN the stored schedule should be returned and eventually the low score leader should be

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -458,7 +458,7 @@ async fn fetch_certificates_v1_basic() {
 
     // Send out a batch of certificate V2s.
     let mut cert_v2_config = latest_protocol_version();
-    cert_v2_config.set_narwhal_certificate_v2(true);
+    cert_v2_config.set_narwhal_certificate_v2_for_testing(true);
     let mut certs = Vec::new();
     for cert in certificates.iter().skip(num_written).take(8) {
         certs.push(fixture.certificate(&cert_v2_config, cert.header()));

--- a/narwhal/primary/tests/randomized_tests.rs
+++ b/narwhal/primary/tests/randomized_tests.rs
@@ -110,7 +110,7 @@ async fn bullshark_randomised_tests() {
     ];
 
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_consensus_bad_nodes_stake_threshold(33);
+    config.set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
     let mut test_execution_list = FuturesUnordered::new();
     let (tx, mut rx) = channel(1000);


### PR DESCRIPTION
## Description 

1. For the feature flags, all setters should be named with _for_testing suffix.
2. For non feature flags, there are already testing setters defined through macro, and there is no need to define them separately.

Also found that there are quite a few non-boolean flags in the feature flags, which we should clean up at some point too.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
