### PR TITLE
[pick][gql-2024.1.0] explicitly setup test scenario for test_query_default_page_limit (#18…

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -873,7 +873,7 @@ pub mod tests {
         );
     }
 
-    pub async fn test_query_default_page_limit_impl() {
+    pub async fn test_query_default_page_limit_impl(connection_config: ConnectionConfig) {
         let service_config = ServiceConfig {
             limits: Limits {
                 default_page_size: 1,
@@ -881,7 +881,7 @@ pub mod tests {
             },
             ..Default::default()
         };
-        let schema = prep_schema(None, Some(service_config)).build_schema();
+        let schema = prep_schema(Some(connection_config), Some(service_config)).build_schema();
 
         let resp = schema
             .execute("{ checkpoints { nodes { sequenceNumber } } }")

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -28,9 +28,7 @@ mod tests {
 
     async fn prep_cluster() -> (ConnectionConfig, ExecutorCluster) {
         let rng = StdRng::from_seed([12; 32]);
-        let data_ingestion_path = tempdir().unwrap().into_path();
         let mut sim = Simulacrum::new_with_rng(rng);
-        sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         sim.create_checkpoint();
         sim.create_checkpoint();
@@ -42,7 +40,6 @@ mod tests {
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
-            data_ingestion_path,
         )
         .await;
 

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -168,25 +168,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_graphql_client_variables() {
-        let rng = StdRng::from_seed([12; 32]);
-        let data_ingestion_path = tempdir().unwrap().into_path();
-        let mut sim = Simulacrum::new_with_rng(rng);
-        sim.set_data_ingestion_path(data_ingestion_path.clone());
-
-        sim.create_checkpoint();
-        sim.create_checkpoint();
-
-        let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
-            ConnectionConfig::default(),
-            DEFAULT_INTERNAL_DATA_SOURCE_PORT,
-            Arc::new(sim),
-            None,
-            data_ingestion_path,
-        )
-        .await;
-        cluster
-            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
-            .await;
+        let (_, cluster) = prep_cluster().await;
 
         let query = r#"{obj1: object(address: $framework_addr) {address}
             obj2: object(address: $deepbook_addr) {address}}"#;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -14,6 +14,7 @@ mod tests {
     use sui_graphql_rpc::client::simple_client::GraphqlQueryVariable;
     use sui_graphql_rpc::client::ClientError;
     use sui_graphql_rpc::config::ConnectionConfig;
+    use sui_graphql_rpc::test_infra::cluster::ExecutorCluster;
     use sui_graphql_rpc::test_infra::cluster::DEFAULT_INTERNAL_DATA_SOURCE_PORT;
     use sui_types::digests::ChainIdentifier;
     use sui_types::gas_coin::GAS;
@@ -24,6 +25,33 @@ mod tests {
     use sui_types::SUI_FRAMEWORK_ADDRESS;
     use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
     use tokio::time::sleep;
+
+    async fn prep_cluster() -> (ConnectionConfig, ExecutorCluster) {
+        let rng = StdRng::from_seed([12; 32]);
+        let data_ingestion_path = tempdir().unwrap().into_path();
+        let mut sim = Simulacrum::new_with_rng(rng);
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        sim.create_checkpoint();
+        sim.create_checkpoint();
+
+        let connection_config = ConnectionConfig::ci_integration_test_cfg();
+
+        let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
+            connection_config.clone(),
+            DEFAULT_INTERNAL_DATA_SOURCE_PORT,
+            Arc::new(sim),
+            None,
+            data_ingestion_path,
+        )
+        .await;
+
+        cluster
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
+            .await;
+
+        (connection_config, cluster)
+    }
 
     #[tokio::test]
     #[serial]
@@ -111,20 +139,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_graphql_client_response() {
-        let rng = StdRng::from_seed([12; 32]);
-        let mut sim = Simulacrum::new_with_rng(rng);
-
-        sim.create_checkpoint();
-        sim.create_checkpoint();
-
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
-        let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
-            connection_config,
-            DEFAULT_INTERNAL_DATA_SOURCE_PORT,
-            Arc::new(sim),
-            None,
-        )
-        .await;
+        let (_, cluster) = prep_cluster().await;
 
         let query = r#"
             {
@@ -154,19 +169,24 @@ mod tests {
     #[serial]
     async fn test_graphql_client_variables() {
         let rng = StdRng::from_seed([12; 32]);
+        let data_ingestion_path = tempdir().unwrap().into_path();
         let mut sim = Simulacrum::new_with_rng(rng);
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         sim.create_checkpoint();
         sim.create_checkpoint();
 
-        let connection_config = ConnectionConfig::ci_integration_test_cfg();
         let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
-            connection_config,
+            ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
+            data_ingestion_path,
         )
         .await;
+        cluster
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
+            .await;
 
         let query = r#"{obj1: object(address: $framework_addr) {address}
             obj2: object(address: $deepbook_addr) {address}}"#;
@@ -830,7 +850,8 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_query_default_page_limit() {
-        test_query_default_page_limit_impl().await;
+        let (connection_config, _) = prep_cluster().await;
+        test_query_default_page_limit_impl(connection_config).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
…393)

Unblock https://github.com/MystenLabs/sui/pull/18277 by explicitly setting up the correct test scenario for the
`test_query_default_page_limit` test.

I think we can follow this up with
1. instead of using the same db url, follow sui-graphql-e2e-tests pattern and generate unique db urls for each test
2. this is so that we can run tests in parallel instead of sequentially (which is the case today due to the serial)
3. we can leverage ExecutorCluster.cleanup_resources to cleanup each test

How did you test the new or updated feature?

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
