### PR TITLE
[move][move-vm] Simplify locals creation

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
@@ -61,10 +61,7 @@ impl<S: MoveResolver> TransactionDataCache<S> {
 
             if !modules.is_empty() {
                 change_set
-                    .add_account_changeset(
-                        addr,
-                        AccountChangeSet::from_modules(modules),
-                    )
+                    .add_account_changeset(addr, AccountChangeSet::from_modules(modules))
                     .expect("accounts should be unique");
             }
         }

--- a/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
@@ -78,10 +78,7 @@ impl MoveVM {
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
-            .load_module(
-                module_id,
-                &TransactionDataCache::new(remote),
-            )
+            .load_module(module_id, &TransactionDataCache::new(remote))
             .map(|(compiled, _)| compiled)
     }
 

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -224,7 +224,7 @@ impl VMRuntime {
 
         // Create a list of dummy locals. Each value stored will be used be borrowed and passed
         // by reference to the invoked function
-        let mut dummy_locals = Locals::new(arg_tys.len());
+        let mut dummy_locals = Locals::new_from(vec![], arg_tys.len());
         // Arguments for the invoked function. These can be owned values or references
         let deserialized_args = arg_tys
             .into_iter()

--- a/external-crates/move/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/session.rs
@@ -179,12 +179,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.
-    pub fn finish_with_extensions(
-        self,
-    ) -> (
-        VMResult<(ChangeSet, NativeContextExtensions<'r>)>,
-        S,
-    ) {
+    pub fn finish_with_extensions(self) -> (VMResult<(ChangeSet, NativeContextExtensions<'r>)>, S) {
         let Session {
             data_cache,
             native_extensions,

--- a/external-crates/move/crates/move-vm-types/src/data_store.rs
+++ b/external-crates/move/crates/move-vm-types/src/data_store.rs
@@ -4,8 +4,7 @@
 
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr,
-    language_storage::ModuleId,
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
 };
 
 /// Provide an implementation for bytecodes related to data with a given data store.

--- a/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
@@ -9,7 +9,7 @@ use move_core_types::{account_address::AccountAddress, u256::U256};
 #[test]
 fn locals() -> PartialVMResult<()> {
     const LEN: usize = 4;
-    let mut locals = Locals::new(LEN);
+    let mut locals = Locals::new_from(vec![], LEN);
     for i in 0..LEN {
         assert!(locals.copy_loc(i).is_err());
         assert!(locals.move_loc(i, true).is_err());
@@ -63,7 +63,7 @@ fn struct_pack_and_unpack() -> PartialVMResult<()> {
 
 #[test]
 fn struct_borrow_field() -> PartialVMResult<()> {
-    let mut locals = Locals::new(1);
+    let mut locals = Locals::new_from(vec![], 1);
     locals.store_loc(
         0,
         Value::struct_(Struct::pack(vec![Value::u8(10), Value::bool(false)])),
@@ -91,7 +91,7 @@ fn struct_borrow_field() -> PartialVMResult<()> {
 
 #[test]
 fn struct_borrow_nested() -> PartialVMResult<()> {
-    let mut locals = Locals::new(1);
+    let mut locals = Locals::new_from(vec![], 1);
 
     fn inner(x: u64) -> Value {
         Value::struct_(Struct::pack(vec![Value::u64(x)]))
@@ -130,7 +130,7 @@ fn global_value_non_struct() -> PartialVMResult<()> {
     assert!(GlobalValue::cached(Value::u64(100)).is_err());
     assert!(GlobalValue::cached(Value::bool(false)).is_err());
 
-    let mut locals = Locals::new(1);
+    let mut locals = Locals::new_from(vec![], 1);
     locals.store_loc(0, Value::u8(0), true)?;
     let r = locals.borrow_loc(0)?;
     assert!(GlobalValue::cached(r).is_err());
@@ -140,7 +140,7 @@ fn global_value_non_struct() -> PartialVMResult<()> {
 
 #[test]
 fn leagacy_ref_abstract_memory_size_consistency() -> PartialVMResult<()> {
-    let mut locals = Locals::new(10);
+    let mut locals = Locals::new_from(vec![], 10);
 
     locals.store_loc(0, Value::u128(0), true)?;
     let r = locals.borrow_loc(0)?;
@@ -198,7 +198,7 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
     ];
 
-    let mut locals = Locals::new(vals.len());
+    let mut locals = Locals::new_from(vec![], vals.len());
     for (idx, val) in vals.iter().enumerate() {
         locals.store_loc(idx, val.copy_value()?, true)?;
 

--- a/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
@@ -1218,7 +1218,7 @@ impl Locals {
         let local_values = params
             .into_iter()
             .map(|v| v.0)
-            .chain(iter::repeat_with(|| ValueImpl::Invalid).take(invalids_len))
+            .chain((0..invalids_len).map(|_| ValueImpl::Invalid))
             .collect();
         Self(Rc::new(RefCell::new(local_values)))
     }


### PR DESCRIPTION
## Description 

Simplify how `Locals` forms are created in the VM's runtime by directly taking any parameters. This removes a rather large number of checks and logic, making the code much more straightforward. It is _ostensibly_ faster (though dominated by other things).

## Test plan 

All the tests still work.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
