### PR TITLE
[move-ide] A dot-completion fix

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -296,17 +296,15 @@ fn call_completion_item(
 fn dot(symbols: &Symbols, use_fpath: &Path, position: &Position) -> Vec<CompletionItem> {
     let mut completions = vec![];
     let Some(fhash) = symbols.file_hash(use_fpath) else {
-        eprintln!("missing file");
+        eprintln!("no dot completions due to missing file");
         return completions;
     };
     let Some(loc) = utils::lsp_position_to_loc(&symbols.files, fhash, position) else {
-        eprintln!("missing loc");
+        eprintln!("no dot completions due to missing loc");
         return completions;
     };
     let Some(info) = symbols.compiler_info.get_autocomplete_info(fhash, &loc) else {
-        eprintln!("compiler info: {:#?}", symbols.compiler_info);
-        eprintln!("loc: {:#?}", loc);
-        eprintln!("no compiler autocomplete info");
+        eprintln!("no dot completions due to no compiler autocomplete info");
         return completions;
     };
     for AutocompleteMethod {
@@ -691,7 +689,12 @@ fn cursor_completion_items(
             let items = dot(symbols, path, &pos);
             let items_is_empty = items.is_empty();
             eprintln!("found items: {}", !items_is_empty);
-            (items, !items_is_empty)
+            // whether completions have been found for the dot or not
+            // it makes no sense to try offering "dumb" autocompletion
+            // options here as they will not fit (an example would
+            // be dot completion of u64 variable without any methods
+            // with u64 receiver being visible)
+            (items, true)
         }
         // TODO: consider using `cursor.position` for this instead
         Some(Tok::ColonColon) => {

--- a/external-crates/move/crates/move-analyzer/tests/completion/sources/init.move
+++ b/external-crates/move/crates/move-analyzer/tests/completion/sources/init.move
@@ -1,0 +1,4 @@
+module Completion::init {
+    
+    fun i
+}

--- a/external-crates/move/crates/move-analyzer/tests/completion/sources/init_otw.move
+++ b/external-crates/move/crates/move-analyzer/tests/completion/sources/init_otw.move
@@ -1,0 +1,6 @@
+module Completion::init_otw {
+
+    public struct INIT_OTW has drop {}
+
+    fun i
+}

--- a/external-crates/move/crates/move-analyzer/tests/completion/sources/object.move
+++ b/external-crates/move/crates/move-analyzer/tests/completion/sources/object.move
@@ -1,0 +1,5 @@
+module Completion::object {
+
+    public struct SomeObject has key {
+
+}

--- a/external-crates/move/crates/move-analyzer/tests/completion/sources/uid.move
+++ b/external-crates/move/crates/move-analyzer/tests/completion/sources/uid.move
@@ -1,5 +1,0 @@
-module Completion::uid {
-    public struct SomeStruct has key {
-        some_field: u64,
-    }
-}

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -184,10 +184,9 @@ impl CompletionTest {
         use_file_path: &Path,
     ) -> anyhow::Result<()> {
         let lsp_use_line = self.use_line - 1; // 0th-based
-        let lsp_use_col = self.use_col - 1; // 0th-based
         let use_pos = Position {
             line: lsp_use_line,
-            character: lsp_use_col,
+            character: self.use_col,
         };
         let items = completion_items(
             symbols,

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -184,9 +184,10 @@ impl CompletionTest {
         use_file_path: &Path,
     ) -> anyhow::Result<()> {
         let lsp_use_line = self.use_line - 1; // 0th-based
+        let lsp_use_col = self.use_col - 1; // 0th-based
         let use_pos = Position {
             line: lsp_use_line,
-            character: self.use_col,
+            character: lsp_use_col,
         };
         let items = completion_items(
             symbols,
@@ -270,10 +271,11 @@ impl HintTest {
         )
         .unwrap();
         let lsp_line = self.use_line - 1; // 0th-based
+        let lsp_col = self.use_col - 1; // 0th-based
 
         writeln!(output, "-- test {test_idx} -------------------")?;
         let Some((hint, label_parts)) = inlay_hints.iter().find_map(|h| {
-            if h.position.line == lsp_line && h.position.character == self.use_col {
+            if h.position.line == lsp_line && h.position.character == lsp_col {
                 if let InlayHintLabel::LabelParts(parts) = &h.label {
                     return Some((h, parts));
                 }

--- a/external-crates/move/crates/move-analyzer/tests/inlay_hints.ide
+++ b/external-crates/move/crates/move-analyzer/tests/inlay_hints.ide
@@ -7,27 +7,27 @@
       "type_hints.move": [
         {
           "use_line": 8,
-          "use_col": 22
-        },
-        {
-          "use_line": 9,
-          "use_col": 24
-        },
-        {
-          "use_line": 25,
           "use_col": 23
         },
         {
-          "use_line": 26,
+          "use_line": 9,
           "use_col": 25
         },
         {
+          "use_line": 25,
+          "use_col": 24
+        },
+        {
+          "use_line": 26,
+          "use_col": 26
+        },
+        {
           "use_line": 27,
-          "use_col": 27
+          "use_col": 28
         },
         {
           "use_line": 28,
-          "use_col": 29
+          "use_col": 30
         }
       ],
       // tests inlay param hints
@@ -35,22 +35,22 @@
         // first arg, same line
         {
           "use_line": 11,
-          "use_col": 12
+          "use_col": 13
         },
         // second arg, same line
         {
           "use_line": 11,
-          "use_col": 16
+          "use_col": 17
         },
         // first arg, first line
         {
           "use_line": 15,
-          "use_col": 12
+          "use_col": 13
         },
         // second arg, second line
         {
           "use_line": 16,
-          "use_col": 12
+          "use_col": 13
         }
       ]
     }

--- a/external-crates/move/crates/move-analyzer/tests/snippet_completion.exp
+++ b/external-crates/move/crates/move-analyzer/tests/snippet_completion.exp
@@ -1,0 +1,27 @@
+== init.move ========================================================
+-- test 0 -------------------
+use line: 3, use_col: 9
+Snippet 'init'
+    INSERT TEXT: 'init(ctx: &mut TxContext) {
+	${1:}
+}
+'
+
+== init_otw.move ========================================================
+-- test 0 -------------------
+use line: 5, use_col: 9
+Snippet 'init'
+    INSERT TEXT: 'init(${1:witness}: INIT_OTW, ctx: &mut TxContext) {
+	${2:}
+}
+'
+
+== object.move ========================================================
+-- test 0 -------------------
+use line: 3, use_col: 38
+Snippet 'id: UID'
+    INSERT TEXT: '
+	id: UID,
+	$1
+'
+

--- a/external-crates/move/crates/move-analyzer/tests/snippet_completion.ide
+++ b/external-crates/move/crates/move-analyzer/tests/snippet_completion.ide
@@ -1,0 +1,29 @@
+// Tests completions of various code snippets
+{
+  "Completion": {
+    "project": "tests/completion",
+    "file_tests": {
+      // tests completion of the object snippet
+      "object.move": [
+        {
+          "use_line": 3,
+          "use_col": 38
+        }
+      ],
+      // tests completion of the init snippet
+      "init.move": [
+        {
+          "use_line": 3,
+          "use_col": 9
+        }
+      ],
+      // tests completion of the init snippet with one-time witness defined
+      "init_otw.move": [
+        {
+          "use_line": 5,
+          "use_col": 9
+        }
+      ]
+    }
+  }
+}

--- a/external-crates/move/crates/move-compiler/src/shared/files.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/files.rs
@@ -280,7 +280,7 @@ impl MappedFiles {
             .line_range(*file_id, line_offset as usize)
             .ok()?;
         let offset = line_range.start as u32 + char_offset;
-        Some(Loc::new(file_hash, offset, offset + 1))
+        Some(Loc::new(file_hash, offset, offset))
     }
 
     /// Given a line number (1-indexed) in the file return the `Loc` for the line.
@@ -419,7 +419,7 @@ impl Position {
         self.line_offset + 1
     }
 
-    /// User-facing (1-indexed) coulmn
+    /// User-facing (1-indexed) column
     pub fn user_column(&self) -> usize {
         self.column_offset + 1
     }

--- a/external-crates/move/crates/move-compiler/src/shared/files.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/files.rs
@@ -280,7 +280,7 @@ impl MappedFiles {
             .line_range(*file_id, line_offset as usize)
             .ok()?;
         let offset = line_range.start as u32 + char_offset;
-        Some(Loc::new(file_hash, offset, offset))
+        Some(Loc::new(file_hash, offset, offset + 1))
     }
 
     /// Given a line number (1-indexed) in the file return the `Loc` for the line.


### PR DESCRIPTION
## Description 

This fixes a problem with dot-completion introduced in https://github.com/MystenLabs/sui/pull/18371

Due to how `Loc` from `Position` computation was changed, dot completion in the IDE stopped working even though unit tests were passing (after a modification that accommodated for `Loc` computation change).

## Test plan 

All unit tests must pass. Also tested that dot completion actually works in the IDE

