### PR TITLE
[bridge-indexer] - smarter checkpoint backfill 

### DIFF
--- a/crates/sui-bridge-indexer/config.yaml
+++ b/crates/sui-bridge-indexer/config.yaml
@@ -1,26 +1,26 @@
 # config.yaml format:
 
 # URL of the remote store
-remote_store_url: https://checkpoints.testnet.sui.io
+# remote_store_url: <url>
 # URL for Ethereum RPC
-eth_rpc_url: https://rpc-sepolia.flashbots.net/
+# eth_rpc_url: <url>
 # Database connection URL
-db_url: postgres://postgres:postgrespw@localhost:5432
+# db_url: <url>
 # Path to the checkpoints
-checkpoints_path: ./checkpoints
+# checkpoints_path: <path>
 # Number of concurrent operations
-concurrency: 10
+# concurrency: 1
 # Bridge genesis checkpoint in SUI, for testnet = 43917829
-bridge_genesis_checkpoint: 43917829
+# bridge_genesis_checkpoint: <sui bridge genesis checkpoint>
 # Ethereum to Sui bridge contract address
-eth_sui_bridge_contract_address: 0xAE68F87938439afEEDd6552B0E83D2CbC2473623
+# eth_sui_bridge_contract_address: <contract_address>
 # Starting block number
-start_block: 5997013
+# start_block: <indexing_start_block>
 # Client metric URL
-metric_url: 0.0.0.0
+# metric_url: <url>
 # Client metric port
-metric_port: 9009
+# metric_port: <port>
 # checkpoint size of each backfill worker, use 432000 for 1 worker per day, assume 5 checkpoint per second
-back_fill_lot_size: 10000
+# back_fill_lot_size: <backfill lot size>
 # Optional starting checkpoint for realtime ingestion task
-resume_from_checkpoint: 68000000
+# resume_from_checkpoint: <Sui checkpoint>

--- a/crates/sui-bridge-indexer/config.yaml
+++ b/crates/sui-bridge-indexer/config.yaml
@@ -1,24 +1,26 @@
 # config.yaml format:
 
 # URL of the remote store
-# remote_store_url: <url>
+remote_store_url: https://checkpoints.testnet.sui.io
 # URL for Ethereum RPC
-# eth_rpc_url: <url>
+eth_rpc_url: https://rpc-sepolia.flashbots.net/
 # Database connection URL
-# db_url: <url>
-# File to store the progress
-# progress_store_file: <path>
+db_url: postgres://postgres:postgrespw@localhost:5432
 # Path to the checkpoints
-# checkpoints_path: <path>
+checkpoints_path: ./checkpoints
 # Number of concurrent operations
-# concurrency: 1
+concurrency: 10
 # Bridge genesis checkpoint in SUI, for testnet = 43917829
-# bridge_genesis_checkpoint: <sui bridge genesis checkpoint>
+bridge_genesis_checkpoint: 43917829
 # Ethereum to Sui bridge contract address
-# eth_sui_bridge_contract_address: <contract_address>
+eth_sui_bridge_contract_address: 0xAE68F87938439afEEDd6552B0E83D2CbC2473623
 # Starting block number
-# start_block: <indexing_start_block>
+start_block: 5997013
 # Client metric URL
-# metric_url: <url>
+metric_url: 0.0.0.0
 # Client metric port
-# metric_port: <port>
+metric_port: 9009
+# checkpoint size of each backfill worker, use 432000 for 1 worker per day, assume 5 checkpoint per second
+back_fill_lot_size: 10000
+# Optional starting checkpoint for realtime ingestion task
+resume_from_checkpoint: 68000000

--- a/crates/sui-bridge-indexer/src/config.rs
+++ b/crates/sui-bridge-indexer/src/config.rs
@@ -19,6 +19,8 @@ pub struct IndexerConfig {
     pub metric_url: String,
     pub metric_port: u16,
     pub sui_rpc_url: Option<String>,
+    pub back_fill_lot_size: u64,
+    pub resume_from_checkpoint: Option<u64>,
 }
 
 impl sui_config::Config for IndexerConfig {}

--- a/crates/sui-bridge-indexer/src/lib.rs
+++ b/crates/sui-bridge-indexer/src/lib.rs
@@ -12,6 +12,7 @@ pub mod metrics;
 pub mod models;
 pub mod postgres_manager;
 pub mod schema;
