### PR TITLE
[GraphQL][RFC] Introduce UInt53 scalar

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -172,7 +172,7 @@ type AuthenticatorStateExpireTransaction {
 	"""
 	The initial version that the AuthenticatorStateUpdate was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: Int!
+	authenticatorObjInitialSharedVersion: UInt!
 }
 
 """
@@ -186,7 +186,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Consensus round of the authenticator state update.
 	"""
-	round: Int!
+	round: UInt!
 	"""
 	Newly active JWKs (JSON Web Keys).
 	"""
@@ -194,7 +194,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	The initial version of the authenticator object that it was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: Int!
+	authenticatorObjInitialSharedVersion: UInt!
 }
 
 """
@@ -216,7 +216,7 @@ type Balance {
 	"""
 	How many coins of this type constitute the balance
 	"""
-	coinObjectCount: Int
+	coinObjectCount: UInt
 	"""
 	Total balance across all coin objects of the coin type
 	"""
@@ -311,7 +311,7 @@ scalar BigInt
 
 
 type BridgeCommitteeInitTransaction {
-	bridgeObjInitialSharedVersion: Int!
+	bridgeObjInitialSharedVersion: UInt!
 }
 
 type BridgeStateCreateTransaction {
@@ -333,7 +333,7 @@ type ChangeEpochTransaction {
 	"""
 	The protocol version in effect in the new epoch.
 	"""
-	protocolVersion: Int!
+	protocolVersion: UInt!
 	"""
 	The total amount of gas charged for storage during the previous epoch (in MIST).
 	"""
@@ -378,7 +378,7 @@ type Checkpoint {
 	This checkpoint's position in the total order of finalized checkpoints, agreed upon by
 	consensus.
 	"""
-	sequenceNumber: Int!
+	sequenceNumber: UInt!
 	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus.
 	Transactions that access time in this checkpoint will observe this timestamp.
@@ -396,7 +396,7 @@ type Checkpoint {
 	"""
 	The total number of transaction blocks in the network by the end of this checkpoint.
 	"""
-	networkTotalTransactions: Int
+	networkTotalTransactions: UInt
 	"""
 	The computation cost, storage cost, storage rebate, and non-refundable storage fee
 	accumulated during this epoch, up to and including this checkpoint. These values increase
@@ -447,7 +447,7 @@ Filter either by the digest, or the sequence number, or neither, to get the late
 """
 input CheckpointId {
 	digest: String
-	sequenceNumber: Int
+	sequenceNumber: UInt
 }
 
 """
@@ -487,7 +487,7 @@ type Coin implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -646,7 +646,7 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -761,7 +761,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Consensus round of the commit.
 	"""
-	round: Int!
+	round: UInt!
 	"""
 	Unix timestamp from consensus.
 	"""
@@ -996,7 +996,7 @@ type Epoch {
 	"""
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
-	epochId: Int!
+	epochId: UInt!
 	"""
 	The minimum gas price that a quorum of validators are guaranteed to sign a transaction for.
 	"""
@@ -1016,11 +1016,11 @@ type Epoch {
 	"""
 	The total number of checkpoints in this epoch.
 	"""
-	totalCheckpoints: BigInt
+	totalCheckpoints: UInt
 	"""
 	The total number of transaction blocks in this epoch.
 	"""
-	totalTransactions: Int
+	totalTransactions: UInt
 	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
@@ -1073,7 +1073,7 @@ type Epoch {
 	version changes whenever the fields contained in the system state object (held in a dynamic
 	field attached to `0x5`) change.
 	"""
-	systemStateVersion: Int
+	systemStateVersion: UInt
 	"""
 	Details of the system that are decided during genesis.
 	"""
@@ -1404,7 +1404,7 @@ Interface implemented by on-chain values that are addressable by an ID (also ref
 address). This includes Move objects and packages.
 """
 interface IObject {
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
 	"""
@@ -1515,7 +1515,7 @@ type Linkage {
 	"""
 	The version of the dependency that this package depends on.
 	"""
-	version: Int!
+	version: UInt!
 }
 
 """
@@ -1942,7 +1942,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2125,7 +2125,7 @@ type MovePackage implements IObject & IOwner {
 	cannot be owned by an address.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2461,7 +2461,7 @@ type Object implements IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2660,7 +2660,7 @@ input ObjectFilter {
 
 input ObjectKey {
 	objectId: SuiAddress!
-	version: Int!
+	version: UInt!
 }
 
 enum ObjectKind {
@@ -2693,7 +2693,7 @@ input ObjectRef {
 	"""
 	Version or sequence number of the object.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	Digest of the object.
 	"""
@@ -2751,7 +2751,7 @@ type OwnedOrImmutable {
 	"""
 	Version of the object being read.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -2935,7 +2935,7 @@ type ProtocolConfigs {
 	The protocol is not required to change on every epoch boundary, so the protocol version
 	tracks which change to the protocol these configs are from.
 	"""
-	protocolVersion: Int!
+	protocolVersion: UInt!
 	"""
 	List all available feature flags and their values.  Feature flags are a form of boolean
 	configuration that are usually used to gate features while they are in development.  Once a
@@ -3021,7 +3021,7 @@ type Query {
 	The object corresponding to the given address at the (optionally) given version.
 	When no version is given, the latest version is returned.
 	"""
-	object(address: SuiAddress!, version: Int): Object
+	object(address: SuiAddress!, version: UInt): Object
 	"""
 	Look-up an Account by its SuiAddress.
 	"""
@@ -3034,7 +3034,7 @@ type Query {
 	"""
 	Fetch epoch information by ID (defaults to the latest epoch).
 	"""
-	epoch(id: Int): Epoch
+	epoch(id: UInt): Epoch
 	"""
 	Fetch checkpoint information by sequence number or digest (defaults to the latest available
 	checkpoint).
@@ -3071,7 +3071,7 @@ type Query {
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).
 	"""
-	protocolConfig(protocolVersion: Int): ProtocolConfigs!
+	protocolConfig(protocolVersion: UInt): ProtocolConfigs!
 	"""
 	Resolves a SuiNS `domain` name to an address, if it has been bound.
 	"""
@@ -3114,7 +3114,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	Randomness round of the update.
 	"""
-	randomnessRound: Int!
+	randomnessRound: UInt!
 	"""
 	Updated random bytes, encoded as Base64.
 	"""
@@ -3122,7 +3122,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	The initial version the randomness object was shared at.
 	"""
-	randomnessObjInitialSharedVersion: Int!
+	randomnessObjInitialSharedVersion: UInt!
 }
 
 """
@@ -3136,7 +3136,7 @@ type Receiving {
 	"""
 	Version of the object being read.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3220,7 +3220,7 @@ type ServiceConfig {
 	Maximum estimated cost of a database query used to serve a GraphQL request.  This is
 	measured in the same units that the database uses in EXPLAIN queries.
 	"""
-	maxDbQueryCost: BigInt!
+	maxDbQueryCost: Int!
 	"""
 	Default number of elements allowed on a single page of a connection.
 	"""
@@ -3269,7 +3269,7 @@ A shared object is an object that is shared using the 0x2::transfer::share_objec
 Unlike owned objects, once an object is shared, it stays mutable and is accessible by anyone.
 """
 type Shared {
-	initialSharedVersion: Int!
+	initialSharedVersion: UInt!
 }
 
 """
@@ -3280,7 +3280,7 @@ type SharedInput {
 	"""
 	The version that this this object was shared at.
 	"""
-	initialSharedVersion: Int!
+	initialSharedVersion: UInt!
 	"""
 	Controls whether the transaction block can reference the shared object as a mutable
 	reference or by value. This has implications for scheduling: Transactions that just read
@@ -3302,7 +3302,7 @@ type SharedObjectCancelled {
 	"""
 	The assigned shared object version. It is a special version indicating transaction cancellation reason.
 	"""
-	version: Int!
+	version: UInt!
 }
 
 """
@@ -3318,7 +3318,7 @@ type SharedObjectDelete {
 	The version of the shared object that was assigned to this transaction during by consensus,
 	during sequencing.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	Whether this transaction intended to use this shared object mutably or not. See
 	`SharedInput.mutable` for further details.
@@ -3337,7 +3337,7 @@ type SharedObjectRead {
 	"""
 	Version of the object being read.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3449,7 +3449,7 @@ type StakedSui implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3651,7 +3651,7 @@ type SuinsRegistration implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3777,7 +3777,7 @@ type SystemParameters {
 	"""
 	The epoch at which stake subsidies start being paid out.
 	"""
-	stakeSubsidyStartEpoch: Int
+	stakeSubsidyStartEpoch: UInt
 	"""
 	The minimum number of active validators that the system supports.
 	"""
@@ -3902,7 +3902,7 @@ type TransactionBlockEffects {
 	The latest version of all objects (apart from packages) that have been created or modified
 	by this transaction, immediately following this transaction.
 	"""
-	lamportVersion: Int!
+	lamportVersion: UInt!
 	"""
 	The reason for a transaction failure, if it did fail.
 	If the error is a Move abort, the error message will be resolved to a human-readable form if
@@ -3958,9 +3958,9 @@ input TransactionBlockFilter {
 	An input filter selecting for either system or programmable transactions.
 	"""
 	kind: TransactionBlockKindInput
-	afterCheckpoint: Int
-	atCheckpoint: Int
-	beforeCheckpoint: Int
+	afterCheckpoint: UInt
+	atCheckpoint: UInt
+	beforeCheckpoint: UInt
 	signAddress: SuiAddress
 	recvAddress: SuiAddress
 	inputObject: SuiAddress
@@ -4028,9 +4028,9 @@ to the sender.
 """
 input TransactionMetadata {
 	sender: SuiAddress
-	gasPrice: Int
+	gasPrice: UInt
 	gasObjects: [ObjectRef!]
-	gasBudget: Int
+	gasBudget: UInt
 	gasSponsor: SuiAddress
 }
 
@@ -4066,6 +4066,12 @@ type TypeOrigin {
 	"""
 	definingId: SuiAddress!
 }
+
+"""
+An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
+but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
+"""
+scalar UInt
 
 """
 Details pertaining to shared objects that are referenced by but not changed by a transaction.
@@ -4184,11 +4190,11 @@ type Validator {
 	"""
 	Number of exchange rates in the table.
 	"""
-	exchangeRatesSize: Int
+	exchangeRatesSize: UInt
 	"""
 	The epoch at which this pool became active.
 	"""
-	stakingPoolActivationEpoch: Int
+	stakingPoolActivationEpoch: UInt
 	"""
 	The total number of SUI tokens in this pool.
 	"""
@@ -4242,7 +4248,7 @@ type Validator {
 	The number of epochs for which this validator has been below the
 	low stake threshold.
 	"""
-	atRisk: Int
+	atRisk: UInt
 	"""
 	The addresses of other validators this validator has reported.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -172,7 +172,7 @@ type AuthenticatorStateExpireTransaction {
 	"""
 	The initial version that the AuthenticatorStateUpdate was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: UInt!
+	authenticatorObjInitialSharedVersion: UInt53!
 }
 
 """
@@ -186,7 +186,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Consensus round of the authenticator state update.
 	"""
-	round: UInt!
+	round: UInt53!
 	"""
 	Newly active JWKs (JSON Web Keys).
 	"""
@@ -194,7 +194,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	The initial version of the authenticator object that it was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: UInt!
+	authenticatorObjInitialSharedVersion: UInt53!
 }
 
 """
@@ -216,7 +216,7 @@ type Balance {
 	"""
 	How many coins of this type constitute the balance
 	"""
-	coinObjectCount: UInt
+	coinObjectCount: UInt53
 	"""
 	Total balance across all coin objects of the coin type
 	"""
@@ -311,7 +311,7 @@ scalar BigInt
 
 
 type BridgeCommitteeInitTransaction {
-	bridgeObjInitialSharedVersion: UInt!
+	bridgeObjInitialSharedVersion: UInt53!
 }
 
 type BridgeStateCreateTransaction {
@@ -333,7 +333,7 @@ type ChangeEpochTransaction {
 	"""
 	The protocol version in effect in the new epoch.
 	"""
-	protocolVersion: UInt!
+	protocolVersion: UInt53!
 	"""
 	The total amount of gas charged for storage during the previous epoch (in MIST).
 	"""
@@ -378,7 +378,7 @@ type Checkpoint {
 	This checkpoint's position in the total order of finalized checkpoints, agreed upon by
 	consensus.
 	"""
-	sequenceNumber: UInt!
+	sequenceNumber: UInt53!
 	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus.
 	Transactions that access time in this checkpoint will observe this timestamp.
@@ -396,7 +396,7 @@ type Checkpoint {
 	"""
 	The total number of transaction blocks in the network by the end of this checkpoint.
 	"""
-	networkTotalTransactions: UInt
+	networkTotalTransactions: UInt53
 	"""
 	The computation cost, storage cost, storage rebate, and non-refundable storage fee
 	accumulated during this epoch, up to and including this checkpoint. These values increase
@@ -447,7 +447,7 @@ Filter either by the digest, or the sequence number, or neither, to get the late
 """
 input CheckpointId {
 	digest: String
-	sequenceNumber: UInt
+	sequenceNumber: UInt53
 }
 
 """
@@ -487,7 +487,7 @@ type Coin implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -646,7 +646,7 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -761,7 +761,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Consensus round of the commit.
 	"""
-	round: UInt!
+	round: UInt53!
 	"""
 	Unix timestamp from consensus.
 	"""
@@ -996,7 +996,7 @@ type Epoch {
 	"""
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
-	epochId: UInt!
+	epochId: UInt53!
 	"""
 	The minimum gas price that a quorum of validators are guaranteed to sign a transaction for.
 	"""
@@ -1016,11 +1016,11 @@ type Epoch {
 	"""
 	The total number of checkpoints in this epoch.
 	"""
-	totalCheckpoints: UInt
+	totalCheckpoints: UInt53
 	"""
 	The total number of transaction blocks in this epoch.
 	"""
-	totalTransactions: UInt
+	totalTransactions: UInt53
 	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
@@ -1073,7 +1073,7 @@ type Epoch {
 	version changes whenever the fields contained in the system state object (held in a dynamic
 	field attached to `0x5`) change.
 	"""
-	systemStateVersion: UInt
+	systemStateVersion: UInt53
 	"""
 	Details of the system that are decided during genesis.
 	"""
@@ -1404,7 +1404,7 @@ Interface implemented by on-chain values that are addressable by an ID (also ref
 address). This includes Move objects and packages.
 """
 interface IObject {
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
 	"""
@@ -1515,7 +1515,7 @@ type Linkage {
 	"""
 	The version of the dependency that this package depends on.
 	"""
-	version: UInt!
+	version: UInt53!
 }
 
 """
@@ -1942,7 +1942,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2125,7 +2125,7 @@ type MovePackage implements IObject & IOwner {
 	cannot be owned by an address.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2461,7 +2461,7 @@ type Object implements IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2660,7 +2660,7 @@ input ObjectFilter {
 
 input ObjectKey {
 	objectId: SuiAddress!
-	version: UInt!
+	version: UInt53!
 }
 
 enum ObjectKind {
@@ -2693,7 +2693,7 @@ input ObjectRef {
 	"""
 	Version or sequence number of the object.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	Digest of the object.
 	"""
@@ -2751,7 +2751,7 @@ type OwnedOrImmutable {
 	"""
 	Version of the object being read.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -2935,7 +2935,7 @@ type ProtocolConfigs {
 	The protocol is not required to change on every epoch boundary, so the protocol version
 	tracks which change to the protocol these configs are from.
 	"""
-	protocolVersion: UInt!
+	protocolVersion: UInt53!
 	"""
 	List all available feature flags and their values.  Feature flags are a form of boolean
 	configuration that are usually used to gate features while they are in development.  Once a
@@ -3021,7 +3021,7 @@ type Query {
 	The object corresponding to the given address at the (optionally) given version.
 	When no version is given, the latest version is returned.
 	"""
-	object(address: SuiAddress!, version: UInt): Object
+	object(address: SuiAddress!, version: UInt53): Object
 	"""
 	Look-up an Account by its SuiAddress.
 	"""
@@ -3034,7 +3034,7 @@ type Query {
 	"""
 	Fetch epoch information by ID (defaults to the latest epoch).
 	"""
-	epoch(id: UInt): Epoch
+	epoch(id: UInt53): Epoch
 	"""
 	Fetch checkpoint information by sequence number or digest (defaults to the latest available
 	checkpoint).
@@ -3071,7 +3071,7 @@ type Query {
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).
 	"""
-	protocolConfig(protocolVersion: UInt): ProtocolConfigs!
+	protocolConfig(protocolVersion: UInt53): ProtocolConfigs!
 	"""
 	Resolves a SuiNS `domain` name to an address, if it has been bound.
 	"""
@@ -3114,7 +3114,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	Randomness round of the update.
 	"""
-	randomnessRound: UInt!
+	randomnessRound: UInt53!
 	"""
 	Updated random bytes, encoded as Base64.
 	"""
@@ -3122,7 +3122,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	The initial version the randomness object was shared at.
 	"""
-	randomnessObjInitialSharedVersion: UInt!
+	randomnessObjInitialSharedVersion: UInt53!
 }
 
 """
@@ -3136,7 +3136,7 @@ type Receiving {
 	"""
 	Version of the object being read.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3269,7 +3269,7 @@ A shared object is an object that is shared using the 0x2::transfer::share_objec
 Unlike owned objects, once an object is shared, it stays mutable and is accessible by anyone.
 """
 type Shared {
-	initialSharedVersion: UInt!
+	initialSharedVersion: UInt53!
 }
 
 """
@@ -3280,7 +3280,7 @@ type SharedInput {
 	"""
 	The version that this this object was shared at.
 	"""
-	initialSharedVersion: UInt!
+	initialSharedVersion: UInt53!
 	"""
 	Controls whether the transaction block can reference the shared object as a mutable
 	reference or by value. This has implications for scheduling: Transactions that just read
@@ -3302,7 +3302,7 @@ type SharedObjectCancelled {
 	"""
 	The assigned shared object version. It is a special version indicating transaction cancellation reason.
 	"""
-	version: UInt!
+	version: UInt53!
 }
 
 """
@@ -3318,7 +3318,7 @@ type SharedObjectDelete {
 	The version of the shared object that was assigned to this transaction during by consensus,
 	during sequencing.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	Whether this transaction intended to use this shared object mutably or not. See
 	`SharedInput.mutable` for further details.
@@ -3337,7 +3337,7 @@ type SharedObjectRead {
 	"""
 	Version of the object being read.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3449,7 +3449,7 @@ type StakedSui implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3651,7 +3651,7 @@ type SuinsRegistration implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3777,7 +3777,7 @@ type SystemParameters {
 	"""
 	The epoch at which stake subsidies start being paid out.
 	"""
-	stakeSubsidyStartEpoch: UInt
+	stakeSubsidyStartEpoch: UInt53
 	"""
 	The minimum number of active validators that the system supports.
 	"""
@@ -3902,7 +3902,7 @@ type TransactionBlockEffects {
 	The latest version of all objects (apart from packages) that have been created or modified
 	by this transaction, immediately following this transaction.
 	"""
-	lamportVersion: UInt!
+	lamportVersion: UInt53!
 	"""
 	The reason for a transaction failure, if it did fail.
 	If the error is a Move abort, the error message will be resolved to a human-readable form if
@@ -3958,9 +3958,9 @@ input TransactionBlockFilter {
 	An input filter selecting for either system or programmable transactions.
 	"""
 	kind: TransactionBlockKindInput
-	afterCheckpoint: UInt
-	atCheckpoint: UInt
-	beforeCheckpoint: UInt
+	afterCheckpoint: UInt53
+	atCheckpoint: UInt53
+	beforeCheckpoint: UInt53
 	signAddress: SuiAddress
 	recvAddress: SuiAddress
 	inputObject: SuiAddress
@@ -4028,9 +4028,9 @@ to the sender.
 """
 input TransactionMetadata {
 	sender: SuiAddress
-	gasPrice: UInt
+	gasPrice: UInt53
 	gasObjects: [ObjectRef!]
-	gasBudget: UInt
+	gasBudget: UInt53
 	gasSponsor: SuiAddress
 }
 
@@ -4071,7 +4071,7 @@ type TypeOrigin {
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
 but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
 """
-scalar UInt
+scalar UInt53
 
 """
 Details pertaining to shared objects that are referenced by but not changed by a transaction.
@@ -4190,11 +4190,11 @@ type Validator {
 	"""
 	Number of exchange rates in the table.
 	"""
-	exchangeRatesSize: UInt
+	exchangeRatesSize: UInt53
 	"""
 	The epoch at which this pool became active.
 	"""
-	stakingPoolActivationEpoch: UInt
+	stakingPoolActivationEpoch: UInt53
 	"""
 	The total number of SUI tokens in this pool.
 	"""
@@ -4248,7 +4248,7 @@ type Validator {
 	The number of epochs for which this validator has been below the
 	low stake threshold.
 	"""
-	atRisk: UInt
+	atRisk: UInt53
 	"""
 	The addresses of other validators this validator has reported.
 	"""

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::functional_group::FunctionalGroup;
-use crate::types::big_int::BigInt;
 use async_graphql::*;
 use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
 use serde::{Deserialize, Serialize};
@@ -67,23 +66,23 @@ pub struct Limits {
     /// Maximum number of nodes in the requests.
     pub max_query_nodes: u32,
     /// Maximum number of output nodes allowed in the response.
-    pub max_output_nodes: u64,
+    pub max_output_nodes: u32,
     /// Maximum size (in bytes) of a GraphQL request.
     pub max_query_payload_size: u32,
     /// Queries whose EXPLAIN cost are more than this will be logged. Given in the units used by the
     /// database (where 1.0 is roughly the cost of a sequential page access).
-    pub max_db_query_cost: u64,
+    pub max_db_query_cost: u32,
     /// Paginated queries will return this many elements if a page size is not provided.
-    pub default_page_size: u64,
+    pub default_page_size: u32,
     /// Paginated queries can return at most this many elements.
-    pub max_page_size: u64,
+    pub max_page_size: u32,
     /// Time (in milliseconds) to wait for a transaction to be executed and the results returned
     /// from GraphQL. If the transaction takes longer than this time to execute, the request will
     /// return a timeout error, but the transaction may continue executing.
-    pub mutation_timeout_ms: u64,
+    pub mutation_timeout_ms: u32,
     /// Time (in milliseconds) to wait for a read request from the GraphQL service. Requests that
     /// take longer than this time to return a result will return a timeout error.
-    pub request_timeout_ms: u64,
+    pub request_timeout_ms: u32,
     /// Maximum amount of nesting among type arguments (type arguments nest when a type argument is
     /// itself generic and has arguments).
     pub max_type_argument_depth: u32,
@@ -223,23 +222,23 @@ impl ServiceConfig {
     /// with a connection of first: 10 and has a field to a connection with last: 20, the count
     /// at the second level would be 200 nodes. This is then summed to the count of 10 nodes
     /// at the first level, for a total of 210 nodes.
-    pub async fn max_output_nodes(&self) -> u64 {
+    pub async fn max_output_nodes(&self) -> u32 {
         self.limits.max_output_nodes
     }
 
     /// Maximum estimated cost of a database query used to serve a GraphQL request.  This is
     /// measured in the same units that the database uses in EXPLAIN queries.
-    async fn max_db_query_cost(&self) -> BigInt {
-        BigInt::from(self.limits.max_db_query_cost)
+    async fn max_db_query_cost(&self) -> u32 {
+        self.limits.max_db_query_cost
     }
 
     /// Default number of elements allowed on a single page of a connection.
-    async fn default_page_size(&self) -> u64 {
+    async fn default_page_size(&self) -> u32 {
         self.limits.default_page_size
     }
 
     /// Maximum number of elements allowed on a single page of a connection.
-    async fn max_page_size(&self) -> u64 {
+    async fn max_page_size(&self) -> u32 {
         self.limits.max_page_size
     }
 
@@ -247,12 +246,12 @@ impl ServiceConfig {
     /// a transaction to execute. Note that the transaction may still succeed even in the case of a
     /// timeout. Transactions are idempotent, so a transaction that times out should be resubmitted
     /// until the network returns a definite response (success or failure, not timeout).
-    async fn mutation_timeout_ms(&self) -> u64 {
+    async fn mutation_timeout_ms(&self) -> u32 {
         self.limits.mutation_timeout_ms
     }
 
     /// Maximum time in milliseconds that will be spent to serve one query request.
-    async fn request_timeout_ms(&self) -> u64 {
+    async fn request_timeout_ms(&self) -> u32 {
         self.limits.request_timeout_ms
     }
 

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -25,7 +25,7 @@ pub(crate) struct PgExecutor {
 }
 
 pub(crate) struct PgConnection<'c> {
-    max_cost: u64,
+    max_cost: u32,
     conn: &'c mut diesel::PgConnection,
 }
 
@@ -147,7 +147,7 @@ mod query_cost {
     }
 
     /// Run `EXPLAIN` on the `query`, and log the estimated cost.
-    pub(crate) fn log<Q>(conn: &mut PgConnection, max_db_query_cost: u64, query: Q)
+    pub(crate) fn log<Q>(conn: &mut PgConnection, max_db_query_cost: u32, query: Q)
     where
         Q: Query + QueryId + QueryFragment<Pg> + RunQueryDsl<PgConnection>,
     {

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -70,7 +70,7 @@ pub enum Error {
     #[error("'first' and 'last' must not be used together")]
     CursorNoFirstLast,
     #[error("Connection's page size of {0} exceeds max of {1}")]
-    PageTooLarge(u64, u64),
+    PageTooLarge(u64, u32),
     // Catch-all for client-fault errors
     #[error("{0}")]
     Client(String),

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -31,7 +31,7 @@ pub(crate) struct ShowUsage;
 #[derive(Clone, Debug, Default)]
 struct ValidationRes {
     input_nodes: u32,
-    output_nodes: u64,
+    output_nodes: u32,
     depth: u32,
     num_variables: u32,
     num_fragments: u32,
@@ -73,7 +73,7 @@ impl ExtensionFactory for QueryLimitsChecker {
 #[derive(Debug)]
 struct ComponentCost {
     pub input_nodes: u32,
-    pub output_nodes: u64,
+    pub output_nodes: u32,
     pub depth: u32,
 }
 
@@ -234,7 +234,7 @@ impl QueryLimitsChecker {
         // Use BFS to analyze the query and count the number of nodes and the depth of the query
         struct ToVisit<'s> {
             selection: &'s Positioned<Selection>,
-            parent_node_count: u64,
+            parent_node_count: u32,
         }
 
         // Queue to store the nodes at each level
@@ -431,8 +431,8 @@ fn check_directives(directives: &[Positioned<Directive>]) -> ServerResult<()> {
 fn estimate_output_nodes_for_curr_node(
     f: &Positioned<Field>,
     variables: &Variables,
-    default_page_size: u64,
-) -> u64 {
+    default_page_size: u32,
+) -> u32 {
     if !is_connection(f) {
         1
     } else {
@@ -447,10 +447,10 @@ fn estimate_output_nodes_for_curr_node(
 }
 
 /// Try to extract a u64 value from the given argument, or return None on failure.
-fn extract_limit(value: Option<&Positioned<GqlValue>>, variables: &Variables) -> Option<u64> {
+fn extract_limit(value: Option<&Positioned<GqlValue>>, variables: &Variables) -> Option<u32> {
     if let GqlValue::Variable(var) = &value?.node {
         return match variables.get(var) {
-            Some(Value::Number(num)) => num.as_u64(),
+            Some(Value::Number(num)) => num.as_u64().map(|v| v as u32),
             _ => None,
         };
     }
@@ -458,7 +458,7 @@ fn extract_limit(value: Option<&Positioned<GqlValue>>, variables: &Variables) ->
     let GqlValue::Number(value) = &value?.node else {
         return None;
     };
-    value.as_u64()
+    value.as_u64().map(|v| v as u32)
 }
 
 /// Checks if the given field is a connection field by whether it has 'edges' or 'nodes' selected.

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -446,7 +446,7 @@ fn estimate_output_nodes_for_curr_node(
     }
 }
 
-/// Try to extract a u64 value from the given argument, or return None on failure.
+/// Try to extract a u32 value from the given argument, or return None on failure.
 fn extract_limit(value: Option<&Positioned<GqlValue>>, variables: &Variables) -> Option<u32> {
     if let GqlValue::Variable(var) = &value?.node {
         return match variables.get(var) {

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -71,9 +71,9 @@ impl Extension for TimeoutExt {
         // increase the timeout if the request is a mutation
         let is_mutation = self.is_mutation.load(Ordering::Relaxed);
         let request_timeout = if is_mutation {
-            Duration::from_millis(cfg.limits.mutation_timeout_ms)
+            Duration::from_millis(cfg.limits.mutation_timeout_ms.into())
         } else {
-            Duration::from_millis(cfg.limits.request_timeout_ms)
+            Duration::from_millis(cfg.limits.request_timeout_ms.into())
         };
 
         timeout(request_timeout, next.run(ctx, operation_name))

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -420,7 +420,7 @@ impl ServerBuilder {
             // Bound each statement in a request with the overall request timeout, to bound DB
             // utilisation (in the worst case we will use 2x the request timeout time in DB wall
             // time).
-            config.service.limits.request_timeout_ms,
+            config.service.limits.request_timeout_ms.into(),
         )
         .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
 
@@ -688,7 +688,7 @@ pub mod tests {
         let reader = PgManager::reader_with_config(
             connection_config.db_url.clone(),
             connection_config.db_pool_size,
-            service_config.limits.request_timeout_ms,
+            service_config.limits.request_timeout_ms.into(),
         )
         .expect("Failed to create pg connection pool");
 
@@ -771,8 +771,8 @@ pub mod tests {
             sui_client: &SuiClient,
         ) -> Response {
             let mut cfg = ServiceConfig::default();
-            cfg.limits.request_timeout_ms = timeout.as_millis() as u64;
-            cfg.limits.mutation_timeout_ms = timeout.as_millis() as u64;
+            cfg.limits.request_timeout_ms = timeout.as_millis() as u32;
+            cfg.limits.mutation_timeout_ms = timeout.as_millis() as u32;
 
             let schema = prep_schema(None, Some(cfg))
                 .context_data(Some(sui_client.clone()))

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -3,7 +3,7 @@
 
 use super::available_range::AvailableRange;
 use super::cursor::{self, Page, RawPaginated, Target};
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
 use crate::consistency::Checkpointed;
 use crate::data::{Db, DbConnection, QueryExecutor};
@@ -27,7 +27,7 @@ pub(crate) struct Balance {
     /// Coin type for the balance, such as 0x2::sui::SUI
     pub(crate) coin_type: MoveType,
     /// How many coins of this type constitute the balance
-    pub(crate) coin_object_count: Option<UInt>,
+    pub(crate) coin_object_count: Option<UInt53>,
     /// Total balance across all coin objects of the coin type
     pub(crate) total_balance: Option<BigInt>,
 }
@@ -175,7 +175,7 @@ impl TryFrom<StoredBalance> for Balance {
             .transpose()
             .map_err(|_| Error::Internal("Failed to read balance.".to_string()))?;
 
-        let coin_object_count = count.map(|c| UInt::from(c as u64));
+        let coin_object_count = count.map(|c| UInt53::from(c as u64));
 
         let coin_type = MoveType::new(
             parse_sui_type_tag(&coin_type)

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -3,6 +3,7 @@
 
 use super::available_range::AvailableRange;
 use super::cursor::{self, Page, RawPaginated, Target};
+use super::uint::UInt;
 use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
 use crate::consistency::Checkpointed;
 use crate::data::{Db, DbConnection, QueryExecutor};
@@ -26,7 +27,7 @@ pub(crate) struct Balance {
     /// Coin type for the balance, such as 0x2::sui::SUI
     pub(crate) coin_type: MoveType,
     /// How many coins of this type constitute the balance
-    pub(crate) coin_object_count: Option<u64>,
+    pub(crate) coin_object_count: Option<UInt>,
     /// Total balance across all coin objects of the coin type
     pub(crate) total_balance: Option<BigInt>,
 }
@@ -174,7 +175,7 @@ impl TryFrom<StoredBalance> for Balance {
             .transpose()
             .map_err(|_| Error::Internal("Failed to read balance.".to_string()))?;
 
-        let coin_object_count = count.map(|c| c as u64);
+        let coin_object_count = count.map(|c| UInt::from(c as u64));
 
         let coin_type = MoveType::new(
             parse_sui_type_tag(&coin_type)

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -11,6 +11,7 @@ use super::{
     epoch::Epoch,
     gas::GasCostSummary,
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
+    uint::UInt,
 };
 use crate::consistency::Checkpointed;
 use crate::{
@@ -32,7 +33,7 @@ use sui_types::messages_checkpoint::CheckpointDigest;
 #[derive(Default, InputObject)]
 pub(crate) struct CheckpointId {
     pub digest: Option<Digest>,
-    pub sequence_number: Option<u64>,
+    pub sequence_number: Option<UInt>,
 }
 
 /// DataLoader key for fetching a `Checkpoint` by its sequence number, constrained by a consistency
@@ -90,8 +91,8 @@ impl Checkpoint {
 
     /// This checkpoint's position in the total order of finalized checkpoints, agreed upon by
     /// consensus.
-    async fn sequence_number(&self) -> u64 {
-        self.sequence_number_impl()
+    async fn sequence_number(&self) -> UInt {
+        self.sequence_number_impl().into()
     }
 
     /// The timestamp at which the checkpoint is agreed to have happened according to consensus.
@@ -115,8 +116,8 @@ impl Checkpoint {
     }
 
     /// The total number of transaction blocks in the network by the end of this checkpoint.
-    async fn network_total_transactions(&self) -> Option<u64> {
-        Some(self.network_total_transactions_impl())
+    async fn network_total_transactions(&self) -> Option<UInt> {
+        Some(self.network_total_transactions_impl().into())
     }
 
     /// The computation cost, storage cost, storage rebate, and non-refundable storage fee
@@ -157,7 +158,7 @@ impl Checkpoint {
         let Some(filter) = filter
             .unwrap_or_default()
             .intersect(TransactionBlockFilter {
-                at_checkpoint: Some(self.stored.sequence_number as u64),
+                at_checkpoint: Some(UInt::from(self.stored.sequence_number as u64)),
                 ..Default::default()
             })
         else {
@@ -178,7 +179,7 @@ impl Checkpoint {
 impl CheckpointId {
     pub(crate) fn by_seq_num(seq_num: u64) -> Self {
         CheckpointId {
-            sequence_number: Some(seq_num),
+            sequence_number: Some(seq_num.into()),
             digest: None,
         }
     }
@@ -213,7 +214,7 @@ impl Checkpoint {
             } => {
                 let DataLoader(dl) = ctx.data_unchecked();
                 dl.load_one(SeqNumKey {
-                    sequence_number,
+                    sequence_number: sequence_number.into(),
                     digest,
                     checkpoint_viewed_at,
                 })

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -11,7 +11,7 @@ use super::{
     epoch::Epoch,
     gas::GasCostSummary,
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
-    uint::UInt,
+    uint53::UInt53,
 };
 use crate::consistency::Checkpointed;
 use crate::{
@@ -33,7 +33,7 @@ use sui_types::messages_checkpoint::CheckpointDigest;
 #[derive(Default, InputObject)]
 pub(crate) struct CheckpointId {
     pub digest: Option<Digest>,
-    pub sequence_number: Option<UInt>,
+    pub sequence_number: Option<UInt53>,
 }
 
 /// DataLoader key for fetching a `Checkpoint` by its sequence number, constrained by a consistency
@@ -91,7 +91,7 @@ impl Checkpoint {
 
     /// This checkpoint's position in the total order of finalized checkpoints, agreed upon by
     /// consensus.
-    async fn sequence_number(&self) -> UInt {
+    async fn sequence_number(&self) -> UInt53 {
         self.sequence_number_impl().into()
     }
 
@@ -116,7 +116,7 @@ impl Checkpoint {
     }
 
     /// The total number of transaction blocks in the network by the end of this checkpoint.
-    async fn network_total_transactions(&self) -> Option<UInt> {
+    async fn network_total_transactions(&self) -> Option<UInt53> {
         Some(self.network_total_transactions_impl().into())
     }
 
@@ -158,7 +158,7 @@ impl Checkpoint {
         let Some(filter) = filter
             .unwrap_or_default()
             .intersect(TransactionBlockFilter {
-                at_checkpoint: Some(UInt::from(self.stored.sequence_number as u64)),
+                at_checkpoint: Some(UInt53::from(self.stored.sequence_number as u64)),
                 ..Default::default()
             })
         else {

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -23,6 +23,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
+use super::uint::UInt;
 use async_graphql::*;
 
 use async_graphql::connection::{Connection, CursorType, Edge};
@@ -150,7 +151,7 @@ impl Coin {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -23,7 +23,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use async_graphql::*;
 
 use async_graphql::connection::{Connection, CursorType, Edge};
@@ -151,7 +151,7 @@ impl Coin {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -16,6 +16,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
+use super::uint::UInt;
 use crate::data::Db;
 use crate::error::Error;
 use async_graphql::connection::Connection;
@@ -139,7 +140,7 @@ impl CoinMetadata {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -16,7 +16,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use crate::data::Db;
 use crate::error::Error;
 use async_graphql::connection::Connection;
@@ -140,7 +140,7 @@ impl CoinMetadata {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -140,7 +140,7 @@ impl<C> Page<C> {
             (limit, after, None, before) => Page {
                 after,
                 before,
-                limit: limit.unwrap_or(limits.default_page_size),
+                limit: limit.unwrap_or(limits.default_page_size as u64),
                 end: End::Front,
             },
 
@@ -152,7 +152,7 @@ impl<C> Page<C> {
             },
         };
 
-        if page.limit > limits.max_page_size {
+        if page.limit > limits.max_page_size as u64 {
             return Err(Error::PageTooLarge(page.limit, limits.max_page_size).extend());
         }
 
@@ -797,7 +797,7 @@ mod tests {
     #[test]
     fn test_err_page_too_big() {
         let config = ServiceConfig::default();
-        let too_big = config.limits.max_page_size + 1;
+        let too_big = config.limits.max_page_size as u64 + 1;
         let err = Page::<JsonCursor<u64>>::from_params(&config, Some(too_big), None, None, None)
             .unwrap_err();
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -15,6 +15,7 @@ use super::date_time::DateTime;
 use super::protocol_config::ProtocolConfigs;
 use super::system_state_summary::SystemStateSummary;
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
+use super::uint::UInt;
 use super::validator_set::ValidatorSet;
 use async_graphql::connection::Connection;
 use async_graphql::dataloader::Loader;
@@ -49,8 +50,8 @@ struct EpochKey {
 #[Object]
 impl Epoch {
     /// The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
-    async fn epoch_id(&self) -> u64 {
-        self.stored.epoch as u64
+    async fn epoch_id(&self) -> UInt {
+        UInt::from(self.stored.epoch as u64)
     }
 
     /// The minimum gas price that a quorum of validators are guaranteed to sign a transaction for.
@@ -101,7 +102,7 @@ impl Epoch {
     }
 
     /// The total number of checkpoints in this epoch.
-    async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<BigInt>> {
+    async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<UInt>> {
         let last = match self.stored.last_checkpoint_id {
             Some(last) => last as u64,
             None => {
@@ -110,15 +111,18 @@ impl Epoch {
             }
         };
 
-        Ok(Some(BigInt::from(
+        Ok(Some(UInt::from(
             last - self.stored.first_checkpoint_id as u64,
         )))
     }
 
     /// The total number of transaction blocks in this epoch.
-    async fn total_transactions(&self) -> Result<Option<u64>> {
+    async fn total_transactions(&self) -> Result<Option<UInt>> {
         // TODO: this currently returns None for the current epoch. Fix this.
-        Ok(self.stored.epoch_total_transactions.map(|v| v as u64))
+        Ok(self
+            .stored
+            .epoch_total_transactions
+            .map(|v| UInt::from(v as u64)))
     }
 
     /// The total amount of gas fees (in MIST) that were paid in this epoch.
@@ -241,8 +245,11 @@ impl Epoch {
             .unwrap_or_default()
             .intersect(TransactionBlockFilter {
                 after_checkpoint: (self.stored.first_checkpoint_id > 0)
-                    .then(|| self.stored.first_checkpoint_id as u64 - 1),
-                before_checkpoint: self.stored.last_checkpoint_id.map(|id| id as u64 + 1),
+                    .then(|| UInt::from(self.stored.first_checkpoint_id as u64 - 1)),
+                before_checkpoint: self
+                    .stored
+                    .last_checkpoint_id
+                    .map(|id| UInt::from(id as u64 + 1)),
                 ..Default::default()
             })
         else {

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -15,7 +15,7 @@ use super::date_time::DateTime;
 use super::protocol_config::ProtocolConfigs;
 use super::system_state_summary::SystemStateSummary;
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::validator_set::ValidatorSet;
 use async_graphql::connection::Connection;
 use async_graphql::dataloader::Loader;
@@ -50,8 +50,8 @@ struct EpochKey {
 #[Object]
 impl Epoch {
     /// The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
-    async fn epoch_id(&self) -> UInt {
-        UInt::from(self.stored.epoch as u64)
+    async fn epoch_id(&self) -> UInt53 {
+        UInt53::from(self.stored.epoch as u64)
     }
 
     /// The minimum gas price that a quorum of validators are guaranteed to sign a transaction for.
@@ -102,7 +102,7 @@ impl Epoch {
     }
 
     /// The total number of checkpoints in this epoch.
-    async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<UInt>> {
+    async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<UInt53>> {
         let last = match self.stored.last_checkpoint_id {
             Some(last) => last as u64,
             None => {
@@ -111,18 +111,18 @@ impl Epoch {
             }
         };
 
-        Ok(Some(UInt::from(
+        Ok(Some(UInt53::from(
             last - self.stored.first_checkpoint_id as u64,
         )))
     }
 
     /// The total number of transaction blocks in this epoch.
-    async fn total_transactions(&self) -> Result<Option<UInt>> {
+    async fn total_transactions(&self) -> Result<Option<UInt53>> {
         // TODO: this currently returns None for the current epoch. Fix this.
         Ok(self
             .stored
             .epoch_total_transactions
-            .map(|v| UInt::from(v as u64)))
+            .map(|v| UInt53::from(v as u64)))
     }
 
     /// The total amount of gas fees (in MIST) that were paid in this epoch.
@@ -245,11 +245,11 @@ impl Epoch {
             .unwrap_or_default()
             .intersect(TransactionBlockFilter {
                 after_checkpoint: (self.stored.first_checkpoint_id > 0)
-                    .then(|| UInt::from(self.stored.first_checkpoint_id as u64 - 1)),
+                    .then(|| UInt53::from(self.stored.first_checkpoint_id as u64 - 1)),
                 before_checkpoint: self
                     .stored
                     .last_checkpoint_id
-                    .map(|id| UInt::from(id as u64 + 1)),
+                    .map(|id| UInt53::from(id as u64 + 1)),
                 ..Default::default()
             })
         else {

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -171,7 +171,7 @@ impl GasInput {
                 .iter()
                 .map(|o| ObjectKey {
                     object_id: o.0.into(),
-                    version: o.1.value(),
+                    version: o.1.value().into(),
                 })
                 .collect(),
             checkpoint_viewed_at,

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -53,6 +53,7 @@ pub(crate) mod transaction_block_effects;
 pub(crate) mod transaction_block_kind;
 pub(crate) mod transaction_metadata;
 pub(crate) mod type_filter;
+pub(crate) mod uint;
 pub(crate) mod unchanged_shared_object;
 pub(crate) mod validator;
 pub(crate) mod validator_credentials;

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -53,7 +53,7 @@ pub(crate) mod transaction_block_effects;
 pub(crate) mod transaction_block_kind;
 pub(crate) mod transaction_metadata;
 pub(crate) mod type_filter;
-pub(crate) mod uint;
+pub(crate) mod uint53;
 pub(crate) mod unchanged_shared_object;
 pub(crate) mod validator;
 pub(crate) mod validator_credentials;

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -18,6 +18,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration, SuinsRegistrationDowncastError};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
+use super::uint::UInt;
 use super::{coin::Coin, object::Object};
 use crate::data::Db;
 use crate::error::Error;
@@ -218,7 +219,7 @@ impl MoveObject {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(&self.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -18,7 +18,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration, SuinsRegistrationDowncastError};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::{coin::Coin, object::Object};
 use crate::data::Db;
 use crate::error::Error;
@@ -219,7 +219,7 @@ impl MoveObject {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(&self.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -17,6 +17,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
+use super::uint::UInt;
 use crate::consistency::ConsistentNamedCursor;
 use crate::error::Error;
 use async_graphql::connection::{Connection, CursorType, Edge};
@@ -44,7 +45,7 @@ struct Linkage {
     upgraded_id: SuiAddress,
 
     /// The version of the dependency that this package depends on.
-    version: u64,
+    version: UInt,
 }
 
 /// Information about which previous versions of a package introduced its types.
@@ -187,7 +188,7 @@ impl MovePackage {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(&self.super_).version().await
     }
 
@@ -347,7 +348,7 @@ impl MovePackage {
             .map(|(&runtime_id, upgrade_info)| Linkage {
                 original_id: runtime_id.into(),
                 upgraded_id: upgrade_info.upgraded_id.into(),
-                version: upgrade_info.upgraded_version.value(),
+                version: upgrade_info.upgraded_version.value().into(),
             })
             .collect();
 

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -17,7 +17,7 @@ use super::sui_address::SuiAddress;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use crate::consistency::ConsistentNamedCursor;
 use crate::error::Error;
 use async_graphql::connection::{Connection, CursorType, Edge};
@@ -45,7 +45,7 @@ struct Linkage {
     upgraded_id: SuiAddress,
 
     /// The version of the dependency that this package depends on.
-    version: UInt,
+    version: UInt53,
 }
 
 /// Information about which previous versions of a package introduced its types.
@@ -188,7 +188,7 @@ impl MovePackage {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(&self.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -21,6 +21,7 @@ use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
+use super::uint::UInt;
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
 use crate::consistency::{build_objects_query, Checkpointed, View};
 use crate::data::package_resolver::PackageResolver;
@@ -101,7 +102,7 @@ pub(crate) struct ObjectRef {
     /// ID of the object.
     pub address: SuiAddress,
     /// Version or sequence number of the object.
-    pub version: u64,
+    pub version: UInt,
     /// Digest of the object.
     pub digest: Digest,
 }
@@ -137,7 +138,7 @@ pub(crate) struct ObjectFilter {
 #[derive(InputObject, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectKey {
     pub object_id: SuiAddress,
-    pub version: u64,
+    pub version: UInt,
 }
 
 /// The object's owner type: Immutable, Shared, Parent, or Address.
@@ -161,7 +162,7 @@ pub(crate) struct Immutable {
 /// Unlike owned objects, once an object is shared, it stays mutable and is accessible by anyone.
 #[derive(SimpleObject, Clone)]
 pub(crate) struct Shared {
-    initial_shared_version: u64,
+    initial_shared_version: UInt,
 }
 
 /// If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
@@ -215,7 +216,7 @@ pub(crate) struct HistoricalObjectCursor {
 #[derive(Interface)]
 #[graphql(
     name = "IObject",
-    field(name = "version", ty = "u64"),
+    field(name = "version", ty = "UInt"),
     field(
         name = "status",
         ty = "ObjectStatus",
@@ -395,7 +396,7 @@ impl Object {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(self).version().await
     }
 
@@ -524,8 +525,8 @@ impl Object {
 }
 
 impl ObjectImpl<'_> {
-    pub(crate) async fn version(&self) -> u64 {
-        self.0.version_impl()
+    pub(crate) async fn version(&self) -> UInt {
+        self.0.version_impl().into()
     }
 
     pub(crate) async fn status(&self) -> ObjectStatus {
@@ -571,7 +572,7 @@ impl ObjectImpl<'_> {
             O::Shared {
                 initial_shared_version,
             } => Some(ObjectOwner::Shared(Shared {
-                initial_shared_version: initial_shared_version.value(),
+                initial_shared_version: initial_shared_version.value().into(),
             })),
         }
     }
@@ -1002,7 +1003,7 @@ impl ObjectFilter {
                 .filter_map(|(id, v)| {
                     Some(ObjectKey {
                         object_id: *id,
-                        version: (*v)?,
+                        version: (*v)?.into(),
                     })
                 })
                 .collect();
@@ -1030,7 +1031,7 @@ impl ObjectFilter {
             self.object_keys
                 .iter()
                 .flatten()
-                .map(|key| (key.object_id, Some(key.version)))
+                .map(|key| (key.object_id, Some(key.version.into())))
                 // Chain ID filters after Key filters so if there is overlap, we overwrite the key
                 // filter with the ID filter.
                 .chain(self.object_ids.iter().flatten().map(|id| (*id, None))),
@@ -1488,11 +1489,11 @@ mod tests {
             object_keys: Some(vec![
                 ObjectKey {
                     object_id: i2,
-                    version: 1,
+                    version: 1.into(),
                 },
                 ObjectKey {
                     object_id: i4,
-                    version: 2,
+                    version: 2.into(),
                 },
             ]),
             ..Default::default()
@@ -1502,7 +1503,7 @@ mod tests {
             object_ids: Some(vec![i1, i2]),
             object_keys: Some(vec![ObjectKey {
                 object_id: i4,
-                version: 2,
+                version: 2.into(),
             }]),
             ..Default::default()
         };
@@ -1516,11 +1517,11 @@ mod tests {
             object_keys: Some(vec![
                 ObjectKey {
                     object_id: i2,
-                    version: 2,
+                    version: 2.into(),
                 },
                 ObjectKey {
                     object_id: i4,
-                    version: 2,
+                    version: 2.into(),
                 },
             ]),
             ..Default::default()
@@ -1533,11 +1534,11 @@ mod tests {
                 object_keys: Some(vec![
                     ObjectKey {
                         object_id: i2,
-                        version: 1
+                        version: 1.into(),
                     },
                     ObjectKey {
                         object_id: i4,
-                        version: 2
+                        version: 2.into(),
                     },
                 ]),
                 ..Default::default()
@@ -1558,11 +1559,11 @@ mod tests {
                 object_keys: Some(vec![
                     ObjectKey {
                         object_id: i2,
-                        version: 2
+                        version: 2.into(),
                     },
                     ObjectKey {
                         object_id: i4,
-                        version: 2
+                        version: 2.into(),
                     },
                 ]),
                 ..Default::default()

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -21,7 +21,7 @@ use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
 use crate::consistency::{build_objects_query, Checkpointed, View};
 use crate::data::package_resolver::PackageResolver;
@@ -102,7 +102,7 @@ pub(crate) struct ObjectRef {
     /// ID of the object.
     pub address: SuiAddress,
     /// Version or sequence number of the object.
-    pub version: UInt,
+    pub version: UInt53,
     /// Digest of the object.
     pub digest: Digest,
 }
@@ -138,7 +138,7 @@ pub(crate) struct ObjectFilter {
 #[derive(InputObject, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectKey {
     pub object_id: SuiAddress,
-    pub version: UInt,
+    pub version: UInt53,
 }
 
 /// The object's owner type: Immutable, Shared, Parent, or Address.
@@ -162,7 +162,7 @@ pub(crate) struct Immutable {
 /// Unlike owned objects, once an object is shared, it stays mutable and is accessible by anyone.
 #[derive(SimpleObject, Clone)]
 pub(crate) struct Shared {
-    initial_shared_version: UInt,
+    initial_shared_version: UInt53,
 }
 
 /// If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
@@ -216,7 +216,7 @@ pub(crate) struct HistoricalObjectCursor {
 #[derive(Interface)]
 #[graphql(
     name = "IObject",
-    field(name = "version", ty = "UInt"),
+    field(name = "version", ty = "UInt53"),
     field(
         name = "status",
         ty = "ObjectStatus",
@@ -396,7 +396,7 @@ impl Object {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(self).version().await
     }
 
@@ -525,7 +525,7 @@ impl Object {
 }
 
 impl ObjectImpl<'_> {
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         self.0.version_impl().into()
     }
 

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -4,7 +4,7 @@
 use async_graphql::*;
 use sui_types::base_types::ObjectRef as NativeObjectRef;
 
-use super::{object::Object, sui_address::SuiAddress, uint::UInt};
+use super::{object::Object, sui_address::SuiAddress, uint53::UInt53};
 
 // A helper type representing the read of a specific version of an object. Intended to be
 // "flattened" into other GraphQL types.
@@ -23,7 +23,7 @@ impl ObjectRead {
     }
 
     /// Version of the object being read.
-    async fn version(&self) -> UInt {
+    async fn version(&self) -> UInt53 {
         self.version_impl().into()
     }
 

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -4,7 +4,7 @@
 use async_graphql::*;
 use sui_types::base_types::ObjectRef as NativeObjectRef;
 
-use super::{object::Object, sui_address::SuiAddress};
+use super::{object::Object, sui_address::SuiAddress, uint::UInt};
 
 // A helper type representing the read of a specific version of an object. Intended to be
 // "flattened" into other GraphQL types.
@@ -23,8 +23,8 @@ impl ObjectRead {
     }
 
     /// Version of the object being read.
-    async fn version(&self) -> u64 {
-        self.version_impl()
+    async fn version(&self) -> UInt {
+        self.version_impl().into()
     }
 
     /// 32-byte hash that identifies the object's contents at this version, encoded as a Base58

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -12,6 +12,8 @@ use crate::{
     types::chain_identifier::ChainIdentifier,
 };
 
+use super::uint::UInt;
+
 /// A single protocol configuration value.
 #[derive(Clone, Debug, SimpleObject)]
 pub(crate) struct ProtocolConfigAttr {
@@ -38,8 +40,8 @@ pub(crate) struct ProtocolConfigs {
 impl ProtocolConfigs {
     /// The protocol is not required to change on every epoch boundary, so the protocol version
     /// tracks which change to the protocol these configs are from.
-    async fn protocol_version(&self) -> u64 {
-        self.native.version.as_u64()
+    async fn protocol_version(&self) -> UInt {
+        self.native.version.as_u64().into()
     }
 
     /// List all available feature flags and their values.  Feature flags are a form of boolean

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -12,7 +12,7 @@ use crate::{
     types::chain_identifier::ChainIdentifier,
 };
 
-use super::uint::UInt;
+use super::uint53::UInt53;
 
 /// A single protocol configuration value.
 #[derive(Clone, Debug, SimpleObject)]
@@ -40,7 +40,7 @@ pub(crate) struct ProtocolConfigs {
 impl ProtocolConfigs {
     /// The protocol is not required to change on every epoch boundary, so the protocol version
     /// tracks which change to the protocol these configs are from.
-    async fn protocol_version(&self) -> UInt {
+    async fn protocol_version(&self) -> UInt53 {
         self.native.version.as_u64().into()
     }
 

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -13,7 +13,7 @@ use sui_types::transaction::{TransactionData, TransactionKind};
 use sui_types::{gas_coin::GAS, transaction::TransactionDataAPI, TypeTag};
 
 use super::suins_registration::NameService;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::{
     address::Address,
     available_range::AvailableRange,
@@ -190,7 +190,7 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         address: SuiAddress,
-        version: Option<UInt>,
+        version: Option<UInt53>,
     ) -> Result<Option<Object>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
 
@@ -227,7 +227,7 @@ impl Query {
     }
 
     /// Fetch epoch information by ID (defaults to the latest epoch).
-    async fn epoch(&self, ctx: &Context<'_>, id: Option<UInt>) -> Result<Option<Epoch>> {
+    async fn epoch(&self, ctx: &Context<'_>, id: Option<UInt53>) -> Result<Option<Epoch>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
         Epoch::query(ctx, id.map(|id| id.into()), checkpoint)
             .await
@@ -383,7 +383,7 @@ impl Query {
     async fn protocol_config(
         &self,
         ctx: &Context<'_>,
-        protocol_version: Option<UInt>,
+        protocol_version: Option<UInt53>,
     ) -> Result<ProtocolConfigs> {
         ProtocolConfigs::query(ctx.data_unchecked(), protocol_version.map(|v| v.into()))
             .await

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -17,7 +17,7 @@ use super::owner::OwnerImpl;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::{
     big_int::BigInt, epoch::Epoch, move_object::MoveObject, object, sui_address::SuiAddress,
 };
@@ -159,7 +159,7 @@ impl StakedSui {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -17,6 +17,7 @@ use super::owner::OwnerImpl;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
+use super::uint::UInt;
 use super::{
     big_int::BigInt, epoch::Epoch, move_object::MoveObject, object, sui_address::SuiAddress,
 };
@@ -158,7 +159,7 @@ impl StakedSui {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -22,7 +22,7 @@ use super::{
     sui_address::SuiAddress,
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
     type_filter::ExactTypeFilter,
-    uint::UInt,
+    uint53::UInt53,
 };
 use crate::{
     consistency::{build_objects_query, View},
@@ -196,7 +196,7 @@ impl SuinsRegistration {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt {
+    pub(crate) async fn version(&self) -> UInt53 {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -22,6 +22,7 @@ use super::{
     sui_address::SuiAddress,
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
     type_filter::ExactTypeFilter,
+    uint::UInt,
 };
 use crate::{
     consistency::{build_objects_query, View},
@@ -195,7 +196,7 @@ impl SuinsRegistration {
             .await
     }
 
-    pub(crate) async fn version(&self) -> u64 {
+    pub(crate) async fn version(&self) -> UInt {
         ObjectImpl(&self.super_.super_).version().await
     }
 

--- a/crates/sui-graphql-rpc/src/types/system_parameters.rs
+++ b/crates/sui-graphql-rpc/src/types/system_parameters.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use super::big_int::BigInt;
+use super::{big_int::BigInt, uint::UInt};
 use async_graphql::*;
 
 /// Details of the system that are decided during genesis.
@@ -10,7 +10,7 @@ pub(crate) struct SystemParameters {
     pub duration_ms: Option<BigInt>,
 
     /// The epoch at which stake subsidies start being paid out.
-    pub stake_subsidy_start_epoch: Option<u64>,
+    pub stake_subsidy_start_epoch: Option<UInt>,
 
     /// The minimum number of active validators that the system supports.
     pub min_validator_count: Option<u64>,

--- a/crates/sui-graphql-rpc/src/types/system_parameters.rs
+++ b/crates/sui-graphql-rpc/src/types/system_parameters.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use super::{big_int::BigInt, uint::UInt};
+use super::{big_int::BigInt, uint53::UInt53};
 use async_graphql::*;
 
 /// Details of the system that are decided during genesis.
@@ -10,7 +10,7 @@ pub(crate) struct SystemParameters {
     pub duration_ms: Option<BigInt>,
 
     /// The epoch at which stake subsidies start being paid out.
-    pub stake_subsidy_start_epoch: Option<UInt>,
+    pub stake_subsidy_start_epoch: Option<UInt53>,
 
     /// The minimum number of active validators that the system supports.
     pub min_validator_count: Option<u64>,

--- a/crates/sui-graphql-rpc/src/types/system_state_summary.rs
+++ b/crates/sui-graphql-rpc/src/types/system_state_summary.rs
@@ -3,7 +3,7 @@
 
 use super::{
     big_int::BigInt, gas::GasCostSummary, safe_mode::SafeMode, stake_subsidy::StakeSubsidy,
-    storage_fund::StorageFund, system_parameters::SystemParameters,
+    storage_fund::StorageFund, system_parameters::SystemParameters, uint::UInt,
 };
 use async_graphql::*;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary as NativeSystemStateSummary;
@@ -47,15 +47,15 @@ impl SystemStateSummary {
     /// The value of the `version` field of `0x5`, the `0x3::sui::SuiSystemState` object.  This
     /// version changes whenever the fields contained in the system state object (held in a dynamic
     /// field attached to `0x5`) change.
-    async fn system_state_version(&self) -> Option<u64> {
-        Some(self.native.system_state_version)
+    async fn system_state_version(&self) -> Option<UInt> {
+        Some(self.native.system_state_version.into())
     }
 
     /// Details of the system that are decided during genesis.
     async fn system_parameters(&self) -> Option<SystemParameters> {
         Some(SystemParameters {
             duration_ms: Some(BigInt::from(self.native.epoch_duration_ms)),
-            stake_subsidy_start_epoch: Some(self.native.stake_subsidy_start_epoch),
+            stake_subsidy_start_epoch: Some(self.native.stake_subsidy_start_epoch.into()),
             // TODO min validator count can be extracted, but it requires some JSON RPC changes,
             // so we decided to wait on it for now.
             min_validator_count: None,

--- a/crates/sui-graphql-rpc/src/types/system_state_summary.rs
+++ b/crates/sui-graphql-rpc/src/types/system_state_summary.rs
@@ -3,7 +3,7 @@
 
 use super::{
     big_int::BigInt, gas::GasCostSummary, safe_mode::SafeMode, stake_subsidy::StakeSubsidy,
-    storage_fund::StorageFund, system_parameters::SystemParameters, uint::UInt,
+    storage_fund::StorageFund, system_parameters::SystemParameters, uint53::UInt53,
 };
 use async_graphql::*;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary as NativeSystemStateSummary;
@@ -47,7 +47,7 @@ impl SystemStateSummary {
     /// The value of the `version` field of `0x5`, the `0x3::sui::SuiSystemState` object.  This
     /// version changes whenever the fields contained in the system state object (held in a dynamic
     /// field attached to `0x5`) change.
-    async fn system_state_version(&self) -> Option<UInt> {
+    async fn system_state_version(&self) -> Option<UInt53> {
         Some(self.native.system_state_version.into())
     }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -48,6 +48,7 @@ use super::{
     transaction_block_effects::{TransactionBlockEffects, TransactionBlockEffectsKind},
     transaction_block_kind::TransactionBlockKind,
     type_filter::FqNameFilter,
+    uint::UInt,
 };
 
 /// Wraps the actual transaction block data with the checkpoint sequence number at which the data
@@ -99,9 +100,9 @@ pub(crate) struct TransactionBlockFilter {
 
     /// An input filter selecting for either system or programmable transactions.
     pub kind: Option<TransactionBlockKindInput>,
-    pub after_checkpoint: Option<u64>,
-    pub at_checkpoint: Option<u64>,
-    pub before_checkpoint: Option<u64>,
+    pub after_checkpoint: Option<UInt>,
+    pub at_checkpoint: Option<UInt>,
+    pub before_checkpoint: Option<UInt>,
 
     pub sign_address: Option<SuiAddress>,
     pub recv_address: Option<SuiAddress>,
@@ -334,17 +335,19 @@ impl TransactionBlock {
                         }
 
                         if let Some(c) = &filter.after_checkpoint {
-                            query = query.filter(tx::dsl::checkpoint_sequence_number.gt(*c as i64));
+                            query =
+                                query.filter(tx::dsl::checkpoint_sequence_number.gt(i64::from(*c)));
                         }
 
                         if let Some(c) = &filter.at_checkpoint {
-                            query = query.filter(tx::dsl::checkpoint_sequence_number.eq(*c as i64));
+                            query =
+                                query.filter(tx::dsl::checkpoint_sequence_number.eq(i64::from(*c)));
                         }
 
                         let before_checkpoint = filter
                             .before_checkpoint
                             .map_or(checkpoint_viewed_at + 1, |c| {
-                                c.min(checkpoint_viewed_at + 1)
+                                u64::from(c).min(checkpoint_viewed_at + 1)
                             });
                         query = query.filter(
                             tx::dsl::checkpoint_sequence_number.lt(before_checkpoint as i64),

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -48,7 +48,7 @@ use super::{
     transaction_block_effects::{TransactionBlockEffects, TransactionBlockEffectsKind},
     transaction_block_kind::TransactionBlockKind,
     type_filter::FqNameFilter,
-    uint::UInt,
+    uint53::UInt53,
 };
 
 /// Wraps the actual transaction block data with the checkpoint sequence number at which the data
@@ -100,9 +100,9 @@ pub(crate) struct TransactionBlockFilter {
 
     /// An input filter selecting for either system or programmable transactions.
     pub kind: Option<TransactionBlockKindInput>,
-    pub after_checkpoint: Option<UInt>,
-    pub at_checkpoint: Option<UInt>,
-    pub before_checkpoint: Option<UInt>,
+    pub after_checkpoint: Option<UInt53>,
+    pub at_checkpoint: Option<UInt53>,
+    pub before_checkpoint: Option<UInt53>,
 
     pub sign_address: Option<SuiAddress>,
     pub recv_address: Option<SuiAddress>,

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -37,7 +37,7 @@ use super::{
     gas::GasEffects,
     object_change::ObjectChange,
     transaction_block::{TransactionBlock, TransactionBlockInner},
-    uint::UInt,
+    uint53::UInt53,
     unchanged_shared_object::UnchangedSharedObject,
 };
 
@@ -111,7 +111,7 @@ impl TransactionBlockEffects {
 
     /// The latest version of all objects (apart from packages) that have been created or modified
     /// by this transaction, immediately following this transaction.
-    async fn lamport_version(&self) -> UInt {
+    async fn lamport_version(&self) -> UInt53 {
         self.native().lamport_version().value().into()
     }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -37,6 +37,7 @@ use super::{
     gas::GasEffects,
     object_change::ObjectChange,
     transaction_block::{TransactionBlock, TransactionBlockInner},
+    uint::UInt,
     unchanged_shared_object::UnchangedSharedObject,
 };
 
@@ -110,8 +111,8 @@ impl TransactionBlockEffects {
 
     /// The latest version of all objects (apart from packages) that have been created or modified
     /// by this transaction, immediately following this transaction.
-    async fn lamport_version(&self) -> u64 {
-        self.native().lamport_version().value()
+    async fn lamport_version(&self) -> UInt {
+        self.native().lamport_version().value().into()
     }
 
     /// The reason for a transaction failure, if it did fail.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -16,6 +16,7 @@ use crate::{
     types::{
         cursor::{JsonCursor, Page},
         epoch::Epoch,
+        uint::UInt,
     },
 };
 
@@ -46,8 +47,8 @@ impl AuthenticatorStateUpdateTransaction {
     }
 
     /// Consensus round of the authenticator state update.
-    async fn round(&self) -> u64 {
-        self.native.round
+    async fn round(&self) -> UInt {
+        self.native.round.into()
     }
 
     /// Newly active JWKs (JSON Web Keys).
@@ -87,8 +88,11 @@ impl AuthenticatorStateUpdateTransaction {
     }
 
     /// The initial version of the authenticator object that it was shared at.
-    async fn authenticator_obj_initial_shared_version(&self) -> u64 {
-        self.native.authenticator_obj_initial_shared_version.value()
+    async fn authenticator_obj_initial_shared_version(&self) -> UInt {
+        self.native
+            .authenticator_obj_initial_shared_version
+            .value()
+            .into()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -16,7 +16,7 @@ use crate::{
     types::{
         cursor::{JsonCursor, Page},
         epoch::Epoch,
-        uint::UInt,
+        uint53::UInt53,
     },
 };
 
@@ -47,7 +47,7 @@ impl AuthenticatorStateUpdateTransaction {
     }
 
     /// Consensus round of the authenticator state update.
-    async fn round(&self) -> UInt {
+    async fn round(&self) -> UInt53 {
         self.native.round.into()
     }
 
@@ -88,7 +88,7 @@ impl AuthenticatorStateUpdateTransaction {
     }
 
     /// The initial version of the authenticator object that it was shared at.
-    async fn authenticator_obj_initial_shared_version(&self) -> UInt {
+    async fn authenticator_obj_initial_shared_version(&self) -> UInt53 {
         self.native
             .authenticator_obj_initial_shared_version
             .value()

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{date_time::DateTime, epoch::Epoch, uint::UInt};
+use crate::types::{date_time::DateTime, epoch::Epoch, uint53::UInt53};
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_types::{
@@ -49,7 +49,7 @@ impl ConsensusCommitPrologueTransaction {
     }
 
     /// Consensus round of the commit.
-    async fn round(&self) -> UInt {
+    async fn round(&self) -> UInt53 {
         self.round.into()
     }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{date_time::DateTime, epoch::Epoch};
+use crate::types::{date_time::DateTime, epoch::Epoch, uint::UInt};
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_types::{
@@ -49,8 +49,8 @@ impl ConsensusCommitPrologueTransaction {
     }
 
     /// Consensus round of the commit.
-    async fn round(&self) -> u64 {
-        self.round
+    async fn round(&self) -> UInt {
+        self.round.into()
     }
 
     /// Unix timestamp from consensus.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -20,6 +20,7 @@ use sui_types::{
 use crate::consistency::ConsistentIndexCursor;
 use crate::types::cursor::{JsonCursor, Page};
 use crate::types::sui_address::SuiAddress;
+use crate::types::uint::UInt;
 use crate::{
     error::Error,
     types::{
@@ -149,8 +150,8 @@ impl ChangeEpochTransaction {
     }
 
     /// The protocol version in effect in the new epoch.
-    async fn protocol_version(&self) -> u64 {
-        self.native.protocol_version.as_u64()
+    async fn protocol_version(&self) -> UInt {
+        self.native.protocol_version.as_u64().into()
     }
 
     /// The total amount of gas charged for storage during the previous epoch (in MIST).
@@ -243,8 +244,11 @@ impl AuthenticatorStateExpireTransaction {
     }
 
     /// The initial version that the AuthenticatorStateUpdate was shared at.
-    async fn authenticator_obj_initial_shared_version(&self) -> u64 {
-        self.native.authenticator_obj_initial_shared_version.value()
+    async fn authenticator_obj_initial_shared_version(&self) -> UInt {
+        self.native
+            .authenticator_obj_initial_shared_version
+            .value()
+            .into()
     }
 }
 
@@ -257,8 +261,8 @@ impl BridgeStateCreateTransaction {
 
 #[Object]
 impl BridgeCommitteeInitTransaction {
-    async fn bridge_obj_initial_shared_version(&self) -> u64 {
-        self.native.value()
+    async fn bridge_obj_initial_shared_version(&self) -> UInt {
+        self.native.value().into()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -20,7 +20,7 @@ use sui_types::{
 use crate::consistency::ConsistentIndexCursor;
 use crate::types::cursor::{JsonCursor, Page};
 use crate::types::sui_address::SuiAddress;
-use crate::types::uint::UInt;
+use crate::types::uint53::UInt53;
 use crate::{
     error::Error,
     types::{
@@ -150,7 +150,7 @@ impl ChangeEpochTransaction {
     }
 
     /// The protocol version in effect in the new epoch.
-    async fn protocol_version(&self) -> UInt {
+    async fn protocol_version(&self) -> UInt53 {
         self.native.protocol_version.as_u64().into()
     }
 
@@ -244,7 +244,7 @@ impl AuthenticatorStateExpireTransaction {
     }
 
     /// The initial version that the AuthenticatorStateUpdate was shared at.
-    async fn authenticator_obj_initial_shared_version(&self) -> UInt {
+    async fn authenticator_obj_initial_shared_version(&self) -> UInt53 {
         self.native
             .authenticator_obj_initial_shared_version
             .value()
@@ -261,7 +261,7 @@ impl BridgeStateCreateTransaction {
 
 #[Object]
 impl BridgeCommitteeInitTransaction {
-    async fn bridge_obj_initial_shared_version(&self) -> UInt {
+    async fn bridge_obj_initial_shared_version(&self) -> UInt53 {
         self.native.value().into()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -10,6 +10,7 @@ use crate::{
         move_type::MoveType,
         object_read::ObjectRead,
         sui_address::SuiAddress,
+        uint::UInt,
     },
 };
 use async_graphql::{
@@ -53,7 +54,7 @@ struct OwnedOrImmutable {
 struct SharedInput {
     address: SuiAddress,
     /// The version that this this object was shared at.
-    initial_shared_version: u64,
+    initial_shared_version: UInt,
     /// Controls whether the transaction block can reference the shared object as a mutable
     /// reference or by value. This has implications for scheduling: Transactions that just read
     /// shared objects at a certain version (mutable = false) can be executed concurrently, while
@@ -336,7 +337,7 @@ impl TransactionInput {
                 mutable,
             }) => I::SharedInput(SharedInput {
                 address: id.into(),
-                initial_shared_version: initial_shared_version.value(),
+                initial_shared_version: initial_shared_version.value().into(),
                 mutable,
             }),
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -10,7 +10,7 @@ use crate::{
         move_type::MoveType,
         object_read::ObjectRead,
         sui_address::SuiAddress,
-        uint::UInt,
+        uint53::UInt53,
     },
 };
 use async_graphql::{
@@ -54,7 +54,7 @@ struct OwnedOrImmutable {
 struct SharedInput {
     address: SuiAddress,
     /// The version that this this object was shared at.
-    initial_shared_version: UInt,
+    initial_shared_version: UInt53,
     /// Controls whether the transaction block can reference the shared object as a mutable
     /// reference or by value. This has implications for scheduling: Transactions that just read
     /// shared objects at a certain version (mutable = false) can be executed concurrently, while

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{base64::Base64, epoch::Epoch};
+use crate::types::{base64::Base64, epoch::Epoch, uint::UInt};
 use async_graphql::*;
 use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
 
@@ -23,8 +23,8 @@ impl RandomnessStateUpdateTransaction {
     }
 
     /// Randomness round of the update.
-    async fn randomness_round(&self) -> u64 {
-        self.native.randomness_round.0
+    async fn randomness_round(&self) -> UInt {
+        self.native.randomness_round.0.into()
     }
 
     /// Updated random bytes, encoded as Base64.
@@ -33,7 +33,10 @@ impl RandomnessStateUpdateTransaction {
     }
 
     /// The initial version the randomness object was shared at.
-    async fn randomness_obj_initial_shared_version(&self) -> u64 {
-        self.native.randomness_obj_initial_shared_version.value()
+    async fn randomness_obj_initial_shared_version(&self) -> UInt {
+        self.native
+            .randomness_obj_initial_shared_version
+            .value()
+            .into()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{base64::Base64, epoch::Epoch, uint::UInt};
+use crate::types::{base64::Base64, epoch::Epoch, uint53::UInt53};
 use async_graphql::*;
 use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
 
@@ -23,7 +23,7 @@ impl RandomnessStateUpdateTransaction {
     }
 
     /// Randomness round of the update.
-    async fn randomness_round(&self) -> UInt {
+    async fn randomness_round(&self) -> UInt53 {
         self.native.randomness_round.0.into()
     }
 
@@ -33,7 +33,7 @@ impl RandomnessStateUpdateTransaction {
     }
 
     /// The initial version the randomness object was shared at.
-    async fn randomness_obj_initial_shared_version(&self) -> UInt {
+    async fn randomness_obj_initial_shared_version(&self) -> UInt53 {
         self.native
             .randomness_obj_initial_shared_version
             .value()

--- a/crates/sui-graphql-rpc/src/types/transaction_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_metadata.rs
@@ -3,6 +3,7 @@
 
 use super::object::ObjectRef;
 use super::sui_address::SuiAddress;
+use super::uint::UInt;
 use async_graphql::*;
 
 /// The optional extra data a user can provide to a transaction dry run.
@@ -13,8 +14,8 @@ use async_graphql::*;
 #[derive(Clone, Debug, PartialEq, Eq, InputObject)]
 pub(crate) struct TransactionMetadata {
     pub sender: Option<SuiAddress>,
-    pub gas_price: Option<u64>,
+    pub gas_price: Option<UInt>,
     pub gas_objects: Option<Vec<ObjectRef>>,
-    pub gas_budget: Option<u64>,
+    pub gas_budget: Option<UInt>,
     pub gas_sponsor: Option<SuiAddress>,
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_metadata.rs
@@ -3,7 +3,7 @@
 
 use super::object::ObjectRef;
 use super::sui_address::SuiAddress;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use async_graphql::*;
 
 /// The optional extra data a user can provide to a transaction dry run.
@@ -14,8 +14,8 @@ use async_graphql::*;
 #[derive(Clone, Debug, PartialEq, Eq, InputObject)]
 pub(crate) struct TransactionMetadata {
     pub sender: Option<SuiAddress>,
-    pub gas_price: Option<UInt>,
+    pub gas_price: Option<UInt53>,
     pub gas_objects: Option<Vec<ObjectRef>>,
-    pub gas_budget: Option<UInt>,
+    pub gas_budget: Option<UInt53>,
     pub gas_sponsor: Option<SuiAddress>,
 }

--- a/crates/sui-graphql-rpc/src/types/uint.rs
+++ b/crates/sui-graphql-rpc/src/types/uint.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use async_graphql::*;
+use sui_types::{base_types::SequenceNumber, sui_serde::BigInt};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct UInt(u64);
+
+/// An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
+/// but it is guaranteed to be non-negative, and it may be larger than 2^31 - 1.
+#[Scalar(name = "UInt")]
+impl ScalarType for UInt {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        let Value::Number(n) = value else {
+            return Err(InputValueError::expected_type(value));
+        };
+
+        let Some(n) = n.as_u64() else {
+            return Err(InputValueError::custom("Expected an unsigned integer."));
+        };
+
+        Ok(UInt(n))
+    }
+
+    fn to_value(&self) -> Value {
+        Value::Number(self.0.into())
+    }
+}
+
+impl fmt::Display for UInt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for UInt {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<UInt> for SequenceNumber {
+    fn from(value: UInt) -> Self {
+        SequenceNumber::from(value.0)
+    }
+}
+
+impl From<UInt> for BigInt<u64> {
+    fn from(value: UInt) -> Self {
+        BigInt::from(value.0)
+    }
+}
+
+impl From<UInt> for u64 {
+    fn from(value: UInt) -> Self {
+        value.0
+    }
+}
+
+impl From<UInt> for i64 {
+    fn from(value: UInt) -> Self {
+        value.0 as i64
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/uint53.rs
+++ b/crates/sui-graphql-rpc/src/types/uint53.rs
@@ -7,12 +7,12 @@ use async_graphql::*;
 use sui_types::{base_types::SequenceNumber, sui_serde::BigInt};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) struct UInt(u64);
+pub(crate) struct UInt53(u64);
 
 /// An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
-/// but it is guaranteed to be non-negative, and it may be larger than 2^31 - 1.
-#[Scalar(name = "UInt")]
-impl ScalarType for UInt {
+/// but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
+#[Scalar(name = "UInt53")]
+impl ScalarType for UInt53 {
     fn parse(value: Value) -> InputValueResult<Self> {
         let Value::Number(n) = value else {
             return Err(InputValueError::expected_type(value));
@@ -22,7 +22,7 @@ impl ScalarType for UInt {
             return Err(InputValueError::custom("Expected an unsigned integer."));
         };
 
-        Ok(UInt(n))
+        Ok(UInt53(n))
     }
 
     fn to_value(&self) -> Value {
@@ -30,38 +30,38 @@ impl ScalarType for UInt {
     }
 }
 
-impl fmt::Display for UInt {
+impl fmt::Display for UInt53 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<u64> for UInt {
+impl From<u64> for UInt53 {
     fn from(value: u64) -> Self {
         Self(value)
     }
 }
 
-impl From<UInt> for SequenceNumber {
-    fn from(value: UInt) -> Self {
+impl From<UInt53> for SequenceNumber {
+    fn from(value: UInt53) -> Self {
         SequenceNumber::from(value.0)
     }
 }
 
-impl From<UInt> for BigInt<u64> {
-    fn from(value: UInt) -> Self {
+impl From<UInt53> for BigInt<u64> {
+    fn from(value: UInt53) -> Self {
         BigInt::from(value.0)
     }
 }
 
-impl From<UInt> for u64 {
-    fn from(value: UInt) -> Self {
+impl From<UInt53> for u64 {
+    fn from(value: UInt53) -> Self {
         value.0
     }
 }
 
-impl From<UInt> for i64 {
-    fn from(value: UInt) -> Self {
+impl From<UInt53> for i64 {
+    fn from(value: UInt53) -> Self {
         value.0 as i64
     }
 }

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -4,7 +4,7 @@
 use async_graphql::*;
 use sui_types::effects::InputSharedObject as NativeInputSharedObject;
 
-use super::{object_read::ObjectRead, sui_address::SuiAddress, uint::UInt};
+use super::{object_read::ObjectRead, sui_address::SuiAddress, uint53::UInt53};
 
 /// Details pertaining to shared objects that are referenced by but not changed by a transaction.
 /// This information is considered part of the effects, because although the transaction specifies
@@ -33,7 +33,7 @@ pub(crate) struct SharedObjectDelete {
 
     /// The version of the shared object that was assigned to this transaction during by consensus,
     /// during sequencing.
-    version: UInt,
+    version: UInt53,
 
     /// Whether this transaction intended to use this shared object mutably or not. See
     /// `SharedInput.mutable` for further details.
@@ -47,7 +47,7 @@ pub(crate) struct SharedObjectCancelled {
     address: SuiAddress,
 
     /// The assigned shared object version. It is a special version indicating transaction cancellation reason.
-    version: UInt,
+    version: UInt53,
 }
 
 /// Error for converting from an `InputSharedObject`.

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -4,7 +4,7 @@
 use async_graphql::*;
 use sui_types::effects::InputSharedObject as NativeInputSharedObject;
 
-use super::{object_read::ObjectRead, sui_address::SuiAddress};
+use super::{object_read::ObjectRead, sui_address::SuiAddress, uint::UInt};
 
 /// Details pertaining to shared objects that are referenced by but not changed by a transaction.
 /// This information is considered part of the effects, because although the transaction specifies
@@ -33,7 +33,7 @@ pub(crate) struct SharedObjectDelete {
 
     /// The version of the shared object that was assigned to this transaction during by consensus,
     /// during sequencing.
-    version: u64,
+    version: UInt,
 
     /// Whether this transaction intended to use this shared object mutably or not. See
     /// `SharedInput.mutable` for further details.
@@ -47,7 +47,7 @@ pub(crate) struct SharedObjectCancelled {
     address: SuiAddress,
 
     /// The assigned shared object version. It is a special version indicating transaction cancellation reason.
-    version: u64,
+    version: UInt,
 }
 
 /// Error for converting from an `InputSharedObject`.
@@ -73,19 +73,19 @@ impl UnchangedSharedObject {
 
             I::ReadDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
-                version: v.value(),
+                version: v.value().into(),
                 mutable: false,
             })),
 
             I::MutateDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
-                version: v.value(),
+                version: v.value().into(),
                 mutable: true,
             })),
 
             I::Cancelled(id, v) => Ok(U::Cancelled(SharedObjectCancelled {
                 address: id.into(),
-                version: v.value(),
+                version: v.value().into(),
             })),
         }
     }

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -19,6 +19,7 @@ use super::move_object::MoveObject;
 use super::object::Object;
 use super::owner::Owner;
 use super::sui_address::SuiAddress;
+use super::uint::UInt;
 use super::validator_credentials::ValidatorCredentials;
 use super::{address::Address, base64::Base64};
 use crate::error::Error;
@@ -237,13 +238,15 @@ impl Validator {
     }
 
     /// Number of exchange rates in the table.
-    async fn exchange_rates_size(&self) -> Option<u64> {
-        Some(self.validator_summary.exchange_rates_size)
+    async fn exchange_rates_size(&self) -> Option<UInt> {
+        Some(self.validator_summary.exchange_rates_size.into())
     }
 
     /// The epoch at which this pool became active.
-    async fn staking_pool_activation_epoch(&self) -> Option<u64> {
-        self.validator_summary.staking_pool_activation_epoch
+    async fn staking_pool_activation_epoch(&self) -> Option<UInt> {
+        self.validator_summary
+            .staking_pool_activation_epoch
+            .map(UInt::from)
     }
 
     /// The total number of SUI tokens in this pool.
@@ -317,8 +320,8 @@ impl Validator {
 
     /// The number of epochs for which this validator has been below the
     /// low stake threshold.
-    async fn at_risk(&self) -> Option<u64> {
-        self.at_risk
+    async fn at_risk(&self) -> Option<UInt> {
+        self.at_risk.map(UInt::from)
     }
 
     /// The addresses of other validators this validator has reported.

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -19,7 +19,7 @@ use super::move_object::MoveObject;
 use super::object::Object;
 use super::owner::Owner;
 use super::sui_address::SuiAddress;
-use super::uint::UInt;
+use super::uint53::UInt53;
 use super::validator_credentials::ValidatorCredentials;
 use super::{address::Address, base64::Base64};
 use crate::error::Error;
@@ -238,15 +238,15 @@ impl Validator {
     }
 
     /// Number of exchange rates in the table.
-    async fn exchange_rates_size(&self) -> Option<UInt> {
+    async fn exchange_rates_size(&self) -> Option<UInt53> {
         Some(self.validator_summary.exchange_rates_size.into())
     }
 
     /// The epoch at which this pool became active.
-    async fn staking_pool_activation_epoch(&self) -> Option<UInt> {
+    async fn staking_pool_activation_epoch(&self) -> Option<UInt53> {
         self.validator_summary
             .staking_pool_activation_epoch
-            .map(UInt::from)
+            .map(UInt53::from)
     }
 
     /// The total number of SUI tokens in this pool.
@@ -320,8 +320,8 @@ impl Validator {
 
     /// The number of epochs for which this validator has been below the
     /// low stake threshold.
-    async fn at_risk(&self) -> Option<UInt> {
-        self.at_risk.map(UInt::from)
+    async fn at_risk(&self) -> Option<UInt53> {
+        self.at_risk.map(UInt53::from)
     }
 
     /// The addresses of other validators this validator has reported.

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -144,7 +144,7 @@ mod tests {
             default_config.max_query_nodes
         );
         assert!(
-            max_output_nodes <= default_config.max_output_nodes,
+            max_output_nodes <= default_config.max_output_nodes as u64,
             "Max output nodes {} exceeds default limit {}",
             max_output_nodes,
             default_config.max_output_nodes

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -176,7 +176,7 @@ type AuthenticatorStateExpireTransaction {
 	"""
 	The initial version that the AuthenticatorStateUpdate was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: UInt!
+	authenticatorObjInitialSharedVersion: UInt53!
 }
 
 """
@@ -190,7 +190,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Consensus round of the authenticator state update.
 	"""
-	round: UInt!
+	round: UInt53!
 	"""
 	Newly active JWKs (JSON Web Keys).
 	"""
@@ -198,7 +198,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	The initial version of the authenticator object that it was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: UInt!
+	authenticatorObjInitialSharedVersion: UInt53!
 }
 
 """
@@ -220,7 +220,7 @@ type Balance {
 	"""
 	How many coins of this type constitute the balance
 	"""
-	coinObjectCount: UInt
+	coinObjectCount: UInt53
 	"""
 	Total balance across all coin objects of the coin type
 	"""
@@ -315,7 +315,7 @@ scalar BigInt
 
 
 type BridgeCommitteeInitTransaction {
-	bridgeObjInitialSharedVersion: UInt!
+	bridgeObjInitialSharedVersion: UInt53!
 }
 
 type BridgeStateCreateTransaction {
@@ -337,7 +337,7 @@ type ChangeEpochTransaction {
 	"""
 	The protocol version in effect in the new epoch.
 	"""
-	protocolVersion: UInt!
+	protocolVersion: UInt53!
 	"""
 	The total amount of gas charged for storage during the previous epoch (in MIST).
 	"""
@@ -382,7 +382,7 @@ type Checkpoint {
 	This checkpoint's position in the total order of finalized checkpoints, agreed upon by
 	consensus.
 	"""
-	sequenceNumber: UInt!
+	sequenceNumber: UInt53!
 	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus.
 	Transactions that access time in this checkpoint will observe this timestamp.
@@ -400,7 +400,7 @@ type Checkpoint {
 	"""
 	The total number of transaction blocks in the network by the end of this checkpoint.
 	"""
-	networkTotalTransactions: UInt
+	networkTotalTransactions: UInt53
 	"""
 	The computation cost, storage cost, storage rebate, and non-refundable storage fee
 	accumulated during this epoch, up to and including this checkpoint. These values increase
@@ -451,7 +451,7 @@ Filter either by the digest, or the sequence number, or neither, to get the late
 """
 input CheckpointId {
 	digest: String
-	sequenceNumber: UInt
+	sequenceNumber: UInt53
 }
 
 """
@@ -491,7 +491,7 @@ type Coin implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -650,7 +650,7 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -765,7 +765,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Consensus round of the commit.
 	"""
-	round: UInt!
+	round: UInt53!
 	"""
 	Unix timestamp from consensus.
 	"""
@@ -1000,7 +1000,7 @@ type Epoch {
 	"""
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
-	epochId: UInt!
+	epochId: UInt53!
 	"""
 	The minimum gas price that a quorum of validators are guaranteed to sign a transaction for.
 	"""
@@ -1020,11 +1020,11 @@ type Epoch {
 	"""
 	The total number of checkpoints in this epoch.
 	"""
-	totalCheckpoints: UInt
+	totalCheckpoints: UInt53
 	"""
 	The total number of transaction blocks in this epoch.
 	"""
-	totalTransactions: UInt
+	totalTransactions: UInt53
 	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
@@ -1077,7 +1077,7 @@ type Epoch {
 	version changes whenever the fields contained in the system state object (held in a dynamic
 	field attached to `0x5`) change.
 	"""
-	systemStateVersion: UInt
+	systemStateVersion: UInt53
 	"""
 	Details of the system that are decided during genesis.
 	"""
@@ -1408,7 +1408,7 @@ Interface implemented by on-chain values that are addressable by an ID (also ref
 address). This includes Move objects and packages.
 """
 interface IObject {
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
 	"""
@@ -1519,7 +1519,7 @@ type Linkage {
 	"""
 	The version of the dependency that this package depends on.
 	"""
-	version: UInt!
+	version: UInt53!
 }
 
 """
@@ -1946,7 +1946,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2129,7 +2129,7 @@ type MovePackage implements IObject & IOwner {
 	cannot be owned by an address.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2465,7 +2465,7 @@ type Object implements IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2664,7 +2664,7 @@ input ObjectFilter {
 
 input ObjectKey {
 	objectId: SuiAddress!
-	version: UInt!
+	version: UInt53!
 }
 
 enum ObjectKind {
@@ -2697,7 +2697,7 @@ input ObjectRef {
 	"""
 	Version or sequence number of the object.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	Digest of the object.
 	"""
@@ -2755,7 +2755,7 @@ type OwnedOrImmutable {
 	"""
 	Version of the object being read.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -2939,7 +2939,7 @@ type ProtocolConfigs {
 	The protocol is not required to change on every epoch boundary, so the protocol version
 	tracks which change to the protocol these configs are from.
 	"""
-	protocolVersion: UInt!
+	protocolVersion: UInt53!
 	"""
 	List all available feature flags and their values.  Feature flags are a form of boolean
 	configuration that are usually used to gate features while they are in development.  Once a
@@ -3025,7 +3025,7 @@ type Query {
 	The object corresponding to the given address at the (optionally) given version.
 	When no version is given, the latest version is returned.
 	"""
-	object(address: SuiAddress!, version: UInt): Object
+	object(address: SuiAddress!, version: UInt53): Object
 	"""
 	Look-up an Account by its SuiAddress.
 	"""
@@ -3038,7 +3038,7 @@ type Query {
 	"""
 	Fetch epoch information by ID (defaults to the latest epoch).
 	"""
-	epoch(id: UInt): Epoch
+	epoch(id: UInt53): Epoch
 	"""
 	Fetch checkpoint information by sequence number or digest (defaults to the latest available
 	checkpoint).
@@ -3075,7 +3075,7 @@ type Query {
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).
 	"""
-	protocolConfig(protocolVersion: UInt): ProtocolConfigs!
+	protocolConfig(protocolVersion: UInt53): ProtocolConfigs!
 	"""
 	Resolves a SuiNS `domain` name to an address, if it has been bound.
 	"""
@@ -3118,7 +3118,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	Randomness round of the update.
 	"""
-	randomnessRound: UInt!
+	randomnessRound: UInt53!
 	"""
 	Updated random bytes, encoded as Base64.
 	"""
@@ -3126,7 +3126,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	The initial version the randomness object was shared at.
 	"""
-	randomnessObjInitialSharedVersion: UInt!
+	randomnessObjInitialSharedVersion: UInt53!
 }
 
 """
@@ -3140,7 +3140,7 @@ type Receiving {
 	"""
 	Version of the object being read.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3273,7 +3273,7 @@ A shared object is an object that is shared using the 0x2::transfer::share_objec
 Unlike owned objects, once an object is shared, it stays mutable and is accessible by anyone.
 """
 type Shared {
-	initialSharedVersion: UInt!
+	initialSharedVersion: UInt53!
 }
 
 """
@@ -3284,7 +3284,7 @@ type SharedInput {
 	"""
 	The version that this this object was shared at.
 	"""
-	initialSharedVersion: UInt!
+	initialSharedVersion: UInt53!
 	"""
 	Controls whether the transaction block can reference the shared object as a mutable
 	reference or by value. This has implications for scheduling: Transactions that just read
@@ -3306,7 +3306,7 @@ type SharedObjectCancelled {
 	"""
 	The assigned shared object version. It is a special version indicating transaction cancellation reason.
 	"""
-	version: UInt!
+	version: UInt53!
 }
 
 """
@@ -3322,7 +3322,7 @@ type SharedObjectDelete {
 	The version of the shared object that was assigned to this transaction during by consensus,
 	during sequencing.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	Whether this transaction intended to use this shared object mutably or not. See
 	`SharedInput.mutable` for further details.
@@ -3341,7 +3341,7 @@ type SharedObjectRead {
 	"""
 	Version of the object being read.
 	"""
-	version: UInt!
+	version: UInt53!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3453,7 +3453,7 @@ type StakedSui implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3655,7 +3655,7 @@ type SuinsRegistration implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: UInt!
+	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3781,7 +3781,7 @@ type SystemParameters {
 	"""
 	The epoch at which stake subsidies start being paid out.
 	"""
-	stakeSubsidyStartEpoch: UInt
+	stakeSubsidyStartEpoch: UInt53
 	"""
 	The minimum number of active validators that the system supports.
 	"""
@@ -3906,7 +3906,7 @@ type TransactionBlockEffects {
 	The latest version of all objects (apart from packages) that have been created or modified
 	by this transaction, immediately following this transaction.
 	"""
-	lamportVersion: UInt!
+	lamportVersion: UInt53!
 	"""
 	The reason for a transaction failure, if it did fail.
 	If the error is a Move abort, the error message will be resolved to a human-readable form if
@@ -3962,9 +3962,9 @@ input TransactionBlockFilter {
 	An input filter selecting for either system or programmable transactions.
 	"""
 	kind: TransactionBlockKindInput
-	afterCheckpoint: UInt
-	atCheckpoint: UInt
-	beforeCheckpoint: UInt
+	afterCheckpoint: UInt53
+	atCheckpoint: UInt53
+	beforeCheckpoint: UInt53
 	signAddress: SuiAddress
 	recvAddress: SuiAddress
 	inputObject: SuiAddress
@@ -4032,9 +4032,9 @@ to the sender.
 """
 input TransactionMetadata {
 	sender: SuiAddress
-	gasPrice: UInt
+	gasPrice: UInt53
 	gasObjects: [ObjectRef!]
-	gasBudget: UInt
+	gasBudget: UInt53
 	gasSponsor: SuiAddress
 }
 
@@ -4075,7 +4075,7 @@ type TypeOrigin {
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
 but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
 """
-scalar UInt
+scalar UInt53
 
 """
 Details pertaining to shared objects that are referenced by but not changed by a transaction.
@@ -4194,11 +4194,11 @@ type Validator {
 	"""
 	Number of exchange rates in the table.
 	"""
-	exchangeRatesSize: UInt
+	exchangeRatesSize: UInt53
 	"""
 	The epoch at which this pool became active.
 	"""
-	stakingPoolActivationEpoch: UInt
+	stakingPoolActivationEpoch: UInt53
 	"""
 	The total number of SUI tokens in this pool.
 	"""
@@ -4252,7 +4252,7 @@ type Validator {
 	The number of epochs for which this validator has been below the
 	low stake threshold.
 	"""
-	atRisk: UInt
+	atRisk: UInt53
 	"""
 	The addresses of other validators this validator has reported.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -176,7 +176,7 @@ type AuthenticatorStateExpireTransaction {
 	"""
 	The initial version that the AuthenticatorStateUpdate was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: Int!
+	authenticatorObjInitialSharedVersion: UInt!
 }
 
 """
@@ -190,7 +190,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Consensus round of the authenticator state update.
 	"""
-	round: Int!
+	round: UInt!
 	"""
 	Newly active JWKs (JSON Web Keys).
 	"""
@@ -198,7 +198,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	The initial version of the authenticator object that it was shared at.
 	"""
-	authenticatorObjInitialSharedVersion: Int!
+	authenticatorObjInitialSharedVersion: UInt!
 }
 
 """
@@ -220,7 +220,7 @@ type Balance {
 	"""
 	How many coins of this type constitute the balance
 	"""
-	coinObjectCount: Int
+	coinObjectCount: UInt
 	"""
 	Total balance across all coin objects of the coin type
 	"""
@@ -315,7 +315,7 @@ scalar BigInt
 
 
 type BridgeCommitteeInitTransaction {
-	bridgeObjInitialSharedVersion: Int!
+	bridgeObjInitialSharedVersion: UInt!
 }
 
 type BridgeStateCreateTransaction {
@@ -337,7 +337,7 @@ type ChangeEpochTransaction {
 	"""
 	The protocol version in effect in the new epoch.
 	"""
-	protocolVersion: Int!
+	protocolVersion: UInt!
 	"""
 	The total amount of gas charged for storage during the previous epoch (in MIST).
 	"""
@@ -382,7 +382,7 @@ type Checkpoint {
 	This checkpoint's position in the total order of finalized checkpoints, agreed upon by
 	consensus.
 	"""
-	sequenceNumber: Int!
+	sequenceNumber: UInt!
 	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus.
 	Transactions that access time in this checkpoint will observe this timestamp.
@@ -400,7 +400,7 @@ type Checkpoint {
 	"""
 	The total number of transaction blocks in the network by the end of this checkpoint.
 	"""
-	networkTotalTransactions: Int
+	networkTotalTransactions: UInt
 	"""
 	The computation cost, storage cost, storage rebate, and non-refundable storage fee
 	accumulated during this epoch, up to and including this checkpoint. These values increase
@@ -451,7 +451,7 @@ Filter either by the digest, or the sequence number, or neither, to get the late
 """
 input CheckpointId {
 	digest: String
-	sequenceNumber: Int
+	sequenceNumber: UInt
 }
 
 """
@@ -491,7 +491,7 @@ type Coin implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -650,7 +650,7 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -765,7 +765,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Consensus round of the commit.
 	"""
-	round: Int!
+	round: UInt!
 	"""
 	Unix timestamp from consensus.
 	"""
@@ -1000,7 +1000,7 @@ type Epoch {
 	"""
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
-	epochId: Int!
+	epochId: UInt!
 	"""
 	The minimum gas price that a quorum of validators are guaranteed to sign a transaction for.
 	"""
@@ -1020,11 +1020,11 @@ type Epoch {
 	"""
 	The total number of checkpoints in this epoch.
 	"""
-	totalCheckpoints: BigInt
+	totalCheckpoints: UInt
 	"""
 	The total number of transaction blocks in this epoch.
 	"""
-	totalTransactions: Int
+	totalTransactions: UInt
 	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
@@ -1077,7 +1077,7 @@ type Epoch {
 	version changes whenever the fields contained in the system state object (held in a dynamic
 	field attached to `0x5`) change.
 	"""
-	systemStateVersion: Int
+	systemStateVersion: UInt
 	"""
 	Details of the system that are decided during genesis.
 	"""
@@ -1408,7 +1408,7 @@ Interface implemented by on-chain values that are addressable by an ID (also ref
 address). This includes Move objects and packages.
 """
 interface IObject {
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded.
 	"""
@@ -1519,7 +1519,7 @@ type Linkage {
 	"""
 	The version of the dependency that this package depends on.
 	"""
-	version: Int!
+	version: UInt!
 }
 
 """
@@ -1946,7 +1946,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2129,7 +2129,7 @@ type MovePackage implements IObject & IOwner {
 	cannot be owned by an address.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2465,7 +2465,7 @@ type Object implements IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -2664,7 +2664,7 @@ input ObjectFilter {
 
 input ObjectKey {
 	objectId: SuiAddress!
-	version: Int!
+	version: UInt!
 }
 
 enum ObjectKind {
@@ -2697,7 +2697,7 @@ input ObjectRef {
 	"""
 	Version or sequence number of the object.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	Digest of the object.
 	"""
@@ -2755,7 +2755,7 @@ type OwnedOrImmutable {
 	"""
 	Version of the object being read.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -2939,7 +2939,7 @@ type ProtocolConfigs {
 	The protocol is not required to change on every epoch boundary, so the protocol version
 	tracks which change to the protocol these configs are from.
 	"""
-	protocolVersion: Int!
+	protocolVersion: UInt!
 	"""
 	List all available feature flags and their values.  Feature flags are a form of boolean
 	configuration that are usually used to gate features while they are in development.  Once a
@@ -3025,7 +3025,7 @@ type Query {
 	The object corresponding to the given address at the (optionally) given version.
 	When no version is given, the latest version is returned.
 	"""
-	object(address: SuiAddress!, version: Int): Object
+	object(address: SuiAddress!, version: UInt): Object
 	"""
 	Look-up an Account by its SuiAddress.
 	"""
@@ -3038,7 +3038,7 @@ type Query {
 	"""
 	Fetch epoch information by ID (defaults to the latest epoch).
 	"""
-	epoch(id: Int): Epoch
+	epoch(id: UInt): Epoch
 	"""
 	Fetch checkpoint information by sequence number or digest (defaults to the latest available
 	checkpoint).
@@ -3075,7 +3075,7 @@ type Query {
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).
 	"""
-	protocolConfig(protocolVersion: Int): ProtocolConfigs!
+	protocolConfig(protocolVersion: UInt): ProtocolConfigs!
 	"""
 	Resolves a SuiNS `domain` name to an address, if it has been bound.
 	"""
@@ -3118,7 +3118,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	Randomness round of the update.
 	"""
-	randomnessRound: Int!
+	randomnessRound: UInt!
 	"""
 	Updated random bytes, encoded as Base64.
 	"""
@@ -3126,7 +3126,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	The initial version the randomness object was shared at.
 	"""
-	randomnessObjInitialSharedVersion: Int!
+	randomnessObjInitialSharedVersion: UInt!
 }
 
 """
@@ -3140,7 +3140,7 @@ type Receiving {
 	"""
 	Version of the object being read.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3224,7 +3224,7 @@ type ServiceConfig {
 	Maximum estimated cost of a database query used to serve a GraphQL request.  This is
 	measured in the same units that the database uses in EXPLAIN queries.
 	"""
-	maxDbQueryCost: BigInt!
+	maxDbQueryCost: Int!
 	"""
 	Default number of elements allowed on a single page of a connection.
 	"""
@@ -3273,7 +3273,7 @@ A shared object is an object that is shared using the 0x2::transfer::share_objec
 Unlike owned objects, once an object is shared, it stays mutable and is accessible by anyone.
 """
 type Shared {
-	initialSharedVersion: Int!
+	initialSharedVersion: UInt!
 }
 
 """
@@ -3284,7 +3284,7 @@ type SharedInput {
 	"""
 	The version that this this object was shared at.
 	"""
-	initialSharedVersion: Int!
+	initialSharedVersion: UInt!
 	"""
 	Controls whether the transaction block can reference the shared object as a mutable
 	reference or by value. This has implications for scheduling: Transactions that just read
@@ -3306,7 +3306,7 @@ type SharedObjectCancelled {
 	"""
 	The assigned shared object version. It is a special version indicating transaction cancellation reason.
 	"""
-	version: Int!
+	version: UInt!
 }
 
 """
@@ -3322,7 +3322,7 @@ type SharedObjectDelete {
 	The version of the shared object that was assigned to this transaction during by consensus,
 	during sequencing.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	Whether this transaction intended to use this shared object mutably or not. See
 	`SharedInput.mutable` for further details.
@@ -3341,7 +3341,7 @@ type SharedObjectRead {
 	"""
 	Version of the object being read.
 	"""
-	version: Int!
+	version: UInt!
 	"""
 	32-byte hash that identifies the object's contents at this version, encoded as a Base58
 	string.
@@ -3453,7 +3453,7 @@ type StakedSui implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3655,7 +3655,7 @@ type SuinsRegistration implements IMoveObject & IObject & IOwner {
 	manage the associated domain.
 	"""
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
-	version: Int!
+	version: UInt!
 	"""
 	The current status of the object as read from the off-chain store. The possible states are:
 	NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or
@@ -3781,7 +3781,7 @@ type SystemParameters {
 	"""
 	The epoch at which stake subsidies start being paid out.
 	"""
-	stakeSubsidyStartEpoch: Int
+	stakeSubsidyStartEpoch: UInt
 	"""
 	The minimum number of active validators that the system supports.
 	"""
@@ -3906,7 +3906,7 @@ type TransactionBlockEffects {
 	The latest version of all objects (apart from packages) that have been created or modified
 	by this transaction, immediately following this transaction.
 	"""
-	lamportVersion: Int!
+	lamportVersion: UInt!
 	"""
 	The reason for a transaction failure, if it did fail.
 	If the error is a Move abort, the error message will be resolved to a human-readable form if
@@ -3962,9 +3962,9 @@ input TransactionBlockFilter {
 	An input filter selecting for either system or programmable transactions.
 	"""
 	kind: TransactionBlockKindInput
-	afterCheckpoint: Int
-	atCheckpoint: Int
-	beforeCheckpoint: Int
+	afterCheckpoint: UInt
+	atCheckpoint: UInt
+	beforeCheckpoint: UInt
 	signAddress: SuiAddress
 	recvAddress: SuiAddress
 	inputObject: SuiAddress
@@ -4032,9 +4032,9 @@ to the sender.
 """
 input TransactionMetadata {
 	sender: SuiAddress
-	gasPrice: Int
+	gasPrice: UInt
 	gasObjects: [ObjectRef!]
-	gasBudget: Int
+	gasBudget: UInt
 	gasSponsor: SuiAddress
 }
 
@@ -4070,6 +4070,12 @@ type TypeOrigin {
 	"""
 	definingId: SuiAddress!
 }
+
+"""
+An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
+but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
+"""
+scalar UInt
 
 """
 Details pertaining to shared objects that are referenced by but not changed by a transaction.
@@ -4188,11 +4194,11 @@ type Validator {
 	"""
 	Number of exchange rates in the table.
 	"""
-	exchangeRatesSize: Int
+	exchangeRatesSize: UInt
 	"""
 	The epoch at which this pool became active.
 	"""
-	stakingPoolActivationEpoch: Int
+	stakingPoolActivationEpoch: UInt
 	"""
 	The total number of SUI tokens in this pool.
 	"""
@@ -4246,7 +4252,7 @@ type Validator {
 	The number of epochs for which this validator has been below the
 	low stake threshold.
 	"""
-	atRisk: Int
+	atRisk: UInt
 	"""
 	The addresses of other validators this validator has reported.
 	"""
@@ -4387,3 +4393,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+


### PR DESCRIPTION
## Description

Whilst working on #18337, I noticed that we were over-using the `Int` scalar -- using it to represent values that could exceed 2^31 - 1 -- when the GraphQL spec states that `Int` must be a 32-bit signed integer.

We made this decision at the time (a) because `async-graphql` allowed converting `u64`s to `Int` and we were primarily concerned with the fact that although JSON doesn't specify a precision for its numeric types, JS (among other languages), assumes it is an IEEE double-precision floating point number, so can only represent integral values precisely below 2^53.

`cynic` (a Rust GraphQL client library) is (correctly) stricter, however, and maps an `Int` to an `i32`, always. There may be other similarly strict client libraries for other languages.

This PR introduces a new scalar, `UInt`, that maps to a JSON number literal, just like `Int`, but allows us to ascribe our own meaning (in this case, it will be an unsigned number, and it can be as large as 2^53).

This scalar has been used in many cases where we had previously used `Int`: sequence numbers, counts of objects, checkpoints, transactions, etc. While other uses continue to use `Int` (pagination limits, service limits, values bounded by the number of validators).

In some cases, we have switched from `BigInt` to using this scalar notably:

- the db cost estimate, which was previously a `BigInt` because we were unsure of its scale, but in hindsight, after benchmarking, it is unlikely that we would want to set a limit greater than 2^31 - 1.

- the number of checkpoints in an epoch, as the number of transactions in an epoch (a number that is guaranteed to be greater) is being represented using an `Int` at the moment (and soon a `UInt53`).

This will be a breaking change, so will only go out with the new major version. Hopefully, this change will be minimal as the format of this scalar over the wire is the same as for `Int`, but it will require existing clients to register a new scalar in most cases.

## Test plan

Existing tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run --features pg_integration
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Introduces a new scalar -- `UInt53` -- to represent unsigned 53 bit integer values. Some uses of `Int` in the existing schema have been replaced with `UInt53`. All clients will need to register the new scalar and clients for statically typed languages will also need to use a wider (e.g. 64 bit), unsigned type to hold the value.
- [ ] CLI: 
- [ ] Rust SDK: 
