### PR TITLE
[move-ide] Fixed inlay type hints

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -585,10 +585,12 @@ fn completion_items(pos: Position, path: &Path, symbols: &Symbols) -> Vec<Comple
             }
             Some(Tok::Period) => {
                 items = dot(symbols, path, &pos);
-                if !items.is_empty() {
-                    // found dot completions - do not look for any other
-                    only_custom_items = true;
-                }
+                // whether completions have been found for the dot or not
+                // it makes no sense to try offering "dumb" autocompletion
+                // options here as they will not fit (an example would
+                // be dot completion of u64 variable without any methods
+                // with u64 receiver being visible)
+                only_custom_items = true;
             }
 
             Some(Tok::ColonColon) => {


### PR DESCRIPTION
## Description 

This PR fixes a problem with inlay type hints introduced in a previous PR (https://github.com/MystenLabs/sui/pull/18124)

Not only inlay type hints could no longer be disabled, they were also displayed in the wrong position.

This PR also changes the `move-analyzer` binary installation process to enable the bundled version overwriting the locally installed one if they both have the same version but different commit sha. This allows a `move-analyzer` fix to be pushed with the new version of the extension without bumping `move-analyzer`'s version number (which is difficult as it's really the Sui release version number)

## Test plan 

Tested that the installation procedure works as expected, that the inlay type hints are displayed correctly, and that they can be enabled/disabled
