### PR TITLE
explicitly setup test scenario for test_query_default_page_limit

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -310,6 +310,14 @@ impl ConnectionConfig {
         }
     }
 
+    pub fn ci_integration_test_cfg() -> Self {
+        Self {
+            db_url: "postgres://postgres:postgrespw@localhost:5432/sui_graphql_rpc_e2e_tests"
+                .to_string(),
+            ..Default::default()
+        }
+    }
+
     pub fn ci_integration_test_cfg_with_db_name(
         db_name: String,
         port: u16,

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -916,7 +916,7 @@ pub mod tests {
         );
     }
 
-    pub async fn test_query_default_page_limit_impl() {
+    pub async fn test_query_default_page_limit_impl(connection_config: ConnectionConfig) {
         let service_config = ServiceConfig {
             limits: Limits {
                 default_page_size: 1,
@@ -924,7 +924,7 @@ pub mod tests {
             },
             ..Default::default()
         };
-        let schema = prep_schema(None, Some(service_config)).build_schema();
+        let schema = prep_schema(Some(connection_config), Some(service_config)).build_schema();
 
         let resp = schema
             .execute("{ checkpoints { nodes { sequenceNumber } } }")


### PR DESCRIPTION
## Description 

Unblock https://github.com/MystenLabs/sui/pull/18277 by explicitly setting up the correct test scenario for the `test_query_default_page_limit` test.

I think we can follow this up with 
1. instead of using the same db url, follow sui-graphql-e2e-tests pattern and generate unique db urls for each test
2. this is so that we can run tests in parallel instead of sequentially (which is the case today due to the serial)
3. we can leverage ExecutorCluster.cleanup_resources to cleanup each test



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 