### PR TITLE
[Examples] Run Move tests for E2E examples in CI

### DIFF
--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -96,7 +96,7 @@ fn check_packages_recursively(path: &Path) -> io::Result<()> {
 fn run_examples_move_unit_tests() -> io::Result<()> {
     let examples = {
         let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        buf.extend(["..", "..", "examples", "move"]);
+        buf.extend(["..", "..", "examples"]);
         buf
     };
 

--- a/examples/trading/contracts/demo/Move.toml
+++ b/examples/trading/contracts/demo/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }
 
 [addresses]
 demo = "0x0"

--- a/examples/trading/contracts/escrow/Move.toml
+++ b/examples/trading/contracts/escrow/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }
 
 [addresses]
 escrow = "0x0"

--- a/examples/trading/contracts/escrow/sources/owned.move
+++ b/examples/trading/contracts/escrow/sources/owned.move
@@ -33,7 +33,7 @@
 ///      `Locked` object that the respective objects resided in immediately
 ///      before being sent to the custodian.
 module escrow::owned {
-    use escrow::lock::{Self, Locked, Key};
+    use escrow::lock::{Locked, Key};
 
     /// An object held in escrow
     public struct Escrow<T: key + store> has key {
@@ -164,6 +164,8 @@ module escrow::owned {
     #[test_only] use sui::coin::{Self, Coin};
     #[test_only] use sui::sui::SUI;
     #[test_only] use sui::test_scenario::{Self as ts, Scenario};
+
+    #[test_only] use escrow::lock;
 
     #[test_only] const ALICE: address = @0xA;
     #[test_only] const BOB: address = @0xB;

--- a/examples/trading/contracts/escrow/sources/shared.move
+++ b/examples/trading/contracts/escrow/sources/shared.move
@@ -32,14 +32,14 @@ module escrow::shared {
         dynamic_object_field::{Self as dof}
     };
 
-    use escrow::lock::{Self, Locked, Key};
+    use escrow::lock::{Locked, Key};
 
     /// The `name` of the DOF that holds the Escrowed object.
     /// Allows easy discoverability for the escrowed object.
     public struct EscrowedObjectKey has copy, store, drop {}
 
     /// An object held in escrow
-    /// 
+    ///
     /// The escrowed object is added as a Dynamic Object Field so it can still be looked-up.
     public struct Escrow<phantom T: key + store> has key, store {
         id: UID,
@@ -172,6 +172,8 @@ module escrow::shared {
     #[test_only] use sui::coin::{Self, Coin};
     #[test_only] use sui::sui::SUI;
     #[test_only] use sui::test_scenario::{Self as ts, Scenario};
+
+    #[test_only] use escrow::lock;
 
     #[test_only] const ALICE: address = @0xA;
     #[test_only] const BOB: address = @0xB;


### PR DESCRIPTION
## Description

Prepare Move code in E2E examples to be run under CI tests:

- Depend on a local version of the Sui framework, to avoid CI refetching the Sui repo.
- Broaden the scope that the test checks for Move packages in, to include Move code in `./examples` but not in `./examples/move`.
- Fixing some things that the CI brought up (`use` statements that were only relevant in test mode.)

## Test plan

```
sui-framework-tests$ cargo nextest run
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
