### PR TITLE
[pick #18347][GraphQL] Fix bug where config types "zero out" fields not in TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12261,6 +12261,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-graphql-config"
+version = "1.18.0"
+dependencies = [
+ "quote 1.0.35",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "sui-graphql-e2e-tests"
 version = "0.1.0"
 dependencies = [
@@ -12320,6 +12328,7 @@ dependencies = [
  "similar",
  "simulacrum",
  "sui-framework",
+ "sui-graphql-config",
  "sui-graphql-rpc-client",
  "sui-graphql-rpc-headers",
  "sui-indexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
   "crates/sui-framework-snapshot",
   "crates/sui-framework-tests",
   "crates/sui-genesis-builder",
+  "crates/sui-graphql-config",
   "crates/sui-graphql-e2e-tests",
   "crates/sui-graphql-rpc",
   "crates/sui-graphql-rpc-client",
@@ -581,6 +582,7 @@ sui-faucet = { path = "crates/sui-faucet" }
 sui-framework = { path = "crates/sui-framework" }
 sui-framework-snapshot = { path = "crates/sui-framework-snapshot" }
 sui-framework-tests = { path = "crates/sui-framework-tests" }
+sui-graphql-config = { path = "crates/sui-graphql-config" }
 sui-graphql-rpc = { path = "crates/sui-graphql-rpc" }
 sui-graphql-rpc-client = { path = "crates/sui-graphql-rpc-client" }
 sui-graphql-rpc-headers = { path = "crates/sui-graphql-rpc-headers" }

--- a/crates/sui-graphql-config/Cargo.toml
+++ b/crates/sui-graphql-config/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sui-graphql-config"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote.workspace = true
+syn.workspace = true

--- a/crates/sui-graphql-config/src/lib.rs
+++ b/crates/sui-graphql-config/src/lib.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    parse_macro_input, Attribute, Data, DataStruct, DeriveInput, Fields, FieldsNamed, Ident, Meta,
+    NestedMeta,
+};
+
+/// Attribute macro to be applied to config-based structs. It ensures that the struct derives serde
+/// traits, and `Debug`, that all fields are renamed with "kebab case", and adds a `#[serde(default
+/// = ...)]` implementation for each field that ensures that if the field is not present during
+/// deserialization, it is replaced with its default value, from the `Default` implementation for
+/// the config struct.
+#[allow(non_snake_case)]
+#[proc_macro_attribute]
+pub fn GraphQLConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let DeriveInput {
+        attrs,
+        vis,
+        ident,
+        generics,
+        data,
+    } = parse_macro_input!(input as DeriveInput);
+
+    let Data::Struct(DataStruct {
+        struct_token,
+        fields,
+        semi_token,
+    }) = data
+    else {
+        panic!("GraphQL configs must be structs.");
+    };
+
+    let Fields::Named(FieldsNamed {
+        brace_token: _,
+        named,
+    }) = fields
+    else {
+        panic!("GraphQL configs must have named fields.");
+    };
+
+    // Figure out which derives need to be added to meet the criteria of a config struct.
+    let core_derives = core_derives(&attrs);
+
+    // Extract field names once to avoid having to check for their existence multiple times.
+    let fields_with_names: Vec<_> = named
+        .iter()
+        .map(|field| {
+            let Some(ident) = &field.ident else {
+                panic!("All fields must have an identifier.");
+            };
+
+            (ident, field)
+        })
+        .collect();
+
+    // Generate the fields with the `#[serde(default = ...)]` attribute.
+    let fields = fields_with_names.iter().map(|(name, field)| {
+        let default = format!("{ident}::__default_{name}");
+        quote! { #[serde(default = #default)] #field }
+    });
+
+    // Generate the default implementations for each field.
+    let defaults = fields_with_names.iter().map(|(name, field)| {
+        let ty = &field.ty;
+        let fn_name = format_ident!("__default_{}", name);
+        let cfg = extract_cfg(&field.attrs);
+
+        quote! {
+            #[doc(hidden)] #cfg
+            fn #fn_name() -> #ty {
+                Self::default().#name
+            }
+        }
+    });
+
+    TokenStream::from(quote! {
+        #[derive(#(#core_derives),*)]
+        #[serde(rename_all = "kebab-case")]
+        #(#attrs)* #vis #struct_token #ident #generics {
+            #(#fields),*
+        } #semi_token
+
+        impl #ident {
+            #(#defaults)*
+        }
+    })
+}
+
+/// Return a set of derives that should be added to the struct to make sure it derives all the
+/// things we expect from a config, namely `Serialize`, `Deserialize`, and `Debug`.
+///
+/// We cannot add core derives unconditionally, because they will conflict with existing ones.
+fn core_derives(attrs: &[Attribute]) -> BTreeSet<Ident> {
+    let mut derives = BTreeSet::from_iter([
+        format_ident!("Serialize"),
+        format_ident!("Deserialize"),
+        format_ident!("Debug"),
+        format_ident!("Clone"),
+        format_ident!("Eq"),
+        format_ident!("PartialEq"),
+    ]);
+
+    for attr in attrs {
+        let Ok(Meta::List(list)) = attr.parse_meta() else {
+            continue;
+        };
+
+        let Some(ident) = list.path.get_ident() else {
+            continue;
+        };
+
+        if ident != "derive" {
+            continue;
+        }
+
+        for nested in list.nested {
+            let NestedMeta::Meta(Meta::Path(path)) = nested else {
+                continue;
+            };
+
+            let Some(ident) = path.get_ident() else {
+                continue;
+            };
+
+            derives.remove(ident);
+        }
+    }
+
+    derives
+}
+
+/// Find the attribute that corresponds to a `#[cfg(...)]` annotation, if it exists.
+fn extract_cfg(attrs: &[Attribute]) -> Option<&Attribute> {
+    attrs.iter().find(|attr| {
+        let meta = attr.parse_meta().ok();
+        meta.is_some_and(|m| m.path().is_ident("cfg"))
+    })
+}

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -60,6 +60,7 @@ thiserror.workspace = true
 uuid.workspace = true
 im.workspace = true
 
