### PR TITLE
[CI] Fix github external prs workflow

### DIFF
--- a/.github/workflows/github-issues-monitor.yml
+++ b/.github/workflows/github-issues-monitor.yml
@@ -7,19 +7,6 @@ on:
     types: [opened]
 
 jobs: 
-  notify-prs:
-    name: Dispatch workflow to notify slack channel on PRs
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch github-issues-external-prs-monitor in MystenLabs/sui-operations
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0
-        with: 
-          repository: MystenLabs/sui-operations
-          token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
-          event-type: github-issues-external-prs-monitor
-          client-payload: '{"author": "${{github.event.pull_request.user.login}}", "event_name": "pull_request", "pull_request_number": "${{github.event.pull_request.number}}"}'
-
   notify-issues:
     name: Dispatch workflow to notify slack channel on issues
     if: github.event_name == 'issues'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,3 +12,16 @@ jobs:
     - uses: actions/labeler@9fd24f1f9d6ceb64ba34d181b329ee72f99978a0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  notify-prs:
+    name: Dispatch workflow to notify slack channel on PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch github-issues-external-prs-monitor in MystenLabs/sui-operations
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0
+        with: 
+          repository: MystenLabs/sui-operations
+          token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
+          event-type: github-issues-external-prs-monitor
+          client-payload: '{"author": "${{github.event.pull_request.user.login}}", "event_name": "pull_request", "pull_request_number": "${{github.event.pull_request.number}}"}'
+


### PR DESCRIPTION
## Description 

The external PR notifier does not get triggered properly, so moved it to the labeler workflow which seems to get triggered every single time an external PR is opened.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
