### PR TITLE
[move-ide] Added tests for inlay type hints

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -5,7 +5,7 @@
 use crate::{
     context::Context,
     symbols::{
-        self, mod_ident_to_ide_string, ret_type_to_ide_str, type_args_to_ide_string,
+        get_symbols, mod_ident_to_ide_string, ret_type_to_ide_str, type_args_to_ide_string,
         type_list_to_ide_string, type_to_ide_string, DefInfo, PrecompiledPkgDeps,
         SymbolicatorRunner, Symbols,
     },
@@ -527,7 +527,7 @@ pub fn on_completion_request(
     let pos = parameters.text_document_position.position;
     let items = match SymbolicatorRunner::root_dir(&path) {
         Some(pkg_path) => {
-            match symbols::get_symbols(
+            match get_symbols(
                 pkg_dependencies,
                 ide_files_root.clone(),
                 &pkg_path,
@@ -686,7 +686,7 @@ fn completion_dot_test() {
     path.push("tests/completion");
 
     let ide_files_layer: VfsPath = MemoryFS::new().into();
-    let (symbols_opt, _) = symbols::get_symbols(
+    let (symbols_opt, _) = get_symbols(
         Arc::new(Mutex::new(BTreeMap::new())),
         ide_files_layer,
         path.as_path(),

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -125,22 +125,23 @@ fn additional_hint_info(sp!(_, t): &N::Type, symbols: &Symbols) -> Option<InlayH
 #[cfg(test)]
 fn validate_type_hint(hints: &[InlayHint], path: &std::path::Path, line: u32, col: u32, ty: &str) {
     let lsp_line = line - 1; // 0th based
-    if let Some(label_parts) = hints.iter().find_map(|h| {
+    let Some(label_parts) = hints.iter().find_map(|h| {
         if h.position.line == lsp_line && h.position.character == col {
             if let InlayHintLabel::LabelParts(parts) = &h.label {
                 return Some(parts);
             }
         }
         None
-    }) {
-        let found_ty = &label_parts[1].value;
-        assert!(
-            found_ty == ty,
-            "incorrect type of hint (found '{found_ty}' instead of expected '{ty}') at line {line} and col {col} in {path:?}"
-        );
-    } else {
+    }) else {
         panic!("hint not found at line {line} and col {col} in {path:?}");
-    }
+    };
+
+    let found_ty = &label_parts[1].value;
+    assert!(
+        found_ty == ty,
+        "incorrect type of hint (found '{}' instead of expected '{}') at line {} and col {} in {:?}",
+            found_ty, ty, line, col, path
+    );
 }
 
 #[test]

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -123,13 +123,7 @@ fn additional_hint_info(sp!(_, t): &N::Type, symbols: &Symbols) -> Option<InlayH
 }
 
 #[cfg(test)]
-fn validate_type_hint(
-    hints: &Vec<InlayHint>,
-    path: &std::path::Path,
-    line: u32,
-    col: u32,
-    ty: &str,
-) {
+fn validate_type_hint(hints: &[InlayHint], path: &std::path::Path, line: u32, col: u32, ty: &str) {
     let lsp_line = line - 1; // 0th based
     if let Some(label_parts) = hints.iter().find_map(|h| {
         if h.position.line == lsp_line && h.position.character == col {

--- a/external-crates/move/crates/move-analyzer/tests/inlay-hints/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/inlay-hints/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "InlayHints"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+InlayHints = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/inlay-hints/sources/type_hints.move
+++ b/external-crates/move/crates/move-analyzer/tests/inlay-hints/sources/type_hints.move
@@ -1,0 +1,31 @@
+module InlayHints::type_hints {
+
+    public struct SomeStruct has drop, copy {
+        some_field: u64,
+    }
+
+    public fun local_hints(s: SomeStruct) {
+        let prim_local = 42;
+        let struct_local = s;
+    }
+
+    macro fun foo($i: u64, $body: |u64| -> u64): u64 {
+        $body($i)
+    }
+
+    macro fun bar($i: SomeStruct, $body: |SomeStruct| -> SomeStruct): SomeStruct {
+        $body($i)
+    }
+
+    macro fun baz<$T>($i: $T, $body: |$T| -> $T): $T {
+        $body($i)
+    }
+
+    public fun lambda_hints(s: SomeStruct) {
+        foo!(42, |x_int| x_int);
+        bar!(s, |x_struct| x_struct);
+        baz!(42, |x_gen_int| x_gen_int);
+        baz!(s, |x_gen_struct| x_gen_struct);
+    }
+
+}


### PR DESCRIPTION
## Description 

What the title says. I decided to go for by-hand tests rather than add a framework similar to what we use for symbols as we really only need a rather limited number of tests and they will be different for different types of inlay hints (e.g. for upcoming parameter hints) so by-hand tests seem to be more cost-efficient.

## Test plan 

All new and existing tests must pass