+pub mod sui_checkpoint_ingestion;
 pub mod sui_transaction_handler;
 pub mod sui_transaction_queries;
 pub mod sui_worker;

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -147,7 +147,7 @@ async fn start_processing_sui_checkpoints(
             // if resume_from_checkpoint, use it for the latest task, if not set, use bridge_genesis_checkpoint
             let start_from_cp = config
                 .resume_from_checkpoint
-                .unwrap_or_else(|| config.bridge_genesis_checkpoint);
+                .unwrap_or(config.bridge_genesis_checkpoint);
             progress_store.register_task(new_task_name(), start_from_cp, i64::MAX)?;
 
             // Create backfill tasks
@@ -173,7 +173,7 @@ async fn start_processing_sui_checkpoints(
                             target_cp - config.back_fill_lot_size,
                             target_cp as i64,
                         )?;
-                        target_cp = target_cp - config.back_fill_lot_size;
+                        target_cp -= config.back_fill_lot_size;
                     }
                     task.target_checkpoint = target_cp;
                     progress_store.update_task(task)?;

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -4,7 +4,9 @@
 use anyhow::Result;
 use clap::*;
 use mysten_metrics::spawn_logged_monitored_task;
-use mysten_metrics::start_prometheus_server;
+use mysten_metrics::{spawn_monitored_task, start_prometheus_server};
+use prometheus::Registry;
+use std::cmp::min;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::PathBuf;
@@ -12,18 +14,19 @@ use std::sync::Arc;
 use sui_bridge::eth_client::EthClient;
 use sui_bridge::metrics::BridgeMetrics;
 use sui_bridge_indexer::eth_worker::EthBridgeWorker;
-use sui_bridge_indexer::metrics::BridgeIndexerMetrics;
 use sui_bridge_indexer::postgres_manager::{
     get_connection_pool, read_sui_progress_store, PgProgressStore,
 };
 use sui_bridge_indexer::sui_transaction_handler::handle_sui_transactions_loop;
 use sui_bridge_indexer::sui_transaction_queries::start_sui_tx_polling_task;
 use sui_bridge_indexer::sui_worker::SuiBridgeWorker;
+use sui_bridge_indexer::{config, config::load_config, metrics::BridgeIndexerMetrics};
 use sui_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
 use sui_sdk::SuiClientBuilder;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::task::JoinHandle;
 
+use sui_types::digests::TransactionDigest;
 use mysten_metrics::metered_channel::channel;
 use sui_bridge_indexer::config::IndexerConfig;
 use sui_config::Config;
