### PR TITLE
Fix empty result set in wallet monitoring service

### DIFF
--- a/crates/sui-security-watchdog/src/query_runner.rs
+++ b/crates/sui-security-watchdog/src/query_runner.rs
@@ -214,7 +214,8 @@ impl QueryRunner for SnowflakeQueryRunner {
         let res = self.make_snowflake_api()?.exec(query).await?;
         match res {
             QueryResult::Arrow(records) => self.parse_record_batches(records),
-            // Handle other result types (Json, Empty) with a unified error message
+            QueryResult::Empty => Ok(Vec::new()),
+            // Handle other result types Json with a unified error message
             _ => Err(anyhow!("Unexpected query result type")),
         }
     }


### PR DESCRIPTION
## Description 

Handle empty result set. Ran locally, works
