### PR TITLE
[move][move-2024][match] Fix mut match bug

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -487,9 +487,10 @@ fn resolve_result(
                 .unfold_to_type_name()
                 .and_then(|sp!(_, name)| name.datatype_name())
                 .unwrap();
+            // Bindings in the arm are always immutable
             let bindings = subject_binders
                 .into_iter()
-                .map(|(mut_, binder)| (binder, (mut_, subject.clone())))
+                .map(|(_mut, binder)| (binder, (Mutability::Imm, subject.clone())))
                 .collect();
 
             let sorted_variants: Vec<VariantName> = context.hlir_context.info.enum_variants(&m, &e);
@@ -530,9 +531,10 @@ fn resolve_result(
                 .unfold_to_type_name()
                 .and_then(|sp!(_, name)| name.datatype_name())
                 .unwrap();
+            // Bindings in the arm are always immutable
             let bindings = subject_binders
                 .into_iter()
-                .map(|(mut_, binder)| (binder, (mut_, subject.clone())))
+                .map(|(_mut, binder)| (binder, (Mutability::Imm, subject.clone())))
                 .collect();
             let unpack_exp = match unpack {
                 StructUnpack::Default(result_ndx) => {
@@ -564,9 +566,10 @@ fn resolve_result(
             Some(sp!(_, BuiltinTypeName_::Bool))
         ) && arms.len() == 2 =>
         {
+            // Bindings in the arm are always immutable
             let bindings = subject_binders
                 .into_iter()
-                .map(|(mut_, binder)| (binder, (mut_, subject.clone())))
+                .map(|(_mut, binder)| (binder, (Mutability::Imm, subject.clone())))
                 .collect();
             // If the literal switch for a boolean is saturated, no default case.
             let lit_subject = make_match_lit(subject.clone());
@@ -595,9 +598,10 @@ fn resolve_result(
             arms: map,
             default,
         } => {
+            // Bindings in the arm are always immutable
             let bindings = subject_binders
                 .into_iter()
-                .map(|(mut_, binder)| (binder, (mut_, subject.clone())))
+                .map(|(_mut, binder)| (binder, (Mutability::Imm, subject.clone())))
                 .collect();
             let lit_subject = make_match_lit(subject.clone());
 
@@ -672,6 +676,11 @@ fn make_guard_exp(
         guard,
         arm,
     } = arm;
+    // Bindings in the guard are always immutable
+    let bindings = bindings
+        .into_iter()
+        .map(|(x, (_mut, entry))| (x, (Mutability::Imm, entry)))
+        .collect();
     let guard_arm = make_arm(context, subject.clone(), arm);
     let body = make_if_else(*guard.unwrap(), guard_arm, cur_exp, result_ty);
     make_copy_bindings(bindings, body)
@@ -1047,7 +1056,6 @@ fn make_match_variant_unpack(
 }
 
 // Performs a struct unpack for the purpose of matching, where we are matching against an imm. ref.
-// Note that unpacking refs is a lie; this is
 fn make_match_struct_unpack(
     mident: ModuleIdent,
     struct_: DatatypeName,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/mut_in_guard.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/mut_in_guard.move
@@ -1,0 +1,23 @@
+module a::m;
+
+public struct SomeStruct has drop {
+    some_field: u64,
+}
+
+public enum SomeEnum has drop {
+    NamedFields{ num1: u64, num2: u64,s: SomeStruct},
+}
+
+ public fun match_variant(s: SomeStruct) {
+    use a::m::SomeEnum as SE;
+    let e = SE::NamedFields { num1: 7, num2: 42, s };
+    match (e) {
+        SE::NamedFields { num1, num2, mut s } if (*num1 < s.some_field) => {
+            s.some_field = num1 + num2;
+        },
+        SE::NamedFields { num1, .. } => if (num1 < 42) {
+            num1;
+        },
+        _ => ()
+    }
+}


### PR DESCRIPTION
## Description 

Fix a bug where mutability was preserved for variables when creating match bindings (not the final arm binders, but the imm. ref binders themselves).

## Test plan 

Test added that demonstrated the issue, and now it works instead.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