@@ -126,27 +129,124 @@ async fn main() -> Result<()> {
 }
 
 async fn start_processing_sui_checkpoints(
-    config: &sui_bridge_indexer::config::IndexerConfig,
+    config: &IndexerConfig,
     db_url: String,
     indexer_meterics: BridgeIndexerMetrics,
     ingestion_metrics: DataIngestionMetrics,
-) -> Result<HashMap<String, CheckpointSequenceNumber>> {
+) -> Result<(), anyhow::Error> {
     // metrics init
-    let (_exit_sender, exit_receiver) = oneshot::channel();
-
     let pg_pool = get_connection_pool(db_url.clone());
     let progress_store = PgProgressStore::new(pg_pool, config.bridge_genesis_checkpoint);
-    let mut executor = IndexerExecutor::new(
+
+    // Update tasks first
+    let tasks = progress_store.tasks()?;
+    // checkpoint workers
+    match tasks.latest_checkpoint_task() {
+        None => {
+            // No task in database, start latest checkpoint task and backfill tasks
+            // if resume_from_checkpoint, use it for the latest task, if not set, use bridge_genesis_checkpoint
+            let start_from_cp = config
+                .resume_from_checkpoint
+                .unwrap_or_else(|| config.bridge_genesis_checkpoint);
+            progress_store.register_task(new_task_name(), start_from_cp, i64::MAX)?;
+
+            // Create backfill tasks
+            if start_from_cp != config.bridge_genesis_checkpoint {
+                let mut current_cp = config.bridge_genesis_checkpoint;
+                while current_cp < start_from_cp {
+                    let target_cp = min(current_cp + config.back_fill_lot_size, start_from_cp);
+                    progress_store.register_task(new_task_name(), current_cp, target_cp as i64)?;
+                    current_cp = target_cp;
+                }
+            }
+        }
+        Some(mut task) => {
+            match config.resume_from_checkpoint {
+                Some(cp) if task.checkpoint < cp => {
+                    // Scenario 1: resume_from_checkpoint is set, and it's > current checkpoint
+                    // create new task from resume_from_checkpoint to u64::MAX
+                    // Update old task to finish at resume_from_checkpoint
+                    let mut target_cp = cp;
+                    while target_cp - task.checkpoint > config.back_fill_lot_size {
+                        progress_store.register_task(
+                            new_task_name(),
+                            target_cp - config.back_fill_lot_size,
+                            target_cp as i64,
+                        )?;
+                        target_cp = target_cp - config.back_fill_lot_size;
+                    }
+                    task.target_checkpoint = target_cp;
+                    progress_store.update_task(task)?;
+                    progress_store.register_task(new_task_name(), cp, i64::MAX)?;
+                }
+                _ => {
+                    // Scenario 2: resume_from_checkpoint is set, but it's < current checkpoint or not set
+                    // ignore resume_from_checkpoint, resume all task as it is.
+                }
+            }
+        }
+    }
+
+    // get updated tasks and start workers
+    let updated_tasks = progress_store.tasks()?;
+    // Start latest checkpoint worker
+    // Tasks are ordered in checkpoint descending order, realtime update task always come first
+    // task won't be empty here, ok to unwrap.
+    let (realtime_task, backfill_tasks) = updated_tasks.split_first().unwrap();
+    let ingestion_metrics_clone = ingestion_metrics.clone();
+    let indexer_meterics_clone = indexer_meterics.clone();
+    let db_url_clone = db_url.clone();
+    let progress_store_clone = progress_store.clone();
+    let config_clone = config.clone();
+    let backfill_tasks = backfill_tasks.to_vec();
+    let handle = spawn_monitored_task!(async {
+        for backfill_task in backfill_tasks {
+            start_executor(
+                progress_store_clone.clone(),
+                ingestion_metrics_clone.clone(),
+                indexer_meterics_clone.clone(),
+                &config_clone,
+                db_url_clone.clone(),
+                &backfill_task,
+            )
+            .await
+            .expect("Backfill task failed");
+        }
+    });
+    start_executor(
+        progress_store,
+        ingestion_metrics,
+        indexer_meterics,
+        config,
+        db_url,
+        realtime_task,
+    )
+    .await?;
+    tokio::try_join!(handle)?;
+    Ok(())
+}
+
+async fn start_executor(
+    progress_store: PgProgressStore,
+    ingestion_metrics: DataIngestionMetrics,
+    indexer_meterics: BridgeIndexerMetrics,
+    config: &Config,
+    db_url: String,
+    task: &Task,
+) -> Result<(), anyhow::Error> {
+    let (_exit_sender, exit_receiver) = oneshot::channel();
+    let mut executor = IndexerExecutor::new_with_upper_limit(
         progress_store,
         1, /* workflow types */
         ingestion_metrics,
+        task.target_checkpoint,
     );
 
     let indexer_metrics_cloned = indexer_meterics.clone();
 
     let worker_pool = WorkerPool::new(
         SuiBridgeWorker::new(vec![], db_url, indexer_metrics_cloned),
-        "bridge worker".into(),
+        task.task_name.clone(),
         config.concurrency as usize,
     );
     executor.register(worker_pool).await?;
@@ -158,7 +258,12 @@ async fn start_processing_sui_checkpoints(
             ReaderOptions::default(),
             exit_receiver,
         )
-        .await
+        .await?;
+    Ok(())
+}
+
+fn new_task_name() -> String {
+    format!("bridge worker - {}", TransactionDigest::random())
 }
 
 async fn start_processing_sui_checkpoints_by_querying_txns(

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -15,7 +15,7 @@ use sui_bridge::eth_client::EthClient;
 use sui_bridge::metrics::BridgeMetrics;
 use sui_bridge_indexer::eth_worker::EthBridgeWorker;
 use sui_bridge_indexer::postgres_manager::{
-    get_connection_pool, read_sui_progress_store, PgProgressStore,
+    get_connection_pool, read_sui_progress_store, PgProgressStore, Task, Tasks,
 };
 use sui_bridge_indexer::sui_transaction_handler::handle_sui_transactions_loop;
 use sui_bridge_indexer::sui_transaction_queries::start_sui_tx_polling_task;
@@ -23,7 +23,6 @@ use sui_bridge_indexer::sui_worker::SuiBridgeWorker;
 use sui_bridge_indexer::{config, config::load_config, metrics::BridgeIndexerMetrics};
 use sui_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
 use sui_sdk::SuiClientBuilder;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::task::JoinHandle;
 
 use sui_types::digests::TransactionDigest;
@@ -191,7 +190,7 @@ async fn start_processing_sui_checkpoints(
     let updated_tasks = progress_store.tasks()?;
     // Start latest checkpoint worker
     // Tasks are ordered in checkpoint descending order, realtime update task always come first
-    // task won't be empty here, ok to unwrap.
+    // tasks won't be empty here, ok to unwrap.
     let (realtime_task, backfill_tasks) = updated_tasks.split_first().unwrap();
     let ingestion_metrics_clone = ingestion_metrics.clone();
     let indexer_meterics_clone = indexer_meterics.clone();

--- a/crates/sui-bridge-indexer/src/migrations/2024-06-25-112132_smart_progress_store/down.sql
+++ b/crates/sui-bridge-indexer/src/migrations/2024-06-25-112132_smart_progress_store/down.sql
@@ -1,0 +1,5 @@
+alter table progress_store
+    drop column target_checkpoint;
+
+alter table progress_store
+    drop column timestamp;

--- a/crates/sui-bridge-indexer/src/migrations/2024-06-25-112132_smart_progress_store/up.sql
+++ b/crates/sui-bridge-indexer/src/migrations/2024-06-25-112132_smart_progress_store/up.sql
@@ -1,0 +1,5 @@
+alter table progress_store
+    add target_checkpoint BIGINT default 9223372036854775807 not null;
+
+alter table progress_store
+    add timestamp timestamp default now() not null;

--- a/crates/sui-bridge-indexer/src/models.rs
+++ b/crates/sui-bridge-indexer/src/models.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::schema::{progress_store, sui_progress_store, token_transfer, token_transfer_data};
+use diesel::data_types::PgTimestamp;
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Selectable, Insertable, Identifiable, Debug)]
@@ -9,6 +10,8 @@ use diesel::{Identifiable, Insertable, Queryable, Selectable};
 pub struct ProgressStore {
     pub task_name: String,
     pub checkpoint: i64,
+    pub target_checkpoint: i64,
+    pub timestamp: Option<PgTimestamp>,
 }
 
 #[derive(Queryable, Selectable, Insertable, Identifiable, Debug)]

--- a/crates/sui-bridge-indexer/src/postgres_manager.rs
+++ b/crates/sui-bridge-indexer/src/postgres_manager.rs
@@ -1,27 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::models::ProgressStore as DBProgressStore;
 use crate::models::SuiProgressStore;
 use crate::models::TokenTransfer as DBTokenTransfer;
 use crate::models::TokenTransferData as DBTokenTransferData;
-use crate::schema::progress_store::columns;
-use crate::schema::progress_store::dsl::progress_store;
 use crate::schema::sui_progress_store::txn_digest;
 use crate::schema::token_transfer_data;
 use crate::{schema, schema::token_transfer, TokenTransfer};
-use async_trait::async_trait;
-use diesel::dsl::now;
 use diesel::result::Error;
-use diesel::{delete, BoolExpressionMethods};
+use diesel::BoolExpressionMethods;
 use diesel::{
     pg::PgConnection,
     r2d2::{ConnectionManager, Pool},
     Connection, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
 };
-use sui_data_ingestion_core::ProgressStore;
 use sui_types::digests::TransactionDigest;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 pub(crate) type PgPool = Pool<ConnectionManager<PgConnection>>;
 
@@ -112,135 +105,5 @@ pub fn get_latest_eth_token_transfer(
             .order(block_height.desc())
             .first::<DBTokenTransfer>(connection)
             .optional()
-    }
-}
-
-#[derive(Clone)]
-pub struct PgProgressStore {
-    pool: PgPool,
-    bridge_genesis_checkpoint: u64,
-}
-
-#[derive(Clone)]
-pub struct Task {
-    pub task_name: String,
-    pub checkpoint: u64,
-    pub target_checkpoint: u64,
-    pub timestamp: u64,
-}
-
-impl From<DBProgressStore> for Task {
-    fn from(value: DBProgressStore) -> Self {
-        Self {
-            task_name: value.task_name,
-            checkpoint: value.checkpoint as u64,
-            target_checkpoint: value.target_checkpoint as u64,
-            // Ok to unwrap, timestamp is defaulted to now() in database
-            timestamp: value.timestamp.expect("Timestamp not set").0 as u64,
-        }
-    }
-}
-
-impl PgProgressStore {
-    pub fn new(pool: PgPool, bridge_genesis_checkpoint: u64) -> Self {
-        // read all task from db
-        PgProgressStore {
-            pool,
-            bridge_genesis_checkpoint,
-        }
-    }
-
-    pub fn tasks(&self) -> Result<Vec<Task>, anyhow::Error> {
-        let mut conn = self.pool.get()?;
-        // clean up completed task
-        delete(progress_store.filter(columns::checkpoint.ge(columns::target_checkpoint)))
-            .execute(&mut conn)?;
-        // get all unfinished tasks
-        let cp: Vec<DBProgressStore> = progress_store
-            .order_by(columns::checkpoint.desc())
-            .load(&mut conn)?;
-        Ok(cp.into_iter().map(|d| d.into()).collect())
-    }
-
-    pub fn register_task(
-        &self,
-        task_name: String,
-        checkpoint: u64,
-        target_checkpoint: i64,
-    ) -> Result<(), anyhow::Error> {
-        let mut conn = self.pool.get()?;
-        diesel::insert_into(schema::progress_store::table)
-            .values(DBProgressStore {
-                task_name,
-                checkpoint: checkpoint as i64,
-                target_checkpoint,
-                timestamp: None,
-            })
-            .execute(&mut conn)?;
-        Ok(())
-    }
-
-    pub fn update_task(&self, task: Task) -> Result<(), anyhow::Error> {
-        let mut conn = self.pool.get()?;
-        diesel::update(progress_store.filter(columns::task_name.eq(task.task_name)))
-            .set((
-                columns::checkpoint.eq(task.checkpoint as i64),
-                columns::target_checkpoint.eq(task.target_checkpoint as i64),
-                columns::timestamp.eq(now),
-            ))
-            .execute(&mut conn)?;
-        Ok(())
-    }
-}
-
-pub trait Tasks {
-    fn latest_checkpoint_task(&self) -> Option<Task>;
-}
-
-impl Tasks for Vec<Task> {
-    fn latest_checkpoint_task(&self) -> Option<Task> {
-        self.iter().fold(None, |result, other_task| match &result {
-            Some(task) if task.checkpoint < other_task.checkpoint => Some(other_task.clone()),
-            None => Some(other_task.clone()),
-            _ => result,
-        })
-    }
-}
-
-#[async_trait]
-impl ProgressStore for PgProgressStore {
-    async fn load(&mut self, task_name: String) -> anyhow::Result<CheckpointSequenceNumber> {
-        let mut conn = self.pool.get()?;
-        let cp: Option<DBProgressStore> = progress_store
-            .find(task_name)
-            .select(DBProgressStore::as_select())
-            .first(&mut conn)
-            .optional()?;
-        Ok(cp
-            .map(|d| d.checkpoint as u64)
-            .unwrap_or(self.bridge_genesis_checkpoint))
-    }
-
-    async fn save(
-        &mut self,
-        task_name: String,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> anyhow::Result<()> {
-        let mut conn = self.pool.get()?;
-        diesel::insert_into(schema::progress_store::table)
-            .values(&DBProgressStore {
-                task_name,
-                checkpoint: checkpoint_number as i64,
-                target_checkpoint: i64::MAX,
-                timestamp: None,
-            })
-            .on_conflict(schema::progress_store::dsl::task_name)
-            .do_update()
-            .set((
-                columns::checkpoint.eq(checkpoint_number as i64),
-                columns::timestamp.eq(now),
-            ))
-            .execute(&mut conn)?;
-        Ok(())
     }
 }

--- a/crates/sui-bridge-indexer/src/schema.rs
+++ b/crates/sui-bridge-indexer/src/schema.rs
@@ -49,6 +49,7 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     progress_store,
-   sui_progress_store, token_transfer,
+    sui_progress_store,
+    token_transfer,
     token_transfer_data,
 );

