### PR TITLE
rest: create and host openapi spec and explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.3.1",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "lexical-core",
  "num",
  "serde",
@@ -873,7 +873,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "lru 0.7.8",
  "mime",
  "multer",
@@ -946,7 +946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d74240f9daa8c1e8f73e9cfcc338d20a88d00bbeb83ded49ce8e5b4dcec0f5"
 dependencies = [
  "bytes",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "serde",
  "serde_json",
 ]
@@ -5091,7 +5091,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5606,9 +5606,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
@@ -7559,7 +7559,7 @@ dependencies = [
  "fastcrypto-tbls",
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "mysten-util-mem-derive",
  "once_cell",
  "parking_lot 0.12.1",
@@ -7642,7 +7642,7 @@ dependencies = [
  "bytes",
  "fastcrypto",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "mockall",
  "mysten-metrics",
  "narwhal-config",
@@ -7757,7 +7757,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "governor",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "mockall",
  "mysten-common",
@@ -7821,7 +7821,7 @@ dependencies = [
  "anemo",
  "fastcrypto",
  "fdlimit",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "mysten-metrics",
  "mysten-network",
@@ -7861,7 +7861,7 @@ dependencies = [
  "enum_dispatch",
  "fastcrypto",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "mockall",
  "mysten-common",
  "mysten-metrics",
@@ -8476,6 +8476,17 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "openapiv3"
+version = "2.0.0"
+source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
+dependencies = [
+ "indexmap 2.2.6",
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10744,9 +10755,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "either",
@@ -10757,14 +10768,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "serde_derive_internals",
- "syn 1.0.107",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -10983,22 +10994,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 1.0.107",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.112"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -12324,7 +12335,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "im",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "jsonrpsee",
  "lru 0.10.0",
@@ -12504,7 +12515,7 @@ dependencies = [
  "fastcrypto-zkp",
  "fs_extra",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "insta",
  "jsonrpsee",
  "move-binary-format",
@@ -12932,7 +12943,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "jsonrpsee",
  "mockall",
@@ -13214,7 +13225,7 @@ dependencies = [
  "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "move-binary-format",
  "move-core-types",
  "move-stdlib-natives",
@@ -13275,7 +13286,7 @@ dependencies = [
  "better_any",
  "fastcrypto",
  "fastcrypto-zkp",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "move-binary-format",
  "move-core-types",
  "move-stdlib-natives-v2",
@@ -13610,16 +13621,20 @@ dependencies = [
  "async-trait",
  "axum",
  "bcs",
+ "diffy",
  "fastcrypto",
  "itertools 0.10.5",
  "mime",
  "mysten-network",
+ "openapiv3",
  "prometheus",
  "rand 0.8.5",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with 2.1.0",
+ "serde_yaml 0.8.26",
  "sui-protocol-config",
  "sui-sdk 0.0.0",
  "sui-types",
@@ -13702,7 +13717,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk.git?rev=bb224b9e6b6edf5eeedcdf71c750a30b68073057#bb224b9e6b6edf5eeedcdf71c750a30b68073057"
+source = "git+https://github.com/mystenlabs/sui-rust-sdk.git?rev=dad0b49a9e4f27bc76457a9c92b8a6a7004b6706#dad0b49a9e4f27bc76457a9c92b8a6a7004b6706"
 dependencies = [
  "base64ct",
  "bcs",
@@ -13710,8 +13725,10 @@ dependencies = [
  "bs58 0.5.0",
  "hex",
  "roaring",
+ "schemars",
  "serde",
  "serde_derive",
+ "serde_json",
  "serde_with 3.8.1",
  "winnow 0.6.9",
 ]
@@ -13994,7 +14011,7 @@ dependencies = [
  "bcs",
  "clap",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "move-binary-format",
  "move-core-types",
  "move-package",
@@ -14278,7 +14295,7 @@ dependencies = [
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "jsonrpsee",
  "lru 0.10.0",
@@ -15618,7 +15635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,7 +443,7 @@ rustls-pemfile = "1.0.2"
 rustversion = "1.0.9"
 rustyline = "9.1.2"
 rustyline-derive = "0.7.0"
-schemars = { version = "0.8.10", features = ["either"] }
+schemars = { version = "0.8.21", features = ["either"] }
 scopeguard = "1.1"
 serial_test = "2.0.0"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -577,7 +577,7 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "26d415eb9a
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7" }
 
 # core-types with json format for REST api
-sui-sdk2 = { package = "sui-sdk", git = "https://github.com/mystenlabs/sui-rust-sdk.git", rev = "bb224b9e6b6edf5eeedcdf71c750a30b68073057", features = ["serde"] }
+sui-sdk2 = { package = "sui-sdk", git = "https://github.com/mystenlabs/sui-rust-sdk.git", rev = "dad0b49a9e4f27bc76457a9c92b8a6a7004b6706", features = ["serde", "schemars"] }
 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2749,7 +2749,7 @@
           "description": "the version of the queried object. If None, default to the latest known version",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/SequenceNumber"
+            "$ref": "#/components/schemas/SequenceNumber2"
           }
         },
         {
@@ -5590,7 +5590,7 @@
                             "$ref": "#/components/schemas/ObjectID"
                           },
                           {
-                            "$ref": "#/components/schemas/SequenceNumber"
+                            "$ref": "#/components/schemas/SequenceNumber2"
                           }
                         ],
                         "maxItems": 2,
@@ -5716,7 +5716,7 @@
                   "$ref": "#/components/schemas/ObjectID"
                 },
                 {
-                  "$ref": "#/components/schemas/SequenceNumber"
+                  "$ref": "#/components/schemas/SequenceNumber2"
                 },
                 {
                   "$ref": "#/components/schemas/ObjectDigest"
@@ -5912,7 +5912,7 @@
             "$ref": "#/components/schemas/DynamicFieldType"
           },
           "version": {
-            "$ref": "#/components/schemas/SequenceNumber"
+            "$ref": "#/components/schemas/SequenceNumber2"
           }
         }
       },
@@ -6571,7 +6571,7 @@
                     "$ref": "#/components/schemas/ObjectID"
                   },
                   "initial_shared_version": {
-                    "$ref": "#/components/schemas/SequenceNumber"
+                    "$ref": "#/components/schemas/SequenceNumber2"
                   },
                   "mutable": {
                     "default": true,
@@ -7326,7 +7326,7 @@
                     "$ref": "#/components/schemas/ObjectID"
                   },
                   {
-                    "$ref": "#/components/schemas/SequenceNumber"
+                    "$ref": "#/components/schemas/SequenceNumber2"
                   }
                 ],
                 "maxItems": 2,
@@ -7357,10 +7357,10 @@
                 ],
                 "properties": {
                   "asked_version": {
-                    "$ref": "#/components/schemas/SequenceNumber"
+                    "$ref": "#/components/schemas/SequenceNumber2"
                   },
                   "latest_version": {
-                    "$ref": "#/components/schemas/SequenceNumber"
+                    "$ref": "#/components/schemas/SequenceNumber2"
                   },
                   "object_id": {
                     "$ref": "#/components/schemas/ObjectID"
@@ -7479,7 +7479,7 @@
                 "description": "Object version.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/SequenceNumber"
+                    "$ref": "#/components/schemas/SequenceNumber2"
                   }
                 ]
               }
@@ -7616,7 +7616,7 @@
                     "description": "The version at which the object became shared",
                     "allOf": [
                       {
-                        "$ref": "#/components/schemas/SequenceNumber"
+                        "$ref": "#/components/schemas/SequenceNumber2"
                       }
                     ]
                   }
@@ -8040,7 +8040,7 @@
                 "type": "string"
               },
               "version": {
-                "$ref": "#/components/schemas/SequenceNumber"
+                "$ref": "#/components/schemas/SequenceNumber2"
               }
             }
           },
@@ -8083,7 +8083,7 @@
                 }
               },
               "version": {
-                "$ref": "#/components/schemas/SequenceNumber"
+                "$ref": "#/components/schemas/SequenceNumber2"
               }
             }
           }
@@ -8099,6 +8099,9 @@
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
+      },
+      "SequenceNumber2": {
+        "$ref": "#/components/schemas/BigInt_for_uint64"
       },
       "Signature": {
         "oneOf": [
@@ -8568,7 +8571,7 @@
             ],
             "properties": {
               "BridgeCommitteeUpdate": {
-                "$ref": "#/components/schemas/SequenceNumber"
+                "$ref": "#/components/schemas/SequenceNumber2"
               }
             },
             "additionalProperties": false
@@ -10926,7 +10929,7 @@
             "description": "Version of the upgraded package",
             "allOf": [
               {
-                "$ref": "#/components/schemas/SequenceNumber"
+                "$ref": "#/components/schemas/SequenceNumber2"
               }
             ]
           }

--- a/crates/sui-rest-api/Cargo.toml
+++ b/crates/sui-rest-api/Cargo.toml
@@ -14,6 +14,7 @@ rand.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 serde_with.workspace = true
 tap.workspace = true
 thiserror.workspace = true
@@ -21,11 +22,15 @@ async-trait.workspace = true
 itertools.workspace = true
 sui-sdk2.workspace = true
 prometheus.workspace = true
+openapiv3 = { git = "https://github.com/bmwill/openapiv3.git", rev = "ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963" }
+schemars.workspace = true
 
 fastcrypto.workspace = true
 sui-types.workspace = true
 mysten-network.workspace = true
 sui-protocol-config.workspace = true
 
+
 [dev-dependencies]
 tokio.workspace = true
+diffy = "0.3"

--- a/crates/sui-rest-api/openapi/elements.html
+++ b/crates/sui-rest-api/openapi/elements.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Sui Node Api</title>
+    <!-- Embed elements Elements via Web Component -->
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+  </head>
+  <body>
+
+    <elements-api
+      apiDescriptionUrl="openapi.json"
+      router="hash"
+      layout="sidebar"
+      logo="https://cdn.prod.website-files.com/6425f546844727ce5fb9e5ab/643775f4a15c9a9e10426daa_Sui_Favicon_256.png"
+    />
+
+  </body>
+</html>

