### PR TITLE
[Consensus] stop commit sync when consensus handler cannot keep up

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -57,8 +57,8 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_commit_sync_batch_size")]
     pub commit_sync_batch_size: u32,
 
-    // Maximum number of commit batches being fetched, before throttling
-    // of outgoing commit fetches starts.
+    // This affects the maximum number of commit batches being fetched, and those fetched but not
+    // processed as consensus output, before throttling of outgoing commit fetches starts.
     #[serde(default = "Parameters::default_commit_sync_batches_ahead")]
     pub commit_sync_batches_ahead: usize,
 
@@ -129,6 +129,8 @@ impl Parameters {
     }
 
     pub(crate) fn default_commit_sync_batches_ahead() -> usize {
+        // This is set to be a multiple of default commit_sync_parallel_fetches to allow fetching ahead,
+        // while keeping the total number of inflight fetches and unprocessed fetched commits limited.
         80
     }
 

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -129,7 +129,7 @@ impl Parameters {
     }
 
     pub(crate) fn default_commit_sync_batches_ahead() -> usize {
-        200
+        80
     }
 
     pub(crate) fn default_sync_last_proposed_block_timeout() -> Duration {

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -15,7 +15,7 @@ max_blocks_per_fetch: 1000
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 20
 commit_sync_batch_size: 100
-commit_sync_batches_ahead: 200
+commit_sync_batches_ahead: 80
 anemo:
   excessive_message_size: 8388608
 tonic:

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -475,7 +475,7 @@ mod tests {
         // Stop authority 1.
         let index = committee.to_authority_index(1).unwrap();
         authorities.remove(index.value()).stop().await;
-        sleep(Duration::from_secs(15)).await;
+        sleep(Duration::from_secs(10)).await;
 
         // Restart authority 1 and let it run.
         let (authority, receiver) = make_authority(
@@ -488,7 +488,7 @@ mod tests {
         .await;
         output_receivers[index] = receiver;
         authorities.insert(index.value(), authority);
-        sleep(Duration::from_secs(15)).await;
+        sleep(Duration::from_secs(10)).await;
 
         // Stop all authorities and exit.
         for authority in authorities {

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -15,7 +15,8 @@ use crate::{
     block_verifier::SignedBlockVerifier,
     broadcaster::Broadcaster,
     commit_observer::CommitObserver,
-    commit_syncer::{CommitSyncer, CommitVoteMonitor},
+    commit_syncer::{CommitSyncer, CommitSyncerHandle},
+    commit_vote_monitor::CommitVoteMonitor,
     context::{Clock, Context},
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
@@ -120,7 +121,7 @@ where
     start_time: Instant,
     transaction_client: Arc<TransactionClient>,
     synchronizer: Arc<SynchronizerHandle>,
-    commit_syncer: CommitSyncer<N::Client>,
+    commit_syncer_handle: CommitSyncerHandle,
     leader_timeout_handle: LeaderTimeoutTaskHandle,
     core_thread_handle: CoreThreadHandle,
     // Only one of broadcaster and subscriber gets created, depending on
@@ -209,6 +210,7 @@ where
             ))
         };
 
+        let commit_consumer_monitor = commit_consumer.monitor();
         let commit_observer = CommitObserver::new(
             context.clone(),
             commit_consumer,
@@ -238,6 +240,7 @@ where
             LeaderTimeoutTask::start(core_dispatcher.clone(), &signals_receivers, context.clone());
 
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+
         let synchronizer = Synchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -247,14 +250,16 @@ where
             dag_state.clone(),
         );
 
-        let commit_syncer = CommitSyncer::new(
+        let commit_syncer_handle = CommitSyncer::new(
             context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
+            commit_consumer_monitor,
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
-        );
+        )
+        .start();
 
         let network_service = Arc::new(AuthorityService::new(
             context.clone(),
@@ -296,7 +301,7 @@ where
             start_time,
             transaction_client: Arc::new(tx_client),
             synchronizer,
-            commit_syncer,
+            commit_syncer_handle,
             leader_timeout_handle,
             core_thread_handle,
             broadcaster,
@@ -312,8 +317,10 @@ where
         );
 
         // First shutdown components calling into Core.
-        self.synchronizer.stop().await.ok();
-        self.commit_syncer.stop().await;
+        if let Err(e) = self.synchronizer.stop().await {
+            info!("Failed to stop synchronizer: {:?}", e);
+        };
+        self.commit_syncer_handle.stop().await;
         self.leader_timeout_handle.stop().await;
         // Shutdown Core to stop block productions and broadcast.
         // When using streaming, all subscribers to broadcasted blocks stop after this.

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -17,7 +17,7 @@ use crate::{
     block::{BlockAPI as _, BlockRef, SignedBlock, VerifiedBlock, GENESIS_ROUND},
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
-    commit_syncer::CommitVoteMonitor,
+    commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
@@ -171,7 +171,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Observe the block for the commit votes. When local commit is lagging too much,
         // commit sync loop will trigger fetching.
-        self.commit_vote_monitor.observe(&verified_block);
+        self.commit_vote_monitor.observe_block(&verified_block);
 
         // Reject blocks when local commit index is lagging too far from quorum commit index.
         //
@@ -567,7 +567,7 @@ mod tests {
         authority_service::AuthorityService,
         block::BlockAPI,
         block::{BlockRef, SignedBlock, TestBlock, VerifiedBlock},
-        commit_syncer::CommitVoteMonitor,
+        commit_vote_monitor::CommitVoteMonitor,
         context::Context,
         core_thread::{CoreError, CoreThreadDispatcher},
         dag_state::DagState,
@@ -689,24 +689,24 @@ mod tests {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
-            commit_vote_monitor,
+            commit_vote_monitor.clone(),
             block_verifier.clone(),
             dag_state.clone(),
         );
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
-            Arc::new(CommitVoteMonitor::new(context.clone())),
+            commit_vote_monitor,
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
@@ -747,24 +747,24 @@ mod tests {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
-            commit_vote_monitor,
+            commit_vote_monitor.clone(),
             block_verifier.clone(),
             dag_state.clone(),
         );
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
-            Arc::new(CommitVoteMonitor::new(context.clone())),
+            commit_vote_monitor,
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -13,7 +13,6 @@ use bytes::Bytes;
 use consensus_config::{AuthorityIndex, DefaultHashFunction, DIGEST_LENGTH};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction as _};
-use mysten_metrics::monitored_mpsc::UnboundedSender;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -396,32 +395,6 @@ pub fn load_committed_subdag_from_store(
         commit.reference(),
         reputation_scores_desc,
     )
-}
-
-pub struct CommitConsumer {
-    // A channel to send the committed sub dags through
-    pub sender: UnboundedSender<CommittedSubDag>,
-    // Leader round of the last commit that the consumer has processed.
-    pub last_processed_commit_round: Round,
-    // Index of the last commit that the consumer has processed. This is useful for
-    // crash/recovery so mysticeti can replay the commits from the next index.
-    // First commit in the replayed sequence will have index last_processed_commit_index + 1.
-    // Set 0 to replay from the start (as generated commit sequence starts at index = 1).
-    pub last_processed_commit_index: CommitIndex,
-}
-
-impl CommitConsumer {
-    pub fn new(
-        sender: UnboundedSender<CommittedSubDag>,
-        last_processed_commit_round: Round,
-        last_processed_commit_index: CommitIndex,
-    ) -> Self {
-        Self {
-            sender,
-            last_processed_commit_round,
-            last_processed_commit_index,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{atomic::AtomicU32, Arc};
+
+use mysten_metrics::monitored_mpsc::UnboundedSender;
+
+use crate::{CommitIndex, CommittedSubDag, Round};
+
+pub struct CommitConsumer {
+    // A channel to send the committed sub dags through
+    pub(crate) sender: UnboundedSender<CommittedSubDag>,
+    // Leader round of the last commit that the consumer has processed.
+    _last_processed_commit_round: Round,
+    // Index of the last commit that the consumer has processed. This is useful for
+    // crash/recovery so mysticeti can replay the commits from the next index.
+    // First commit in the replayed sequence will have index last_processed_commit_index + 1.
+    // Set 0 to replay from the start (as generated commit sequence starts at index = 1).
+    pub(crate) last_processed_commit_index: CommitIndex,
+    // Allows the commit consumer to report its progress.
+    monitor: Arc<CommitConsumerMonitor>,
+}
+
+impl CommitConsumer {
+    pub fn new(
+        sender: UnboundedSender<CommittedSubDag>,
+        last_processed_commit_round: Round,
+        last_processed_commit_index: CommitIndex,
+    ) -> Self {
+        let monitor = Arc::new(CommitConsumerMonitor::new(last_processed_commit_index));
+        Self {
+            sender,
+            _last_processed_commit_round: last_processed_commit_round,
+            last_processed_commit_index,
+            monitor,
+        }
+    }
+
+    pub fn monitor(&self) -> Arc<CommitConsumerMonitor> {
+        self.monitor.clone()
+    }
+}
+
+pub struct CommitConsumerMonitor {
+    highest_handled_commit: AtomicU32,
+}
+
+impl CommitConsumerMonitor {
+    pub(crate) fn new(last_handled_commit: CommitIndex) -> Self {
+        Self {
+            highest_handled_commit: AtomicU32::new(last_handled_commit),
+        }
+    }
+
+    pub(crate) fn highest_handled_commit(&self) -> CommitIndex {
+        self.highest_handled_commit
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub fn set_highest_handled_commit(&self, highest_handled_commit: CommitIndex) {
+        self.highest_handled_commit
+            .store(highest_handled_commit, std::sync::atomic::Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::CommitConsumerMonitor;
+
+    #[test]
+    fn test_commit_consumer_monitor() {
+        let monitor = CommitConsumerMonitor::new(10);
+        assert_eq!(monitor.highest_handled_commit(), 10);
+
+        monitor.set_highest_handled_commit(100);
+        assert_eq!(monitor.highest_handled_commit(), 100);
+    }
+}

--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -5,13 +5,11 @@ use std::sync::{atomic::AtomicU32, Arc};
 
 use mysten_metrics::monitored_mpsc::UnboundedSender;
 
-use crate::{CommitIndex, CommittedSubDag, Round};
+use crate::{CommitIndex, CommittedSubDag};
 
 pub struct CommitConsumer {
     // A channel to send the committed sub dags through
     pub(crate) sender: UnboundedSender<CommittedSubDag>,
-    // Leader round of the last commit that the consumer has processed.
-    _last_processed_commit_round: Round,
     // Index of the last commit that the consumer has processed. This is useful for
     // crash/recovery so mysticeti can replay the commits from the next index.
     // First commit in the replayed sequence will have index last_processed_commit_index + 1.
@@ -24,13 +22,11 @@ pub struct CommitConsumer {
 impl CommitConsumer {
     pub fn new(
         sender: UnboundedSender<CommittedSubDag>,
-        last_processed_commit_round: Round,
         last_processed_commit_index: CommitIndex,
     ) -> Self {
         let monitor = Arc::new(CommitConsumerMonitor::new(last_processed_commit_index));
         Self {
             sender,
-            _last_processed_commit_round: last_processed_commit_round,
             last_processed_commit_index,
             monitor,
         }

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -210,11 +210,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block::{BlockRef, Round},
-        commit::DEFAULT_WAVE_LENGTH,
-        context::Context,
-        dag_state::DagState,
-        storage::mem_store::MemStore,
+        block::BlockRef, context::Context, dag_state::DagState, storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
 
@@ -228,7 +224,6 @@ mod tests {
             context.clone(),
             mem_store.clone(),
         )));
-        let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel("consensus_output");
 
@@ -239,11 +234,7 @@ mod tests {
 
         let mut observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(
-                sender,
-                last_processed_commit_round,
-                last_processed_commit_index,
-            ),
+            CommitConsumer::new(sender, last_processed_commit_index),
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule,
@@ -332,7 +323,6 @@ mod tests {
             context.clone(),
             mem_store.clone(),
         )));
-        let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel("consensus_output");
 
@@ -343,11 +333,7 @@ mod tests {
 
         let mut observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(
-                sender.clone(),
-                last_processed_commit_round,
-                last_processed_commit_index,
-            ),
+            CommitConsumer::new(sender.clone(), last_processed_commit_index),
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
@@ -370,8 +356,6 @@ mod tests {
         // Commit first batch of leaders (2) and "receive" the subdags as the
         // consumer of the consensus output channel.
         let expected_last_processed_index: usize = 2;
-        let expected_last_processed_round =
-            expected_last_processed_index as u32 * DEFAULT_WAVE_LENGTH;
         let mut commits = observer
             .handle_commit(
                 leaders
@@ -443,11 +427,7 @@ mod tests {
         // last processed index from the consumer over consensus output channel
         let _observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(
-                sender,
-                expected_last_processed_round as Round,
-                expected_last_processed_index as CommitIndex,
-            ),
+            CommitConsumer::new(sender, expected_last_processed_index as CommitIndex),
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule,
@@ -480,7 +460,6 @@ mod tests {
             context.clone(),
             mem_store.clone(),
         )));
-        let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel("consensus_output");
 
@@ -491,11 +470,7 @@ mod tests {
 
         let mut observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(
-                sender.clone(),
-                last_processed_commit_round,
-                last_processed_commit_index,
-            ),
+            CommitConsumer::new(sender.clone(), last_processed_commit_index),
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
@@ -518,8 +493,6 @@ mod tests {
         // Commit all of the leaders and "receive" the subdags as the consumer of
         // the consensus output channel.
         let expected_last_processed_index: usize = 10;
-        let expected_last_processed_round =
-            expected_last_processed_index as u32 * DEFAULT_WAVE_LENGTH;
         let commits = observer.handle_commit(leaders.clone()).unwrap();
 
         // Check commits sent over consensus output channel is accurate
@@ -548,11 +521,7 @@ mod tests {
         // last processed index from the consumer over consensus output channel
         let _observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(
-                sender,
-                expected_last_processed_round as Round,
-                expected_last_processed_index as CommitIndex,
-            ),
+            CommitConsumer::new(sender, expected_last_processed_index as CommitIndex),
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule,

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -47,23 +47,54 @@ use tracing::{debug, info, warn};
 use crate::{
     block::{BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
     block_verifier::BlockVerifier,
-    commit::{
-        Commit, CommitAPI as _, CommitDigest, CommitRange, CommitRef, TrustedCommit,
-        GENESIS_COMMIT_INDEX,
-    },
+    commit::{Commit, CommitAPI as _, CommitDigest, CommitRange, CommitRef, TrustedCommit},
+    commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    CommitIndex,
+    CommitConsumerMonitor, CommitIndex,
 };
 
-pub(crate) struct CommitSyncer<C: NetworkClient> {
+pub(crate) struct CommitSyncerHandle {
     schedule_task: JoinHandle<()>,
     tx_shutdown: oneshot::Sender<()>,
-    _phantom: std::marker::PhantomData<C>,
+}
+
+impl CommitSyncerHandle {
+    pub(crate) async fn stop(self) {
+        let _ = self.tx_shutdown.send(());
+        // Do not abort schedule task, which waits for fetches to shut down.
+        let _ = self.schedule_task.await;
+    }
+}
+
+pub(crate) struct CommitSyncer<C: NetworkClient> {
+    // States shared by scheduler and fetch tasks.
+
+    // Shared components.
+    inner: Arc<Inner<C>>,
+    // State of peers shared by fetch tasks, to determine the peer to against.
+    peer_state: Arc<Mutex<PeerState>>,
+
+    // States only used by the scheduler logic.
+
+    // Inflight requests to fetch commits from different authorities.
+    inflight_fetches: JoinSet<(u32, Vec<TrustedCommit>, Vec<VerifiedBlock>)>,
+    // Additional ranges (inclusive start and end) of commits to fetch.
+    pending_fetches: BTreeSet<CommitRange>,
+    // Fetched commits and blocks by commit indices.
+    fetched_blocks: BTreeMap<CommitRange, Vec<VerifiedBlock>>,
+    // Highest commit index among inflight and pending fetches.
+    // Used to determine if and which new range to fetch.
+    highest_scheduled_index: Option<CommitIndex>,
+    // Highest index among fetched commits, before verifications.
+    highest_fetched_commit_index: CommitIndex,
+    // The commit index that is the max of local last commit index and highest commit index of blocks sent to Core.
+    // Used to determine if fetched blocks can be sent to Core without gaps.
+    synced_commit_index: CommitIndex,
 }
 
 impl<C: NetworkClient> CommitSyncer<C> {
@@ -71,219 +102,270 @@ impl<C: NetworkClient> CommitSyncer<C> {
         context: Arc<Context>,
         core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
+        commit_consumer_monitor: Arc<CommitConsumerMonitor>,
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
-        let fetch_state = Arc::new(Mutex::new(FetchState::new(&context)));
+        let peer_state = Arc::new(Mutex::new(PeerState::new(&context)));
         let inner = Arc::new(Inner {
             context,
             core_thread_dispatcher,
             commit_vote_monitor,
+            commit_consumer_monitor,
             network_client,
             block_verifier,
             dag_state,
         });
-        let (tx_shutdown, rx_shutdown) = oneshot::channel();
-        let schedule_task =
-            spawn_logged_monitored_task!(Self::schedule_loop(inner, fetch_state, rx_shutdown));
+        let synced_commit_index = inner.dag_state.read().last_commit_index();
         CommitSyncer {
-            schedule_task,
-            tx_shutdown,
-            _phantom: Default::default(),
+            inner,
+            peer_state,
+            inflight_fetches: JoinSet::new(),
+            pending_fetches: BTreeSet::new(),
+            fetched_blocks: BTreeMap::new(),
+            highest_scheduled_index: None,
+            highest_fetched_commit_index: 0,
+            synced_commit_index,
         }
     }
 
-    pub(crate) async fn stop(self) {
-        let _ = self.tx_shutdown.send(());
-        // Do not abort schedule task, which waits for fetches to shut down.
-        let _ = self.schedule_task.await;
+    pub(crate) fn start(self) -> CommitSyncerHandle {
+        let (tx_shutdown, rx_shutdown) = oneshot::channel();
+        let schedule_task = spawn_logged_monitored_task!(self.schedule_loop(rx_shutdown,));
+        CommitSyncerHandle {
+            schedule_task,
+            tx_shutdown,
+        }
     }
 
-    async fn schedule_loop(
-        inner: Arc<Inner<C>>,
-        fetch_state: Arc<Mutex<FetchState>>,
-        mut rx_shutdown: oneshot::Receiver<()>,
-    ) {
+    async fn schedule_loop(mut self, mut rx_shutdown: oneshot::Receiver<()>) {
         let mut interval = tokio::time::interval(Duration::from_secs(2));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        // Inflight requests to fetch commits from different authorities.
-        let mut inflight_fetches = JoinSet::new();
-        // Additional ranges (inclusive start and end) of commits to fetch.
-        let mut pending_fetches = BTreeSet::<CommitRange>::new();
-        // Fetched commits and blocks by commit indices.
-        let mut fetched_blocks = BTreeMap::<CommitRange, Vec<VerifiedBlock>>::new();
-        // Highest end index among inflight and pending fetches.
-        // Used to determine if and which new ranges to fetch.
-        let mut highest_scheduled_index = Option::<CommitIndex>::None;
-        // The commit index that is the max of local last commit index and highest commit index of blocks sent to Core.
-        // Used to determine if fetched blocks can be sent to Core without gaps.
-        let mut synced_commit_index = inner.dag_state.read().last_commit_index();
-        let mut highest_fetched_commit_index = 0;
 
         loop {
             tokio::select! {
                 // Periodically, schedule new fetches if the node is falling behind.
                 _ = interval.tick() => {
-                    let quorum_commit_index = inner.commit_vote_monitor.quorum_commit_index();
-                    let local_commit_index = inner.dag_state.read().last_commit_index();
-                    let metrics = &inner.context.metrics.node_metrics;
-                    metrics.commit_sync_quorum_index.set(quorum_commit_index as i64);
-                    metrics.commit_sync_local_index.set(local_commit_index as i64);
-                    // Update synced_commit_index periodically to make sure it is not smaller than
-                    // local commit index.
-                    synced_commit_index = synced_commit_index.max(local_commit_index);
-                    info!(
-                        "Checking to schedule fetches: synced_commit_index={}, highest_scheduled_index={}, quorum_commit_index={}",
-                        synced_commit_index, highest_scheduled_index.unwrap_or(0), quorum_commit_index,
-                    );
-                    // TODO: pause commit sync when execution of commits is lagging behind, maybe through Core.
-                    // TODO: cleanup inflight fetches that are no longer needed.
-                    let fetch_after_index = synced_commit_index.max(highest_scheduled_index.unwrap_or(0));
-                    // When the node is falling behind, schedule pending fetches which will be executed on later.
-                    'pending: for prev_end in (fetch_after_index..=quorum_commit_index).step_by(inner.context.parameters.commit_sync_batch_size as usize) {
-                        // Create range with inclusive start and end.
-                        let range_start = prev_end + 1;
-                        let range_end = prev_end + inner.context.parameters.commit_sync_batch_size;
-                        // When the condition below is true, [range_start, range_end] contains less number of commits
-                        // than the target batch size. Not creating the smaller batch is intentional, to avoid the
-                        // cost of processing more and smaller batches.
-                        // Block broadcast, subscription and synchronization will help the node catchup.
-                        if range_end > quorum_commit_index {
-                            break 'pending;
-                        }
-                        pending_fetches.insert((range_start..=range_end).into());
-                        // quorum_commit_index should be non-decreasing, so highest_scheduled_index should not
-                        // decrease either.
-                        highest_scheduled_index = Some(range_end);
-                    }
+                    self.try_schedule_once();
                 }
-
-                // Processed fetched blocks.
-                Some(result) = inflight_fetches.join_next(), if !inflight_fetches.is_empty() => {
+                // Handles results from fetch tasks.
+                Some(result) = self.inflight_fetches.join_next(), if !self.inflight_fetches.is_empty() => {
                     if let Err(e) = result {
                         warn!("Fetch cancelled or panicked, CommitSyncer shutting down: {}", e);
                         // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
-                        inflight_fetches.shutdown().await;
+                        self.inflight_fetches.shutdown().await;
                         return;
                     }
                     let (target_end, commits, blocks): (CommitIndex, Vec<TrustedCommit>, Vec<VerifiedBlock>) = result.unwrap();
-                    assert!(!commits.is_empty());
-                    let metrics = &inner.context.metrics.node_metrics;
-                    metrics.commit_sync_fetched_commits.inc_by(commits.len() as u64);
-                    metrics.commit_sync_fetched_blocks.inc_by(blocks.len() as u64);
-                    metrics.commit_sync_total_fetched_blocks_size.inc_by(
-                        blocks.iter().map(|b| b.serialized().len() as u64).sum::<u64>()
-                    );
-
-                    let (commit_start, commit_end) = (commits.first().unwrap().index(), commits.last().unwrap().index());
-
-                    highest_fetched_commit_index = highest_fetched_commit_index.max(commit_end);
-                    metrics.commit_sync_highest_fetched_index.set(highest_fetched_commit_index.into());
-
-                    // Allow returning partial results, and try fetching the rest separately.
-                    if commit_end < target_end {
-                        pending_fetches.insert((commit_end + 1..=target_end).into());
-                    }
-                    // Make sure synced_commit_index is up to date.
-                    synced_commit_index = synced_commit_index.max(inner.dag_state.read().last_commit_index());
-                    // Only add new blocks if at least some of them are not already synced.
-                    if synced_commit_index < commit_end {
-                        fetched_blocks.insert((commit_start..=commit_end).into(), blocks);
-                    }
-                    // Try to process as many fetched blocks as possible.
-                    'fetched: while let Some((fetched_commit_range, _blocks)) = fetched_blocks.first_key_value() {
-                        // Only pop fetched_blocks if there is no gap with blocks already synced.
-                        // Note: start, end and synced_commit_index are all inclusive.
-                        let (fetched_commit_range, blocks) = if fetched_commit_range.start() <= synced_commit_index + 1 {
-                            fetched_blocks.pop_first().unwrap()
-                        } else {
-                            // Found gap between earliest fetched block and latest synced block,
-                            // so not sending additional blocks to Core.
-                            metrics.commit_sync_gap_on_processing.inc();
-                            break 'fetched;
-                        };
-                        // Avoid sending to Core a whole batch of already synced blocks.
-                        if fetched_commit_range.end() <= synced_commit_index {
-                            continue 'fetched;
-                        }
-                        debug!(
-                            "Fetched certified blocks: {}",
-                            blocks
-                                .iter()
-                                .map(|b| b.reference().to_string())
-                                .join(","),
-                        );
-                        // If core thread cannot handle the incoming blocks, it is ok to block here.
-                        // Also it is possible to have missing ancestors because an equivocating validator
-                        // may produce blocks that are not included in commits but are ancestors to other blocks.
-                        // Synchronizer is needed to fill in the missing ancestors in this case.
-                        match inner.core_thread_dispatcher.add_blocks(blocks).await {
-                            Ok(missing) => {
-                                if !missing.is_empty() {
-                                    warn!("Fetched blocks have missing ancestors: {:?}", missing);
-                                }
-                            }
-                            Err(e) => {
-                                info!("Failed to add blocks, shutting down: {}", e);
-                                return;
-                            }
-                        };
-                        // Once commits and blocks are sent to Core, ratchet up synced_commit_index
-                        synced_commit_index = synced_commit_index.max(fetched_commit_range.end());
-                    }
+                    self.handle_fetch_result(target_end, commits, blocks).await;
                 }
-
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
                     info!("CommitSyncer shutting down ...");
-                    inflight_fetches.shutdown().await;
+                    self.inflight_fetches.shutdown().await;
                     return;
                 }
             }
 
-            // Cap parallel fetches based on configured limit and committee size, to avoid overloading the network.
-            // Also when there are too many fetched blocks that cannot be sent to Core before an earlier fetch
-            // has not finished, reduce parallelism so the earlier fetch can retry on a better host and succeed.
-            let target_parallel_fetches = inner
-                .context
-                .parameters
-                .commit_sync_parallel_fetches
-                .min(inner.context.committee.size() * 2 / 3)
-                .min(
-                    inner
-                        .context
-                        .parameters
-                        .commit_sync_batches_ahead
-                        .saturating_sub(fetched_blocks.len()),
-                )
-                .max(1);
-            // Start new fetches if there are pending batches and available slots.
-            loop {
-                if inflight_fetches.len() >= target_parallel_fetches {
-                    break;
-                }
-                let Some(commit_range) = pending_fetches.pop_first() else {
+            self.try_start_fetches();
+        }
+    }
+
+    fn try_schedule_once(&mut self) {
+        let quorum_commit_index = self.inner.commit_vote_monitor.quorum_commit_index();
+        let local_commit_index = self.inner.dag_state.read().last_commit_index();
+        let metrics = &self.inner.context.metrics.node_metrics;
+        metrics
+            .commit_sync_quorum_index
+            .set(quorum_commit_index as i64);
+        metrics
+            .commit_sync_local_index
+            .set(local_commit_index as i64);
+        let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
+        let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
+        // Update synced_commit_index periodically to make sure it is not smaller than
+        // local commit index.
+        self.synced_commit_index = self.synced_commit_index.max(local_commit_index);
+        info!(
+            "Checking to schedule fetches: synced_commit_index={}, highest_handled_index={}, highest_scheduled_index={}, quorum_commit_index={}",
+            self.synced_commit_index, highest_handled_index, highest_scheduled_index, quorum_commit_index,
+        );
+
+        // Pause scheduling new fetches when handling of commits is lagging.
+        // Reuse the threshold parameters elsewhere to compute the limit to unhandled commits.
+        let unhandled_commits_threshold = self.inner.context.parameters.commit_sync_batch_size
+            * (self.inner.context.parameters.commit_sync_batches_ahead as u32);
+        if highest_handled_index + unhandled_commits_threshold < highest_scheduled_index {
+            warn!("Skip scheduling new commit fetches: consensus handler is lagging. highest_handled_index={}, highest_scheduled_index={}", highest_handled_index, highest_scheduled_index);
+            return;
+        }
+
+        // TODO: cleanup inflight fetches that are no longer needed.
+        let fetch_after_index = self
+            .synced_commit_index
+            .max(self.highest_scheduled_index.unwrap_or(0));
+        // When the node is falling behind, schedule pending fetches which will be executed on later.
+        for prev_end in (fetch_after_index..=quorum_commit_index)
+            .step_by(self.inner.context.parameters.commit_sync_batch_size as usize)
+        {
+            // Create range with inclusive start and end.
+            let range_start = prev_end + 1;
+            let range_end = prev_end + self.inner.context.parameters.commit_sync_batch_size;
+            // When the condition below is true, [range_start, range_end] contains less number of commits
+            // than the target batch size. Not creating the smaller batch is intentional, to avoid the
+            // cost of processing more and smaller batches.
+            // Block broadcast, subscription and synchronization will help the node catchup.
+            if range_end > quorum_commit_index {
+                break;
+            }
+            self.pending_fetches
+                .insert((range_start..=range_end).into());
+            // quorum_commit_index should be non-decreasing, so highest_scheduled_index should not
+            // decrease either.
+            self.highest_scheduled_index = Some(range_end);
+        }
+    }
+
+    async fn handle_fetch_result(
+        &mut self,
+        target_end: CommitIndex,
+        commits: Vec<TrustedCommit>,
+        blocks: Vec<VerifiedBlock>,
+    ) {
+        assert!(!commits.is_empty());
+        let metrics = &self.inner.context.metrics.node_metrics;
+        metrics
+            .commit_sync_fetched_commits
+            .inc_by(commits.len() as u64);
+        metrics
+            .commit_sync_fetched_blocks
+            .inc_by(blocks.len() as u64);
+        metrics.commit_sync_total_fetched_blocks_size.inc_by(
+            blocks
+                .iter()
+                .map(|b| b.serialized().len() as u64)
+                .sum::<u64>(),
+        );
+
+        let (commit_start, commit_end) = (
+            commits.first().unwrap().index(),
+            commits.last().unwrap().index(),
+        );
+        self.highest_fetched_commit_index = self.highest_fetched_commit_index.max(commit_end);
+        metrics
+            .commit_sync_highest_fetched_index
+            .set(self.highest_fetched_commit_index as i64);
+
+        // Allow returning partial results, and try fetching the rest separately.
+        if commit_end < target_end {
+            self.pending_fetches
+                .insert((commit_end + 1..=target_end).into());
+        }
+        // Make sure synced_commit_index is up to date.
+        self.synced_commit_index = self
+            .synced_commit_index
+            .max(self.inner.dag_state.read().last_commit_index());
+        // Only add new blocks if at least some of them are not already synced.
+        if self.synced_commit_index < commit_end {
+            self.fetched_blocks
+                .insert((commit_start..=commit_end).into(), blocks);
+        }
+        // Try to process as many fetched blocks as possible.
+        while let Some((fetched_commit_range, _blocks)) = self.fetched_blocks.first_key_value() {
+            // Only pop fetched_blocks if there is no gap with blocks already synced.
+            // Note: start, end and synced_commit_index are all inclusive.
+            let (fetched_commit_range, blocks) =
+                if fetched_commit_range.start() <= self.synced_commit_index + 1 {
+                    self.fetched_blocks.pop_first().unwrap()
+                } else {
+                    // Found gap between earliest fetched block and latest synced block,
+                    // so not sending additional blocks to Core.
+                    metrics.commit_sync_gap_on_processing.inc();
                     break;
                 };
-                inflight_fetches.spawn(Self::fetch_loop(
-                    inner.clone(),
-                    fetch_state.clone(),
-                    commit_range,
-                ));
+            // Avoid sending to Core a whole batch of already synced blocks.
+            if fetched_commit_range.end() <= self.synced_commit_index {
+                continue;
             }
 
-            let metrics = &inner.context.metrics.node_metrics;
-            metrics
-                .commit_sync_inflight_fetches
-                .set(inflight_fetches.len() as i64);
-            metrics
-                .commit_sync_pending_fetches
-                .set(pending_fetches.len() as i64);
-            metrics
-                .commit_sync_highest_synced_index
-                .set(synced_commit_index as i64);
+            debug!(
+                "Fetched certified blocks: {}",
+                blocks.iter().map(|b| b.reference().to_string()).join(","),
+            );
+            // If core thread cannot handle the incoming blocks, it is ok to block here.
+            // Also it is possible to have missing ancestors because an equivocating validator
+            // may produce blocks that are not included in commits but are ancestors to other blocks.
+            // Synchronizer is needed to fill in the missing ancestors in this case.
+            match self.inner.core_thread_dispatcher.add_blocks(blocks).await {
+                Ok(missing) => {
+                    if !missing.is_empty() {
+                        warn!("Fetched blocks have missing ancestors: {:?}", missing);
+                    }
+                }
+                Err(e) => {
+                    info!("Failed to add blocks, shutting down: {}", e);
+                    return;
+                }
+            };
+            // Once commits and blocks are sent to Core, ratchet up synced_commit_index
+            self.synced_commit_index = self.synced_commit_index.max(fetched_commit_range.end());
         }
+
+        metrics
+            .commit_sync_inflight_fetches
+            .set(self.inflight_fetches.len() as i64);
+        metrics
+            .commit_sync_pending_fetches
+            .set(self.pending_fetches.len() as i64);
+        metrics
+            .commit_sync_highest_synced_index
+            .set(self.synced_commit_index as i64);
+    }
+
+    fn try_start_fetches(&mut self) {
+        // Cap parallel fetches based on configured limit and committee size, to avoid overloading the network.
+        // Also when there are too many fetched blocks that cannot be sent to Core before an earlier fetch
+        // has not finished, reduce parallelism so the earlier fetch can retry on a better host and succeed.
+        let target_parallel_fetches = self
+            .inner
+            .context
+            .parameters
+            .commit_sync_parallel_fetches
+            .min(self.inner.context.committee.size() * 2 / 3)
+            .min(
+                self.inner
+                    .context
+                    .parameters
+                    .commit_sync_batches_ahead
+                    .saturating_sub(self.fetched_blocks.len()),
+            )
+            .max(1);
+        // Start new fetches if there are pending batches and available slots.
+        loop {
+            if self.inflight_fetches.len() >= target_parallel_fetches {
+                break;
+            }
+            let Some(commit_range) = self.pending_fetches.pop_first() else {
+                break;
+            };
+            self.inflight_fetches.spawn(Self::fetch_loop(
+                self.inner.clone(),
+                self.peer_state.clone(),
+                commit_range,
+            ));
+        }
+
+        let metrics = &self.inner.context.metrics.node_metrics;
+        metrics
+            .commit_sync_inflight_fetches
+            .set(self.inflight_fetches.len() as i64);
+        metrics
+            .commit_sync_pending_fetches
+            .set(self.pending_fetches.len() as i64);
+        metrics
+            .commit_sync_highest_synced_index
+            .set(self.synced_commit_index as i64);
     }
 
     // Retries fetching commits and blocks from available authorities, until a request succeeds
@@ -291,7 +373,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
     // Returns the fetched commits and blocks referenced by the commits.
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
-        fetch_state: Arc<Mutex<FetchState>>,
+        peer_state: Arc<Mutex<PeerState>>,
         commit_range: CommitRange,
     ) -> (CommitIndex, Vec<TrustedCommit>, Vec<VerifiedBlock>) {
         let _timer = inner
@@ -302,7 +384,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .start_timer();
         info!("Starting to fetch commits in {commit_range:?} ...",);
         loop {
-            match Self::fetch_once(inner.clone(), fetch_state.clone(), commit_range.clone()).await {
+            match Self::fetch_once(inner.clone(), peer_state.clone(), commit_range.clone()).await {
                 Ok((commits, blocks)) => {
                     info!("Finished fetching commits in {commit_range:?}",);
                     return (commit_range.end(), commits, blocks);
@@ -327,7 +409,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
     // and sent to Core for processing.
     async fn fetch_once(
         inner: Arc<Inner<C>>,
-        fetch_state: Arc<Mutex<FetchState>>,
+        peer_state: Arc<Mutex<PeerState>>,
         commit_range: CommitRange,
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
         const FETCH_COMMITS_TIMEOUT: Duration = Duration::from_secs(30);
@@ -346,7 +428,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         // 1. Find an available authority to fetch commits and blocks from, and wait
         // if it is not yet ready.
         let Some((available_time, retries, target_authority)) =
-            fetch_state.lock().available_authorities.pop_first()
+            peer_state.lock().available_authorities.pop_first()
         else {
             sleep(MAX_RETRY_INTERVAL).await;
             return Err(ConsensusError::NoAvailableAuthorityToFetchCommits);
@@ -367,17 +449,17 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .await
         {
             Ok(result) => {
-                let mut fetch_state = fetch_state.lock();
+                let mut peer_state = peer_state.lock();
                 let now = Instant::now();
-                fetch_state
+                peer_state
                     .available_authorities
                     .insert((now, 0, target_authority));
                 result
             }
             Err(e) => {
-                let mut fetch_state = fetch_state.lock();
+                let mut peer_state = peer_state.lock();
                 let now = Instant::now();
-                fetch_state.available_authorities.insert((
+                peer_state.available_authorities.insert((
                     now + FETCH_RETRY_BASE_INTERVAL * retries.min(FETCH_RETRY_INTERVAL_LIMIT),
                     retries.saturating_add(1),
                     target_authority,
@@ -497,61 +579,11 @@ impl<C: NetworkClient> CommitSyncer<C> {
     }
 }
 
-/// Monitors commit votes from received and verified blocks,
-/// and keeps track of the highest commit voted by each authority and certified by a quorum.
-pub(crate) struct CommitVoteMonitor {
-    context: Arc<Context>,
-    // Highest commit index voted by each authority.
-    highest_voted_commits: Mutex<Vec<CommitIndex>>,
-}
-
-impl CommitVoteMonitor {
-    pub(crate) fn new(context: Arc<Context>) -> Self {
-        let highest_voted_commits = Mutex::new(vec![0; context.committee.size()]);
-        Self {
-            context,
-            highest_voted_commits,
-        }
-    }
-
-    // Records the highest commit index voted in each block.
-    pub(crate) fn observe(&self, block: &VerifiedBlock) {
-        let mut highest_voted_commits = self.highest_voted_commits.lock();
-        for vote in block.commit_votes() {
-            if vote.index > highest_voted_commits[block.author()] {
-                highest_voted_commits[block.author()] = vote.index;
-            }
-        }
-    }
-
-    // Finds the highest commit index certified by a quorum.
-    // When an authority votes for commit index S, it is also voting for all commit indices 1 <= i < S.
-    // So the quorum commit index is the smallest index S such that the sum of stakes of authorities
-    // voting for commit indices >= S passes the quorum threshold.
-    pub(crate) fn quorum_commit_index(&self) -> CommitIndex {
-        let highest_voted_commits = self.highest_voted_commits.lock();
-        let mut highest_voted_commits = highest_voted_commits
-            .iter()
-            .zip(self.context.committee.authorities())
-            .map(|(commit_index, (_, a))| (*commit_index, a.stake))
-            .collect::<Vec<_>>();
-        // Sort by commit index then stake, in descending order.
-        highest_voted_commits.sort_by(|a, b| a.cmp(b).reverse());
-        let mut total_stake = 0;
-        for (commit_index, stake) in highest_voted_commits {
-            total_stake += stake;
-            if total_stake >= self.context.committee.quorum_threshold() {
-                return commit_index;
-            }
-        }
-        GENESIS_COMMIT_INDEX
-    }
-}
-
 struct Inner<C: NetworkClient> {
     context: Arc<Context>,
     core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
+    commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     network_client: Arc<C>,
     block_verifier: Arc<dyn BlockVerifier>,
     dag_state: Arc<RwLock<DagState>>,
@@ -636,7 +668,7 @@ impl<C: NetworkClient> Inner<C> {
     }
 }
 
-struct FetchState {
+struct PeerState {
     // The value is a tuple of
     // - the next available time for the authority to fetch from,
     // - count of current consecutive failures fetching from the authority, reset on success,
@@ -646,7 +678,7 @@ struct FetchState {
     available_authorities: BTreeSet<(Instant, u32, AuthorityIndex)>,
 }
 
-impl FetchState {
+impl PeerState {
     fn new(context: &Context) -> Self {
         // Randomize the initial order of authorities.
         let mut shuffled_authority_indices: Vec<_> = context
@@ -667,61 +699,5 @@ impl FetchState {
                 .map(|i| (Instant::now(), 0, i))
                 .collect(),
         }
-    }
-}
-
-// TODO: add more unit and integration tests.
-#[cfg(test)]
-mod test {
-    use std::sync::Arc;
-
-    use super::CommitVoteMonitor;
-    use crate::{
-        block::{TestBlock, VerifiedBlock},
-        commit::{CommitDigest, CommitRef},
-        context::Context,
-    };
-
-    #[tokio::test]
-    async fn test_commit_vote_monitor() {
-        let context = Arc::new(Context::new_for_test(4).0);
-        let monitor = CommitVoteMonitor::new(context.clone());
-
-        // Observe commit votes for indices 5, 6, 7, 8 from blocks.
-        let blocks = (0..4)
-            .map(|i| {
-                VerifiedBlock::new_for_test(
-                    TestBlock::new(10, i)
-                        .set_commit_votes(vec![CommitRef::new(5 + i, CommitDigest::MIN)])
-                        .build(),
-                )
-            })
-            .collect::<Vec<_>>();
-        for b in blocks {
-            monitor.observe(&b);
-        }
-
-        // CommitIndex 6 is the highest index supported by a quorum.
-        assert_eq!(monitor.quorum_commit_index(), 6);
-
-        // Observe new blocks with new votes from authority 0 and 1.
-        let blocks = (0..2)
-            .map(|i| {
-                VerifiedBlock::new_for_test(
-                    TestBlock::new(11, i)
-                        .set_commit_votes(vec![
-                            CommitRef::new(6 + i, CommitDigest::MIN),
-                            CommitRef::new(7 + i, CommitDigest::MIN),
-                        ])
-                        .build(),
-                )
-            })
-            .collect::<Vec<_>>();
-        for b in blocks {
-            monitor.observe(&b);
-        }
-
-        // Highest commit index per authority should be 7, 8, 7, 8 now.
-        assert_eq!(monitor.quorum_commit_index(), 7);
     }
 }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -886,7 +886,7 @@ mod tests {
         // Fetches should be scheduled until the unhandled commits threshold.
         commit_syncer.try_schedule_once();
 
-        // Verify commit syncer paused after scheduling commit index 15.
+        // Verify commit syncer is paused after scheduling 15 commits to index 25.
         assert_eq!(commit_syncer.unhandled_commits_threshold(), 25);
         assert_eq!(commit_syncer.highest_scheduled_index(), Some(25));
         let pending_fetches = commit_syncer.pending_fetches();

--- a/consensus/core/src/commit_vote_monitor.rs
+++ b/consensus/core/src/commit_vote_monitor.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::{
+    block::{BlockAPI as _, VerifiedBlock},
+    commit::GENESIS_COMMIT_INDEX,
+    context::Context,
+    CommitIndex,
+};
+
+/// Monitors the progress of consensus commits across the network.
+pub(crate) struct CommitVoteMonitor {
+    context: Arc<Context>,
+    // Highest commit index voted by each authority.
+    highest_voted_commits: Mutex<Vec<CommitIndex>>,
+}
+
+impl CommitVoteMonitor {
+    pub(crate) fn new(context: Arc<Context>) -> Self {
+        let highest_voted_commits = Mutex::new(vec![0; context.committee.size()]);
+        Self {
+            context,
+            highest_voted_commits,
+        }
+    }
+
+    /// Keeps track of the highest commit voted by each authority.
+    pub(crate) fn observe_block(&self, block: &VerifiedBlock) {
+        let mut highest_voted_commits = self.highest_voted_commits.lock();
+        for vote in block.commit_votes() {
+            if vote.index > highest_voted_commits[block.author()] {
+                highest_voted_commits[block.author()] = vote.index;
+            }
+        }
+    }
+
+    // Finds the highest commit index certified by a quorum.
+    // When an authority votes for commit index S, it is also voting for all commit indices 1 <= i < S.
+    // So the quorum commit index is the smallest index S such that the sum of stakes of authorities
+    // voting for commit indices >= S passes the quorum threshold.
+    pub(crate) fn quorum_commit_index(&self) -> CommitIndex {
+        let highest_voted_commits = self.highest_voted_commits.lock();
+        let mut highest_voted_commits = highest_voted_commits
+            .iter()
+            .zip(self.context.committee.authorities())
+            .map(|(commit_index, (_, a))| (*commit_index, a.stake))
+            .collect::<Vec<_>>();
+        // Sort by commit index then stake, in descending order.
+        highest_voted_commits.sort_by(|a, b| a.cmp(b).reverse());
+        let mut total_stake = 0;
+        for (commit_index, stake) in highest_voted_commits {
+            total_stake += stake;
+            if total_stake >= self.context.committee.quorum_threshold() {
+                return commit_index;
+            }
+        }
+        GENESIS_COMMIT_INDEX
+    }
+}
+
+// TODO: add more unit and integration tests.
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use super::CommitVoteMonitor;
+    use crate::{
+        block::{TestBlock, VerifiedBlock},
+        commit::{CommitDigest, CommitRef},
+        context::Context,
+    };
+
+    #[tokio::test]
+    async fn test_commit_vote_monitor() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let monitor = CommitVoteMonitor::new(context.clone());
+
+        // Observe commit votes for indices 5, 6, 7, 8 from blocks.
+        let blocks = (0..4)
+            .map(|i| {
+                VerifiedBlock::new_for_test(
+                    TestBlock::new(10, i)
+                        .set_commit_votes(vec![CommitRef::new(5 + i, CommitDigest::MIN)])
+                        .build(),
+                )
+            })
+            .collect::<Vec<_>>();
+        for b in blocks {
+            monitor.observe_block(&b);
+        }
+
+        // CommitIndex 6 is the highest index supported by a quorum.
+        assert_eq!(monitor.quorum_commit_index(), 6);
+
+        // Observe new blocks with new votes from authority 0 and 1.
+        let blocks = (0..2)
+            .map(|i| {
+                VerifiedBlock::new_for_test(
+                    TestBlock::new(11, i)
+                        .set_commit_votes(vec![
+                            CommitRef::new(6 + i, CommitDigest::MIN),
+                            CommitRef::new(7 + i, CommitDigest::MIN),
+                        ])
+                        .build(),
+                )
+            })
+            .collect::<Vec<_>>();
+        for b in blocks {
+            monitor.observe_block(&b);
+        }
+
+        // Highest commit index per authority should be 7, 8, 7, 8 now.
+        assert_eq!(monitor.quorum_commit_index(), 7);
+    }
+}

--- a/consensus/core/src/commit_vote_monitor.rs
+++ b/consensus/core/src/commit_vote_monitor.rs
@@ -62,7 +62,6 @@ impl CommitVoteMonitor {
     }
 }
 
-// TODO: add more unit and integration tests.
 #[cfg(test)]
 mod test {
     use std::sync::Arc;

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -876,7 +876,7 @@ impl CoreTextFixture {
         let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(commit_sender.clone(), 0, 0),
+            CommitConsumer::new(commit_sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -974,7 +974,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1091,7 +1091,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1187,7 +1187,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1296,7 +1296,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1384,7 +1384,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1571,7 +1571,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -335,7 +335,7 @@ mod test {
         ));
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0, 0),
+            CommitConsumer::new(sender.clone(), 0),
             dag_state.clone(),
             store,
             leader_schedule.clone(),

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -8,6 +8,7 @@ use mysten_metrics::{
     monitored_mpsc::{channel, Receiver, Sender, WeakSender},
     monitored_scope, spawn_logged_monitored_task,
 };
+use parking_lot::Mutex;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch};
 use tracing::warn;
@@ -228,6 +229,67 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         self.tx_last_known_proposed_round
             .send(round)
             .map_err(|e| Shutdown(e.to_string()))
+    }
+}
+
+// TODO: complete the Mock for thread dispatcher to be used from several tests
+#[derive(Default)]
+pub(crate) struct MockCoreThreadDispatcher {
+    add_blocks: Mutex<Vec<VerifiedBlock>>,
+    missing_blocks: Mutex<BTreeSet<BlockRef>>,
+    last_known_proposed_round: Mutex<Vec<Round>>,
+}
+
+impl MockCoreThreadDispatcher {
+    #[cfg(test)]
+    pub(crate) async fn get_add_blocks(&self) -> Vec<VerifiedBlock> {
+        let mut add_blocks = self.add_blocks.lock();
+        add_blocks.drain(0..).collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn stub_missing_blocks(&self, block_refs: BTreeSet<BlockRef>) {
+        let mut missing_blocks = self.missing_blocks.lock();
+        missing_blocks.extend(block_refs);
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn get_last_own_proposed_round(&self) -> Vec<Round> {
+        let last_known_proposed_round = self.last_known_proposed_round.lock();
+        last_known_proposed_round.clone()
+    }
+}
+
+#[async_trait]
+impl CoreThreadDispatcher for MockCoreThreadDispatcher {
+    async fn add_blocks(
+        &self,
+        blocks: Vec<VerifiedBlock>,
+    ) -> Result<BTreeSet<BlockRef>, CoreError> {
+        let mut add_blocks = self.add_blocks.lock();
+        add_blocks.extend(blocks);
+        Ok(BTreeSet::new())
+    }
+
+    async fn new_block(&self, _round: Round, _force: bool) -> Result<(), CoreError> {
+        Ok(())
+    }
+
+    async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+        let mut missing_blocks = self.missing_blocks.lock();
+        let result = missing_blocks.clone();
+        missing_blocks.clear();
+        Ok(result)
+    }
+
+    fn set_consumer_availability(&self, _available: bool) -> Result<(), CoreError> {
+        todo!()
+    }
+
+    fn set_last_known_proposed_round(&self, round: Round) -> Result<(), CoreError> {
+        let mut last_known_proposed_round = self.last_known_proposed_round.lock();
+        last_known_proposed_round.push(round);
+        Ok(())
     }
 }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -31,6 +31,8 @@ mod threshold_clock;
 mod transaction;
 mod universal_committer;
 
+mod commit_consumer;
+mod commit_vote_monitor;
 #[cfg(test)]
 mod test_dag;
 #[cfg(test)]
@@ -40,7 +42,8 @@ mod test_dag_parser;
 
 pub use authority_node::ConsensusAuthority;
 pub use block::{BlockAPI, Round};
-pub use commit::{CommitConsumer, CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
+pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
+pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use transaction::{TransactionClient, TransactionVerifier, ValidationError};
 
 #[cfg(test)]

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -28,10 +28,10 @@ use tokio::{
 use tracing::{debug, error, info, trace, warn};
 
 use crate::authority_service::COMMIT_LAG_MULTIPLIER;
-use crate::commit_syncer::CommitVoteMonitor;
 use crate::{
     block::{BlockRef, SignedBlock, VerifiedBlock},
     block_verifier::BlockVerifier,
+    commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
@@ -259,33 +259,28 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             }
             let (sender, receiver) =
                 channel("consensus_synchronizer_fetches", FETCH_BLOCKS_CONCURRENCY);
-            let context_cloned = context.clone();
-            let network_cloned = network_client.clone();
-            let block_verified_cloned = block_verifier.clone();
-            let core_thread_dispatcher_cloned = core_dispatcher.clone();
-            let dag_state_cloned = dag_state.clone();
-            let command_sender_cloned = commands_sender.clone();
-
-            tasks.spawn(monitored_future!(Self::fetch_blocks_from_authority(
+            let fetch_blocks_from_authority_async = Self::fetch_blocks_from_authority(
                 index,
-                network_cloned,
-                block_verified_cloned,
-                context_cloned,
-                core_thread_dispatcher_cloned,
-                dag_state_cloned,
+                network_client.clone(),
+                block_verifier.clone(),
+                commit_vote_monitor.clone(),
+                context.clone(),
+                core_dispatcher.clone(),
+                dag_state.clone(),
                 receiver,
-                command_sender_cloned,
-            )));
+                commands_sender.clone(),
+            );
+            tasks.spawn(monitored_future!(fetch_blocks_from_authority_async));
             fetch_block_senders.insert(index, sender);
         }
-
-        let commands_sender_clone = commands_sender.clone();
 
         if context.parameters.is_sync_last_proposed_block_enabled() {
             commands_sender
                 .try_send(Command::FetchOwnLastBlock)
                 .expect("Failed to sync our last block");
         }
+
+        let commands_sender_clone = commands_sender.clone();
 
         // Spawn the task to listen to the requests & periodic runs
         tasks.spawn(monitored_future!(async move {
@@ -294,6 +289,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 commands_receiver,
                 fetch_block_senders,
                 core_dispatcher,
+                commit_vote_monitor,
                 fetch_blocks_scheduler_task: JoinSet::new(),
                 fetch_own_last_block_task: JoinSet::new(),
                 network_client,
@@ -301,7 +297,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 inflight_blocks_map,
                 commands_sender: commands_sender_clone,
                 dag_state,
-                commit_vote_monitor,
             };
             s.run().await;
         }));
@@ -427,6 +422,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         peer_index: AuthorityIndex,
         network_client: Arc<C>,
         block_verifier: Arc<V>,
+        commit_vote_monitor: Arc<CommitVoteMonitor>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
         dag_state: Arc<RwLock<DagState>>,
@@ -453,6 +449,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 blocks_guard,
                                 core_dispatcher.clone(),
                                 block_verifier.clone(),
+                                commit_vote_monitor.clone(),
                                 context.clone(),
                                 commands_sender.clone(),
                                 "live"
@@ -487,6 +484,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
+        commit_vote_monitor: Arc<CommitVoteMonitor>,
         context: Arc<Context>,
         commands_sender: Sender<Command>,
         sync_method: &str,
@@ -528,6 +526,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     block_ref: block.reference(),
                 });
             }
+        }
+
+        // Record commit votes from the verified blocks.
+        for block in &blocks {
+            commit_vote_monitor.observe_block(block);
         }
 
         let metrics = &context.metrics.node_metrics;
@@ -706,11 +709,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 let mut results = FuturesUnordered::new();
 
                 let fetch_own_block = |authority_index: AuthorityIndex, fetch_own_block_delay: Duration| {
-                    let network_client_cloned = network_client.clone();
-                    let context_cloned = context.clone();
+                    let network_client = network_client.clone();
+                    let own_index = context.own_index;
                     async move {
                         sleep(fetch_own_block_delay).await;
-                        let r = network_client_cloned.fetch_latest_blocks(authority_index, vec![context_cloned.own_index], FETCH_REQUEST_TIMEOUT).await;
+                        let r = network_client.fetch_latest_blocks(authority_index, vec![own_index], FETCH_REQUEST_TIMEOUT).await;
                         (r, authority_index)
                     }
                 };
@@ -826,6 +829,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let block_verifier = self.block_verifier.clone();
+        let commit_vote_monitor = self.commit_vote_monitor.clone();
         let core_dispatcher = self.core_dispatcher.clone();
         let blocks_to_fetch = self.inflight_blocks_map.clone();
         let commands_sender = self.commands_sender.clone();
@@ -851,7 +855,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 for (blocks_guard, fetched_blocks, peer) in results {
                     total_fetched += fetched_blocks.len();
 
-                    if let Err(err) = Self::process_fetched_blocks(fetched_blocks, peer, blocks_guard, core_dispatcher.clone(), block_verifier.clone(), context.clone(), commands_sender.clone(), "periodic").await {
+                    if let Err(err) = Self::process_fetched_blocks(fetched_blocks, peer, blocks_guard, core_dispatcher.clone(), block_verifier.clone(), commit_vote_monitor.clone(), context.clone(), commands_sender.clone(), "periodic").await {
                         warn!("Error occurred while processing fetched blocks from peer {peer}: {err}");
                     }
                 }
@@ -998,11 +1002,11 @@ mod tests {
 
     use crate::authority_service::COMMIT_LAG_MULTIPLIER;
     use crate::commit::{CommitVote, TrustedCommit};
-    use crate::commit_syncer::CommitVoteMonitor;
     use crate::{
         block::{BlockDigest, BlockRef, Round, TestBlock, VerifiedBlock},
         block_verifier::NoopBlockVerifier,
         commit::CommitRange,
+        commit_vote_monitor::CommitVoteMonitor,
         context::Context,
         core_thread::{CoreError, CoreThreadDispatcher},
         dag_state::DagState,
@@ -1272,10 +1276,10 @@ mod tests {
         let context = Arc::new(context);
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let network_client = Arc::new(MockNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         let handle = Synchronizer::start(
             network_client.clone(),
@@ -1318,11 +1322,11 @@ mod tests {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         let handle = Synchronizer::start(
             network_client.clone(),
@@ -1376,11 +1380,11 @@ mod tests {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         // Create some test blocks
         let expected_blocks = (0..10)
@@ -1497,7 +1501,7 @@ mod tests {
         // Pass them through the commit vote monitor - so now there will be a big commit lag to prevent
         // the scheduled synchronizer from running
         for block in blocks {
-            commit_vote_monitor.observe(&block);
+            commit_vote_monitor.observe_block(&block);
         }
 
         // WHEN start the synchronizer and wait for a couple of seconds where normally the synchronizer should have kicked in.

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -10,6 +10,7 @@ use std::{
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use consensus_core::CommitConsumerMonitor;
 use lru::LruCache;
 use mysten_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
 use narwhal_config::Committee;
@@ -504,12 +505,16 @@ impl MysticetiConsensusHandler {
     pub fn new(
         mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
+        commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     ) -> Self {
         let handle = spawn_monitored_task!(async move {
+            // TODO: pause when execution is overloaded.
             while let Some(consensus_output) = receiver.recv().await {
+                let commit_index = consensus_output.commit_ref.index;
                 consensus_handler
                     .handle_consensus_output_internal(consensus_output)
                     .await;
+                commit_consumer_monitor.set_highest_handled_commit(commit_index);
             }
         });
         Self {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -508,7 +508,7 @@ impl MysticetiConsensusHandler {
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     ) -> Self {
         let handle = spawn_monitored_task!(async move {
-            // TODO: pause when execution is overloaded.
+            // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
             while let Some(consensus_output) = receiver.recv().await {
                 let commit_index = consensus_output.commit_ref.index;
                 consensus_handler

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -146,6 +146,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             consensus_handler.last_executed_sub_dag_round() as Round,
             consensus_handler.last_executed_sub_dag_index() as CommitIndex,
         );
+        let monitor = consumer.monitor();
 
         // TODO(mysticeti): Investigate if we need to return potential errors from
         // AuthorityNode and add retries here?
@@ -173,7 +174,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         self.client.set(client);
 
         // spin up the new mysticeti consensus handler to listen for committed sub dags
-        let handler = MysticetiConsensusHandler::new(consensus_handler, commit_receiver);
+        let handler = MysticetiConsensusHandler::new(consensus_handler, commit_receiver, monitor);
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);
     }

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use consensus_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
-use consensus_core::{CommitConsumer, CommitIndex, ConsensusAuthority, Round};
+use consensus_core::{CommitConsumer, CommitIndex, ConsensusAuthority};
 use fastcrypto::ed25519;
 use mysten_metrics::{monitored_mpsc::unbounded_channel, RegistryID, RegistryService};
 use narwhal_executor::ExecutionState;
@@ -143,7 +143,6 @@ impl ConsensusManagerTrait for MysticetiManager {
         let consumer = CommitConsumer::new(
             commit_sender,
             // TODO(mysticeti): remove dependency on narwhal executor
-            consensus_handler.last_executed_sub_dag_round() as Round,
             consensus_handler.last_executed_sub_dag_index() as CommitIndex,
         );
         let monitor = consumer.monitor();


### PR DESCRIPTION
## Description 

`CommitSyncer` can download more transactions than what consensus handler and execution can process in the same amount of time. This PR adds backpressure to commit syncer based on # of commits not processed by consensus handler.

Also, record commit votes from blocks fetched through Synchronizer for completeness.
 
## Test plan 

CI
Private testnet

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
