### PR TITLE
[move] Fix crash

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -343,6 +343,7 @@ pub enum LValue_ {
         unused_binding: bool,
     },
     Unpack(ModuleIdent, DatatypeName, Option<Vec<Type>>, Fields<LValue>),
+    Error,
 }
 pub type LValue = Spanned<LValue_>;
 pub type LValueList_ = Vec<LValue>;
@@ -1996,6 +1997,7 @@ impl AstDebug for LValue_ {
         use LValue_ as L;
         match self {
             L::Ignore => w.write("_"),
+            L::Error => w.write("<_error>"),
             L::Var {
                 mut_,
                 var,

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -360,6 +360,7 @@ mod recolor_struct {
         pub fn add_lvalue(&mut self, sp!(_, lvalue_): &N::LValue) {
             match lvalue_ {
                 N::LValue_::Ignore => (),
+                N::LValue_::Error => (),
                 N::LValue_::Var { var, .. } => {
                     self.vars.insert(*var);
                 }
@@ -507,6 +508,7 @@ fn recolor_lvalues(ctx: &mut Recolor, lvalues: &mut N::LValueList) {
 fn recolor_lvalue(ctx: &mut Recolor, sp!(_, lvalue_): &mut N::LValue) {
     match lvalue_ {
         N::LValue_::Ignore => (),
+        N::LValue_::Error => (),
         N::LValue_::Var { var, .. } => recolor_var(ctx, var),
         N::LValue_::Unpack(_, _, _, lvalues) => {
             for (_, _, (_, lvalue)) in lvalues {
@@ -785,6 +787,7 @@ fn lvalues(context: &mut Context, sp!(_, lvs_): &mut N::LValueList) {
 fn lvalue(context: &mut Context, sp!(_, lv_): &mut N::LValue) {
     match lv_ {
         N::LValue_::Ignore => (),
+        N::LValue_::Error => (),
         N::LValue_::Var {
             var: sp!(_, v_), ..
         } => {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -2644,6 +2644,10 @@ fn lvalue(
             );
             TL::Ignore
         }
+        NL::Error => {
+            assert!(context.env.has_errors());
+            TL::Ignore
+        }
         NL::Var {
             mut_,
             var,

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/partially_invalid_binding_with_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/partially_invalid_binding_with_usage.exp
@@ -1,0 +1,15 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/naming/partially_invalid_binding_with_usage.move:3:13
+  │
+3 │         let (b, R{f}): (); b;
+  │             ^^^^^^^^^  -- Given: '()'
+  │             │           
+  │             Invalid value for binding
+  │             Expected: '(_, _)'
+
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/partially_invalid_binding_with_usage.move:3:17
+  │
+3 │         let (b, R{f}): (); b;
+  │                 ^ Unbound type 'R' in current scope
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/partially_invalid_binding_with_usage.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/partially_invalid_binding_with_usage.move
@@ -1,0 +1,5 @@
+module 0x0::M {
+    public fun crash() {
+        let (b, R{f}): (); b;
+    }
+}


### PR DESCRIPTION
## Description 

Fix a crash (now ICE) in the compiler that occurred due to how naming erased invalid `lvalue` forms.

Also modifies `diagnostics` to be better-behaved when errors without locations are reported (e.g., due to `sui_mode` implicits).

## Test plan 

Added a new test with updated output.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
