### PR TITLE
split-cluster-check - Verify that DKG completes if enabled

### DIFF
--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -478,10 +478,12 @@ impl RandomnessManager {
             // DKG already started (or completed or failed).
             return Ok(());
         }
+
         let _ = self.dkg_start_time.set(Instant::now());
 
         let epoch_store = self.epoch_store()?;
         let dkg_version = epoch_store.protocol_config().dkg_version();
+        info!("random beacon: starting DKG, version {dkg_version}");
 
         let msg = match VersionedDkgMessage::create(dkg_version, self.party.clone()) {
             Ok(msg) => msg,

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -99,10 +99,18 @@ if ! grep -q "Node State has been reconfigured" "$LOG_DIR/fullnode.log"; then
 fi
 
 # ensure that the random beacon's DKG completes on both versions.
-if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log" || ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
-  echo "Could not find 'random beacon: DKG complete' in either node-0 or node-2"
+# "random beacon: created" indicates that the random beacon is enabled and started.
+if grep -q "random beacon: created" "$LOG_DIR/node-0.log" && ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log"; then
+  echo "Could not find 'random beacon: DKG complete' in node-0"
   exit 1
 fi
+
+if grep -q "random beacon: created" "$LOG_DIR/node-2.log" && ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
+  echo "Could not find 'random beacon: DKG complete' in node-2"
+  exit 1
+fi
+
+
 
 echo "Cluster reconfigured successfully"
 

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -98,6 +98,12 @@ if ! grep -q "Node State has been reconfigured" "$LOG_DIR/fullnode.log"; then
   exit 1
 fi
 
+# ensure that the random beacon's DKG completes on both versions.
+if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log" || ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
+  echo "Could not find 'random beacon: DKG complete' in either node-0 or node-2"
+  exit 1
+fi
+
 echo "Cluster reconfigured successfully"
 
 exit 0


### PR DESCRIPTION
## Description 

Verify that DKG completes after the reconf in split-cluster-check.
Also add a more concrete log for 'DKG start' event, to be used in the future in the above verification.

## Test plan 

manually tested

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
