### PR TITLE
[move][move-2024][enums] Fix a small issue when match is malformed

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -88,16 +88,16 @@ pub(super) fn compile_match(
     subject: T::Exp,
     arms: Spanned<Vec<T::MatchArm>>,
 ) -> T::Exp {
-    let arms_loc = arms.loc;
+    let loc = arms.loc;
     // NB: `from` also flattens `or` and converts constants into guards.
-    let (pattern_matrix, arms) = PatternMatrix::from(context, subject.ty.clone(), arms.value);
+    let (pattern_matrix, arms) = PatternMatrix::from(context, loc, subject.ty.clone(), arms.value);
 
     let mut compilation_results: BTreeMap<usize, WorkResult> = BTreeMap::new();
 
     let (mut initial_binders, init_subject, match_subject) = {
-        let subject_var = context.new_match_var("unpack_subject".to_string(), arms_loc);
+        let subject_var = context.new_match_var("unpack_subject".to_string(), loc);
         let subject_loc = subject.exp.loc;
-        let match_var = context.new_match_var("match_subject".to_string(), arms_loc);
+        let match_var = context.new_match_var("match_subject".to_string(), loc);
 
         let subject_entry = FringeEntry {
             var: subject_var,
@@ -122,7 +122,7 @@ pub(super) fn compile_match(
         };
 
         let subject_borrow = {
-            let lhs_loc = arms_loc;
+            let lhs_loc = loc;
             let lhs_lvalue = make_lvalue(match_var, Mutability::Imm, subject_borrow_rhs.ty.clone());
             let binder = T::SequenceItem_::Bind(
                 sp(lhs_loc, vec![lhs_lvalue]),
@@ -241,7 +241,7 @@ pub(super) fn compile_match(
         ice_assert!(
             context.env,
             redefined.is_none(),
-            arms_loc,
+            loc,
             "Match work queue went awry"
         );
     }
@@ -251,7 +251,7 @@ pub(super) fn compile_match(
         hlir_context: context,
         output_type: result_type,
         arms: &arms,
-        arms_loc,
+        arms_loc: loc,
         results: &mut compilation_results,
     };
     let match_exp = resolve_result(&mut resolution_context, &init_subject, match_start);

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -48,6 +48,7 @@ pub struct PatternArm {
 #[derive(Clone, Debug)]
 pub struct PatternMatrix {
     pub tys: Vec<Type>,
+    pub loc: Loc,
     pub patterns: Vec<PatternArm>,
 }
 
@@ -445,6 +446,7 @@ impl PatternMatrix {
     ///       index for all of them.
     pub fn from<const AFTER_TYPING: bool, MC: MatchContext<AFTER_TYPING>>(
         context: &mut MC,
+        loc: Loc,
         subject_ty: Type,
         arms: Vec<T::MatchArm>,
     ) -> (PatternMatrix, Vec<T::Exp>) {
@@ -484,7 +486,7 @@ impl PatternMatrix {
                 });
             }
         }
-        (PatternMatrix { tys, patterns }, rhss)
+        (PatternMatrix { tys, loc, patterns }, rhss)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -541,6 +543,7 @@ impl PatternMatrix {
     ) -> (Binders, PatternMatrix) {
         let mut patterns = vec![];
         let mut bindings = vec![];
+        let loc = self.loc;
         for entry in &self.patterns {
             if let Some((mut new_bindings, arm)) =
                 entry.specialize_variant(context, ctor_name, &arg_types)
@@ -554,7 +557,7 @@ impl PatternMatrix {
             .cloned()
             .chain(self.tys.clone().into_iter().skip(1))
             .collect::<Vec<_>>();
-        let matrix = PatternMatrix { tys, patterns };
+        let matrix = PatternMatrix { tys, loc, patterns };
         (bindings, matrix)
     }
 
@@ -565,6 +568,7 @@ impl PatternMatrix {
     ) -> (Binders, PatternMatrix) {
         let mut patterns = vec![];
         let mut bindings = vec![];
+        let loc = self.loc;
         for entry in &self.patterns {
             if let Some((mut new_bindings, arm)) = entry.specialize_struct(context, &arg_types) {
                 bindings.append(&mut new_bindings);
@@ -576,13 +580,14 @@ impl PatternMatrix {
             .cloned()
             .chain(self.tys.clone().into_iter().skip(1))
             .collect::<Vec<_>>();
-        let matrix = PatternMatrix { tys, patterns };
+        let matrix = PatternMatrix { tys, loc, patterns };
         (bindings, matrix)
     }
 
     pub fn specialize_literal(&self, lit: &Value) -> (Binders, PatternMatrix) {
         let mut patterns = vec![];
         let mut bindings = vec![];
+        let loc = self.loc;
         for entry in &self.patterns {
             if let Some((mut new_bindings, arm)) = entry.specialize_literal(lit) {
                 bindings.append(&mut new_bindings);
@@ -590,13 +595,14 @@ impl PatternMatrix {
             }
         }
         let tys = self.tys[1..].to_vec();
-        let matrix = PatternMatrix { tys, patterns };
+        let matrix = PatternMatrix { tys, loc, patterns };
         (bindings, matrix)
     }
 
     pub fn specialize_default(&self) -> (Binders, PatternMatrix) {
         let mut patterns = vec![];
         let mut bindings = vec![];
+        let loc = self.loc;
         for entry in &self.patterns {
             if let Some((mut new_bindings, arm)) = entry.specialize_default() {
                 bindings.append(&mut new_bindings);
@@ -604,7 +610,7 @@ impl PatternMatrix {
             }
         }
         let tys = self.tys[1..].to_vec();
-        let matrix = PatternMatrix { tys, patterns };
+        let matrix = PatternMatrix { tys, loc, patterns };
         (bindings, matrix)
     }
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match.exp
@@ -1,0 +1,6 @@
+error[E04016]: too few arguments
+   ┌─ tests/move_2024/matching/counterexample_malformed_match.move:18:9
+   │
+18 │         SomeEnum::PositionalFields(_, ) => (),
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing pattern for field '1' in 'a::m::SomeEnum::PositionalFields'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match.move
@@ -1,0 +1,20 @@
+module a::m;
+
+public struct SomeStruct has drop {
+    some_field: u64,
+}
+
+public enum SomeEnum has drop {
+    PositionalFields(u64, SomeStruct),
+}
+
+ public fun match_variant(s: SomeStruct) {
+    use a::m::SomeEnum as SE;
+    let e = SE::PositionalFields(42, s);
+    match (e) {
+        SomeEnum::PositionalFields(num, s) => {
+            num + s.some_field;
+        },
+        SomeEnum::PositionalFields(_, ) => (),
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match_2.exp
@@ -1,0 +1,6 @@
+error[E03010]: unbound field
+   ┌─ tests/move_2024/matching/counterexample_malformed_match_2.move:18:9
+   │
+18 │         SomeEnum::PositionalFields(_, _, _) => (),
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unbound field '2' in 'a::m::SomeEnum::PositionalFields'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match_2.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/counterexample_malformed_match_2.move
@@ -1,0 +1,20 @@
+module a::m;
+
+public struct SomeStruct has drop {
+    some_field: u64,
+}
+
+public enum SomeEnum has drop {
+    PositionalFields(u64, SomeStruct),
+}
+
+ public fun match_variant(s: SomeStruct) {
+    use a::m::SomeEnum as SE;
+    let e = SE::PositionalFields(42, s);
+    match (e) {
+        SomeEnum::PositionalFields(num, s) => {
+            num + s.some_field;
+        },
+        SomeEnum::PositionalFields(_, _, _) => (),
+    }
+}


### PR DESCRIPTION
## Description 

This fixes a bug that was previously a compiler crash when a match was malformed and counterexample generation occurred. This was due to some changes for parser resilience combined with moving match analysis to typing.

## Test plan 

Added the repro test, and it now produces the error as expected.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
