### PR TITLE
sdk: fix prepare command with sui binary

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -102,7 +102,7 @@
 		"test:unit": "vitest run unit __tests__",
 		"test:e2e": "wait-on http://127.0.0.1:9123 -l --timeout 180000 && vitest run e2e",
 		"test:e2e:nowait": "vitest run e2e",
-		"prepare:e2e": "docker-compose down && docker-compose up -d && cargo build --bin sui --features indexer --profile dev && cross-env RUST_LOG=warn,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui -- start --with-faucet --force-regenesis --with-indexer --pg-port 5435 --pg-db-name sui_indexer_v2 --with-graphql",
+		"prepare:e2e": "docker-compose down && docker-compose up -d && cargo build --bin sui --features indexer --profile dev && cross-env RUST_LOG=warn,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui -- start --with-faucet --force-regenesis",
 		"prepublishOnly": "pnpm build",
 		"size": "size-limit",
 		"analyze": "size-limit --why",


### PR DESCRIPTION
## Description 

**_I don't actually know if this fix is correct_**, but it does seem the case that this command isn't caught up with the changes in ~dca6bfec0705fc107dee960bfc5e296c7c7c3d67~ 07c512abb5505defcc53a2b2274626e1c47be914

**_edit_** looking at the notes in 07c512abb5505defcc53a2b2274626e1c47be914 maybe the solution is to run this with `sui-pg` binary?

**_edit_** well I see the command is being built with `cargo build --bin sui --features indexer `, not sure why it doesn't work locally then! Will convert to draft to get feedback directly.

In any case, right now running `pnpm prepare:e2e` (after I've run `cargo build` and without features enabled in the source repo) will result in

```
error: unexpected argument '--with-graphql' found
```

I removed all the unrecognized flags until it succeeded, so I think this might be want we want now?

Not sure where `pnpm prepare` is all used, there's at least one reference to it in `sdk/deepbook/README.md` and at some point in the past I think I found it in other documentation for running sdk e2e tests

## Test plan 

Ran `pnpm prepare:e2e` locally with success

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