--- a/crates/sui-bridge-indexer/src/schema.rs
+++ b/crates/sui-bridge-indexer/src/schema.rs
@@ -6,6 +6,8 @@ diesel::table! {
     progress_store (task_name) {
         task_name -> Text,
         checkpoint -> Int8,
+        target_checkpoint -> Int8,
+        timestamp -> Nullable<Timestamp>,
     }
 }
 
@@ -47,7 +49,6 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     progress_store,
-    sui_progress_store,
-    token_transfer,
+   sui_progress_store, token_transfer,
     token_transfer_data,
 );

--- a/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
+++ b/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
@@ -101,7 +101,7 @@ impl SuiCheckpointSyncer {
             self.bridge_genesis_checkpoint,
             ingestion_metrics.clone(),
             indexer_meterics.clone(),
-            &config,
+            config,
             realtime_task,
         );
 

--- a/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
+++ b/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 use crate::metrics::BridgeIndexerMetrics;
 use crate::postgres_manager::PgPool;

--- a/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
+++ b/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::Config;
+use crate::config::IndexerConfig;
 use crate::metrics::BridgeIndexerMetrics;
 use crate::postgres_manager::PgPool;
 use crate::schema::progress_store::{columns, dsl};
@@ -37,7 +37,7 @@ impl SuiCheckpointSyncer {
     }
     pub async fn start(
         self,
-        config: &Config,
+        config: &IndexerConfig,
         indexer_meterics: BridgeIndexerMetrics,
         ingestion_metrics: DataIngestionMetrics,
     ) -> anyhow::Result<(), anyhow::Error> {
@@ -175,7 +175,7 @@ impl SuiCheckpointSyncer {
         bridge_genesis_checkpoint: u64,
         ingestion_metrics: DataIngestionMetrics,
         indexer_meterics: BridgeIndexerMetrics,
-        config: &Config,
+        config: &IndexerConfig,
         task: &Task,
     ) -> anyhow::Result<()> {
         let (exit_sender, exit_receiver) = oneshot::channel();

--- a/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
+++ b/crates/sui-bridge-indexer/src/sui_checkpoint_ingestion.rs
@@ -1,0 +1,299 @@
+use crate::config::Config;
+use crate::metrics::BridgeIndexerMetrics;
+use crate::postgres_manager::PgPool;
+use crate::schema::progress_store::{columns, dsl};
+use crate::sui_worker::SuiBridgeWorker;
+use crate::{models, schema};
+use async_trait::async_trait;
+use diesel::dsl::now;
+use diesel::{
+    delete, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
+};
+use mysten_metrics::spawn_monitored_task;
+use std::cmp::min;
+use sui_data_ingestion_core::{
+    DataIngestionMetrics, IndexerExecutor, ProgressStore, ReaderOptions, WorkerPool,
+};
+use sui_types::base_types::TransactionDigest;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Sender;
+
+pub struct SuiCheckpointSyncer {
+    pool: PgPool,
+    bridge_genesis_checkpoint: u64,
+}
+
+impl SuiCheckpointSyncer {
+    pub fn new(pool: PgPool, bridge_genesis_checkpoint: u64) -> Self {
+        // read all task from db
+        SuiCheckpointSyncer {
+            pool: pool.clone(),
+            bridge_genesis_checkpoint,
+        }
+    }
+    pub async fn start(
+        self,
+        config: &Config,
+        indexer_meterics: BridgeIndexerMetrics,
+        ingestion_metrics: DataIngestionMetrics,
+    ) -> anyhow::Result<(), anyhow::Error> {
+        // Update tasks first
+        let tasks = self.tasks()?;
+        // checkpoint workers
+        match tasks.latest_checkpoint_task() {
+            None => {
+                // No task in database, start latest checkpoint task and backfill tasks
+                // if resume_from_checkpoint, use it for the latest task, if not set, use bridge_genesis_checkpoint
+                let start_from_cp = config
+                    .resume_from_checkpoint
+                    .unwrap_or(self.bridge_genesis_checkpoint);
+                self.register_task(new_task_name(), start_from_cp, i64::MAX)?;
+
+                // Create backfill tasks
+                if start_from_cp != config.bridge_genesis_checkpoint {
+                    let mut current_cp = self.bridge_genesis_checkpoint;
+                    while current_cp < start_from_cp {
+                        let target_cp = min(current_cp + config.back_fill_lot_size, start_from_cp);
+                        self.register_task(new_task_name(), current_cp, target_cp as i64)?;
+                        current_cp = target_cp;
+                    }
+                }
+            }
+            Some(mut task) => {
+                match config.resume_from_checkpoint {
+                    Some(cp) if task.checkpoint < cp => {
+                        // Scenario 1: resume_from_checkpoint is set, and it's > current checkpoint
+                        // create new task from resume_from_checkpoint to u64::MAX
+                        // Update old task to finish at resume_from_checkpoint
+                        let mut target_cp = cp;
+                        while target_cp - task.checkpoint > config.back_fill_lot_size {
+                            self.register_task(
+                                new_task_name(),
+                                target_cp - config.back_fill_lot_size,
+                                target_cp as i64,
+                            )?;
+                            target_cp -= config.back_fill_lot_size;
+                        }
+                        task.target_checkpoint = target_cp;
+                        self.update_task(task)?;
+                        self.register_task(new_task_name(), cp, i64::MAX)?;
+                    }
+                    _ => {
+                        // Scenario 2: resume_from_checkpoint is set, but it's < current checkpoint or not set
+                        // ignore resume_from_checkpoint, resume all task as it is.
+                    }
+                }
+            }
+        }
+
+        // get updated tasks and start workers
+        let updated_tasks = self.tasks()?;
+        // Start latest checkpoint worker
+        // Tasks are ordered in checkpoint descending order, realtime update task always come first
+        // tasks won't be empty here, ok to unwrap.
+        let (realtime_task, backfill_tasks) = updated_tasks.split_first().unwrap();
+        let realtime_task_future = Self::start_executor(
+            self.pool.clone(),
+            self.bridge_genesis_checkpoint,
+            ingestion_metrics.clone(),
+            indexer_meterics.clone(),
+            &config,
+            realtime_task,
+        );
+
+        let backfill_tasks = backfill_tasks.to_vec();
+        let config_clone = config.clone();
+        let pool_clone = self.pool.clone();
+        let bridge_genesis_checkpoint = self.bridge_genesis_checkpoint;
+        let handle = spawn_monitored_task!(async {
+            for backfill_task in backfill_tasks {
+                Self::start_executor(
+                    pool_clone.clone(),
+                    bridge_genesis_checkpoint,
+                    ingestion_metrics.clone(),
+                    indexer_meterics.clone(),
+                    &config_clone,
+                    &backfill_task,
+                )
+                .await
+                .expect("Backfill task failed");
+            }
+        });
+        realtime_task_future.await?;
+        tokio::try_join!(handle)?;
+        Ok(())
+    }
+
+    pub fn tasks(&self) -> Result<Vec<Task>, anyhow::Error> {
+        let mut conn = self.pool.get()?;
+        // clean up completed task
+        delete(dsl::progress_store.filter(columns::checkpoint.ge(columns::target_checkpoint)))
+            .execute(&mut conn)?;
+        // get all unfinished tasks
+        let cp: Vec<models::ProgressStore> = dsl::progress_store
+            .order_by(columns::checkpoint.desc())
+            .load(&mut conn)?;
+        Ok(cp.into_iter().map(|d| d.into()).collect())
+    }
+
+    pub fn register_task(
+        &self,
+        task_name: String,
+        checkpoint: u64,
+        target_checkpoint: i64,
+    ) -> Result<(), anyhow::Error> {
+        let mut conn = self.pool.get()?;
+        diesel::insert_into(schema::progress_store::table)
+            .values(models::ProgressStore {
+                task_name,
+                checkpoint: checkpoint as i64,
+                target_checkpoint,
+                timestamp: None,
+            })
+            .execute(&mut conn)?;
+        Ok(())
+    }
+
+    pub fn update_task(&self, task: Task) -> Result<(), anyhow::Error> {
+        let mut conn = self.pool.get()?;
+        diesel::update(dsl::progress_store.filter(columns::task_name.eq(task.task_name)))
+            .set((
+                columns::checkpoint.eq(task.checkpoint as i64),
+                columns::target_checkpoint.eq(task.target_checkpoint as i64),
+                columns::timestamp.eq(now),
+            ))
+            .execute(&mut conn)?;
+        Ok(())
+    }
+
+    async fn start_executor(
+        pool: PgPool,
+        bridge_genesis_checkpoint: u64,
+        ingestion_metrics: DataIngestionMetrics,
+        indexer_meterics: BridgeIndexerMetrics,
+        config: &Config,
+        task: &Task,
+    ) -> anyhow::Result<()> {
+        let (exit_sender, exit_receiver) = oneshot::channel();
+
+        let progress_store = PgProgressStore {
+            pool: pool.clone(),
+            bridge_genesis_checkpoint,
+            exit_checkpoint: task.target_checkpoint,
+            exit_sender: Some(exit_sender),
+        };
+
+        let mut executor = IndexerExecutor::new(
+            progress_store,
+            1, /* workflow types */
+            ingestion_metrics,
+        );
+
+        let indexer_metrics_cloned = indexer_meterics.clone();
+
+        let worker = SuiBridgeWorker::new(vec![], pool, indexer_metrics_cloned);
+        let worker_pool =
+            WorkerPool::new(worker, task.task_name.clone(), config.concurrency as usize);
+        executor.register(worker_pool).await?;
+        executor
+            .run(
+                config.checkpoints_path.clone().into(),
+                Some(config.remote_store_url.clone()),
+                vec![], // optional remote store access options
+                ReaderOptions::default(),
+                exit_receiver,
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct Task {
+    pub task_name: String,
+    pub checkpoint: u64,
+    pub target_checkpoint: u64,
+    pub timestamp: u64,
+}
+
+impl From<models::ProgressStore> for Task {
+    fn from(value: models::ProgressStore) -> Self {
+        Self {
+            task_name: value.task_name,
+            checkpoint: value.checkpoint as u64,
+            target_checkpoint: value.target_checkpoint as u64,
+            // Ok to unwrap, timestamp is defaulted to now() in database
+            timestamp: value.timestamp.expect("Timestamp not set").0 as u64,
+        }
+    }
+}
+
+pub trait Tasks {
+    fn latest_checkpoint_task(&self) -> Option<Task>;
+}
+
+impl Tasks for Vec<Task> {
+    fn latest_checkpoint_task(&self) -> Option<Task> {
+        self.iter().fold(None, |result, other_task| match &result {
+            Some(task) if task.checkpoint < other_task.checkpoint => Some(other_task.clone()),
+            None => Some(other_task.clone()),
+            _ => result,
+        })
+    }
+}
+
+pub struct PgProgressStore {
+    pool: PgPool,
+    bridge_genesis_checkpoint: u64,
+    exit_checkpoint: u64,
+    exit_sender: Option<Sender<()>>,
+}
+
+#[async_trait]
+impl ProgressStore for PgProgressStore {
+    async fn load(&mut self, task_name: String) -> anyhow::Result<CheckpointSequenceNumber> {
+        let mut conn = self.pool.get()?;
+        let cp: Option<models::ProgressStore> = dsl::progress_store
+            .find(task_name)
+            .select(models::ProgressStore::as_select())
+            .first(&mut conn)
+            .optional()?;
+        Ok(cp
+            .map(|d| d.checkpoint as u64)
+            .unwrap_or(self.bridge_genesis_checkpoint))
+    }
+
+    async fn save(
+        &mut self,
+        task_name: String,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<()> {
+        if checkpoint_number >= self.exit_checkpoint {
+            if let Some(sender) = self.exit_sender.take() {
+                let _ = sender.send(());
+            }
+        }
+        let mut conn = self.pool.get()?;
+        diesel::insert_into(schema::progress_store::table)
+            .values(&models::ProgressStore {
+                task_name,
+                checkpoint: checkpoint_number as i64,
+                target_checkpoint: i64::MAX,
+                timestamp: None,
+            })
+            .on_conflict(dsl::task_name)
+            .do_update()
+            .set((
+                columns::checkpoint.eq(checkpoint_number as i64),
+                columns::timestamp.eq(now),
+            ))
+            .execute(&mut conn)?;
+        Ok(())
+    }
+}
+
+fn new_task_name() -> String {
+    format!("bridge worker - {}", TransactionDigest::random())
+}

--- a/crates/sui-bridge-indexer/src/sui_worker.rs
+++ b/crates/sui-bridge-indexer/src/sui_worker.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::postgres_manager::{get_connection_pool, write, PgPool};
+use crate::postgres_manager::{write, PgPool};
 use crate::{
     metrics::BridgeIndexerMetrics, BridgeDataSource, TokenTransfer, TokenTransferData,
     TokenTransferStatus,
@@ -33,12 +33,11 @@ pub struct SuiBridgeWorker {
 impl SuiBridgeWorker {
     pub fn new(
         bridge_object_ids: Vec<ObjectID>,
-        db_url: String,
+        pg_pool: PgPool,
         metrics: BridgeIndexerMetrics,
     ) -> Self {
         let mut bridge_object_ids = bridge_object_ids.into_iter().collect::<BTreeSet<_>>();
         bridge_object_ids.insert(SUI_BRIDGE_OBJECT_ID);
-        let pg_pool = get_connection_pool(db_url);
         Self {
             bridge_object_ids,
             pg_pool,


### PR DESCRIPTION
## Description 

This PR adds ability to the indexer to ingest checkpoint data in a smarter way, we added a task to ingest "live" data and a separate task to backfill historical data, the historical data are ingested using a range based method and the lot size of each task can be configured, this allow us to Ingest the "latest" historical data first.  

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
