### PR TITLE
Add back the simple test of Random to cluster-test

### DIFF
--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -31,7 +31,8 @@ use test_case::{
     coin_index_test::CoinIndexTest, coin_merge_split_test::CoinMergeSplitTest,
     fullnode_build_publish_transaction_test::FullNodeBuildPublishTransactionTest,
     fullnode_execute_transaction_test::FullNodeExecuteTransactionTest,
-    native_transfer_test::NativeTransferTest, shared_object_test::SharedCounterTest,
+    native_transfer_test::NativeTransferTest, random_beacon_test::RandomBeaconTest,
+    shared_object_test::SharedCounterTest,
 };
 use tokio::time::{self, Duration};
 use tracing::{error, info};
@@ -308,6 +309,7 @@ impl ClusterTest {
             TestCase::new(FullNodeExecuteTransactionTest {}),
             TestCase::new(FullNodeBuildPublishTransactionTest {}),
             TestCase::new(CoinIndexTest {}),
+            TestCase::new(RandomBeaconTest {}),
         ];
 
         // TODO: improve the runner parallelism for efficiency

--- a/crates/sui-cluster-test/src/test_case.rs
+++ b/crates/sui-cluster-test/src/test_case.rs
@@ -6,4 +6,5 @@ pub mod coin_merge_split_test;
 pub mod fullnode_build_publish_transaction_test;
 pub mod fullnode_execute_transaction_test;
 pub mod native_transfer_test;
+pub mod random_beacon_test;
 pub mod shared_object_test;

--- a/crates/sui-cluster-test/src/test_case/random_beacon_test.rs
+++ b/crates/sui-cluster-test/src/test_case/random_beacon_test.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{TestCaseImpl, TestContext};
+use async_trait::async_trait;
+use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
+use sui_sdk::wallet_context::WalletContext;
+use sui_test_transaction_builder::{emit_new_random_u128, publish_basics_package};
+use tracing::info;
+
+pub struct RandomBeaconTest;
+
+#[async_trait]
+impl TestCaseImpl for RandomBeaconTest {
+    fn name(&self) -> &'static str {
+        "RandomBeacon"
+    }
+
+    fn description(&self) -> &'static str {
+        "Test publishing basics packages and emitting an event that depends on a random value."
+    }
+
+    async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
+        let wallet_context: &WalletContext = ctx.get_wallet();
+        // Test only if the beacon is enabled.
+        if Self::is_beacon_enabled(wallet_context).await {
+            info!("Random beacon is not enabled. Skipping test.");
+            return Ok(());
+        }
+
+        info!("Testing a transaction that uses Random.");
+
+        let sui_objs = ctx.get_sui_from_faucet(Some(1)).await;
+        assert!(!sui_objs.is_empty());
+
+        let package_ref = publish_basics_package(wallet_context).await;
+
+        let response = emit_new_random_u128(wallet_context, package_ref.0).await;
+        assert_eq!(
+            *response.effects.as_ref().unwrap().status(),
+            SuiExecutionStatus::Success,
+            "Generate new random value txn failed: {:?}",
+            *response.effects.as_ref().unwrap().status()
+        );
+
+        // Check that only the expected event was emitted.
+        let events = response.events.unwrap();
+        assert_eq!(
+            1,
+            events.data.len(),
+            "Expected 1 event, got {:?}",
+            events.data.len()
+        );
+        assert_eq!(
+            "RandomU128Event".to_string(),
+            events.data[0].type_.name.to_string()
+        );
+
+        // Verify fullnode observes the txn
+        ctx.let_fullnode_sync(vec![response.digest], 5).await;
+
+        Ok(())
+    }
+}
+
+impl RandomBeaconTest {
+    async fn is_beacon_enabled(wallet_context: &WalletContext) -> bool {
+        let client = wallet_context.get_client().await.unwrap();
+        let config = client.read_api().get_protocol_config(None).await.unwrap();
+        *config.feature_flags.get("random_beacon").unwrap()
+    }
+}

--- a/crates/sui-cluster-test/src/test_case/random_beacon_test.rs
+++ b/crates/sui-cluster-test/src/test_case/random_beacon_test.rs
@@ -23,7 +23,7 @@ impl TestCaseImpl for RandomBeaconTest {
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         let wallet_context: &WalletContext = ctx.get_wallet();
         // Test only if the beacon is enabled.
-        if Self::is_beacon_enabled(wallet_context).await {
+        if !Self::is_beacon_enabled(wallet_context).await {
             info!("Random beacon is not enabled. Skipping test.");
             return Ok(());
         }

--- a/sui_programmability/examples/basics/sources/random.move
+++ b/sui_programmability/examples/basics/sources/random.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This example demonstrates emitting a random u128 (e.g., for an offchain lottery)
+module basics::random {
+    use sui::event;
+    use sui::random::Random;
+
+    public struct RandomU128Event has copy, drop {
+        value: u128,
+    }
+
+    entry fun new(r: &Random, ctx: &mut TxContext) {
+        let mut gen = r.new_generator(ctx);
+        let value = gen.generate_u128();
+        event::emit(RandomU128Event { value });
+    }
+}


### PR DESCRIPTION
Was reverted in https://github.com/MystenLabs/sui/pull/18585 since the wrong check was committed 
(`if Self::is_beacon_enabled(wallet_context).await` instead of `if !Self::is_beacon_enabled(wallet_context).await`).

[Confirmed](https://github.com/MystenLabs/sui-operations/actions/runs/9870085557/job/27255754698) that the problem was fixed.