### PR TITLE
Refactor consensus output to write to an intermediate store before going to the db

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -69,7 +69,7 @@ use crate::consensus_handler::{
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::randomness::{
     DkgStatus, RandomnessManager, RandomnessReporter, VersionedProcessedMessage,
-    VersionedUsedProcessedMessages,
+    VersionedUsedProcessedMessages, SINGLETON_KEY,
 };
 use crate::epoch::reconfiguration::ReconfigState;
 use crate::execution_cache::ObjectCacheRead;
@@ -100,7 +100,7 @@ use sui_types::messages_consensus::{
     check_total_jwk_size, AuthorityCapabilities, ConsensusTransaction, ConsensusTransactionKey,
     ConsensusTransactionKind,
 };
-use sui_types::messages_consensus::{VersionedDkgConfimation, VersionedDkgMessage};
+use sui_types::messages_consensus::{VersionedDkgConfirmation, VersionedDkgMessage};
 use sui_types::storage::GetSharedLocks;
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
     EpochStartSystemState, EpochStartSystemStateTrait,
@@ -525,7 +525,7 @@ pub struct AuthorityEpochTables {
 
     /// Records confirmations received from other nodes. Updated when receiving a new
     /// dkg::Confirmation via consensus.
-    pub(crate) dkg_confirmations_v2: DBMap<PartyId, VersionedDkgConfimation>,
+    pub(crate) dkg_confirmations_v2: DBMap<PartyId, VersionedDkgConfirmation>,
     #[deprecated]
     pub(crate) dkg_confirmations: DBMap<PartyId, dkg::Confirmation<EncG>>,
     /// Records the final output of DKG after completion, including the public VSS key and
@@ -1101,18 +1101,6 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    fn store_reconfig_state_batch(
-        &self,
-        new_state: &ReconfigState,
-        batch: &mut DBBatch,
-    ) -> SuiResult {
-        batch.insert_batch(
-            &self.tables()?.reconfig_state,
-            [(&RECONFIG_STATE_INDEX, new_state)],
-        )?;
-        Ok(())
-    }
-
     pub fn insert_signed_transaction(&self, transaction: VerifiedSignedTransaction) -> SuiResult {
         Ok(self
             .tables()?
@@ -1599,34 +1587,21 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    fn defer_transactions(
-        &self,
-        batch: &mut DBBatch,
-        key: DeferralKey,
-        transactions: Vec<VerifiedSequencedConsensusTransaction>,
-    ) -> SuiResult {
-        batch.insert_batch(
-            &self.tables()?.deferred_transactions,
-            std::iter::once((key, transactions)),
-        )?;
-        Ok(())
-    }
-
     fn load_deferred_transactions_for_randomness(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
     ) -> SuiResult<Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)>> {
         let (min, max) = DeferralKey::full_range_for_randomness();
-        self.load_deferred_transactions(batch, min, max)
+        self.load_deferred_transactions(output, min, max)
     }
 
     fn load_and_process_deferred_transactions_for_randomness(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         previously_deferred_tx_digests: &mut HashMap<TransactionDigest, DeferralKey>,
         sequenced_randomness_transactions: &mut Vec<VerifiedSequencedConsensusTransaction>,
     ) -> SuiResult {
-        let deferred_randomness_txs = self.load_deferred_transactions_for_randomness(batch)?;
+        let deferred_randomness_txs = self.load_deferred_transactions_for_randomness(output)?;
         previously_deferred_tx_digests.extend(deferred_randomness_txs.iter().flat_map(
             |(deferral_key, txs)| {
                 txs.iter().map(|tx| match tx.0.transaction.key() {
@@ -1646,17 +1621,17 @@ impl AuthorityPerEpochStore {
 
     fn load_deferred_transactions_for_up_to_consensus_round(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         consensus_round: u64,
     ) -> SuiResult<Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)>> {
         let (min, max) = DeferralKey::range_for_up_to_consensus_round(consensus_round);
-        self.load_deferred_transactions(batch, min, max)
+        self.load_deferred_transactions(output, min, max)
     }
 
     // factoring of the above
     fn load_deferred_transactions(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         min: DeferralKey,
         max: DeferralKey,
     ) -> SuiResult<Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)>> {
@@ -1692,10 +1667,7 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        // Transactional DBs do not support range deletes, so we have to delete keys one-by-one.
-        // This shouldn't be a problem, there should not usually be more than a small handful of
-        // keys loaded in each round.
-        batch.delete_batch(&self.tables()?.deferred_transactions, keys)?;
+        output.delete_loaded_deferred_transactions(&keys);
 
         Ok(txns)
     }
@@ -1847,22 +1819,6 @@ impl AuthorityPerEpochStore {
             .expect("deferred transactions should not be read past end of epoch")
             .deferred_transactions
             .is_empty()
-    }
-
-    /// Stores a list of pending certificates to be executed.
-    pub fn insert_pending_execution(
-        &self,
-        certs: &[TrustedExecutableTransaction],
-    ) -> SuiResult<()> {
-        let mut batch = self.tables()?.pending_execution.batch();
-        batch.insert_batch(
-            &self.tables()?.pending_execution,
-            certs
-                .iter()
-                .map(|cert| (*cert.inner().digest(), cert.clone())),
-        )?;
-        batch.write()?;
-        Ok(())
     }
 
     /// Check whether certificate was processed by consensus.
@@ -2117,9 +2073,9 @@ impl AuthorityPerEpochStore {
         Ok(result?)
     }
 
-    pub fn record_jwk_vote(
+    fn record_jwk_vote(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         round: u64,
         authority: AuthorityName,
         id: &JwkId,
@@ -2155,10 +2111,7 @@ impl AuthorityPerEpochStore {
             return Ok(());
         }
 
-        batch.insert_batch(
-            &self.tables()?.pending_jwks,
-            std::iter::once(((authority, id.clone(), jwk.clone()), ())),
-        )?;
+        output.insert_pending_jwk(authority, id.clone(), jwk.clone());
 
         let key = (id.clone(), jwk.clone());
         let previously_active = jwk_aggregator.has_quorum_for_key(&key);
@@ -2166,10 +2119,7 @@ impl AuthorityPerEpochStore {
 
         if !previously_active && insert_result.is_quorum_reached() {
             info!(epoch = ?self.epoch(), ?round, jwk = ?key, "jwk became active");
-            batch.insert_batch(
-                &self.tables()?.active_jwks,
-                std::iter::once(((round, key), ())),
-            )?;
+            output.insert_active_jwk(round, key);
         }
 
         Ok(())
@@ -2206,40 +2156,6 @@ impl AuthorityPerEpochStore {
         jwk_aggregator.has_quorum_for_key(&(jwk_id.clone(), jwk.clone()))
     }
 
-    /// Record when finished processing a transaction from consensus.
-    fn record_consensus_message_processed(
-        &self,
-        batch: &mut DBBatch,
-        key: SequencedConsensusTransactionKey,
-    ) -> SuiResult {
-        batch.insert_batch(&self.tables()?.consensus_message_processed, [(key, true)])?;
-        Ok(())
-    }
-
-    /// Record when finished processing a consensus commit.
-    fn record_consensus_commit_stats(
-        &self,
-        batch: &mut DBBatch,
-        consensus_stats: &ExecutionIndicesWithStats,
-    ) -> SuiResult {
-        // TODO: remove writing to last_consensus_index.
-        batch.insert_batch(
-            &self.tables()?.last_consensus_index,
-            [(
-                LAST_CONSENSUS_STATS_ADDR,
-                ExecutionIndicesWithHash {
-                    index: consensus_stats.index,
-                    hash: consensus_stats.hash,
-                },
-            )],
-        )?;
-        batch.insert_batch(
-            &self.tables()?.last_consensus_stats,
-            [(LAST_CONSENSUS_STATS_ADDR, consensus_stats)],
-        )?;
-        Ok(())
-    }
-
     pub fn test_insert_user_signature(
         &self,
         digest: TransactionDigest,
@@ -2260,26 +2176,24 @@ impl AuthorityPerEpochStore {
         self.consensus_notify_read.notify(&key, &());
     }
 
-    pub fn finish_consensus_certificate_process_with_batch(
+    fn finish_consensus_certificate_process_with_batch(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         certificates: &[VerifiedExecutableTransaction],
     ) -> SuiResult {
-        for certificate in certificates {
-            batch.insert_batch(
-                &self.tables()?.pending_execution,
-                [(*certificate.digest(), certificate.clone().serializable())],
-            )?;
-            // User signatures are written in the same batch as consensus certificate processed flag,
-            // which means we won't attempt to insert this twice for the same tx digest
-            debug_assert!(!self
-                .tables()?
-                .user_signatures_for_checkpoints
-                .contains_key(certificate.digest())?);
-            batch.insert_batch(
-                &self.tables()?.user_signatures_for_checkpoints,
-                [(*certificate.digest(), certificate.tx_signatures().to_vec())],
-            )?;
+        output.insert_pending_execution(certificates);
+        output.insert_user_signatures_for_checkpoints(certificates);
+
+        if cfg!(debug_assertions) {
+            for certificate in certificates {
+                // User signatures are written in the same batch as consensus certificate processed flag,
+                // which means we won't attempt to insert this twice for the same tx digest
+                assert!(!self
+                    .tables()?
+                    .user_signatures_for_checkpoints
+                    .contains_key(certificate.digest())
+                    .unwrap());
+            }
         }
         Ok(())
     }
@@ -2530,14 +2444,13 @@ impl AuthorityPerEpochStore {
                 current_commit_sequenced_consensus_transactions.push(tx);
             }
         }
-        let mut batch = self
-            .db_batch()
-            .expect("Failed to create DBBatch for processing consensus transactions");
+
+        let mut output = ConsensusCommitOutput::new();
 
         // Load transactions deferred from previous commits.
         let deferred_txs: Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)> = self
             .load_deferred_transactions_for_up_to_consensus_round(
-                &mut batch,
+                &mut output,
                 consensus_commit_info.round,
             )?
             .into_iter()
@@ -2596,7 +2509,7 @@ impl AuthorityPerEpochStore {
                         .should_accept_tx()
                     {
                         randomness_manager
-                            .reserve_next_randomness(consensus_commit_info.timestamp, &mut batch)?
+                            .reserve_next_randomness(consensus_commit_info.timestamp, &mut output)?
                     } else {
                         None
                     }
@@ -2611,7 +2524,7 @@ impl AuthorityPerEpochStore {
         // - if randomness is being generated, so we can process them
         if dkg_failed || randomness_round.is_some() {
             self.load_and_process_deferred_transactions_for_randomness(
-                &mut batch,
+                &mut output,
                 &mut previously_deferred_tx_digests,
                 &mut sequenced_randomness_transactions,
             )?;
@@ -2682,7 +2595,7 @@ impl AuthorityPerEpochStore {
             consensus_commit_prologue_root,
         ) = self
             .process_consensus_transactions(
-                &mut batch,
+                &mut output,
                 &consensus_transactions,
                 &end_of_publish_transactions,
                 checkpoint_service,
@@ -2698,10 +2611,10 @@ impl AuthorityPerEpochStore {
             )
             .await?;
         self.finish_consensus_certificate_process_with_batch(
-            &mut batch,
+            &mut output,
             &transactions_to_schedule,
         )?;
-        self.record_consensus_commit_stats(&mut batch, consensus_stats)?;
+        output.record_consensus_commit_stats(consensus_stats.clone());
 
         // Create pending checkpoints if we are still accepting tx.
         let should_accept_tx = if let Some(lock) = &lock {
@@ -2744,7 +2657,7 @@ impl AuthorityPerEpochStore {
                     checkpoint_height,
                 },
             });
-            self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
+            self.write_pending_checkpoint(&mut output, &pending_checkpoint)?;
 
             // Generate pending checkpoint for user tx with randomness.
             // Note if randomness is not generated for this commit, we will skip the
@@ -2764,10 +2677,12 @@ impl AuthorityPerEpochStore {
                         checkpoint_height: checkpoint_height + 1,
                     },
                 });
-                self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
+                self.write_pending_checkpoint(&mut output, &pending_checkpoint)?;
             }
         }
 
+        let mut batch = self.db_batch()?;
+        output.write_to_batch(self, &mut batch)?;
         batch.write()?;
 
         // Only after batch is written, notify checkpoint service to start building any new
@@ -2811,7 +2726,7 @@ impl AuthorityPerEpochStore {
     // Returns the root of the consensus commit prologue transaction if it was added to the input.
     fn add_consensus_commit_prologue_transaction(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         transactions: &mut VecDeque<VerifiedExecutableTransaction>,
         consensus_commit_info: &ConsensusCommitInfo,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
@@ -2865,10 +2780,9 @@ impl AuthorityPerEpochStore {
             _ => unreachable!("process_consensus_system_transaction returned unexpected ConsensusCertificateResult."),
         };
 
-        self.record_consensus_message_processed(
-            batch,
-            SequencedConsensusTransactionKey::System(*transaction.digest()),
-        )?;
+        output.record_consensus_message_processed(SequencedConsensusTransactionKey::System(
+            *transaction.digest(),
+        ));
         Ok(consensus_commit_prologue_root)
     }
 
@@ -2881,7 +2795,8 @@ impl AuthorityPerEpochStore {
         transactions: &[VerifiedExecutableTransaction],
         randomness_round: Option<RandomnessRound>,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
-        db_batch: &mut DBBatch,
+        //db_batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
     ) -> SuiResult {
         let ConsensusSharedObjVerAssignment {
             shared_input_next_versions,
@@ -2894,12 +2809,9 @@ impl AuthorityPerEpochStore {
             cancelled_txns,
         )
         .await?;
-        self.set_assigned_shared_object_versions_with_db_batch(assigned_versions, db_batch)
-            .await?;
-        db_batch.insert_batch(
-            &self.tables()?.next_shared_object_versions,
-            shared_input_next_versions,
-        )?;
+        //self.set_assigned_shared_object_versions_with_db_batch(assigned_versions, output)
+        //    .await?;
+        output.set_assigned_shared_object_versions(assigned_versions, shared_input_next_versions);
         Ok(())
     }
 
@@ -2976,7 +2888,7 @@ impl AuthorityPerEpochStore {
     #[allow(clippy::type_complexity)]
     pub(crate) async fn process_consensus_transactions<C: CheckpointServiceNotify>(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         transactions: &[VerifiedSequencedConsensusTransaction],
         end_of_publish_transactions: &[VerifiedSequencedConsensusTransaction],
         checkpoint_service: &Arc<C>,
@@ -3044,7 +2956,7 @@ impl AuthorityPerEpochStore {
             };
             match self
                 .process_consensus_transaction(
-                    batch,
+                    output,
                     tx,
                     checkpoint_service,
                     consensus_commit_info.round,
@@ -3095,7 +3007,7 @@ impl AuthorityPerEpochStore {
                 }
             }
             if !ignored {
-                self.record_consensus_message_processed(batch, key.clone())?;
+                output.record_consensus_message_processed(key.clone());
             }
             if filter_roots {
                 if let Some(txn_key) =
@@ -3113,7 +3025,8 @@ impl AuthorityPerEpochStore {
         let mut total_deferred_txns = 0;
         for (key, txns) in deferred_txns.into_iter() {
             total_deferred_txns += txns.len();
-            self.defer_transactions(batch, key, txns)?;
+            output.defer_transactions(key, txns);
+            //self.defer_transactions(output, key, txns)?;
         }
         authority_metrics
             .consensus_handler_deferred_transactions
@@ -3125,14 +3038,14 @@ impl AuthorityPerEpochStore {
         if randomness_state_updated {
             if let Some(randomness_manager) = randomness_manager.as_mut() {
                 randomness_manager
-                    .advance_dkg(batch, consensus_commit_info.round)
+                    .advance_dkg(output, consensus_commit_info.round)
                     .await?;
             }
         }
 
         // Add the consensus commit prologue transaction to the beginning of `verified_certificates`.
         let consensus_commit_prologue_root = self.add_consensus_commit_prologue_transaction(
-            batch,
+            output,
             &mut verified_certificates,
             consensus_commit_info,
             &cancelled_txns,
@@ -3145,12 +3058,12 @@ impl AuthorityPerEpochStore {
             &verified_certificates,
             randomness_round,
             &cancelled_txns,
-            batch,
+            output,
         )
         .await?;
 
         let (lock, final_round) = self.process_end_of_publish_transactions_and_reconfig(
-            batch,
+            output,
             end_of_publish_transactions,
             commit_has_deferred_txns,
         )?;
@@ -3166,7 +3079,7 @@ impl AuthorityPerEpochStore {
 
     fn process_end_of_publish_transactions_and_reconfig(
         &self,
-        write_batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         transactions: &[VerifiedSequencedConsensusTransaction],
         commit_has_deferred_txns: bool,
     ) -> SuiResult<(
@@ -3199,7 +3112,7 @@ impl AuthorityPerEpochStore {
                         .get_reconfig_state_read_lock_guard()
                         .should_accept_consensus_certs()
                 {
-                    write_batch.insert_batch(&self.tables()?.end_of_publish, [(authority, ())])?;
+                    output.insert_end_of_publish(*authority);
                     self.end_of_publish.try_lock()
                         .expect("No contention on Authority::end_of_publish as it is only accessed from consensus handler")
                         .insert_generic(*authority, ()).is_quorum_reached()
@@ -3219,7 +3132,8 @@ impl AuthorityPerEpochStore {
                     );
                     let mut l = self.get_reconfig_state_write_lock_guard();
                     l.close_all_certs();
-                    self.store_reconfig_state_batch(&l, write_batch)?;
+                    output.store_reconfig_state(l.clone());
+                    //self.store_reconfig_state_batch(&l, output)?;
                     // Holding this lock until end of process_consensus_transactions_and_commit_boundary() where we write batch to DB
                     lock = Some(l);
                 };
@@ -3227,7 +3141,7 @@ impl AuthorityPerEpochStore {
                 // operation returns error. If some day we won't panic in ConsensusHandler on error
                 // we need to figure out here how to revert in-memory state of .end_of_publish
                 // and .reconfig_state when write fails.
-                self.record_consensus_message_processed(write_batch, transaction.key())?;
+                output.record_consensus_message_processed(transaction.key());
             } else {
                 panic!(
                     "process_end_of_publish_transactions_and_reconfig called with non-end-of-publish transaction"
@@ -3260,14 +3174,14 @@ impl AuthorityPerEpochStore {
         // Acquire lock to advance state if we don't already have it.
         let mut lock = lock.unwrap_or_else(|| self.get_reconfig_state_write_lock_guard());
         lock.close_all_tx();
-        self.store_reconfig_state_batch(&lock, write_batch)?;
+        output.store_reconfig_state(lock.clone());
         Ok((Some(lock), true))
     }
 
     #[instrument(level = "trace", skip_all)]
     async fn process_consensus_transaction<C: CheckpointServiceNotify>(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         transaction: &VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
         commit_round: Round,
@@ -3449,7 +3363,7 @@ impl AuthorityPerEpochStore {
                     .should_accept_consensus_certs()
                 {
                     self.record_jwk_vote(
-                        batch,
+                        output,
                         consensus_index.last_committed_round,
                         *authority,
                         jwk_id,
@@ -3521,13 +3435,13 @@ impl AuthorityPerEpochStore {
 
                         let versioned_dkg_confirmation = match self.protocol_config.dkg_version() {
                             // old message was not an enum
-                            0 => bcs::from_bytes(bytes).map(VersionedDkgConfimation::V0),
+                            0 => bcs::from_bytes(bytes).map(VersionedDkgConfirmation::V0),
                             _ => bcs::from_bytes(bytes),
                         };
 
                         match versioned_dkg_confirmation {
                             Ok(message) => {
-                                randomness_manager.add_confirmation(batch, authority, message)?
+                                randomness_manager.add_confirmation(output, authority, message)?
                             }
                             Err(e) => {
                                 warn!(
@@ -3575,9 +3489,10 @@ impl AuthorityPerEpochStore {
 
     pub(crate) fn write_pending_checkpoint(
         &self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         checkpoint: &PendingCheckpointV2,
     ) -> SuiResult {
+        // TODO: is this check necessary?
         if let Some(pending) = self.get_pending_checkpoint(&checkpoint.height())? {
             if pending.roots() != checkpoint.roots() {
                 panic!("Received checkpoint at index {} that contradicts previously stored checkpoint. Old roots: {:?}, new roots: {:?}", checkpoint.height(), pending.roots(), checkpoint.roots());
@@ -3599,17 +3514,7 @@ impl AuthorityPerEpochStore {
             checkpoint.roots()
         );
 
-        if self.randomness_state_enabled() {
-            batch.insert_batch(
-                &self.tables()?.pending_checkpoints_v2,
-                std::iter::once((checkpoint.height(), checkpoint)),
-            )?;
-        } else {
-            batch.insert_batch(
-                &self.tables()?.pending_checkpoints,
-                std::iter::once((checkpoint.height(), checkpoint.clone().expect_v1())),
-            )?;
-        }
+        output.insert_pending_checkpoint(checkpoint.clone());
 
         Ok(())
     }
@@ -3863,6 +3768,299 @@ impl AuthorityPerEpochStore {
 
     pub fn clear_signature_cache(&self) {
         self.signature_verifier.clear_signature_cache();
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ConsensusCommitOutput {
+    // Consensus and reconfig state
+    consensus_messages_processed: BTreeSet<SequencedConsensusTransactionKey>,
+    end_of_publish: BTreeSet<AuthorityName>,
+    reconfig_state: Option<ReconfigState>,
+    consensus_commit_stats: Option<ExecutionIndicesWithStats>,
+    pending_execution: Vec<VerifiedExecutableTransaction>,
+
+    // transaction scheduling state
+    shared_object_versions: Option<(AssignedTxAndVersions, HashMap<ObjectID, SequenceNumber>)>,
+
+    deferred_txns: Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)>,
+    // deferred txns that have been loaded and can be removed
+    deleted_deferred_txns: BTreeSet<DeferralKey>,
+
+    // checkpoint state
+    user_signatures_for_checkpoints: Vec<(TransactionDigest, Vec<GenericSignature>)>,
+    pending_checkpoints: Vec<PendingCheckpointV2>,
+
+    // random beacon state
+    next_randomness_round: Option<(RandomnessRound, TimestampMs)>,
+
+    dkg_confirmations: BTreeMap<PartyId, VersionedDkgConfirmation>,
+    dkg_processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
+    dkg_used_message: Option<VersionedUsedProcessedMessages>,
+    dkg_output: Option<dkg::Output<PkG, EncG>>,
+
+    // jwk state
+    pending_jwks: BTreeSet<(AuthorityName, JwkId, JWK)>,
+    active_jwks: BTreeSet<(u64, (JwkId, JWK))>,
+}
+
+impl ConsensusCommitOutput {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    fn insert_end_of_publish(&mut self, authority: AuthorityName) {
+        self.end_of_publish.insert(authority);
+    }
+
+    fn insert_pending_execution(&mut self, transactions: &[VerifiedExecutableTransaction]) {
+        self.pending_execution.reserve(transactions.len());
+        self.pending_execution.extend_from_slice(transactions);
+    }
+
+    fn insert_user_signatures_for_checkpoints(
+        &mut self,
+        transactions: &[VerifiedExecutableTransaction],
+    ) {
+        self.user_signatures_for_checkpoints
+            .reserve(transactions.len());
+        for tx in transactions {
+            self.user_signatures_for_checkpoints
+                .push((*tx.digest(), tx.tx_signatures().to_vec()));
+        }
+    }
+
+    fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStats) {
+        self.consensus_commit_stats = Some(stats);
+    }
+
+    fn store_reconfig_state(&mut self, state: ReconfigState) {
+        self.reconfig_state = Some(state);
+    }
+
+    fn record_consensus_message_processed(&mut self, key: SequencedConsensusTransactionKey) {
+        self.consensus_messages_processed.insert(key);
+    }
+
+    fn set_assigned_shared_object_versions(
+        &mut self,
+        versions: AssignedTxAndVersions,
+        next_versions: HashMap<ObjectID, SequenceNumber>,
+    ) {
+        assert!(self.shared_object_versions.is_none());
+        self.shared_object_versions = Some((versions, next_versions));
+    }
+
+    fn defer_transactions(
+        &mut self,
+        key: DeferralKey,
+        transactions: Vec<VerifiedSequencedConsensusTransaction>,
+    ) {
+        self.deferred_txns.push((key, transactions));
+    }
+
+    fn delete_loaded_deferred_transactions(&mut self, deferral_keys: &[DeferralKey]) {
+        self.deleted_deferred_txns
+            .extend(deferral_keys.iter().cloned());
+    }
+
+    fn insert_pending_checkpoint(&mut self, checkpoint: PendingCheckpointV2) {
+        self.pending_checkpoints.push(checkpoint);
+    }
+
+    pub fn reserve_next_random_round(
+        &mut self,
+        next_randomness_round: RandomnessRound,
+        commit_timestamp: TimestampMs,
+    ) {
+        assert!(self.next_randomness_round.is_none());
+        self.next_randomness_round = Some((next_randomness_round, commit_timestamp));
+    }
+
+    pub fn insert_dkg_confirmation(&mut self, conf: VersionedDkgConfirmation) {
+        self.dkg_confirmations.insert(conf.sender(), conf);
+    }
+
+    pub fn insert_dkg_processed_message(&mut self, message: VersionedProcessedMessage) {
+        self.dkg_processed_messages
+            .insert(message.sender(), message);
+    }
+
+    pub fn insert_dkg_used_messages(&mut self, used_messages: VersionedUsedProcessedMessages) {
+        self.dkg_used_message = Some(used_messages);
+    }
+
+    pub fn set_dkg_output(&mut self, output: dkg::Output<PkG, EncG>) {
+        self.dkg_output = Some(output);
+    }
+
+    fn insert_pending_jwk(&mut self, authority: AuthorityName, id: JwkId, jwk: JWK) {
+        self.pending_jwks.insert((authority, id, jwk));
+    }
+
+    fn insert_active_jwk(&mut self, round: u64, key: (JwkId, JWK)) {
+        self.active_jwks.insert((round, key));
+    }
+
+    pub fn write_to_batch(
+        self,
+        epoch_store: &AuthorityPerEpochStore,
+        batch: &mut DBBatch,
+    ) -> SuiResult {
+        let tables = epoch_store.tables()?;
+        batch.insert_batch(
+            &tables.consensus_message_processed,
+            self.consensus_messages_processed
+                .iter()
+                .map(|key| (key, true)),
+        )?;
+
+        batch.insert_batch(
+            &tables.end_of_publish,
+            self.end_of_publish.iter().map(|authority| (authority, ())),
+        )?;
+
+        if let Some(reconfig_state) = &self.reconfig_state {
+            batch.insert_batch(
+                &tables.reconfig_state,
+                [(RECONFIG_STATE_INDEX, reconfig_state)],
+            )?;
+        }
+
+        if let Some(consensus_commit_stats) = &self.consensus_commit_stats {
+            batch.insert_batch(
+                &tables.last_consensus_index,
+                [(
+                    LAST_CONSENSUS_STATS_ADDR,
+                    ExecutionIndicesWithHash {
+                        index: consensus_commit_stats.index,
+                        hash: consensus_commit_stats.hash,
+                    },
+                )],
+            )?;
+            batch.insert_batch(
+                &tables.last_consensus_stats,
+                [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],
+            )?;
+        }
+
+        batch.insert_batch(
+            &tables.pending_execution,
+            self.pending_execution
+                .into_iter()
+                .map(|tx| (*tx.inner().digest(), tx.serializable())),
+        )?;
+
+        if let Some((assigned_versions, next_versions)) = self.shared_object_versions {
+            if epoch_store.randomness_state_enabled() {
+                batch.insert_batch(
+                    &tables.assigned_shared_object_versions_v2,
+                    assigned_versions,
+                )?;
+            } else {
+                batch.insert_batch(
+                    &tables.assigned_shared_object_versions,
+                    assigned_versions
+                        .into_iter()
+                        .map(|(key, versions)| (*key.unwrap_digest(), versions)),
+                )?;
+            }
+
+            batch.insert_batch(&tables.next_shared_object_versions, next_versions)?;
+        }
+
+        batch.delete_batch(&tables.deferred_transactions, self.deleted_deferred_txns)?;
+        batch.insert_batch(&tables.deferred_transactions, self.deferred_txns)?;
+
+        batch.insert_batch(
+            &tables.user_signatures_for_checkpoints,
+            self.user_signatures_for_checkpoints,
+        )?;
+
+        if epoch_store.randomness_state_enabled() {
+            batch.insert_batch(
+                &tables.pending_checkpoints_v2,
+                self.pending_checkpoints
+                    .into_iter()
+                    .map(|cp| (cp.height(), cp)),
+            )?;
+        } else {
+            batch.insert_batch(
+                &tables.pending_checkpoints,
+                self.pending_checkpoints
+                    .into_iter()
+                    .map(|cp| (cp.height(), cp.expect_v1())),
+            )?;
+        }
+
+        if let Some((round, commit_timestamp)) = self.next_randomness_round {
+            batch.insert_batch(&tables.randomness_next_round, [(SINGLETON_KEY, round)])?;
+            batch.insert_batch(
+                &tables.randomness_last_round_timestamp,
+                [(SINGLETON_KEY, commit_timestamp)],
+            )?;
+        }
+
+        let dkg_version = epoch_store.protocol_config().dkg_version();
+        match dkg_version {
+            0 => {
+                #[allow(deprecated)]
+                {
+                    batch.insert_batch(
+                        &tables.dkg_confirmations,
+                        self.dkg_confirmations
+                            .into_iter()
+                            .map(|(sender, conf)| (sender, conf.unwrap_v0().clone())),
+                    )?;
+                    batch.insert_batch(
+                        &tables.dkg_processed_messages,
+                        self.dkg_processed_messages
+                            .into_iter()
+                            .map(|(sender, processed)| (sender, processed.unwrap_v0())),
+                    )?;
+                    batch.insert_batch(
+                        &tables.dkg_used_messages,
+                        // using Option as iter
+                        self.dkg_used_message
+                            .into_iter()
+                            .map(|used_msgs| (SINGLETON_KEY, used_msgs.unwrap_v0())),
+                    )?;
+                }
+            }
+            1 => {
+                batch.insert_batch(
+                    &tables.dkg_confirmations_v2,
+                    self.dkg_confirmations
+                        .into_iter()
+                        .map(|(sender, conf)| (sender, conf.expect_v1())),
+                )?;
+                batch.insert_batch(
+                    &tables.dkg_processed_messages_v2,
+                    self.dkg_processed_messages
+                        .into_iter()
+                        .map(|(sender, processed)| (sender, processed.expect_v1())),
+                )?;
+                batch.insert_batch(
+                    &tables.dkg_used_messages_v2,
+                    // using Option as iter
+                    self.dkg_used_message
+                        .into_iter()
+                        .map(|used_msgs| (SINGLETON_KEY, used_msgs.expect_v1())),
+                )?;
+            }
+            _ => panic!("BUG: invalid DKG version {dkg_version}"),
+        }
+
+        batch.insert_batch(
+            &tables.pending_jwks,
+            self.pending_jwks.into_iter().map(|j| (j, ())),
+        )?;
+        batch.insert_batch(
+            &tables.active_jwks,
+            self.active_jwks.into_iter().map(|j| (j, ())),
+        )?;
+
+        Ok(())
     }
 }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2284,8 +2284,12 @@ impl CheckpointService {
         epoch_store: &AuthorityPerEpochStore,
         checkpoint: PendingCheckpointV2,
     ) -> SuiResult {
+        use crate::authority::authority_per_epoch_store::ConsensusCommitOutput;
+
+        let mut output = ConsensusCommitOutput::new();
+        epoch_store.write_pending_checkpoint(&mut output, &checkpoint)?;
         let mut batch = epoch_store.db_batch_for_test();
-        epoch_store.write_pending_checkpoint(&mut batch, &checkpoint)?;
+        output.write_to_batch(epoch_store, &mut batch)?;
         batch.write()?;
         self.notify_checkpoint()?;
         Ok(())

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -643,7 +643,7 @@ impl From<SerializableSequencedConsensusTransactionKind> for SequencedConsensusT
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
 pub enum SequencedConsensusTransactionKey {
     External(ConsensusTransactionKey),
     System(TransactionDigest),

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -25,15 +25,14 @@ use sui_types::committee::{Committee, EpochId, StakeUnit};
 use sui_types::crypto::{AuthorityKeyPair, RandomnessRound};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages_consensus::VersionedDkgMessage;
-use sui_types::messages_consensus::{ConsensusTransaction, VersionedDkgConfimation};
+use sui_types::messages_consensus::{ConsensusTransaction, VersionedDkgConfirmation};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use tokio::sync::OnceCell;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
-use typed_store::rocks::DBBatch;
 use typed_store::Map;
 
-use crate::authority::authority_per_epoch_store::{AuthorityEpochTables, AuthorityPerEpochStore};
+use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, ConsensusCommitOutput};
 use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::consensus_adapter::ConsensusAdapter;
 
@@ -59,7 +58,7 @@ impl VersionedProcessedMessage {
         }
     }
 
-    fn unwrap_v0(self) -> dkg_v0::ProcessedMessage<PkG, EncG> {
+    pub fn unwrap_v0(self) -> dkg_v0::ProcessedMessage<PkG, EncG> {
         if let VersionedProcessedMessage::V0(msg) = self {
             msg
         } else {
@@ -67,7 +66,7 @@ impl VersionedProcessedMessage {
         }
     }
 
-    fn unwrap_v1(self) -> dkg_v1::ProcessedMessage<PkG, EncG> {
+    pub fn unwrap_v1(self) -> dkg_v1::ProcessedMessage<PkG, EncG> {
         if let VersionedProcessedMessage::V1(msg) = self {
             msg
         } else {
@@ -75,7 +74,7 @@ impl VersionedProcessedMessage {
         }
     }
 
-    fn expect_v1(self) -> Self {
+    pub fn expect_v1(self) -> Self {
         if let VersionedProcessedMessage::V1(_) = self {
             self
         } else {
@@ -107,7 +106,7 @@ impl VersionedProcessedMessage {
         dkg_version: u64,
         party: Arc<dkg::Party<PkG, EncG>>,
         messages: Vec<Self>,
-    ) -> FastCryptoResult<(VersionedDkgConfimation, VersionedUsedProcessedMessages)> {
+    ) -> FastCryptoResult<(VersionedDkgConfirmation, VersionedUsedProcessedMessages)> {
         match dkg_version {
             0 => {
                 let (conf, msgs) = party.merge(
@@ -117,7 +116,7 @@ impl VersionedProcessedMessage {
                         .collect::<Vec<_>>(),
                 )?;
                 Ok((
-                    VersionedDkgConfimation::V0(conf),
+                    VersionedDkgConfirmation::V0(conf),
                     VersionedUsedProcessedMessages::V0(msgs),
                 ))
             }
@@ -129,7 +128,7 @@ impl VersionedProcessedMessage {
                         .collect::<Vec<_>>(),
                 )?;
                 Ok((
-                    VersionedDkgConfimation::V1(conf),
+                    VersionedDkgConfirmation::V1(conf),
                     VersionedUsedProcessedMessages::V1(msgs),
                 ))
             }
@@ -145,7 +144,7 @@ pub enum VersionedUsedProcessedMessages {
 }
 
 impl VersionedUsedProcessedMessages {
-    fn complete_dkg<'a, Iter: Iterator<Item = &'a VersionedDkgConfimation>>(
+    fn complete_dkg<'a, Iter: Iterator<Item = &'a VersionedDkgConfirmation>>(
         &self,
         party: Arc<dkg::Party<PkG, EncG>>,
         confirmations: Iter,
@@ -171,7 +170,7 @@ impl VersionedUsedProcessedMessages {
         }
     }
 
-    fn unwrap_v0(self) -> dkg_v0::UsedProcessedMessages<PkG, EncG> {
+    pub fn unwrap_v0(self) -> dkg_v0::UsedProcessedMessages<PkG, EncG> {
         if let VersionedUsedProcessedMessages::V0(msg) = self {
             msg
         } else {
@@ -179,7 +178,7 @@ impl VersionedUsedProcessedMessages {
         }
     }
 
-    fn expect_v1(self) -> Self {
+    pub fn expect_v1(self) -> Self {
         if let VersionedUsedProcessedMessages::V1(_) = self {
             self
         } else {
@@ -220,7 +219,7 @@ pub struct RandomnessManager {
     enqueued_messages: BTreeMap<PartyId, JoinHandle<Option<VersionedProcessedMessage>>>,
     processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
     used_messages: OnceCell<VersionedUsedProcessedMessages>,
-    confirmations: BTreeMap<PartyId, VersionedDkgConfimation>,
+    confirmations: BTreeMap<PartyId, VersionedDkgConfirmation>,
     dkg_output: OnceCell<Option<dkg::Output<PkG, EncG>>>,
 
     // State for randomness generation.
@@ -409,7 +408,7 @@ impl RandomnessManager {
                     rm.confirmations
                         .extend(tables.dkg_confirmations.safe_iter().map(|result| {
                             let (pid, msg) = result.expect("typed_store should not fail");
-                            (pid, VersionedDkgConfimation::V0(msg))
+                            (pid, VersionedDkgConfirmation::V0(msg))
                         }));
                 }
                 1 => {
@@ -529,9 +528,12 @@ impl RandomnessManager {
 
     /// Processes all received messages and advances the randomness DKG state machine when possible,
     /// sending out a dkg::Confirmation and generating final output.
-    pub async fn advance_dkg(&mut self, batch: &mut DBBatch, round: Round) -> SuiResult {
+    pub(crate) async fn advance_dkg(
+        &mut self,
+        consensus_output: &mut ConsensusCommitOutput,
+        round: Round,
+    ) -> SuiResult {
         let epoch_store = self.epoch_store()?;
-        let dkg_version = epoch_store.protocol_config().dkg_version();
 
         // Once we have enough Messages, send a Confirmation.
         if !self.dkg_output.initialized() && !self.used_messages.initialized() {
@@ -543,22 +545,7 @@ impl RandomnessManager {
                 if let Ok(Some(processed)) = res {
                     self.processed_messages
                         .insert(processed.sender(), processed.clone());
-                    match dkg_version {
-                        0 => {
-                            #[allow(deprecated)]
-                            batch.insert_batch(
-                                &epoch_store.tables()?.dkg_processed_messages,
-                                std::iter::once((processed.sender(), processed.unwrap_v0())),
-                            )?;
-                        }
-                        1 => {
-                            batch.insert_batch(
-                                &epoch_store.tables()?.dkg_processed_messages_v2,
-                                std::iter::once((processed.sender(), processed.expect_v1())),
-                            )?;
-                        }
-                        _ => panic!("BUG: invalid DKG version {dkg_version}"),
-                    }
+                    consensus_output.insert_dkg_processed_message(processed);
                 }
             }
 
@@ -579,22 +566,7 @@ impl RandomnessManager {
                     if self.used_messages.set(used_msgs.clone()).is_err() {
                         error!("BUG: used_messages should only ever be set once");
                     }
-                    match dkg_version {
-                        0 => {
-                            #[allow(deprecated)]
-                            batch.insert_batch(
-                                &epoch_store.tables()?.dkg_used_messages,
-                                std::iter::once((SINGLETON_KEY, used_msgs.unwrap_v0())),
-                            )?;
-                        }
-                        1 => {
-                            batch.insert_batch(
-                                &epoch_store.tables()?.dkg_used_messages_v2,
-                                std::iter::once((SINGLETON_KEY, used_msgs.expect_v1())),
-                            )?;
-                        }
-                        _ => panic!("BUG: invalid DKG version {dkg_version}"),
-                    };
+                    consensus_output.insert_dkg_used_messages(used_msgs);
 
                     let transaction = ConsensusTransaction::new_randomness_dkg_confirmation(
                         epoch_store.name,
@@ -663,10 +635,7 @@ impl RandomnessManager {
                         self.party.t(),
                         None,
                     );
-                    batch.insert_batch(
-                        &epoch_store.tables()?.dkg_output,
-                        std::iter::once((SINGLETON_KEY, output)),
-                    )?;
+                    consensus_output.set_dkg_output(output);
                 }
                 Err(fastcrypto::error::FastCryptoError::NotEnoughInputs) => (), // wait for more input
                 Err(e) => error!("random beacon: error while processing DKG Confirmations: {e:?}"),
@@ -735,11 +704,11 @@ impl RandomnessManager {
     }
 
     /// Adds a received dkg::Confirmation to the randomness DKG state machine.
-    pub fn add_confirmation(
+    pub(crate) fn add_confirmation(
         &mut self,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
         authority: &AuthorityName,
-        conf: VersionedDkgConfimation,
+        conf: VersionedDkgConfirmation,
     ) -> SuiResult {
         if self.dkg_output.initialized() {
             // Once we have completed DKG, no more `Confirmation`s are needed.
@@ -756,23 +725,7 @@ impl RandomnessManager {
             return Ok(());
         }
         self.confirmations.insert(conf.sender(), conf.clone());
-        let dkg_version = self.epoch_store()?.protocol_config().dkg_version();
-        match dkg_version {
-            0 => {
-                #[allow(deprecated)]
-                batch.insert_batch(
-                    &self.tables()?.dkg_confirmations,
-                    std::iter::once((conf.sender(), conf.unwrap_v0())),
-                )?;
-            }
-            1 => {
-                batch.insert_batch(
-                    &self.tables()?.dkg_confirmations_v2,
-                    std::iter::once((conf.sender(), conf.expect_v1())),
-                )?;
-            }
-            _ => panic!("BUG: invalid DKG version {dkg_version}"),
-        }
+        output.insert_dkg_confirmation(conf);
         Ok(())
     }
 
@@ -780,10 +733,10 @@ impl RandomnessManager {
     /// elapsed, or returns None if not yet ready (based on ProtocolConfig setting). Once the given
     /// batch is written, `generate_randomness` must be called to start the process. On restart,
     /// any reserved rounds for which the batch was written will automatically be resumed.
-    pub fn reserve_next_randomness(
+    pub(crate) fn reserve_next_randomness(
         &mut self,
         commit_timestamp: TimestampMs,
-        batch: &mut DBBatch,
+        output: &mut ConsensusCommitOutput,
     ) -> SuiResult<Option<RandomnessRound>> {
         let epoch_store = self.epoch_store()?;
         let tables = epoch_store.tables()?;
@@ -808,14 +761,7 @@ impl RandomnessManager {
             .checked_add(1)
             .expect("RandomnessRound should not overflow");
 
-        batch.insert_batch(
-            &tables.randomness_next_round,
-            std::iter::once((SINGLETON_KEY, self.next_randomness_round)),
-        )?;
-        batch.insert_batch(
-            &tables.randomness_last_round_timestamp,
-            std::iter::once((SINGLETON_KEY, commit_timestamp)),
-        )?;
+        output.reserve_next_random_round(self.next_randomness_round, commit_timestamp);
 
         Ok(Some(randomness_round))
     }
@@ -848,10 +794,6 @@ impl RandomnessManager {
         self.epoch_store
             .upgrade()
             .ok_or(SuiError::EpochEnded(self.epoch))
-    }
-
-    fn tables(&self) -> SuiResult<Arc<AuthorityEpochTables>> {
-        self.epoch_store()?.tables()
     }
 
     fn randomness_dkg_info_from_committee(
@@ -1038,16 +980,18 @@ mod tests {
             }
         }
         for i in 0..randomness_managers.len() {
-            let mut batch = epoch_stores[i].db_batch_for_test();
+            let mut output = ConsensusCommitOutput::new();
             for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_message(&epoch_stores[j].name, dkg_message)
                     .unwrap();
             }
             randomness_managers[i]
-                .advance_dkg(&mut batch, 0)
+                .advance_dkg(&mut output, 0)
                 .await
                 .unwrap();
+            let mut batch = epoch_stores[i].db_batch_for_test();
+            output.write_to_batch(&epoch_stores[i], &mut batch);
             batch.write().unwrap();
         }
 
@@ -1061,9 +1005,9 @@ mod tests {
                     if version == 0 {
                         let msg: fastcrypto_tbls::dkg::Confirmation<EncG> = bcs::from_bytes(&bytes)
                             .expect("DKG confirmation deserialization should not fail");
-                        dkg_confirmations.push(VersionedDkgConfimation::V0(msg));
+                        dkg_confirmations.push(VersionedDkgConfirmation::V0(msg));
                     } else {
-                        let msg: VersionedDkgConfimation = bcs::from_bytes(&bytes)
+                        let msg: VersionedDkgConfirmation = bcs::from_bytes(&bytes)
                             .expect("DKG message deserialization should not fail");
                         dkg_confirmations.push(msg);
                     }
@@ -1072,16 +1016,18 @@ mod tests {
             }
         }
         for i in 0..randomness_managers.len() {
-            let mut batch = epoch_stores[i].db_batch_for_test();
+            let mut output = ConsensusCommitOutput::new();
             for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
                 randomness_managers[i]
-                    .add_confirmation(&mut batch, &epoch_stores[j].name, dkg_confirmation)
+                    .add_confirmation(&mut output, &epoch_stores[j].name, dkg_confirmation)
                     .unwrap();
             }
             randomness_managers[i]
-                .advance_dkg(&mut batch, 0)
+                .advance_dkg(&mut output, 0)
                 .await
                 .unwrap();
+            let mut batch = epoch_stores[i].db_batch_for_test();
+            output.write_to_batch(&epoch_stores[i], &mut batch);
             batch.write().unwrap();
         }
 
@@ -1184,16 +1130,18 @@ mod tests {
             }
         }
         for i in 0..randomness_managers.len() {
-            let mut batch = epoch_stores[i].db_batch_for_test();
+            let mut output = ConsensusCommitOutput::new();
             for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_message(&epoch_stores[j].name, dkg_message)
                     .unwrap();
             }
             randomness_managers[i]
-                .advance_dkg(&mut batch, u64::MAX)
+                .advance_dkg(&mut output, u64::MAX)
                 .await
                 .unwrap();
+            let mut batch = epoch_stores[i].db_batch_for_test();
+            output.write_to_batch(&epoch_stores[i], &mut batch);
             batch.write().unwrap();
         }
 

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -87,7 +87,7 @@ pub struct ConsensusTransaction {
     pub kind: ConsensusTransactionKind,
 }
 
-#[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ConsensusTransactionKey {
     Certificate(TransactionDigest),
     CheckpointSignature(AuthorityName, CheckpointSequenceNumber),
@@ -226,7 +226,7 @@ pub enum VersionedDkgMessage {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum VersionedDkgConfimation {
+pub enum VersionedDkgConfirmation {
     V0(dkg::Confirmation<bls12381::G2Element>),
     V1(dkg::Confirmation<bls12381::G2Element>),
 }
@@ -292,38 +292,38 @@ impl VersionedDkgMessage {
     }
 }
 
-impl VersionedDkgConfimation {
+impl VersionedDkgConfirmation {
     pub fn sender(&self) -> u16 {
         match self {
-            VersionedDkgConfimation::V0(msg) => msg.sender,
-            VersionedDkgConfimation::V1(msg) => msg.sender,
+            VersionedDkgConfirmation::V0(msg) => msg.sender,
+            VersionedDkgConfirmation::V1(msg) => msg.sender,
         }
     }
 
     pub fn num_of_complaints(&self) -> usize {
         match self {
-            VersionedDkgConfimation::V0(msg) => msg.complaints.len(),
-            VersionedDkgConfimation::V1(msg) => msg.complaints.len(),
+            VersionedDkgConfirmation::V0(msg) => msg.complaints.len(),
+            VersionedDkgConfirmation::V1(msg) => msg.complaints.len(),
         }
     }
 
     pub fn unwrap_v0(&self) -> &dkg::Confirmation<bls12381::G2Element> {
         match self {
-            VersionedDkgConfimation::V0(msg) => msg,
+            VersionedDkgConfirmation::V0(msg) => msg,
             _ => panic!("BUG: expected V0 confirmation"),
         }
     }
 
     pub fn unwrap_v1(&self) -> &dkg::Confirmation<bls12381::G2Element> {
         match self {
-            VersionedDkgConfimation::V1(msg) => msg,
+            VersionedDkgConfirmation::V1(msg) => msg,
             _ => panic!("BUG: expected V1 confirmation"),
         }
     }
 
     pub fn expect_v1(self) -> Self {
         match self {
-            VersionedDkgConfimation::V1(_) => self,
+            VersionedDkgConfirmation::V1(_) => self,
             _ => panic!("BUG: expected V1 confirmation"),
         }
     }
@@ -423,10 +423,10 @@ impl ConsensusTransaction {
     }
     pub fn new_randomness_dkg_confirmation(
         authority: AuthorityName,
-        versioned_confirmation: &VersionedDkgConfimation,
+        versioned_confirmation: &VersionedDkgConfirmation,
     ) -> Self {
         let confirmation = match versioned_confirmation {
-            VersionedDkgConfimation::V0(msg) => {
+            VersionedDkgConfirmation::V0(msg) => {
                 // Old version does not use the enum, so we need to serialize it separately.
                 bcs::to_bytes(msg).expect("message serialization should not fail")
             }


### PR DESCRIPTION
This PR should have no behavior changes. It introduces a new struct, `ConsensusCommitOutput`, which stores all writes generated while processing a consensus commit, prior to writing them to the db.

This is the first stage of caching/quarantining consensus-specific epoch-db state. The next step will be to hold `ConsensusCommitOutput` structs in memory until the checkpoints created for the commit have been certified. This will also require reading from `ConsensusCommitOutput` (or more likely, a broader caching struct which holds information from a set of `ConsensusCommitOutput` objects), since required information will not always be available from the db.
