### PR TITLE
Add ability to add urgency to the pagerduty incident for the query

### DIFF
--- a/crates/sui-security-watchdog/src/pagerduty.rs
+++ b/crates/sui-security-watchdog/src/pagerduty.rs
@@ -46,6 +46,7 @@ pub struct Incident {
     pub title: String,
     pub service: Service,
     pub body: Body,
+    pub urgency: Option<String>,
 }
 
 impl Default for Incident {
@@ -56,6 +57,7 @@ impl Default for Incident {
             title: "".to_string(),
             service: Service::default(),
             body: Body::default(),
+            urgency: None,
         }
     }
 }


### PR DESCRIPTION
## Description 

Add an optional urgency parameter to the pagerduty incident when cron query fails.

## Test plan 

Running locally