### PR TITLE
Commit per epoch config load to effects v2

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/coin_deny_and_undeny.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/coin_deny_and_undeny.exp
@@ -6,6 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 12-35:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 18316000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 37-37:
@@ -133,6 +134,7 @@ Contents: sui::coin::TreasuryCap<test::regulated_coin::REGULATED_COIN> {
 task 8 'run'. lines 50-52:
 created: object(8,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 9 'run'. lines 53-55:
@@ -153,4 +155,5 @@ gas summary: computation_cost: 1000000, storage_cost: 9522800,  storage_rebate: 
 
 task 13 'transfer-object'. lines 65-65:
 mutated: object(0,1), object(8,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 1459656, non_refundable_storage_fee: 14744

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/coin_deny_multiple_per_module.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/coin_deny_multiple_per_module.exp
@@ -6,6 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-56:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10)
 mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 33082800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 58-58:
@@ -259,4 +260,5 @@ Error: Error checking transaction input objects: AddressDeniedForCoin { address:
 
 task 15 'transfer-object'. lines 87-87:
 mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 2416800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/coin_deny_tto.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/coin_deny_tto.exp
@@ -6,6 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-47:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6)
 mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 21766400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 49-49:
@@ -156,4 +157,5 @@ gas summary: computation_cost: 1000000, storage_cost: 9522800,  storage_rebate: 
 
 task 12 'run'. lines 73-73:
 mutated: object(0,0), object(1,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3807600,  storage_rebate: 3769524, non_refundable_storage_fee: 38076

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_receiver.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_receiver.exp
@@ -6,11 +6,13 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 12-37:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 18392000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 38-40:
 created: object(2,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 3 'run'. lines 41-43:
@@ -22,6 +24,7 @@ gas summary: computation_cost: 1000000, storage_cost: 12190400,  storage_rebate:
 task 4 'run'. lines 44-44:
 created: object(4,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 5 'advance-epoch'. lines 46-48:
@@ -45,4 +48,5 @@ Epoch advanced: 2
 task 10 'run'. lines 60-60:
 created: object(10,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_sender.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_sender.exp
@@ -6,6 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 13-48:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 19471200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 49-51:
@@ -23,6 +24,7 @@ Contents: sui::coin::DenyCapV2<test::regulated_coin::REGULATED_COIN> {
 task 3 'run'. lines 52-54:
 created: object(3,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 4 'run'. lines 55-57:
@@ -54,4 +56,5 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 
 task 10 'transfer-object'. lines 73-73:
 mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 1459656, non_refundable_storage_fee: 14744

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_global_pause.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_global_pause.exp
@@ -6,21 +6,25 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 10-72:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 21964000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 73-75:
 created: object(2,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 3 'run'. lines 76-78:
 created: object(3,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4119200,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 4 'run'. lines 79-81:
 created: object(4,0)
 mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4119200,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
 
 task 5 'run'. lines 82-84:
@@ -47,6 +51,7 @@ task 10 'run'. lines 98-98:
 mutated: object(0,0)
 unwrapped: object(10,0)
 deleted: object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 2618352, non_refundable_storage_fee: 26448
 
 task 11 'advance-epoch'. lines 100-103:
@@ -94,4 +99,5 @@ task 21 'run'. lines 131-131:
 mutated: object(0,0)
 unwrapped: object(1,1)
 deleted: object(18,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 2618352, non_refundable_storage_fee: 26448

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.exp
@@ -11,6 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate:
 task 2 'programmable'. lines 22-24:
 created: object(2,0)
 mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
 task 3 'programmable'. lines 26-27:

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.exp
@@ -11,6 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate:
 task 2 'programmable'. lines 22-24:
 created: object(2,0)
 mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
 task 3 'view-object'. lines 26-26:
@@ -31,4 +32,5 @@ task 4 'programmable'. lines 28-34:
 created: object(4,0)
 mutated: object(0,0), object(1,2)
 deleted: object(2,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 3972672, non_refundable_storage_fee: 40128

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.exp
@@ -11,6 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate:
 task 2 'programmable'. lines 22-24:
 created: object(2,0)
 mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
 task 3 'programmable'. lines 26-28:

--- a/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
@@ -11,6 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate:
 task 2 'programmable'. lines 22-24:
 created: object(2,0)
 mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
 task 3 'view-object'. lines 26-26:

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -1107,6 +1107,8 @@ UnchangedSharedKind:
       Cancelled:
         NEWTYPE:
           TYPENAME: SequenceNumber
+    4:
+      PerEpochConfig: UNIT
 UpgradeInfo:
   STRUCT:
     - upgraded_id:

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -16,9 +16,9 @@ use crate::gas::GasCostSummary;
 use crate::is_system_package;
 use crate::object::{Owner, OBJECT_START_VERSION};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 #[cfg(debug_assertions)]
 use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The response from processing a transaction or a certified transaction
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
@@ -107,22 +107,28 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
                 }
                 _ => None,
             })
-            .chain(self.unchanged_shared_objects.iter().map(
-                |(id, change_kind)| match change_kind {
-                    UnchangedSharedKind::ReadOnlyRoot((version, digest)) => {
-                        InputSharedObject::ReadOnly((*id, *version, *digest))
-                    }
-                    UnchangedSharedKind::MutateDeleted(seqno) => {
-                        InputSharedObject::MutateDeleted(*id, *seqno)
-                    }
-                    UnchangedSharedKind::ReadDeleted(seqno) => {
-                        InputSharedObject::ReadDeleted(*id, *seqno)
-                    }
-                    UnchangedSharedKind::Cancelled(seqno) => {
-                        InputSharedObject::Cancelled(*id, *seqno)
-                    }
-                },
-            ))
+            .chain(
+                self.unchanged_shared_objects
+                    .iter()
+                    .filter_map(|(id, change_kind)| match change_kind {
+                        UnchangedSharedKind::ReadOnlyRoot((version, digest)) => {
+                            Some(InputSharedObject::ReadOnly((*id, *version, *digest)))
+                        }
+                        UnchangedSharedKind::MutateDeleted(seqno) => {
+                            Some(InputSharedObject::MutateDeleted(*id, *seqno))
+                        }
+                        UnchangedSharedKind::ReadDeleted(seqno) => {
+                            Some(InputSharedObject::ReadDeleted(*id, *seqno))
+                        }
+                        UnchangedSharedKind::Cancelled(seqno) => {
+                            Some(InputSharedObject::Cancelled(*id, *seqno))
+                        }
+                        // We can not expose the per epoch config object as input shared object,
+                        // since it does not require sequencing, and hence shall not be considered
+                        // as a normal input shared object.
+                        UnchangedSharedKind::PerEpochConfig => None,
+                    }),
+            )
             .collect()
     }
 
@@ -405,6 +411,7 @@ impl TransactionEffectsV2 {
         executed_epoch: EpochId,
         gas_used: GasCostSummary,
         shared_objects: Vec<SharedInput>,
+        loaded_per_epoch_config_objects: BTreeSet<ObjectID>,
         transaction_digest: TransactionDigest,
         lamport_version: SequenceNumber,
         changed_objects: BTreeMap<ObjectID, EffectsObjectChange>,
@@ -435,6 +442,11 @@ impl TransactionEffectsV2 {
                     Some((id, UnchangedSharedKind::Cancelled(version)))
                 }
             })
+            .chain(
+                loaded_per_epoch_config_objects
+                    .into_iter()
+                    .map(|id| (id, UnchangedSharedKind::PerEpochConfig)),
+            )
             .collect();
         let changed_objects: Vec<_> = changed_objects.into_iter().collect();
 
@@ -595,4 +607,6 @@ pub enum UnchangedSharedKind {
     ReadDeleted(SequenceNumber),
     /// Shared objects in cancelled transaction. The sequence number embed cancellation reason.
     Cancelled(SequenceNumber),
+    /// Read of a per-epoch config object that should remain the same during an epoch.
+    PerEpochConfig,
 }

--- a/crates/sui-types/src/effects/test_effects_builder.rs
+++ b/crates/sui-types/src/effects/test_effects_builder.rs
@@ -10,7 +10,7 @@ use crate::gas::GasCostSummary;
 use crate::message_envelope::Message;
 use crate::object::Owner;
 use crate::transaction::{InputObjectKind, SenderSignedData, TransactionDataAPI};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub struct TestEffectsBuilder {
     transaction: SenderSignedData,
@@ -139,6 +139,7 @@ impl TestEffectsBuilder {
             executed_epoch,
             GasCostSummary::default(),
             shared_objects,
+            BTreeSet::new(),
             self.transaction.digest(),
             lamport_version,
             changed_objects,

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -208,10 +208,11 @@ pub trait Storage {
         wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
     );
 
+    /// Check coin denylist during execution, and returns the number of regulated transfers.
     fn check_coin_deny_list(
         &self,
         written_objects: &BTreeMap<ObjectID, Object>,
-    ) -> Result<(), ExecutionError>;
+    ) -> (Result<(), ExecutionError>, u64);
 }
 
 pub type PackageFetchResults<Package> = Result<Vec<Package>, Vec<ObjectID>>;

--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -14,5 +14,6 @@ ROOT="$SCRIPT_DIR/.."
 cd "$ROOT/crates/sui-protocol-config" && cargo insta test --review
 cd "$ROOT/crates/sui-swarm-config" && cargo insta test --review
 cd "$ROOT/crates/sui-open-rpc" && cargo run --example generate-json-rpc-spec -- record
+cd "$ROOT/crates/sui-core" && cargo -q run --example generate-format -- print > tests/staged/sui.yaml
 UPDATE=1 cargo test -p sui-framework --test build-system-packages
 UPDATE=1 cargo test -p sui-rest-api

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -830,7 +830,10 @@ mod checked {
             }
 
             if protocol_config.enable_coin_deny_list_v2() {
-                state_view.check_coin_deny_list(&written_objects)?;
+                let (result, _num_regulated_transfers) =
+                    state_view.check_coin_deny_list(&written_objects);
+                // TODO: Charge gas based on the number of regulated transfers.
+                result?;
             }
 
             let user_events = user_events

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -32,6 +32,7 @@ use sui_types::{
     object::{Data, Object},
     storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
     transaction::InputObjects,
+    SUI_DENY_LIST_OBJECT_ID,
 };
 use sui_types::{is_system_package, SUI_SYSTEM_STATE_OBJECT_ID};
 
@@ -65,6 +66,10 @@ pub struct TemporaryStore<'backing> {
     // TODO: Now that we track epoch here, there are a few places we don't need to pass it around.
     /// The current epoch.
     cur_epoch: EpochId,
+
+    /// The set of per-epoch config objects that were loaded during execution, and are not in the
+    /// input objects. This allows us to commit them to the effects.
+    loaded_per_epoch_config_objects: RwLock<BTreeSet<ObjectID>>,
 }
 
 impl<'backing> TemporaryStore<'backing> {
@@ -109,6 +114,7 @@ impl<'backing> TemporaryStore<'backing> {
             runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
             receiving_objects,
             cur_epoch,
+            loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
         }
     }
 
@@ -235,6 +241,8 @@ impl<'backing> TemporaryStore<'backing> {
         let object_changes = self.get_object_changes();
 
         let lamport_version = self.lamport_timestamp;
+        // TODO: Cleanup this clone. Potentially add unchanged_shraed_objects directly to InnerTempStore.
+        let loaded_per_epoch_config_objects = self.loaded_per_epoch_config_objects.read().clone();
         let inner = self.into_inner();
 
         let effects = TransactionEffects::new_from_execution_v2(
@@ -243,6 +251,7 @@ impl<'backing> TemporaryStore<'backing> {
             gas_cost_summary,
             // TODO: Provide the list of read-only shared objects directly.
             shared_object_refs,
+            loaded_per_epoch_config_objects,
             *transaction_digest,
             lamport_version,
             object_changes,
@@ -1015,13 +1024,21 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     fn check_coin_deny_list(
         &self,
         written_objects: &BTreeMap<ObjectID, Object>,
-    ) -> Result<(), ExecutionError> {
-        // TODO: How do we track runtime loaded objects for replay?
-        check_coin_deny_list_v2_during_execution(
+    ) -> (Result<(), ExecutionError>, u64) {
+        let (result, num_regulated_transfers) = check_coin_deny_list_v2_during_execution(
             written_objects,
             self.cur_epoch,
             self.store.as_object_store(),
-        )
+        );
+        // The denylist object is only loaded if there are regulated transfers.
+        // And also if we already have it in the input there is no need to commit it again in the effects.
+        if num_regulated_transfers > 0 && !self.input_objects.contains_key(&SUI_DENY_LIST_OBJECT_ID)
+        {
+            self.loaded_per_epoch_config_objects
+                .write()
+                .insert(SUI_DENY_LIST_OBJECT_ID);
+        }
+        (result, num_regulated_transfers)
     }
 }
 

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -1005,7 +1005,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     fn check_coin_deny_list(
         &self,
         _written_objects: &BTreeMap<ObjectID, Object>,
-    ) -> Result<(), ExecutionError> {
+    ) -> (Result<(), ExecutionError>, u64) {
         unreachable!("Coin denylist v2 is not supported in sui-execution v0");
     }
 }

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -358,6 +358,7 @@ impl<'backing> TemporaryStore<'backing> {
             gas_cost_summary,
             // TODO: Provide the list of read-only shared objects directly.
             shared_object_refs,
+            BTreeSet::new(),
             *transaction_digest,
             lamport_version,
             object_changes,
@@ -1116,7 +1117,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     fn check_coin_deny_list(
         &self,
         _written_objects: &BTreeMap<ObjectID, Object>,
-    ) -> Result<(), ExecutionError> {
+    ) -> (Result<(), ExecutionError>, u64) {
         unreachable!("Coin denylist v2 is not supported in sui-execution v1");
     }
 }

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -376,6 +376,7 @@ impl<'backing> TemporaryStore<'backing> {
             gas_cost_summary,
             // TODO: Provide the list of read-only shared objects directly.
             shared_object_refs,
+            BTreeSet::new(),
             *transaction_digest,
             lamport_version,
             object_changes,
@@ -1168,7 +1169,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     fn check_coin_deny_list(
         &self,
         _written_objects: &BTreeMap<ObjectID, Object>,
-    ) -> Result<(), ExecutionError> {
+    ) -> (Result<(), ExecutionError>, u64) {
         unreachable!("Coin denylist v2 is not supported in sui-execution v2");
     }
 }


### PR DESCRIPTION
## Description 

Commit per epoch config object load to effects.
This is done by introducing another variant to UnchangedSharedObject.
This does not need to be in input shared objects since it's not a sequenced input object.
This however does mean that this will not be added to the UnchangedSharedObject graphql rpc types since that relies on the input shared objects.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
