### PR TITLE
Include digest of ProtocolConfig when voting for a version

### DIFF
--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -67,7 +67,6 @@ pub enum IntentScope {
     HeaderDigest = 6,      // Used for narwhal authority signature on header digest.
     BridgeEventUnused = 7, // for bridge purposes but it's currently not included in messages.
     ConsensusBlock = 8,    // Used for consensus authority signature on block's digest
-    ProtocolConfigDigest = 9, // Used for getting digest of ProtocolConfig
 }
 
 impl TryFrom<u8> for IntentScope {

--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -67,6 +67,7 @@ pub enum IntentScope {
     HeaderDigest = 6,      // Used for narwhal authority signature on header digest.
     BridgeEventUnused = 7, // for bridge purposes but it's currently not included in messages.
     ConsensusBlock = 8,    // Used for consensus authority signature on block's digest
+    ProtocolConfigDigest = 9, // Used for getting digest of ProtocolConfig
 }
 
 impl TryFrom<u8> for IntentScope {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4316,6 +4316,7 @@ impl AuthorityState {
         Some(res)
     }
 
+    // TODO: delete once authority_capabilities_v2 is deployed everywhere
     fn is_protocol_version_supported_v1(
         current_protocol_version: ProtocolVersion,
         proposed_protocol_version: ProtocolVersion,
@@ -4491,6 +4492,7 @@ impl AuthorityState {
             })
     }
 
+    // TODO: delete once authority_capabilities_v2 is deployed everywhere
     fn choose_protocol_version_and_system_packages_v1(
         current_protocol_version: ProtocolVersion,
         protocol_config: &ProtocolConfig,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -47,6 +47,7 @@ use sui_config::NodeConfig;
 use sui_types::crypto::RandomnessRound;
 use sui_types::execution_status::ExecutionStatus;
 use sui_types::inner_temporary_store::PackageStoreWithFallback;
+use sui_types::messages_consensus::{AuthorityCapabilitiesV1, AuthorityCapabilitiesV2};
 use sui_types::type_resolver::into_struct_layout;
 use sui_types::type_resolver::LayoutResolver;
 use tap::{TapFallible, TapOptional};
@@ -101,7 +102,6 @@ use sui_types::messages_checkpoint::{
     CheckpointResponseV2, CheckpointSequenceNumber, CheckpointSummary, CheckpointSummaryResponse,
     CheckpointTimestamp, ECMHLiveObjectSetDigest, VerifiedCheckpoint,
 };
-use sui_types::messages_consensus::AuthorityCapabilitiesV1;
 use sui_types::messages_grpc::{
     HandleTransactionResponse, LayoutGenerationOption, ObjectInfoRequest, ObjectInfoRequestKind,
     ObjectInfoResponse, TransactionInfoRequest, TransactionInfoResponse, TransactionStatus,
@@ -4316,7 +4316,7 @@ impl AuthorityState {
         Some(res)
     }
 
-    fn is_protocol_version_supported(
+    fn is_protocol_version_supported_v1(
         current_protocol_version: ProtocolVersion,
         proposed_protocol_version: ProtocolVersion,
         protocol_config: &ProtocolConfig,
@@ -4403,7 +4403,95 @@ impl AuthorityState {
             })
     }
 
-    fn choose_protocol_version_and_system_packages(
+    fn is_protocol_version_supported_v2(
+        current_protocol_version: ProtocolVersion,
+        proposed_protocol_version: ProtocolVersion,
+        protocol_config: &ProtocolConfig,
+        committee: &Committee,
+        capabilities: Vec<AuthorityCapabilitiesV2>,
+        mut buffer_stake_bps: u64,
+    ) -> Option<(ProtocolVersion, Vec<ObjectRef>)> {
+        if proposed_protocol_version > current_protocol_version + 1
+            && !protocol_config.advance_to_highest_supported_protocol_version()
+        {
+            return None;
+        }
+
+        if buffer_stake_bps > 10000 {
+            warn!("clamping buffer_stake_bps to 10000");
+            buffer_stake_bps = 10000;
+        }
+
+        // For each validator, gather the protocol version and system packages that it would like
+        // to upgrade to in the next epoch.
+        let mut desired_upgrades: Vec<_> = capabilities
+            .into_iter()
+            .filter_map(|mut cap| {
+                // A validator that lists no packages is voting against any change at all.
+                if cap.available_system_packages.is_empty() {
+                    return None;
+                }
+
+                cap.available_system_packages.sort();
+
+                info!(
+                    "validator {:?} supports {:?} with system packages: {:?}",
+                    cap.authority.concise(),
+                    cap.supported_protocol_versions,
+                    cap.available_system_packages,
+                );
+
+                // A validator that only supports the current protosl version is also voting
+                // against any change, because framework upgrades aways require a protocol version
+                // bump.
+                cap.supported_protocol_versions
+                    .get_version_digest(proposed_protocol_version)
+                    .map(|digest| (digest, cap.available_system_packages, cap.authority))
+            })
+            .collect();
+
+        // There can only be one set of votes that have a majority, find one if it exists.
+        desired_upgrades.sort();
+        desired_upgrades
+            .into_iter()
+            .group_by(|(digest, packages, _authority)| (*digest, packages.clone()))
+            .into_iter()
+            .find_map(|((digest, packages), group)| {
+                // should have been filtered out earlier.
+                assert!(!packages.is_empty());
+
+                let mut stake_aggregator: StakeAggregator<(), true> =
+                    StakeAggregator::new(Arc::new(committee.clone()));
+
+                for (_, _, authority) in group {
+                    stake_aggregator.insert_generic(authority, ());
+                }
+
+                let total_votes = stake_aggregator.total_votes();
+                let quorum_threshold = committee.quorum_threshold();
+                let f = committee.total_votes() - committee.quorum_threshold();
+
+                // multiple by buffer_stake_bps / 10000, rounded up.
+                let buffer_stake = (f * buffer_stake_bps + 9999) / 10000;
+                let effective_threshold = quorum_threshold + buffer_stake;
+
+                info!(
+                    protocol_config_digest = ?digest,
+                    ?total_votes,
+                    ?quorum_threshold,
+                    ?buffer_stake_bps,
+                    ?effective_threshold,
+                    ?proposed_protocol_version,
+                    ?packages,
+                    "support for upgrade"
+                );
+
+                let has_support = total_votes >= effective_threshold;
+                has_support.then_some((proposed_protocol_version, packages))
+            })
+    }
+
+    fn choose_protocol_version_and_system_packages_v1(
         current_protocol_version: ProtocolVersion,
         protocol_config: &ProtocolConfig,
         committee: &Committee,
@@ -4413,7 +4501,32 @@ impl AuthorityState {
         let mut next_protocol_version = current_protocol_version;
         let mut system_packages = vec![];
 
-        while let Some((version, packages)) = Self::is_protocol_version_supported(
+        while let Some((version, packages)) = Self::is_protocol_version_supported_v1(
+            current_protocol_version,
+            next_protocol_version + 1,
+            protocol_config,
+            committee,
+            capabilities.clone(),
+            buffer_stake_bps,
+        ) {
+            next_protocol_version = version;
+            system_packages = packages;
+        }
+
+        (next_protocol_version, system_packages)
+    }
+
+    fn choose_protocol_version_and_system_packages_v2(
+        current_protocol_version: ProtocolVersion,
+        protocol_config: &ProtocolConfig,
+        committee: &Committee,
+        capabilities: Vec<AuthorityCapabilitiesV2>,
+        buffer_stake_bps: u64,
+    ) -> (ProtocolVersion, Vec<ObjectRef>) {
+        let mut next_protocol_version = current_protocol_version;
+        let mut system_packages = vec![];
+
+        while let Some((version, packages)) = Self::is_protocol_version_supported_v2(
             current_protocol_version,
             next_protocol_version + 1,
             protocol_config,
@@ -4593,15 +4706,27 @@ impl AuthorityState {
         let buffer_stake_bps = epoch_store.get_effective_buffer_stake_bps();
 
         let (next_epoch_protocol_version, next_epoch_system_packages) =
-            Self::choose_protocol_version_and_system_packages(
-                epoch_store.protocol_version(),
-                epoch_store.protocol_config(),
-                epoch_store.committee(),
-                epoch_store
-                    .get_capabilities()
-                    .expect("read capabilities from db cannot fail"),
-                buffer_stake_bps,
-            );
+            if epoch_store.protocol_config().authority_capabilities_v2() {
+                Self::choose_protocol_version_and_system_packages_v2(
+                    epoch_store.protocol_version(),
+                    epoch_store.protocol_config(),
+                    epoch_store.committee(),
+                    epoch_store
+                        .get_capabilities_v2()
+                        .expect("read capabilities from db cannot fail"),
+                    buffer_stake_bps,
+                )
+            } else {
+                Self::choose_protocol_version_and_system_packages_v1(
+                    epoch_store.protocol_version(),
+                    epoch_store.protocol_config(),
+                    epoch_store.committee(),
+                    epoch_store
+                        .get_capabilities_v1()
+                        .expect("read capabilities from db cannot fail"),
+                    buffer_stake_bps,
+                )
+            };
 
         // since system packages are created during the current epoch, they should abide by the
         // rules of the current epoch, including the current epoch's max Move binary format version

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -750,6 +750,7 @@ impl ConsensusAdapter {
                 transactions[0].kind,
                 ConsensusTransactionKind::EndOfPublish(_)
                     | ConsensusTransactionKind::CapabilityNotification(_)
+                    | ConsensusTransactionKind::CapabilityNotificationV2(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
             ) {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -572,6 +572,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::CheckpointSignature(_) => "checkpoint_signature",
         ConsensusTransactionKind::EndOfPublish(_) => "end_of_publish",
         ConsensusTransactionKind::CapabilityNotification(_) => "capability_notification",
+        ConsensusTransactionKind::CapabilityNotificationV2(_) => "capability_notification_v2",
         ConsensusTransactionKind::NewJWKFetched(_, _, _) => "new_jwk_fetched",
         ConsensusTransactionKind::RandomnessStateUpdate(_, _) => "randomness_state_update",
         ConsensusTransactionKind::RandomnessDkgMessage(_, _) => "randomness_dkg_message",

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -85,9 +85,12 @@ impl SuiTxValidator {
                         return Err(SuiError::InvalidDkgMessageSize.into());
                     }
                 }
+
+                ConsensusTransactionKind::CapabilityNotification(_) => {}
+
                 ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotification(_)
                 | ConsensusTransactionKind::NewJWKFetched(_, _, _)
+                | ConsensusTransactionKind::CapabilityNotificationV2(_)
                 | ConsensusTransactionKind::RandomnessStateUpdate(_, _) => {}
             }
         }

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -103,6 +103,7 @@ impl SubmitToConsensus for LazyMysticetiClient {
                 transactions[0].kind,
                 ConsensusTransactionKind::EndOfPublish(_)
                     | ConsensusTransactionKind::CapabilityNotification(_)
+                    | ConsensusTransactionKind::CapabilityNotificationV2(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
             )

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -31,6 +31,7 @@ use sui_json_rpc_types::{
 };
 use sui_macros::sim_test;
 use sui_protocol_config::{Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion};
+use sui_types::digests::Digest;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::effects::TransactionEffects;
 use sui_types::epoch_data::EpochData;
@@ -38,7 +39,9 @@ use sui_types::error::UserInputError;
 use sui_types::execution::SharedInput;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
-use sui_types::messages_consensus::ConsensusDeterminedVersionAssignments;
+use sui_types::messages_consensus::{
+    AuthorityCapabilitiesV2, ConsensusDeterminedVersionAssignments,
+};
 use sui_types::object::Data;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
@@ -4957,12 +4960,30 @@ fn test_choose_next_system_packages() {
 
     macro_rules! make_capabilities {
         ($v: expr, $name: expr, $packages: expr) => {
-            AuthorityCapabilitiesV1::new(
+            AuthorityCapabilitiesV2::new(
                 $name,
+                Chain::Unknown,
                 SupportedProtocolVersions::new_for_testing(1, $v),
                 $packages,
             )
         };
+
+        ($v: expr, $name: expr, $packages: expr, $digest: expr) => {{
+            let mut cap = AuthorityCapabilitiesV2::new(
+                $name,
+                Chain::Unknown,
+                SupportedProtocolVersions::new_for_testing(1, $v),
+                $packages,
+            );
+
+            for (version, digest) in cap.supported_protocol_versions.versions.iter_mut() {
+                if version.as_u64() == $v {
+                    *digest = $digest;
+                }
+            }
+
+            cap
+        }};
     }
 
     let committee = Committee::new_simple_test_committee().0;
@@ -4982,7 +5003,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5001,7 +5022,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5015,7 +5036,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5034,7 +5055,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5053,7 +5074,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5072,7 +5093,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5092,7 +5113,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5111,7 +5132,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5132,7 +5153,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(3), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5152,7 +5173,7 @@ fn test_choose_next_system_packages() {
     // 3 which is the highest supported version
     assert_eq!(
         (ver(3), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5173,7 +5194,29 @@ fn test_choose_next_system_packages() {
     // a way to detect that. The upgrade simply won't happen until everyone moves to 3.
     assert_eq!(
         (ver(1), sort(vec![])),
-        AuthorityState::choose_protocol_version_and_system_packages(
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
+            ProtocolVersion::MIN,
+            &protocol_config,
+            &committee,
+            capabilities,
+            protocol_config.buffer_stake_for_protocol_upgrade_bps(),
+        )
+    );
+
+    // all validators support 2, but they disagree on the digest of the protocol config for 2, so
+    // no upgrade happens.
+    let digest_a = Digest::random();
+    let digest_b = Digest::random();
+    let capabilities = vec![
+        make_capabilities!(2, v[0].0, vec![o1, o2], digest_a),
+        make_capabilities!(2, v[1].0, vec![o1, o2], digest_a),
+        make_capabilities!(2, v[2].0, vec![o1, o2], digest_b),
+        make_capabilities!(2, v[3].0, vec![o1, o2], digest_b),
+    ];
+
+    assert_eq!(
+        (ver(1), sort(vec![])),
+        AuthorityState::choose_protocol_version_and_system_packages_v2(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,

--- a/crates/sui-json-rpc-types/src/sui_protocol.rs
+++ b/crates/sui-json-rpc-types/src/sui_protocol.rs
@@ -48,7 +48,6 @@ impl From<ProtocolConfigValue> for SuiProtocolConfigValue {
             ProtocolConfigValue::u16(y) => SuiProtocolConfigValue::U16(y),
             ProtocolConfigValue::u32(y) => SuiProtocolConfigValue::U32(y),
             ProtocolConfigValue::u64(x) => SuiProtocolConfigValue::U64(x),
-            ProtocolConfigValue::f64(z) => SuiProtocolConfigValue::F64(z),
             ProtocolConfigValue::bool(z) => SuiProtocolConfigValue::Bool(z),
         }
     }

--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -232,9 +232,15 @@ async fn set_filter(
 
 async fn capabilities(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
     let epoch_store = state.node.state().load_epoch_store_one_call_per_task();
-    let capabilities = epoch_store.get_capabilities();
 
+    // Only one of v1 or v2 will be populated at a time
+    let capabilities = epoch_store.get_capabilities_v1();
     let mut output = String::new();
+    for capability in &capabilities {
+        output.push_str(&format!("{:?}\n", capability));
+    }
+
+    let capabilities = epoch_store.get_capabilities_v2();
     for capability in &capabilities {
         output.push_str(&format!("{:?}\n", capability));
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1300,6 +1300,7 @@
                 "advance_epoch_start_time_in_safe_mode": true,
                 "advance_to_highest_supported_protocol_version": false,
                 "allow_receiving_object_id": false,
+                "authority_capabilities_v2": false,
                 "ban_entry_init": false,
                 "bridge": false,
                 "commit_root_state_digest": false,
@@ -1863,12 +1864,6 @@
                 "random_beacon_reduction_lower_bound": null,
                 "reward_slashing_rate": {
                   "u64": "10000"
-                },
-                "scoring_decision_cutoff_value": {
-                  "f64": "2.5"
-                },
-                "scoring_decision_mad_divisor": {
-                  "f64": "2.3"
                 },
                 "storage_fund_reinvest_rate": {
                   "u64": "500"

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -497,6 +497,10 @@ struct FeatureFlags {
     // Enable passkey auth (SIP-9)
     #[serde(skip_serializing_if = "is_false")]
     passkey_auth: bool,
+
+    // Use AuthorityCapabilitiesV2
+    #[serde(skip_serializing_if = "is_false")]
+    authority_capabilities_v2: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1470,6 +1474,10 @@ impl ProtocolConfig {
 
     pub fn passkey_auth(&self) -> bool {
         self.feature_flags.passkey_auth
+    }
+
+    pub fn authority_capabilities_v2(&self) -> bool {
+        self.feature_flags.authority_capabilities_v2
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2511,6 +2511,10 @@ impl ProtocolConfig {
                         .record_consensus_determined_version_assignments_in_prologue = true;
                     cfg.feature_flags
                         .prepend_prologue_tx_in_consensus_commit_in_checkpoints = true;
+
+                    if chain == Chain::Unknown {
+                        cfg.feature_flags.authority_capabilities_v2 = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1100,12 +1100,13 @@ pub struct ProtocolConfig {
     vdf_verify_vdf_cost: Option<u64>,
     vdf_hash_to_input_cost: Option<u64>,
 
+    // ==== Ephemeral (consensus only) params deleted ====
+    //
     // Const params for consensus scoring decision
     // The scaling factor property for the MED outlier detection
-    scoring_decision_mad_divisor: Option<f64>,
+    // scoring_decision_mad_divisor: Option<f64>,
     // The cutoff value for the MED outlier detection
-    scoring_decision_cutoff_value: Option<f64>,
-
+    // scoring_decision_cutoff_value: Option<f64>,
     /// === Execution Version ===
     execution_version: Option<u64>,
 
@@ -1900,9 +1901,10 @@ impl ProtocolConfig {
             max_size_written_objects: None,
             max_size_written_objects_system_tx: None,
 
+            // ==== Ephemeral (consensus only) params deleted ====
             // Const params for consensus scoring decision
-            scoring_decision_mad_divisor: None,
-            scoring_decision_cutoff_value: None,
+            // scoring_decision_mad_divisor: None,
+            // scoring_decision_cutoff_value: None,
 
             // Limits the length of a Move identifier
             max_move_identifier_len: None,
@@ -1987,8 +1989,9 @@ impl ProtocolConfig {
                     cfg.feature_flags.missing_type_is_compatibility_error = true;
                     cfg.gas_model_version = Some(4);
                     cfg.feature_flags.scoring_decision_with_validity_cutoff = true;
-                    cfg.scoring_decision_mad_divisor = Some(2.3);
-                    cfg.scoring_decision_cutoff_value = Some(2.5);
+                    // ==== Ephemeral (consensus only) params deleted ====
+                    // cfg.scoring_decision_mad_divisor = Some(2.3);
+                    // cfg.scoring_decision_cutoff_value = Some(2.5);
                 }
                 6 => {
                     cfg.gas_model_version = Some(5);

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_10.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_10.snap
@@ -174,6 +174,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_11.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_11.snap
@@ -175,6 +175,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_12.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_12.snap
@@ -176,6 +176,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_13.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_13.snap
@@ -176,6 +176,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_14.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_14.snap
@@ -177,6 +177,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_15.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_15.snap
@@ -178,6 +178,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
@@ -179,6 +179,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_17.snap
@@ -180,6 +180,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_18.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_18.snap
@@ -181,7 +181,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_19.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_19.snap
@@ -182,7 +182,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_20.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_20.snap
@@ -183,7 +183,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_21.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_21.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
-assertion_line: 1578
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 21
@@ -184,7 +183,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_22.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_22.snap
@@ -184,7 +184,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
@@ -186,8 +186,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_24.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_24.snap
@@ -189,8 +189,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_25.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_25.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_26.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_26.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_27.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_27.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_28.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_28.snap
@@ -197,8 +197,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_29.snap
@@ -198,8 +198,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_30.snap
@@ -195,8 +195,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_31.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_31.snap
@@ -195,8 +195,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_32.snap
@@ -196,8 +196,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_33.snap
@@ -201,8 +201,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_34.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_34.snap
@@ -201,8 +201,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_35.snap
@@ -202,8 +202,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
@@ -203,8 +203,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_37.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_37.snap
@@ -204,8 +204,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_38.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_38.snap
@@ -219,8 +219,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_39.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_39.snap
@@ -219,8 +219,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_40.snap
@@ -219,8 +219,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_41.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_41.snap
@@ -250,8 +250,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
@@ -250,8 +250,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_43.snap
@@ -252,8 +252,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_44.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_44.snap
@@ -253,8 +253,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
@@ -262,3 +260,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_45.snap
@@ -255,8 +255,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_46.snap
@@ -256,8 +256,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_47.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_47.snap
@@ -256,8 +256,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_48.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_48.snap
@@ -259,8 +259,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_49.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_49.snap
@@ -260,8 +260,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_5.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_5.snap
@@ -165,6 +165,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
@@ -261,8 +261,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
@@ -271,3 +269,4 @@ random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
 max_deferral_rounds_for_congestion_control: 10
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_51.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_51.snap
@@ -261,8 +261,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_52.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_52.snap
@@ -266,8 +266,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_53.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_53.snap
@@ -268,8 +268,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_6.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_6.snap
@@ -166,6 +166,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_7.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_7.snap
@@ -170,6 +170,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_8.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_8.snap
@@ -171,6 +171,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_9.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_9.snap
@@ -174,6 +174,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_10.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_10.snap
@@ -174,6 +174,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_11.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_11.snap
@@ -175,6 +175,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_12.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_12.snap
@@ -177,6 +177,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_13.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_13.snap
@@ -177,6 +177,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_14.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_14.snap
@@ -178,6 +178,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_15.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_15.snap
@@ -179,6 +179,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
@@ -180,6 +180,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_17.snap
@@ -181,6 +181,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_18.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_18.snap
@@ -182,7 +182,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_19.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_19.snap
@@ -183,7 +183,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_20.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_20.snap
@@ -184,8 +184,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_21.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_21.snap
@@ -188,8 +188,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_22.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_22.snap
@@ -189,8 +189,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_23.snap
@@ -190,8 +190,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_24.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_24.snap
@@ -194,8 +194,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_25.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_25.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_26.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_26.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_27.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_27.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_28.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_28.snap
@@ -197,8 +197,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_29.snap
@@ -198,8 +198,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
@@ -197,8 +197,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_31.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_31.snap
@@ -197,8 +197,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_32.snap
@@ -200,8 +200,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_33.snap
@@ -203,8 +203,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_34.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_34.snap
@@ -203,8 +203,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_35.snap
@@ -204,8 +204,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_36.snap
@@ -204,8 +204,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_37.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_37.snap
@@ -206,8 +206,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_38.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_38.snap
@@ -221,8 +221,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_39.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_39.snap
@@ -221,8 +221,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_40.snap
@@ -221,8 +221,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_41.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_41.snap
@@ -252,8 +252,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
@@ -252,8 +252,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_43.snap
@@ -254,8 +254,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_44.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_44.snap
@@ -255,8 +255,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
@@ -264,3 +262,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_45.snap
@@ -257,8 +257,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_46.snap
@@ -259,8 +259,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_47.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_47.snap
@@ -259,8 +259,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_48.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_48.snap
@@ -263,8 +263,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_49.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_49.snap
@@ -264,8 +264,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_5.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_5.snap
@@ -165,6 +165,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
@@ -265,8 +265,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
@@ -280,3 +278,4 @@ consensus_max_transactions_in_block_bytes: 6291456
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_51.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_51.snap
@@ -265,8 +265,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_52.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_52.snap
@@ -271,8 +271,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_53.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_53.snap
@@ -271,8 +271,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_6.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_6.snap
@@ -166,6 +166,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_7.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_7.snap
@@ -170,6 +170,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_8.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_8.snap
@@ -171,6 +171,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_9.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_9.snap
@@ -174,6 +174,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_10.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_10.snap
@@ -174,6 +174,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_11.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_11.snap
@@ -175,6 +175,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_12.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_12.snap
@@ -178,6 +178,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_13.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_13.snap
@@ -178,6 +178,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_14.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_14.snap
@@ -179,6 +179,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_15.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_15.snap
@@ -180,6 +180,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
@@ -181,6 +181,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_17.snap
@@ -182,6 +182,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_18.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_18.snap
@@ -183,7 +183,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_19.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_19.snap
@@ -184,7 +184,5 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_20.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_20.snap
@@ -185,8 +185,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_21.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_21.snap
@@ -189,8 +189,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_22.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_22.snap
@@ -190,8 +190,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_23.snap
@@ -191,8 +191,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_24.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_24.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_25.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_25.snap
@@ -195,8 +195,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_26.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_26.snap
@@ -197,8 +197,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_27.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_27.snap
@@ -197,8 +197,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_28.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_28.snap
@@ -200,8 +200,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_29.snap
@@ -201,8 +201,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
@@ -199,8 +199,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_31.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_31.snap
@@ -200,8 +200,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_32.snap
@@ -203,8 +203,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_33.snap
@@ -205,8 +205,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_34.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_34.snap
@@ -205,8 +205,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_35.snap
@@ -209,8 +209,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
@@ -241,8 +241,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_37.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_37.snap
@@ -242,8 +242,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 2
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_38.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_38.snap
@@ -257,8 +257,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_39.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_39.snap
@@ -257,8 +257,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_40.snap
@@ -257,8 +257,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_41.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_41.snap
@@ -257,8 +257,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
@@ -257,8 +257,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_43.snap
@@ -259,8 +259,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_44.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_44.snap
@@ -260,8 +260,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_45.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_45.snap
@@ -264,8 +264,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_46.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_46.snap
@@ -265,8 +265,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_47.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_47.snap
@@ -265,8 +265,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_48.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_48.snap
@@ -267,8 +267,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_49.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_49.snap
@@ -272,8 +272,6 @@ check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
 vdf_verify_vdf_cost: 1500
 vdf_hash_to_input_cost: 100
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
@@ -165,6 +165,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_50.snap
@@ -274,8 +274,6 @@ check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
 vdf_verify_vdf_cost: 1500
 vdf_hash_to_input_cost: 100
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_51.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_51.snap
@@ -275,8 +275,6 @@ check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
 vdf_verify_vdf_cost: 1500
 vdf_hash_to_input_cost: 100
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_52.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_52.snap
@@ -280,8 +280,6 @@ check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
 vdf_verify_vdf_cost: 1500
 vdf_hash_to_input_cost: 100
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_53.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_53.snap
@@ -63,6 +63,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
+  authority_capabilities_v2: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -280,8 +281,6 @@ check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
 vdf_verify_vdf_cost: 1500
 vdf_hash_to_input_cost: 100
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 execution_version: 3
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_6.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_6.snap
@@ -166,6 +166,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_7.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_7.snap
@@ -170,6 +170,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_8.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_8.snap
@@ -171,6 +171,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_9.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_9.snap
@@ -174,6 +174,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-scoring_decision_mad_divisor: 2.3
-scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-rest-api/src/system.rs
+++ b/crates/sui-rest-api/src/system.rs
@@ -626,7 +626,6 @@ impl From<ProtocolConfig> for ProtocolConfigResponse {
                         ProtocolConfigValue::u16(x) => x.to_string(),
                         ProtocolConfigValue::u32(y) => y.to_string(),
                         ProtocolConfigValue::u64(z) => z.to_string(),
-                        ProtocolConfigValue::f64(f) => f.to_string(),
                         ProtocolConfigValue::bool(b) => b.to_string(),
                     };
                     (k, v)

--- a/crates/sui-types/src/supported_protocol_versions.rs
+++ b/crates/sui-types/src/supported_protocol_versions.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::RangeInclusive;
+
+use crate::{crypto::DefaultHash, digests::Digest};
+use fastcrypto::hash::HashFunction;
 use serde::{Deserialize, Serialize};
+use shared_crypto::intent::{AppId, Intent, IntentScope, IntentVersion};
 pub use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 
 /// Models the set of protocol versions supported by a validator.
@@ -35,5 +40,62 @@ impl SupportedProtocolVersions {
 
     pub fn is_version_supported(&self, v: ProtocolVersion) -> bool {
         v.as_u64() >= self.min.as_u64() && v.as_u64() <= self.max.as_u64()
+    }
+
+    pub fn as_range(&self) -> RangeInclusive<u64> {
+        self.min.as_u64()..=self.max.as_u64()
+    }
+
+    pub fn truncate_below(self, v: ProtocolVersion) -> Self {
+        let min = std::cmp::max(self.min, v);
+        Self { min, max: self.max }
+    }
+}
+
+/// Models the set of protocol versions supported by a validator.
+/// The `sui-node` binary will always use the SYSTEM_DEFAULT constant, but for testing we need
+/// to be able to inject arbitrary versions into SuiNode.
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+pub struct SupportedProtocolVersionsWithHashes {
+    pub versions: Vec<(ProtocolVersion, Digest)>,
+}
+
+impl SupportedProtocolVersionsWithHashes {
+    pub fn get_version_digest(&self, v: ProtocolVersion) -> Option<Digest> {
+        self.versions
+            .iter()
+            .find(|(version, _)| *version == v)
+            .map(|(_, digest)| *digest)
+    }
+
+    // Ideally this would be in sui-protocol-config, but sui-types depends on sui-protocol-config,
+    // so it would introduce a circular dependency.
+    fn protocol_config_digest(config: &ProtocolConfig) -> Digest {
+        let intent = Intent {
+            scope: IntentScope::ProtocolConfigDigest,
+            version: IntentVersion::V0,
+            app_id: AppId::Sui,
+        };
+        let mut digest = DefaultHash::default();
+        bcs::serialize_into(&mut digest, &intent).expect("serialization cannot fail");
+        bcs::serialize_into(&mut digest, &config).expect("serialization cannot fail");
+        Digest::new(digest.finalize().into())
+    }
+
+    pub fn from_supported_versions(supported: SupportedProtocolVersions, chain: Chain) -> Self {
+        Self {
+            versions: supported
+                .as_range()
+                .map(|v| {
+                    (
+                        v.into(),
+                        Self::protocol_config_digest(&ProtocolConfig::get_for_version(
+                            v.into(),
+                            chain,
+                        )),
+                    )
+                })
+                .collect(),
+        }
     }
 }

--- a/crates/sui-types/src/supported_protocol_versions.rs
+++ b/crates/sui-types/src/supported_protocol_versions.rs
@@ -6,7 +6,6 @@ use std::ops::RangeInclusive;
 use crate::{crypto::DefaultHash, digests::Digest};
 use fastcrypto::hash::HashFunction;
 use serde::{Deserialize, Serialize};
-use shared_crypto::intent::{AppId, Intent, IntentScope, IntentVersion};
 pub use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 
 /// Models the set of protocol versions supported by a validator.
@@ -71,13 +70,7 @@ impl SupportedProtocolVersionsWithHashes {
     // Ideally this would be in sui-protocol-config, but sui-types depends on sui-protocol-config,
     // so it would introduce a circular dependency.
     fn protocol_config_digest(config: &ProtocolConfig) -> Digest {
-        let intent = Intent {
-            scope: IntentScope::ProtocolConfigDigest,
-            version: IntentVersion::V0,
-            app_id: AppId::Sui,
-        };
         let mut digest = DefaultHash::default();
-        bcs::serialize_into(&mut digest, &intent).expect("serialization cannot fail");
         bcs::serialize_into(&mut digest, &config).expect("serialization cannot fail");
         Digest::new(digest.finalize().into())
     }


### PR DESCRIPTION
Add AuthorityCapabilitiesV2, which includes the digest of the protocol config for each version.

This makes it impossible for the committee to approve a protocol upgrade if (due to a release mistake) there is disagreement about what is in the config.
