### PR TITLE
docs: automated address management

### DIFF
--- a/docs/content/concepts/sui-move-concepts/packages.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages.mdx
@@ -1,5 +1,5 @@
 ---
-title: Package Upgrades
+title: Packages
 description: A Move package on Sui includes one or more modules that define that package's interaction with on-chain objects. Upgrading on-chain packages provides a way to improve your code or add features without affecting packages that use your published modules.
 ---
 

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -15,9 +15,8 @@ Previously a `published-at` entry was **mandatory** in the `Move.toml` file, whi
 1. Switch to your active environment for the chain that your package is published on
       ```
       sui client --switch --env <YOUR-CHAIN-ENVIRONMENT>
-```
-
-2. Run the `manage-package` command with the data for your published package
+      ```
+1. Run the `manage-package` command with the data for your published package
       ```
       sui move manage-package --environment "$(sui client active-env)" \
                         --network-id "$(sui client chain-identifier)" \

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -4,7 +4,7 @@ title: Automated Address Management
 
 When you publish or upgrade a package, its address (also known as the package ID) is tracked in the `Move.lock` file. This bookkeeping is done automatically so that you can avoid recording or updating hex addresses (for example, in the `Move.toml` file). 
 
-When you publish or upgrade your package on multiple chains (e.g., `mainnet`, `testnet`, `devnet`) separate addresses for each chain will be tracked for you. This tracking is based on your active environment (e.g., run `sui client active-env`). For example, if you set your active environment to an RPC connected to `testnet` and publish a package, the `Move.lock` will record the address for that package and associate it with your active environment (`testnet`).
+When you publish or upgrade your package on multiple chains (Mainnet, Testnet, Devnet) separate addresses for each chain are tracked for you. This tracking is based on your active environment (run `sui client active-env` if unsure). For example, if you set your active environment to an RPC connected to `testnet` and publish a package, the `Move.lock` records the address for that package and associates it with your active environment (`testnet`).
 
 Note that automated address management works for one package published to one or more chains. When you publish or upgrade, it uses the contents of the package's working directory. If a package is republished to a chain, addresses tracked for the previously published package will be overwritten for that chain.
 

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -2,7 +2,7 @@
 title: Automated Address Management
 ---
 
