### PR TITLE
[chore][GraphQL/Limits] Clean up headers

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
@@ -16,7 +16,7 @@ Response: {
         }
       ],
       "extensions": {
-        "code": "INTERNAL_SERVER_ERROR"
+        "code": "BAD_USER_INPUT"
       }
     }
   ]
@@ -35,7 +35,7 @@ Response: {
         }
       ],
       "extensions": {
-        "code": "INTERNAL_SERVER_ERROR"
+        "code": "BAD_USER_INPUT"
       }
     }
   ]

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -408,7 +408,7 @@ fn check_directives(directives: &[Positioned<Directive>]) -> ServerResult<()> {
     for directive in directives {
         if !allowed_directives().contains(&directive.node.name.node.as_str()) {
             return Err(graphql_error_at_pos(
-                code::INTERNAL_SERVER_ERROR,
+                code::BAD_USER_INPUT,
                 format!(
                     "Directive `@{}` is not supported. Supported directives are {}",
                     directive.node.name.node,

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -12,9 +12,7 @@ use async_graphql::parser::types::{
 };
 use async_graphql::{value, Name, Pos, Positioned, Response, ServerResult, Value, Variables};
 use async_graphql_value::Value as GqlValue;
-use axum::headers;
 use axum::http::HeaderName;
-use axum::http::HeaderValue;
 use once_cell::sync::Lazy;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::net::SocketAddr;
@@ -48,20 +46,9 @@ struct QueryLimitsCheckerExt {
 
 pub(crate) const CONNECTION_FIELDS: [&str; 2] = ["edges", "nodes"];
 
-impl headers::Header for ShowUsage {
-    fn name() -> &'static HeaderName {
+impl ShowUsage {
+    pub(crate) fn name() -> &'static HeaderName {
         &LIMITS_HEADER
-    }
-
-    fn decode<'i, I>(_: &mut I) -> Result<Self, headers::Error>
-    where
-        I: Iterator<Item = &'i HeaderValue>,
-    {
-        Ok(ShowUsage)
-    }
-
-    fn encode<E: Extend<HeaderValue>>(&self, _: &mut E) {
-        unimplemented!()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -44,7 +44,7 @@ use axum::middleware::{self};
 use axum::response::IntoResponse;
 use axum::routing::{get, post, MethodRouter, Route};
 use axum::Extension;
-use axum::{headers::Header, Router};
+use axum::Router;
 use chrono::Utc;
 use http::{HeaderValue, Method, Request};
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
@@ -57,7 +57,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{any::Any, net::SocketAddr, time::Instant};
-use sui_graphql_rpc_headers::{LIMITS_HEADER, VERSION_HEADER};
+use sui_graphql_rpc_headers::LIMITS_HEADER;
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
 use sui_sdk::SuiClientBuilder;
 use tokio::join;
@@ -309,11 +309,7 @@ impl ServerBuilder {
             .allow_methods([Method::POST])
             // Allow requests from any origin
             .allow_origin(acl)
-            .allow_headers([
-                hyper::header::CONTENT_TYPE,
-                VERSION_HEADER.clone(),
-                LIMITS_HEADER.clone(),
-            ]);
+            .allow_headers([hyper::header::CONTENT_TYPE, LIMITS_HEADER.clone()]);
         Ok(cors)
     }
 


### PR DESCRIPTION
## Description

Two header related clean-ups:

- The version header should no longer be part of the CORS configuration, because we don't expect versions to be configured by (request) header.
- The `ShowUsage` type doesn't need to implement `Header` because we only care about comparing its name.

## Test plan

CI

## Stack
- #18660
- #18661 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: `x-sui-rpc-version` is no longer an accepted request header, as versions are now selected by modifying the path.
- [ ] CLI: 
- [ ] Rust SDK: 
