### PR TITLE
build statically-linked sui-node for testing on glibc-based hosts

### DIFF
--- a/docker/sui-node-deterministic/Dockerfile
+++ b/docker/sui-node-deterministic/Dockerfile
@@ -60,11 +60,11 @@ ARG PROFILE
 ARG GIT_REVISION
 
 ENV RUST_BACKTRACE=1
-ENV RUSTFLAGS='-C target-feature=-crt-static -C codegen-units=1'
+ENV RUSTFLAGS='-C target-feature=+crt-static -C codegen-units=1'
 ENV GIT_REVISION=${GIT_REVISION}
 ENV PROFILE=${PROFILE}
 
-RUN --network=none cargo build --frozen --profile ${PROFILE} --bin sui-node
+RUN --network=none cargo build --target x86_64-unknown-linux-musl --frozen --profile ${PROFILE} --bin sui-node
 
 FROM scratch AS install
 
@@ -78,7 +78,7 @@ COPY --from=musl . /rootfs
 # support current + legacy paths
 RUN mkdir -p /rootfs/opt/sui/bin
 RUN mkdir -p /rootfs/usr/local/bin
-COPY --from=build sui/target/release/sui-node /rootfs/opt/sui/bin/sui-node
+COPY --from=build sui/target/x86_64-unknown-linux-musl/release/sui-node /rootfs/opt/sui/bin/sui-node
 
 
 RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +


### PR DESCRIPTION
## Description 

Update Deterministic Sui Build to compile a statically-linked binary.
StageX uses `musl` for compiling `sui-node`. 

In order for this to run the `sui-node` binary directly on glibc-based linux macines, it must be statically linked.

## Test plan 

Cherry-pick commit to `testnet` branch and test on a private testnet.

* build docker image
* extract `sui-node` binary
* confirm statically linked (run `file` on mac, `ldd` on linux)
* upload to baremetal test server + run
* check build is still deterministic from github action build, linux machine, macOS machine

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
