### PR TITLE
Integrate validator tx finalizer

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -190,6 +190,9 @@ pub struct NodeConfig {
 
     #[serde(default = "bool_true")]
     pub enable_soft_bundle: bool,
+
+    #[serde(default = "bool_true")]
+    pub enable_validator_tx_finalizer: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -7,8 +7,7 @@ use crate::authority::AuthorityState;
 use crate::authority_aggregator::authority_aggregator_tests::{
     create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
 };
-use crate::authority_server::ValidatorService;
-use crate::authority_server::ValidatorServiceMetrics;
+use crate::authority_server::{ValidatorService, ValidatorServiceMetrics};
 use crate::consensus_adapter::ConnectionMonitorStatusForTests;
 use crate::consensus_adapter::ConsensusAdapter;
 use crate::consensus_adapter::ConsensusAdapterMetrics;
@@ -28,7 +27,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::traffic_controller::metrics::TrafficControllerMetrics;
 use itertools::Itertools;
 use sui_config::node::AuthorityOverloadConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
@@ -776,13 +774,10 @@ async fn test_authority_txn_signing_pushback() {
         ConsensusAdapterMetrics::new_test(),
         epoch_store.protocol_config().clone(),
     ));
-    let validator_service = Arc::new(ValidatorService::new(
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
         authority_state.clone(),
         consensus_adapter,
         Arc::new(ValidatorServiceMetrics::new_for_tests()),
-        TrafficControllerMetrics::new_for_tests(),
-        None,
-        None,
     ));
 
     // Manually make the authority into overload state and reject 100% of traffic.
@@ -908,13 +903,10 @@ async fn test_authority_txn_execution_pushback() {
         ConsensusAdapterMetrics::new_test(),
         epoch_store.protocol_config().clone(),
     ));
-    let validator_service = Arc::new(ValidatorService::new(
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
         authority_state.clone(),
         consensus_adapter,
         Arc::new(ValidatorServiceMetrics::new_for_tests()),
-        TrafficControllerMetrics::new_for_tests(),
-        None,
-        None,
     ));
 
     // Manually make the authority into overload state and reject 100% of traffic.

--- a/crates/sui-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/sui-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+use sui_macros::sim_test;
+use sui_test_transaction_builder::publish_basics_package_and_make_counter;
+use sui_types::base_types::dbg_addr;
+use test_cluster::TestClusterBuilder;
+
+#[sim_test]
+async fn test_validator_tx_finalizer_fastpath_tx() {
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(7)
+        // Make epoch duration large enough so that reconfig is never triggered.
+        .with_epoch_duration_ms(1000 * 1000)
+        .build()
+        .await;
+    let tx_data = cluster
+        .test_transaction_builder()
+        .await
+        .transfer_sui(None, dbg_addr(1))
+        .build();
+    let tx = cluster.sign_transaction(&tx_data);
+    let tx_digest = *tx.digest();
+    cluster
+        .authority_aggregator()
+        .authority_clients
+        .values()
+        .next()
+        .unwrap()
+        .handle_transaction(tx, None)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_secs(120)).await;
+    for node in cluster.all_node_handles() {
+        node.with(|n| assert!(n.state().is_tx_already_executed(&tx_digest).unwrap()));
+    }
+}
+
+#[sim_test]
+async fn test_validator_tx_finalizer_consensus_tx() {
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(7)
+        // Make epoch duration large enough so that reconfig is never triggered.
+        .with_epoch_duration_ms(1000 * 1000)
+        .build()
+        .await;
+    let (package, counter) = publish_basics_package_and_make_counter(&cluster.wallet).await;
+    let tx_data = cluster
+        .test_transaction_builder()
+        .await
+        .call_counter_increment(package.0, counter.0, counter.1)
+        .build();
+    let tx = cluster.sign_transaction(&tx_data);
+    let tx_digest = *tx.digest();
+    cluster
+        .authority_aggregator()
+        .authority_clients
+        .values()
+        .next()
+        .unwrap()
+        .handle_transaction(tx, None)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_secs(120)).await;
+    for node in cluster.all_node_handles() {
+        node.with(|n| assert!(n.state().is_tx_already_executed(&tx_digest).unwrap()));
+    }
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -213,6 +213,7 @@ use simulator::*;
 pub use simulator::set_jwk_injector;
 use sui_core::consensus_handler::ConsensusHandlerInitializer;
 use sui_core::safe_client::SafeClientMetricsBase;
