### PR TITLE
Speed up object_pruning_test, print TIMEOUT errors in simtest nightly

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -57,6 +57,8 @@ pub struct AuthorityStorePruner {
     _objects_pruner_cancel_handle: oneshot::Sender<()>,
 }
 
+static MIN_PRUNING_TICK_DURATION_MS: u64 = 10 * 1000;
+
 pub struct AuthorityStorePruningMetrics {
     pub last_pruned_checkpoint: IntGauge,
     pub num_pruned_objects: IntCounter,
@@ -583,7 +585,7 @@ impl AuthorityStorePruner {
     }
 
     fn pruning_tick_duration_ms(epoch_duration_ms: u64) -> u64 {
-        min(epoch_duration_ms / 2, 60 * 1000)
+        min(epoch_duration_ms / 2, MIN_PRUNING_TICK_DURATION_MS)
     }
 
     fn smoothed_max_eligible_checkpoint_number(

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -121,7 +121,7 @@ echo "Failures detected, printing logs..."
 
 # read all filenames in $LOG_DIR that contain the string "FAIL" into a bash array
 # and print the line number and filename for each
-readarray -t FAILED_LOG_FILES < <(grep -l FAIL "$LOG_DIR"/*)
+readarray -t FAILED_LOG_FILES < <(grep -El 'TIMEOUT|FAIL' "$LOG_DIR"/*)
 
 # iterate over the array and print the contents of each file
 for LOG_FILE in "${FAILED_LOG_FILES[@]}"; do


### PR DESCRIPTION
- Print TIMEOUT errors when test fails
- Shorten minimum pruning tick interval to speed up tests
