### PR TITLE
[move-ide] Macro expansion crash workaround

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1606,7 +1606,7 @@ fn value(
             error_exp(eloc)
         }
         E::UnresolvedError => {
-            assert!(context.env.has_errors());
+            assert!(context.env.has_errors() || context.env.ide_mode());
             make_exp(HE::UnresolvedError)
         }
     };

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4441,7 +4441,7 @@ fn expand_macro(
     let res = match macro_expand::call(context, call_loc, m, f, type_args.clone(), args, return_ty)
     {
         None => {
-            assert!(context.env.has_errors());
+            assert!(context.env.has_errors() || context.env.ide_mode());
             (context.error_type(call_loc), TE::UnresolvedError)
         }
         Some(macro_expand::ExpandedMacro {


### PR DESCRIPTION
## Description 

This is a workaround for an issue with IDE caching pre-compiled binaries which do not include source code needed for macro expansion. It's only a workaround to avoid `move-analyzer` crashing rather than a proper fix.
