### PR TITLE
Remove effects signing from execution path

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1180,6 +1180,18 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    pub fn insert_effects_signature(
+        &self,
+        tx_digest: &TransactionDigest,
+        effects_signature: &AuthoritySignInfo,
+    ) -> SuiResult {
+        let tables = self.tables()?;
+        tables
+            .effects_signatures
+            .insert(tx_digest, effects_signature)?;
+        Ok(())
+    }
+
     pub fn transactions_executed_in_cur_epoch<'a>(
         &self,
         digests: impl IntoIterator<Item = &'a TransactionDigest>,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -345,8 +345,11 @@ pub struct AuthorityEpochTables {
     #[default_options_override_fn = "owned_object_transaction_locks_table_default_config"]
     owned_object_locked_transactions: DBMap<ObjectRef, LockDetailsWrapper>,
 
-    /// Signatures over transaction effects that were executed in the current epoch.
-    /// Store this to avoid re-signing the same effects twice.
+    /// Signatures over transaction effects that we have signed and returned to users.
+    /// We store this to avoid re-signing the same effects twice.
+    /// Note that this may contain signatures for effects from previous epochs, in the case
+    /// that a user requests a signature for effects from a previous epoch. However, the
+    /// signature is still epoch-specific and so is stored in the epoch store.
     effects_signatures: DBMap<TransactionDigest, AuthoritySignInfo>,
 
     /// Signatures of transaction certificates that are executed locally.

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -591,8 +591,10 @@ impl ValidatorService {
                     .then(|| self.state.get_transaction_output_objects(&effects))
                     .and_then(Result::ok);
 
+                let signed_effects = self.state.sign_effects(effects, epoch_store)?;
+
                 Ok::<_, SuiError>(HandleCertificateResponseV3 {
-                    effects: effects.into_inner(),
+                    effects: signed_effects.into_inner(),
                     events,
                     input_objects,
                     output_objects,

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -237,10 +237,7 @@ impl TestRunner {
             .authority_state
             .execute_certificate(&ct, &epoch_store)
             .await
-            .unwrap()
-            .inner()
-            .clone()
-            .into_data();
+            .unwrap();
 
         if self.aggressive_pruning_enabled {
             self.authority_state

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -168,8 +168,6 @@ impl SingleValidator {
                     .execute_certificate(&cert, &self.epoch_store)
                     .await
                     .unwrap()
-                    .into_inner()
-                    .into_data()
             }
             Component::ValidatorWithoutConsensus | Component::ValidatorWithFakeConsensus => {
                 let response = self


### PR DESCRIPTION
This provides a small optimization for sequential execution and/or catchup, and will simplify the job of preventing equivocation on effects when WB cache is enabled.

