### PR TITLE
[CI] Only trigger this on pull request being opened

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@ jobs:
   notify-prs:
     name: Dispatch workflow to notify slack channel on PRs
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+    if: ${{ github.event.action == 'opened' }}
     steps:
       - name: Dispatch github-issues-external-prs-monitor in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,7 @@ jobs:
   notify-prs:
     name: Dispatch workflow to notify slack channel on PRs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
     steps:
       - name: Dispatch github-issues-external-prs-monitor in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0


### PR DESCRIPTION
## Description 

This gets triggered when changes happen on a PR, so just force it to only dispatch the workflow when a PR is opened. That's what we want anyway for someone to label it and tag it to the right person.

Sorry for the churn @after-ephemera 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
