### PR TITLE
move: ptb flow publishes packages with automated addy mgmt

### DIFF
--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -27,6 +27,7 @@ use move_package::BuildConfig;
 use std::{collections::BTreeMap, path::Path};
 use sui_json::{is_receiving_argument, primitive_type};
 use sui_json_rpc_types::{SuiObjectData, SuiObjectDataOptions, SuiRawData};
+use sui_move::manage_package::resolve_lock_file_path;
 use sui_sdk::apis::ReadApi;
 use sui_types::{
     base_types::{is_primitive_type_tag, ObjectID, TxContext, TxContextKind},
@@ -926,15 +927,42 @@ impl<'a> PTBBuilder<'a> {
                 self.last_command = Some(res);
             }
             ParsedPTBCommand::Publish(sp!(pkg_loc, package_path)) => {
-                let (dependencies, compiled_modules, _, _) = compile_package(
+                let chain_id = self.reader.get_chain_identifier().await.ok();
+                let build_config = BuildConfig::default();
+                let package_path = Path::new(&package_path);
+                let build_config = resolve_lock_file_path(build_config.clone(), Some(package_path))
+                    .map_err(|e| err!(pkg_loc, "{e}"))?;
+                let previous_id = if let Some(ref chain_id) = chain_id {
+                    sui_package_management::set_package_id(
+                        &package_path,
+                        build_config.install_dir.clone(),
+                        chain_id,
+                        AccountAddress::ZERO,
+                    )
+                    .map_err(|e| err!(pkg_loc, "{e}"))?
+                } else {
+                    None
+                };
+                let compile_result = compile_package(
                     self.reader,
-                    BuildConfig::default(),
-                    Path::new(&package_path),
+                    build_config.clone(),
+                    package_path,
                     false, /* with_unpublished_dependencies */
                     false, /* skip_dependency_verification */
                 )
-                .await
-                .map_err(|e| err!(pkg_loc, "{e}"))?;
+                .await;
+                // Restore original ID, then check result.
+                if let (Some(chain_id), Some(previous_id)) = (chain_id, previous_id) {
+                    let _ = sui_package_management::set_package_id(
+                        &package_path,
+                        build_config.install_dir.clone(),
+                        &chain_id,
+                        previous_id,
+                    )
+                    .map_err(|e| err!(pkg_loc, "{e}"))?;
+                }
+                let (dependencies, compiled_modules, _, _) =
+                    compile_result.map_err(|e| err!(pkg_loc, "{e}"))?;
 
                 let res = self.ptb.publish_upgradeable(
                     compiled_modules,
@@ -966,18 +994,44 @@ impl<'a> PTBBuilder<'a> {
                     )
                     .await?;
 
-                let (package_id, compiled_modules, dependencies, package_digest, upgrade_policy) =
-                    upgrade_package(
-                        self.reader,
-                        BuildConfig::default(),
-                        Path::new(&package_path),
-                        ObjectID::from_address(upgrade_cap_id.into_inner()),
-                        false, /* with_unpublished_dependencies */
-                        false, /* skip_dependency_verification */
-                        None,
-                    )
-                    .await
+                let chain_id = self.reader.get_chain_identifier().await.ok();
+                let build_config = BuildConfig::default();
+                let package_path = Path::new(&package_path);
+                let build_config = resolve_lock_file_path(build_config.clone(), Some(package_path))
                     .map_err(|e| err!(path_loc, "{e}"))?;
+                let previous_id = if let Some(ref chain_id) = chain_id {
+                    sui_package_management::set_package_id(
+                        &package_path,
+                        build_config.install_dir.clone(),
+                        chain_id,
+                        AccountAddress::ZERO,
+                    )
+                    .map_err(|e| err!(path_loc, "{e}"))?
+                } else {
+                    None
+                };
+                let upgrade_result = upgrade_package(
+                    self.reader,
+                    build_config.clone(),
+                    &package_path,
+                    ObjectID::from_address(upgrade_cap_id.into_inner()),
+                    false, /* with_unpublished_dependencies */
+                    false, /* skip_dependency_verification */
+                    None,
+                )
+                .await;
+                // Restore original ID, then check result.
+                if let (Some(chain_id), Some(previous_id)) = (chain_id, previous_id) {
+                    let _ = sui_package_management::set_package_id(
+                        &package_path,
+                        build_config.install_dir.clone(),
+                        &chain_id,
+                        previous_id,
+                    )
+                    .map_err(|e| err!(path_loc, "{e}"))?;
+                }
+                let (package_id, compiled_modules, dependencies, package_digest, upgrade_policy) =
+                    upgrade_result.map_err(|e| err!(path_loc, "{e}"))?;
 
                 let upgrade_arg = self
                     .ptb

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -934,7 +934,7 @@ impl<'a> PTBBuilder<'a> {
                     .map_err(|e| err!(pkg_loc, "{e}"))?;
                 let previous_id = if let Some(ref chain_id) = chain_id {
                     sui_package_management::set_package_id(
-                        &package_path,
+                        package_path,
                         build_config.install_dir.clone(),
                         chain_id,
                         AccountAddress::ZERO,
@@ -954,7 +954,7 @@ impl<'a> PTBBuilder<'a> {
                 // Restore original ID, then check result.
                 if let (Some(chain_id), Some(previous_id)) = (chain_id, previous_id) {
                     let _ = sui_package_management::set_package_id(
-                        &package_path,
+                        package_path,
                         build_config.install_dir.clone(),
                         &chain_id,
                         previous_id,
@@ -1001,7 +1001,7 @@ impl<'a> PTBBuilder<'a> {
                     .map_err(|e| err!(path_loc, "{e}"))?;
                 let previous_id = if let Some(ref chain_id) = chain_id {
                     sui_package_management::set_package_id(
-                        &package_path,
+                        package_path,
                         build_config.install_dir.clone(),
                         chain_id,
                         AccountAddress::ZERO,
@@ -1013,7 +1013,7 @@ impl<'a> PTBBuilder<'a> {
                 let upgrade_result = upgrade_package(
                     self.reader,
                     build_config.clone(),
-                    &package_path,
+                    package_path,
                     ObjectID::from_address(upgrade_cap_id.into_inner()),
                     false, /* with_unpublished_dependencies */
                     false, /* skip_dependency_verification */
@@ -1023,7 +1023,7 @@ impl<'a> PTBBuilder<'a> {
                 // Restore original ID, then check result.
                 if let (Some(chain_id), Some(previous_id)) = (chain_id, previous_id) {
                     let _ = sui_package_management::set_package_id(
-                        &package_path,
+                        package_path,
                         build_config.install_dir.clone(),
                         &chain_id,
                         previous_id,

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -326,6 +326,31 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
     Ok(())
 }
 
+#[sim_test]
+async fn test_ptb_publish() -> Result<(), anyhow::Error> {
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("ptb_complex_args_test_functions");
+
+    let publish_ptb_string = format!(
+        r#"
+         --move-call sui::tx_context::sender
+         --assign sender
+         --publish {}
+         --assign upgrade_cap
+         --transfer-objects "[upgrade_cap]" sender
+        "#,
+        package_path.display()
+    );
+    let args = shlex::split(&publish_ptb_string).unwrap();
+    sui::client_ptb::ptb::PTB { args: args.clone() }
+        .execute(context)
+        .await?;
+    Ok(())
+}
+
 // fixing issue https://github.com/MystenLabs/sui/issues/6546
 #[tokio::test]
 async fn test_regression_6546() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## Description 

Fixes the case where the `Move.lock` state isn't prepared for publish/upgrade via PTBs.

Issue reported in https://mysten-labs.slack.com/archives/C04HS54LHUM/p1720554945603299

More details--

In https://github.com/MystenLabs/sui/pull/18470 `sui client publish` / `sui client upgrade` supports setting/resetting published addresses to `0x0` in the `Move.lock` to prepare publish actions. I was under the impression PTBs used the same internal `::Publish` and `::Upgrade` commands, but it has its own, meaning that it doesn't prepare the `Move.lock` state for PTB publish/upgrades.

The implementation does _exactly_ what we do in `client_commands.rs`, but for PTBs, so that this PR introduces the same mechanical change with predictable behavior. There is an opportunity to squash this logic (so that both `sui client` and PTBs use the same logic) but I feel strongly that should be a separate step, because it will affect testing setup for both cases. The testing / logic would be simpler, but needs a separate effort.

## Test plan 

Tests incoming, will add before assigning PR reviewers.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
