### PR TITLE
Prevent effects equivocation

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1205,7 +1205,7 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub fn insert_effects_signature(
+    pub fn insert_effects_digest_and_signature(
         &self,
         tx_digest: &TransactionDigest,
         effects_digest: &TransactionEffectsDigest,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -29,7 +29,7 @@ use sui_types::base_types::{ConciseableName, ObjectRef};
 use sui_types::committee::Committee;
 use sui_types::committee::CommitteeTrait;
 use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound};
-use sui_types::digests::ChainIdentifier;
+use sui_types::digests::{ChainIdentifier, TransactionEffectsDigest};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{BackingPackageStore, InputKey, ObjectStore};
@@ -351,6 +351,13 @@ pub struct AuthorityEpochTables {
     /// that a user requests a signature for effects from a previous epoch. However, the
     /// signature is still epoch-specific and so is stored in the epoch store.
     effects_signatures: DBMap<TransactionDigest, AuthoritySignInfo>,
+
+    /// When we sign a TransactionEffects, we must record the digest of the effects in order
+    /// to detect and prevent equivocation when re-executing a transaction that may not have been
+    /// committed to disk.
+    /// Entries are removed from this table after the transaction in question has been committed
+    /// to disk.
+    signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
     /// Signatures of transaction certificates that are executed locally.
     transaction_cert_signatures: DBMap<TransactionDigest, AuthorityStrongQuorumSignInfo>,
@@ -1168,6 +1175,7 @@ impl AuthorityPerEpochStore {
         &self,
         tx_key: &TransactionKey,
         tx_digest: &TransactionDigest,
+        effects_digest: &TransactionEffectsDigest,
         effects_signature: Option<&AuthoritySignInfo>,
     ) -> SuiResult {
         let tables = self.tables()?;
@@ -1179,7 +1187,13 @@ impl AuthorityPerEpochStore {
 
         if let Some(effects_signature) = effects_signature {
             batch.insert_batch(&tables.effects_signatures, [(tx_digest, effects_signature)])?;
+
+            batch.insert_batch(
+                &tables.signed_effects_digests,
+                [(tx_digest, effects_digest)],
+            )?;
         }
+
         if !matches!(tx_key, TransactionKey::Digest(_)) {
             batch.insert_batch(&tables.transaction_key_to_digest, [(tx_key, tx_digest)])?;
         }
@@ -1194,12 +1208,17 @@ impl AuthorityPerEpochStore {
     pub fn insert_effects_signature(
         &self,
         tx_digest: &TransactionDigest,
+        effects_digest: &TransactionEffectsDigest,
         effects_signature: &AuthoritySignInfo,
     ) -> SuiResult {
         let tables = self.tables()?;
-        tables
-            .effects_signatures
-            .insert(tx_digest, effects_signature)?;
+        let mut batch = tables.effects_signatures.batch();
+        batch.insert_batch(&tables.effects_signatures, [(tx_digest, effects_signature)])?;
+        batch.insert_batch(
+            &tables.signed_effects_digests,
+            [(tx_digest, effects_digest)],
+        )?;
+        batch.write()?;
         Ok(())
     }
 
@@ -1219,7 +1238,16 @@ impl AuthorityPerEpochStore {
         &self,
         tx_digest: &TransactionDigest,
     ) -> SuiResult<Option<AuthoritySignInfo>> {
-        Ok(self.tables()?.effects_signatures.get(tx_digest)?)
+        let tables = self.tables()?;
+        Ok(tables.effects_signatures.get(tx_digest)?)
+    }
+
+    pub fn get_signed_effects_digest(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> SuiResult<Option<TransactionEffectsDigest>> {
+        let tables = self.tables()?;
+        Ok(tables.signed_effects_digests.get(tx_digest)?)
     }
 
     pub fn get_transaction_cert_sig(
@@ -1373,9 +1401,9 @@ impl AuthorityPerEpochStore {
             .collect())
     }
 
-    /// Deletes many pending certificates.
+    /// Called when transaction outputs are committed to disk
     #[instrument(level = "trace", skip_all)]
-    pub fn multi_remove_pending_execution(&self, digests: &[TransactionDigest]) -> SuiResult<()> {
+    pub fn handle_committed_transactions(&self, digests: &[TransactionDigest]) -> SuiResult<()> {
         let tables = match self.tables() {
             Ok(tables) => tables,
             // After Epoch ends, it is no longer necessary to remove pending transactions
@@ -1384,7 +1412,16 @@ impl AuthorityPerEpochStore {
             Err(e) => return Err(e),
         };
         let mut batch = tables.pending_execution.batch();
+        // pending_execution stores transactions received from consensus which may not have
+        // been executed yet. At this point, they have been committed to the db durably and
+        // can be removed.
+        // After end-to-end quarantining, we will not need pending_execution since the consensus
+        // log itself will be used for recovery.
         batch.delete_batch(&tables.pending_execution, digests)?;
+
+        // Now that the transaction effects are committed, we will never re-execute, so we
+        // don't need to worry about equivocating.
+        batch.delete_batch(&tables.signed_effects_digests, digests)?;
         batch.write()?;
         Ok(())
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -432,13 +432,8 @@ impl CheckpointExecutor {
             .await
             .expect("commit_transaction_outputs cannot fail");
 
-        // pending_execution stores transactions received from consensus which may not have
-        // been executed yet. At this point, they have been committed to the db durably and
-        // can be removed.
-        // After end-to-end quarantining, we will not need pending_execution since the consensus
-        // log itself will be used for recovery.
         epoch_store
-            .multi_remove_pending_execution(all_tx_digests)
+            .handle_committed_transactions(all_tx_digests)
             .expect("cannot fail");
 
         if !checkpoint.is_last_checkpoint_of_epoch() {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2765,6 +2765,7 @@ mod tests {
             .insert_tx_key_and_effects_signature(
                 &TransactionKey::Digest(digest),
                 &digest,
+                &effects.digest(),
                 Some(&AuthoritySignInfo::new(
                     epoch_store.epoch(),
                     &effects,


### PR DESCRIPTION
With the writeback cache enabled, a validator can lose execution outputs when restarting, if they have not yet been committed to disk. But the validator may have returned signed effects for those transactions to users. If they have done so, we must be sure we do not produce differing outputs when re-executing any such transaction. (The most likely way this would happen would be due to switching to an upgraded binary that changes execution in some way).
