### PR TITLE
[Sui/move] Enable enums in testnet and switch them to 2024.beta

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -155,6 +155,7 @@ const MAX_PROTOCOL_VERSION: u64 = 53;
 //             Enable Mysticeti on mainnet.
 //             Turn on count based shared object congestion control in devnet.
 // Version 53: Enable consensus commit prologue V3 in testnet.
+//             Enable enums on testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2476,6 +2477,11 @@ impl ProtocolConfig {
                             .record_consensus_determined_version_assignments_in_prologue = true;
                         cfg.feature_flags
                             .prepend_prologue_tx_in_consensus_commit_in_checkpoints = true;
+                    }
+
+                    // Turn on enums in testnet and devnet
+                    if chain != Chain::Mainnet {
+                        cfg.move_binary_format_version = Some(7);
                     }
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_52.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_52.snap
@@ -285,3 +285,4 @@ max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_53.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_53.snap
@@ -71,7 +71,7 @@ max_type_arguments: 16
 max_type_argument_depth: 16
 max_pure_argument_size: 16384
 max_programmable_tx_commands: 1024
-move_binary_format_version: 6
+move_binary_format_version: 7
 min_move_binary_format_version: 6
 binary_module_handles: 100
 binary_struct_handles: 300
@@ -287,3 +287,4 @@ max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
+

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_binder.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_binder.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_mut_ref.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_mut_ref.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_no_drop.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_no_drop.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_ref.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_ref.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_twice.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_twice.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_value_wildcard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_value_wildcard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_copy.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_copy.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_drop.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_drop.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_lit.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_lit.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_reuse.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_reuse.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_1.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_2.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/basic.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/basic.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bind_subject.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bind_subject.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_at.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_at.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_in_guard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_in_guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_matching.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_matching.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_mut_guard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_mut_guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 
 //# publish

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_pair.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_pair.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_result.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_result.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_self.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_self.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/drop_ref.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/drop_ref.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_no_tyargs_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_no_tyargs_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_poly_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_poly_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/exhaustive_struct.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/exhaustive_struct.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/fib.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/fib.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_2.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_3.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_3.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_4.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_4.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_5.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_5.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_mut_borrow_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_mut_borrow_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/macro_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/macro_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_mut_lit.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_mut_lit.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_type.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_type.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/multi_or.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/multi_or.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_at.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_at.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_bindings.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_bindings.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_either_borrow.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_either_borrow.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_default.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_default.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_enum_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_enum_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match_mut.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match_mut.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named_value.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named_value.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/tuple_specialize.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/tuple_specialize.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init --edition 2024.beta
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -134,7 +134,7 @@ pub fn valid_editions_for_feature(feature: FeatureGate) -> Vec<Edition> {
 static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
     Lazy::new(|| BTreeMap::from_iter(Edition::ALL.iter().map(|e| (*e, e.features()))));
 
-const E2024_ALPHA_FEATURES: &[FeatureGate] = &[FeatureGate::Enums];
+const E2024_ALPHA_FEATURES: &[FeatureGate] = &[];
 
 const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::NestedUse,
@@ -156,6 +156,7 @@ const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::CleverAssertions,
     FeatureGate::Lambda,
     FeatureGate::ModuleLabel,
+    FeatureGate::Enums,
 ];
 
 const DEVELOPMENT_FEATURES: &[FeatureGate] = &[];

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/const_at.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/const_at.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/const_in_guard.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/const_in_guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/incr_in_container.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/incr_in_container.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_match_mut.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_match_mut.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_match_mut_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_match_mut_invalid.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.alpha
+//# init
 
 //# publish
 module 0x42::m {


### PR DESCRIPTION
## Description 

Enables Move enums on testnet and enables them in Move `2024.beta`.
* Bottom commit is the protocol config changes
* Middle commit is the switch of enums to 2024.beta
* Top commit is updates to match tests that specified the edition to be 2024.alpha to use 2024.beta now.

## Test plan 

Made sure existing tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Enables Move enums (https://move-book.com/reference/enums.html) in testnet.
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
