### PR TITLE
[GraphQL/Limits] Separate out directive checks

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
@@ -16,7 +16,7 @@ Response: {
         }
       ],
       "extensions": {
-        "code": "INTERNAL_SERVER_ERROR"
+        "code": "BAD_USER_INPUT"
       }
     }
   ]
@@ -35,7 +35,7 @@ Response: {
         }
       ],
       "extensions": {
-        "code": "INTERNAL_SERVER_ERROR"
+        "code": "BAD_USER_INPUT"
       }
     }
   ]

--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
@@ -1,4 +1,4 @@
-processed 7 tasks
+processed 8 tasks
 
 init:
 A: object(0,0)
@@ -31,7 +31,7 @@ Response: {
       "locations": [
         {
           "line": 1,
-          "column": 29
+          "column": 28
         }
       ],
       "extensions": {
@@ -41,26 +41,45 @@ Response: {
   ]
 }
 
-task 3 'run-graphql'. lines 44-48:
+task 3 'run-graphql'. lines 44-50:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Directive `@deprecated` is not supported. Supported directives are `@include`, `@skip`",
+      "locations": [
+        {
+          "line": 1,
+          "column": 24
+        }
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 4 'run-graphql'. lines 52-56:
 Response: {
   "data": {}
 }
 
-task 4 'run-graphql'. lines 50-54:
+task 5 'run-graphql'. lines 58-62:
 Response: {
   "data": {
     "chainIdentifier": "3989ac57"
   }
 }
 
-task 5 'run-graphql'. lines 56-60:
+task 6 'run-graphql'. lines 64-68:
 Response: {
   "data": {
     "chainIdentifier": "3989ac57"
   }
 }
 
-task 6 'run-graphql'. lines 62-66:
+task 7 'run-graphql'. lines 70-74:
 Response: {
   "data": {}
 }

--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.move
@@ -11,7 +11,7 @@
 
 //# run-graphql
 
-fragment Modules on Object  @deprecated {
+fragment Modules on Object @deprecated {
     address
     asMovePackage {
         module(name: "m") {
@@ -39,6 +39,14 @@ fragment Modules on Object  @deprecated {
             }
         }
     }
+}
+
+//# run-graphql
+
+query($id: SuiAddress! @deprecated) {
+  object(id: $id) {
+    address
+  }
 }
 
 //# run-graphql

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -159,6 +159,7 @@ pub struct Experiments {
 #[GraphQLConfig]
 pub struct InternalFeatureConfig {
     pub(crate) query_limits_checker: bool,
+    pub(crate) directive_checker: bool,
     pub(crate) feature_gate: bool,
     pub(crate) logger: bool,
     pub(crate) query_timeout: bool,
@@ -459,6 +460,7 @@ impl Default for InternalFeatureConfig {
     fn default() -> Self {
         Self {
             query_limits_checker: true,
+            directive_checker: true,
             feature_gate: true,
             logger: true,
             query_timeout: true,

--- a/crates/sui-graphql-rpc/src/extensions/directive_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/directive_checker.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextParseQuery},
+    parser::types::{Directive, ExecutableDocument, Selection},
+    Positioned, ServerResult,
+};
+use async_graphql_value::Variables;
+use async_trait::async_trait;
+
+use crate::error::{code, graphql_error_at_pos};
+
+const ALLOWED_DIRECTIVES: [&str; 2] = ["include", "skip"];
+
+/// Extension factory to add a check that all the directives used in the query are accepted and
+/// understood by the service.
+pub(crate) struct DirectiveChecker;
+
+struct DirectiveCheckerExt;
+
+impl ExtensionFactory for DirectiveChecker {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(DirectiveCheckerExt)
+    }
+}
+
+#[async_trait]
+impl Extension for DirectiveCheckerExt {
+    async fn parse_query(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        query: &str,
+        variables: &Variables,
+        next: NextParseQuery<'_>,
+    ) -> ServerResult<ExecutableDocument> {
+        let doc = next.run(ctx, query, variables).await?;
+
+        let mut selection_sets = vec![];
+        for fragment in doc.fragments.values() {
+            check_directives(&fragment.node.directives)?;
+            selection_sets.push(&fragment.node.selection_set);
+        }
+
+        for (_name, op) in doc.operations.iter() {
+            check_directives(&op.node.directives)?;
+
+            for var in &op.node.variable_definitions {
+                check_directives(&var.node.directives)?;
+            }
+
+            selection_sets.push(&op.node.selection_set);
+        }
+
+        while let Some(selection_set) = selection_sets.pop() {
+            for selection in &selection_set.node.items {
+                match &selection.node {
+                    Selection::Field(field) => {
+                        check_directives(&field.node.directives)?;
+                        selection_sets.push(&field.node.selection_set);
+                    }
+                    Selection::FragmentSpread(spread) => {
+                        check_directives(&spread.node.directives)?;
+                    }
+                    Selection::InlineFragment(fragment) => {
+                        check_directives(&fragment.node.directives)?;
+                        selection_sets.push(&fragment.node.selection_set);
+                    }
+                }
+            }
+        }
+
+        Ok(doc)
+    }
+}
+
+fn check_directives(directives: &[Positioned<Directive>]) -> ServerResult<()> {
+    for directive in directives {
+        let name = &directive.node.name.node;
+        if !ALLOWED_DIRECTIVES.contains(&name.as_str()) {
+            let supported: Vec<_> = ALLOWED_DIRECTIVES
+                .iter()
+                .map(|s| format!("`@{s}`"))
+                .collect();
+
+            return Err(graphql_error_at_pos(
+                code::BAD_USER_INPUT,
+                format!(
+                    "Directive `@{name}` is not supported. Supported directives are {}",
+                    supported.join(", "),
+                ),
+                directive.pos,
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod directive_checker;
 pub(crate) mod feature_gate;
 pub(crate) mod logger;
-pub mod query_limits_checker;
+pub(crate) mod query_limits_checker;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -408,7 +408,7 @@ fn check_directives(directives: &[Positioned<Directive>]) -> ServerResult<()> {
     for directive in directives {
         if !allowed_directives().contains(&directive.node.name.node.as_str()) {
             return Err(graphql_error_at_pos(
-                code::INTERNAL_SERVER_ERROR,
+                code::BAD_USER_INPUT,
                 format!(
                     "Directive `@{}` is not supported. Supported directives are {}",
                     directive.node.name.node,

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -12,9 +12,7 @@ use async_graphql::parser::types::{
 };
 use async_graphql::{value, Name, Pos, Positioned, Response, ServerResult, Value, Variables};
 use async_graphql_value::Value as GqlValue;
-use axum::headers;
 use axum::http::HeaderName;
-use axum::http::HeaderValue;
 use once_cell::sync::Lazy;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::net::SocketAddr;
@@ -48,20 +46,9 @@ struct QueryLimitsCheckerExt {
 
 pub(crate) const CONNECTION_FIELDS: [&str; 2] = ["edges", "nodes"];
 
-impl headers::Header for ShowUsage {
-    fn name() -> &'static HeaderName {
+impl ShowUsage {
+    pub(crate) fn name() -> &'static HeaderName {
         &LIMITS_HEADER
-    }
-
-    fn decode<'i, I>(_: &mut I) -> Result<Self, headers::Error>
-    where
-        I: Iterator<Item = &'i HeaderValue>,
-    {
-        Ok(ShowUsage)
-    }
-
-    fn encode<E: Extend<HeaderValue>>(&self, _: &mut E) {
-        unimplemented!()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -44,7 +44,7 @@ use axum::middleware::{self};
 use axum::response::IntoResponse;
 use axum::routing::{get, post, MethodRouter, Route};
 use axum::Extension;
-use axum::{headers::Header, Router};
+use axum::Router;
 use chrono::Utc;
 use http::{HeaderValue, Method, Request};
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
@@ -57,7 +57,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{any::Any, net::SocketAddr, time::Instant};
-use sui_graphql_rpc_headers::{LIMITS_HEADER, VERSION_HEADER};
+use sui_graphql_rpc_headers::LIMITS_HEADER;
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
 use sui_sdk::SuiClientBuilder;
 use tokio::join;
@@ -309,11 +309,7 @@ impl ServerBuilder {
             .allow_methods([Method::POST])
             // Allow requests from any origin
             .allow_origin(acl)
-            .allow_headers([
-                hyper::header::CONTENT_TYPE,
-                VERSION_HEADER.clone(),
-                LIMITS_HEADER.clone(),
-            ]);
+            .allow_headers([hyper::header::CONTENT_TYPE, LIMITS_HEADER.clone()]);
         Ok(cors)
     }
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -11,6 +11,7 @@ use crate::config::{
 };
 use crate::data::package_resolver::{DbPackageStore, PackageResolver};
 use crate::data::{DataLoader, Db};
+use crate::extensions::directive_checker::DirectiveChecker;
 use crate::metrics::Metrics;
 use crate::mutation::Mutation;
 use crate::types::datatype::IMoveDatatype;
@@ -468,18 +469,27 @@ impl ServerBuilder {
         if config.internal_features.feature_gate {
             builder = builder.extension(FeatureGate);
         }
+
         if config.internal_features.logger {
             builder = builder.extension(Logger::default());
         }
+
         if config.internal_features.query_limits_checker {
             builder = builder.extension(QueryLimitsChecker);
         }
+
+        if config.internal_features.directive_checker {
+            builder = builder.extension(DirectiveChecker);
+        }
+
         if config.internal_features.query_timeout {
             builder = builder.extension(Timeout);
         }
+
         if config.internal_features.tracing {
             builder = builder.extension(Tracing);
         }
+
         if config.internal_features.apollo_tracing {
             builder = builder.extension(ApolloTracing);
         }


### PR DESCRIPTION
## Description

Trying to do the directive checks at the same time as the query checks complicates both implementations. Split out the directive check into its own extension.

Also fix the directive checks not looking at directives on variable definitions.

## Test plan

```
sui-graphql-e2e-tests$ cargo nextest run \
  --features pg_integration              \
  -- limits/directives.move
```

## Stack
- #18660
- #18661 
- #18662 
- #18663 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: The service now detects unsupported directives on query variable definitions.
- [ ] CLI: 
- [ ] Rust SDK: 
