### PR TITLE
Skip submitting checkpoint signatures when checkpoint is already certified

### DIFF
--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -125,7 +125,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 debug!(
                     "Delaying retry {} of peer {} subscription, in {} seconds",
                     retries,
-                    peer,
+                    peer_hostname,
                     delay.as_secs_f32(),
                 );
                 sleep(delay).await;

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -17,7 +17,7 @@ use sui_types::messages_checkpoint::{
 use sui_types::messages_consensus::ConsensusTransaction;
 use tracing::{debug, info, instrument, trace};
 
-use super::CheckpointMetrics;
+use super::{CheckpointMetrics, CheckpointStore};
 
 #[async_trait]
 pub trait CheckpointOutput: Sync + Send + 'static {
@@ -26,6 +26,7 @@ pub trait CheckpointOutput: Sync + Send + 'static {
         summary: &CheckpointSummary,
         contents: &CheckpointContents,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        checkpoint_store: &Arc<CheckpointStore>,
     ) -> SuiResult;
 }
 
@@ -65,9 +66,14 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         summary: &CheckpointSummary,
         contents: &CheckpointContents,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        checkpoint_store: &Arc<CheckpointStore>,
     ) -> SuiResult {
-        let checkpoint_seq = summary.sequence_number;
+        LogCheckpointOutput
+            .checkpoint_created(summary, contents, epoch_store, checkpoint_store)
+            .await?;
+
         let checkpoint_timestamp = summary.timestamp_ms;
+        let checkpoint_seq = summary.sequence_number;
         self.metrics.checkpoint_creation_latency_ms.observe(
             summary
                 .timestamp()
@@ -75,30 +81,39 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .unwrap_or_default()
                 .as_millis() as u64,
         );
-        debug!(
-            "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}.
-            {}ms left till end of epoch at timestamp {}",
-            self.next_reconfiguration_timestamp_ms.saturating_sub(checkpoint_timestamp), self.next_reconfiguration_timestamp_ms
-        );
-        LogCheckpointOutput
-            .checkpoint_created(summary, contents, epoch_store)
-            .await?;
 
-        let summary = SignedCheckpointSummary::new(
-            epoch_store.epoch(),
-            summary.clone(),
-            &*self.signer,
-            self.authority,
-        );
+        let highest_verified_checkpoint = checkpoint_store
+            .get_highest_verified_checkpoint()?
+            .map(|x| *x.sequence_number());
 
-        let message = CheckpointSignatureMessage { summary };
-        let transaction = ConsensusTransaction::new_checkpoint_signature_message(message);
-        self.sender
-            .submit_to_consensus(&vec![transaction], epoch_store)
-            .await?;
-        self.metrics
-            .last_sent_checkpoint_signature
-            .set(checkpoint_seq as i64);
+        if Some(checkpoint_seq) > highest_verified_checkpoint {
+            debug!(
+                "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}.
+                {}ms left till end of epoch at timestamp {}",
+                self.next_reconfiguration_timestamp_ms.saturating_sub(checkpoint_timestamp), self.next_reconfiguration_timestamp_ms
+            );
+
+            let summary = SignedCheckpointSummary::new(
+                epoch_store.epoch(),
+                summary.clone(),
+                &*self.signer,
+                self.authority,
+            );
+
+            let message = CheckpointSignatureMessage { summary };
+            let transaction = ConsensusTransaction::new_checkpoint_signature_message(message);
+            self.sender
+                .submit_to_consensus(&vec![transaction], epoch_store)
+                .await?;
+            self.metrics
+                .last_sent_checkpoint_signature
+                .set(checkpoint_seq as i64);
+        } else {
+            debug!(
+                "Checkpoint at sequence {checkpoint_seq} is already certified, skipping signature submission to consensus",
+            );
+        }
+
         if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {
             // close_epoch is ok if called multiple times
             self.sender.close_epoch(epoch_store);
@@ -114,6 +129,7 @@ impl CheckpointOutput for LogCheckpointOutput {
         summary: &CheckpointSummary,
         contents: &CheckpointContents,
         _epoch_store: &Arc<AuthorityPerEpochStore>,
+        _checkpoint_store: &Arc<CheckpointStore>,
     ) -> SuiResult {
         trace!(
             "Including following transactions in checkpoint {}: {:?}",

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -112,6 +112,9 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
             debug!(
                 "Checkpoint at sequence {checkpoint_seq} is already certified, skipping signature submission to consensus",
             );
+            self.metrics
+                .last_skipped_checkpoint_signature_submission
+                .set(checkpoint_seq as i64);
         }
 
         if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -18,6 +18,8 @@ pub struct CheckpointMetrics {
     pub checkpoint_participation: IntCounterVec,
     pub last_received_checkpoint_signatures: IntGaugeVec,
     pub last_sent_checkpoint_signature: IntGauge,
+    pub last_skipped_checkpoint_signature_submission: IntGauge,
+    pub last_ignored_checkpoint_signature_received: IntGauge,
     pub highest_accumulated_epoch: IntGauge,
     pub checkpoint_creation_latency_ms: Histogram,
     pub remote_checkpoint_forks: IntCounter,
@@ -86,6 +88,18 @@ impl CheckpointMetrics {
             last_sent_checkpoint_signature: register_int_gauge_with_registry!(
                 "last_sent_checkpoint_signature",
                 "Last checkpoint signature sent by myself",
+                registry
+            )
+            .unwrap(),
+            last_skipped_checkpoint_signature_submission: register_int_gauge_with_registry!(
+                "last_skipped_checkpoint_signature_submission",
+                "Last checkpoint signature that this validator skipped submitting because it was already certfied.",
+                registry
+            )
+            .unwrap(),
+            last_ignored_checkpoint_signature_received: register_int_gauge_with_registry!(
+                "last_ignored_checkpoint_signature_received",
+                "Last received checkpoint signature that this validator ignored because it was already certfied.",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2307,6 +2307,9 @@ impl CheckpointServiceNotify for CheckpointService {
                     checkpoint_seq = sequence,
                     "Ignore checkpoint signature from {} - already certified", signer,
                 );
+                self.metrics
+                    .last_ignored_checkpoint_signature_received
+                    .set(sequence as i64);
                 return Ok(());
             }
         }


### PR DESCRIPTION
## Description

During catchup in mysticeti if the validator was down for long periods of time we will see a large number of checkpoint signatures start to get [backlogged](https://metrics.sui.io/goto/HgmncvwSR?orgId=1) and then submitted to consensus quickly after the node has caught up. This will cause the block size to increase in consensus and then a variance in the distribution of those blocks across the network leading to a round rate dip. This PR will skip submitting checkpoint signatures when checkpoint is already certified to mitigate the issue and we will look into properly handling block size variance in a separate PR

## Testing

Recreated the issue and tested the fix in private-testnet

![Screenshot 2024-06-25 at 5 15 33 PM](https://github.com/MystenLabs/sui/assets/97870774/b3be4e36-6e56-4c28-a231-f2a43a358118)
