### PR TITLE
Refactor CommitteeWithNetworkMetadata

### DIFF
--- a/crates/sui-benchmark/src/embedded_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/embedded_reconfig_observer.rs
@@ -50,7 +50,7 @@ impl EmbeddedReconfigObserver {
             Err(err) => Err(err),
             Ok(committee_info) => {
                 let network_config = default_mysten_network_config();
-                let new_epoch = committee_info.committee.epoch;
+                let new_epoch = committee_info.epoch();
                 if new_epoch <= cur_epoch {
                     trace!(
                         cur_epoch,

--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -69,10 +69,10 @@ impl ReconfigObserver<NetworkAuthorityClient> for FullNodeReconfigObserver {
                     let epoch_id = sui_system_state.epoch;
                     if epoch_id > quorum_driver.current_epoch() {
                         debug!(epoch_id, "Got SuiSystemState in newer epoch");
-                        let new_committee = sui_system_state
-                            .get_sui_committee_for_benchmarking()
-                            .committee;
-                        let _ = self.committee_store.insert_new_committee(&new_committee);
+                        let new_committee = sui_system_state.get_sui_committee_for_benchmarking();
+                        let _ = self
+                            .committee_store
+                            .insert_new_committee(new_committee.committee());
                         match AuthorityAggregator::new_from_committee(
                             sui_system_state.get_sui_committee_for_benchmarking(),
                             &self.committee_store,

--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -73,21 +73,14 @@ impl ReconfigObserver<NetworkAuthorityClient> for FullNodeReconfigObserver {
                         let _ = self
                             .committee_store
                             .insert_new_committee(new_committee.committee());
-                        match AuthorityAggregator::new_from_committee(
+                        let auth_agg = AuthorityAggregator::new_from_committee(
                             sui_system_state.get_sui_committee_for_benchmarking(),
                             &self.committee_store,
                             self.safe_client_metrics_base.clone(),
                             self.auth_agg_metrics.clone(),
                             Arc::new(HashMap::new()),
-                        ) {
-                            Ok(auth_agg) => {
-                                quorum_driver.update_validators(Arc::new(auth_agg)).await
-                            }
-                            Err(err) => error!(
-                                "Can't create AuthorityAggregator from SuiSystemState: {:?}",
-                                err
-                            ),
-                        }
+                        );
+                        quorum_driver.update_validators(Arc::new(auth_agg)).await
                     } else {
                         trace!(
                             epoch_id,

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -266,8 +266,7 @@ impl LocalValidatorAggregatorProxy {
             &committee,
             DEFAULT_CONNECT_TIMEOUT_SEC,
             DEFAULT_REQUEST_TIMEOUT_SEC,
-        )
-        .unwrap();
+        );
 
         Self::new_impl(
             aggregator,

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -274,7 +274,7 @@ impl LocalValidatorAggregatorProxy {
             registry,
             reconfig_fullnode_rpc_url,
             clients,
-            committee.committee,
+            committee.committee().clone(),
         )
         .await
     }

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -140,9 +140,9 @@ impl Genesis {
         self.sui_system_object().reference_gas_price()
     }
 
-    // TODO: No need to return SuiResult.
+    // TODO: No need to return SuiResult. Also consider return &.
     pub fn committee(&self) -> SuiResult<Committee> {
-        Ok(self.committee_with_network().committee)
+        Ok(self.committee_with_network().committee().clone())
     }
 
     pub fn sui_system_wrapper_object(&self) -> SuiSystemStateWrapper {

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -582,13 +582,7 @@ impl<A: Clone> AuthorityAggregator<A> {
         disallow_missing_intermediate_committees: bool,
     ) -> SuiResult<AuthorityAggregator<NetworkAuthorityClient>> {
         let network_clients =
-            make_network_authority_clients_with_network_config(&committee, network_config)
-                .map_err(|err| SuiError::GenericAuthorityError {
-                    error: format!(
-                        "Failed to make authority clients from committee {committee}, err: {:?}",
-                        err
-                    ),
-                })?;
+            make_network_authority_clients_with_network_config(&committee, network_config);
 
         let safe_clients = network_clients
             .into_iter()
@@ -697,11 +691,13 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
         committee_store: &Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
         auth_agg_metrics: AuthAggMetrics,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         // TODO: We should get the committee from the epoch store instead to ensure consistency.
         // Instead of this function use AuthorityEpochStore::epoch_start_configuration() to access this object everywhere
         // besides when we are reading fields for the current epoch
-        let sui_system_state = store.get_sui_system_state_object_unsafe()?;
+        let sui_system_state = store
+            .get_sui_system_state_object_unsafe()
+            .expect("Get system state object should never fail");
         let committee = sui_system_state.get_current_epoch_committee();
         let validator_display_names = sui_system_state
             .into_sui_system_state_summary()
@@ -732,18 +728,18 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
         safe_client_metrics_base: SafeClientMetricsBase,
         auth_agg_metrics: Arc<AuthAggMetrics>,
         validator_display_names: Arc<HashMap<AuthorityName, String>>,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let net_config = default_mysten_network_config();
         let authority_clients =
-            make_network_authority_clients_with_network_config(&committee, &net_config)?;
-        Ok(Self::new_with_metrics(
+            make_network_authority_clients_with_network_config(&committee, &net_config);
+        Self::new_with_metrics(
             committee.committee().clone(),
             committee_store.clone(),
             authority_clients,
             safe_client_metrics_base,
             auth_agg_metrics,
             validator_display_names,
-        ))
+        )
     }
 }
 
@@ -1953,7 +1949,7 @@ impl<'a> AuthorityAggregatorBuilder<'a> {
             &committee,
             DEFAULT_CONNECT_TIMEOUT_SEC,
             DEFAULT_REQUEST_TIMEOUT_SEC,
-        )?;
+        );
         let committee_store = if let Some(committee_store) = self.committee_store {
             committee_store
         } else {

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -607,7 +607,7 @@ impl<A: Clone> AuthorityAggregator<A> {
 
         // TODO: It's likely safer to do the following operations atomically, in case this function
         // gets called from different threads. It cannot happen today, but worth the caution.
-        let new_committee = committee.committee;
+        let new_committee = committee.committee().clone();
         if disallow_missing_intermediate_committees {
             fp_ensure!(
                 self.committee.epoch + 1 == new_committee.epoch,
@@ -737,7 +737,7 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
         let authority_clients =
             make_network_authority_clients_with_network_config(&committee, &net_config)?;
         Ok(Self::new_with_metrics(
-            committee.committee,
+            committee.committee().clone(),
             committee_store.clone(),
             authority_clients,
             safe_client_metrics_base,
@@ -1957,11 +1957,11 @@ impl<'a> AuthorityAggregatorBuilder<'a> {
         let committee_store = if let Some(committee_store) = self.committee_store {
             committee_store
         } else {
-            Arc::new(CommitteeStore::new_for_testing(&committee.committee))
+            Arc::new(CommitteeStore::new_for_testing(committee.committee()))
         };
         Ok((
             AuthorityAggregator::new(
-                committee.committee,
+                committee.committee().clone(),
                 committee_store,
                 auth_clients.clone(),
                 registry,

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -260,7 +260,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
 pub fn make_network_authority_clients_with_network_config(
     committee: &CommitteeWithNetworkMetadata,
     network_config: &Config,
-) -> anyhow::Result<BTreeMap<AuthorityName, NetworkAuthorityClient>> {
+) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
     let mut authority_clients = BTreeMap::new();
     for (name, (_state, network_metadata)) in committee.validators() {
         let address = network_metadata.network_address.clone();
@@ -276,14 +276,14 @@ pub fn make_network_authority_clients_with_network_config(
         let client = NetworkAuthorityClient::new_lazy(maybe_channel);
         authority_clients.insert(*name, client);
     }
-    Ok(authority_clients)
+    authority_clients
 }
 
 pub fn make_authority_clients_with_timeout_config(
     committee: &CommitteeWithNetworkMetadata,
     connect_timeout: Duration,
     request_timeout: Duration,
-) -> anyhow::Result<BTreeMap<AuthorityName, NetworkAuthorityClient>> {
+) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
     let mut network_config = mysten_network::config::Config::new();
     network_config.connect_timeout = Some(connect_timeout);
     network_config.request_timeout = Some(request_timeout);

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -262,14 +262,8 @@ pub fn make_network_authority_clients_with_network_config(
     network_config: &Config,
 ) -> anyhow::Result<BTreeMap<AuthorityName, NetworkAuthorityClient>> {
     let mut authority_clients = BTreeMap::new();
-    for (name, _stakes) in &committee.committee.voting_rights {
-        let address = &committee
-            .network_metadata
-            .get(name)
-            .ok_or_else(|| {
-                SuiError::from("Missing network metadata in CommitteeWithNetworkMetadata")
-            })?
-            .network_address;
+    for (name, (_state, network_metadata)) in committee.validators() {
+        let address = network_metadata.network_address.clone();
         let address = address.rewrite_udp_to_tcp();
         let maybe_channel = network_config.connect_lazy(&address).map_err(|e| {
             tracing::error!(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2058,8 +2058,7 @@ async fn diagnose_split_brain(
         .get_sui_committee_with_network_metadata();
     let network_config = default_mysten_network_config();
     let network_clients =
-        make_network_authority_clients_with_network_config(&committee, &network_config)
-            .expect("Failed to make authority clients from committee {committee}");
+        make_network_authority_clients_with_network_config(&committee, &network_config);
 
     // Query all disagreeing validators
     let response_futures = digest_to_validator

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1432,7 +1432,10 @@ impl CheckpointBuilder {
                     )
                     .await?;
 
-                let committee = system_state_obj.get_current_epoch_committee().committee;
+                let committee = system_state_obj
+                    .get_current_epoch_committee()
+                    .committee()
+                    .clone();
 
                 // This must happen after the call to augment_epoch_last_checkpoint,
                 // otherwise we will not capture the change_epoch tx.

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -59,12 +59,6 @@ impl OnsiteReconfigObserver {
             self.safe_client_metrics_base.clone(),
             self.auth_agg_metrics.clone(),
         )
-        .unwrap_or_else(|e| {
-            panic!(
-                "Failed to create AuthorityAggregator from System State: {:?}",
-                e
-            )
-        })
     }
 }
 

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -96,7 +96,7 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
                     let committee = system_state.get_current_epoch_committee();
                     info!(
                         "Got reconfig message. New committee: {}",
-                        committee.committee
+                        committee.committee()
                     );
                     if committee.epoch() > quorum_driver.current_epoch() {
                         let authority_agg =

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -68,7 +68,7 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
         reconfig_channel: Receiver<SuiSystemState>,
         parent_path: &Path,
         prometheus_registry: &Registry,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let safe_client_metrics_base = SafeClientMetricsBase::new(prometheus_registry);
         let auth_agg_metrics = AuthAggMetrics::new(prometheus_registry);
         let validators = AuthorityAggregator::new_from_local_system_state(
@@ -76,7 +76,7 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
             validator_state.committee_store(),
             safe_client_metrics_base.clone(),
             auth_agg_metrics.clone(),
-        )?;
+        );
 
         let observer = OnsiteReconfigObserver::new(
             reconfig_channel,
@@ -85,13 +85,13 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
             safe_client_metrics_base,
             auth_agg_metrics,
         );
-        Ok(TransactiondOrchestrator::new(
+        TransactiondOrchestrator::new(
             Arc::new(validators),
             validator_state,
             parent_path,
             prometheus_registry,
             observer,
-        ))
+        )
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3215,7 +3215,10 @@ async fn test_genesis_sui_system_state_object() {
         .get_sui_system_state_object_for_testing()
         .unwrap();
     assert_eq!(
-        &sui_system_state.get_current_epoch_committee().committee,
+        &sui_system_state
+            .get_current_epoch_committee()
+            .committee()
+            .clone(),
         authority_state
             .epoch_store_for_testing()
             .committee()

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -572,7 +572,7 @@ async fn test_inactive_validator_pool_read() {
         assert_eq!(
             system_state
                 .get_current_epoch_committee()
-                .committee
+                .committee()
                 .num_members(),
             4
         );

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -226,8 +226,7 @@ async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Er
     let local_clients = make_network_authority_clients_with_network_config(
         &committee,
         &default_mysten_network_config(),
-    )
-    .unwrap();
+    );
     let (_, auth_client) = local_clients.first_key_value().unwrap();
 
     // transaction signed using user wallet from a different chain/genesis,
@@ -350,8 +349,7 @@ async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::
     let local_clients = make_network_authority_clients_with_network_config(
         &committee,
         &default_mysten_network_config(),
-    )
-    .unwrap();
+    );
     let (_, auth_client) = local_clients.first_key_value().unwrap();
 
     // transaction signed using user wallet from a different chain/genesis,
@@ -494,7 +492,7 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
     let _tc = TrafficController::spawn_for_test(policy_config, Some(firewall_config));
     assert!(
         !drain_path.exists(),
-        "Expected drain file to not exist after statup unless previously set",
+        "Expected drain file to not exist after startup unless previously set",
     );
 
     // after n seconds with no traffic, the dead mans switch should be engaged
@@ -512,7 +510,7 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
     for _ in 0..3 {
         assert!(
             drain_path.exists(),
-            "Expected drain file to be disabled at statup unless previously enabled",
+            "Expected drain file to be disabled at startup unless previously enabled",
         );
         tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     }
@@ -604,7 +602,7 @@ async fn test_traffic_sketch_with_slow_blocks() {
     // due to averaging, we will take 4 seconds to start blocking, then
     // will be in blocklist for 1 second (roughly)
     assert!(metrics.num_blocked as f64 > (expected_requests as f64 / 4.0) * 0.90);
-    // 10 clients, blocked at least every 5 sceonds, over 20 seconds
+    // 10 clients, blocked at least every 5 seconds, over 20 seconds
     assert!(metrics.num_blocklist_adds >= 40);
     assert!(metrics.abs_time_to_first_block.unwrap() < Duration::from_secs(5));
     assert!(metrics.total_time_blocked > Duration::from_millis(3500));

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -35,16 +35,14 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let temp_dir = tempfile::tempdir().unwrap();
     let registry = Registry::new();
     // Start orchestrator inside container so that it will be properly shutdown.
-    let orchestrator = handle
-        .with(|node| {
-            TransactiondOrchestrator::new_with_network_clients(
-                node.state(),
-                node.subscribe_to_epoch_change(),
-                temp_dir.path(),
-                &registry,
-            )
-        })
-        .unwrap();
+    let orchestrator = handle.with(|node| {
+        TransactiondOrchestrator::new_with_network_clients(
+            node.state(),
+            node.subscribe_to_epoch_change(),
+            temp_dir.path(),
+            &registry,
+        )
+    });
 
     let txn_count = 4;
     let mut txns = batch_make_transfer_transactions(context, txn_count).await;
@@ -127,16 +125,14 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     tokio::task::yield_now().await;
     let registry = Registry::new();
     // Start orchestrator inside container so that it will be properly shutdown.
-    let orchestrator = handle
-        .with(|node| {
-            TransactiondOrchestrator::new_with_network_clients(
-                node.state(),
-                node.subscribe_to_epoch_change(),
-                temp_dir.path(),
-                &registry,
-            )
-        })
-        .unwrap();
+    let orchestrator = handle.with(|node| {
+        TransactiondOrchestrator::new_with_network_clients(
+            node.state(),
+            node.subscribe_to_epoch_change(),
+            temp_dir.path(),
+            &registry,
+        )
+    });
 
     let txn_count = 2;
     let context = &mut test_cluster.wallet;
@@ -343,16 +339,14 @@ async fn execute_transaction_v3() -> Result<(), anyhow::Error> {
     let temp_dir = tempfile::tempdir().unwrap();
     let registry = Registry::new();
     // Start orchestrator inside container so that it will be properly shutdown.
-    let orchestrator = handle
-        .with(|node| {
-            TransactiondOrchestrator::new_with_network_clients(
-                node.state(),
-                node.subscribe_to_epoch_change(),
-                temp_dir.path(),
-                &registry,
-            )
-        })
-        .unwrap();
+    let orchestrator = handle.with(|node| {
+        TransactiondOrchestrator::new_with_network_clients(
+            node.state(),
+            node.subscribe_to_epoch_change(),
+            temp_dir.path(),
+            &registry,
+        )
+    });
 
     let txn_count = 1;
     let mut txns = batch_make_transfer_transactions(context, txn_count).await;
@@ -384,23 +378,23 @@ async fn execute_transaction_v3() -> Result<(), anyhow::Error> {
         .collect::<Vec<_>>();
     expected_output_objects.sort_by_key(|&(id, _version, _digest)| id);
 
-    let mut actual_input_objects_recieved = response
+    let mut actual_input_objects_received = response
         .input_objects
         .unwrap()
         .iter()
         .map(|object| (object.id(), object.version()))
         .collect::<Vec<_>>();
-    actual_input_objects_recieved.sort_by_key(|&(id, _version)| id);
-    assert_eq!(expected_input_objects, actual_input_objects_recieved);
+    actual_input_objects_received.sort_by_key(|&(id, _version)| id);
+    assert_eq!(expected_input_objects, actual_input_objects_received);
 
-    let mut actual_output_objects_recieved = response
+    let mut actual_output_objects_received = response
         .output_objects
         .unwrap()
         .iter()
         .map(|object| (object.id(), object.version(), object.digest()))
         .collect::<Vec<_>>();
-    actual_output_objects_recieved.sort_by_key(|&(id, _version, _digest)| id);
-    assert_eq!(expected_output_objects, actual_output_objects_recieved);
+    actual_output_objects_received.sort_by_key(|&(id, _version, _digest)| id);
+    assert_eq!(expected_output_objects, actual_output_objects_received);
 
     Ok(())
 }
@@ -414,16 +408,14 @@ async fn execute_transaction_v3_staking_transaction() -> Result<(), anyhow::Erro
     let temp_dir = tempfile::tempdir().unwrap();
     let registry = Registry::new();
     // Start orchestrator inside container so that it will be properly shutdown.
-    let orchestrator = handle
-        .with(|node| {
-            TransactiondOrchestrator::new_with_network_clients(
-                node.state(),
-                node.subscribe_to_epoch_change(),
-                temp_dir.path(),
-                &registry,
-            )
-        })
-        .unwrap();
+    let orchestrator = handle.with(|node| {
+        TransactiondOrchestrator::new_with_network_clients(
+            node.state(),
+            node.subscribe_to_epoch_change(),
+            temp_dir.path(),
+            &registry,
+        )
+    });
 
     let validator_address = context
         .get_client()
@@ -456,23 +448,23 @@ async fn execute_transaction_v3_staking_transaction() -> Result<(), anyhow::Erro
         .collect::<Vec<_>>();
     expected_output_objects.sort_by_key(|&(id, _version, _digest)| id);
 
-    let mut actual_input_objects_recieved = response
+    let mut actual_input_objects_received = response
         .input_objects
         .unwrap()
         .iter()
         .map(|object| (object.id(), object.version()))
         .collect::<Vec<_>>();
-    actual_input_objects_recieved.sort_by_key(|&(id, _version)| id);
-    assert_eq!(expected_input_objects, actual_input_objects_recieved);
+    actual_input_objects_received.sort_by_key(|&(id, _version)| id);
+    assert_eq!(expected_input_objects, actual_input_objects_received);
 
-    let mut actual_output_objects_recieved = response
+    let mut actual_output_objects_received = response
         .output_objects
         .unwrap()
         .iter()
         .map(|object| (object.id(), object.version(), object.digest()))
         .collect::<Vec<_>>();
-    actual_output_objects_recieved.sort_by_key(|&(id, _version, _digest)| id);
-    assert_eq!(expected_output_objects, actual_output_objects_recieved);
+    actual_output_objects_received.sort_by_key(|&(id, _version, _digest)| id);
+    assert_eq!(expected_output_objects, actual_output_objects_received);
 
     Ok(())
 }

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -205,7 +205,10 @@ impl Builder {
     fn committee(objects: &[Object]) -> Committee {
         let sui_system_object =
             get_sui_system_state(&objects).expect("Sui System State object must always exist");
-        sui_system_object.get_current_epoch_committee().committee
+        sui_system_object
+            .get_current_epoch_committee()
+            .committee()
+            .clone()
     }
 
     pub fn protocol_version(&self) -> ProtocolVersion {
@@ -520,7 +523,7 @@ impl Builder {
             assert!(staked_sui_objects.is_empty());
         }
 
-        let committee = system_state.get_current_epoch_committee().committee;
+        let committee = system_state.get_current_epoch_committee();
         for signature in self.signatures.values() {
             if self.validators.get(&signature.authority).is_none() {
                 panic!("found signature for unknown validator: {:#?}", signature);
@@ -530,7 +533,7 @@ impl Builder {
                 .verify_secure(
                     unsigned_genesis.checkpoint(),
                     Intent::sui_app(IntentScope::CheckpointSummary),
-                    &committee,
+                    committee.committee(),
                 )
                 .expect("signature should be valid");
         }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -696,7 +696,7 @@ impl SuiNode {
                     end_of_epoch_receiver,
                     &config.db_path(),
                     &prometheus_registry,
-                )?,
+                ),
             ))
         } else {
             None

--- a/crates/sui-swarm-config/src/network_config.rs
+++ b/crates/sui-swarm-config/src/network_config.rs
@@ -28,9 +28,9 @@ impl NetworkConfig {
     pub fn net_addresses(&self) -> Vec<Multiaddr> {
         self.genesis
             .committee_with_network()
-            .network_metadata
-            .into_values()
-            .map(|n| n.network_address)
+            .validators()
+            .values()
+            .map(|(_, n)| n.network_address.clone())
             .collect()
     }
 

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -153,14 +153,14 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
     }
 
     fn get_sui_committee_with_network_metadata(&self) -> CommitteeWithNetworkMetadata {
-        let (voting_rights, network_metadata) = self
+        let validators = self
             .active_validators
             .iter()
             .map(|validator| {
                 (
-                    (validator.authority_name(), validator.voting_power),
+                    validator.authority_name(),
                     (
-                        validator.authority_name(),
+                        validator.voting_power,
                         NetworkMetadata {
                             network_address: validator.sui_net_address.clone(),
                             narwhal_primary_address: validator.narwhal_primary_address.clone(),
@@ -168,12 +168,9 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
                     ),
                 )
             })
-            .unzip();
+            .collect();
 
-        CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights),
-            network_metadata,
-        }
+        CommitteeWithNetworkMetadata::new(self.epoch, validators)
     }
 
     fn get_sui_committee(&self) -> Committee {

--- a/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
+++ b/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
@@ -164,24 +164,26 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerV1 {
     }
 
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata {
-        let mut voting_rights = BTreeMap::new();
-        let mut network_metadata = BTreeMap::new();
-        for validator in &self.validators.active_validators {
-            let verified_metadata = validator.verified_metadata();
-            let name = verified_metadata.sui_pubkey_bytes();
-            voting_rights.insert(name, validator.voting_power);
-            network_metadata.insert(
-                name,
-                NetworkMetadata {
-                    network_address: verified_metadata.net_address.clone(),
-                    narwhal_primary_address: verified_metadata.primary_address.clone(),
-                },
-            );
-        }
-        CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights),
-            network_metadata,
-        }
+        let validators = self
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let verified_metadata = validator.verified_metadata();
+                let name = verified_metadata.sui_pubkey_bytes();
+                (
+                    name,
+                    (
+                        validator.voting_power,
+                        NetworkMetadata {
+                            network_address: verified_metadata.net_address.clone(),
+                            narwhal_primary_address: verified_metadata.primary_address.clone(),
+                        },
+                    ),
+                )
+            })
+            .collect();
+        CommitteeWithNetworkMetadata::new(self.epoch, validators)
     }
 
     fn get_pending_active_validators<S: ObjectStore + ?Sized>(
@@ -278,24 +280,26 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerShallowV2 {
     }
 
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata {
-        let mut voting_rights = BTreeMap::new();
-        let mut network_metadata = BTreeMap::new();
-        for validator in &self.validators.active_validators {
-            let verified_metadata = validator.verified_metadata();
-            let name = verified_metadata.sui_pubkey_bytes();
-            voting_rights.insert(name, validator.voting_power);
-            network_metadata.insert(
-                name,
-                NetworkMetadata {
-                    network_address: verified_metadata.net_address.clone(),
-                    narwhal_primary_address: verified_metadata.primary_address.clone(),
-                },
-            );
-        }
-        CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights),
-            network_metadata,
-        }
+        let validators = self
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let verified_metadata = validator.verified_metadata();
+                let name = verified_metadata.sui_pubkey_bytes();
+                (
+                    name,
+                    (
+                        validator.voting_power,
+                        NetworkMetadata {
+                            network_address: verified_metadata.net_address.clone(),
+                            narwhal_primary_address: verified_metadata.primary_address.clone(),
+                        },
+                    ),
+                )
+            })
+            .collect();
+        CommitteeWithNetworkMetadata::new(self.epoch, validators)
     }
 
     fn get_pending_active_validators<S: ObjectStore + ?Sized>(
@@ -421,24 +425,26 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerDeepV2 {
     }
 
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata {
-        let mut voting_rights = BTreeMap::new();
-        let mut network_metadata = BTreeMap::new();
-        for validator in &self.validators.active_validators {
-            let verified_metadata = validator.verified_metadata();
-            let name = verified_metadata.sui_pubkey_bytes();
-            voting_rights.insert(name, validator.voting_power);
-            network_metadata.insert(
-                name,
-                NetworkMetadata {
-                    network_address: verified_metadata.net_address.clone(),
-                    narwhal_primary_address: verified_metadata.primary_address.clone(),
-                },
-            );
-        }
-        CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights),
-            network_metadata,
-        }
+        let validators = self
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let verified_metadata = validator.verified_metadata();
+                let name = verified_metadata.sui_pubkey_bytes();
+                (
+                    name,
+                    (
+                        validator.voting_power,
+                        NetworkMetadata {
+                            network_address: verified_metadata.net_address.clone(),
+                            narwhal_primary_address: verified_metadata.primary_address.clone(),
+                        },
+                    ),
+                )
+            })
+            .collect();
+        CommitteeWithNetworkMetadata::new(self.epoch, validators)
     }
 
     fn get_pending_active_validators<S: ObjectStore + ?Sized>(

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{SuiSystemState, SuiSystemStateTrait};
 use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
-use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
+use crate::committee::{CommitteeWithNetworkMetadata, NetworkMetadata};
 use crate::dynamic_field::get_dynamic_field_from_store;
 use crate::error::SuiError;
 use crate::id::ID;
@@ -16,9 +17,6 @@ use fastcrypto::traits::ToFromBytes;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::BTreeMap;
-
-use super::{SuiSystemState, SuiSystemStateTrait};
 
 /// This is the JSON-RPC type for the SUI system state object.
 /// It flattens all fields to make them top-level fields such that it as minimum
@@ -188,24 +186,28 @@ pub struct SuiSystemStateSummary {
 
 impl SuiSystemStateSummary {
     pub fn get_sui_committee_for_benchmarking(&self) -> CommitteeWithNetworkMetadata {
-        let mut voting_rights = BTreeMap::new();
-        let mut network_metadata = BTreeMap::new();
-        for validator in &self.active_validators {
-            let name = AuthorityName::from_bytes(&validator.protocol_pubkey_bytes).unwrap();
-            voting_rights.insert(name, validator.voting_power);
-            network_metadata.insert(
-                name,
-                NetworkMetadata {
-                    network_address: Multiaddr::try_from(validator.net_address.clone()).unwrap(),
-                    narwhal_primary_address: Multiaddr::try_from(validator.primary_address.clone())
-                        .unwrap(),
-                },
-            );
-        }
-        CommitteeWithNetworkMetadata {
-            committee: Committee::new(self.epoch, voting_rights),
-            network_metadata,
-        }
+        let validators = self
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let name = AuthorityName::from_bytes(&validator.protocol_pubkey_bytes).unwrap();
+                (
+                    name,
+                    (
+                        validator.voting_power,
+                        NetworkMetadata {
+                            network_address: Multiaddr::try_from(validator.net_address.clone())
+                                .unwrap(),
+                            narwhal_primary_address: Multiaddr::try_from(
+                                validator.primary_address.clone(),
+                            )
+                            .unwrap(),
+                        },
+                    ),
+                )
+            })
+            .collect();
+        CommitteeWithNetworkMetadata::new(self.epoch, validators)
     }
 }
 


### PR DESCRIPTION
## Description 

This PR restructures the inner fields of CommitteeWithNetworkMetadata such that it guarantees each authority name must corresponding to a pair of stake and network metadata. Potential mismatch was the last reason that AuthAggregator construction could fail. This PR addresses that from type system. After this we could make AuthAggregator constructor a non-fallable function.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
