### PR TITLE
[move-ide] Added support for param inlay hints

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -92,7 +92,9 @@ Move source file (a file with a `.move` file extension) and:
   - go to references
   - type on hover
   - outline view showing symbol tree for Move source files
-  - inlay type hints (local declarations and lambda parameters)
+  - inlay hints:
+    - types: local declarations and lambda parameters
+    - parameter names at function calls
 - If the opened Move source file is located within a buildable project you can build and (locally)
   test this project using `Move: Build a Move package` and `Move: Test a Move package` commands from
   VSCode's command palette

--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.4",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.4",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",
@@ -56,6 +56,11 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable/disable type inlay hints"
+        },
+        "move.inlay-hints.param": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable/disable parameter inlay hints"
         },
         "move.lint": {
           "type": "string",

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 export const MOVE_CONF_NAME = 'move';
 export const LINT_OPT = 'lint';
 export const TYPE_HINTS_OPT = 'inlay-hints.type';
+export const PARAM_HINTS_OPT = 'inlay-hints.param';
 export const SUI_PATH_OPT = 'sui.path';
 export const SERVER_PATH_OPT = 'server.path';
 
@@ -76,5 +77,10 @@ export class Configuration {
     get inlayHintsForType(): boolean {
         return this.configuration.get(TYPE_HINTS_OPT) ?? false;
     }
+
+    get inlayHintsForParam(): boolean {
+        return this.configuration.get(PARAM_HINTS_OPT) ?? false;
+    }
+
 
 } // Configuration

--- a/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    MOVE_CONF_NAME, LINT_OPT, TYPE_HINTS_OPT,
+    MOVE_CONF_NAME, LINT_OPT, TYPE_HINTS_OPT, PARAM_HINTS_OPT,
     SUI_PATH_OPT, SERVER_PATH_OPT, Configuration,
 } from './configuration';
 import * as childProcess from 'child_process';
