### PR TITLE
[move-ide] Added inlay type hints for unpacks

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -93,7 +93,7 @@ Move source file (a file with a `.move` file extension) and:
   - type on hover
   - outline view showing symbol tree for Move source files
   - inlay hints:
-    - types: local declarations and lambda parameters
+    - types: local declarations, lambda parameters, variant and struct pattern matching
     - parameter names at function calls
 - If the opened Move source file is located within a buildable project you can build and (locally)
   test this project using `Move: Build a Move package` and `Move: Test a Move package` commands from

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
+++ b/external-crates/move/crates/move-analyzer/src/inlay_hints.rs
@@ -69,7 +69,7 @@ fn inlay_type_hints_internal(symbols: &Symbols, mod_defs: &ModuleDefs, hints: &m
                 command: None,
             };
             let type_label = InlayHintLabelPart {
-                value: type_to_ide_string(t, /* verbose */ true),
+                value: type_to_ide_string(t, /* verbose */ false),
                 tooltip: None,
                 location: None,
                 command: None,

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -375,6 +375,7 @@ pub struct ModuleDefs {
     /// Function definitions
     pub functions: BTreeMap<Symbol, MemberDef>,
     /// Definitions where the type is not explicitly specified
+    /// and should be inserted as an inlay hint
     pub untyped_defs: BTreeSet<Loc>,
     /// Information about calls in this module
     pub call_infos: BTreeMap<Loc, CallInfo>,
@@ -2729,7 +2730,17 @@ impl<'a> ParsingSymbolicator<'a> {
                     }
                 })
             }
