### PR TITLE
[CLI] Make service hosts configurable in `sui start` 

### DIFF
--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -74,6 +74,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         fullnode_rpc_port: 9000,
         epoch_duration_ms: None,
         no_full_node: false,
+        faucet_host: "127.0.0.1".to_string(),
         #[cfg(feature = "indexer")]
         indexer_feature_args: IndexerFeatureArgs::for_testing(),
     }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3938,22 +3938,22 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
 async fn test_parse_host_port() {
     let input = "127.0.0.0";
     let result = parse_host_port(input.to_string(), 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("127.0.0.0:9123").unwrap());
+    assert_eq!(result, "127.0.0.0:9123".parse::<SocketAddr>().unwrap());
 
     let input = "127.0.0.5:9124";
     let result = parse_host_port(input.to_string(), 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("127.0.0.5:9124").unwrap());
+    assert_eq!(result, "127.0.0.5:9124".parse::<SocketAddr>().unwrap());
 
     let input = "9090";
     let result = parse_host_port(input.to_string(), 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("0.0.0.0:9090").unwrap());
+    assert_eq!(result, "0.0.0.0:9090".parse::<SocketAddr>().unwrap());
 
     let input = "";
     let result = parse_host_port(input.to_string(), 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("0.0.0.0:9123").unwrap());
+    assert_eq!(result, "0.0.0.0:9123".parse::<SocketAddr>().unwrap());
 
     let result = parse_host_port("localhost".to_string(), 9899).unwrap();
-    assert_eq!(result, SocketAddr::from_str("127.0.0.1:9899").unwrap());
+    assert_eq!(result, "127.0.0.1:9899".parse::<SocketAddr>().unwrap());
 
     let input = "asg";
     assert!(parse_host_port(input.to_string(), 9123).is_err());

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3937,35 +3937,32 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_parse_host_port() {
     let input = "127.0.0.0";
-    let result = parse_host_port(Some(input.to_string()), 9123).unwrap();
+    let result = parse_host_port(input.to_string(), 9123).unwrap();
     assert_eq!(result, SocketAddr::from_str("127.0.0.0:9123").unwrap());
 
     let input = "127.0.0.5:9124";
-    let result = parse_host_port(Some(input.to_string()), 9123).unwrap();
+    let result = parse_host_port(input.to_string(), 9123).unwrap();
     assert_eq!(result, SocketAddr::from_str("127.0.0.5:9124").unwrap());
 
     let input = "9090";
-    let result = parse_host_port(Some(input.to_string()), 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("127.0.0.1:9090").unwrap());
+    let result = parse_host_port(input.to_string(), 9123).unwrap();
+    assert_eq!(result, SocketAddr::from_str("0.0.0.0:9090").unwrap());
 
     let input = "";
-    let result = parse_host_port(Some(input.to_string()), 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("127.0.0.1:9123").unwrap());
+    let result = parse_host_port(input.to_string(), 9123).unwrap();
+    assert_eq!(result, SocketAddr::from_str("0.0.0.0:9123").unwrap());
 
-    let result = parse_host_port(None, 9123).unwrap();
-    assert_eq!(result, SocketAddr::from_str("127.0.0.1:9123").unwrap());
-
-    let result = parse_host_port(None, 9899).unwrap();
+    let result = parse_host_port("localhost".to_string(), 9899).unwrap();
     assert_eq!(result, SocketAddr::from_str("127.0.0.1:9899").unwrap());
 
     let input = "asg";
-    assert!(parse_host_port(Some(input.to_string()), 9123).is_err());
+    assert!(parse_host_port(input.to_string(), 9123).is_err());
     let input = "127.0.0:900";
-    assert!(parse_host_port(Some(input.to_string()), 9123).is_err());
+    assert!(parse_host_port(input.to_string(), 9123).is_err());
     let input = "127.0.0";
-    assert!(parse_host_port(Some(input.to_string()), 9123).is_err());
+    assert!(parse_host_port(input.to_string(), 9123).is_err());
     let input = "127.";
-    assert!(parse_host_port(Some(input.to_string()), 9123).is_err());
+    assert!(parse_host_port(input.to_string(), 9123).is_err());
     let input = "127.9.0.1:asb";
-    assert!(parse_host_port(Some(input.to_string()), 9123).is_err());
+    assert!(parse_host_port(input.to_string(), 9123).is_err());
 }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use sui::client_ptb::ptb::PTB;
 use sui::key_identity::{get_identity_address, KeyIdentity};
 #[cfg(feature = "indexer")]
-use sui::sui_commands::{parse_host_port, IndexerFeatureArgs};
+use sui::sui_commands::IndexerFeatureArgs;
 use sui_sdk::SuiClient;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
 use sui_types::object::Owner;
@@ -32,8 +32,7 @@ use sui::{
         estimate_gas_budget, Opts, OptsWithGas, SuiClientCommandResult, SuiClientCommands,
         SwitchResponse,
     },
-    sui_commands::parse_host_port,
-    sui_commands::SuiCommand,
+    sui_commands::{parse_host_port, SuiCommand},
 };
 use sui_config::{
     PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG, SUI_GENESIS_FILENAME,


### PR DESCRIPTION
## Description 

Make indexer, GraphQL, faucet hosts configurable. When using Docker, due to the way it sets up a network interface for the container, the services need to bind to 0.0.0.0 to be able to be accessed from outside the container. This PR enables configurable hosts for these three services via optional flags:
- `--indexer-host 0.0.0.0`
- `--faucet-host 0.0.0.0`
- `--graphql-host 0.0.0.0`

If no host flag is provided, it will use the default `0.0.0.0` one.

In addition, I found a bug where if the `default_value` is not provided, calling `unwrap_or_default` will return value 0 (if that field is an int). For example, if we call `--with-graphql`, the indexer port would have been set to 0 because the `default_missing_value` is only set when the flag is passed, but not when it is not passed, which is the case here due `with-indexer` being implicit enabled.

This supersedes #14701 and should close #14701.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Changed `sui start` to allow configurable hosts for indexer (`--indexer-host `), GraphQL (`--graphql-host `), and faucet (`--faucet-host`) services. This will enable to use `sui start` from a Docker container. By default, all services start with `0.0.0.0` host.
- [ ] Rust SDK: 