### PR TITLE
[suiop][image] add list and get current status endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14402,7 +14402,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.2.3"
+version = "0.2.4"
 
 [lib]
 name = "suioplib"


### PR DESCRIPTION
## Description 

Adding two endpoints for improving image building process visibility:
1. list: show all the images in the AR
2. status: check whether the image is built and stored in AR, if not in AR, show real-time status of the building process

## Test plan 
list
<img width="469" alt="image" src="https://github.com/MystenLabs/sui/assets/147538877/651a1e1c-b4fa-4b99-b343-8a9d1e1e2652">

status
```
suiop ci image status --repo-name infra-metadata-service --image-name go-executor
Requested status for repo: infra-metadata-service, image: go-executor, ref: branch:main
Image Status: Found
Image SHA: 1d01c74ca5cfb3c7103
```

```
suiop ci image status --repo-name infra-metadata-service --image-name go-executor --ref-type=commit --ref-val=123
Requested status for repo: infra-metadata-service, image: go-executor, ref: commit:123
Image Status: Not built and image not found
Image SHA: 123
```
How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
