### PR TITLE
[bridge] add metrics for SignerWithCache

### DIFF
--- a/crates/sui-bridge/src/metrics.rs
+++ b/crates/sui-bridge/src/metrics.rs
@@ -34,6 +34,9 @@ pub struct BridgeMetrics {
     pub(crate) action_executor_signing_queue_skipped_actions: IntCounter,
     pub(crate) action_executor_execution_queue_received_actions: IntCounter,
 
+    pub(crate) signer_with_cache_hit: IntCounterVec,
+    pub(crate) signer_with_cache_miss: IntCounterVec,
+
     pub(crate) eth_provider_queries: IntCounter,
     pub(crate) gas_coin_balance: IntGauge,
 }
@@ -186,6 +189,20 @@ impl BridgeMetrics {
             last_finalized_eth_block: register_int_gauge_with_registry!(
                 "bridge_last_finalized_eth_block",
                 "The latest finalized eth block that indexer observed",
+                registry,
+            )
+            .unwrap(),
+            signer_with_cache_hit: register_int_counter_vec_with_registry!(
+                "bridge_signer_with_cache_hit",
+                "Total number of hit in signer's cache, by verifier type",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            signer_with_cache_miss: register_int_counter_vec_with_registry!(
+                "bridge_signer_with_cache_miss",
+                "Total number of miss in signer's cache, by verifier type",
+                &["type"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -56,6 +56,7 @@ pub async fn run_bridge_node(
             server_config.sui_client,
             server_config.eth_client,
             server_config.approved_governance_actions,
+            metrics.clone(),
         ),
         metrics,
         Arc::new(metadata),

--- a/crates/sui-bridge/src/server/governance_verifier.rs
+++ b/crates/sui-bridge/src/server/governance_verifier.rs
@@ -30,6 +30,10 @@ impl GovernanceVerifier {
 
 #[async_trait::async_trait]
 impl ActionVerifier<BridgeAction> for GovernanceVerifier {
+    fn name(&self) -> &'static str {
+        "GovernanceVerifier"
+    }
+
     async fn verify(&self, key: BridgeAction) -> BridgeResult<BridgeAction> {
         // TODO: an optimization would be to check the current nonce on chain and err for older ones
         if !key.is_governace_action() {

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -6,6 +6,7 @@
 use crate::crypto::{BridgeAuthorityKeyPair, BridgeAuthoritySignInfo};
 use crate::error::{BridgeError, BridgeResult};
 use crate::eth_client::EthClient;
+use crate::metrics::BridgeMetrics;
 use crate::sui_client::{SuiClient, SuiClientInner};
 use crate::types::{BridgeAction, SignedBridgeAction};
 use async_trait::async_trait;
@@ -51,6 +52,8 @@ pub trait BridgeRequestHandlerTrait {
 
 #[async_trait::async_trait]
 pub trait ActionVerifier<K>: Send + Sync {
+    // Name of the verifier, used for metrics
+    fn name(&self) -> &'static str;
     async fn verify(&self, key: K) -> BridgeResult<BridgeAction>;
 }
 
@@ -67,6 +70,10 @@ impl<C> ActionVerifier<(TransactionDigest, u16)> for SuiActionVerifier<C>
 where
     C: SuiClientInner + Send + Sync + 'static,
 {
+    fn name(&self) -> &'static str {
+        "SuiActionVerifier"
+    }
+
     async fn verify(&self, key: (TransactionDigest, u16)) -> BridgeResult<BridgeAction> {
         let (tx_digest, event_idx) = key;
         self.sui_client
@@ -81,6 +88,10 @@ impl<C> ActionVerifier<(TxHash, u16)> for EthActionVerifier<C>
 where
     C: JsonRpcClient + Send + Sync + 'static,
 {
+    fn name(&self) -> &'static str {
+        "EthActionVerifier"
+    }
+
     async fn verify(&self, key: (TxHash, u16)) -> BridgeResult<BridgeAction> {
         let (tx_hash, event_idx) = key;
         self.eth_client
@@ -95,6 +106,7 @@ struct SignerWithCache<K> {
     verifier: Arc<dyn ActionVerifier<K>>,
     mutex: Arc<Mutex<()>>,
     cache: LruCache<K, Arc<Mutex<Option<BridgeResult<SignedBridgeAction>>>>>,
+    metrics: Arc<BridgeMetrics>,
 }
 
 impl<K> SignerWithCache<K>
@@ -104,12 +116,14 @@ where
     fn new(
         signer: Arc<BridgeAuthorityKeyPair>,
         verifier: impl ActionVerifier<K> + 'static,
+        metrics: Arc<BridgeMetrics>,
     ) -> Self {
         Self {
             signer,
             verifier: Arc::new(verifier),
             mutex: Arc::new(Mutex::new(())),
             cache: LruCache::new(NonZeroUsize::new(1000).unwrap()),
+            metrics,
         }
     }
 
@@ -148,11 +162,20 @@ where
     async fn sign(&mut self, key: K) -> BridgeResult<SignedBridgeAction> {
         let signer = self.signer.clone();
         let verifier = self.verifier.clone();
+        let verifier_name = verifier.name();
         let entry = self.get_cache_entry(key.clone()).await;
         let mut guard = entry.lock().await;
         if let Some(result) = &*guard {
+            self.metrics
+                .signer_with_cache_hit
+                .with_label_values(&[verifier_name])
+                .inc();
             return result.clone();
         }
+        self.metrics
+            .signer_with_cache_miss
+            .with_label_values(&[verifier_name])
+            .inc();
         match verifier.verify(key.clone()).await {
             Ok(bridge_action) => {
                 let sig = BridgeAuthoritySignInfo::new(&bridge_action, &signer);
@@ -213,6 +236,7 @@ impl BridgeRequestHandler {
         sui_client: Arc<SuiClient<SC>>,
         eth_client: Arc<EthClient<EP>>,
         approved_governance_actions: Vec<BridgeAction>,
+        metrics: Arc<BridgeMetrics>,
     ) -> Self {
         let (sui_signer_tx, sui_rx) = mysten_metrics::metered_channel::channel(
             1000,
@@ -237,11 +261,22 @@ impl BridgeRequestHandler {
         );
         let signer = Arc::new(signer);
 
-        SignerWithCache::new(signer.clone(), SuiActionVerifier { sui_client }).spawn(sui_rx);
-        SignerWithCache::new(signer.clone(), EthActionVerifier { eth_client }).spawn(eth_rx);
+        SignerWithCache::new(
+            signer.clone(),
+            SuiActionVerifier { sui_client },
+            metrics.clone(),
+        )
+        .spawn(sui_rx);
+        SignerWithCache::new(
+            signer.clone(),
+            EthActionVerifier { eth_client },
+            metrics.clone(),
+        )
+        .spawn(eth_rx);
         SignerWithCache::new(
             signer.clone(),
             GovernanceVerifier::new(approved_governance_actions).unwrap(),
+            metrics.clone(),
         )
         .spawn(governance_rx);
 
@@ -337,7 +372,8 @@ mod tests {
         let sui_verifier = SuiActionVerifier {
             sui_client: Arc::new(SuiClient::new_for_testing(sui_client_mock.clone())),
         };
-        let mut sui_signer_with_cache = SignerWithCache::new(signer.clone(), sui_verifier);
+        let metrics = Arc::new(BridgeMetrics::new_for_testing());
+        let mut sui_signer_with_cache = SignerWithCache::new(signer.clone(), sui_verifier, metrics);
 
         // Test `get_cache_entry` creates a new entry if not exist
         let sui_tx_digest = TransactionDigest::random();
@@ -474,7 +510,9 @@ mod tests {
         let eth_verifier = EthActionVerifier {
             eth_client: Arc::new(eth_client),
         };
-        let mut eth_signer_with_cache = SignerWithCache::new(signer.clone(), eth_verifier);
+        let metrics = Arc::new(BridgeMetrics::new_for_testing());
+        let mut eth_signer_with_cache =
+            SignerWithCache::new(signer.clone(), eth_verifier, metrics.clone());
 
         // Test `get_cache_entry` creates a new entry if not exist
         let eth_tx_hash = TxHash::random();
@@ -557,7 +595,8 @@ mod tests {
 
         let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
         let signer = Arc::new(kp);
-        let mut signer_with_cache = SignerWithCache::new(signer.clone(), verifier);
+        let metrics = Arc::new(BridgeMetrics::new_for_testing());
+        let mut signer_with_cache = SignerWithCache::new(signer.clone(), verifier, metrics.clone());
 
         // action_1 is signable
         signer_with_cache.sign(action_1.clone()).await.unwrap();


### PR DESCRIPTION
## Description 

as title. `SignerWithCache` today already guarantees single processing of one request (if they are received in a short period of time and not evicted in cache). In this PR we add hit and miss metrics for us to understand how well it works.

https://github.com/MystenLabs/sui/blob/main/crates/sui-bridge/src/server/handler.rs#L152


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
