### PR TITLE
[bridge indexer] increase the max elapsed time for the eth query retry loops

### DIFF
--- a/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
+++ b/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
@@ -101,7 +101,7 @@ where
             interval.tick().await;
             let Ok(Ok(new_block)) = retry_with_max_elapsed_time!(
                 provider.get_block_number(),
-                time::Duration::from_secs(10)
+                time::Duration::from_secs(600)
             ) else {
                 error!("Failed to get latest block from eth client after retry");
                 continue;
@@ -125,7 +125,7 @@ where
             let timer = Instant::now();
             let Ok(Ok(events)) = retry_with_max_elapsed_time!(
                 eth_client.get_events_in_range(contract_address, start_block, end_block),
-                Duration::from_secs(30)
+                Duration::from_secs(600)
             ) else {
                 error!("Failed to get events from eth client after retry");
                 continue;

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -41,12 +41,12 @@ pub mod e2e_tests;
 macro_rules! retry_with_max_elapsed_time {
     ($func:expr, $max_elapsed_time:expr) => {{
         // The following delay sequence (in secs) will be used, applied with jitter
-        // 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 30, 30, 30 ...
+        // 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 30, 60, 120, 120 ...
         let backoff = backoff::ExponentialBackoff {
             initial_interval: Duration::from_millis(400),
             randomization_factor: 0.1,
             multiplier: 2.0,
-            max_interval: Duration::from_secs(30),
+            max_interval: Duration::from_secs(120),
             max_elapsed_time: Some($max_elapsed_time),
             ..Default::default()
         };

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y libpq5 libpq-dev ca-certificates
 COPY --from=builder /sui/target/release/sui-node /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin
 COPY --from=builder /sui/target/release/sui-bridge /usr/local/bin
+COPY --from=builder /sui/target/release/bridge-indexer /usr/local/bin
 COPY --from=builder /sui/target/release/sui-bridge-cli /usr/local/bin
 COPY --from=builder /sui/target/release/sui-analytics-indexer /usr/local/bin
 COPY --from=builder /sui/target/release/sui-proxy /usr/local/bin


### PR DESCRIPTION
## Description 

This change makes the exponential backoff to duration longer hence reduce the amount of queries we send to eth providers.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