-            MP::Name(_, chain) => self.chain_symbols(chain),
+            MP::Name(_, chain) => {
+                self.chain_symbols(chain);
+                assert!(self.current_mod_ident_str.is_some());
+                let Some(mod_defs) = self
+                    .mod_outer_defs
+                    .get_mut(&self.current_mod_ident_str.clone().unwrap())
+                else {
+                    return;
+                };
+                mod_defs.untyped_defs.insert(chain.loc);
+            }
             MP::Or(m1, m2) => {
                 self.match_pattern_symbols(m2);
                 self.match_pattern_symbols(m1);

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2733,13 +2733,12 @@ impl<'a> ParsingSymbolicator<'a> {
             MP::Name(_, chain) => {
                 self.chain_symbols(chain);
                 assert!(self.current_mod_ident_str.is_some());
-                let Some(mod_defs) = self
+                if let Some(mod_defs) = self
                     .mod_outer_defs
                     .get_mut(&self.current_mod_ident_str.clone().unwrap())
-                else {
-                    return;
+                {
+                    mod_defs.untyped_defs.insert(chain.loc);
                 };
-                mod_defs.untyped_defs.insert(chain.loc);
             }
             MP::Or(m1, m2) => {
                 self.match_pattern_symbols(m2);
@@ -2959,13 +2958,12 @@ impl<'a> ParsingSymbolicator<'a> {
             B::Var(_, var) => {
                 if !explicitly_typed {
                     assert!(self.current_mod_ident_str.is_some());
-                    let Some(mod_defs) = self
+                    if let Some(mod_defs) = self
                         .mod_outer_defs
                         .get_mut(&self.current_mod_ident_str.clone().unwrap())
-                    else {
-                        return;
+                    {
+                        mod_defs.untyped_defs.insert(var.loc());
                     };
-                    mod_defs.untyped_defs.insert(var.loc());
                 }
             }
         }

--- a/external-crates/move/crates/move-analyzer/tests/inlay_hints.exp
+++ b/external-crates/move/crates/move-analyzer/tests/inlay_hints.exp
@@ -27,7 +27,7 @@ second_param: InlayHints::param_hints::SomeStruct
 -- test 0 -------------------
 INLAY TYPE HINT : u64
 -- test 1 -------------------
-INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+INLAY TYPE HINT : SomeStruct
 ON HOVER:
 ```rust
 public struct InlayHints::type_hints::SomeStruct has copy, drop {
@@ -37,7 +37,7 @@ public struct InlayHints::type_hints::SomeStruct has copy, drop {
 -- test 2 -------------------
 INLAY TYPE HINT : u64
 -- test 3 -------------------
-INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+INLAY TYPE HINT : SomeStruct
 ON HOVER:
 ```rust
 public struct InlayHints::type_hints::SomeStruct has copy, drop {
@@ -47,10 +47,40 @@ public struct InlayHints::type_hints::SomeStruct has copy, drop {
 -- test 4 -------------------
 INLAY TYPE HINT : u64
 -- test 5 -------------------
-INLAY TYPE HINT : InlayHints::type_hints::SomeStruct
+INLAY TYPE HINT : SomeStruct
 ON HOVER:
 ```rust
 public struct InlayHints::type_hints::SomeStruct has copy, drop {
 	some_field: u64
 }
 ```
+-- test 6 -------------------
+INLAY TYPE HINT : u64
+-- test 7 -------------------
+INLAY TYPE HINT : u64
+-- test 8 -------------------
+INLAY TYPE HINT : u64
+-- test 9 -------------------
+INLAY TYPE HINT : AnotherStruct
+ON HOVER:
+```rust
+public struct InlayHints::type_hints::AnotherStruct<T> has copy, drop {
+	some_field: T
+}
+```
+-- test 10 -------------------
+INLAY TYPE HINT : u64
+-- test 11 -------------------
+INLAY TYPE HINT : AnotherStruct
+ON HOVER:
+```rust
+public struct InlayHints::type_hints::AnotherStruct<T> has copy, drop {
+	some_field: T
+}
+```
+-- test 12 -------------------
+INLAY TYPE HINT : u64
+-- test 13 -------------------
+INLAY TYPE HINT : u64
+-- test 14 -------------------
+INLAY TYPE HINT : u64

--- a/external-crates/move/crates/move-analyzer/tests/inlay_hints.ide
+++ b/external-crates/move/crates/move-analyzer/tests/inlay_hints.ide
@@ -5,6 +5,7 @@
     "file_tests": {
       // tests inlay type hints
       "type_hints.move": [
+        // local vars
         {
           "use_line": 8,
           "use_col": 23
@@ -13,6 +14,7 @@
           "use_line": 9,
           "use_col": 25
         },
+        // lambdas
         {
           "use_line": 25,
           "use_col": 24
@@ -28,6 +30,44 @@
         {
           "use_line": 28,
           "use_col": 30
+        },
+        // struct unpacks
+        {
+          "use_line": 42,
+          "use_col": 36
+        },
+        {
+          "use_line": 44,
+          "use_col": 39
+        },
+        // variant unpacks
+        {
+          "use_line": 48,
+          "use_col": 43
+        },
+        {
+          "use_line": 48,
+          "use_col": 46
+        },
+        {
+          "use_line": 51,
+          "use_col": 37
+        },
+        {
+          "use_line": 51,
+          "use_col": 40
+        },
+        {
+          "use_line": 69,
+          "use_col": 44
+        },
+        {
+          "use_line": 69,
+          "use_col": 71
+        },
+        {
+          "use_line": 70,
+          "use_col": 71
         }
       ],
       // tests inlay param hints


### PR DESCRIPTION
## Description 

With this PR inlay type hints work for variant unpacks (they already worked for struct unpacks):

![image](https://github.com/user-attachments/assets/5bef6232-62c3-407a-8bcb-89504efb4a40)

This includes nested patterns:

![image](https://github.com/user-attachments/assets/581af7ae-9471-426c-9db5-5376674f4539)

This PR also changes the way that types are displayed for type hints - the fully qualified name seemed too long (particularly for functions with multiple parameters on the same line) and not really necessary (or redundant even) since you can hover over the hint to see the full type.


## Test plan 

All new and existing tests must pass