--- a/crates/sui-rest-api/openapi/openapi.json
+++ b/crates/sui-rest-api/openapi/openapi.json
@@ -1,0 +1,4409 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sui Node Api",
+    "description": "REST Api for interacting with the Sui Blockchain",
+    "contact": {
+      "name": "Mysten Labs",
+      "url": "https://github.com/MystenLabs/sui"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "0.0.0"
+  },
+  "servers": [
+    {
+      "url": "/v2"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {}
+    },
+    "/health": {
+      "get": {}
+    },
+    "/accounts/{account}/objects": {
+      "get": {}
+    },
+    "/objects/{object_id}": {
+      "get": {
+        "tags": [
+          "Objects"
+        ],
+        "operationId": "GetObject",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ObjectId"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Object"
+                }
+              },
+              "application/bcs": {}
+            }
+          }
+        }
+      }
+    },
+    "/objects/{object_id}/version/{version}": {
+      "get": {
+        "tags": [
+          "Objects"
+        ],
+        "operationId": "GetObjectWithVersion",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ObjectId"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Object"
+                }
+              },
+              "application/bcs": {}
+            }
+          }
+        }
+      }
+    },
+    "/objects/{object_id}/dynamic-fields": {
+      "get": {
+        "tags": [
+          "Objects"
+        ],
+        "operationId": "ListDynamicFields",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ObjectId"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "start",
+            "schema": {
+              "$ref": "#/components/schemas/ObjectId"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {
+              "x-sui-cursor": {
+                "style": "simple",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DynamicFieldInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/checkpoints": {
+      "get": {}
+    },
+    "/checkpoints/{checkpoint}": {
+      "get": {}
+    },
+    "/checkpoints/{checkpoint}/full": {
+      "get": {}
+    },
+    "/transactions/{transaction}": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "operationId": "GetTransaction",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "transaction",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionDigest"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              },
+              "application/bcs": {}
+            }
+          }
+        }
+      }
+    },
+    "/transactions": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "operationId": "ListTransactions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "$ref": "#/components/schemas/Direction"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "start",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {
+              "x-sui-cursor": {
+                "style": "simple",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TransactionResponse"
+                  }
+                }
+              },
+              "application/bcs": {}
+            }
+          },
+          "410": {
+            "description": ""
+          }
+        }
+      },
+      "post": {}
+    },
+    "/committee/{epoch}": {
+      "get": {}
+    },
+    "/committee": {
+      "get": {}
+    },
+    "/system": {
+      "get": {}
+    },
+    "/system/protocol": {
+      "get": {}
+    },
+    "/system/protocol/{version}": {
+      "get": {}
+    },
+    "/system/gas": {
+      "get": {}
+    },
+    "/coins/{coin_type}": {
+      "get": {}
+    },
+    "/openapi": {
+      "get": {
+        "tags": [
+          "OpenApi"
+        ],
+        "operationId": "OpenApi Explorer",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/html; charset=utf-8": {}
+            }
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "tags": [
+          "OpenApi"
+        ],
+        "operationId": "openapi.json",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/openapi.yaml": {
+      "get": {
+        "tags": [
+          "OpenApi"
+        ],
+        "operationId": "openapi.yaml",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain; charset=utf-8": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActiveJwk": {
+        "type": "object",
+        "required": [
+          "epoch",
+          "jwk",
+          "jwk_id"
+        ],
+        "properties": {
+          "epoch": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "jwk": {
+            "$ref": "#/components/schemas/Jwk"
+          },
+          "jwk_id": {
+            "$ref": "#/components/schemas/JwkId"
+          }
+        }
+      },
+      "Address": {
+        "title": "Address",
+        "description": "A 32-byte Sui address, encoded as a hex string.",
+        "examples": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002"
+        ],
+        "type": "string",
+        "format": "hex",
+        "maxLength": 66,
+        "pattern": "0x[a-z0-9]{1,64}"
+      },
+      "Argument": {
+        "anyOf": [
+          {
+            "title": "Gas",
+            "type": "string",
+            "enum": [
+              "gas"
+            ]
+          },
+          {
+            "title": "Input",
+            "type": "object",
+            "required": [
+              "input"
+            ],
+            "properties": {
+              "input": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Result",
+            "type": "object",
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "NestedResult",
+            "type": "object",
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "integer",
+                    "format": "uint16",
+                    "minimum": 0.0
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint16",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          }
+        ]
+      },
+      "Bls12381PublicKey": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "Bls12381Signature": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "Bn254FieldElement": {
+        "description": "Radix-10 encoded 256-bit unsigned integer",
+        "type": "string",
+        "format": "u256"
+      },
+      "CancelledTransaction": {
+        "type": "object",
+        "required": [
+          "digest",
+          "version_assignments"
+        ],
+        "properties": {
+          "digest": {
+            "$ref": "#/components/schemas/TransactionDigest"
+          },
+          "version_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VersionAssignment"
+            }
+          }
+        }
+      },
+      "ChangedObject": {
+        "type": "object",
+        "required": [
+          "id_operation",
+          "input_state",
+          "object_id",
+          "output_state"
+        ],
+        "properties": {
+          "id_operation": {
+            "description": "Whether this object ID is created or deleted in this transaction. This information isn't required by the protocol but is useful for providing more detailed semantics on object changes.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdOperation"
+              }
+            ]
+          },
+          "input_state": {
+            "description": "State of the object in the store prior to this transaction.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectIn"
+              }
+            ]
+          },
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "output_state": {
+            "description": "State of the object in the store after this transaction.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectOut"
+              }
+            ]
+          }
+        }
+      },
+      "CheckpointCommitment": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "digest",
+              "type"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/Digest"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ecmh_live_object_set"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "CheckpointContents": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CheckpointTransactionInfo"
+        }
+      },
+      "CheckpointContentsDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "CheckpointData": {
+        "type": "object",
+        "required": [
+          "checkpoint_contents",
+          "checkpoint_summary",
+          "transactions"
+        ],
+        "properties": {
+          "checkpoint_contents": {
+            "$ref": "#/components/schemas/CheckpointContents"
+          },
+          "checkpoint_summary": {
+            "$ref": "#/components/schemas/SignedCheckpointSummary"
+          },
+          "transactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointTransaction"
+            }
+          }
+        }
+      },
+      "CheckpointDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "CheckpointSummary": {
+        "type": "object",
+        "required": [
+          "content_digest",
+          "epoch",
+          "epoch_rolling_gas_cost_summary",
+          "network_total_transactions",
+          "sequence_number",
+          "timestamp_ms"
+        ],
+        "properties": {
+          "checkpoint_commitments": {
+            "description": "Commitments to checkpoint-specific state (e.g. txns in checkpoint, objects read/written in checkpoint).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointCommitment"
+            }
+          },
+          "content_digest": {
+            "$ref": "#/components/schemas/CheckpointContentsDigest"
+          },
+          "end_of_epoch_data": {
+            "description": "Present only on the final checkpoint of the epoch.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EndOfEpochData"
+              }
+            ]
+          },
+          "epoch": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "epoch_rolling_gas_cost_summary": {
+            "description": "The running total gas costs of all transactions included in the current epoch so far until this checkpoint.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GasCostSummary"
+              }
+            ]
+          },
+          "network_total_transactions": {
+            "description": "Total number of transactions committed since genesis, including those in this checkpoint.",
+            "type": "string",
+            "format": "u64"
+          },
+          "previous_digest": {
+            "$ref": "#/components/schemas/CheckpointDigest"
+          },
+          "sequence_number": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "timestamp_ms": {
+            "description": "Timestamp of the checkpoint - number of milliseconds from the Unix epoch Checkpoint timestamps are monotonic, but not strongly monotonic - subsequent checkpoints can have same timestamp if they originate from the same underlining consensus commit",
+            "type": "string",
+            "format": "u64"
+          },
+          "version_specific_data": {
+            "description": "CheckpointSummary is not an evolvable structure - it must be readable by any version of the code. Therefore, in order to allow extensions to be added to CheckpointSummary, we allow opaque data to be added to checkpoints which can be deserialized based on the current protocol version.",
+            "type": "string",
+            "format": "base64"
+          }
+        }
+      },
+      "CheckpointTransaction": {
+        "type": "object",
+        "required": [
+          "effects",
+          "input_objects",
+          "output_objects",
+          "transaction"
+        ],
+        "properties": {
+          "effects": {
+            "description": "The effects produced by executing this transaction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionEffects"
+              }
+            ]
+          },
+          "events": {
+            "description": "The events, if any, emitted by this transaciton during execution",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionEvents"
+              }
+            ]
+          },
+          "input_objects": {
+            "description": "The state of all inputs to this transaction as they were prior to execution.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Object"
+            }
+          },
+          "output_objects": {
+            "description": "The state of all output objects created or mutated by this transaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Object"
+            }
+          },
+          "transaction": {
+            "description": "The input Transaction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SignedTransaction"
+              }
+            ]
+          }
+        }
+      },
+      "CheckpointTransactionInfo": {
+        "type": "object",
+        "required": [
+          "effects",
+          "signatures",
+          "transaction"
+        ],
+        "properties": {
+          "effects": {
+            "$ref": "#/components/schemas/TransactionEffectsDigest"
+          },
+          "signatures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserSignature"
+            }
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/TransactionDigest"
+          }
+        }
+      },
+      "CircomG1": {
+        "description": "A G1 point in BN254 serialized as a vector of three strings which is the canonical decimal representation of the projective coordinates in Fq.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Bn254FieldElement"
+        },
+        "maxItems": 3,
+        "minItems": 3
+      },
+      "CircomG2": {
+        "description": "A G2 point in BN254 serialized as a vector of three vectors each being a vector of two strings which are the canonical decimal representation of the coefficients of the projective coordinates in Fq2.",
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/Bn254FieldElement"
+          },
+          "maxItems": 2,
+          "minItems": 2
+        },
+        "maxItems": 3,
+        "minItems": 3
+      },
+      "Claim": {
+        "description": "A claim consists of value and index_mod_4.",
+        "type": "object",
+        "required": [
+          "index_mod_4",
+          "value"
+        ],
+        "properties": {
+          "index_mod_4": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "Command": {
+        "description": "A single command in a programmable transaction.",
+        "oneOf": [
+          {
+            "description": "A call to either an entry or a public Move function",
+            "type": "object",
+            "required": [
+              "arguments",
+              "command",
+              "function",
+              "module",
+              "package",
+              "type_arguments"
+            ],
+            "properties": {
+              "arguments": {
+                "description": "The arguments to the function.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Argument"
+                }
+              },
+              "command": {
+                "type": "string",
+                "enum": [
+                  "move_call"
+                ]
+              },
+              "function": {
+                "description": "The function to be called.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Identifier"
+                  }
+                ]
+              },
+              "module": {
+                "description": "The specific module in the package containing the function.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Identifier"
+                  }
+                ]
+              },
+              "package": {
+                "description": "The package containing the module and function.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ObjectId"
+                  }
+                ]
+              },
+              "type_arguments": {
+                "description": "The type arguments to the function.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TypeTag"
+                }
+              }
+            }
+          },
+          {
+            "description": "`(Vec<forall T:key+store. T>, address)` It sends n-objects to the specified address. These objects must have store (public transfer) and either the previous owner must be an address or the object must be newly created.",
+            "type": "object",
+            "required": [
+              "address",
+              "command",
+              "objects"
+            ],
+            "properties": {
+              "address": {
+                "$ref": "#/components/schemas/Argument"
+              },
+              "command": {
+                "type": "string",
+                "enum": [
+                  "transfer_objects"
+                ]
+              },
+              "objects": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Argument"
+                }
+              }
+            }
+          },
+          {
+            "description": "`(&mut Coin<T>, Vec<u64>)` -> `Vec<Coin<T>>` It splits off some amounts into a new coins with those amounts",
+            "type": "object",
+            "required": [
+              "amounts",
+              "coin",
+              "command"
+            ],
+            "properties": {
+              "amounts": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Argument"
+                }
+              },
+              "coin": {
+                "$ref": "#/components/schemas/Argument"
+              },
+              "command": {
+                "type": "string",
+                "enum": [
+                  "split_coins"
+                ]
+              }
+            }
+          },
+          {
+            "description": "`(&mut Coin<T>, Vec<Coin<T>>)` It merges n-coins into the first coin",
+            "type": "object",
+            "required": [
+              "coin",
+              "coins_to_merge",
+              "command"
+            ],
+            "properties": {
+              "coin": {
+                "$ref": "#/components/schemas/Argument"
+              },
+              "coins_to_merge": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Argument"
+                }
+              },
+              "command": {
+                "type": "string",
+                "enum": [
+                  "merge_coins"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Publishes a Move package. It takes the package bytes and a list of the package's transitive dependencies to link against on-chain.",
+            "type": "object",
+            "required": [
+              "command",
+              "dependencies",
+              "modules"
+            ],
+            "properties": {
+              "command": {
+                "type": "string",
+                "enum": [
+                  "publish"
+                ]
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectId"
+                }
+              },
+              "modules": {
+                "type": "array",
+                "items": {
+                  "description": "Base64 encoded data",
+                  "type": "string",
+                  "format": "base64"
+                }
+              }
+            }
+          },
+          {
+            "description": "`forall T: Vec<T> -> vector<T>` Given n-values of the same type, it constructs a vector. For non objects or an empty vector, the type tag must be specified.",
+            "type": "object",
+            "required": [
+              "command",
+              "elements"
+            ],
+            "properties": {
+              "command": {
+                "type": "string",
+                "enum": [
+                  "make_move_vector"
+                ]
+              },
+              "elements": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Argument"
+                }
+              },
+              "type": {
+                "$ref": "#/components/schemas/TypeTag"
+              }
+            }
+          },
+          {
+            "description": "Upgrades a Move package Takes (in order): 1. A vector of serialized modules for the package. 2. A vector of object ids for the transitive dependencies of the new package. 3. The object ID of the package being upgraded. 4. An argument holding the `UpgradeTicket` that must have been produced from an earlier command in the same programmable transaction.",
+            "type": "object",
+            "required": [
+              "command",
+              "dependencies",
+              "modules",
+              "package",
+              "ticket"
+            ],
+            "properties": {
+              "command": {
+                "type": "string",
+                "enum": [
+                  "upgrade"
+                ]
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectId"
+                }
+              },
+              "modules": {
+                "type": "array",
+                "items": {
+                  "description": "Base64 encoded data",
+                  "type": "string",
+                  "format": "base64"
+                }
+              },
+              "package": {
+                "$ref": "#/components/schemas/ObjectId"
+              },
+              "ticket": {
+                "$ref": "#/components/schemas/Argument"
+              }
+            }
+          }
+        ]
+      },
+      "CommandArgumentError": {
+        "oneOf": [
+          {
+            "description": "The type of the value does not match the expected type",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "type_mismatch"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The argument cannot be deserialized into a value of the specified type",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_bcs_bytes"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The argument cannot be instantiated from raw bytes",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_usage_of_pure_argument"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Invalid argument to private entry function. Private entry functions cannot take arguments from other Move functions.",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_argument_to_private_entry_function"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Out of bounds access to input or results",
+            "type": "object",
+            "required": [
+              "index",
+              "kind"
+            ],
+            "properties": {
+              "index": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "index_out_of_bounds"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Out of bounds access to subresult",
+            "type": "object",
+            "required": [
+              "kind",
+              "result",
+              "subresult"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "secondary_index_out_of_bounds"
+                ]
+              },
+              "result": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              },
+              "subresult": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "description": "Invalid usage of result. Expected a single result but found either no return value or multiple.",
+            "type": "object",
+            "required": [
+              "kind",
+              "result"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_result_arity"
+                ]
+              },
+              "result": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "description": "Invalid usage of Gas coin. The Gas coin can only be used by-value with a TransferObjects command.",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_gas_coin_usage"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Invalid usage of move value.",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_value_usage"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Immutable objects cannot be passed by-value.",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_object_by_value"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Immutable objects cannot be passed by mutable reference, &mut.",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "invalid_object_by_mut_ref"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Shared object operations such a wrapping, freezing, or converting to owned are not allowed.",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "shared_object_operation_not_allowed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "ConsensusCommitDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "ConsensusDeterminedVersionAssignments": {
+        "oneOf": [
+          {
+            "description": "Cancelled transaction version assignment.",
+            "type": "object",
+            "required": [
+              "cancelled_transactions",
+              "kind"
+            ],
+            "properties": {
+              "cancelled_transactions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CancelledTransaction"
+                }
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "cancelled_transactions"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Digest": {
+        "description": "A representation of a 32 byte digest",
+        "type": "string",
+        "format": "base58"
+      },
+      "Direction": {
+        "type": "string",
+        "enum": [
+          "ascending",
+          "descending"
+        ]
+      },
+      "DynamicFieldInfo": {
+        "description": "DynamicFieldInfo",
+        "type": "object",
+        "required": [
+          "dynamic_field_type",
+          "field_id",
+          "name_type",
+          "name_value",
+          "parent"
+        ],
+        "properties": {
+          "dynamic_field_type": {
+            "$ref": "#/components/schemas/DynamicFieldType"
+          },
+          "dynamic_object_id": {
+            "description": "ObjectId of the child object when `dynamic_field_type == DynamicFieldType::Object`",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            ]
+          },
+          "field_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "name_type": {
+            "$ref": "#/components/schemas/TypeTag"
+          },
+          "name_value": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "parent": {
+            "$ref": "#/components/schemas/ObjectId"
+          }
+        }
+      },
+      "DynamicFieldType": {
+        "type": "string",
+        "enum": [
+          "field",
+          "object"
+        ]
+      },
+      "Ed25519PublicKey": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "Ed25519Signature": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "EffectsAuxiliaryDataDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "EndOfEpochData": {
+        "type": "object",
+        "required": [
+          "epoch_commitments",
+          "next_epoch_committee",
+          "next_epoch_protocol_version"
+        ],
+        "properties": {
+          "epoch_commitments": {
+            "description": "Commitments to epoch specific state (e.g. live object set)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointCommitment"
+            }
+          },
+          "next_epoch_committee": {
+            "description": "next_epoch_committee is `Some` if and only if the current checkpoint is the last checkpoint of an epoch. Therefore next_epoch_committee can be used to pick the last checkpoint of an epoch, which is often useful to get epoch level summary stats like total gas cost of an epoch, or the total number of transactions from genesis to the end of an epoch. The committee is stored as a vector of validator pub key and stake pairs. The vector should be sorted based on the Committee data structure.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidatorCommitteeMember"
+            }
+          },
+          "next_epoch_protocol_version": {
+            "description": "The protocol version that is in effect during the epoch that starts immediately after this checkpoint.",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "EndOfEpochTransactionKind": {
+        "description": "EndOfEpochTransactionKind",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "computation_charge",
+              "epoch",
+              "epoch_start_timestamp_ms",
+              "kind",
+              "non_refundable_storage_fee",
+              "protocol_version",
+              "storage_charge",
+              "storage_rebate",
+              "system_packages"
+            ],
+            "properties": {
+              "computation_charge": {
+                "description": "The total amount of gas charged for computation during the epoch.",
+                "type": "string",
+                "format": "u64"
+              },
+              "epoch": {
+                "description": "The next (to become) epoch ID.",
+                "type": "string",
+                "format": "u64"
+              },
+              "epoch_start_timestamp_ms": {
+                "description": "Unix timestamp when epoch started",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "change_epoch"
+                ]
+              },
+              "non_refundable_storage_fee": {
+                "description": "The non-refundable storage fee.",
+                "type": "string",
+                "format": "u64"
+              },
+              "protocol_version": {
+                "description": "The protocol version in effect in the new epoch.",
+                "type": "string",
+                "format": "u64"
+              },
+              "storage_charge": {
+                "description": "The total amount of gas charged for storage during the epoch.",
+                "type": "string",
+                "format": "u64"
+              },
+              "storage_rebate": {
+                "description": "The amount of storage rebate refunded to the txn senders.",
+                "type": "string",
+                "format": "u64"
+              },
+              "system_packages": {
+                "description": "System packages (specifically framework and move stdlib) that are written before the new epoch starts. This tracks framework upgrades on chain. When executing the ChangeEpoch txn, the validator must write out the modules below.  Modules are provided with the version they will be upgraded to, their modules in serialized form (which include their package ID), and a list of their transitive dependencies.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SystemPackage"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "authenticator_state_create"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "authenticator_obj_initial_shared_version",
+              "kind",
+              "min_epoch"
+            ],
+            "properties": {
+              "authenticator_obj_initial_shared_version": {
+                "description": "The initial version of the authenticator object that it was shared at.",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "authenticator_state_expire"
+                ]
+              },
+              "min_epoch": {
+                "description": "expire JWKs that have a lower epoch than this",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "randomness_state_create"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "deny_list_state_create"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "chain_id",
+              "kind"
+            ],
+            "properties": {
+              "chain_id": {
+                "$ref": "#/components/schemas/CheckpointDigest"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "bridge_state_create"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "bridge_object_version",
+              "kind"
+            ],
+            "properties": {
+              "bridge_object_version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "bridge_committee_init"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Event": {
+        "description": "Specific type of event",
+        "type": "object",
+        "required": [
+          "contents",
+          "module",
+          "package_id",
+          "sender",
+          "type"
+        ],
+        "properties": {
+          "contents": {
+            "description": "Base64 encoded data",
+            "type": "string",
+            "format": "base64"
+          },
+          "module": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "package_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "sender": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "type": {
+            "$ref": "#/components/schemas/StructTag"
+          }
+        }
+      },
+      "ExecutionError": {
+        "oneOf": [
+          {
+            "description": "Insufficient Gas",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "insufficient_gas"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Invalid Gas Object.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "invalid_gas_object"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Invariant Violation",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "invariant_violation"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Attempted to used feature that is not supported yet",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "feature_not_yet_supported"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Move object is larger than the maximum allowed size",
+            "type": "object",
+            "required": [
+              "error",
+              "max_object_size",
+              "object_size"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "object_too_big"
+                ]
+              },
+              "max_object_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "object_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "description": "Package is larger than the maximum allowed size",
+            "type": "object",
+            "required": [
+              "error",
+              "max_object_size",
+              "object_size"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "package_too_big"
+                ]
+              },
+              "max_object_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "object_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "description": "Circular Object Ownership",
+            "type": "object",
+            "required": [
+              "error",
+              "object"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "circular_object_ownership"
+                ]
+              },
+              "object": {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            }
+          },
+          {
+            "description": "Insufficient coin balance for requested operation",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "insufficient_coin_balance"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Coin balance overflowed an u64",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "coin_balance_overflow"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Publish Error, Non-zero Address. The modules in the package must have their self-addresses set to zero.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "publish_error_non_zero_address"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Sui Move Bytecode Verification Error.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "sui_move_verification_error"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Error from a non-abort instruction. Possible causes: Arithmetic error, stack overflow, max value depth, etc.\"",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "move_primitive_runtime_error"
+                ]
+              },
+              "location": {
+                "$ref": "#/components/schemas/MoveLocation"
+              }
+            }
+          },
+          {
+            "description": "Move runtime abort",
+            "type": "object",
+            "required": [
+              "code",
+              "error",
+              "location"
+            ],
+            "properties": {
+              "code": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "error": {
+                "type": "string",
+                "enum": [
+                  "move_abort"
+                ]
+              },
+              "location": {
+                "$ref": "#/components/schemas/MoveLocation"
+              }
+            }
+          },
+          {
+            "description": "Bytecode verification error.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "vm_verification_or_deserialization_error"
+                ]
+              }
+            }
+          },
+          {
+            "description": "MoveVm invariant violation",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "vm_invariant_violation"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Function not found",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "function_not_found"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Arity mismatch for Move function. The number of arguments does not match the number of parameters",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "arity_mismatch"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Type arity mismatch for Move function. Mismatch between the number of actual versus expected type arguments.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "type_arity_mismatch"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Non Entry Function Invoked. Move Call must start with an entry function.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "non_entry_function_invoked"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Invalid command argument",
+            "type": "object",
+            "required": [
+              "argument",
+              "error",
+              "kind"
+            ],
+            "properties": {
+              "argument": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              },
+              "error": {
+                "type": "string",
+                "enum": [
+                  "command_argument_error"
+                ]
+              },
+              "kind": {
+                "$ref": "#/components/schemas/CommandArgumentError"
+              }
+            }
+          },
+          {
+            "description": "Type argument error",
+            "type": "object",
+            "required": [
+              "error",
+              "kind",
+              "type_argument"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "type_argument_error"
+                ]
+              },
+              "kind": {
+                "$ref": "#/components/schemas/TypeArgumentError"
+              },
+              "type_argument": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "description": "Unused result without the drop ability.",
+            "type": "object",
+            "required": [
+              "error",
+              "result",
+              "subresult"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "unused_value_without_drop"
+                ]
+              },
+              "result": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              },
+              "subresult": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "description": "Invalid public Move function signature. Unsupported return type for return value",
+            "type": "object",
+            "required": [
+              "error",
+              "index"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "invalid_public_function_return_type"
+                ]
+              },
+              "index": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "description": "Invalid Transfer Object, object does not have public transfer.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "invalid_transfer_object"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Effects from the transaction are too large",
+            "type": "object",
+            "required": [
+              "current_size",
+              "error",
+              "max_size"
+            ],
+            "properties": {
+              "current_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "error": {
+                "type": "string",
+                "enum": [
+                  "effects_too_large"
+                ]
+              },
+              "max_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "description": "Publish or Upgrade is missing dependency",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "publish_upgrade_missing_dependency"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Publish or Upgrade dependency downgrade.\n\nIndirect (transitive) dependency of published or upgraded package has been assigned an on-chain version that is less than the version required by one of the package's transitive dependencies.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "publish_upgrade_dependency_downgrade"
+                ]
+              }
+            }
+          },
+          {
+            "title": "PackageUpgradeError",
+            "description": "Invalid package upgrade",
+            "type": "object",
+            "required": [
+              "error",
+              "kind"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "package_upgrade_error"
+                ]
+              },
+              "kind": {
+                "$ref": "#/components/schemas/PackageUpgradeError"
+              }
+            }
+          },
+          {
+            "description": "Indicates the transaction tried to write objects too large to storage",
+            "type": "object",
+            "required": [
+              "error",
+              "max_object_size",
+              "object_size"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "written_objects_too_large"
+                ]
+              },
+              "max_object_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "object_size": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "description": "Certificate is on the deny list",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "certificate_denied"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Sui Move Bytecode verification timed out.",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "sui_move_verification_timedout"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The requested shared object operation is not allowed",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "shared_object_operation_not_allowed"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Requested shared object has been deleted",
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "input_object_deleted"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "FailureStatus": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "command": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "error": {
+            "$ref": "#/components/schemas/ExecutionError"
+          }
+        }
+      },
+      "GasCostSummary": {
+        "description": "Summary of gas charges.\n\nStorage is charged independently of computation. There are 3 parts to the storage charges: `storage_cost`: it is the charge of storage at the time the transaction is executed. The cost of storage is the number of bytes of the objects being mutated multiplied by a variable storage cost per byte `storage_rebate`: this is the amount a user gets back when manipulating an object. The `storage_rebate` is the `storage_cost` for an object minus fees. `non_refundable_storage_fee`: not all the value of the object storage cost is given back to user and there is a small fraction that is kept by the system. This value tracks that charge.\n\nWhen looking at a gas cost summary the amount charged to the user is `computation_cost + storage_cost - storage_rebate` and that is the amount that is deducted from the gas coins. `non_refundable_storage_fee` is collected from the objects being mutated/deleted and it is tracked by the system in storage funds.\n\nObjects deleted, including the older versions of objects mutated, have the storage field on the objects added up to a pool of \"potential rebate\". This rebate then is reduced by the \"nonrefundable rate\" such that: `potential_rebate(storage cost of deleted/mutated objects) = storage_rebate + non_refundable_storage_fee`",
+        "type": "object",
+        "required": [
+          "computation_cost",
+          "non_refundable_storage_fee",
+          "storage_cost",
+          "storage_rebate"
+        ],
+        "properties": {
+          "computation_cost": {
+            "description": "Cost of computation/execution",
+            "type": "string",
+            "format": "u64"
+          },
+          "non_refundable_storage_fee": {
+            "description": "The fee for the rebate. The portion of the storage rebate kept by the system.",
+            "type": "string",
+            "format": "u64"
+          },
+          "storage_cost": {
+            "description": "Storage cost, it's the sum of all storage cost for all objects created or mutated.",
+            "type": "string",
+            "format": "u64"
+          },
+          "storage_rebate": {
+            "description": "The amount of storage cost refunded to the user for all objects deleted or mutated in the transaction.",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "GasPayment": {
+        "type": "object",
+        "required": [
+          "budget",
+          "objects",
+          "owner",
+          "price"
+        ],
+        "properties": {
+          "budget": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "objects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectReference"
+            }
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "price": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "GenesisObject": {
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/MoveStruct"
+          },
+          {
+            "$ref": "#/components/schemas/Package"
+          }
+        ],
+        "required": [
+          "object_id",
+          "owner",
+          "type",
+          "version"
+        ],
+        "properties": {
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Owner"
+          },
+          "type": {
+            "type": "string"
+          },
+          "version": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "IdOperation": {
+        "type": "string",
+        "enum": [
+          "none",
+          "created",
+          "deleted"
+        ]
+      },
+      "Identifier": {
+        "title": "Identifier",
+        "description": "A Move Identifier",
+        "examples": [
+          "sui"
+        ],
+        "type": "string",
+        "pattern": "(?:[a-zA-Z][a-zA-Z0-9_]{0,127})|(?:_[a-zA-Z0-9_]{0,127})"
+      },
+      "InputArgument": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pure"
+                ]
+              },
+              "value": {
+                "description": "Base64 encoded data",
+                "type": "string",
+                "format": "base64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "digest",
+              "object_id",
+              "type",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "object_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "immutable_or_owned"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "initial_shared_version",
+              "mutable",
+              "object_id",
+              "type"
+            ],
+            "properties": {
+              "initial_shared_version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "mutable": {
+                "type": "boolean"
+              },
+              "object_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "shared"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "digest",
+              "object_id",
+              "type",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "object_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "receiving"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          }
+        ]
+      },
+      "Jwk": {
+        "description": "Struct that contains info for a JWK. A list of them for different kids can be retrieved from the JWK endpoint (e.g. <https://www.googleapis.com/oauth2/v3/certs>). The JWK is used to verify the JWT token.",
+        "type": "object",
+        "required": [
+          "alg",
+          "e",
+          "kty",
+          "n"
+        ],
+        "properties": {
+          "alg": {
+            "description": "Algorithm parameter, <https://datatracker.ietf.org/doc/html/rfc7517#section-4.4>",
+            "type": "string"
+          },
+          "e": {
+            "description": "RSA public exponent, <https://datatracker.ietf.org/doc/html/rfc7517#section-9.3>",
+            "type": "string"
+          },
+          "kty": {
+            "description": "Key type parameter, <https://datatracker.ietf.org/doc/html/rfc7517#section-4.1>",
+            "type": "string"
+          },
+          "n": {
+            "description": "RSA modulus, <https://datatracker.ietf.org/doc/html/rfc7517#section-9.3>",
+            "type": "string"
+          }
+        }
+      },
+      "JwkId": {
+        "description": "Key to identify a JWK, consists of iss and kid.",
+        "type": "object",
+        "required": [
+          "iss",
+          "kid"
+        ],
+        "properties": {
+          "iss": {
+            "description": "iss string that identifies the OIDC provider.",
+            "type": "string"
+          },
+          "kid": {
+            "description": "kid string that identifies the JWK.",
+            "type": "string"
+          }
+        }
+      },
+      "ModifiedAtVersion": {
+        "type": "object",
+        "required": [
+          "object_id",
+          "version"
+        ],
+        "properties": {
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "version": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "MoveLocation": {
+        "type": "object",
+        "required": [
+          "function",
+          "instruction",
+          "module",
+          "package"
+        ],
+        "properties": {
+          "function": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "function_name": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "instruction": {
+            "description": "Index into the code stream for a jump. The offset is relative to the beginning of the instruction stream.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "module": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "package": {
+            "$ref": "#/components/schemas/ObjectId"
+          }
+        }
+      },
+      "MoveStruct": {
+        "type": "object",
+        "required": [
+          "contents",
+          "has_public_transfer"
+        ],
+        "properties": {
+          "contents": {
+            "description": "Base64 encoded data",
+            "type": "string",
+            "format": "base64"
+          },
+          "has_public_transfer": {
+            "type": "boolean"
+          }
+        }
+      },
+      "MultisigCommittee": {
+        "type": "object",
+        "required": [
+          "members",
+          "threshold"
+        ],
+        "properties": {
+          "members": {
+            "description": "A list of committee members and their corresponding weight.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultisigMember"
+            }
+          },
+          "threshold": {
+            "description": "If the total weight of the public keys corresponding to verified signatures is larger than threshold, the Multisig is verified.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "MultisigMember": {
+        "type": "object",
+        "required": [
+          "public_key",
+          "weight"
+        ],
+        "properties": {
+          "public_key": {
+            "$ref": "#/components/schemas/MultisigMemberPublicKey"
+          },
+          "weight": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          }
+        }
+      },
+      "MultisigMemberPublicKey": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Ed25519PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "ed25519"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Secp256k1PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256k1"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Secp256r1PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256r1"
+                ]
+              }
+            }
+          },
+          {
+            "description": "A wrapper struct to retrofit in [enum PublicKey] for zkLogin. Useful to construct [struct MultiSigPublicKey].",
+            "type": "object",
+            "required": [
+              "address_seed",
+              "iss",
+              "scheme"
+            ],
+            "properties": {
+              "address_seed": {
+                "$ref": "#/components/schemas/Bn254FieldElement"
+              },
+              "iss": {
+                "type": "string"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "zklogin"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "MultisigMemberSignature": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "ed25519"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Ed25519Signature"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256k1"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Secp256k1Signature"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256r1"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Secp256r1Signature"
+              }
+            }
+          },
+          {
+            "description": "An zk login authenticator with all the necessary fields.",
+            "type": "object",
+            "required": [
+              "inputs",
+              "max_epoch",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "inputs": {
+                "$ref": "#/components/schemas/ZkLoginInputs"
+              },
+              "max_epoch": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "zklogin"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/SimpleSignature"
+              }
+            }
+          }
+        ]
+      },
+      "NodeInfo": {
+        "type": "object",
+        "required": [
+          "chain",
+          "chain_id",
+          "checkpoint_height",
+          "epoch",
+          "lowest_available_checkpoint",
+          "lowest_available_checkpoint_objects",
+          "software_version",
+          "timestamp_ms"
+        ],
+        "properties": {
+          "chain": {
+            "type": "string"
+          },
+          "chain_id": {
+            "$ref": "#/components/schemas/CheckpointDigest"
+          },
+          "checkpoint_height": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "lowest_available_checkpoint": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "lowest_available_checkpoint_objects": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "software_version": {
+            "type": "string"
+          },
+          "timestamp_ms": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
+      "Object": {
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/MoveStruct"
+          },
+          {
+            "$ref": "#/components/schemas/Package"
+          }
+        ],
+        "required": [
+          "object_id",
+          "owner",
+          "previous_transaction",
+          "storage_rebate",
+          "type",
+          "version"
+        ],
+        "properties": {
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Owner"
+          },
+          "previous_transaction": {
+            "$ref": "#/components/schemas/TransactionDigest"
+          },
+          "storage_rebate": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "type": {
+            "type": "string"
+          },
+          "version": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "ObjectDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "ObjectId": {
+        "$ref": "#/components/schemas/Address"
+      },
+      "ObjectIn": {
+        "description": "If an object exists (at root-level) in the store prior to this transaction, it should be Exist, otherwise it's NonExist, e.g. wrapped objects should be NonExist.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "state"
+            ],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "not_exist"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The old version, digest and owner.",
+            "type": "object",
+            "required": [
+              "digest",
+              "owner",
+              "state",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "owner": {
+                "$ref": "#/components/schemas/Owner"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "exist"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          }
+        ]
+      },
+      "ObjectOut": {
+        "oneOf": [
+          {
+            "description": "Same definition as in ObjectIn.",
+            "type": "object",
+            "required": [
+              "state"
+            ],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "not_exist"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Any written object, including all of mutated, created, unwrapped today.",
+            "type": "object",
+            "required": [
+              "digest",
+              "owner",
+              "state"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "owner": {
+                "$ref": "#/components/schemas/Owner"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "object_write"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Packages writes need to be tracked separately with version because we don't use lamport version for package publish and upgrades.",
+            "type": "object",
+            "required": [
+              "digest",
+              "state",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "package_write"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          }
+        ]
+      },
+      "ObjectReference": {
+        "type": "object",
+        "required": [
+          "digest",
+          "object_id",
+          "version"
+        ],
+        "properties": {
+          "digest": {
+            "$ref": "#/components/schemas/ObjectDigest"
+          },
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "version": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "ObjectReferenceWithOwner": {
+        "type": "object",
+        "required": [
+          "owner",
+          "reference"
+        ],
+        "properties": {
+          "owner": {
+            "$ref": "#/components/schemas/Owner"
+          },
+          "reference": {
+            "$ref": "#/components/schemas/ObjectReference"
+          }
+        }
+      },
+      "Owner": {
+        "oneOf": [
+          {
+            "title": "Address Owned",
+            "description": "Object is exclusively owned by a single address, and is mutable.",
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "$ref": "#/components/schemas/Address"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Object Owned",
+            "description": "Object is exclusively owned by a single object, and is mutable.",
+            "type": "object",
+            "required": [
+              "object"
+            ],
+            "properties": {
+              "object": {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Shared Object",
+            "description": "Object is shared, can be used by any address, and is mutable.",
+            "type": "object",
+            "required": [
+              "shared"
+            ],
+            "properties": {
+              "shared": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Immutable",
+            "description": "Object is immutable, and hence ownership doesn't matter.",
+            "type": "string",
+            "enum": [
+              "immutable"
+            ]
+          }
+        ]
+      },
+      "Package": {
+        "type": "object",
+        "required": [
+          "linkage_table",
+          "modules",
+          "type_origin_table"
+        ],
+        "properties": {
+          "linkage_table": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/UpgradeInfo"
+            }
+          },
+          "modules": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Base64 encoded data",
+              "type": "string",
+              "format": "base64"
+            }
+          },
+          "type_origin_table": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TypeOrigin"
+            }
+          }
+        }
+      },
+      "PackageUpgradeError": {
+        "oneOf": [
+          {
+            "description": "Unable to fetch package",
+            "type": "object",
+            "required": [
+              "kind",
+              "package_id"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "unable_to_fetch_package"
+                ]
+              },
+              "package_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            }
+          },
+          {
+            "description": "Object is not a package",
+            "type": "object",
+            "required": [
+              "kind",
+              "object_id"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "not_a_package"
+                ]
+              },
+              "object_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            }
+          },
+          {
+            "description": "Package upgrade is incompatible with previous version",
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "incompatible_upgrade"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Digest in upgrade ticket and computed digest differ",
+            "type": "object",
+            "required": [
+              "digest",
+              "kind"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/Digest"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "digest_does_not_match"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Upgrade policy is not valid",
+            "type": "object",
+            "required": [
+              "kind",
+              "policy"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "unknown_upgrade_policy"
+                ]
+              },
+              "policy": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "description": "PackageId does not matach PackageId in upgrade ticket",
+            "type": "object",
+            "required": [
+              "kind",
+              "package_id",
+              "ticket_id"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "package_id_does_not_match"
+                ]
+              },
+              "package_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              },
+              "ticket_id": {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            }
+          }
+        ]
+      },
+      "Secp256k1PublicKey": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "Secp256k1Signature": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "Secp256r1PublicKey": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "Secp256r1Signature": {
+        "description": "Base64 encoded data",
+        "type": "string",
+        "format": "base64"
+      },
+      "SignedCheckpointSummary": {
+        "type": "object",
+        "required": [
+          "checkpoint",
+          "signature"
+        ],
+        "properties": {
+          "checkpoint": {
+            "$ref": "#/components/schemas/CheckpointSummary"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/ValidatorAggregatedSignature"
+          }
+        }
+      },
+      "SignedTransaction": {
+        "type": "object",
+        "required": [
+          "signatures",
+          "transaction"
+        ],
+        "properties": {
+          "signatures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserSignature"
+            }
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        }
+      },
+      "SimpleSignature": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Ed25519PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "ed25519"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Ed25519Signature"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Secp256k1PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256k1"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Secp256k1Signature"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Secp256r1PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256r1"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Secp256r1Signature"
+              }
+            }
+          }
+        ]
+      },
+      "StructTag": {
+        "title": "StructTag",
+        "description": "A Move StructTag",
+        "examples": [
+          "0x2::coin::Coin<0x2::sui::SUI>"
+        ],
+        "type": "string"
+      },
+      "SystemPackage": {
+        "type": "object",
+        "required": [
+          "dependencies",
+          "modules",
+          "version"
+        ],
+        "properties": {
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectId"
+            }
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "description": "Base64 encoded data",
+              "type": "string",
+              "format": "base64"
+            }
+          },
+          "version": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "Transaction": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "expiration",
+              "gas_payment",
+              "kind",
+              "sender",
+              "version"
+            ],
+            "properties": {
+              "expiration": {
+                "$ref": "#/components/schemas/TransactionExpiration"
+              },
+              "gas_payment": {
+                "$ref": "#/components/schemas/GasPayment"
+              },
+              "kind": {
+                "$ref": "#/components/schemas/TransactionKind"
+              },
+              "sender": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "version": {
+                "type": "string",
+                "enum": [
+                  "1"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "TransactionDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "TransactionEffects": {
+        "description": "The response from processing a transaction or a certified transaction",
+        "oneOf": [
+          {
+            "description": "The response from processing a transaction or a certified transaction",
+            "type": "object",
+            "required": [
+              "created",
+              "deleted",
+              "dependencies",
+              "epoch",
+              "gas_object",
+              "gas_used",
+              "modified_at_versions",
+              "mutated",
+              "shared_objects",
+              "success",
+              "transaction_digest",
+              "unwrapped",
+              "unwrapped_then_deleted",
+              "version",
+              "wrapped"
+            ],
+            "properties": {
+              "created": {
+                "description": "ObjectReference and owner of new objects created.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReferenceWithOwner"
+                }
+              },
+              "deleted": {
+                "description": "Object Refs of objects now deleted (the new refs).",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReference"
+                }
+              },
+              "dependencies": {
+                "description": "The set of transaction digests this transaction depends on.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TransactionDigest"
+                }
+              },
+              "epoch": {
+                "description": "The epoch when this transaction was executed.",
+                "type": "string",
+                "format": "u64"
+              },
+              "events_digest": {
+                "description": "The digest of the events emitted during execution, can be None if the transaction does not emit any event.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TransactionEventsDigest"
+                  }
+                ]
+              },
+              "gas_object": {
+                "description": "The updated gas object reference. Have a dedicated field for convenient access. It's also included in mutated.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ObjectReferenceWithOwner"
+                  }
+                ]
+              },
+              "gas_used": {
+                "$ref": "#/components/schemas/GasCostSummary"
+              },
+              "modified_at_versions": {
+                "description": "The version that every modified (mutated or deleted) object had before it was modified by this transaction.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ModifiedAtVersion"
+                }
+              },
+              "mutated": {
+                "description": "ObjectReference and owner of mutated objects, including gas object.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReferenceWithOwner"
+                }
+              },
+              "shared_objects": {
+                "description": "The object references of the shared objects used in this transaction. Empty if no shared objects were used.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReference"
+                }
+              },
+              "status": {
+                "$ref": "#/components/schemas/FailureStatus"
+              },
+              "success": {
+                "type": "boolean"
+              },
+              "transaction_digest": {
+                "description": "The transaction digest",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TransactionDigest"
+                  }
+                ]
+              },
+              "unwrapped": {
+                "description": "ObjectReference and owner of objects that are unwrapped in this transaction. Unwrapped objects are objects that were wrapped into other objects in the past, and just got extracted out.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReferenceWithOwner"
+                }
+              },
+              "unwrapped_then_deleted": {
+                "description": "Object refs of objects previously wrapped in other objects but now deleted.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReference"
+                }
+              },
+              "version": {
+                "type": "string",
+                "enum": [
+                  "1"
+                ]
+              },
+              "wrapped": {
+                "description": "Object refs of objects now wrapped in other objects.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReference"
+                }
+              }
+            }
+          },
+          {
+            "description": "The response from processing a transaction or a certified transaction",
+            "type": "object",
+            "required": [
+              "changed_objects",
+              "dependencies",
+              "epoch",
+              "gas_used",
+              "lamport_version",
+              "success",
+              "transaction_digest",
+              "unchanged_shared_objects",
+              "version"
+            ],
+            "properties": {
+              "auxiliary_data_digest": {
+                "description": "Auxiliary data that are not protocol-critical, generated as part of the effects but are stored separately. Storing it separately allows us to avoid bloating the effects with data that are not critical. It also provides more flexibility on the format and type of the data.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EffectsAuxiliaryDataDigest"
+                  }
+                ]
+              },
+              "changed_objects": {
+                "description": "Objects whose state are changed in the object store.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ChangedObject"
+                }
+              },
+              "dependencies": {
+                "description": "The set of transaction digests this transaction depends on.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TransactionDigest"
+                }
+              },
+              "epoch": {
+                "description": "The epoch when this transaction was executed.",
+                "type": "string",
+                "format": "u64"
+              },
+              "events_digest": {
+                "description": "The digest of the events emitted during execution, can be None if the transaction does not emit any event.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TransactionEventsDigest"
+                  }
+                ]
+              },
+              "gas_object_index": {
+                "description": "The updated gas object reference, as an index into the `changed_objects` vector. Having a dedicated field for convenient access. System transaction that don't require gas will leave this as None.",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "gas_used": {
+                "$ref": "#/components/schemas/GasCostSummary"
+              },
+              "lamport_version": {
+                "description": "The version number of all the written Move objects by this transaction.",
+                "type": "string",
+                "format": "u64"
+              },
+              "status": {
+                "$ref": "#/components/schemas/FailureStatus"
+              },
+              "success": {
+                "type": "boolean"
+              },
+              "transaction_digest": {
+                "description": "The transaction digest",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TransactionDigest"
+                  }
+                ]
+              },
+              "unchanged_shared_objects": {
+                "description": "Shared objects that are not mutated in this transaction. Unlike owned objects, read-only shared objects' version are not committed in the transaction, and in order for a node to catch up and execute it without consensus sequencing, the version needs to be committed in the effects.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/UnchangedSharedObject"
+                }
+              },
+              "version": {
+                "type": "string",
+                "enum": [
+                  "2"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "TransactionEffectsDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "TransactionEvents": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Event"
+        }
+      },
+      "TransactionEventsDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
+      "TransactionExpiration": {
+        "oneOf": [
+          {
+            "description": "Validators wont sign a transaction unless the expiration Epoch is greater than or equal to the current epoch",
+            "type": "object",
+            "required": [
+              "epoch"
+            ],
+            "properties": {
+              "epoch": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "TransactionKind": {
+        "oneOf": [
+          {
+            "description": "A series of commands where the results of one command can be used in future commands",
+            "type": "object",
+            "required": [
+              "commands",
+              "inputs",
+              "kind"
+            ],
+            "properties": {
+              "commands": {
+                "description": "The commands to be executed sequentially. A failure in any command will result in the failure of the entire transaction.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Command"
+                }
+              },
+              "inputs": {
+                "description": "Input objects or primitive values",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/InputArgument"
+                }
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "programmable_transaction"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "computation_charge",
+              "epoch",
+              "epoch_start_timestamp_ms",
+              "kind",
+              "non_refundable_storage_fee",
+              "protocol_version",
+              "storage_charge",
+              "storage_rebate",
+              "system_packages"
+            ],
+            "properties": {
+              "computation_charge": {
+                "description": "The total amount of gas charged for computation during the epoch.",
+                "type": "string",
+                "format": "u64"
+              },
+              "epoch": {
+                "description": "The next (to become) epoch ID.",
+                "type": "string",
+                "format": "u64"
+              },
+              "epoch_start_timestamp_ms": {
+                "description": "Unix timestamp when epoch started",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "change_epoch"
+                ]
+              },
+              "non_refundable_storage_fee": {
+                "description": "The non-refundable storage fee.",
+                "type": "string",
+                "format": "u64"
+              },
+              "protocol_version": {
+                "description": "The protocol version in effect in the new epoch.",
+                "type": "string",
+                "format": "u64"
+              },
+              "storage_charge": {
+                "description": "The total amount of gas charged for storage during the epoch.",
+                "type": "string",
+                "format": "u64"
+              },
+              "storage_rebate": {
+                "description": "The amount of storage rebate refunded to the txn senders.",
+                "type": "string",
+                "format": "u64"
+              },
+              "system_packages": {
+                "description": "System packages (specifically framework and move stdlib) that are written before the new epoch starts. This tracks framework upgrades on chain. When executing the ChangeEpoch txn, the validator must write out the modules below.  Modules are provided with the version they will be upgraded to, their modules in serialized form (which include their package ID), and a list of their transitive dependencies.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SystemPackage"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind",
+              "objects"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "genesis"
+                ]
+              },
+              "objects": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GenesisObject"
+                }
+              }
+            }
+          },
+          {
+            "description": "Only commit_timestamp_ms is passed to the move call currently. However we include epoch and round to make sure each ConsensusCommitPrologue has a unique tx digest.",
+            "type": "object",
+            "required": [
+              "commit_timestamp_ms",
+              "epoch",
+              "kind",
+              "round"
+            ],
+            "properties": {
+              "commit_timestamp_ms": {
+                "description": "Unix timestamp from consensus",
+                "type": "string",
+                "format": "u64"
+              },
+              "epoch": {
+                "description": "Epoch of the commit prologue transaction",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "consensus_commit_prologue"
+                ]
+              },
+              "round": {
+                "description": "Consensus round of the commit",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "authenticator_obj_initial_shared_version",
+              "epoch",
+              "kind",
+              "new_active_jwks",
+              "round"
+            ],
+            "properties": {
+              "authenticator_obj_initial_shared_version": {
+                "description": "The initial version of the authenticator object that it was shared at.",
+                "type": "string",
+                "format": "u64"
+              },
+              "epoch": {
+                "description": "Epoch of the authenticator state update transaction",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "authenticator_state_update"
+                ]
+              },
+              "new_active_jwks": {
+                "description": "newly active jwks",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ActiveJwk"
+                }
+              },
+              "round": {
+                "description": "Consensus round of the authenticator state update",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "commands",
+              "kind"
+            ],
+            "properties": {
+              "commands": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EndOfEpochTransactionKind"
+                }
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "end_of_epoch"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "epoch",
+              "kind",
+              "random_bytes",
+              "randomness_obj_initial_shared_version",
+              "randomness_round"
+            ],
+            "properties": {
+              "epoch": {
+                "description": "Epoch of the randomness state update transaction",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "randomness_state_update"
+                ]
+              },
+              "random_bytes": {
+                "description": "Updated random bytes",
+                "type": "string",
+                "format": "base64"
+              },
+              "randomness_obj_initial_shared_version": {
+                "description": "The initial version of the randomness object that it was shared at.",
+                "type": "string",
+                "format": "u64"
+              },
+              "randomness_round": {
+                "description": "Randomness round of the update",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "commit_timestamp_ms",
+              "consensus_commit_digest",
+              "epoch",
+              "kind",
+              "round"
+            ],
+            "properties": {
+              "commit_timestamp_ms": {
+                "description": "Unix timestamp from consensus",
+                "type": "string",
+                "format": "u64"
+              },
+              "consensus_commit_digest": {
+                "description": "Digest of consensus output",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ConsensusCommitDigest"
+                  }
+                ]
+              },
+              "epoch": {
+                "description": "Epoch of the commit prologue transaction",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "consensus_commit_prologue_v2"
+                ]
+              },
+              "round": {
+                "description": "Consensus round of the commit",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "commit_timestamp_ms",
+              "consensus_commit_digest",
+              "consensus_determined_version_assignments",
+              "epoch",
+              "kind",
+              "round"
+            ],
+            "properties": {
+              "commit_timestamp_ms": {
+                "description": "Unix timestamp from consensus",
+                "type": "string",
+                "format": "u64"
+              },
+              "consensus_commit_digest": {
+                "description": "Digest of consensus output",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ConsensusCommitDigest"
+                  }
+                ]
+              },
+              "consensus_determined_version_assignments": {
+                "description": "Stores consensus handler determined shared object version assignments.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ConsensusDeterminedVersionAssignments"
+                  }
+                ]
+              },
+              "epoch": {
+                "description": "Epoch of the commit prologue transaction",
+                "type": "string",
+                "format": "u64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "consensus_commit_prologue_v3"
+                ]
+              },
+              "round": {
+                "description": "Consensus round of the commit",
+                "type": "string",
+                "format": "u64"
+              },
+              "sub_dag_index": {
+                "description": "The sub DAG index of the consensus commit. This field will be populated if there are multiple consensus commits per round.",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          }
+        ]
+      },
+      "TransactionResponse": {
+        "type": "object",
+        "required": [
+          "effects",
+          "transaction"
+        ],
+        "properties": {
+          "checkpoint": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "effects": {
+            "$ref": "#/components/schemas/TransactionEffects"
+          },
+          "events": {
+            "$ref": "#/components/schemas/TransactionEvents"
+          },
+          "timestamp_ms": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/SignedTransaction"
+          }
+        }
+      },
+      "TypeArgumentError": {
+        "oneOf": [
+          {
+            "description": "A type was not found in the module specified",
+            "type": "string",
+            "enum": [
+              "type_not_found"
+            ]
+          },
+          {
+            "description": "A type provided did not match the specified constraint",
+            "type": "string",
+            "enum": [
+              "constraint_not_satisfied"
+            ]
+          }
+        ]
+      },
+      "TypeOrigin": {
+        "description": "Identifies a struct and the module it was defined in",
+        "type": "object",
+        "required": [
+          "module_name",
+          "package",
+          "struct_name"
+        ],
+        "properties": {
+          "module_name": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "package": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "struct_name": {
+            "$ref": "#/components/schemas/Identifier"
+          }
+        }
+      },
+      "TypeTag": {
+        "title": "TypeTag",
+        "description": "A Move TypeTag",
+        "examples": [
+          "vector<u8>"
+        ],
+        "type": "string"
+      },
+      "UnchangedSharedKind": {
+        "oneOf": [
+          {
+            "description": "Read-only shared objects from the input. We don't really need ObjectDigest for protocol correctness, but it will make it easier to verify untrusted read.",
+            "type": "object",
+            "required": [
+              "digest",
+              "kind",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "read_only_root"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "description": "Deleted shared objects that appear mutably/owned in the input.",
+            "type": "object",
+            "required": [
+              "kind",
+              "version"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "mutate_deleted"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          },
+          {
+            "description": "Deleted shared objects that appear as read-only in the input.",
+            "type": "object",
+            "required": [
+              "kind",
+              "version"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "read_deleted"
+                ]
+              },
+              "version": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              }
+            }
+          }
+        ]
+      },
+      "UnchangedSharedObject": {
+        "type": "object",
+        "required": [
+          "kind",
+          "object_id"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/UnchangedSharedKind"
+          },
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          }
+        }
+      },
+      "UpgradeInfo": {
+        "description": "Upgraded package info for the linkage table",
+        "type": "object",
+        "required": [
+          "upgraded_id",
+          "upgraded_version"
+        ],
+        "properties": {
+          "upgraded_id": {
+            "description": "Id of the upgraded packages",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            ]
+          },
+          "upgraded_version": {
+            "description": "Version of the upgraded package",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "UserSignature": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Ed25519PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "ed25519"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Ed25519Signature"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Secp256k1PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256k1"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Secp256k1Signature"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "public_key",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "public_key": {
+                "$ref": "#/components/schemas/Secp256r1PublicKey"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "secp256r1"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Secp256r1Signature"
+              }
+            }
+          },
+          {
+            "description": "The struct that contains signatures and public keys necessary for authenticating a Multisig.",
+            "type": "object",
+            "required": [
+              "bitmap",
+              "committee",
+              "scheme",
+              "signatures"
+            ],
+            "properties": {
+              "bitmap": {
+                "description": "A bitmap that indicates the position of which public key the signature should be authenticated with.",
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0.0
+              },
+              "committee": {
+                "description": "The public key encoded with each public key with its signature scheme used along with the corresponding weight.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/MultisigCommittee"
+                  }
+                ]
+              },
+              "legacy_bitmap": {
+                "description": "Legacy encoding for the bitmap.",
+                "type": "string",
+                "format": "base64"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "multisig"
+                ]
+              },
+              "signatures": {
+                "description": "The plain signature encoded with signature scheme.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/MultisigMemberSignature"
+                }
+              }
+            }
+          },
+          {
+            "description": "An zk login authenticator with all the necessary fields.",
+            "type": "object",
+            "required": [
+              "inputs",
+              "max_epoch",
+              "scheme",
+              "signature"
+            ],
+            "properties": {
+              "inputs": {
+                "$ref": "#/components/schemas/ZkLoginInputs"
+              },
+              "max_epoch": {
+                "description": "Radix-10 encoded 64-bit unsigned integer",
+                "type": "string",
+                "format": "u64"
+              },
+              "scheme": {
+                "type": "string",
+                "enum": [
+                  "zklogin"
+                ]
+              },
+              "signature": {
+                "$ref": "#/components/schemas/SimpleSignature"
+              }
+            }
+          }
+        ]
+      },
+      "ValidatorAggregatedSignature": {
+        "type": "object",
+        "required": [
+          "bitmap",
+          "epoch",
+          "signature"
+        ],
+        "properties": {
+          "bitmap": {
+            "description": "Base64 encoded data",
+            "type": "string",
+            "format": "base64"
+          },
+          "epoch": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Bls12381Signature"
+          }
+        }
+      },
+      "ValidatorCommittee": {
+        "type": "object",
+        "required": [
+          "epoch",
+          "members"
+        ],
+        "properties": {
+          "epoch": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidatorCommitteeMember"
+            }
+          }
+        }
+      },
+      "ValidatorCommitteeMember": {
+        "type": "object",
+        "required": [
+          "public_key",
+          "stake"
+        ],
+        "properties": {
+          "public_key": {
+            "$ref": "#/components/schemas/Bls12381PublicKey"
+          },
+          "stake": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "VersionAssignment": {
+        "type": "object",
+        "required": [
+          "object_id",
+          "version"
+        ],
+        "properties": {
+          "object_id": {
+            "$ref": "#/components/schemas/ObjectId"
+          },
+          "version": {
+            "description": "Radix-10 encoded 64-bit unsigned integer",
+            "type": "string",
+            "format": "u64"
+          }
+        }
+      },
+      "ZkLoginInputs": {
+        "description": "All inputs required for the zk login proof verification and other public inputs.",
+        "type": "object",
+        "required": [
+          "address_seed",
+          "header_base64",
+          "iss_base64_details",
+          "proof_points"
+        ],
+        "properties": {
+          "address_seed": {
+            "$ref": "#/components/schemas/Bn254FieldElement"
+          },
+          "header_base64": {
+            "type": "string"
+          },
+          "iss_base64_details": {
+            "$ref": "#/components/schemas/Claim"
+          },
+          "proof_points": {
+            "$ref": "#/components/schemas/ZkLoginProof"
+          }
+        }
+      },
+      "ZkLoginProof": {
+        "description": "The struct for zk login proof.",
+        "type": "object",
+        "required": [
+          "a",
+          "b",
+          "c"
+        ],
+        "properties": {
+          "a": {
+            "$ref": "#/components/schemas/CircomG1"
+          },
+          "b": {
+            "$ref": "#/components/schemas/CircomG2"
+          },
+          "c": {
+            "$ref": "#/components/schemas/CircomG1"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Objects"
+    },
+    {
+      "name": "OpenApi"
+    },
+    {
+      "name": "Transactions"
+    }
+  ]
+}

--- a/crates/sui-rest-api/openapi/swagger.html
+++ b/crates/sui-rest-api/openapi/swagger.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="SwaggerUI" />
+  <title>SwaggerUI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+<script>
+  window.onload = () => {
+    window.ui = SwaggerUIBundle({
+      url: 'openapi.json',
+      dom_id: '#swagger-ui',
+    });
+  };
+</script>
+</body>
+</html>

--- a/crates/sui-rest-api/src/coins.rs
+++ b/crates/sui-rest-api/src/coins.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::openapi::{ApiEndpoint, RouteHandler};
 use crate::RestError;
+use crate::RestService;
 use crate::{accept::AcceptFormat, reader::StateReader, Result};
 use axum::extract::{Path, State};
 use axum::Json;
@@ -9,9 +11,30 @@ use serde::{Deserialize, Serialize};
 use sui_sdk2::types::{ObjectId, StructTag};
 use sui_types::sui_sdk2_conversions::struct_tag_sdk_to_core;
 
-pub const GET_COIN_INFO_PATH: &str = "/coins/:coin_type";
+pub struct GetCoinInfo;
 
-pub async fn get_coin_info(
+impl ApiEndpoint<RestService> for GetCoinInfo {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/coins/{coin_type}"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        openapiv3::v3_1::Operation::default()
+    }
+
+    fn handler(&self) -> crate::openapi::RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_coin_info)
+    }
+}
+
+async fn get_coin_info(
     Path(coin_type): Path<StructTag>,
     accept: AcceptFormat,
     State(state): State<StateReader>,

--- a/crates/sui-rest-api/src/committee.rs
+++ b/crates/sui-rest-api/src/committee.rs
@@ -1,15 +1,43 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{accept::AcceptFormat, reader::StateReader, response::ResponseContent, Result};
+use crate::{
+    accept::AcceptFormat,
+    openapi::{ApiEndpoint, RouteHandler},
+    reader::StateReader,
+    response::ResponseContent,
+    RestService, Result,
+};
 use axum::extract::{Path, State};
 use sui_sdk2::types::{EpochId, ValidatorCommittee};
 use sui_types::storage::ReadStore;
 use tap::Pipe;
 
-pub const GET_LATEST_COMMITTEE_PATH: &str = "/committee";
+pub struct GetLatestCommittee;
 
-pub async fn get_latest_committee(
+impl ApiEndpoint<RestService> for GetLatestCommittee {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/committee"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        generator.subschema_for::<ValidatorCommittee>();
+        openapiv3::v3_1::Operation::default()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_latest_committee)
+    }
+}
+
+async fn get_latest_committee(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<ResponseContent<ValidatorCommittee>> {
@@ -25,9 +53,31 @@ pub async fn get_latest_committee(
     .pipe(Ok)
 }
 
-pub const GET_COMMITTEE_PATH: &str = "/committee/:epoch";
+pub struct GetCommittee;
 
-pub async fn get_committee(
+impl ApiEndpoint<RestService> for GetCommittee {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/committee/{epoch}"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        generator.subschema_for::<ValidatorCommittee>();
+        openapiv3::v3_1::Operation::default()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_committee)
+    }
+}
+
+async fn get_committee(
     Path(epoch): Path<EpochId>,
     accept: AcceptFormat,
     State(state): State<StateReader>,

--- a/crates/sui-rest-api/src/health.rs
+++ b/crates/sui-rest-api/src/health.rs
@@ -1,26 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, SystemTime};
-
+use crate::{
+    openapi::{ApiEndpoint, RouteHandler},
+    reader::StateReader,
+    RestService, Result,
+};
 use axum::{
     extract::{Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
+use std::time::{Duration, SystemTime};
 use sui_types::storage::ReadStore;
 use tap::Pipe;
 
-use crate::{reader::StateReader, Result};
+pub struct HealthCheck;
 
-pub const HEALTH_PATH: &str = "/health";
+impl ApiEndpoint<RestService> for HealthCheck {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/health"
+    }
+
+    fn handler(&self) -> crate::openapi::RouteHandler<RestService> {
+        RouteHandler::new(self.method(), health)
+    }
+}
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct Threshold {
     pub threshold_seconds: Option<u32>,
 }
 
-pub async fn health(
+async fn health(
     Query(Threshold { threshold_seconds }): Query<Threshold>,
     State(state): State<StateReader>,
 ) -> Result<impl IntoResponse> {

--- a/crates/sui-rest-api/src/objects.rs
+++ b/crates/sui-rest-api/src/objects.rs
@@ -1,8 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Page;
-use crate::{accept::AcceptFormat, reader::StateReader, response::ResponseContent, Result};
+use crate::{
+    accept::AcceptFormat,
+    openapi::{ApiEndpoint, OperationBuilder, ResponseBuilder, RouteHandler},
+    reader::StateReader,
+    response::ResponseContent,
+    Page, RestError, RestService, Result,
+};
 use axum::extract::Query;
 use axum::extract::{Path, State};
 use serde::{Deserialize, Serialize};
@@ -11,7 +16,39 @@ use sui_types::storage::{DynamicFieldIndexInfo, DynamicFieldKey};
 use sui_types::sui_sdk2_conversions::type_tag_core_to_sdk;
 use tap::Pipe;
 
-pub const GET_OBJECT_PATH: &str = "/objects/:object_id";
+pub struct GetObject;
+
+impl ApiEndpoint<RestService> for GetObject {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/objects/{object_id}"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("Objects")
+            .operation_id("GetObject")
+            .path_parameter::<ObjectId>("object_id", generator)
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .json_content::<Object>(generator)
+                    .bcs_content()
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> crate::openapi::RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_object)
+    }
+}
 
 pub async fn get_object(
     Path(object_id): Path<ObjectId>,
@@ -29,7 +66,40 @@ pub async fn get_object(
     .pipe(Ok)
 }
 
-pub const GET_OBJECT_WITH_VERSION_PATH: &str = "/objects/:object_id/version/:version";
+pub struct GetObjectWithVersion;
+
+impl ApiEndpoint<RestService> for GetObjectWithVersion {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/objects/{object_id}/version/{version}"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("Objects")
+            .operation_id("GetObjectWithVersion")
+            .path_parameter::<ObjectId>("object_id", generator)
+            .path_parameter::<Version>("version", generator)
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .json_content::<Object>(generator)
+                    .bcs_content()
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> crate::openapi::RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_object_with_version)
+    }
+}
 
 pub async fn get_object_with_version(
     Path((object_id, version)): Path<(ObjectId, Version)>,
@@ -89,14 +159,57 @@ impl From<ObjectNotFoundError> for crate::RestError {
     }
 }
 
-pub const LIST_DYNAMIC_FIELDS_PATH: &str = "/objects/:object_id/dynamic-fields";
+pub struct ListDynamicFields;
 
-pub async fn list_dynamic_fields(
+impl ApiEndpoint<RestService> for ListDynamicFields {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/objects/{object_id}/dynamic-fields"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("Objects")
+            .operation_id("ListDynamicFields")
+            .path_parameter::<ObjectId>("object_id", generator)
+            .query_parameters::<ListDynamicFieldsQueryParameters>(generator)
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .json_content::<Vec<DynamicFieldInfo>>(generator)
+                    .header::<String>(crate::types::X_SUI_CURSOR, generator)
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> crate::openapi::RouteHandler<RestService> {
+        RouteHandler::new(self.method(), list_dynamic_fields)
+    }
+}
+
+async fn list_dynamic_fields(
     Path(parent): Path<ObjectId>,
     Query(parameters): Query<ListDynamicFieldsQueryParameters>,
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<Page<DynamicFieldInfo, ObjectId>> {
+    match accept {
+        AcceptFormat::Json => {}
+        _ => {
+            return Err(RestError::new(
+                axum::http::StatusCode::BAD_REQUEST,
+                "invalid accept type",
+            ))
+        }
+    }
+
     let limit = parameters.limit();
     let start = parameters.start();
 
@@ -120,15 +233,12 @@ pub async fn list_dynamic_fields(
         None
     };
 
-    match accept {
-        AcceptFormat::Json => ResponseContent::Json(dynamic_fields),
-        AcceptFormat::Bcs => ResponseContent::Bcs(dynamic_fields),
-    }
-    .pipe(|entries| Page { entries, cursor })
-    .pipe(Ok)
+    ResponseContent::Json(dynamic_fields)
+        .pipe(|entries| Page { entries, cursor })
+        .pipe(Ok)
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ListDynamicFieldsQueryParameters {
     pub limit: Option<u32>,
     pub start: Option<ObjectId>,
@@ -146,12 +256,14 @@ impl ListDynamicFieldsQueryParameters {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, schemars::JsonSchema)]
+/// DynamicFieldInfo
 pub struct DynamicFieldInfo {
     pub parent: ObjectId,
     pub field_id: ObjectId,
     pub dynamic_field_type: DynamicFieldType,
     pub name_type: TypeTag,
+    //TODO fix the json format of this type to be base64 encoded
     pub name_value: Vec<u8>,
     /// ObjectId of the child object when `dynamic_field_type == DynamicFieldType::Object`
     pub dynamic_object_id: Option<ObjectId>,
@@ -178,7 +290,9 @@ impl From<(DynamicFieldKey, DynamicFieldIndexInfo)> for DynamicFieldInfo {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(
+    Clone, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug, schemars::JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum DynamicFieldType {
     Field,

--- a/crates/sui-rest-api/src/openapi.rs
+++ b/crates/sui-rest-api/src/openapi.rs
@@ -1,0 +1,640 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, OnceLock},
+};
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    handler::Handler,
+    http::Method,
+    response::Html,
+    routing::{get, MethodRouter},
+    Router,
+};
+use openapiv3::v3_1::{
+    Components, Header, Info, MediaType, OpenApi, Operation, Parameter, ParameterData, PathItem,
+    Paths, ReferenceOr, RequestBody, Response, SchemaObject, Tag,
+};
+use schemars::{gen::SchemaGenerator, JsonSchema};
+use tap::Pipe;
+
+pub trait ApiEndpoint<S> {
+    fn method(&self) -> Method;
+    fn path(&self) -> &'static str;
+    fn hidden(&self) -> bool {
+        false
+    }
+
+    fn operation(&self, _generator: &mut SchemaGenerator) -> Operation {
+        Operation::default()
+    }
+
+    fn handler(&self) -> RouteHandler<S>;
+}
+
+pub struct RouteHandler<S> {
+    method: axum::http::Method,
+    handler: MethodRouter<S>,
+}
+
+impl<S: Clone> RouteHandler<S> {
+    pub fn new<H, T>(method: axum::http::Method, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+        S: Send + Sync + 'static,
+    {
+        let handler = MethodRouter::new().on(method.clone().try_into().unwrap(), handler);
+
+        Self { method, handler }
+    }
+
+    pub fn method(&self) -> &axum::http::Method {
+        &self.method
+    }
+}
+
+pub struct Api<'a, S> {
+    endpoints: Vec<&'a dyn ApiEndpoint<S>>,
+    info: Info,
+}
+
+impl<'a, S> Api<'a, S> {
+    pub fn new(info: Info) -> Self {
+        Self {
+            endpoints: Vec::new(),
+            info,
+        }
+    }
+
+    pub fn register_endpoints<I: IntoIterator<Item = &'a dyn ApiEndpoint<S>>>(
+        &mut self,
+        endpoints: I,
+    ) {
+        self.endpoints.extend(endpoints);
+    }
+
+    pub fn to_router(&self) -> axum::Router<S>
+    where
+        S: Clone + Send + Sync + 'static,
+    {
+        let mut router = OpenApiDocument::new(self.openapi()).into_router();
+        for endpoint in &self.endpoints {
+            let handler = endpoint.handler();
+            assert_eq!(handler.method(), endpoint.method());
+
+            // we need to replace any path parameters wrapped in braces to be prefaced by a colon
+            // until axum updates matchit: https://github.com/tokio-rs/axum/pull/2645
+            let path = endpoint.path().replace('{', ":").replace('}', "");
+
+            router = router.route(&path, handler.handler);
+        }
+
+        router
+    }
+
+    pub fn openapi(&self) -> openapiv3::versioned::OpenApi {
+        self.gen_openapi(self.info.clone())
+    }
+
+    /// Internal routine for constructing the OpenAPI definition describing this
+    /// API in its JSON form.
+    fn gen_openapi(&self, info: Info) -> openapiv3::versioned::OpenApi {
+        let mut openapi = OpenApi {
+            info,
+            ..Default::default()
+        };
+
+        let settings = schemars::gen::SchemaSettings::draft07().with(|s| {
+            s.definitions_path = "#/components/schemas/".into();
+            s.option_add_null_type = false;
+        });
+        let mut generator = schemars::gen::SchemaGenerator::new(settings);
+        let mut tags = HashSet::new();
+
+        let paths = openapi
+            .paths
+            .get_or_insert(openapiv3::v3_1::Paths::default());
+
+        for endpoint in &self.endpoints {
+            // Skip hidden endpoints
+            if endpoint.hidden() {
+                continue;
+            }
+
+            Self::register_endpoint(*endpoint, &mut generator, paths, &mut tags);
+        }
+
+        // Add OpenApi routes themselves
+        let openapi_endpoints: [&dyn ApiEndpoint<_>; 3] =
+            [&OpenApiExplorer, &OpenApiJson, &OpenApiYaml];
+        for endpoint in openapi_endpoints {
+            Self::register_endpoint(endpoint, &mut generator, paths, &mut tags);
+        }
+
+        let components = &mut openapi.components.get_or_insert_with(Components::default);
+
+        // Add the schemas for which we generated references.
+        let schemas = &mut components.schemas;
+
+        generator
+            .into_root_schema_for::<()>()
+            .definitions
+            .into_iter()
+            .for_each(|(key, schema)| {
+                let schema_object = SchemaObject {
+                    json_schema: schema,
+                    external_docs: None,
+                    example: None,
+                };
+                schemas.insert(key, schema_object);
+            });
+
+        openapi.tags = tags
+            .into_iter()
+            .map(|tag| Tag {
+                name: tag,
+                ..Default::default()
+            })
+            .collect();
+        // Sort the tags for stability
+        openapi.tags.sort_by(|a, b| a.name.cmp(&b.name));
+
+        openapi.servers = vec![openapiv3::v3_1::Server {
+            url: "/v2".into(),
+            ..Default::default()
+        }];
+
+        openapiv3::versioned::OpenApi::Version31(openapi)
+    }
+
+    fn register_endpoint<S2>(
+        endpoint: &dyn ApiEndpoint<S2>,
+        generator: &mut schemars::gen::SchemaGenerator,
+        paths: &mut Paths,
+        tags: &mut HashSet<String>,
+    ) {
+        let path = paths
+            .paths
+            .entry(endpoint.path().to_owned())
+            .or_insert(ReferenceOr::Item(PathItem::default()));
+
+        let pathitem = match path {
+            openapiv3::v3_1::ReferenceOr::Item(ref mut item) => item,
+            _ => panic!("reference not expected"),
+        };
+
+        let method_ref = match endpoint.method() {
+            Method::DELETE => &mut pathitem.delete,
+            Method::GET => &mut pathitem.get,
+            Method::HEAD => &mut pathitem.head,
+            Method::OPTIONS => &mut pathitem.options,
+            Method::PATCH => &mut pathitem.patch,
+            Method::POST => &mut pathitem.post,
+            Method::PUT => &mut pathitem.put,
+            Method::TRACE => &mut pathitem.trace,
+            other => panic!("unexpected method `{}`", other),
+        };
+
+        let operation = endpoint.operation(generator);
+
+        // Collect tags defined by this operation
+        tags.extend(operation.tags.clone());
+
+        method_ref.replace(operation);
+    }
+}
+
+pub struct OpenApiDocument {
+    openapi: openapiv3::versioned::OpenApi,
+    json: OnceLock<Bytes>,
+    yaml: OnceLock<Bytes>,
+    ui: &'static str,
+}
+
+impl OpenApiDocument {
+    pub fn new(openapi: openapiv3::versioned::OpenApi) -> Self {
+        const OPENAPI_UI: &str = include_str!("../openapi/elements.html");
+        // const OPENAPI_UI: &str = include_str!("../openapi/swagger.html");
+
+        Self {
+            openapi,
+            json: OnceLock::new(),
+            yaml: OnceLock::new(),
+            ui: OPENAPI_UI,
+        }
+    }
+
+    fn openapi(&self) -> &openapiv3::versioned::OpenApi {
+        &self.openapi
+    }
+
+    fn json(&self) -> Bytes {
+        self.json
+            .get_or_init(|| {
+                self.openapi()
+                    .pipe(serde_json::to_string_pretty)
+                    .unwrap()
+                    .pipe(Bytes::from)
+            })
+            .clone()
+    }
+
+    fn yaml(&self) -> Bytes {
+        self.yaml
+            .get_or_init(|| {
+                self.openapi()
+                    .pipe(serde_yaml::to_string)
+                    .unwrap()
+                    .pipe(Bytes::from)
+            })
+            .clone()
+    }
+
+    fn ui(&self) -> &'static str {
+        self.ui
+    }
+
+    pub fn into_router<S>(self) -> Router<S> {
+        Router::new()
+            .route("/openapi", get(openapi_ui))
+            .route("/openapi.json", get(openapi_json))
+            .route("/openapi.yaml", get(openapi_yaml))
+            .with_state(Arc::new(self))
+    }
+}
+
+pub struct OpenApiJson;
+
+impl ApiEndpoint<Arc<OpenApiDocument>> for OpenApiJson {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/openapi.json"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("OpenApi")
+            .operation_id("openapi.json")
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .content(mime::APPLICATION_JSON.as_ref(), MediaType::default())
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> RouteHandler<Arc<OpenApiDocument>> {
+        RouteHandler::new(self.method(), openapi_json)
+    }
+}
+
+pub struct OpenApiYaml;
+
+impl ApiEndpoint<Arc<OpenApiDocument>> for OpenApiYaml {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/openapi.yaml"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("OpenApi")
+            .operation_id("openapi.yaml")
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .content(mime::TEXT_PLAIN_UTF_8.as_ref(), MediaType::default())
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> RouteHandler<Arc<OpenApiDocument>> {
+        RouteHandler::new(self.method(), openapi_yaml)
+    }
+}
+
+pub struct OpenApiExplorer;
+
+impl ApiEndpoint<Arc<OpenApiDocument>> for OpenApiExplorer {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/openapi"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("OpenApi")
+            .operation_id("OpenApi Explorer")
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .content(mime::TEXT_HTML_UTF_8.as_ref(), MediaType::default())
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> RouteHandler<Arc<OpenApiDocument>> {
+        RouteHandler::new(self.method(), openapi_ui)
+    }
+}
+
+async fn openapi_json(
+    State(document): State<Arc<OpenApiDocument>>,
+) -> impl axum::response::IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+        )],
+        document.json(),
+    )
+}
+
+async fn openapi_yaml(
+    State(document): State<Arc<OpenApiDocument>>,
+) -> impl axum::response::IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+        )],
+        document.yaml(),
+    )
+}
+
+async fn openapi_ui(State(document): State<Arc<OpenApiDocument>>) -> Html<&'static str> {
+    Html(document.ui())
+}
+
+fn path_parameter<T: JsonSchema>(
+    name: &str,
+    generator: &mut SchemaGenerator,
+) -> ReferenceOr<Parameter> {
+    let schema_object = SchemaObject {
+        json_schema: generator.subschema_for::<T>(),
+        external_docs: None,
+        example: None,
+    };
+
+    let parameter_data = ParameterData {
+        name: name.into(),
+        required: true,
+        format: openapiv3::v3_1::ParameterSchemaOrContent::Schema(schema_object),
+        description: None,
+        deprecated: None,
+        example: None,
+        examples: Default::default(),
+        explode: None,
+        extensions: Default::default(),
+    };
+
+    ReferenceOr::Item(Parameter::Path {
+        parameter_data,
+        style: openapiv3::v3_1::PathStyle::Simple,
+    })
+}
+
+fn query_parameters<T: JsonSchema>(generator: &mut SchemaGenerator) -> Vec<ReferenceOr<Parameter>> {
+    let mut params = Vec::new();
+
+    let schema = generator.root_schema_for::<T>().schema;
+
+    let Some(object) = &schema.object else {
+        return params;
+    };
+
+    for (name, schema) in &object.properties {
+        let s = schema.clone().into_object();
+
+        params.push(ReferenceOr::Item(Parameter::Query {
+            parameter_data: ParameterData {
+                name: name.clone(),
+                description: s.metadata.as_ref().and_then(|m| m.description.clone()),
+                required: object.required.contains(name),
+                format: openapiv3::v3_1::ParameterSchemaOrContent::Schema(SchemaObject {
+                    json_schema: s.into(),
+                    example: None,
+                    external_docs: None,
+                }),
+                extensions: Default::default(),
+                deprecated: None,
+                example: None,
+                examples: Default::default(),
+                explode: None,
+            },
+            allow_reserved: false,
+            style: openapiv3::v3_1::QueryStyle::Form,
+            allow_empty_value: None,
+        }));
+    }
+
+    params
+}
+
+#[derive(Default)]
+pub struct OperationBuilder {
+    inner: Operation,
+}
+
+impl OperationBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+
+    pub fn build(&mut self) -> Operation {
+        self.inner.clone()
+    }
+
+    pub fn tag<T: Into<String>>(&mut self, tag: T) -> &mut Self {
+        self.inner.tags.push(tag.into());
+        self
+    }
+
+    pub fn summary<T: Into<String>>(&mut self, summary: T) -> &mut Self {
+        self.inner.summary = Some(summary.into());
+        self
+    }
+
+    pub fn description<T: Into<String>>(&mut self, description: T) -> &mut Self {
+        self.inner.description = Some(description.into());
+        self
+    }
+
+    pub fn operation_id<T: Into<String>>(&mut self, operation_id: T) -> &mut Self {
+        self.inner.operation_id = Some(operation_id.into());
+        self
+    }
+
+    pub fn path_parameter<T: JsonSchema>(
+        &mut self,
+        name: &str,
+        generator: &mut SchemaGenerator,
+    ) -> &mut Self {
+        self.inner
+            .parameters
+            .push(path_parameter::<T>(name, generator));
+        self
+    }
+
+    pub fn query_parameters<T: JsonSchema>(
+        &mut self,
+        generator: &mut SchemaGenerator,
+    ) -> &mut Self {
+        self.inner
+            .parameters
+            .extend(query_parameters::<T>(generator));
+        self
+    }
+
+    pub fn response(&mut self, status_code: u16, response: Response) -> &mut Self {
+        let responses = self.inner.responses.get_or_insert(Default::default());
+        responses.responses.insert(
+            openapiv3::v3_1::StatusCode::Code(status_code),
+            ReferenceOr::Item(response),
+        );
+
+        self
+    }
+}
+
+#[derive(Default)]
+pub struct ResponseBuilder {
+    inner: Response,
+}
+
+impl ResponseBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+
+    pub fn build(&mut self) -> Response {
+        self.inner.clone()
+    }
+
+    pub fn header<T: JsonSchema>(
+        &mut self,
+        name: &str,
+        generator: &mut SchemaGenerator,
+    ) -> &mut Self {
+        let schema_object = SchemaObject {
+            json_schema: generator.subschema_for::<T>(),
+            external_docs: None,
+            example: None,
+        };
+
+        let header = ReferenceOr::Item(Header {
+            description: None,
+            style: Default::default(),
+            required: false,
+            deprecated: None,
+            format: openapiv3::v3_1::ParameterSchemaOrContent::Schema(schema_object),
+            example: None,
+            examples: Default::default(),
+            extensions: Default::default(),
+        });
+
+        self.inner.headers.insert(name.into(), header);
+        self
+    }
+
+    pub fn content<T: Into<String>>(
+        &mut self,
+        content_type: T,
+        media_type: MediaType,
+    ) -> &mut Self {
+        self.inner.content.insert(content_type.into(), media_type);
+        self
+    }
+
+    pub fn json_content<T: JsonSchema>(&mut self, generator: &mut SchemaGenerator) -> &mut Self {
+        let schema_object = SchemaObject {
+            json_schema: generator.subschema_for::<T>(),
+            external_docs: None,
+            example: None,
+        };
+        let media_type = MediaType {
+            schema: Some(schema_object),
+            ..Default::default()
+        };
+
+        self.content(mime::APPLICATION_JSON.as_ref(), media_type)
+    }
+
+    pub fn bcs_content(&mut self) -> &mut Self {
+        self.content(crate::APPLICATION_BCS, MediaType::default())
+    }
+}
+
+#[derive(Default)]
+pub struct RequestBodyBuilder {
+    inner: RequestBody,
+}
+
+impl RequestBodyBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+
+    pub fn build(&mut self) -> RequestBody {
+        self.inner.clone()
+    }
+
+    pub fn content<T: Into<String>>(
+        &mut self,
+        content_type: T,
+        media_type: MediaType,
+    ) -> &mut Self {
+        self.inner.content.insert(content_type.into(), media_type);
+        self
+    }
+
+    pub fn json_content<T: JsonSchema>(&mut self, generator: &mut SchemaGenerator) -> &mut Self {
+        let schema_object = SchemaObject {
+            json_schema: generator.subschema_for::<T>(),
+            external_docs: None,
+            example: None,
+        };
+        let media_type = MediaType {
+            schema: Some(schema_object),
+            ..Default::default()
+        };
+
+        self.content(mime::APPLICATION_JSON.as_ref(), media_type)
+    }
+
+    pub fn bcs_content(&mut self) -> &mut Self {
+        self.content(crate::APPLICATION_BCS, MediaType::default())
+    }
+}

