### PR TITLE
[move][transactional tests] Add advance-epoch support

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/epoch/advance.exp
+++ b/crates/sui-adapter-transactional-tests/tests/epoch/advance.exp
@@ -1,0 +1,15 @@
+processed 4 tasks
+
+task 1 'publish'. lines 6-24:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5684800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 26-26:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2257200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 28-28:
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::check (function index 1) at offset 11, Abort Code: 0
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 11, function_name: Some("check") }, 0) at command Some(0)

--- a/crates/sui-adapter-transactional-tests/tests/epoch/advance.exp
+++ b/crates/sui-adapter-transactional-tests/tests/epoch/advance.exp
@@ -1,9 +1,9 @@
-processed 4 tasks
+processed 6 tasks
 
 task 1 'publish'. lines 6-24:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5684800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5639200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 26-26:
 created: object(2,0)
@@ -11,5 +11,12 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2257200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'run'. lines 28-28:
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::check (function index 1) at offset 11, Abort Code: 0
-Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 11, function_name: Some("check") }, 0) at command Some(0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2257200,  storage_rebate: 2234628, non_refundable_storage_fee: 22572
+
+task 4 'advance-epoch'. lines 30-30:
+Epoch advanced: 1
+
+task 5 'run'. lines 32-32:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2257200,  storage_rebate: 2234628, non_refundable_storage_fee: 22572

--- a/crates/sui-adapter-transactional-tests/tests/epoch/advance.move
+++ b/crates/sui-adapter-transactional-tests/tests/epoch/advance.move
@@ -18,15 +18,15 @@ module test::m {
         })
     }
 
-    public fun check(s: &S, ctx: &TxContext) {
-        assert!(s.value == ctx.epoch() + 1, 0);
+    public fun check(s: &S, epoch_diff: u64, ctx: &TxContext) {
+        assert!(s.value + epoch_diff == ctx.epoch());
     }
 }
 
 //# run test::m::create
 
-//# run test::m::check --args object(2,0)
+//# run test::m::check --args object(2,0) 0
 
 //# advance-epoch
 
-//# run test::m::check --args object(2,0)
+//# run test::m::check --args object(2,0) 1

--- a/crates/sui-adapter-transactional-tests/tests/epoch/advance.move
+++ b/crates/sui-adapter-transactional-tests/tests/epoch/advance.move
@@ -28,3 +28,5 @@ module test::m {
 //# run test::m::check --args object(2,0)
 
 //# advance-epoch
+
+//# run test::m::check --args object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/epoch/advance.move
+++ b/crates/sui-adapter-transactional-tests/tests/epoch/advance.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0
+
+//# publish
+
+module test::m {
+    public struct S has key, store {
+        id: UID,
+        value: u64
+    }
+
+    public fun create(ctx: &mut TxContext) {
+        transfer::public_share_object(S {
+            id: object::new(ctx),
+            value: ctx.epoch(),
+        })
+    }
+
+    public fun check(s: &S, ctx: &TxContext) {
+        assert!(s.value == ctx.epoch() + 1, 0);
+    }
+}
+
+//# run test::m::create
+
+//# run test::m::check --args object(2,0)
+
+//# advance-epoch

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -217,7 +217,9 @@ impl TransactionalAdapter for ValidatorWithFullnode {
     }
 
     async fn advance_epoch(&mut self, _create_random_state: bool) -> anyhow::Result<()> {
-        unimplemented!("advance_epoch not supported")
+        self.validator.reconfigure_for_testing().await;
+        // self.fullnode.reconfigure_for_testing().await;
+        Ok(())
     }
 
     async fn request_gas(

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -24,6 +24,7 @@ use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 use sui_types::base_types::VersionNumber;
+use sui_types::committee::EpochId;
 use sui_types::digests::TransactionDigest;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::effects::TransactionEffects;
@@ -218,7 +219,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
 
     async fn advance_epoch(&mut self, _create_random_state: bool) -> anyhow::Result<()> {
         self.validator.reconfigure_for_testing().await;
-        // self.fullnode.reconfigure_for_testing().await;
+        self.fullnode.reconfigure_for_testing().await;
         Ok(())
     }
 
@@ -254,6 +255,10 @@ impl ReadStore for ValidatorWithFullnode {
         _epoch: sui_types::committee::EpochId,
     ) -> sui_types::storage::error::Result<Option<Arc<sui_types::committee::Committee>>> {
         todo!()
+    }
+
+    fn get_latest_epoch_id(&self) -> sui_types::storage::error::Result<EpochId> {
+        Ok(self.validator.epoch_store_for_testing().epoch())
     }
 
     fn get_latest_checkpoint(&self) -> sui_types::storage::error::Result<VerifiedCheckpoint> {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -62,6 +62,7 @@ use sui_storage::{
 };
 use sui_swarm_config::genesis_config::AccountConfig;
 use sui_types::base_types::{SequenceNumber, VersionNumber};
+use sui_types::committee::EpochId;
 use sui_types::crypto::{get_authority_key_pair, RandomnessRound};
 use sui_types::digests::{ConsensusCommitDigest, TransactionDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
@@ -2257,6 +2258,10 @@ impl ObjectStore for SuiTestAdapter {
 }
 
 impl ReadStore for SuiTestAdapter {
+    fn get_latest_epoch_id(&self) -> sui_types::storage::error::Result<EpochId> {
+        self.executor.get_latest_epoch_id()
+    }
+
     fn get_committee(
         &self,
         epoch: sui_types::committee::EpochId,


### PR DESCRIPTION
## Description 

- Added advance epoch support to normal sui-adapter-transactional-tests

## Test plan 

- added a test 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
