### PR TITLE
Add a metric to track per object cost in consensus commit for congestion control

### DIFF
--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -55,7 +55,7 @@ impl Payload for BatchPaymentTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
         if !effects.is_ok() {
             effects.print_gas_summary();
-            error!("Batch payment failed...");
+            error!("Batch payment failed... Status: {:?}", effects.status());
         }
 
         self.state.update(effects);

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -41,7 +41,7 @@ impl Payload for DelegationTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
         if !effects.is_ok() {
             effects.print_gas_summary();
-            error!("Delegation tx failed...");
+            error!("Delegation tx failed... Status: {:?}", effects.status());
         }
 
         let coin = match self.coin {

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -48,7 +48,7 @@ impl Payload for SharedCounterTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
         if !effects.is_ok() {
             effects.print_gas_summary();
-            error!("Shared counter tx failed...");
+            error!("Shared counter tx failed... Status: {:?}", effects.status());
         }
         self.gas.0 = effects.gas_object().0;
     }

--- a/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
@@ -50,7 +50,10 @@ impl Payload for SharedCounterDeletionTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
         if !effects.is_ok() && !self.is_counter_deleted {
             effects.print_gas_summary();
-            warn!("Shared counter deletion tx failed: {}", effects.status());
+            warn!(
+                "Shared counter deletion tx failed...  Status: {:?}",
+                effects.status()
+            );
         }
 
         self.gas.0 = effects.gas_object().0;

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -41,7 +41,7 @@ impl Payload for TransferObjectTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
         if !effects.is_ok() {
             effects.print_gas_summary();
-            error!("Transfer tx failed...");
+            error!("Transfer tx failed... Status: {:?}", effects.status());
         }
 
         let recipient = self.gas.iter().find(|x| x.1 != self.transfer_to).unwrap().1;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -278,6 +278,7 @@ pub struct AuthorityMetrics {
     pub consensus_handler_deferred_transactions: IntCounter,
     pub consensus_handler_congested_transactions: IntCounter,
     pub consensus_handler_cancelled_transactions: IntCounter,
+    pub consensus_handler_max_object_costs: IntGaugeVec,
     pub consensus_committed_subdags: IntCounterVec,
     pub consensus_committed_messages: IntGaugeVec,
     pub consensus_committed_user_transactions: IntGaugeVec,
@@ -674,6 +675,12 @@ impl AuthorityMetrics {
             consensus_handler_cancelled_transactions: register_int_counter_with_registry!(
                 "consensus_handler_cancelled_transactions",
                 "Number of transactions cancelled by consensus handler",
+                registry,
+            ).unwrap(),
+            consensus_handler_max_object_costs: register_int_gauge_vec_with_registry!(
+                "consensus_handler_max_congestion_control_object_costs",
+                "Max object costs for congestion control in the current consensus commit",
+                &["commit_type"],
                 registry,
             ).unwrap(),
             consensus_committed_subdags: register_int_counter_vec_with_registry!(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3180,6 +3180,14 @@ impl AuthorityPerEpochStore {
         authority_metrics
             .consensus_handler_cancelled_transactions
             .inc_by(cancelled_txns.len() as u64);
+        authority_metrics
+            .consensus_handler_max_object_costs
+            .with_label_values(&["regular_commit"])
+            .set(shared_object_congestion_tracker.max_cost() as i64);
+        authority_metrics
+            .consensus_handler_max_object_costs
+            .with_label_values(&["randomness_commit"])
+            .set(shared_object_using_randomness_congestion_tracker.max_cost() as i64);
 
         if randomness_state_updated {
             if let Some(randomness_manager) = randomness_manager.as_mut() {

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -147,6 +147,15 @@ impl SharedObjectCongestionTracker {
             }
         }
     }
+
+    // Returns the maximum cost of all objects.
+    pub fn max_cost(&self) -> u64 {
+        self.object_execution_cost
+            .values()
+            .max()
+            .copied()
+            .unwrap_or(0)
+    }
 }
 
 #[cfg(test)]
@@ -466,6 +475,7 @@ mod object_cost_tests {
                 &[(object_id_0, 5), (object_id_1, 10)],
                 mode,
             );
+        assert_eq!(shared_object_congestion_tracker.max_cost(), 10);
 
         // Read two objects should not change the object execution cost.
         let cert = build_transaction(&[(object_id_0, false), (object_id_1, false)], 10);
@@ -477,6 +487,7 @@ mod object_cost_tests {
                 mode
             )
         );
+        assert_eq!(shared_object_congestion_tracker.max_cost(), 10);
 
         // Write to object 0 should only bump object 0's execution cost. The start cost should be object 1's cost.
         let cert = build_transaction(&[(object_id_0, true), (object_id_1, false)], 10);
@@ -492,6 +503,10 @@ mod object_cost_tests {
                 &[(object_id_0, expected_object_0_cost), (object_id_1, 10)],
                 mode
             )
+        );
+        assert_eq!(
+            shared_object_congestion_tracker.max_cost(),
+            expected_object_0_cost
         );
 
         // Write to all objects should bump all objects' execution cost, including objects that are seen for the first time.
@@ -519,6 +534,10 @@ mod object_cost_tests {
                 ],
                 mode
             )
+        );
+        assert_eq!(
+            shared_object_congestion_tracker.max_cost(),
+            expected_object_cost
         );
     }
 }


### PR DESCRIPTION
## Description 

Also some chore to add txn execution status in workloads.

## Test plan 

Unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