@@ -78,6 +78,8 @@ export class Context {
 
     private inlayHintsType: boolean;
 
+    private inlayHintsParam: boolean;
+
     resolvedServerPath: string;
 
     resolvedServerArgs: string[];
@@ -99,6 +101,7 @@ export class Context {
         log.info(`configuration: ${this.configuration.toString()}`);
         this.lintLevel = this.configuration.lint;
         this.inlayHintsType = this.configuration.inlayHintsForType;
+        this.inlayHintsParam = this.configuration.inlayHintsForParam;
         // Default to configuration.serverPath but may change during server installation
         this.resolvedServerPath = this.configuration.serverPath;
         // Default to no additional args but may change during server installation
@@ -191,6 +194,7 @@ export class Context {
             initializationOptions: {
                 lintLevel: this.lintLevel,
                 inlayHintsType: this.inlayHintsType,
+                inlayHintsParam: this.inlayHintsParam,
             },
         };
 
@@ -239,9 +243,11 @@ export class Context {
             const sui_path_conf = MOVE_CONF_NAME.concat('.').concat(SUI_PATH_OPT);
             const lint_conf = MOVE_CONF_NAME.concat('.').concat(LINT_OPT);
             const type_hints_conf = MOVE_CONF_NAME.concat('.').concat(TYPE_HINTS_OPT);
+            const param_hints_conf = MOVE_CONF_NAME.concat('.').concat(PARAM_HINTS_OPT);
 
             const optionsChanged = event.affectsConfiguration(lint_conf) ||
-                event.affectsConfiguration(type_hints_conf);
+                event.affectsConfiguration(type_hints_conf) ||
+                event.affectsConfiguration(param_hints_conf);
             const pathsChanged = event.affectsConfiguration(server_path_conf) ||
                 event.affectsConfiguration(sui_path_conf);
 
@@ -251,6 +257,7 @@ export class Context {
 
                 this.lintLevel = this.configuration.lint;
                 this.inlayHintsType = this.configuration.inlayHintsForType;
+                this.inlayHintsParam = this.configuration.inlayHintsForParam;
                 try {
                     await this.stopClient();
                         if (pathsChanged) {

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -4,9 +4,8 @@
 use crate::{
     compiler_info::CompilerInfo,
     symbols::{
-        add_member_use_def, def_info_to_type_def_loc, expansion_mod_ident_to_map_key, type_def_loc,
-        DefInfo, DefMap, FieldDef, LocalDef, MemberDefInfo, ModuleDefs, References, UseDef,
-        UseDefMap,
+        add_member_use_def, expansion_mod_ident_to_map_key, find_datatype, type_def_loc, DefInfo,
+        DefMap, LocalDef, MemberDefInfo, ModuleDefs, References, UseDef, UseDefMap,
     },
     utils::{ignored_function, loc_start_to_lsp_position_opt},
 };
@@ -34,7 +33,7 @@ pub struct TypingAnalysisContext<'a> {
     /// Outermost definitions in a module (structs, consts, functions), keyd on a ModuleIdent
     /// string so that we can access it regardless of the ModuleIdent representation
     /// (e.g., in the parsing AST or in the typing AST)
-    pub mod_outer_defs: &'a BTreeMap<String, ModuleDefs>,
+    pub mod_outer_defs: &'a mut BTreeMap<String, ModuleDefs>,
     /// Mapped file information for translating locations into positions
     pub files: &'a MappedFiles,
     /// Associates uses for a given definition to allow displaying all references
@@ -44,6 +43,9 @@ pub struct TypingAnalysisContext<'a> {
     /// A UseDefMap for a given module (needs to be appropriately set before the module
     /// processing starts)
     pub use_defs: UseDefMap,
+    /// Current module identifier string (needs to be appropriately set before the module
+    /// processing starts)
+    pub current_mod_ident_str: Option<String>,
     /// Alias lengths in access paths for a given module (needs to be appropriately
     /// set before the module processing starts)
     pub alias_lengths: &'a BTreeMap<Position, usize>,
@@ -57,6 +59,35 @@ pub struct TypingAnalysisContext<'a> {
     pub expression_scope: OrdMap<Symbol, LocalDef>,
     /// IDE Annotation Information from the Compiler
     pub compiler_info: &'a mut CompilerInfo,
+}
+
+fn def_info_to_type_def_loc(
+    mod_outer_defs: &BTreeMap<String, ModuleDefs>,
+    def_info: &DefInfo,
+) -> Option<Loc> {
+    match def_info {
+        DefInfo::Type(t) => type_def_loc(mod_outer_defs, t),
+        DefInfo::Function(..) => None,
+        DefInfo::Struct(mod_ident, name, ..) => {
+            let mod_ident_str = expansion_mod_ident_to_map_key(mod_ident);
+            mod_outer_defs
+                .get(&mod_ident_str)
+                .map(|mod_defs| find_datatype(mod_defs, name))
+                .flatten()
+        }
+        DefInfo::Enum(mod_ident, name, ..) => {
+            let mod_ident_str = expansion_mod_ident_to_map_key(mod_ident);
+            mod_outer_defs
+                .get(&mod_ident_str)
+                .map(|mod_defs| find_datatype(mod_defs, name))
+                .flatten()
+        }
+        DefInfo::Variant(..) => None,
+        DefInfo::Field(.., t, _) => type_def_loc(mod_outer_defs, t),
+        DefInfo::Local(_, t, _, _, _) => type_def_loc(mod_outer_defs, t),
+        DefInfo::Const(_, _, t, _, _) => type_def_loc(mod_outer_defs, t),
+        DefInfo::Module(..) => None,
+    }
 }
 
 impl TypingAnalysisContext<'_> {
@@ -241,17 +272,28 @@ impl TypingAnalysisContext<'_> {
         fun_def_name: &Symbol, // may be different from use_name for methods
         use_name: &Symbol,
         use_pos: &Loc,
-    ) {
+    ) -> Option<UseDef> {
         if self.traverse_only {
-            return;
+            return None;
         }
-        let mod_ident_str = expansion_mod_ident_to_map_key(&module_ident.value);
-        let Some(mod_defs) = self.mod_outer_defs.get(&mod_ident_str) else {
-            return;
+        let mod_name = module_ident.value.module;
+        let mod_name_start_opt = self.file_start_position_opt(&mod_name.loc());
+
+        let Some(mod_defs) = self
+            .mod_outer_defs
+            .get_mut(&expansion_mod_ident_to_map_key(&module_ident.value))
+        else {
+            // this should not happen but due to a fix in unifying generation of mod ident map keys,
+            // but just in case - it's better to report it than to crash the analyzer due to
+            // unchecked unwrap
+            eprintln!(
+                "WARNING: could not locate module {:?} when processing a call to {}{}",
+                module_ident.value, module_ident.value, fun_def_name
+            );
+            return None;
         };
         // insert use of the functions's module
-        let mod_name = module_ident.value.module;
-        if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
+        if let Some(mod_name_start) = mod_name_start_opt {
             // a module will not be present if a function belongs to an implicit module
             self.use_defs.insert(
                 mod_name_start.line,
@@ -271,7 +313,6 @@ impl TypingAnalysisContext<'_> {
         let mut refs = std::mem::take(self.references);
         let result = add_member_use_def(
             fun_def_name,
-            self.mod_outer_defs,
             self.files,
             mod_defs,
             use_name,
@@ -287,6 +328,7 @@ impl TypingAnalysisContext<'_> {
         if result.is_none() {
             debug_assert!(false);
         }
+        result
     }
 
     /// Add use of a datatype identifier
@@ -320,7 +362,6 @@ impl TypingAnalysisContext<'_> {
         let mut refs = std::mem::take(self.references);
         add_member_use_def(
             &use_name.value(),
-            self.mod_outer_defs,
             self.files,
             mod_defs,
             &use_name.value(),
@@ -349,71 +390,10 @@ impl TypingAnalysisContext<'_> {
                 sp!(_, N::TypeName_::ModuleType(sp!(_, mod_ident), struct_name)),
                 _,
             ) => {
-                self.add_struct_field_use_def(mod_ident, &struct_name.value(), use_name, use_pos);
+                self.add_field_use_def(mod_ident, &struct_name.value(), None, use_name, use_pos);
             }
             _ => (),
         }
-    }
-
-    fn add_field_use_def_internal(
-        &mut self,
-        field_defs: &[FieldDef],
-        use_name: &Symbol,
-        use_loc: &Loc,
-        use_pos: &Position,
-    ) {
-        for fdef in field_defs {
-            if fdef.name == *use_name {
-                let field_info = self.def_info.get(&fdef.loc).unwrap();
-                let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, field_info);
-                self.use_defs.insert(
-                    use_pos.line,
-                    UseDef::new(
-                        self.references,
-                        self.alias_lengths,
-                        use_loc.file_hash(),
-                        *use_pos,
-                        fdef.loc,
-                        use_name,
-                        ident_type_def_loc,
-                    ),
-                );
-            }
-        }
-    }
-
-    /// Add use of a struct field identifier
-    fn add_struct_field_use_def(
-        &mut self,
-        module_ident: &E::ModuleIdent_,
-        struct_name: &Symbol,
-        use_name: &Symbol,
-        use_pos: &Loc,
-    ) {
-        if self.traverse_only {
-            return;
-        }
-        let mod_ident_str = expansion_mod_ident_to_map_key(module_ident);
-        let Some(name_start) = self.file_start_position_opt(use_pos) else {
-            debug_assert!(false);
-            return;
-        };
-        let Some(mod_defs) = self.mod_outer_defs.get(&mod_ident_str) else {
-            return;
-        };
-        // get the struct
-        let Some(def) = mod_defs.structs.get(struct_name) else {
-            return;
-        };
-        // get variant's fields
-        let MemberDefInfo::Struct {
-            field_defs,
-            positional: _,
-        } = &def.info
-        else {
-            return;
-        };
-        self.add_field_use_def_internal(field_defs, use_name, use_pos, &name_start);
     }
 
     fn add_variant_use_def(
@@ -464,11 +444,11 @@ impl TypingAnalysisContext<'_> {
     }
 
     /// Add use of a variant field identifier
-    fn add_variant_field_use_def(
+    fn add_field_use_def(
         &mut self,
         module_ident: &E::ModuleIdent_,
-        enum_name: &Symbol,
-        variant_name: &Symbol,
+        datatype_name: &Symbol,
+        variant_name_opt: Option<&Symbol>,
         use_name: &Symbol,
         use_loc: &Loc,
     ) {
@@ -484,19 +464,56 @@ impl TypingAnalysisContext<'_> {
         let Some(mod_defs) = self.mod_outer_defs.get(&mod_ident_str) else {
             return;
         };
-        // get the enum
-        let Some(def) = mod_defs.enums.get(enum_name) else {
-            return;
+
+        let field_defs = if let Some(variant_name) = variant_name_opt {
+            // get the enum
+            let Some(def) = mod_defs.enums.get(datatype_name) else {
+                return;
+            };
+
+            // get variants info
+            let MemberDefInfo::Enum { variants_info } = &def.info else {
+                return;
+            };
+            // get variant's fields
+            let Some((_, field_defs, _)) = variants_info.get(variant_name) else {
+                return;
+            };
+            field_defs
+        } else {
+            // get the struct
+            let Some(def) = mod_defs.structs.get(datatype_name) else {
+                return;
+            };
+            // get variant's fields
+            let MemberDefInfo::Struct {
+                field_defs,
+                positional: _,
+            } = &def.info
+            else {
+                return;
+            };
+            field_defs
         };
-        // get variants info
-        let MemberDefInfo::Enum { variants_info } = &def.info else {
-            return;
-        };
-        // get variant's fields
-        let Some((_, field_defs, _)) = variants_info.get(variant_name) else {
-            return;
-        };
-        self.add_field_use_def_internal(field_defs, use_name, use_loc, &name_start);
+
+        for fdef in field_defs {
+            if fdef.name == *use_name {
+                let field_info = self.def_info.get(&fdef.loc).unwrap();
+                let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, field_info);
+                self.use_defs.insert(
+                    name_start.line,
+                    UseDef::new(
+                        self.references,
+                        self.alias_lengths,
+                        use_loc.file_hash(),
+                        name_start,
+                        fdef.loc,
+                        use_name,
+                        ident_type_def_loc,
+                    ),
+                );
+            }
+        }
     }
 
     fn process_module_call(
@@ -507,34 +524,31 @@ impl TypingAnalysisContext<'_> {
         tyargs: &mut [N::Type],
         args: Option<&mut Box<T::Exp>>,
     ) {
-        let Some(mod_def) = self
-            .mod_outer_defs
-            .get(&expansion_mod_ident_to_map_key(&module.value))
-        else {
-            // this should not happen but due to a fix in unifying generation of mod ident map keys,
-            // but just in case - it's better to report it than to crash the analyzer due to
-            // unchecked unwrap
-            eprintln!(
-                "WARNING: could not locate module {:?} when processing a call to {}{}",
-                module, module, name
-            );
-            return;
-        };
-
-        if mod_def.functions.get(&name.value()).is_none() {
-            return;
-        }
-
         let fun_name = name.value();
         // a function name (same as fun_name) or method name (different from fun_name)
         let fun_use = method_name.unwrap_or_else(|| sp(name.loc(), name.value()));
-        self.add_fun_use_def(module, &fun_name, &fun_use.value, &fun_use.loc);
+        let call_use_def = self.add_fun_use_def(module, &fun_name, &fun_use.value, &fun_use.loc);
         // handle type parameters
         for t in tyargs.iter_mut() {
             self.visit_type(None, t);
         }
         if let Some(args) = args {
             self.visit_exp(args);
+        }
+
+        // populate call info obtained during parsing with the location of the call site's target function
+        let Some(use_def) = call_use_def else {
+            return;
+        };
+        assert!(self.current_mod_ident_str.is_some());
+        let Some(callsite_mod_defs) = self
+            .mod_outer_defs
+            .get_mut(&self.current_mod_ident_str.clone().unwrap())
+        else {
+            return;
+        };
+        if let Some(info) = callsite_mod_defs.call_infos.get_mut(&fun_use.loc) {
+            info.def_loc = Some(use_def.def_loc());
         }
     }
 
@@ -550,10 +564,10 @@ impl TypingAnalysisContext<'_> {
                 tyargs.iter_mut().for_each(|t| self.visit_type(None, t));
                 for (fpos, fname, (_, (_, pat))) in fields.iter_mut() {
                     if self.compiler_info.ellipsis_binders.get(&fpos).is_none() {
-                        self.add_variant_field_use_def(
+                        self.add_field_use_def(
                             &mident.value,
                             &name.value(),
-                            &vname.value(),
+                            Some(&vname.value()),
                             fname,
                             &fpos,
                         );
@@ -567,7 +581,7 @@ impl TypingAnalysisContext<'_> {
                 tyargs.iter_mut().for_each(|t| self.visit_type(None, t));
                 for (fpos, fname, (_, (_, pat))) in fields.iter_mut() {
                     if self.compiler_info.ellipsis_binders.get(&fpos).is_none() {
-                        self.add_struct_field_use_def(&mident.value, &name.value(), fname, &fpos);
+                        self.add_field_use_def(&mident.value, &name.value(), None, fname, &fpos);
                     }
                     self.process_match_patterm(pat);
                 }
@@ -644,12 +658,13 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
 
     fn visit_struct(
         &mut self,
-        _module: move_compiler::expansion::ast::ModuleIdent,
+        module: move_compiler::expansion::ast::ModuleIdent,
         struct_name: P::DatatypeName,
         sdef: &mut N::StructDefinition,
     ) {
         self.reset_for_module_member();
-
+        assert!(self.current_mod_ident_str.is_none());
+        self.current_mod_ident_str = Some(expansion_mod_ident_to_map_key(&module.value));
         let file_hash = struct_name.loc().file_hash();
         // enter self-definition for struct name (unwrap safe - done when inserting def)
         let name_start = self.file_start_position(&struct_name.loc());
@@ -699,6 +714,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                 }
             }
         }
+        self.current_mod_ident_str = None;
     }
 
     fn visit_enum_custom(
@@ -708,6 +724,8 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
         edef: &mut N::EnumDefinition,
     ) -> bool {
         self.reset_for_module_member();
+        assert!(self.current_mod_ident_str.is_none());
+        self.current_mod_ident_str = Some(expansion_mod_ident_to_map_key(&module.value));
         let file_hash = enum_name.loc().file_hash();
         // enter self-definition for enum name (unwrap safe - done when inserting def)
         let name_start = self.file_start_position(&enum_name.loc());
@@ -732,6 +750,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
         for (vname, vdef) in edef.variants.key_cloned_iter_mut() {
             self.visit_variant(&module, &enum_name, vname, vdef);
         }
+        self.current_mod_ident_str = None;
         true
     }
 
@@ -791,11 +810,13 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
 
     fn visit_constant(
         &mut self,
-        _module: move_compiler::expansion::ast::ModuleIdent,
+        module: move_compiler::expansion::ast::ModuleIdent,
         constant_name: P::ConstantName,
         cdef: &mut T::Constant,
     ) {
         self.reset_for_module_member();
+        assert!(self.current_mod_ident_str.is_none());
+        self.current_mod_ident_str = Some(expansion_mod_ident_to_map_key(&module.value));
         let loc = constant_name.loc();
         // enter self-definition for const name (unwrap safe - done when inserting def)
         let name_start = self.file_start_position(&loc);
@@ -814,11 +835,12 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
             ),
         );
         self.visit_exp(&mut cdef.value);
+        self.current_mod_ident_str = None;
     }
 
     fn visit_function(
         &mut self,
-        _module: move_compiler::expansion::ast::ModuleIdent,
+        module: move_compiler::expansion::ast::ModuleIdent,
         function_name: P::FunctionName,
         fdef: &mut T::Function,
     ) {
@@ -826,6 +848,8 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
         if ignored_function(function_name.value()) {
             return;
         }
+        assert!(self.current_mod_ident_str.is_none());
+        self.current_mod_ident_str = Some(expansion_mod_ident_to_map_key(&module.value));
         let loc = function_name.loc();
         // first, enter self-definition for function name (unwrap safe - done when inserting def)
         let name_start = self.file_start_position(&loc);
@@ -873,6 +897,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
 
         // clear type params from the scope
         self.type_params.clear();
+        self.current_mod_ident_str = None;
     }
 
     fn visit_lvalue(&mut self, kind: &LValueKind, lvalue: &mut T::LValue) {
@@ -909,7 +934,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                     self.add_datatype_use_def(mident, name);
                     tyargs.iter_mut().for_each(|t| self.visit_type(None, t));
                     for (fpos, fname, (_, (_, lvalue))) in fields {
-                        self.add_struct_field_use_def(&mident.value, &name.value(), fname, &fpos);
+                        self.add_field_use_def(&mident.value, &name.value(), None, fname, &fpos);
                         lvalue_queue.push(lvalue);
                     }
                 }
@@ -919,10 +944,10 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                     self.add_datatype_use_def(mident, name);
                     tyargs.iter_mut().for_each(|t| self.visit_type(None, t));
                     for (fpos, fname, (_, (_, lvalue))) in fields {
-                        self.add_variant_field_use_def(
+                        self.add_field_use_def(
                             &mident.value,
                             &name.value(),
-                            &vname.value(),
+                            Some(&vname.value()),
                             fname,
                             &fpos,
                         );
@@ -984,12 +1009,7 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                 TE::Pack(mident, name, tyargs, fields) => {
                     visitor.add_datatype_use_def(mident, name);
                     for (fpos, fname, (_, (_, init_exp))) in fields.iter_mut() {
-                        visitor.add_struct_field_use_def(
-                            &mident.value,
-                            &name.value(),
-                            fname,
-                            &fpos,
-                        );
+                        visitor.add_field_use_def(&mident.value, &name.value(), None, fname, &fpos);
                         visitor.visit_exp(init_exp);
                     }
                     tyargs
@@ -1005,10 +1025,10 @@ impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
                 TE::PackVariant(mident, name, vname, tyargs, fields) => {
                     visitor.add_datatype_use_def(mident, name);
                     for (fpos, fname, (_, (_, init_exp))) in fields.iter_mut() {
-                        visitor.add_variant_field_use_def(
+                        visitor.add_field_use_def(
                             &mident.value,
                             &name.value(),
-                            &vname.value(),
+                            Some(&vname.value()),
                             fname,
                             &fpos,
                         );

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -72,15 +72,13 @@ fn def_info_to_type_def_loc(
             let mod_ident_str = expansion_mod_ident_to_map_key(mod_ident);
             mod_outer_defs
                 .get(&mod_ident_str)
-                .map(|mod_defs| find_datatype(mod_defs, name))
-                .flatten()
+                .and_then(|mod_defs| find_datatype(mod_defs, name))
         }
         DefInfo::Enum(mod_ident, name, ..) => {
             let mod_ident_str = expansion_mod_ident_to_map_key(mod_ident);
             mod_outer_defs
                 .get(&mod_ident_str)
-                .map(|mod_defs| find_datatype(mod_defs, name))
-                .flatten()
+                .and_then(|mod_defs| find_datatype(mod_defs, name))
         }
         DefInfo::Variant(..) => None,
         DefInfo::Field(.., t, _) => type_def_loc(mod_outer_defs, t),

--- a/external-crates/move/crates/move-analyzer/src/analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/analyzer.rs
@@ -170,9 +170,16 @@ pub fn run() {
             .and_then(|init_options| init_options.get("inlayHintsType"))
             .and_then(serde_json::Value::as_bool)
             .unwrap_or_default(),
+        inlay_param_hints: initialize_params
+            .initialization_options
+            .as_ref()
+            .and_then(|init_options| init_options.get("inlayHintsParam"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or_default(),
     };
 
     eprintln!("inlay type hints enabled: {}", context.inlay_type_hints);
+    eprintln!("inlay param hints enabled: {}", context.inlay_param_hints);
 
     context
         .connection

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -27,7 +27,7 @@ use move_compiler::{
         keywords::{BUILTINS, CONTEXTUAL_KEYWORDS, KEYWORDS, PRIMITIVE_TYPES},
         lexer::{Lexer, Tok},
     },
-    shared::{ide::AutocompleteMethod, Identifier},
+    shared::{ide::AutocompleteMethod, Identifier, Name},
 };
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
@@ -239,7 +239,7 @@ fn call_completion_item(
     method_name: &Symbol,
     function_name: &Symbol,
     type_args: &[Type],
-    arg_names: &[Symbol],
+    arg_names: &[Name],
     arg_types: &[Type],
     ret_type: &Type,
 ) -> CompletionItem {

--- a/external-crates/move/crates/move-analyzer/src/context.rs
+++ b/external-crates/move/crates/move-analyzer/src/context.rs
@@ -18,4 +18,6 @@ pub struct Context {
     pub symbols: Arc<Mutex<BTreeMap<PathBuf, Symbols>>>,
     /// Are inlay type hints enabled?
     pub inlay_type_hints: bool,
+    /// Are param type hints enabled?
+    pub inlay_param_hints: bool,
 }

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -123,12 +123,10 @@ fn inlay_param_hints_internal(
                 command: None,
             };
             let position = symbols.files.start_position(use_loc);
-            let tooltip = symbols.def_info(def_loc).and_then(|arg_def_info| {
+            let tooltip = symbols.def_info(def_loc).map(|arg_def_info| {
                 // see doc comment for `additional_type_hint_info` to see
                 // why we only support on hover tooltip for now
-                Some(InlayHintTooltip::MarkupContent(on_hover_markup(
-                    arg_def_info,
-                )))
+                InlayHintTooltip::MarkupContent(on_hover_markup(arg_def_info))
             });
             let h = InlayHint {
                 position: position.into(),

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -357,7 +357,7 @@ impl CallInfo {
     }
 }
 
-/// Module-level definitions
+/// Module-level definitions and other module-related info
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ModuleDefs {
     /// File where this module is located

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -348,7 +348,7 @@ pub struct CallInfo {
 }
 
 impl CallInfo {
-    pub fn new(dot_call: bool, args: &Vec<P::Exp>) -> Self {
+    pub fn new(dot_call: bool, args: &[P::Exp]) -> Self {
         Self {
             dot_call,
             arg_locs: args.iter().map(|e| e.loc).collect(),
@@ -3071,8 +3071,7 @@ pub fn type_def_loc(
             let mod_ident_str = expansion_mod_ident_to_map_key(mod_ident);
             mod_outer_defs
                 .get(&mod_ident_str)
-                .map(|mod_defs| find_datatype(mod_defs, &struct_name.value()))
-                .flatten()
+                .and_then(|mod_defs| find_datatype(mod_defs, &struct_name.value()))
         }
         _ => None,
     }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -175,7 +175,7 @@ pub enum DefInfo {
         /// Type args
         Vec<Type>,
         /// Arg names
-        Vec<Symbol>,
+        Vec<Name>,
         /// Arg types
         Vec<Type>,
         /// Ret type
@@ -195,7 +195,7 @@ pub enum DefInfo {
         /// Abilities
         AbilitySet,
         /// Field names
-        Vec<Symbol>,
+        Vec<Name>,
         /// Field types
         Vec<Type>,
         /// Doc string
@@ -227,7 +227,7 @@ pub enum DefInfo {
         /// Positional fields?
         bool,
         /// Field names
-        Vec<Symbol>,
+        Vec<Name>,
         /// Field types
         Vec<Type>,
         /// Doc string
@@ -818,7 +818,7 @@ fn datatype_type_args_to_ide_string(type_args: &[(Type, bool)], verbose: bool) -
 }
 
 fn typed_id_list_to_ide_string(
-    names: &[Symbol],
+    names: &[Name],
     types: &[Type],
     separate_lines: bool,
     verbose: bool,
@@ -828,9 +828,9 @@ fn typed_id_list_to_ide_string(
         .zip(types.iter())
         .map(|(n, t)| {
             if separate_lines {
-                format!("\t{}: {}", n, type_to_ide_string(t, verbose))
+                format!("\t{}: {}", n.value, type_to_ide_string(t, verbose))
             } else {
-                format!("{}: {}", n, type_to_ide_string(t, verbose))
+                format!("{}: {}", n.value, type_to_ide_string(t, verbose))
             }
         })
         .collect::<Vec<_>>()
@@ -2098,7 +2098,7 @@ fn get_mod_outer_defs(
         };
 
         // process the struct itself
-        let field_names = field_defs.iter().map(|f| f.name).collect();
+        let field_names = field_defs.iter().map(|f| sp(f.loc, f.name)).collect();
         structs.insert(
             *name,
             MemberDef {
@@ -2154,7 +2154,7 @@ fn get_mod_outer_defs(
                 }
                 VariantFields::Empty => (vec![], vec![], false),
             };
-            let field_names = field_defs.iter().map(|f| f.name).collect();
+            let field_names = field_defs.iter().map(|f| sp(f.loc, f.name)).collect();
             def_info_variants.push(VariantInfo {
                 name: *vname,
                 empty: field_defs.is_empty(),
@@ -2246,7 +2246,7 @@ fn get_mod_outer_defs(
             fun.signature
                 .parameters
                 .iter()
-                .map(|(_, n, _)| n.value.name)
+                .map(|(_, n, _)| sp(n.loc, n.value.name))
                 .collect(),
             fun.signature
                 .parameters

--- a/external-crates/move/crates/move-analyzer/tests/dot_completion.ide
+++ b/external-crates/move/crates/move-analyzer/tests/dot_completion.ide
@@ -1,35 +1,35 @@
 // Tests dot completions
-    // tests completion for fields and "regular" functions
-        // simple test
-        // with aliasing
-        // with shadowing
-    // tests completion for macros including addition of `!` at the call site
-    // and expansion of lambda parameters into their own snippets
-    // tests completions coming from a different module
 {
   "Completion": {
     "project": "tests/completion",
     "file_tests": {
+      // tests completion for fields and "regular" functions
       "dot.move": [
+        // simple test
         {
           "use_line": 15,
           "use_col": 10
         },
+        // with aliasing
         {
           "use_line": 21,
           "use_col": 10
         },
+        // with shadowing
         {
           "use_line": 27,
           "use_col": 10
         }
       ],
+      // tests completion for macros including addition of `!` at the call site
+      // and expansion of lambda parameters into their own snippets
       "macro_dot.move": [
         {
           "use_line": 8,
           "use_col": 10
         }
       ],
+      // tests completions coming from a different module
       "other_mod_dot.move": [
         {
           "use_line": 4,

--- a/external-crates/move/crates/move-analyzer/tests/enums.ide
+++ b/external-crates/move/crates/move-analyzer/tests/enums.ide
@@ -1,16 +1,9 @@
 // Checks if symbolication enums work correctly.
-    // test matching of variants
-    // test matching of structs
-    // test matching of ints
-    // test displaying of enum with many variants
-    // test matching of mutable value (guards should be immutable refs)
-    // test matching of nested patterns
-    // tests if a nested pattern var is displayed correctly (it's inside outer guard
-    // but should only be displayed as immutable reference when inside inner guard)
 {
   "UseDef": {
     "project": "tests/enums",
     "file_tests": {
+      // test matching of variants
       "variant_match.move": [
         {
           "use_line": 7,
@@ -141,6 +134,7 @@
           "use_ndx": 3
         }
       ],
+      // test matching of structs
       "struct_match.move": [
         {
           "use_line": 13,
@@ -175,6 +169,7 @@
           "use_ndx": 4
         }
       ],
+      // test matching of ints
       "int_match.move": [
         {
           "use_line": 5,
@@ -197,12 +192,14 @@
           "use_ndx": 1
         }
       ],
+      // test displaying of enum with many variants
       "long_enum.move": [
         {
           "use_line": 3,
           "use_ndx": 0
         }
       ],
+      // test matching of mutable value (guards should be immutable refs)
       "mut_match.move": [
         {
           "use_line": 4,
@@ -221,6 +218,7 @@
           "use_ndx": 2
         }
       ],
+      // test matching of nested patterns
       "nested_match.move": [
         {
           "use_line": 15,
@@ -267,6 +265,8 @@
           "use_ndx": 6
         }
       ],
+      // tests if a nested pattern var is displayed correctly (it's inside outer guard
+      // but should only be displayed as immutable reference when inside inner guard)
       "nested_guard.move": [
         {
           "use_line": 4,

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -264,7 +264,7 @@ impl HintTest {
         use_file_path: &Path,
     ) -> anyhow::Result<()> {
         let inlay_hints = inlay_hints_internal(
-            &symbols,
+            symbols,
             use_file_path.to_path_buf(),
             /* type_hints */ true,
             /* param_hints */ true,

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -10,9 +10,10 @@ use std::{
 };
 
 use json_comments::StripComments;
-use lsp_types::Position;
+use lsp_types::{InlayHintKind, InlayHintLabel, Position};
 use move_analyzer::{
     completion::completion_items,
+    inlay_hints::inlay_hints_internal,
     symbols::{
         def_info_doc_string, get_symbols, maybe_convert_for_guard, PrecompiledPkgDeps, Symbols,
         UseDefMap,
@@ -43,6 +44,10 @@ enum TestSuite {
         project: String,
         file_tests: BTreeMap<String, Vec<CursorTest>>,
     },
+    Hint {
+        project: String,
+        file_tests: BTreeMap<String, Vec<HintTest>>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -62,6 +67,12 @@ struct CursorTest {
     line: u32,
     character: u32,
     description: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct HintTest {
+    use_line: u32,
+    use_col: u32,
 }
 
 //**************************************************************************************************
@@ -244,6 +255,50 @@ impl CursorTest {
     }
 }
 
+impl HintTest {
+    fn test(
+        &self,
+        test_idx: usize,
+        symbols: &Symbols,
+        output: &mut dyn std::io::Write,
+        use_file_path: &Path,
+    ) -> anyhow::Result<()> {
+        let inlay_hints = inlay_hints_internal(
+            &symbols,
+            use_file_path.to_path_buf(),
+            /* type_hints */ true,
+            /* param_hints */ true,
+        )
+        .unwrap();
+        let lsp_line = self.use_line - 1; // 0th-based
+
+        writeln!(output, "-- test {test_idx} -------------------")?;
+        let Some((hint, label_parts)) = inlay_hints.iter().find_map(|h| {
+            if h.position.line == lsp_line && h.position.character == self.use_col {
+                if let InlayHintLabel::LabelParts(parts) = &h.label {
+                    return Some((h, parts));
+                }
+            }
+            None
+        }) else {
+            writeln!(output, "NO INLAY HINT FOUND")?;
+            return Ok(());
+        };
+
+        match hint.kind {
+            Some(InlayHintKind::TYPE) => {
+                writeln!(output, "INLAY TYPE HINT : {}", label_parts[1].value)?
+            }
+            Some(InlayHintKind::PARAMETER) => {
+                writeln!(output, "INLAY PARAM HINT: {}", label_parts[0].value)?
+            }
+            _ => writeln!(output, "INLAY HINT OF UNKNOWN TYPE")?,
+        }
+
+        Ok(())
+    }
+}
+
 //**************************************************************************************************
 // Test Suite Runner Code
 //**************************************************************************************************
@@ -402,6 +457,35 @@ fn cursor_test_suite(
     Ok(result)
 }
 
+fn hint_test_suite(
+    project: String,
+    file_tests: BTreeMap<String, Vec<HintTest>>,
+) -> datatest_stable::Result<String> {
+    let (project_path, _, _, symbols) = initial_symbols(project)?;
+
+    let mut output: BufWriter<_> = BufWriter::new(Vec::new());
+    let writer: &mut dyn io::Write = output.get_mut();
+
+    for (file, tests) in file_tests {
+        writeln!(
+            writer,
+            "== {file} ========================================================"
+        )?;
+
+        let mut fpath = project_path.clone();
+
+        fpath.push(format!("sources/{file}"));
+        let cpath = dunce::canonicalize(&fpath).unwrap();
+
+        for (idx, test) in tests.iter().enumerate() {
+            test.test(idx, &symbols, writer, &cpath)?;
+        }
+    }
+
+    let result: String = String::from_utf8(output.into_inner().unwrap()).unwrap();
+    Ok(result)
+}
+
 fn move_ide_testsuite(test_path: &Path) -> datatest_stable::Result<()> {
     let suite_file = io::BufReader::new(File::open(test_path)?);
     let stripped = StripComments::new(suite_file);
@@ -420,6 +504,10 @@ fn move_ide_testsuite(test_path: &Path) -> datatest_stable::Result<()> {
             project,
             file_tests,
         } => cursor_test_suite(project, file_tests),
+        TestSuite::Hint {
+            project,
+            file_tests,
+        } => hint_test_suite(project, file_tests),
     }?;
 
     let exp_string = test_path

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use json_comments::StripComments;
-use lsp_types::{InlayHintKind, InlayHintLabel, Position};
+use lsp_types::{InlayHintKind, InlayHintLabel, InlayHintTooltip, Position};
 use move_analyzer::{
     completion::completion_items,
     inlay_hints::inlay_hints_internal,
@@ -285,6 +285,11 @@ impl HintTest {
             return Ok(());
         };
 
+        let tooltip = hint.tooltip.as_ref().map(|tip| match tip {
+            InlayHintTooltip::String(s) => s.clone(),
+            InlayHintTooltip::MarkupContent(m) => m.value.clone(),
+        });
+
         match hint.kind {
             Some(InlayHintKind::TYPE) => {
                 writeln!(output, "INLAY TYPE HINT : {}", label_parts[1].value)?
@@ -293,6 +298,9 @@ impl HintTest {
                 writeln!(output, "INLAY PARAM HINT: {}", label_parts[0].value)?
             }
             _ => writeln!(output, "INLAY HINT OF UNKNOWN TYPE")?,
+        }
+        if let Some(tip) = tooltip {
+            writeln!(output, "ON HOVER:\n{}", tip)?;
         }
 
         Ok(())

--- a/external-crates/move/crates/move-analyzer/tests/inlay-hints/sources/param_hints.move
+++ b/external-crates/move/crates/move-analyzer/tests/inlay-hints/sources/param_hints.move
@@ -1,0 +1,21 @@
+module InlayHints::param_hints {
+
+    public struct SomeStruct has drop {
+        some_field: u64,
+    }
+
+    public fun foo(first_param: u64, second_param: SomeStruct) {}
+
+
+    public fun test_one_line(s: SomeStruct) {
+        foo(42, s);
+    }
+
+    public fun test_mulit_line(s: SomeStruct) {
+        foo(42, 
+            s);
+    }
+    
+
+
+}

--- a/external-crates/move/crates/move-analyzer/tests/inlay-hints/sources/param_hints.move
+++ b/external-crates/move/crates/move-analyzer/tests/inlay-hints/sources/param_hints.move
@@ -12,10 +12,10 @@ module InlayHints::param_hints {
     }
 
     public fun test_mulit_line(s: SomeStruct) {
-        foo(42, 
+        foo(s.some_field + 42,
             s);
     }
-    
+
 
 
 }

--- a/external-crates/move/crates/move-analyzer/tests/inlay_hints.exp
+++ b/external-crates/move/crates/move-analyzer/tests/inlay_hints.exp
@@ -1,22 +1,56 @@
 == param_hints.move ========================================================
 -- test 0 -------------------
 INLAY PARAM HINT: first_param
+ON HOVER:
+```rust
+first_param: u64
+```
 -- test 1 -------------------
 INLAY PARAM HINT: second_param
+ON HOVER:
+```rust
+second_param: InlayHints::param_hints::SomeStruct
+```
 -- test 2 -------------------
 INLAY PARAM HINT: first_param
+ON HOVER:
+```rust
+first_param: u64
+```
 -- test 3 -------------------
 INLAY PARAM HINT: second_param
+ON HOVER:
+```rust
+second_param: InlayHints::param_hints::SomeStruct
+```
 == type_hints.move ========================================================
 -- test 0 -------------------
 INLAY TYPE HINT : u64
 -- test 1 -------------------
 INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+ON HOVER:
+```rust
+public struct InlayHints::type_hints::SomeStruct has copy, drop {
+	some_field: u64
+}
+```
 -- test 2 -------------------
 INLAY TYPE HINT : u64
 -- test 3 -------------------
 INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+ON HOVER:
+```rust
+public struct InlayHints::type_hints::SomeStruct has copy, drop {
+	some_field: u64
+}
+```
 -- test 4 -------------------
 INLAY TYPE HINT : u64
 -- test 5 -------------------
 INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+ON HOVER:
+```rust
+public struct InlayHints::type_hints::SomeStruct has copy, drop {
+	some_field: u64
+}
+```

--- a/external-crates/move/crates/move-analyzer/tests/inlay_hints.exp
+++ b/external-crates/move/crates/move-analyzer/tests/inlay_hints.exp
@@ -1,0 +1,22 @@
+== param_hints.move ========================================================
+-- test 0 -------------------
+INLAY PARAM HINT: first_param
+-- test 1 -------------------
+INLAY PARAM HINT: second_param
+-- test 2 -------------------
+INLAY PARAM HINT: first_param
+-- test 3 -------------------
+INLAY PARAM HINT: second_param
+== type_hints.move ========================================================
+-- test 0 -------------------
+INLAY TYPE HINT : u64
+-- test 1 -------------------
+INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+-- test 2 -------------------
+INLAY TYPE HINT : u64
+-- test 3 -------------------
+INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+-- test 4 -------------------
+INLAY TYPE HINT : u64
+-- test 5 -------------------
+INLAY TYPE HINT : InlayHints::type_hints::SomeStruct

--- a/external-crates/move/crates/move-analyzer/tests/inlay_hints.ide
+++ b/external-crates/move/crates/move-analyzer/tests/inlay_hints.ide
@@ -1,0 +1,58 @@
+// Tests dot completions
+{
+  "Hint": {
+    "project": "tests/inlay-hints",
+    "file_tests": {
+      // tests inlay type hints
+      "type_hints.move": [
+        {
+          "use_line": 8,
+          "use_col": 22
+        },
+        {
+          "use_line": 9,
+          "use_col": 24
+        },
+        {
+          "use_line": 25,
+          "use_col": 23
+        },
+        {
+          "use_line": 26,
+          "use_col": 25
+        },
+        {
+          "use_line": 27,
+          "use_col": 27
+        },
+        {
+          "use_line": 28,
+          "use_col": 29
+        }
+      ],
+      // tests inlay param hints
+      "param_hints.move": [
+        // first arg, same line
+        {
+          "use_line": 11,
+          "use_col": 12
+        },
+        // second arg, same line
+        {
+          "use_line": 11,
+          "use_col": 16
+        },
+        // first arg, first line
+        {
+          "use_line": 15,
+          "use_col": 12
+        },
+        // second arg, second line
+        {
+          "use_line": 16,
+          "use_col": 12
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description 

What the title says. Here is an example:

![image](https://github.com/MystenLabs/sui/assets/1724397/507c27ed-7465-4411-93df-d7bf4dbceb08)

We also support on-hover for param inlay hints:

![image](https://github.com/MystenLabs/sui/assets/1724397/b9c20085-e097-4888-a1d5-2268e62cee56)

The algorithm works in two stages:
- collect information about expressions representing arguments when visiting parsing AST (as that'w when they are still represented as a vector of expressions rather than a single expression as in typed AST)
- find the call's function target when visiting typed AST to be able to combine its signature with argument locations collected in the previous step to generate param hints when they are requested

Also this PR drops by-hand testing for inlay hints and replaces it with an extension of the IDE testing harness

## Test plan 

All old and new tests must pass