+use sui_core::validator_tx_finalizer::ValidatorTxFinalizer;
 use sui_types::execution_config_utils::to_binary_config;
 
 pub struct SuiNode {
@@ -253,7 +254,7 @@ pub struct SuiNode {
     /// Use ArcSwap so that we could mutate it without taking mut reference.
     // TODO: Eventually we can make this auth aggregator a shared reference so that this
     // update will automatically propagate to other uses.
-    auth_agg: ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>,
+    auth_agg: Arc<ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>>,
 }
 
 impl fmt::Debug for SuiNode {
@@ -477,12 +478,14 @@ impl SuiNode {
         let auth_agg = {
             let safe_client_metrics_base = SafeClientMetricsBase::new(&prometheus_registry);
             let auth_agg_metrics = Arc::new(AuthAggMetrics::new(&prometheus_registry));
-            Arc::new(AuthorityAggregator::new_from_epoch_start_state(
-                epoch_start_configuration.epoch_start_state(),
-                &committee_store,
-                safe_client_metrics_base,
-                auth_agg_metrics,
-            ))
+            Arc::new(ArcSwap::new(Arc::new(
+                AuthorityAggregator::new_from_epoch_start_state(
+                    epoch_start_configuration.epoch_start_state(),
+                    &committee_store,
+                    safe_client_metrics_base,
+                    auth_agg_metrics,
+                ),
+            )))
         };
 
         let epoch_options = default_db_options().optimize_db_for_write_throughput(4);
@@ -711,7 +714,7 @@ impl SuiNode {
         let transaction_orchestrator = if is_full_node && run_with_range.is_none() {
             Some(Arc::new(
                 TransactiondOrchestrator::new_with_auth_aggregator(
-                    auth_agg.clone(),
+                    auth_agg.load_full(),
                     state.clone(),
                     end_of_epoch_receiver,
                     &config.db_path(),
@@ -777,6 +780,7 @@ impl SuiNode {
                 connection_monitor_status.clone(),
                 &registry_service,
                 sui_node_metrics.clone(),
+                auth_agg.clone(),
             )
             .await?;
             // This is only needed during cold start.
@@ -817,7 +821,7 @@ impl SuiNode {
             _state_snapshot_uploader_handle: state_snapshot_handle,
             shutdown_channel_tx: shutdown_channel,
 
-            auth_agg: ArcSwap::new(auth_agg),
+            auth_agg,
         };
 
         info!("SuiNode started!");
@@ -1141,6 +1145,7 @@ impl SuiNode {
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         registry_service: &RegistryService,
         sui_node_metrics: Arc<SuiNodeMetrics>,
+        auth_agg: Arc<ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>>,
     ) -> Result<ValidatorComponents> {
         let mut config_clone = config.clone();
         let consensus_config = config_clone
@@ -1175,6 +1180,8 @@ impl SuiNode {
             &config,
             state.clone(),
             consensus_adapter.clone(),
+            auth_agg,
+            epoch_store.get_chain_identifier().chain(),
             &registry_service.default_registry(),
         )
         .await?;
@@ -1403,8 +1410,15 @@ impl SuiNode {
         config: &NodeConfig,
         state: Arc<AuthorityState>,
         consensus_adapter: Arc<ConsensusAdapter>,
+        auth_agg: Arc<ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>>,
+        chain: Chain,
         prometheus_registry: &Registry,
     ) -> Result<tokio::task::JoinHandle<Result<()>>> {
+        let enable_validator_tx_finalizer =
+            config.enable_validator_tx_finalizer && chain != Chain::Mainnet;
+        let validator_tx_finalizer = enable_validator_tx_finalizer.then_some(Arc::new(
+            ValidatorTxFinalizer::new(auth_agg, prometheus_registry),
+        ));
         let validator_service = ValidatorService::new(
             state.clone(),
             consensus_adapter,
@@ -1412,6 +1426,7 @@ impl SuiNode {
             TrafficControllerMetrics::new(prometheus_registry),
             config.policy_config.clone(),
             config.firewall_config.clone(),
+            validator_tx_finalizer,
         );
 
         let mut server_conf = mysten_network::config::Config::new();
@@ -1718,6 +1733,7 @@ impl SuiNode {
                             self.connection_monitor_status.clone(),
                             &self.registry_service,
                             self.metrics.clone(),
+                            self.auth_agg.clone(),
                         )
                         .await?,
                     )

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -16,7 +16,6 @@ use sui_core::consensus_adapter::{
 };
 use sui_core::mock_consensus::{ConsensusMode, MockConsensusClient};
 use sui_core::state_accumulator::StateAccumulator;
-use sui_core::traffic_controller::metrics::TrafficControllerMetrics;
 use sui_test_transaction_builder::{PublishData, TestTransactionBuilder};
 use sui_types::base_types::{AuthorityName, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::committee::Committee;
@@ -67,16 +66,13 @@ impl SingleValidator {
             ConsensusAdapterMetrics::new_test(),
             epoch_store.protocol_config().clone(),
         ));
-        let validator_service = Arc::new(ValidatorService::new(
+        // TODO: for validator benchmarking purposes, we should allow for traffic control
+        // to be configurable and introduce traffic control benchmarks to test
+        // against different policies
+        let validator_service = Arc::new(ValidatorService::new_for_tests(
             validator,
             consensus_adapter,
             Arc::new(ValidatorServiceMetrics::new_for_tests()),
-            TrafficControllerMetrics::new_for_tests(),
-            // TODO: for validator benchmarking purposes, we should allow for this
-            // to be configurable and introduce traffic control benchmarks to test
-            // against different policies
-            None, /* PolicyConfig */
-            None, /* RemoteFirewallConfig */
         ));
         Self {
             validator_service,

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -238,6 +238,7 @@ impl ValidatorConfigBuilder {
             execution_cache: ExecutionCacheConfig::default(),
             state_accumulator_v2: self.state_accumulator_v2,
             enable_soft_bundle: true,
+            enable_validator_tx_finalizer: true,
         }
     }
 
@@ -519,6 +520,8 @@ impl FullnodeConfigBuilder {
             execution_cache: ExecutionCacheConfig::default(),
             state_accumulator_v2: true,
             enable_soft_bundle: true,
+            // This is a validator specific feature.
+            enable_validator_tx_finalizer: false,
         }
     }
 }

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -140,6 +140,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -277,6 +278,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -414,6 +416,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -551,6 +554,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -688,6 +692,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -825,6 +830,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -962,6 +968,7 @@ validator_configs:
     execution-cache: passthrough-cache
     state-accumulator-v2: true
     enable-soft-bundle: true
+    enable-validator-tx-finalizer: true
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
+++ b/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
@@ -4,7 +4,7 @@
 use crate::balance::Balance;
 use crate::base_types::SuiAddress;
 use crate::collection_types::{Bag, Table};
-use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
+use crate::committee::{CommitteeWithNetworkMetadata, NetworkMetadata};
 use crate::crypto::AuthorityPublicKeyBytes;
 use crate::error::SuiError;
 use crate::storage::ObjectStore;
@@ -19,7 +19,6 @@ use fastcrypto::traits::ToFromBytes;
 use mysten_network::Multiaddr;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SimTestSuiSystemStateInnerV1 {


### PR DESCRIPTION
## Description 

This PR integrates the validator tx finalizer with the validator service, which is then invoked after handling a transaction.
A node config is used to control whether an instance of the service is created when the service starts.
It is enabled on devnet and testnet. We will enable for mainnet later when we feel confident.

## Test plan 

Added e2e simtests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
