### PR TITLE
[TrafficController] correctly categorize spam

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -971,7 +971,7 @@ fn make_tonic_request_for_testing<T>(message: T) -> tonic::Request<T> {
 
 // TODO: refine error matching here
 fn normalize(err: SuiError) -> Weight {
-    match err {
+    match dbg!(err) {
         SuiError::UserInputError { .. }
         | SuiError::InvalidSignature { .. }
         | SuiError::SignerSignatureAbsent { .. }
@@ -990,14 +990,7 @@ fn normalize(err: SuiError) -> Weight {
 macro_rules! handle_with_decoration {
     ($self:ident, $func_name:ident, $request:ident) => {{
         if $self.client_id_source.is_none() {
-            return match $self.$func_name($request).await {
-                Ok((result, _)) => {
-                    Ok(result)
-                }
-                Err(err) => {
-                    Err(err)
-                }
-            }
+            return $self.$func_name($request).await.map(|(result, _)| result);
         }
 
         let client = match $self.client_id_source.as_ref().unwrap() {

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -330,7 +330,7 @@ async fn handle_error_tally(
     metrics: Arc<TrafficControllerMetrics>,
     mem_drainfile_present: bool,
 ) -> Result<(), reqwest::Error> {
-    if !tally.error_weight.is_sampled().await {
+    if !tally.error_weight.is_sampled() {
         return Ok(());
     }
     let resp = policy.handle_tally(tally.clone());
@@ -364,15 +364,7 @@ async fn handle_spam_tally(
     metrics: Arc<TrafficControllerMetrics>,
     mem_drainfile_present: bool,
 ) -> Result<(), reqwest::Error> {
-    let sampled = futures::future::join_all(vec![
-        tally.spam_weight.is_sampled(),
-        policy_config.spam_sample_rate.is_sampled(),
-    ])
-    .await
-    .into_iter()
-    .all(|sampled| sampled);
-
-    if !sampled {
+    if !(tally.spam_weight.is_sampled() && policy_config.spam_sample_rate.is_sampled()) {
         return Ok(());
     }
     let resp = policy.handle_tally(tally.clone());

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -364,7 +364,7 @@ async fn handle_spam_tally(
     metrics: Arc<TrafficControllerMetrics>,
     mem_drainfile_present: bool,
 ) -> Result<(), reqwest::Error> {
-    if !policy_config.spam_sample_rate.is_sampled().await {
+    if tally.tally_spam && !policy_config.spam_sample_rate.is_sampled().await {
         return Ok(());
     }
     let resp = policy.handle_tally(tally.clone());
@@ -651,6 +651,7 @@ impl TrafficSim {
                     None,
                     // TODO add weight adjustment
                     Weight::one(),
+                    true,
                 ));
             } else {
                 if !currently_blocked {

--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -137,6 +137,7 @@ pub struct TrafficTally {
     pub direct: Option<IpAddr>,
     pub through_fullnode: Option<IpAddr>,
     pub error_weight: Weight,
+    pub tally_spam: bool,
     pub timestamp: SystemTime,
 }
 
@@ -145,11 +146,13 @@ impl TrafficTally {
         direct: Option<IpAddr>,
         through_fullnode: Option<IpAddr>,
         error_weight: Weight,
+        tally_spam: bool,
     ) -> Self {
         Self {
             direct,
             through_fullnode,
             error_weight,
+            tally_spam,
             timestamp: SystemTime::now(),
         }
     }
@@ -418,18 +421,21 @@ mod tests {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
             through_fullnode: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
             error_weight: Weight::zero(),
+            tally_spam: true,
             timestamp: SystemTime::now(),
         };
         let bob = TrafficTally {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
             through_fullnode: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
             error_weight: Weight::zero(),
+            tally_spam: true,
             timestamp: SystemTime::now(),
         };
         let charlie = TrafficTally {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
             through_fullnode: Some(IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8))),
             error_weight: Weight::zero(),
+            tally_spam: true,
             timestamp: SystemTime::now(),
         };
 

--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -137,7 +137,7 @@ pub struct TrafficTally {
     pub direct: Option<IpAddr>,
     pub through_fullnode: Option<IpAddr>,
     pub error_weight: Weight,
-    pub tally_spam: bool,
+    pub spam_weight: Weight,
     pub timestamp: SystemTime,
 }
 
@@ -146,13 +146,13 @@ impl TrafficTally {
         direct: Option<IpAddr>,
         through_fullnode: Option<IpAddr>,
         error_weight: Weight,
-        tally_spam: bool,
+        spam_weight: Weight,
     ) -> Self {
         Self {
             direct,
             through_fullnode,
             error_weight,
-            tally_spam,
+            spam_weight,
             timestamp: SystemTime::now(),
         }
     }
@@ -421,21 +421,21 @@ mod tests {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
             through_fullnode: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
             error_weight: Weight::zero(),
-            tally_spam: true,
+            spam_weight: Weight::one(),
             timestamp: SystemTime::now(),
         };
         let bob = TrafficTally {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
             through_fullnode: Some(IpAddr::V4(Ipv4Addr::new(4, 3, 2, 1))),
             error_weight: Weight::zero(),
-            tally_spam: true,
+            spam_weight: Weight::one(),
             timestamp: SystemTime::now(),
         };
         let charlie = TrafficTally {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
             through_fullnode: Some(IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8))),
             error_weight: Weight::zero(),
-            tally_spam: true,
+            spam_weight: Weight::one(),
             timestamp: SystemTime::now(),
         };
 

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -4,12 +4,15 @@
 //! NB: Most tests in this module expect real network connections and interactions, thus
 //! they should nearly all be tokio::test rather than simtest.
 
+use core::panic;
 use jsonrpsee::{
     core::{client::ClientT, RpcResult},
     rpc_params,
 };
 use std::fs::File;
 use std::time::Duration;
+use sui_core::authority_client::make_network_authority_clients_with_network_config;
+use sui_core::authority_client::AuthorityAPI;
 use sui_core::traffic_controller::{
     nodefw_test_server::NodeFwTestServer, TrafficController, TrafficSim,
 };
@@ -17,6 +20,7 @@ use sui_json_rpc_types::{
     SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_macros::sim_test;
+use sui_network::default_mysten_network_config;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
 use sui_types::{
@@ -157,11 +161,11 @@ async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
         .build()
         .await;
 
-    let context = &mut test_cluster.wallet;
+    let context = test_cluster.wallet;
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
-    let mut txns = batch_make_transfer_transactions(context, txn_count).await;
+    let mut txns = batch_make_transfer_transactions(&context, txn_count as usize).await;
     assert!(
-        txns.len() >= txn_count,
+        txns.len() >= txn_count as usize,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",
         txn_count,
     );
@@ -202,24 +206,47 @@ async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-async fn test_validator_traffic_control_spam_blocked() -> Result<(), anyhow::Error> {
+async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Error> {
     let n = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         // Test that any N requests will cause an IP to be added to the blocklist.
-        spam_policy_type: PolicyType::TestNConnIP(n - 1),
-        spam_sample_rate: Weight::one(),
+        error_policy_type: PolicyType::TestNConnIP(n - 1),
         dry_run: false,
         ..Default::default()
     };
     let network_config = ConfigBuilder::new_with_temp_dir()
         .with_policy_config(Some(policy_config))
         .build();
-    let test_cluster = TestClusterBuilder::new()
+    let committee = network_config.committee_with_network();
+    let _test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
         .build()
         .await;
-    assert_validator_traffic_control_spam_blocked(test_cluster, n as usize).await
+    let local_clients = make_network_authority_clients_with_network_config(
+        &committee,
+        &default_mysten_network_config(),
+    )
+    .unwrap();
+    let (_, auth_client) = local_clients.first_key_value().unwrap();
+
+    // transaction signed using user wallet from a different chain/genesis,
+    // therefore we should fail with UserInputError
+    let other_cluster = TestClusterBuilder::new().build().await;
+
+    let mut txns = batch_make_transfer_transactions(&other_cluster.wallet, n as usize).await;
+    let tx = txns.swap_remove(0);
+
+    // it should take no more than 4 requests to be added to the blocklist
+    for _ in 0..n {
+        let response = auth_client.handle_transaction(tx.clone(), None).await;
+        if let Err(err) = response {
+            if err.to_string().contains("Too many requests") {
+                return Ok(());
+            }
+        }
+    }
+    panic!("Expected spam policy to trigger within {n} requests");
 }
 
 #[tokio::test]
@@ -238,12 +265,12 @@ async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Erro
         .build()
         .await;
 
-    let context = &mut test_cluster.wallet;
+    let context = test_cluster.wallet;
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 
-    let mut txns = batch_make_transfer_transactions(context, txn_count).await;
+    let mut txns = batch_make_transfer_transactions(&context, txn_count as usize).await;
     assert!(
-        txns.len() >= txn_count,
+        txns.len() >= txn_count as usize,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",
         txn_count,
     );
@@ -291,15 +318,14 @@ async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Erro
 }
 
 #[tokio::test]
-async fn test_validator_traffic_control_spam_delegated() -> Result<(), anyhow::Error> {
-    let n = 4;
+async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::Error> {
+    let n = 5;
     let port = 65000;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 120,
         proxy_blocklist_ttl_sec: 120,
         // Test that any N - 1 requests will cause an IP to be added to the blocklist.
-        spam_policy_type: PolicyType::TestNConnIP(n - 1),
-        spam_sample_rate: Weight::one(),
+        error_policy_type: PolicyType::TestNConnIP(n - 1),
         dry_run: false,
         ..Default::default()
     };
@@ -316,11 +342,47 @@ async fn test_validator_traffic_control_spam_delegated() -> Result<(), anyhow::E
         .with_policy_config(Some(policy_config))
         .with_firewall_config(Some(firewall_config))
         .build();
-    let test_cluster = TestClusterBuilder::new()
+    let committee = network_config.committee_with_network();
+    let _test_cluster = TestClusterBuilder::new()
         .set_network_config(network_config)
         .build()
         .await;
-    assert_validator_traffic_control_spam_delegated(test_cluster, n as usize, port).await
+    let local_clients = make_network_authority_clients_with_network_config(
+        &committee,
+        &default_mysten_network_config(),
+    )
+    .unwrap();
+    let (_, auth_client) = local_clients.first_key_value().unwrap();
+
+    // transaction signed using user wallet from a different chain/genesis,
+    // therefore we should fail with UserInputError
+    let other_cluster = TestClusterBuilder::new().build().await;
+
+    let mut txns = batch_make_transfer_transactions(&other_cluster.wallet, n as usize).await;
+    let tx = txns.swap_remove(0);
+
+    // start test firewall server
+    let mut server = NodeFwTestServer::new();
+    server.start(port).await;
+    // await for the server to start
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+    // it should take no more than 4 requests to be added to the blocklist
+    for _ in 0..n {
+        let response = auth_client.handle_transaction(tx.clone(), None).await;
+        if let Err(err) = response {
+            if err.to_string().contains("Too many requests") {
+                return Ok(());
+            }
+        }
+    }
+    let fw_blocklist = server.list_addresses_rpc().await;
+    assert!(
+        !fw_blocklist.is_empty(),
+        "Expected blocklist to be non-empty"
+    );
+    server.stop().await;
+    Ok(())
 }
 
 #[tokio::test]
@@ -353,14 +415,14 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
 
     // start test firewall server
     let mut server = NodeFwTestServer::new();
-    server.start(listen_port).await;
+    server.start(port).await;
     // await for the server to start
     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-    let context = &mut test_cluster.wallet;
+    let context = test_cluster.wallet;
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
-    let mut txns = batch_make_transfer_transactions(context, txn_count).await;
+    let mut txns = batch_make_transfer_transactions(&context, txn_count as usize).await;
     assert!(
-        txns.len() >= txn_count,
+        txns.len() >= txn_count as usize,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",
         txn_count,
     );
@@ -698,118 +760,5 @@ async fn assert_validator_traffic_control_dry_run(
             "Expected request to succeed in dry-run mode"
         );
     }
-    Ok(())
-}
-
-async fn assert_validator_traffic_control_spam_blocked(
-    mut test_cluster: TestCluster,
-    txn_count: usize,
-) -> Result<(), anyhow::Error> {
-    let context = &mut test_cluster.wallet;
-    let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
-
-    let mut txns = batch_make_transfer_transactions(context, txn_count).await;
-    assert!(
-        txns.len() >= txn_count,
-        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
-        txn_count,
-    );
-
-    let txn = txns.swap_remove(0);
-    let tx_digest = txn.digest();
-    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
-    let params = rpc_params![
-        tx_bytes,
-        signatures,
-        SuiTransactionBlockResponseOptions::new(),
-        ExecuteTransactionRequestType::WaitForLocalExecution
-    ];
-
-    let response: SuiTransactionBlockResponse = jsonrpc_client
-        .request("sui_executeTransactionBlock", params.clone())
-        .await
-        .unwrap();
-    let SuiTransactionBlockResponse {
-        digest,
-        confirmed_local_execution,
-        ..
-    } = response;
-    assert_eq!(&digest, tx_digest);
-    assert!(confirmed_local_execution.unwrap());
-
-    // it should take no more than 4 requests to be added to the blocklist
-    for _ in 0..txn_count {
-        let response: RpcResult<SuiTransactionBlockResponse> = jsonrpc_client
-            .request("sui_getTransactionBlock", rpc_params![*tx_digest])
-            .await;
-        if let Err(err) = response {
-            // TODO: fix validator blocking error handling such that the error message
-            // is not misleading. The full error message currently is the following:
-            //  Transaction execution failed due to issues with transaction inputs, please
-            //  review the errors and try again: Too many requests.
-            assert!(
-                err.to_string().contains("Too many requests"),
-                "Error not due to spam policy"
-            );
-            return Ok(());
-        }
-    }
-    panic!("Expected spam policy to trigger within {txn_count} requests");
-}
-
-async fn assert_validator_traffic_control_spam_delegated(
-    mut test_cluster: TestCluster,
-    txn_count: usize,
-    listen_port: u16,
-) -> Result<(), anyhow::Error> {
-    // start test firewall server
-    let mut server = NodeFwTestServer::new();
-    server.start(listen_port).await;
-    // await for the server to start
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-    let context = &mut test_cluster.wallet;
-    let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
-    let mut txns = batch_make_transfer_transactions(context, txn_count).await;
-    assert!(
-        txns.len() >= txn_count,
-        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
-        txn_count,
-    );
-
-    let txn = txns.swap_remove(0);
-    let tx_digest = txn.digest();
-    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
-    let params = rpc_params![
-        tx_bytes,
-        signatures,
-        SuiTransactionBlockResponseOptions::new(),
-        ExecuteTransactionRequestType::WaitForLocalExecution
-    ];
-
-    // it should take no more than 4 requests to be added to the blocklist
-    let response: SuiTransactionBlockResponse = jsonrpc_client
-        .request("sui_executeTransactionBlock", params.clone())
-        .await
-        .unwrap();
-    let SuiTransactionBlockResponse {
-        digest,
-        confirmed_local_execution,
-        ..
-    } = response;
-    assert_eq!(&digest, tx_digest);
-    assert!(confirmed_local_execution.unwrap());
-
-    for _ in 0..txn_count {
-        let response: RpcResult<SuiTransactionBlockResponse> = jsonrpc_client
-            .request("sui_getTransactionBlock", rpc_params![*tx_digest])
-            .await;
-        assert!(response.is_ok(), "Expected request to succeed");
-    }
-    let fw_blocklist = server.list_addresses_rpc().await;
-    assert!(
-        !fw_blocklist.is_empty(),
-        "Expected blocklist to be non-empty"
-    );
-    server.stop().await;
     Ok(())
 }

--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -165,13 +165,14 @@ async fn process_raw_request<L: Logger>(
                 return blocked_response;
             }
         }
-        let tally_spam = tally_spam_for_method(&request.method);
-        let response = process_request(request, api_version, service.call_data()).await;
 
         // handle response tallying
+        let method = request.method.to_string();
+        let response = process_request(request, api_version, service.call_data()).await;
         if let Some(traffic_controller) = &service.traffic_controller {
-            handle_traffic_resp(traffic_controller.clone(), client, &response, tally_spam);
+            handle_traffic_resp(traffic_controller.clone(), client, &response, method);
         }
+
         response
     } else if let Ok(_batch) = serde_json::from_str::<Vec<&RawValue>>(raw_request) {
         MethodResponse::error(
@@ -198,12 +199,12 @@ async fn handle_traffic_req(
     }
 }
 
-fn tally_spam_for_method(method: &str) -> bool {
+fn spam_weight_for_method(method: String) -> Weight {
     // unless request requires gas payment, count against
     // spam tally
-    match method {
-        "sui_executeTransactionBlock" | "sui_devInspectTransactionBlock" => false,
-        _ => true,
+    match method.as_str() {
+        "sui_executeTransactionBlock" | "sui_devInspectTransactionBlock" => Weight::zero(),
+        _ => Weight::one(),
     }
 }
 
@@ -211,14 +212,14 @@ fn handle_traffic_resp(
     traffic_controller: Arc<TrafficController>,
     client: Option<IpAddr>,
     response: &MethodResponse,
-    tally_spam: bool,
+    method: String,
 ) {
     let error = response.error_code.map(ErrorCode::from);
     traffic_controller.tally(TrafficTally {
         direct: client,
         through_fullnode: None,
         error_weight: error.map(normalize).unwrap_or(Weight::zero()),
-        tally_spam,
+        spam_weight: spam_weight_for_method(method),
         timestamp: SystemTime::now(),
     });
 }

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -53,7 +53,7 @@ impl Weight {
         self.0
     }
 
-    pub async fn is_sampled(&self) -> bool {
+    pub fn is_sampled(&self) -> bool {
         let mut rng = rand::thread_rng();
         let sample = rand::distributions::Uniform::new(0.0, 1.0).sample(&mut rng);
         sample <= self.value()
@@ -201,6 +201,11 @@ pub struct PolicyConfig {
     #[serde(default = "default_channel_capacity")]
     pub channel_capacity: usize,
     #[serde(default = "default_spam_sample_rate")]
+    /// Note that this sample policy is applied on top of the
+    /// endpoint-specific sample policy (not configurable) which
+    /// weighs endpoints by the relative effort required to serve
+    /// them. Therefore a sample rate of N will yield an actual
+    /// sample rate <= N.
     pub spam_sample_rate: Weight,
     #[serde(default = "default_dry_run")]
     pub dry_run: bool,

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -23,6 +23,7 @@ use sui_bridge::types::CertifiedBridgeAction;
 use sui_bridge::types::VerifiedCertifiedBridgeAction;
 use sui_bridge::utils::publish_and_register_coins_return_add_coins_on_sui_action;
 use sui_bridge::utils::wait_for_server_to_be_up;
+use sui_config::genesis::Genesis;
 use sui_config::local_ip_utils::get_available_port;
 use sui_config::node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange};
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
@@ -208,6 +209,10 @@ impl TestCluster {
 
     pub fn get_validator_pubkeys(&self) -> Vec<AuthorityName> {
         self.swarm.active_validators().map(|v| v.name()).collect()
+    }
+
+    pub fn get_genesis(&self) -> Genesis {
+        self.swarm.config().genesis.clone()
     }
 
     pub fn stop_node(&self, name: &AuthorityName) {


### PR DESCRIPTION
## Description 

This PR redefines spam in the context of traffic controller as any request type that does not consume gas. There are two such categories that have bee considered so far - read api requests and transaction execution requests that do not invoke the vm (which, to my knowledge, should only happen on submitting a certificate for an already executed transaction, at which point all validators simply read and return the effects). Both cases are hadled here.

## Test plan 

Fixed existing tests to exercise the new logic

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
