### PR TITLE
Store AuthorityAggregator in sui-node

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -66,7 +66,7 @@ use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::authority::epoch_start_configuration::EpochStartConfigTrait;
 use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
-use sui_core::authority_aggregator::AuthorityAggregator;
+use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use sui_core::authority_server::{ValidatorService, ValidatorServiceMetrics};
 use sui_core::checkpoints::checkpoint_executor::metrics::CheckpointExecutorMetrics;
 use sui_core::checkpoints::checkpoint_executor::{CheckpointExecutor, StopReason};
@@ -212,6 +212,7 @@ use simulator::*;
 #[cfg(msim)]
 pub use simulator::set_jwk_injector;
 use sui_core::consensus_handler::ConsensusHandlerInitializer;
+use sui_core::safe_client::SafeClientMetricsBase;
 use sui_types::execution_config_utils::to_binary_config;
 
 pub struct SuiNode {
@@ -247,6 +248,12 @@ pub struct SuiNode {
     _state_snapshot_uploader_handle: Option<broadcast::Sender<()>>,
     // Channel to allow signaling upstream to shutdown sui-node
     shutdown_channel_tx: broadcast::Sender<Option<RunWithRange>>,
+
+    /// AuthorityAggregator of the network, created at start and beginning of each epoch.
+    /// Use ArcSwap so that we could mutate it without taking mut reference.
+    // TODO: Eventually we can make this auth aggregator a shared reference so that this
+    // update will automatically propagate to other uses.
+    auth_agg: ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>,
 }
 
 impl fmt::Debug for SuiNode {
@@ -466,6 +473,17 @@ impl SuiNode {
 
         let cache_traits =
             build_execution_cache(&epoch_start_configuration, &prometheus_registry, &store);
+
+        let auth_agg = {
+            let safe_client_metrics_base = SafeClientMetricsBase::new(&prometheus_registry);
+            let auth_agg_metrics = Arc::new(AuthAggMetrics::new(&prometheus_registry));
+            Arc::new(AuthorityAggregator::new_from_epoch_start_state(
+                epoch_start_configuration.epoch_start_state(),
+                &committee_store,
+                safe_client_metrics_base,
+                auth_agg_metrics,
+            ))
+        };
 
         let epoch_options = default_db_options().optimize_db_for_write_throughput(4);
         let epoch_store = AuthorityPerEpochStore::new(
@@ -692,8 +710,8 @@ impl SuiNode {
 
         let transaction_orchestrator = if is_full_node && run_with_range.is_none() {
             Some(Arc::new(
-                TransactiondOrchestrator::new_with_network_clients(
-                    epoch_store.epoch_start_state(),
+                TransactiondOrchestrator::new_with_auth_aggregator(
+                    auth_agg.clone(),
                     state.clone(),
                     end_of_epoch_receiver,
                     &config.db_path(),
@@ -798,6 +816,8 @@ impl SuiNode {
             _state_archive_handle: state_archive_handle,
             _state_snapshot_uploader_handle: state_snapshot_handle,
             shutdown_channel_tx: shutdown_channel,
+
+            auth_agg: ArcSwap::new(auth_agg),
         };
 
         info!("SuiNode started!");
@@ -1549,6 +1569,12 @@ impl SuiNode {
 
             cur_epoch_store.record_is_safe_mode_metric(latest_system_state.safe_mode());
             let new_epoch_start_state = latest_system_state.into_epoch_start_state();
+
+            self.auth_agg.store(Arc::new(
+                self.auth_agg
+                    .load()
+                    .recreate_with_new_epoch_start_state(&new_epoch_start_state),
+            ));
 
             let next_epoch_committee = new_epoch_start_state.get_sui_committee();
             let next_epoch = next_epoch_committee.epoch();


### PR DESCRIPTION
## Description 

This PR moves the construction of AuthorityAggregator to sui-node and stores a reference there.
This will make sure that all the metrics are ever only instantiated once (to avoid double register problem).
It will also allow us to use AuthorityAggregator later in ValidatorTxFinalizer.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
