### PR TITLE
Only store cert signatures for certs handled by AuthorityServer

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1433,10 +1433,9 @@ impl AuthorityState {
 
         // The insertion to epoch_store is not atomic with the insertion to the perpetual store. This is OK because
         // we insert to the epoch store first. And during lookups we always look up in the perpetual store first.
-        epoch_store.insert_tx_cert_and_effects_signature(
+        epoch_store.insert_tx_key_and_effects_signature(
             &tx_key,
             tx_digest,
-            certificate.certificate_sig(),
             effects_sig.as_ref(),
         )?;
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -592,6 +592,7 @@ impl ValidatorService {
                     .and_then(Result::ok);
 
                 let signed_effects = self.state.sign_effects(effects, epoch_store)?;
+                epoch_store.insert_tx_cert_sig(certificate.digest(), certificate.auth_sig())?;
 
                 Ok::<_, SuiError>(HandleCertificateResponseV3 {
                     effects: signed_effects.into_inner(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2762,10 +2762,9 @@ mod tests {
         let effects = e(digest, dependencies, gas_used);
         store.insert(digest, effects.clone());
         epoch_store
-            .insert_tx_cert_and_effects_signature(
+            .insert_tx_key_and_effects_signature(
                 &TransactionKey::Digest(digest),
                 &digest,
-                None,
                 Some(&AuthoritySignInfo::new(
                     epoch_store.epoch(),
                     &effects,


### PR DESCRIPTION
The main behavior change caused here is that we will no longer store signatures of certificates that arrive via consensus. However, once a certificate has been committed in consensus, there is little need for quorum driver to be able to obtain a certificate via the `transaction` API