--- a/crates/sui-rest-api/src/system.rs
+++ b/crates/sui-rest-api/src/system.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{accept::AcceptFormat, reader::StateReader, RestError, Result};
+use crate::{
+    accept::AcceptFormat,
+    openapi::{ApiEndpoint, RouteHandler},
+    reader::StateReader,
+    RestError, RestService, Result,
+};
 use axum::{
     extract::{Path, State},
     Json,
@@ -11,9 +16,30 @@ use std::collections::BTreeMap;
 use sui_protocol_config::{ProtocolConfig, ProtocolConfigValue, ProtocolVersion};
 use sui_sdk2::types::{Address, ObjectId};
 
-pub const GET_SYSTEM_STATE_SUMMARY_PATH: &str = "/system";
+pub struct GetSystemStateSummary;
 
-pub async fn get_system_state_summary(
+impl ApiEndpoint<RestService> for GetSystemStateSummary {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/system"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        openapiv3::v3_1::Operation::default()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_system_state_summary)
+    }
+}
+
+async fn get_system_state_summary(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<Json<SystemStateSummary>> {
@@ -441,9 +467,30 @@ impl From<sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateS
     }
 }
 
-pub const GET_CURRENT_PROTOCOL_CONFIG_PATH: &str = "/system/protocol";
+pub struct GetCurrentProtocolConfig;
 
-pub async fn get_current_protocol_config(
+impl ApiEndpoint<RestService> for GetCurrentProtocolConfig {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/system/protocol"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        openapiv3::v3_1::Operation::default()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_current_protocol_config)
+    }
+}
+
+async fn get_current_protocol_config(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<(SupportedProtocolHeaders, Json<ProtocolConfigResponse>)> {
@@ -468,9 +515,30 @@ pub async fn get_current_protocol_config(
     Ok((supported_protocol_headers(), Json(config.into())))
 }
 
-pub const GET_PROTOCOL_CONFIG_PATH: &str = "/system/protocol/:version";
+pub struct GetProtocolConfig;
 
-pub async fn get_protocol_config(
+impl ApiEndpoint<RestService> for GetProtocolConfig {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/system/protocol/{version}"
+    }
+
+    fn operation(
+        &self,
+        _generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        openapiv3::v3_1::Operation::default()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_protocol_config)
+    }
+}
+
+async fn get_protocol_config(
     Path(version): Path<u64>,
     accept: AcceptFormat,
     State(state): State<StateReader>,
@@ -572,9 +640,23 @@ impl From<ProtocolConfig> for ProtocolConfigResponse {
     }
 }
 
-pub const GET_GAS_INFO_PATH: &str = "/system/gas";
+pub struct GetGasInfo;
 
-pub async fn get_gas_info(
+impl ApiEndpoint<RestService> for GetGasInfo {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/system/gas"
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_gas_info)
+    }
+}
+
+async fn get_gas_info(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<Json<GasInfo>> {

--- a/crates/sui-rest-api/src/transactions/mod.rs
+++ b/crates/sui-rest-api/src/transactions/mod.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod execution;
-pub use execution::execute_transaction;
+pub use execution::ExecuteTransaction;
 pub use execution::ExecuteTransactionQueryParameters;
 pub use execution::TransactionExecutor;
-pub use execution::POST_EXECUTE_TRANSACTION_PATH;
 
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -15,16 +14,53 @@ use sui_sdk2::types::{
 };
 use tap::Pipe;
 
+use crate::openapi::ApiEndpoint;
+use crate::openapi::OperationBuilder;
+use crate::openapi::ResponseBuilder;
+use crate::openapi::RouteHandler;
 use crate::reader::StateReader;
 use crate::Direction;
 use crate::Page;
 use crate::RestError;
+use crate::RestService;
 use crate::Result;
 use crate::{accept::AcceptFormat, response::ResponseContent};
 
-pub const GET_TRANSACTION_PATH: &str = "/transactions/:transaction";
+pub struct GetTransaction;
 
-pub async fn get_transaction(
+impl ApiEndpoint<RestService> for GetTransaction {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/transactions/{transaction}"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("Transactions")
+            .operation_id("GetTransaction")
+            .path_parameter::<TransactionDigest>("transaction", generator)
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .json_content::<TransactionResponse>(generator)
+                    .bcs_content()
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), get_transaction)
+    }
+}
+
+async fn get_transaction(
     Path(transaction_digest): Path<TransactionDigest>,
     accept: AcceptFormat,
     State(state): State<StateReader>,
@@ -38,11 +74,12 @@ pub async fn get_transaction(
     .pipe(Ok)
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct TransactionResponse {
     pub transaction: SignedTransaction,
     pub effects: TransactionEffects,
     pub events: Option<TransactionEvents>,
+    //TODO fix format of u64s
     pub checkpoint: Option<u64>,
     pub timestamp_ms: Option<u64>,
 }
@@ -64,9 +101,43 @@ impl From<TransactionNotFoundError> for crate::RestError {
     }
 }
 
-pub const LIST_TRANSACTIONS_PATH: &str = "/transactions";
+pub struct ListTransactions;
 
-pub async fn list_transactions(
+impl ApiEndpoint<RestService> for ListTransactions {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::GET
+    }
+
+    fn path(&self) -> &'static str {
+        "/transactions"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        OperationBuilder::new()
+            .tag("Transactions")
+            .operation_id("ListTransactions")
+            .query_parameters::<ListTransactionsQueryParameters>(generator)
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .json_content::<Vec<TransactionResponse>>(generator)
+                    .bcs_content()
+                    .header::<String>(crate::types::X_SUI_CURSOR, generator)
+                    .build(),
+            )
+            .response(410, ResponseBuilder::new().build())
+            .build()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(self.method(), list_transactions)
+    }
+}
+
+async fn list_transactions(
     Query(parameters): Query<ListTransactionsQueryParameters>,
     accept: AcceptFormat,
     State(state): State<StateReader>,
@@ -184,9 +255,10 @@ impl serde::Serialize for TransactionCursor {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ListTransactionsQueryParameters {
     pub limit: Option<u32>,
+    #[schemars(with = "Option<String>")]
     pub start: Option<TransactionCursor>,
     pub direction: Option<Direction>,
 }

--- a/crates/sui-types/src/sui_sdk2_conversions.rs
+++ b/crates/sui-types/src/sui_sdk2_conversions.rs
@@ -95,9 +95,7 @@ impl From<crate::object::Owner> for Owner {
             crate::object::Owner::ObjectOwner(object_id) => Self::Object(object_id.into()),
             crate::object::Owner::Shared {
                 initial_shared_version,
-            } => Self::Shared {
-                initial_shared_version: initial_shared_version.value(),
-            },
+            } => Self::Shared(initial_shared_version.value()),
             crate::object::Owner::Immutable => Self::Immutable,
         }
     }