-When you publish or upgrade a package, its address (also known as the package ID) is tracked in the `Move.lock` file. This bookkeeping is done automatically so that you can avoid recording or updating hex addresses (e.g., in the `Move.toml` file). 
+When you publish or upgrade a package, its address (also known as the package ID) is tracked in the `Move.lock` file. This bookkeeping is done automatically so that you can avoid recording or updating hex addresses (for example, in the `Move.toml` file). 
 
 When you publish or upgrade your package on multiple chains (e.g., `mainnet`, `testnet`, `devnet`) separate addresses for each chain will be tracked for you. This tracking is based on your active environment (e.g., run `sui client active-env`). For example, if you set your active environment to an RPC connected to `testnet` and publish a package, the `Move.lock` will record the address for that package and associate it with your active environment (`testnet`).
 

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -6,16 +6,15 @@ When you publish or upgrade a package, its address (also known as the package ID
 
 When you publish or upgrade your package on multiple chains (Mainnet, Testnet, Devnet) separate addresses for each chain are tracked for you. This tracking is based on your active environment (run `sui client active-env` if unsure). For example, if you set your active environment to an RPC connected to `testnet` and publish a package, the `Move.lock` records the address for that package and associates it with your active environment (`testnet`).
 
-Note that automated address management works for one package published to one or more chains. When you publish or upgrade, it uses the contents of the package's working directory. If a package is republished to a chain, addresses tracked for the previously published package will be overwritten for that chain.
+Note that automated address management works for one package published to one or more chains. When you publish or upgrade, address management uses the contents of the package's working directory. If a package is republished to a chain, addresses tracked for the previously published package are overwritten for that chain.
 
 ## Adopting automated address management for published packages
 
-Previously a `published-at` entry was **mandatory** in the `Move.toml` file, which sets the address of the latest published package. It is no longer required if this data is tracked in the `Move.lock` file. For an existing package, you'll need to add the necessary data to the `Move.lock` file so that it can be automatically tracked:
+Previously a `published-at` entry was **mandatory** in the `Move.toml` file, which sets the address of the latest published package. It is no longer required if this data is tracked in the `Move.lock` file. For an existing package, add the necessary data to the `Move.lock` file so that it can be automatically tracked:
 
 1. Switch to your active environment for the chain that your package is published on
-
-```
-sui client --switch --env <YOUR-CHAIN-ENVIRONMENT>
+      ```
+      sui client --switch --env <YOUR-CHAIN-ENVIRONMENT>
 ```
 
 2. Run the `manage-package` command with the data for your published package

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -55,7 +55,7 @@ Here are steps to remediate conflicting addresses:
 
 ## Internal reference
 
-This section is an overview of the schema and internal operation of tracked address in the `Move.lock` file. The ordinary developer does not need to understand these internals. It is a reference for those who want a complete interface or control to internal state tracking.
+This section is an overview of the schema and internal operation of tracked address in the `Move.lock` file. Most developers do not need to understand these internals. It is a reference for those who want a complete interface or control to internal state tracking.
 
 A concrete example of the schema and state you might find in a `Move.lock` file:
 
@@ -75,10 +75,11 @@ latest-published-id = "0xaee5759aedf6c533634cdd2de412f6e6dfc754a89b0ec554a735973
 published-version = "1"
 ```
 
-Notes:
+:::info
 
 - An `[env]` table contains entries for each environment. When a package is published for an active environment, an entry is added or updated.
  
-- An entry is added or updated based on its the `chain-id` of the environment. I.e., addresses are keyed by `chain-id`, not the `[env.NAME]` part. This is so that packages and their dependencies are resolved canonically by chain identifier: keying by `[env.NAME]` is not robust when users may choose arbitrary environment `NAME` aliases.
+- An entry is added or updated based on its the `chain-id` of the environment. As in, addresses are keyed by `chain-id`, not the `[env.NAME]` part. This is so that packages and their dependencies are resolved canonically by chain identifier: keying by `[env.NAME]` is not robust when users can choose arbitrary environment `NAME` aliases.
 
 - Key-value entries correspond to data explained in [adopting automated address management](#adopting-automated-address-management-for-published-packages). Use the `sui move manage-package` command as a frontend to manipulate these values.
+:::

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -27,13 +27,12 @@ sui move manage-package --environment "$(sui client active-env)" \
                         --version-number 'VERSION-NUMBER'
 ```
 
-- `ORIGINAL-ADDRESS` should be the address your package was first published at. If you never upgraded your package, this the same address as your `published-at` address in the `Move.toml`
-- `LATEST-ADDRESS` should be the latest package address. If you never upgraded your package, it is the same as `ORIGINAL-ADDRESS`. If you upgraded your package, this is the same address as your current `published-at` address in the `Move.toml`.
-- `VERSION-NUMBER` is `1` if you never upgraded your package. Otherwise, it is a number greater than `1` depending on how many times you upgraded your package. In this case, look up the package at `LATEST-ADDRESS` to determine the version number.
+      - `ORIGINAL-ADDRESS` should be the address your package was first published at. If you never upgraded your package, this the same address as your `published-at` address in the `Move.toml`
+      - `LATEST-ADDRESS` should be the latest package address. If you never upgraded your package, it is the same as `ORIGINAL-ADDRESS`. If you upgraded your package, this is the same address as your current `published-at` address in the `Move.toml`.
+      - `VERSION-NUMBER` is `1` if you never upgraded your package. Otherwise, it is a number greater than `1` depending on how many times you upgraded your package. In this case, look up the package at `LATEST-ADDRESS` to determine the version number.
+1. Delete the `published-at` line in your `Move.toml`. Your package is now tracked. You can repeat the above steps to track addresses for additional environments.
 
-3. Delete the `published-at` line in your `Move.toml`. Your package is now tracked. You can repeat the above steps to track addresses for additional environments.
-
-## Package Upgrade Guidance
+## Package upgrade guidance
 
 - When [upgrading](./upgrade#upgrade-requirements), you need to retrieve the `UpgradeCap` ID of your published package. Automated address management does not track your `UpgradeCap`.
 

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -18,15 +18,13 @@ Previously a `published-at` entry was **mandatory** in the `Move.toml` file, whi
 ```
 
 2. Run the `manage-package` command with the data for your published package
-
-```
-sui move manage-package --environment "$(sui client active-env)" \
+      ```
+      sui move manage-package --environment "$(sui client active-env)" \
                         --network-id "$(sui client chain-identifier)" \
                         --original-id 'ORIGINAL-ADDRESS' \
                         --latest-id 'LATEST-ADDRESS' \
                         --version-number 'VERSION-NUMBER'
-```
-
+      ```
       - `ORIGINAL-ADDRESS` should be the address your package was first published at. If you never upgraded your package, this the same address as your `published-at` address in the `Move.toml`
       - `LATEST-ADDRESS` should be the latest package address. If you never upgraded your package, it is the same as `ORIGINAL-ADDRESS`. If you upgraded your package, this is the same address as your current `published-at` address in the `Move.toml`.
       - `VERSION-NUMBER` is `1` if you never upgraded your package. Otherwise, it is a number greater than `1` depending on how many times you upgraded your package. In this case, look up the package at `LATEST-ADDRESS` to determine the version number.

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -1,0 +1,85 @@
+---
+title: Automated Address Management
+---
+
+When you publish or upgrade a package, its address (also known as the package ID) is tracked in the `Move.lock` file. This bookkeeping is done automatically so that you can avoid recording or updating hex addresses (e.g., in the `Move.toml` file). 
+
+When you publish or upgrade your package on multiple chains (e.g., `mainnet`, `testnet`, `devnet`) separate addresses for each chain will be tracked for you. This tracking is based on your active environment (e.g., run `sui client active-env`). For example, if you set your active environment to an RPC connected to `testnet` and publish a package, the `Move.lock` will record the address for that package and associate it with your active environment (`testnet`).
+
+Note that automated address management works for one package published to one or more chains. When you publish or upgrade, it uses the contents of the package's working directory. If a package is republished to a chain, addresses tracked for the previously published package will be overwritten for that chain.
+
+## Adopting automated address management for published packages
+
+Previously a `published-at` entry was **mandatory** in the `Move.toml` file, which sets the address of the latest published package. It is no longer required if this data is tracked in the `Move.lock` file. For an existing package, you'll need to add the necessary data to the `Move.lock` file so that it can be automatically tracked:
+
+1. Switch to your active environment for the chain that your package is published on
+
+```
+sui client --switch --env <YOUR-CHAIN-ENVIRONMENT>
+```
+
+2. Run the `manage-package` command with the data for your published package
+
+```
+sui move manage-package --environment "$(sui client active-env)" \
+                        --network-id "$(sui client chain-identifier)" \
+                        --original-id 'ORIGINAL-ADDRESS' \
+                        --latest-id 'LATEST-ADDRESS' \
+                        --version-number 'VERSION-NUMBER'
+```
+
+- `ORIGINAL-ADDRESS` should be the address your package was first published at. If you never upgraded your package, this the same address as your `published-at` address in the `Move.toml`
+- `LATEST-ADDRESS` should be the latest package address. If you never upgraded your package, it is the same as `ORIGINAL-ADDRESS`. If you upgraded your package, this is the same address as your current `published-at` address in the `Move.toml`.
+- `VERSION-NUMBER` is `1` if you never upgraded your package. Otherwise, it is a number greater than `1` depending on how many times you upgraded your package. In this case, look up the package at `LATEST-ADDRESS` to determine the version number.
+
+3. Delete the `published-at` line in your `Move.toml`. Your package is now tracked. You can repeat the above steps to track addresses for additional environments.
+
+## Package Upgrade Guidance
+
+- When [upgrading](./upgrade#upgrade-requirements), you will need to retrieve the `UpgradeCap` ID of your published package. Automated address management does not track your `UpgradeCap`.
+
+- When [upgrading](./upgrade#example), you will first need to set the `[addresses]` value for your package to `0x0` in the `Move.toml`, and restore its ID with the `ORIGINAL-ADDRESS` after upgrading.
+
+## Troubleshooting
+
+Conflicting published package addresses may happen when the state of package data is inconsistent.
+
+For example, you may have an existing package with a `published-at` value in the `Move.toml`. The package is re-published for testing purposes, and is now tracked in `Move.lock` with automated address management. The address in the `Move.toml` and `Move.lock` now differ, and there will be an error the next time you try to publish or upgrade the package.
+
+Here are steps to remediate conflicting addresses:
+
+- If the conflict is in a package you maintain:
+  - Delete the `published-at` value in your `Move.toml` if this published address is no longer needed
+  - Alternatively, follow the steps to [adopt automated address management](#adopting-automated-address-management-for-published-packages)
+
+- If the conflict is in a package that you do not maintain (e.g., a dependency), consider fixing the issue locally with the steps above, or contacting the maintainer to upstream changes.
+
+## Internal reference
+
+This section is an overview of the schema and internal operation of tracked address in the `Move.lock` file. The ordinary developer does not need to understand these internals. It is a reference for those who want a complete interface or control to internal state tracking.
+
+A concrete example of the schema and state you might find in a `Move.lock` file:
+
+```toml
+[env]
+
+[env.testnet]
+chain-id = "4c78adac"
+original-published-id = "0xa6041ac57f9151d49d00dcdc4f79f8c5ba1e399e1005dcb0fdd1c8632020d5a6"
+latest-published-id = "0xa6041ac57f9151d49d00dcdc4f79f8c5ba1e399e1005dcb0fdd1c8632020d5a6"
+published-version = "1"
+
+[env.mainnet]
+chain-id = "35834a8a"
+original-published-id = "0xaee5759aedf6c533634cdd2de412f6e6dfc754a89b0ec554a73597348f334477"
+latest-published-id = "0xaee5759aedf6c533634cdd2de412f6e6dfc754a89b0ec554a73597348f334477"
+published-version = "1"
+```
+
+Notes:
+
+- An `[env]` table contains entries for each environment. When a package is published for an active environment, an entry is added or updated.
+ 
+- An entry is added or updated based on its the `chain-id` of the environment. I.e., addresses are keyed by `chain-id`, not the `[env.NAME]` part. This is so that packages and their dependencies are resolved canonically by chain identifier: keying by `[env.NAME]` is not robust when users may choose arbitrary environment `NAME` aliases.
+
+- Key-value entries correspond to data explained in [adopting automated address management](#adopting-automated-address-management-for-published-packages). Use the `sui move manage-package` command as a frontend to manipulate these values.

--- a/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/automated-address-management.mdx
@@ -35,15 +35,15 @@ sui move manage-package --environment "$(sui client active-env)" \
 
 ## Package Upgrade Guidance
 
-- When [upgrading](./upgrade#upgrade-requirements), you will need to retrieve the `UpgradeCap` ID of your published package. Automated address management does not track your `UpgradeCap`.
+- When [upgrading](./upgrade#upgrade-requirements), you need to retrieve the `UpgradeCap` ID of your published package. Automated address management does not track your `UpgradeCap`.
 
-- When [upgrading](./upgrade#example), you will first need to set the `[addresses]` value for your package to `0x0` in the `Move.toml`, and restore its ID with the `ORIGINAL-ADDRESS` after upgrading.
+- When [upgrading](./upgrade#example), you first need to set the `[addresses]` value for your package to `0x0` in the `Move.toml`, and restore its ID with the `ORIGINAL-ADDRESS` after upgrading.
 
 ## Troubleshooting
 
-Conflicting published package addresses may happen when the state of package data is inconsistent.
+Conflicting published package addresses might happen when the state of package data is inconsistent.
 
-For example, you may have an existing package with a `published-at` value in the `Move.toml`. The package is re-published for testing purposes, and is now tracked in `Move.lock` with automated address management. The address in the `Move.toml` and `Move.lock` now differ, and there will be an error the next time you try to publish or upgrade the package.
+For example, you might have an existing package with a `published-at` value in the `Move.toml`. The package is re-published for testing purposes, and is now tracked in `Move.lock` with automated address management. The address in the `Move.toml` and `Move.lock` now differ, and there will be an error the next time you try to publish or upgrade the package.
 
 Here are steps to remediate conflicting addresses:
 
@@ -51,7 +51,7 @@ Here are steps to remediate conflicting addresses:
   - Delete the `published-at` value in your `Move.toml` if this published address is no longer needed
   - Alternatively, follow the steps to [adopt automated address management](#adopting-automated-address-management-for-published-packages)
 
-- If the conflict is in a package that you do not maintain (e.g., a dependency), consider fixing the issue locally with the steps above, or contacting the maintainer to upstream changes.
+- If the conflict is in a package that you do not maintain (such as a dependency), consider fixing the issue locally with the steps above, or contacting the maintainer to upstream changes.
 
 ## Internal reference
 

--- a/docs/content/concepts/sui-move-concepts/packages/upgrade.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/upgrade.mdx
@@ -377,7 +377,22 @@ The result includes an **Object changes** section with two pieces of information
 
 You can identify the different objects using the `Object.objectType` value in the response. The `UpgradeCap` entry has a value of `String("0x2::package::UpgradeCap")` and the `objectType` for the package reads `String("<PACKAGE-ID>::sui_package::<MODULE-NAME>")`
 
-To make sure your other packages can use this package as a dependency, you must update the manifest (Move.toml file) for your package to include this information.
+To make sure your other packages can use this package as a dependency, you must update the `Move.toml` manifest file for your package to include this information.
+
+<Tabs>
+
+<TabItem value="automated-address-management" label="Automated Addresses">
+
+Add an entry for the package in the `[addresses]` section that points to the value of the on-chain ID:
+
+```toml
+[addresses]
+sui_package = "<ORIGINAL-PACKAGE-ID>"
+```
+
+</TabItem>
+
+<TabItem value="manual-address-management" label="Manual Addresses">
 
 Update the alias address and add a new `published-at` entry in the `[package]` section, both pointing to the value of the on-chain ID:
 
@@ -391,9 +406,29 @@ published-at = "<ORIGINAL-PACKAGE-ID>"
 sui_package = "<ORIGINAL-PACKAGE-ID>"
 ```
 
-The `published-at` value allows the Move compiler to verify dependencies against on-chain versions of those packages.
+</TabItem>
 
-After a while, you decide to upgrade your `sui_package` to include some requested features. Before running the `upgrade` command, you need to edit the manifest again. In the `[addresses]` section, you update the `sui_package` address value to `0x0` again so the validator issues a new address for the upgrade package. You can leave the `published-at` value the same, because it is only read by the toolchain when publishing a dependent package. The saved manifest now resembles the following:
+</Tabs>
+
+
+After a while, you decide to upgrade your `sui_package` to include some requested features. Before running the `upgrade` command, you need to edit the manifest again.
+
+<Tabs>
+
+<TabItem value="automated-address-management" label="Automated Addresses">
+
+In the `[addresses]` section, you update the `sui_package` address value to `0x0` again so the validator issues a new address for the upgrade package.
+
+```toml
+[addresses]
+sui_package = "0x0"
+```
+
+</TabItem>
+
+<TabItem value="manual-address-management" label="Manual Addresses">
+
+In the `[addresses]` section, you update the `sui_package` address value to `0x0` again so the validator issues a new address for the upgrade package. You can leave the `published-at` value the same, because it is only read by the toolchain when publishing a dependent package. The saved manifest now resembles the following:
 
 ```toml
 [package]
@@ -404,6 +439,11 @@ published-at = "<ORIGINAL-PACKAGE-ID>"
 [addresses]
 sui_package = "0x0"
 ```
+
+</TabItem>
+
+</Tabs>
+
 
 With the new manifest and code in place, it's time to use the `sui client upgrade` command to upgrade your package. Pass the `UpgradeCap` ID (the `<UPGRADE-CAP-ID>` value from the example) to the `--upgrade-capability` flag.
 
@@ -496,7 +536,23 @@ Array [
 
 ```
 
-The result provides a new ID for the upgraded package. As was the case before the upgrade, you need to include that information in your manifest so any of your other packages that depend on your `sui_package` know where to find the on-chain bytecode for verification. Edit your manifest once again to provide the upgraded package ID for the `published-at` value, and return the original `sui_package` ID value in the `[addresses]` section:
+The result provides a new ID for the upgraded package.
+
+<Tabs>
+
+<TabItem value="automated-address-management" label="Automated Addresses">
+
+After upgrading, return the original `sui_package` ID value in the `[addresses]` section:
+
+```toml
+[addresses]
+sui_package = "<ORIGINAL-PACKAGE-ID>"
+```
+</TabItem>
+
+<TabItem value="manual-address-management" label="Manual Addresses">
+
+So that any of your other packages that depend on your `sui_package` know where to find the on-chain bytecode for verification, edit your manifest once again to provide the upgraded package ID for the `published-at` value, and return the original `sui_package` ID value in the `[addresses]` section:
 
 
 ```toml
@@ -509,4 +565,10 @@ published-at = "<UPGRADED-PACKAGE-ID>"
 sui_package = "<ORIGINAL-PACKAGE-ID>"
 ```
 
-The `published-at` value changes with every upgrade. The ID for the `sui_package` in the `[addresses]` section always points to the original package ID after upgrading. You must always change that value back to `0x0`, however, before running the `upgrade` command so the validator knows to create a new ID for the upgrade.
+Note the `published-at` value changes with every upgrade and needs to be updated after every upgrade.
+
+</TabItem>
+
+</Tabs>
+
+The ID for the `sui_package` in the `[addresses]` section always points to the original package ID after upgrading. You must always change that value back to `0x0`, however, before running the `upgrade` command so the validator knows to create a new ID for the upgrade.

--- a/docs/content/concepts/sui-move-concepts/packages/upgrade.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/upgrade.mdx
@@ -552,7 +552,7 @@ sui_package = "<ORIGINAL-PACKAGE-ID>"
 
 <TabItem value="manual-address-management" label="Manual Addresses">
 
-So that any of your other packages that depend on your `sui_package` know where to find the on-chain bytecode for verification, edit your manifest once again to provide the upgraded package ID for the `published-at` value, and return the original `sui_package` ID value in the `[addresses]` section:
+So that packages that depend on your `sui_package` know where to find the on-chain bytecode for verification, edit your manifest again. Provide the upgraded package ID for the `published-at` value and return the original `sui_package` ID value in the `[addresses]` section:
 
 
 ```toml

--- a/docs/content/guides/developer/nft/asset-tokenization.mdx
+++ b/docs/content/guides/developer/nft/asset-tokenization.mdx
@@ -719,7 +719,7 @@ You can also view a multitude of information and transactional effects.
 
 You should choose and store the `package ID` and the `registry ID` from the created objects in the respective fields within your .env file.
 
-Afterward, it's necessary to modify the `Move.toml` file. Under the `[package]` section, add `published-at = <package ID>`. Additionally, under the `[addresses]` section, replace `0x0` with the same `package ID`.
+Afterward, it's necessary to modify the `Move.toml` file. Under the `[addresses]` section, replace `0x0` with the same `package ID`. Optionally, under the `[package]` section, add `published-at = <package ID>` (this step is not needed if you see a `Move.lock` file after running `sui client publish`).
 
 ### Automatically
 
@@ -768,8 +768,8 @@ You should choose and store the `package ID`, asset `metadata ID`, `asset cap ID
 
 The process of automatic deployment for the template package refers to publishing a new asset via the WASM library. Quick start steps:
 
-- Make sure that the `asset_tokenization/Move.toml` file has its published-at field uncommented and populated with the latest deployment of the package.
-- Ensure that the `asset_tokenization` package address is the same as the original deployment (if upgraded otherwise same as published-at).
+- Ensure that the `asset_tokenization` package address is set in the `[addresses]` section of `asset_tokenization/Move.toml`. This address should be the same as the original package deployment.
+- If a `Move.lock` file exists after running`sui client publish`, go on to the next step. If not, ensure that the `asset_tokenization/Move.toml` file has its `published-at` field uncommented and populated with the address of the latest package deployment.
 - Make any changes to the template fields by changing the input parameters of the `publishNewAsset` function.
 - Run `npm run publish-template`.
 - You should choose and store the _Template Package ID_, _asset metadata ID_, _asset cap ID_ and the _publisher ID_ from the created objects in the respective fields within your **.env** file.

--- a/docs/content/sidebars/concepts.js
+++ b/docs/content/sidebars/concepts.js
@@ -72,7 +72,7 @@ const concepts = [
 					'concepts/sui-move-concepts/one-time-witness',
 					{
 						type: 'category',
-						label: 'Package Upgrades',
+						label: 'Packages',
 						link: {
 							type: 'doc',
 							id: 'concepts/sui-move-concepts/packages',
@@ -80,6 +80,7 @@ const concepts = [
 						items: [
 							'concepts/sui-move-concepts/packages/upgrade',
 							'concepts/sui-move-concepts/packages/custom-policies',
+							'concepts/sui-move-concepts/packages/automated-address-management',
 						],
 					},
 					'concepts/sui-move-concepts/conventions',

--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -55,6 +55,7 @@
       { "source": "/build/zk_login", "destination": "/concepts/cryptography/zklogin", "permanent": true },
       { "source": "/build/package-upgrades", "destination": "/concepts/sui-move-concepts/packages/upgrade", "permanent": true },
       { "source": "/build/custom-upgrade-policy", "destination": "/concepts/sui-move-concepts/packages/custom-policies", "permanent": true },
+      { "source": "/build/automated-address-management", "destination": "/concepts/sui-move-concepts/packages/automated-address-management", "permanent": true },
       { "source": "/build/cli-client", "destination": "/references/cli/client", "permanent": true },
       { "source": "/build/connect-sui-network", "destination": "/guides/developer/getting-started/connect", "permanent": true },
       { "source": "/build/prog-trans-ts-sdk", "destination": "/guides/developer/sui-101/building-ptb", "permanent": true },


### PR DESCRIPTION
## Description 

Adds docs that reflect the functionality in https://github.com/MystenLabs/sui/pull/17995.

I just wanted to get the bulk of documentation for automated address management out, which is this PR. The main addition is a page on `Automated Address Management`.

Some nitty gritty:

Coming up in a PR soon™️, the need for manipulating `[addresses]` will go away with automated address management and that will be reflected in the docs as well. In the interest of reflecting the current functionality (post https://github.com/MystenLabs/sui/pull/17995 merge), this PR preserves the instructions that go along with upgrading and setting `0x0` in `[addresses]`. I've carved out tabs in the `Upgrading Packages` doc section to separate steps with `Automated Addresses` versus (legacy) `Manual Addresses`:

![Screenshot 2024-06-26 at 11 58 37 PM](https://github.com/MystenLabs/sui/assets/888624/6f7e07c9-8b7f-44c1-a326-88f8c11e9b59)

## Test plan 

N/A docs, ran the doc commands manually

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
