### PR TITLE
[move examples] Depend only on local framework not devnet for examples

### DIFF
--- a/examples/move/transfer-to-object/common/Move.toml
+++ b/examples/move/transfer-to-object/common/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }
 
 [addresses]
 common = "0x0"

--- a/examples/move/transfer-to-object/owned-no-tto/Move.toml
+++ b/examples/move/transfer-to-object/owned-no-tto/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }
 common = { local = "../common" }
 
 [addresses]

--- a/examples/move/transfer-to-object/shared-no-tto/Move.toml
+++ b/examples/move/transfer-to-object/shared-no-tto/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }
 common = { local = "../common" }
 
 [addresses]

--- a/examples/move/transfer-to-object/shared-with-tto/Move.toml
+++ b/examples/move/transfer-to-object/shared-with-tto/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }
 common = { local = "../common" }
 
 [addresses]


### PR DESCRIPTION
## Description 

These started failing after some new macros landed, and we should be depending on the local framework and not devnet for them.

## Test plan 

CI