+sui-graphql-config.workspace = true
 sui-graphql-rpc-headers.workspace = true
 sui-graphql-rpc-client.workspace = true
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::{DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
     types::{address::Address, sui_address::SuiAddress, validator::Validator},
 };
@@ -29,14 +28,6 @@ impl PgManager {
     }
 
     /// Create a new underlying reader, which is used by this type as well as other data providers.
-    pub(crate) fn reader(db_url: impl Into<String>) -> Result<IndexerReader, Error> {
-        Self::reader_with_config(
-            db_url,
-            DEFAULT_SERVER_DB_POOL_SIZE,
-            DEFAULT_REQUEST_TIMEOUT_MS,
-        )
-    }
-
     pub(crate) fn reader_with_config(
         db_url: impl Into<String>,
         pool_size: u32,

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -183,7 +183,7 @@ mod query_cost {
 #[cfg(all(test, feature = "pg_integration"))]
 mod tests {
     use super::*;
-    use crate::config::DEFAULT_SERVER_DB_URL;
+    use crate::config::ConnectionConfig;
     use diesel::QueryDsl;
     use sui_framework::BuiltInFramework;
     use sui_indexer::{
@@ -193,7 +193,8 @@ mod tests {
 
     #[test]
     fn test_query_cost() {
-        let pool = new_pg_connection_pool_impl(DEFAULT_SERVER_DB_URL, Some(5)).unwrap();
+        let connection_config = ConnectionConfig::default();
+        let pool = new_pg_connection_pool_impl(&connection_config.db_url, Some(5)).unwrap();
         let mut conn = get_pg_pool_connection(&pool).unwrap();
         reset_database(&mut conn, /* drop_all */ true, /* use_v2 */ true).unwrap();
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -385,7 +385,11 @@ impl ServerBuilder {
         .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
 
         // DB
-        let db = Db::new(reader.clone(), config.service.limits, metrics.clone());
+        let db = Db::new(
+            reader.clone(),
+            config.service.limits.clone(),
+            metrics.clone(),
+        );
         let loader = DataLoader::new(db.clone());
         let pg_conn_pool = PgManager::new(reader.clone());
         let package_store = DbPackageStore::new(loader.clone());
@@ -595,15 +599,23 @@ pub mod tests {
         connection_config: Option<ConnectionConfig>,
         service_config: Option<ServiceConfig>,
     ) -> ServerBuilder {
-        let connection_config =
-            connection_config.unwrap_or_else(ConnectionConfig::ci_integration_test_cfg);
+        let connection_config = connection_config.unwrap_or_default();
         let service_config = service_config.unwrap_or_default();
 
-        let db_url: String = connection_config.db_url.clone();
-        let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
+        let reader = PgManager::reader_with_config(
+            connection_config.db_url.clone(),
+            connection_config.db_pool_size,
+            service_config.limits.request_timeout_ms,
+        )
+        .expect("Failed to create pg connection pool");
+
         let version = Version::for_testing();
         let metrics = metrics();
-        let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
+        let db = Db::new(
+            reader.clone(),
+            service_config.limits.clone(),
+            metrics.clone(),
+        );
         let pg_conn_pool = PgManager::new(reader);
         let cancellation_token = CancellationToken::new();
         let watermark = Watermark {

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -149,7 +149,7 @@ mod tests {
         let version = Version::for_testing();
         let metrics = metrics();
         let cancellation_token = CancellationToken::new();
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
+        let connection_config = ConnectionConfig::default();
         let service_config = ServiceConfig::default();
         let state = AppState::new(
             connection_config.clone(),

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -33,8 +33,7 @@ mod tests {
         sim.create_checkpoint();
         sim.create_checkpoint();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
+        let connection_config = ConnectionConfig::default();
         let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
             connection_config.clone(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
@@ -57,10 +56,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         // Wait for servers to start and catchup
 
@@ -110,9 +108,8 @@ mod tests {
             "{{\"data\":{{\"chainIdentifier\":\"{}\"}}}}",
             chain_id_actual
         );
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
         let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
-            connection_config,
+            ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
@@ -309,10 +306,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
 
@@ -411,9 +407,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         // wait for epoch to be indexed, so that current epoch and JWK are populated in db.
         let test_cluster = cluster.validator_fullnode_handle;
@@ -502,10 +498,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
 
@@ -596,10 +591,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
 
@@ -667,10 +661,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         let addresses = cluster.validator_fullnode_handle.wallet.get_addresses();
 
@@ -755,10 +748,9 @@ mod tests {
             .with_env()
             .init();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
 
         cluster
             .validator_fullnode_handle
@@ -802,9 +794,9 @@ mod tests {
         let _guard = telemetry_subscribers::TelemetryConfig::new()
             .with_env()
             .init();
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
         let cluster =
-            sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+            sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
+                .await;
         cluster
             .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
             .await;

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -107,10 +107,8 @@ mod tests {
 
         sim.create_checkpoint();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
-            connection_config,
+            ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
@@ -172,10 +170,8 @@ mod tests {
 
         sim.create_checkpoint();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-
         let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
-            connection_config,
+            ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,


### PR DESCRIPTION
## Description

When a field is labeled with `#[serde(default)]` it means that if that field is not present, it is populated using the `Default` impl for the field's type:

```rust
#[derive(Serialize, Deserialize, Clone, Debug)]
struct Foo {
    #[serde(default)]
    bar: Bar,
}

Foo { bar: Bar::default() }
```

This is not the behaviour we want, however. We want fields that have not been supplied to be populated with their value from the `Default` impl of the type they are part of:

```rust
Foo { bar: Foo::default().bar }
```

Implementing this manually requires a lot of boilerplate -- each field needs to have an associated function that returns its default value:

```rust
#[derive(Serialize, Deserialize, Clone, Debug)]
struct Foo {
    #[serde(default = "Foo::__default_bar")]
    bar: Bar,
}
```

So this PR introduces an attribute proc macro to perform this transformation:

```rust
#[GraphQLConfig]
struct Foo {
    bar: Bar,
}
```

It also performs some other related clean-ups:

- Moves default values inline into the respective `Default` impls, to prevent them being used in isolation.
- Move the documentation for what the field is onto the struct definition, and the documentation for how the default was chosen onto the `Default` impl.
- Moved the implementation of `Display` for `Version`.
- Got rid of `ConnectionConfig::ci_integration_test_cfg` as it is the same as its `Default` impl now.
- Improved various docs about what various configs are.

## Test plan

Added a test for reading a `ServiceConfig` from an incomplete/partial TOML:

```sh
sui-graphql-rpc$ cargo nextest run -- read_partial_in_service_config
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL: Fix a bug where starting the service using a config with not all fields set would result in the unset fields being zeroed out rather than taking their usual default values (as would happen if no config had been explicitly supplied).
- [ ] CLI:
- [ ] Rust SDK: