### PR TITLE
[Consensus] disable scheduled synchronizer when commit lag

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -244,15 +244,16 @@ where
         let leader_timeout_handle =
             LeaderTimeoutTask::start(core_dispatcher.clone(), &signals_receivers, context.clone());
 
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
             block_verifier.clone(),
             dag_state.clone(),
         );
 
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_syncer = CommitSyncer::new(
             context.clone(),
             core_dispatcher.clone(),

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -29,6 +29,8 @@ use crate::{
     CommitIndex, Round,
 };
 
+pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
+
 /// Authority's network service implementation, agnostic to the actual networking stack used.
 pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     context: Arc<Context>,
@@ -172,7 +174,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
         // The threshold to ignore block should be larger than commit_sync_batch_size,
         // to avoid excessive block rejections and synchronizations.
-        const COMMIT_LAG_MULTIPLIER: u32 = 5;
         if last_commit_index
             + self.context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER
             < quorum_commit_index
@@ -683,10 +684,12 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
+            commit_vote_monitor,
             block_verifier.clone(),
             dag_state.clone(),
         );
@@ -739,10 +742,12 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
+            commit_vote_monitor,
             block_verifier.clone(),
             dag_state.clone(),
         );

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -120,6 +120,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_store_read_count: IntCounterVec,
     pub(crate) dag_state_store_write_count: IntCounter,
     pub(crate) fetch_blocks_scheduler_inflight: IntGauge,
+    pub(crate) fetch_blocks_scheduler_skipped: IntCounterVec,
     pub(crate) synchronizer_fetched_blocks_by_peer: IntCounterVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) invalid_blocks: IntCounterVec,
@@ -301,6 +302,12 @@ impl NodeMetrics {
                 "fetch_blocks_scheduler_inflight",
                 "Designates whether the synchronizer scheduler task to fetch blocks is currently running",
                 registry,
+            ).unwrap(),
+            fetch_blocks_scheduler_skipped: register_int_counter_vec_with_registry!(
+                "fetch_blocks_scheduler_skipped",
+                "Number of times the scheduler skipped fetching blocks",
+                &["reason"],
+                registry
             ).unwrap(),
             synchronizer_fetched_blocks_by_peer: register_int_counter_vec_with_registry!(
                 "synchronizer_fetched_blocks_by_peer",


### PR DESCRIPTION
## Description 

The PR disables the scheduled synchronizer when we detect local commit to lag compared to the quorum index, same as we do during block processing. It has to be noted that we do not disable the live synchronizer as this will normally be taken care of from the `authority_service` block processing path.

With this change we'll avoid issues that have been observed during crash recovery (or even lagging nodes) where some blocks are received (until the commit voter finally gathers a quorum and cut off the block processing path) and trigger the block synchronization attempting to complete the causal history for the received blocks leading to a big queue of suspended & missing blocks.

## Test plan 

CI/PT

Testing on PT environment, on the first screenshot we can see the number of pending suspended blocks in block_manager when the synchronization is not disabled during crash recovery - which is constantly increasing. On the second screenshot we see that number does not increase while node recovers and remains constant:

<img width="574" alt="Screenshot 2024-07-04 at 17 56 39" src="https://github.com/MystenLabs/sui/assets/17335598/e78e3a7f-6db8-48bc-a1d2-b8fa2ebb918d">

<img width="573" alt="Screenshot 2024-07-04 at 18 05 31" src="https://github.com/MystenLabs/sui/assets/17335598/e4b80309-06ff-4b76-85a9-ebea64da0ecb">


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
