### PR TITLE
[script] no need for GITHUB_TOKEN because sui is a public repo

### DIFF
--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -124,7 +124,6 @@ def extract_notes_from_rebase_commit(commit):
     url = f"https://api.github.com/repos/MystenLabs/sui/commits/{commit}/pulls"
     headers = {
         "Accept": "application/vnd.github.v3+json",
-        "Authorization": f"token {os.environ['GITHUB_TOKEN']}",
     }
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req) as response:


### PR DESCRIPTION
## Description 

Remove the Auth header because `sui` is a public repo..no need for GTIHUB_TOKEN

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
