### PR TITLE
[move][move-2024] Revised index syntax typing to avoid crash

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4123,7 +4123,7 @@ fn syntax_call_return_ty(
                 &m, &f, &param.value.name
             )
         };
-        valid &= subtype_impl(context, loc, msg, arg_ty, param_ty).is_ok();
+        valid &= subtype_opt(context, loc, msg, arg_ty, param_ty).is_some();
     }
 
     // The failure case for dotted expressions hands an error expression up the chain: if a field

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4094,9 +4094,9 @@ fn syntax_call_return_ty(
     // First, make sure we have a valid function for this. These are never macro calls, so this is
     // just double-checking.
     check_call_target(context, loc, None, macro_, declared, f);
-    let msg = || format!("Invalid call of '{}::{}'", &m, &f);
     // Next we take our args in question and get their types.
     let arg_tys = {
+        let msg = || format!("Invalid call of '{}::{}'", &m, &f);
         let arity = parameters.len();
         make_arg_types(context, loc, msg, arity, argloc, tys)
     };

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -3532,6 +3532,11 @@ fn borrow_exp_dotted(
                     exp = make_error_exp(context, loc);
                     break;
                 };
+                if matches!(index_base_type.value, Type_::UnresolvedError) {
+                    assert!(context.env.has_errors());
+                    exp = make_error_exp(context, loc);
+                    break;
+                }
                 let (m, f) = if mut_ {
                     if let Some(index_mut) = index_methods.index_mut {
                         index_mut.target_function
@@ -3556,6 +3561,8 @@ fn borrow_exp_dotted(
                 let sp!(argloc, mut args_) = args;
                 args_.insert(0, *exp);
                 let mut_type = sp(index_loc, Type_::Ref(mut_, Box::new(index_base_type)));
+                // Note that `module_call` here never raise parameter subtyping errors, since we
+                // already checked them when processing the index functions.
                 let (ret_ty, e_) = module_call(context, error_loc, m, f, None, argloc, args_);
                 if invariant_no_report(context, mut_type.clone(), ret_ty.clone()).is_err() {
                     let msg = format!(
@@ -4087,9 +4094,9 @@ fn syntax_call_return_ty(
     // First, make sure we have a valid function for this. These are never macro calls, so this is
     // just double-checking.
     check_call_target(context, loc, None, macro_, declared, f);
+    let msg = || format!("Invalid call of '{}::{}'", &m, &f);
     // Next we take our args in question and get their types.
     let arg_tys = {
-        let msg = || format!("Invalid call of '{}::{}'", &m, &f);
         let arity = parameters.len();
         make_arg_types(context, loc, msg, arity, argloc, tys)
     };
@@ -4099,17 +4106,32 @@ fn syntax_call_return_ty(
     // the type in the case of a polymorphic return type, e.g.,
     //     fun index<T>(&mut S, x: &T): &T { ... }
     // We don't know what the base type is until we have T in our hand and do this. The subtyping
-    // takes care of this for us. If it fails, however, we're in error mode (explained below).
-    for (arg_ty, (_, param_ty)) in arg_tys.into_iter().zip(parameters.clone()) {
-        if let Err(_failure) = subtype_no_report(context, arg_ty, param_ty) {
-            valid = false;
-        }
+    // takes care of this for us.
+
+    // For the first argument, since it may be incorrectly mut/imm, we don't report an error.
+    let mut args_params = arg_tys.into_iter().zip(parameters.clone());
+    if let Some((arg_ty, (_, param_ty))) = args_params.next() {
+        let _ = subtype_no_report(context, arg_ty, param_ty);
     }
+
+    // For the other arguments, failure should be reported. If it is, we also mark the call as
+    // invalid, indicating a return type error.
+    for (arg_ty, (param, param_ty)) in args_params {
+        let msg = || {
+            format!(
+                "Invalid call of '{}::{}'. Invalid argument for parameter '{}'",
+                &m, &f, &param.value.name
+            )
+        };
+        valid &= subtype_impl(context, loc, msg, arg_ty, param_ty).is_ok();
+    }
+
     // The failure case for dotted expressions hands an error expression up the chain: if a field
-    // or syntax index function fails to resolve, we hand up an error and propagate it, instead of
-    // re-attempting to handle it at each step in the accessors (which would cause the user to get
-    // a new error for each part of the access path). Similarly, if our call arguments are wrong,
-    // the path is already bad so we're done trying to resolve it and drop into this error case.
+    // or syntax index function is invalid or failed to resolve, we hand up an error and propagate
+    // it, instead of re-attempting to handle it at each step in the accessors (which would cause
+    // the user to get a new error for each part of the access path). Similarly, if our call
+    // arguments are wrong, the path is already bad so we're done trying to resolve it and drop
+    // into this error case.
     if !valid {
         context.error_type(return_.loc)
     } else {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_call_invalid_args.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_call_invalid_args.exp
@@ -7,5 +7,5 @@ error[E04007]: incompatible types
 12 │ public fun foo (y: Y, i: &u64) {
    │                           --- Given: 'u64'
 13 │     y.x[i].i;
-   │     ^^^^^^^^ Invalid call of '0x42::t::f'. Invalid argument for parameter 'z'
+   │     ^^^^^^ Invalid call of '0x42::t::f'. Invalid argument for parameter 'z'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.exp
@@ -1,0 +1,12 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/index_invalid_crash.move:14:5
+   │
+12 │ public fun index_by_reference(table: &mut Table<u64, vector<u64>>) {
+   │                                                 --- Expected: 'u64'
+13 │     // borrow(table, &1).push_back(3);
+14 │     table[&1].push_back(3);
+   │     ^^^^^^^^^
+   │     │     │
+   │     │     Given: '&{integer}'
+   │     Invalid call of 'a::m::borrow'. Invalid argument for parameter '_k'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.exp
@@ -1,10 +1,9 @@
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_invalid_crash.move:14:5
+   ┌─ tests/move_2024/typing/index_invalid_crash.move:13:5
    │
 12 │ public fun index_by_reference(table: &mut Table<u64, vector<u64>>) {
    │                                                 --- Expected: 'u64'
-13 │     // borrow(table, &1).push_back(3);
-14 │     table[&1].push_back(3);
+13 │     table[&1].push_back(3);
    │     ^^^^^^^^^
    │     │     │
    │     │     Given: '&{integer}'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.move
@@ -1,0 +1,16 @@
+module a::m;
+
+public struct Table<phantom K: copy + drop + store, phantom V: store> has drop {
+    size: u64,
+}
+
+#[syntax(index)]
+public fun borrow<K: copy + drop + store, V: store>(_table: &mut Table<K, V>, _k: K): &mut V {
+    abort 0
+}
+
+public fun index_by_reference(table: &mut Table<u64, vector<u64>>) {
+    // borrow(table, &1).push_back(3);
+    table[&1].push_back(3);
+}
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_invalid_crash.move
@@ -10,7 +10,6 @@ public fun borrow<K: copy + drop + store, V: store>(_table: &mut Table<K, V>, _k
 }
 
 public fun index_by_reference(table: &mut Table<u64, vector<u64>>) {
-    // borrow(table, &1).push_back(3);
     table[&1].push_back(3);
 }
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_syntax_methods_miscalled.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_syntax_methods_miscalled.exp
@@ -1,5 +1,5 @@
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:30:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:30:10
    │
  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
    │                                                               --- Expected: 'u64'
@@ -7,21 +7,21 @@ error[E04007]: incompatible types
 29 │     public fun miscall0(s: &S, i: u32): &u64 {
    │                                   --- Given: 'u32'
 30 │         &s.t[i]
-   │         ^^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
+   │          ^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:34:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:34:14
    │
-12 │     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-   │                                                                       --- Expected: 'u64'
+ 8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+   │                                                               --- Expected: 'u64'
    ·
 33 │     public fun miscall1(s: &mut S, i: u32): &mut u64 {
    │                                       --- Given: 'u32'
 34 │         &mut s.t[i]
-   │         ^^^^^^^^^^^ Invalid call of 'std::vector::borrow_mut'. Invalid argument for parameter 'i'
+   │              ^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:38:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:38:10
    │
  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
    │                                                               --- Expected: 'u64'
@@ -29,21 +29,21 @@ error[E04007]: incompatible types
 37 │     public fun miscall2<T>(s: &S, i: T): &u64 {
    │                                      - Given: 'T'
 38 │         &s.t[i]
-   │         ^^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
+   │          ^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:43:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:43:14
    │
-12 │     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-   │                                                                       --- Expected: 'u64'
+ 8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+   │                                                               --- Expected: 'u64'
    ·
 42 │     public fun miscall3<T>(s: &mut S, i: T): &mut u64 {
    │                                          - Given: 'T'
 43 │         &mut s.t[i]
-   │         ^^^^^^^^^^^ Invalid call of 'std::vector::borrow_mut'. Invalid argument for parameter 'i'
+   │              ^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:52:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:52:10
    │
 20 │     public fun borrow_s(s: &S, i: u64): &u64 {
    │                                   --- Expected: 'u64'
@@ -51,21 +51,21 @@ error[E04007]: incompatible types
 51 │     fun miscall0(s: &s::S, i: u32): &u64 {
    │                               --- Given: 'u32'
 52 │         &s[i]
-   │         ^^^^^ Invalid call of 'a::s::borrow_s'. Invalid argument for parameter 'i'
+   │          ^^^^ Invalid call of 'a::s::borrow_s'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:56:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:56:14
    │
-25 │     public fun borrow_s_mut(s: &mut S, i: u64): &mut u64 {
-   │                                           --- Expected: 'u64'
+20 │     public fun borrow_s(s: &S, i: u64): &u64 {
+   │                                   --- Expected: 'u64'
    ·
 55 │     fun miscall1(s: &mut s::S, i: u32): &mut u64 {
    │                                   --- Given: 'u32'
 56 │         &mut s[i]
-   │         ^^^^^^^^^ Invalid call of 'a::s::borrow_s_mut'. Invalid argument for parameter 'i'
+   │              ^^^^ Invalid call of 'a::s::borrow_s'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:60:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:60:10
    │
 20 │     public fun borrow_s(s: &S, i: u64): &u64 {
    │                                   --- Expected: 'u64'
@@ -73,21 +73,21 @@ error[E04007]: incompatible types
 59 │     fun miscall2<T>(s: &s::S, i: T): &u64 {
    │                                  - Given: 'T'
 60 │         &s[i]
-   │         ^^^^^ Invalid call of 'a::s::borrow_s'. Invalid argument for parameter 'i'
+   │          ^^^^ Invalid call of 'a::s::borrow_s'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:64:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:64:14
    │
-25 │     public fun borrow_s_mut(s: &mut S, i: u64): &mut u64 {
-   │                                           --- Expected: 'u64'
+20 │     public fun borrow_s(s: &S, i: u64): &u64 {
+   │                                   --- Expected: 'u64'
    ·
 63 │     fun miscall3<T>(s: &mut s::S, i: T): &mut u64 {
    │                                      - Given: 'T'
 64 │         &mut s[i]
-   │         ^^^^^^^^^ Invalid call of 'a::s::borrow_s_mut'. Invalid argument for parameter 'i'
+   │              ^^^^ Invalid call of 'a::s::borrow_s'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:80:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:80:10
    │
 77 │     public fun borrow_mirror(_q: &Q, i: &mut u64): &u64 { i }
    │                                         -------- Expected: '&mut u64'
@@ -95,21 +95,21 @@ error[E04007]: incompatible types
 79 │     fun miscall0(q: &Q, i: u32): &u64 {
    │                            --- Given: 'u32'
 80 │         &q[i]
-   │         ^^^^^ Invalid call of 'a::mirror::borrow_mirror'. Invalid argument for parameter 'i'
+   │          ^^^^ Invalid call of 'a::mirror::borrow_mirror'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:84:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:84:14
    │
-74 │     public fun borrow_mirror_mut(_q: &mut Q, i: &mut u64): &mut u64 { i }
-   │                                                 -------- Expected: '&mut u64'
+77 │     public fun borrow_mirror(_q: &Q, i: &mut u64): &u64 { i }
+   │                                         -------- Expected: '&mut u64'
    ·
 83 │     fun miscall1(q: &mut Q, i: u32): &mut u64 {
    │                                --- Given: 'u32'
 84 │         &mut q[i]
-   │         ^^^^^^^^^ Invalid call of 'a::mirror::borrow_mirror_mut'. Invalid argument for parameter 'i'
+   │              ^^^^ Invalid call of 'a::mirror::borrow_mirror'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:88:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:88:10
    │
 77 │     public fun borrow_mirror(_q: &Q, i: &mut u64): &u64 { i }
    │                                         -------- Expected: '&mut u64'
@@ -117,21 +117,21 @@ error[E04007]: incompatible types
 87 │     fun miscall2<T>(q: &Q, i: T): &u64 {
    │                               - Given: 'T'
 88 │         &q[i]
-   │         ^^^^^ Invalid call of 'a::mirror::borrow_mirror'. Invalid argument for parameter 'i'
+   │          ^^^^ Invalid call of 'a::mirror::borrow_mirror'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:92:9
+   ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:92:14
    │
-74 │     public fun borrow_mirror_mut(_q: &mut Q, i: &mut u64): &mut u64 { i }
-   │                                                 -------- Expected: '&mut u64'
+77 │     public fun borrow_mirror(_q: &Q, i: &mut u64): &u64 { i }
+   │                                         -------- Expected: '&mut u64'
    ·
 91 │     fun miscall3<T>(q: &mut Q, i: T): &mut u64 {
    │                                   - Given: 'T'
 92 │         &mut q[i]
-   │         ^^^^^^^^^ Invalid call of 'a::mirror::borrow_mirror_mut'. Invalid argument for parameter 'i'
+   │              ^^^^ Invalid call of 'a::mirror::borrow_mirror'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:100:9
+    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:100:10
     │
   8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
     │                                                               --- Expected: 'u64'
@@ -139,21 +139,21 @@ error[E04007]: incompatible types
  99 │     public fun miscall1<T>(v: &vector<T>, i: u32): &T {
     │                                              --- Given: 'u32'
 100 │         &v[i]
-    │         ^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
+    │          ^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:104:9
+    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:104:14
     │
- 12 │     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-    │                                                                       --- Expected: 'u64'
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                                                               --- Expected: 'u64'
     ·
 103 │     public fun miscall2<T>(v: &mut vector<T>, i: u32): &mut T {
     │                                                  --- Given: 'u32'
 104 │         &mut v[i]
-    │         ^^^^^^^^^ Invalid call of 'std::vector::borrow_mut'. Invalid argument for parameter 'i'
+    │              ^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:108:9
+    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:108:10
     │
   8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
     │                                                               --- Expected: 'u64'
@@ -161,18 +161,18 @@ error[E04007]: incompatible types
 107 │     public fun miscall3<T,U>(v: &vector<T>, i: U): &T {
     │                                                - Given: 'U'
 108 │         &v[i]
-    │         ^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
+    │          ^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04007]: incompatible types
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:112:9
+    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:112:14
     │
- 12 │     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-    │                                                                       --- Expected: 'u64'
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                                                               --- Expected: 'u64'
     ·
 111 │     public fun miscall4<T,U>(v: &mut vector<T>, i: U): &mut T {
     │                                                    - Given: 'U'
 112 │         &mut v[i]
-    │         ^^^^^^^^^ Invalid call of 'std::vector::borrow_mut'. Invalid argument for parameter 'i'
+    │              ^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:120:9
@@ -211,26 +211,6 @@ error[E04017]: too many arguments
     │              Invalid call of 'std::vector::borrow'. The call expected 2 argument(s) but got 3
 
 error[E04017]: too many arguments
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:128:9
-    │
-128 │         &v[i, j]
-    │         ^^^^^^^^
-    │         │ │
-    │         │ Found 3 argument(s) here
-    │         Invalid call of 'std::vector::borrow'. The call expected 2 argument(s) but got 3
-
-error[E04007]: incompatible types
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:128:9
-    │
-  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
-    │                                                               --- Expected: 'u64'
-    ·
-127 │     public fun miscall3<T,U,V>(v: &vector<T>, i: U, j: V): &T {
-    │                                                  - Given: 'U'
-128 │         &v[i, j]
-    │         ^^^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
-
-error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:128:10
     │
 128 │         &v[i, j]
@@ -239,31 +219,22 @@ error[E04017]: too many arguments
     │          │Found 3 argument(s) here
     │          Invalid call of 'std::vector::borrow'. The call expected 2 argument(s) but got 3
 
+error[E04007]: incompatible types
+    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:128:10
+    │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                                                               --- Expected: 'u64'
+    ·
+127 │     public fun miscall3<T,U,V>(v: &vector<T>, i: U, j: V): &T {
+    │                                                  - Given: 'U'
+128 │         &v[i, j]
+    │          ^^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
+
 error[E03004]: unbound type
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:131:59
     │
 131 │     public fun miscall4<T,U>(v: &mut vector<T>, i: U, j : V): &mut T {
     │                                                           ^ Unbound type 'V' in current scope
-
-error[E04017]: too many arguments
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:132:9
-    │
-132 │         &mut v[i, j]
-    │         ^^^^^^^^^^^^
-    │         │     │
-    │         │     Found 3 argument(s) here
-    │         Invalid call of 'std::vector::borrow_mut'. The call expected 2 argument(s) but got 3
-
-error[E04007]: incompatible types
-    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:132:9
-    │
- 12 │     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-    │                                                                       --- Expected: 'u64'
-    ·
-131 │     public fun miscall4<T,U>(v: &mut vector<T>, i: U, j : V): &mut T {
-    │                                                    - Given: 'U'
-132 │         &mut v[i, j]
-    │         ^^^^^^^^^^^^ Invalid call of 'std::vector::borrow_mut'. Invalid argument for parameter 'i'
 
 error[E04017]: too many arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:132:14
@@ -273,6 +244,17 @@ error[E04017]: too many arguments
     │              ││
     │              │Found 3 argument(s) here
     │              Invalid call of 'std::vector::borrow'. The call expected 2 argument(s) but got 3
+
+error[E04007]: incompatible types
+    ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:132:14
+    │
+  8 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+    │                                                               --- Expected: 'u64'
+    ·
+131 │     public fun miscall4<T,U>(v: &mut vector<T>, i: U, j : V): &mut T {
+    │                                                    - Given: 'U'
+132 │         &mut v[i, j]
+    │              ^^^^^^^ Invalid call of 'std::vector::borrow'. Invalid argument for parameter 'i'
 
 error[E04016]: too few arguments
     ┌─ tests/move_2024/typing/index_syntax_methods_miscalled.move:152:9

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_underspecified.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_underspecified.exp
@@ -1,0 +1,11 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/index_underspecified.move:13:5
+   │
+12 │ public fun index_by_reference<T: store>(table: &mut Table<u64, T>) {
+   │                                                           --- Expected: 'u64'
+13 │     table[&1].push_back(3);
+   │     ^^^^^^^^^
+   │     │     │
+   │     │     Given: '&{integer}'
+   │     Invalid call of 'a::m::borrow'. Invalid argument for parameter '_k'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_underspecified.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/index_underspecified.move
@@ -1,0 +1,14 @@
+module a::m;
+
+public struct Table<phantom K: copy + drop + store, phantom V: store> has drop {
+    size: u64,
+}
+
+#[syntax(index)]
+public fun borrow<K: copy + drop + store, V: store>(_table: &mut Table<K, V>, _k: K): &mut V {
+    abort 0
+}
+
+public fun index_by_reference<T: store>(table: &mut Table<u64, T>) {
+    table[&1].push_back(3);
+}


### PR DESCRIPTION
## Description 

This fixes an issue reported around crashing when there are errors in index calls that then chain to method calls.

## Test plan 

Repros added to the compiler suite

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
