### PR TITLE
Deprecate Sui_Owned_Object_Pools

### DIFF
--- a/sdk/docs/pages/typescript/owned-object-pool/index.mdx
+++ b/sdk/docs/pages/typescript/owned-object-pool/index.mdx
@@ -3,12 +3,11 @@
 import { Callout } from 'nextra/components';
 
 <Callout type="warning">
-	Sui Owned Object Pools (SuiOOP) will likely be replaced by
-	[`ParallelTransactionExecutor`](../executors#paralleltransactionexecutor) from
+	Sui Owned Object Pools (SuiOOP) has been replaced by
+	[`ParallelTransactionExecutor`](../typescript/executors#paralleltransactionexecutor) from
 	`@mysten/sui/transactions`
 
-    Sui Owned Object Pools (SuiOOP) is a beta library. Enhancements and changes are likely during
-    development.
+    Sui Owned Object Pools (SuiOOP) is no longer maintained.
 
 </Callout>
 


### PR DESCRIPTION
## Description 

`Sui_Owned_Objects_Pools` has been deprecated and replaced by `ParallelTransactionExecutor`. 

Adding these changes will redirect the users to the correct solution. 

Bonus: Fixed the hyperlink to `ParallelTransactionExecutor` which was broken. 