### PR TITLE
[GraphQL] `generate-config` sub-command

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -13,6 +13,13 @@ use std::path::PathBuf;
     version
 )]
 pub enum Command {
+    /// Output a TOML config (suitable for passing into the --config parameter of the start-server
+    /// command) with all values set to their defaults.
+    GenerateConfig {
+        /// Optional path to a file to output to. Prints to stdout if none is provided.
+        output: Option<PathBuf>
+    },
+
     StartServer {
         /// The title to display at the top of the page
         #[clap(short, long)]

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -37,6 +37,19 @@ static VERSION: Version = Version {
 async fn main() {
     let cmd: Command = Command::parse();
     match cmd {
+        Command::GenerateConfig { output } => {
+            let config = ServiceConfig::default();
+            let toml = toml::to_string_pretty(&config).expect("Failed to serialize configuration");
+
+            if let Some(path) = output {
+                fs::write(&path, toml).unwrap_or_else(|e| {
+                    panic!("Failed to write configuration to {}: {e}", path.display())
+                });
+            } else {
+                println!("{}", toml);
+            }
+        }
+
         Command::StartServer {
             ide_title,
             db_url,

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -31,7 +31,7 @@ pub async fn start_graphiql_server(
     version: &Version,
     cancellation_token: CancellationToken,
 ) -> Result<(), Error> {
-    info!("Starting server with config: {:?}", server_config);
+    info!("Starting server with config: {:#?}", server_config);
     info!("Server version: {}", version);
     start_graphiql_server_impl(
         ServerBuilder::from_config(server_config, version, cancellation_token).await?,


### PR DESCRIPTION
## Description

Add a command for generating a config TOML file for the GraphQL service with all its parameters set to their default values. (We used to have a similar command for the YAML file which we weren't using, but we still use the TOML file).

## Test plan

```
cargo run --bin sui-graphql-rpc -- generate-config /tmp/config.toml
```

## Stack

- #17543
- #17692 
- #17693 
- #17696 
- #18287 
- #18288 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: New sub-command for `sui-graphql-rpc`, `generate-config` for creating a TOML config with all default values set.
- [ ] CLI: 
- [ ] Rust SDK: 
