### PR TITLE
move: canonicalize path before all uses of package path

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -863,13 +863,13 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let chain_id = client.read_api().get_chain_identifier().await.ok();
 
-                let build_config = resolve_lock_file_path(build_config, Some(&package_path))?;
                 let package_path =
                     package_path
                         .canonicalize()
                         .map_err(|e| SuiError::ModulePublishFailure {
                             error: format!("Failed to canonicalize package path: {}", e),
                         })?;
+                let build_config = resolve_lock_file_path(build_config, Some(&package_path))?;
                 let previous_id = if let Some(ref chain_id) = chain_id {
                     sui_package_management::set_package_id(
                         &package_path,
@@ -971,6 +971,12 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let chain_id = client.read_api().get_chain_identifier().await.ok();
 
+                let package_path =
+                    package_path
+                        .canonicalize()
+                        .map_err(|e| SuiError::ModulePublishFailure {
+                            error: format!("Failed to canonicalize package path: {}", e),
+                        })?;
                 let build_config = resolve_lock_file_path(build_config, Some(&package_path))?;
                 let previous_id = if let Some(ref chain_id) = chain_id {
                     sui_package_management::set_package_id(
@@ -982,12 +988,6 @@ impl SuiClientCommands {
                 } else {
                     None
                 };
-                let package_path =
-                    package_path
-                        .canonicalize()
-                        .map_err(|e| SuiError::ModulePublishFailure {
-                            error: format!("Failed to canonicalize package path: {}", e),
-                        })?;
                 let compile_result = compile_package(
                     client.read_api(),
                     build_config.clone(),


### PR DESCRIPTION
## Description 

In https://github.com/MystenLabs/sui/pull/18470 I made a change that uses the `package_path` before canonicalizing, causing relative paths to the package to not work on `publish`.

This PR reorders the statements to canonicalize the path before any uses.

## Test plan 

Tested locally, will follow up immediately with a CLI test for relative paths in a separate PR--want to plug this first.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
