### PR TITLE
fix typo

### DIFF
--- a/docs/content/references/cli/cheatsheet.mdx
+++ b/docs/content/references/cli/cheatsheet.mdx
@@ -185,7 +185,7 @@ The cheat sheet highlights common Sui CLI commands.
 			<td class="w-1/3">Merge two coins</td>
 		</tr>
 		<tr>
-			<td class="w-2/3">`sui client split-coins \`<br/>&nbsp;&nbsp;`--coin-id COIN_ID \`<br/>&nbsp;&nbsp;`--amounts 1000`</td>
+			<td class="w-2/3">`sui client split-coin \`<br/>&nbsp;&nbsp;`--coin-id COIN_ID \`<br/>&nbsp;&nbsp;`--amounts 1000`</td>
 			<td class="w-1/3">Split a coin into two coins: one with 1000 MIST and the rest</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Description 

There's a typo in Sui CLI Cheat Sheet.

As there seems to have been a typo here, it might be better to standardize the commands `sui client split-coin` and `sui client ptb --split-coins`.
