### PR TITLE
[Consensus] reduce connection shutdown grace period

### DIFF
--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -69,6 +69,10 @@ const MAX_TOTAL_FETCHED_BYTES: usize = 128 * 1024 * 1024;
 #[cfg(not(msim))]
 const MAX_CONNECTIONS_BACKLOG: u32 = 1024;
 
+// The time we are willing to wait for a connection to get gracefully shutdown before we attempt to
+// forcefully shutdown its task.
+const CONNECTION_SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(1);
+
 // Implements Tonic RPC client for Consensus.
 pub(crate) struct TonicClient {
     context: Arc<Context>,
@@ -797,10 +801,10 @@ impl<S: NetworkService> NetworkManager<S> for TonicManager {
                     },
                     _ = shutdown_notif.wait() => {
                         info!("Received shutdown. Stopping consensus service.");
-                        if timeout(Duration::from_secs(5), async {
+                        if timeout(CONNECTION_SHUTDOWN_GRACE_PERIOD, async {
                             while connection_handlers.join_next().await.is_some() {}
                         }).await.is_err() {
-                            warn!("Failed to stop all connection handlers in 5s. Forcing shutdown.");
+                            warn!("Failed to stop all connection handlers in {CONNECTION_SHUTDOWN_GRACE_PERIOD:?}. Forcing shutdown.");
                             connection_handlers.shutdown().await;
                         }
                         return;

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -27,12 +27,12 @@ pub struct EpochMetrics {
     // An active validator reconfigures through the following steps:
     // 1. Halt validator (a.k.a. close epoch) and stop accepting user transaction certs.
     // 2. Finishes processing all pending certificates and then send EndOfPublish message.
-    // 3. Stop accepting messages from Narwhal after seeing 2f+1 EndOfPublish messages.
+    // 3. Stop accepting messages from consensus after seeing 2f+1 EndOfPublish messages.
     // 4. Creating the last checkpoint of the epoch by augmenting it with AdvanceEpoch transaction.
     // 5. CheckpointExecutor finishes executing the last checkpoint, and triggers reconfiguration.
-    // 6. During reconfiguration, we tear down Narwhal, reconfigure state (at which point we opens
-    //    up user certs), and start Narwhal again.
-    // 7. After reconfiguration, and eventually Narwhal starts successfully, at some point the first
+    // 6. During reconfiguration, we tear down consensus, reconfigure state (at which point we opens
+    //    up user certs), and start consensus again.
+    // 7. After reconfiguration, and eventually consensus starts successfully, at some point the first
     //    checkpoint of the new epoch will be created.
     // We introduce various metrics to cover the latency of above steps.
     /// The duration from when the epoch is closed (i.e. validator halted) to when all pending


### PR DESCRIPTION
## Description 

Currently in testnet we seem to frequently hit the `5 second` connection shutdown timeout which seems to stall even more the epoch change. We can lower the grace period (similar to what used in Anemo - 1 second) .

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
