### PR TITLE
[bridge indexer] add get_raw_events_in_range for indexer to reduce # of eth queries

### DIFF
--- a/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
+++ b/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
@@ -96,8 +96,9 @@ where
         metrics: BridgeIndexerMetrics,
     ) {
         tracing::info!(contract_address=?contract_address, "Starting eth events listening task from block {start_block}");
+        let mut interval = time::interval(BLOCK_QUERY_INTERVAL);
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
         loop {
-            let mut interval = time::interval(BLOCK_QUERY_INTERVAL);
             interval.tick().await;
             let Ok(Ok(new_block)) = retry_with_max_elapsed_time!(
                 provider.get_block_number(),

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -478,8 +478,46 @@ pub struct EthLog {
     pub block_number: u64,
     pub tx_hash: H256,
     pub log_index_in_tx: u16,
-    // TODO: pull necessary fields from `Log`.
     pub log: Log,
+}
+
+/// The version of EthLog that does not have
+/// `log_index_in_tx`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawEthLog {
+    pub block_number: u64,
+    pub tx_hash: H256,
+    pub log: Log,
+}
+
+pub trait EthEvent {
+    fn block_number(&self) -> u64;
+    fn tx_hash(&self) -> H256;
+    fn log(&self) -> &Log;
+}
+
+impl EthEvent for EthLog {
+    fn block_number(&self) -> u64 {
+        self.block_number
+    }
+    fn tx_hash(&self) -> H256 {
+        self.tx_hash
+    }
+    fn log(&self) -> &Log {
+        &self.log
+    }
+}
+
+impl EthEvent for RawEthLog {
+    fn block_number(&self) -> u64 {
+        self.block_number
+    }
+    fn tx_hash(&self) -> H256 {
+        self.tx_hash
+    }
+    fn log(&self) -> &Log {
+        &self.log
+    }
 }
 
 /// Check if the bridge route is valid


### PR DESCRIPTION
## Description 

in `get_events_in_range` it issues extra queries to get `log_index_in_tx`. Indexer does not need this info. This PR adds `get_raw_events_in_range` and `RawEthLog` to replace that for indexer.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
