### PR TITLE
Changes to support multi-version tests in antithesis

### DIFF
--- a/docker/sui-network/Dockerfile
+++ b/docker/sui-network/Dockerfile
@@ -1,6 +1,6 @@
 ARG SUI_TOOLS_IMAGE_TAG
 
-FROM mysten/sui-tools:$SUI_TOOLS_IMAGE_TAG as setup
+FROM mysten/sui-tools:$SUI_TOOLS_IMAGE_TAG AS setup
 
 RUN apt update
 RUN apt install python3 python3-pip -y
@@ -11,11 +11,20 @@ COPY ./genesis /genesis
 
 WORKDIR /
 
-RUN ./new-genesis.sh
+ARG SUI_NODE_A_TAG
+ARG SUI_NODE_B_TAG
+ENV SUI_NODE_A_TAG=$SUI_NODE_A_TAG
+ENV SUI_NODE_B_TAG=$SUI_NODE_B_TAG
 
-FROM scratch 
+RUN ./new-genesis.sh
+RUN echo "SUI_NODE_A_TAG=$SUI_NODE_A_TAG" >> /.env
+RUN echo "SUI_NODE_B_TAG=$SUI_NODE_B_TAG" >> /.env
+
+FROM scratch
 
 COPY ./docker-compose-antithesis.yaml /docker-compose.yaml
 COPY /genesis/overlays/* /genesis/overlays/
 COPY /genesis/static/* /genesis/static/
 COPY --from=setup /genesis/files/* /genesis/files/
+COPY --from=setup /.env /.env
+

--- a/docker/sui-network/docker-compose-antithesis.yaml
+++ b/docker/sui-network/docker-compose-antithesis.yaml
@@ -5,7 +5,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.11
-    image: sui-node:mainnet
+    image: sui-node:${SUI_NODE_A_TAG}
     container_name: validator1
     hostname: validator1
     environment:
@@ -32,7 +32,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.12
-    image: sui-node:mainnet
+    image: sui-node:${SUI_NODE_A_TAG}
     container_name: validator2
     hostname: validator2
     environment:
@@ -59,7 +59,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.13
-    image: sui-node:mainnet
+    image: sui-node:${SUI_NODE_B_TAG}
     container_name: validator3
     hostname: validator3
     environment:
@@ -86,7 +86,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.14
-    image: sui-node:mainnet
+    image: sui-node:${SUI_NODE_B_TAG}
     container_name: validator4
     hostname: validator4
     environment:
@@ -113,7 +113,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.15
-    image: sui-node:mainnet
+    image: sui-node:${SUI_NODE_B_TAG}
     hostname: fullnode1
     container_name: fullnode1
     environment:


### PR DESCRIPTION
Allows the antithesis docker-compose network to be run with two different sui-node images, with half of the validators running one image and half running the other.