### PR TITLE
[GraphQL/Limits] BUGFIX: directives test error type

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
@@ -16,7 +16,7 @@ Response: {
         }
       ],
       "extensions": {
-        "code": "INTERNAL_SERVER_ERROR"
+        "code": "BAD_USER_INPUT"
       }
     }
   ]
@@ -35,7 +35,7 @@ Response: {
         }
       ],
       "extensions": {
-        "code": "INTERNAL_SERVER_ERROR"
+        "code": "BAD_USER_INPUT"
       }
     }
   ]

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -408,7 +408,7 @@ fn check_directives(directives: &[Positioned<Directive>]) -> ServerResult<()> {
     for directive in directives {
         if !allowed_directives().contains(&directive.node.name.node.as_str()) {
             return Err(graphql_error_at_pos(
-                code::INTERNAL_SERVER_ERROR,
+                code::BAD_USER_INPUT,
                 format!(
                     "Directive `@{}` is not supported. Supported directives are {}",
                     directive.node.name.node,


### PR DESCRIPTION
## Description

Passing an unsupported directive should be a user input error, not an internal error.

## Test plan

```
sui-graphql-e2e-tests$ cargo nextest run --features pg_integration -- limits/directives
```

## Stack
- #18660

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Passing an unsupported directive to the service will be treated as a `BAD_USER_INPUT` rather than an `INTERNAL_SERVER_ERROR`.
- [ ] CLI: 
- [ ] Rust SDK: 
