### PR TITLE
[suiop] allow specifying CPU/RAM/DISK requests and build args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14445,7 +14445,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.2.4"
+version = "0.2.5"
 
 [lib]
 name = "suioplib"

--- a/crates/suiop-cli/src/cli/ci/image.rs
+++ b/crates/suiop-cli/src/cli/ci/image.rs
@@ -488,14 +488,6 @@ fn generate_image_request(token: &str, action: &ImageAction) -> reqwest::Request
                     RepoRegion::UsEast1 => region = "us-east1".to_string(),
                 }
             }
-            let mut args = vec![];
-            for arg in build_args.clone().iter_mut() {
-                let needle = "--";
-                if !arg.starts_with(needle) {
-                    arg.insert_str(0, needle);
-                }
-                args.push(arg.to_string())
-            }
             let body = RequestBuildRequest {
                 repo_name: repo_name.clone(),
                 dockerfile: dockerfile.clone(),
@@ -507,7 +499,7 @@ fn generate_image_request(token: &str, action: &ImageAction) -> reqwest::Request
                 cpu,
                 memory,
                 disk,
-                build_args: args,
+                build_args: build_args.clone(),
             };
             debug!("req body: {:?}", body);
             req.json(&body).headers(generate_headers_with_auth(token))

--- a/crates/suiop-cli/src/cli/ci/image.rs
+++ b/crates/suiop-cli/src/cli/ci/image.rs
@@ -81,6 +81,18 @@ pub enum ImageAction {
         /// Optional reference value, default to "main"
         #[arg(long)]
         ref_val: Option<String>,
+        /// Optional cpu resource request, default to "2"
+        #[arg(long)]
+        cpu: Option<String>,
+        /// Optional memory resource request, default to "4Gi"
+        #[arg(long)]
+        memory: Option<String>,
+        /// Optional disk resource request, default to "10Gi"
+        #[arg(long)]
+        disk: Option<String>,
+        /// Optional build args to pass to the docker build command
+        #[arg(long)]
+        build_args: Vec<String>,
     },
     #[command(name = "query")]
     Query {
@@ -115,10 +127,14 @@ pub enum ImageAction {
 struct RequestBuildRequest {
     repo_name: String,
     dockerfile: String,
-    image_tag: Option<String>,
     image_name: Option<String>,
+    image_tag: Option<String>,
     ref_type: Option<RefType>,
     ref_val: Option<String>,
+    cpu: Option<String>,
+    memory: Option<String>,
+    disk: Option<String>,
+    build_args: Vec<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -256,6 +272,10 @@ async fn send_image_request(token: &str, action: &ImageAction) -> Result<()> {
                 image_tag,
                 ref_type,
                 ref_val,
+                cpu: _,
+                memory: _,
+                disk: _,
+                build_args: _,
             } => {
                 let ref_type = ref_type.clone().unwrap_or(RefType::Branch);
                 let ref_val = ref_val.clone().unwrap_or("main".to_string());
@@ -401,6 +421,10 @@ fn generate_image_request(token: &str, action: &ImageAction) -> reqwest::Request
             image_tag,
             ref_type,
             ref_val,
+            cpu,
+            memory,
+            disk,
+            build_args,
         } => {
             let full_url = format!("{}{}", api_server, ENDPOINT);
             debug!("full_url: {}", full_url);
@@ -412,6 +436,10 @@ fn generate_image_request(token: &str, action: &ImageAction) -> reqwest::Request
                 image_tag: image_tag.clone(),
                 ref_type: ref_type.clone(),
                 ref_val: ref_val.clone(),
+                cpu: cpu.clone(),
+                memory: memory.clone(),
+                disk: disk.clone(),
+                build_args: build_args.clone(),
             };
             debug!("req body: {:?}", body);
             req.json(&body).headers(generate_headers_with_auth(token))


### PR DESCRIPTION
## Description 

after adding the support for specifying hardware request in infra-metadata-servcie, we could now allow this from suiop CLI as well.

## Test plan 

`suiop ci image build --repo-name=sui --dockerfile=docker/sui-node/Dockerfile --ref-type=branch --ref-val=testnet --build-mode=beast --build-args="PROFILE=release" --repo-region=us-west1 --image-name=sui-node`

```
Requested built image for repo: sui, ref: branch:testnet, dockerfile: docker/sui-node/Dockerfile, image: sui-node
Build Job Status: Pending
Build Job Name: sui-ywgdt
Build Job Start Time: 2024-07-03 14:58:48
```

then in k8s, hardware request is actually beast mode 
```
Args:
      --dockerfile=docker/sui-node/Dockerfile
      --context=git://github.com/MystenLabs/sui.git#refs/heads/testnet
      --build-arg=PROFILE=release
    State:          Running
      Started:      Wed, 03 Jul 2024 14:58:52 -0700
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:                6
      ephemeral-storage:  40Gi
      memory:             16Gi
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
