### PR TITLE
[StateAccumulator] Fix genesis edge case

### DIFF
--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -710,21 +710,32 @@ impl StateAccumulatorV2 {
             // bootstrap from the previous epoch's root state hash. Because this
             // should only occur at beginning of epoch, we shouldn't have to worry
             // about race conditions on reading the highest running root accumulator.
-            let (prev_epoch, (last_checkpoint_prev_epoch, prev_acc)) = self
-                .store
-                .get_root_state_accumulator_for_highest_epoch()?
-                .expect("Expected root state hash for previous epoch to exist");
-            if last_checkpoint_prev_epoch != checkpoint_seq_num - 1 {
+            if let Some((prev_epoch, (last_checkpoint_prev_epoch, prev_acc))) =
+                self.store.get_root_state_accumulator_for_highest_epoch()?
+            {
+                if last_checkpoint_prev_epoch != checkpoint_seq_num - 1 {
+                    epoch_store
+                        .notify_read_running_root(checkpoint_seq_num - 1)
+                        .await?
+                } else {
+                    assert_eq!(
+                        prev_epoch + 1,
+                        epoch_store.epoch(),
+                        "Expected highest existing root state hash to be for previous epoch",
+                    );
+                    prev_acc
+                }
+            } else {
+                // Rare edge case where we manage to somehow lag in checkpoint execution from genesis
+                // such that the end of epoch checkpoint is built before we execute any checkpoints.
+                assert_eq!(
+                    epoch_store.epoch(),
+                    0,
+                    "Expected epoch to be 0 if previous root state hash does not exist"
+                );
                 epoch_store
                     .notify_read_running_root(checkpoint_seq_num - 1)
                     .await?
-            } else {
-                assert_eq!(
-                    prev_epoch + 1,
-                    epoch_store.epoch(),
-                    "Expected highest existing root state hash to be for previous epoch",
-                );
-                prev_acc
             }
         } else {
             epoch_store


### PR DESCRIPTION
## Description 

Testing infra surfaced a rare edge case where, if a validator on a newly genesis'ed chain is slow in execution such that the epoch 0 end of epoch checkpoint is proposed before we have executed and accumulated genesis checkpoint, we will panic due to attempting to bootstrap the running root from the previous epoch root state hash, which does not exist in that case.

Note that this is not a critical fix as it only would affect a newly genesis'ed chain.

## Test plan 

Existing tests for now

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
