### PR TITLE
sdk test setup: fix racy access on tmp config file

### DIFF
--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execSync } from 'child_process';
+import { mkdtemp } from 'fs/promises';
 import { tmpdir } from 'os';
 import path, { resolve } from 'path';
 import tmp from 'tmp';
@@ -118,7 +119,9 @@ export function getClient(url = DEFAULT_FULLNODE_URL): SuiClient {
 export async function setup(options: { graphQLURL?: string; rpcURL?: string } = {}) {
 	const keypair = Ed25519Keypair.generate();
 	const address = keypair.getPublicKey().toSuiAddress();
-	const configPath = path.join(tmpdir(), 'client.yaml');
+	const tmpDirPath = path.join(tmpdir(), 'config-');
+	const tmpDir = await mkdtemp(tmpDirPath);
+	const configPath = path.join(tmpDir, 'client.yaml');
 	return setupWithFundedAddress(keypair, address, configPath, options);
 }
 


### PR DESCRIPTION
## Description 

Some test setups call [`[setup(), setup()]`](https://github.com/MystenLabs/sui/blob/9c588e14f284a8feb10f29791f32ad6bb3f36ae4/sdk/typescript/test/e2e/coin-with-balance.test.ts#L22) which can cause a race on accessing the tmp `config.yaml` (which happens in the same tmp directory). This change ensures `setup()` is creates `config.yaml` in unique directories. 

This issue is probably what caused the flakiness in [CI](https://github.com/MystenLabs/sui/actions/runs/9897466376/job/27342099106#step:10:2279), note the:

```
Cannot open wallet config file at "/tmp/client.yaml
```

## Test plan 

Tested locally that running the test creates separate directories and passes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
