### PR TITLE
[suiop][incidents] add --with-priority flag

### DIFF
--- a/crates/suiop-cli/src/cli/incidents/mod.rs
+++ b/crates/suiop-cli/src/cli/incidents/mod.rs
@@ -30,6 +30,9 @@ pub enum IncidentsAction {
         /// the days to go back
         #[arg(short, long, default_value = "7")]
         days: usize,
+        /// limit to incidents with any priority set
+        #[arg(long, short = 'p', default_value = "false")]
+        with_priority: bool,
     },
     /// generate Jira tasks for incident follow ups
     #[command(name = "generate follow up tasks", aliases=["g", "gen", "generate"])]
@@ -42,9 +45,12 @@ pub enum IncidentsAction {
 
 pub async fn incidents_cmd(args: &IncidentsArgs) -> Result<()> {
     match &args.action {
-        IncidentsAction::GetRecentIncidents { long, limit, days } => {
-            print_recent_incidents(*long, *limit, *days).await?
-        }
+        IncidentsAction::GetRecentIncidents {
+            long,
+            limit,
+            days,
+            with_priority,
+        } => print_recent_incidents(*long, *limit, *days, *with_priority).await?,
         IncidentsAction::GenerateFollowUpTasks { input_filename } => {
             generate_follow_up_tasks(input_filename).await?
         }

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -87,7 +87,12 @@ async fn fetch_incidents(
     Ok(all_incidents)
 }
 
-pub async fn print_recent_incidents(long: bool, limit: usize, days: usize) -> Result<()> {
+pub async fn print_recent_incidents(
+    long: bool,
+    limit: usize,
+    days: usize,
+    with_priority: bool,
+) -> Result<()> {
     let current_time = Local::now();
     let start_time = current_time - Duration::days(days as i64);
     let date_format_in = "%Y-%m-%dT%H:%M:%SZ";
@@ -151,6 +156,10 @@ pub async fn print_recent_incidents(long: bool, limit: usize, days: usize) -> Re
                 Some("P4") => "P4".white(),
                 _ => "  ".white(),
             };
+            if with_priority && priority == "  ".white() {
+                // skip incidents without priority
+                continue;
+            }
             println!(
                 "{}: ({}) {} {} ({})",
                 incident["incident_number"]


### PR DESCRIPTION
## Description 

enable limiting incident results to those with a priority set via the `--with-priority`/`-p` flag.

## Test plan 

```
» cargo run --bin suiop -- i r -p     
    Finished dev [unoptimized + debuginfo] target(s) in 0.43s
     Running `/Users/jordankylejensen/mysten/sui/target/debug/suiop i r -p`
2433: (2d) P0 dummy incident
3135: (2d) P2 [FIRING:2] incident for something
3134: (2d) P2 [FIRING:2] redacted
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
