### PR TITLE
[auth-agg] Use epoch start state for authority aggregator creation

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -6,9 +6,7 @@ use crate::authority_client::{
     make_authority_clients_with_timeout_config, make_network_authority_clients_with_network_config,
     AuthorityAPI, NetworkAuthorityClient,
 };
-use crate::execution_cache::ObjectCacheRead;
 use crate::safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase};
-use fastcrypto::traits::ToFromBytes;
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use mysten_metrics::histogram::Histogram;
 use mysten_metrics::{monitored_future, spawn_monitored_task, GaugeGuard};
@@ -28,6 +26,7 @@ use sui_types::fp_ensure;
 use sui_types::message_envelope::Message;
 use sui_types::object::Object;
 use sui_types::quorum_driver_types::{GroupedErrors, QuorumDriverResponse};
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
 use sui_types::{
     base_types::*,
@@ -38,6 +37,8 @@ use sui_types::{
 use thiserror::Error;
 use tracing::{debug, error, info, trace, warn, Instrument};
 
+use crate::epoch::committee_store::CommitteeStore;
+use crate::stake_aggregator::{InsertResult, MultiStakeAggregator, StakeAggregator};
 use prometheus::{
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, IntCounter, IntCounterVec, IntGauge, Registry,
@@ -56,10 +57,8 @@ use sui_types::messages_grpc::{
     ObjectInfoRequest, TransactionInfoRequest,
 };
 use sui_types::messages_safe_client::PlainTransactionInfoResponse;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use tokio::time::{sleep, timeout};
-
-use crate::epoch::committee_store::CommitteeStore;
-use crate::stake_aggregator::{InsertResult, MultiStakeAggregator, StakeAggregator};
 
 pub const DEFAULT_RETRIES: usize = 4;
 
@@ -509,50 +508,10 @@ impl<A: Clone> AuthorityAggregator<A> {
         committee: Committee,
         committee_store: Arc<CommitteeStore>,
         authority_clients: BTreeMap<AuthorityName, A>,
-        registry: &Registry,
-        validator_display_names: Arc<HashMap<AuthorityName, String>>,
-    ) -> Self {
-        Self::new_with_timeouts(
-            committee,
-            committee_store,
-            authority_clients,
-            registry,
-            validator_display_names,
-            Default::default(),
-        )
-    }
-
-    pub fn new_with_timeouts(
-        committee: Committee,
-        committee_store: Arc<CommitteeStore>,
-        authority_clients: BTreeMap<AuthorityName, A>,
-        registry: &Registry,
-        validator_display_names: Arc<HashMap<AuthorityName, String>>,
-        timeouts: TimeoutConfig,
-    ) -> Self {
-        let safe_client_metrics_base = SafeClientMetricsBase::new(registry);
-        Self {
-            committee: Arc::new(committee),
-            validator_display_names,
-            authority_clients: create_safe_clients(
-                authority_clients,
-                &committee_store,
-                &safe_client_metrics_base,
-            ),
-            metrics: Arc::new(AuthAggMetrics::new(registry)),
-            safe_client_metrics_base,
-            timeouts,
-            committee_store,
-        }
-    }
-
-    pub fn new_with_metrics(
-        committee: Committee,
-        committee_store: Arc<CommitteeStore>,
-        authority_clients: BTreeMap<AuthorityName, A>,
         safe_client_metrics_base: SafeClientMetricsBase,
         auth_agg_metrics: Arc<AuthAggMetrics>,
         validator_display_names: Arc<HashMap<AuthorityName, String>>,
+        timeouts: TimeoutConfig,
     ) -> Self {
         Self {
             committee: Arc::new(committee),
@@ -563,7 +522,7 @@ impl<A: Clone> AuthorityAggregator<A> {
             ),
             metrics: auth_agg_metrics,
             safe_client_metrics_base,
-            timeouts: Default::default(),
+            timeouts,
             committee_store,
             validator_display_names,
         }
@@ -682,43 +641,37 @@ fn create_safe_clients<A: Clone>(
 }
 
 impl AuthorityAggregator<NetworkAuthorityClient> {
-    /// Create a new network authority aggregator by reading the committee and
-    /// network address information from the system state object on-chain.
-    /// This function needs metrics parameters because registry will panic
-    /// if we attempt to register already-registered metrics again.
-    pub fn new_from_local_system_state(
-        store: &Arc<dyn ObjectCacheRead>,
+    /// Create a new network authority aggregator by reading the committee and network addresses
+    /// information from the given epoch start system state.
+    pub fn new_from_epoch_start_state(
+        epoch_start_state: &EpochStartSystemState,
         committee_store: &Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
-        auth_agg_metrics: AuthAggMetrics,
+        auth_agg_metrics: Arc<AuthAggMetrics>,
     ) -> Self {
-        // TODO: We should get the committee from the epoch store instead to ensure consistency.
-        // Instead of this function use AuthorityEpochStore::epoch_start_configuration() to access this object everywhere
-        // besides when we are reading fields for the current epoch
-        let sui_system_state = store
-            .get_sui_system_state_object_unsafe()
-            .expect("Get system state object should never fail");
-        let committee = sui_system_state.get_current_epoch_committee();
-        let validator_display_names = sui_system_state
-            .into_sui_system_state_summary()
-            .active_validators
-            .into_iter()
-            .filter_map(|s| {
-                let authority_name =
-                    AuthorityPublicKeyBytes::from_bytes(s.protocol_pubkey_bytes.as_slice());
-                if authority_name.is_err() {
-                    return None;
-                }
-                let human_readable_name = s.name;
-                Some((authority_name.unwrap(), human_readable_name))
-            })
-            .collect();
+        let committee = epoch_start_state.get_sui_committee_with_network_metadata();
+        let validator_display_names = epoch_start_state.get_authority_names_to_hostnames();
         Self::new_from_committee(
             committee,
             committee_store,
             safe_client_metrics_base,
-            Arc::new(auth_agg_metrics),
+            auth_agg_metrics,
             Arc::new(validator_display_names),
+        )
+    }
+
+    /// Create a new AuthorityAggregator using information from the given epoch start system state.
+    /// This is typically used during reconfiguration to create a new AuthorityAggregator with the
+    /// new committee and network addresses.
+    pub fn recreate_with_new_epoch_start_state(
+        &self,
+        epoch_start_state: &EpochStartSystemState,
+    ) -> Self {
+        Self::new_from_epoch_start_state(
+            epoch_start_state,
+            &self.committee_store,
+            self.safe_client_metrics_base.clone(),
+            self.metrics.clone(),
         )
     }
 
@@ -732,13 +685,14 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
         let net_config = default_mysten_network_config();
         let authority_clients =
             make_network_authority_clients_with_network_config(&committee, &net_config);
-        Self::new_with_metrics(
+        Self::new(
             committee.committee().clone(),
             committee_store.clone(),
             authority_clients,
             safe_client_metrics_base,
             auth_agg_metrics,
             validator_display_names,
+            Default::default(),
         )
     }
 }
@@ -1955,13 +1909,18 @@ impl<'a> AuthorityAggregatorBuilder<'a> {
         } else {
             Arc::new(CommitteeStore::new_for_testing(committee.committee()))
         };
+        let safe_client_metrics_base = SafeClientMetricsBase::new(registry);
+        let auth_agg_metrics = Arc::new(AuthAggMetrics::new(registry));
+
         Ok((
             AuthorityAggregator::new(
                 committee.committee().clone(),
                 committee_store,
                 auth_clients.clone(),
-                registry,
+                safe_client_metrics_base,
+                auth_agg_metrics,
                 Arc::new(HashMap::new()),
+                Default::default(),
             ),
             auth_clients,
         ))

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -630,7 +630,7 @@ where
         let (subscriber_tx, subscriber_rx) =
             tokio::sync::broadcast::channel::<_>(EFFECTS_QUEUE_SIZE);
         let quorum_driver = Arc::new(QuorumDriver::new(
-            ArcSwap::from(validators),
+            ArcSwap::new(validators),
             task_tx,
             subscriber_tx,
             notifier,

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -1,21 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
-use std::sync::Arc;
-use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
-use tokio::sync::broadcast::error::RecvError;
-use tracing::{info, warn};
-
+use super::QuorumDriver;
 use crate::{
-    authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
+    authority_aggregator::AuthAggMetrics,
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     epoch::committee_store::CommitteeStore,
     execution_cache::ObjectCacheRead,
     safe_client::SafeClientMetricsBase,
 };
-
-use super::QuorumDriver;
+use async_trait::async_trait;
+use std::sync::Arc;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
+use sui_types::sui_system_state::SuiSystemState;
+use sui_types::sui_system_state::SuiSystemStateTrait;
+use tokio::sync::broadcast::error::RecvError;
+use tracing::{info, warn};
 
 #[async_trait]
 pub trait ReconfigObserver<A: Clone> {
@@ -29,6 +29,7 @@ pub struct OnsiteReconfigObserver {
     reconfig_rx: tokio::sync::broadcast::Receiver<SuiSystemState>,
     execution_cache: Arc<dyn ObjectCacheRead>,
     committee_store: Arc<CommitteeStore>,
+    // TODO: Use Arc for both metrics.
     safe_client_metrics_base: SafeClientMetricsBase,
     auth_agg_metrics: AuthAggMetrics,
 }
@@ -49,17 +50,6 @@ impl OnsiteReconfigObserver {
             auth_agg_metrics,
         }
     }
-
-    async fn create_authority_aggregator_from_system_state(
-        &self,
-    ) -> AuthorityAggregator<NetworkAuthorityClient> {
-        AuthorityAggregator::new_from_local_system_state(
-            &self.execution_cache,
-            &self.committee_store,
-            self.safe_client_metrics_base.clone(),
-            self.auth_agg_metrics.clone(),
-        )
-    }
 }
 
 #[async_trait]
@@ -75,28 +65,19 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
     }
 
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>) {
-        // A tiny optimization: when a very stale node just starts, the
-        // channel may fill up committees quickly. Here we skip directly to
-        // the last known committee by looking at SuiSystemState.
-        let authority_agg = self.create_authority_aggregator_from_system_state().await;
-        if authority_agg.committee.epoch > quorum_driver.current_epoch() {
-            quorum_driver
-                .update_validators(Arc::new(authority_agg))
-                .await;
-        }
         loop {
             match self.reconfig_rx.recv().await {
                 Ok(system_state) => {
-                    let committee = system_state.get_current_epoch_committee();
-                    info!(
-                        "Got reconfig message. New committee: {}",
-                        committee.committee()
-                    );
+                    let epoch_start_state = system_state.into_epoch_start_state();
+                    let committee = epoch_start_state.get_sui_committee();
+                    info!("Got reconfig message. New committee: {}", committee);
                     if committee.epoch() > quorum_driver.current_epoch() {
-                        let authority_agg =
-                            self.create_authority_aggregator_from_system_state().await;
+                        let new_auth_agg = quorum_driver
+                            .authority_aggregator()
+                            .load()
+                            .recreate_with_new_epoch_start_state(&epoch_start_state);
                         quorum_driver
-                            .update_validators(Arc::new(authority_agg))
+                            .update_validators(Arc::new(new_auth_agg))
                             .await;
                     } else {
                         // This should only happen when the node just starts

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -38,14 +38,14 @@ use sui_types::quorum_driver_types::{
     ExecuteTransactionResponse, ExecuteTransactionResponseV3, FinalizedEffects,
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
 };
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::sui_system_state::SuiSystemState;
+use sui_types::transaction::VerifiedTransaction;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Receiver;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::{debug, error, error_span, info, instrument, warn, Instrument};
-
-use sui_types::transaction::VerifiedTransaction;
 
 // How long to wait for local execution (including parents) before a timeout
 // is returned to client.
@@ -64,6 +64,7 @@ pub struct TransactiondOrchestrator<A: Clone> {
 
 impl TransactiondOrchestrator<NetworkAuthorityClient> {
     pub fn new_with_network_clients(
+        epoch_start_state: &EpochStartSystemState,
         validator_state: Arc<AuthorityState>,
         reconfig_channel: Receiver<SuiSystemState>,
         parent_path: &Path,
@@ -71,11 +72,11 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
     ) -> Self {
         let safe_client_metrics_base = SafeClientMetricsBase::new(prometheus_registry);
         let auth_agg_metrics = AuthAggMetrics::new(prometheus_registry);
-        let validators = AuthorityAggregator::new_from_local_system_state(
-            validator_state.get_object_cache_reader(),
+        let validators = AuthorityAggregator::new_from_epoch_start_state(
+            epoch_start_state,
             validator_state.committee_store(),
             safe_client_metrics_base.clone(),
-            auth_agg_metrics.clone(),
+            Arc::new(auth_agg_metrics.clone()),
         );
 
         let observer = OnsiteReconfigObserver::new(

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -693,6 +693,7 @@ impl SuiNode {
         let transaction_orchestrator = if is_full_node && run_with_range.is_none() {
             Some(Arc::new(
                 TransactiondOrchestrator::new_with_network_clients(
+                    epoch_store.epoch_start_state(),
                     state.clone(),
                     end_of_epoch_receiver,
                     &config.db_path(),
@@ -1548,6 +1549,7 @@ impl SuiNode {
 
             cur_epoch_store.record_is_safe_mode_metric(latest_system_state.safe_mode());
             let new_epoch_start_state = latest_system_state.into_epoch_start_state();
+
             let next_epoch_committee = new_epoch_start_state.get_sui_committee();
             let next_epoch = next_epoch_committee.epoch();
             assert_eq!(cur_epoch_store.epoch() + 1, next_epoch);


### PR DESCRIPTION
## Description 

Instead of reading the system state object from the object store directly, which is unsafe and should not be used in prod code, this PR changes this to use epoch start state instead. When we reach a new epoch, we get that directly from the new epoch start config.
Also some clean up in AuthorityAggregator constructors.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
