### PR TITLE
Use dedicated table for determining if transaction was executed in current epoch

### DIFF
--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -52,6 +52,7 @@ pub enum EpochFlag {
 
     WritebackCacheEnabled,
     StateAccumulatorV2Enabled,
+    ExecutedInEpochTable,
 }
 
 impl EpochFlag {
@@ -68,7 +69,7 @@ impl EpochFlag {
         cache_config: &ExecutionCacheConfig,
         enable_state_accumulator_v2: bool,
     ) -> Vec<Self> {
-        let mut new_flags = vec![];
+        let mut new_flags = vec![EpochFlag::ExecutedInEpochTable];
 
         if matches!(
             choose_execution_cache(cache_config),
@@ -100,6 +101,7 @@ impl fmt::Display for EpochFlag {
             }
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
             EpochFlag::StateAccumulatorV2Enabled => write!(f, "StateAccumulatorV2Enabled"),
+            EpochFlag::ExecutedInEpochTable => write!(f, "ExecutedInEpochTable"),
         }
     }
 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1612,7 +1612,7 @@ impl CheckpointBuilder {
 
                 let existing_effects = self
                     .epoch_store
-                    .effects_signatures_exists(effect.dependencies().iter())?;
+                    .transactions_executed_in_cur_epoch(effect.dependencies().iter())?;
 
                 for (dependency, effects_signature_exists) in
                     effect.dependencies().iter().zip(existing_effects.iter())


### PR DESCRIPTION
This is the first step of a change to remove effects signing from the execution path and adding effects equivocation prevention (necessary for WB cache on validators).
