### PR TITLE
[snapshots] Ignore .tmp files during db checkpoint scan

### DIFF
--- a/crates/sui-storage/src/object_store/util.rs
+++ b/crates/sui-storage/src/object_store/util.rs
@@ -243,7 +243,7 @@ pub async fn find_all_dirs_with_epoch_prefix(
     let entries = store.list_with_delimiter(prefix).await?;
     for entry in entries.common_prefixes {
         if let Some(filename) = entry.filename() {
-            if !filename.starts_with("epoch_") {
+            if !filename.starts_with("epoch_") || filename.ends_with(".tmp") {
                 continue;
             }
             let epoch = filename


### PR DESCRIPTION
## Description 

During rocksdb snapshotting of the db (for creating rocksdb checkpoints), we temporarily suffix the toplevel dir with `.tmp`, and remove it after the snapshotting is complete. There is cleanup code to ensure that these temp files get deleted if we were to crash mid-operation, however there may be some rare edge cases where this is not the case, for example if we crash mid-operation, then start the node up again without db checkpointing enabled, causing the node to progress to the next epoch never having executed the cleanup code. 

In such cases, we will panic on all subsequent snapshot upload attempts due to inability to parse the db checkpoint name due to the unexpected `.tmp` suffix. This handles that edge case by ignoring such files.

## Test plan 

👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