@@ -108,9 +106,7 @@ impl From<Owner> for crate::object::Owner {
         match value {
             Owner::Address(address) => crate::object::Owner::AddressOwner(address.into()),
             Owner::Object(object_id) => crate::object::Owner::ObjectOwner(object_id.into()),
-            Owner::Shared {
-                initial_shared_version,
-            } => crate::object::Owner::Shared {
+            Owner::Shared(initial_shared_version) => crate::object::Owner::Shared {
                 initial_shared_version: initial_shared_version.into(),
             },
             Owner::Immutable => crate::object::Owner::Immutable,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -202,7 +202,7 @@ impl<'a> ObjectRuntime<'a> {
         // remove from deleted_ids for the case in dynamic fields where the Field object was deleted
         // and then re-added in a single transaction. In that case, we also skip adding it
         // to new_ids.
-        let was_present = self.state.deleted_ids.remove(&id);
+        let was_present = self.state.deleted_ids.shift_remove(&id);
         if !was_present {
             // mark the id as new
             self.state.new_ids.insert(id);
@@ -230,7 +230,7 @@ impl<'a> ObjectRuntime<'a> {
                 ));
         };
 
-        let was_new = self.state.new_ids.remove(&id);
+        let was_new = self.state.new_ids.shift_remove(&id);
         if !was_new {
             self.state.deleted_ids.insert(id);
         }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -156,14 +156,14 @@ pub fn end_transaction(
     {
         for addr_inventory in inventories.address_inventories.values_mut() {
             for s in addr_inventory.values_mut() {
-                s.remove(id);
+                s.shift_remove(id);
             }
         }
         for s in &mut inventories.shared_inventory.values_mut() {
-            s.remove(id);
+            s.shift_remove(id);
         }
         for s in &mut inventories.immutable_inventory.values_mut() {
-            s.remove(id);
+            s.shift_remove(id);
         }
         inventories.taken.remove(id);
     }

--- a/sui-execution/v2/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v2/sui-move-natives/src/object_runtime/mod.rs
@@ -198,7 +198,7 @@ impl<'a> ObjectRuntime<'a> {
         // remove from deleted_ids for the case in dynamic fields where the Field object was deleted
         // and then re-added in a single transaction. In that case, we also skip adding it
         // to new_ids.
-        let was_present = self.state.deleted_ids.remove(&id);
+        let was_present = self.state.deleted_ids.shift_remove(&id);
         if !was_present {
             // mark the id as new
             self.state.new_ids.insert(id);
@@ -226,7 +226,7 @@ impl<'a> ObjectRuntime<'a> {
                 ));
         };
 
-        let was_new = self.state.new_ids.remove(&id);
+        let was_new = self.state.new_ids.shift_remove(&id);
         if !was_new {
             self.state.deleted_ids.insert(id);
         }

--- a/sui-execution/v2/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v2/sui-move-natives/src/test_scenario.rs
@@ -100,14 +100,14 @@ pub fn end_transaction(
     {
         for addr_inventory in inventories.address_inventories.values_mut() {
             for s in addr_inventory.values_mut() {
-                s.remove(id);
+                s.shift_remove(id);
             }
         }
         for s in &mut inventories.shared_inventory.values_mut() {
-            s.remove(id);
+            s.shift_remove(id);
         }
         for s in &mut inventories.immutable_inventory.values_mut() {
-            s.remove(id);
+            s.shift_remove(id);
         }
         inventories.taken.remove(id);
     }


### PR DESCRIPTION
## Description 

This PR introduces an OpenAPI spec for the REST api and hosts the spec and an explorer off of the main rest service. While the spec as introduced in this PR enumerates all of the available endpoints, the documentation, inputs, request and response types for all of the endpoints has not been completed and will be done in a follow up PR. The spec can be explored locally (without the actual backend service) by running:

```
OPENAPI_EXPLORER=1 cargo test -p sui-rest-api openapi_explorer
```

and navigating to `http://127.0.0.1:8000/openapi` in a browser.

The openapi spec is checked-in to the repo and a test exists to ensure that the checked-in version matches what is derived by the service. This allows for subsequent changes to the spec to be reviewed at code review time.

The api spec is still under development and is not to be considered stable yet.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
