### PR TITLE
[indexer] Fix indexer to compile for Rust 1.75

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -69,7 +69,7 @@ pub async fn new_handlers<S, T>(
 ) -> Result<CheckpointHandler<S, T>, IndexerError>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
-    T: R2D2Connection,
+    T: R2D2Connection + 'static,
 {
     let checkpoint_queue_size = std::env::var("CHECKPOINT_QUEUE_SIZE")
         .unwrap_or(CHECKPOINT_QUEUE_SIZE.to_string())

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -40,7 +40,7 @@ impl ReaderWriterConfig {
     }
 }
 
-pub async fn start_test_indexer<T: R2D2Connection + Send>(
+pub async fn start_test_indexer<T: R2D2Connection + Send + 'static>(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
@@ -57,7 +57,7 @@ pub async fn start_test_indexer<T: R2D2Connection + Send>(
     .await
 }
 
-pub async fn start_test_indexer_impl<T: R2D2Connection>(
+pub async fn start_test_indexer_impl<T: R2D2Connection + 'static>(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,


### PR DESCRIPTION
## Description 

These changes ensure that brew can compile our code to release `sui` binary, and similarly, that `cargo install [..] sui --branch testnet` does not break. We need this to go with the testnet release today.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
