### PR TITLE
Record batch writes and inserts that are slower than 1s

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -255,6 +255,10 @@ pub struct OperationMetrics {
     pub rocksdb_batch_commit_latency_seconds: HistogramVec,
     pub rocksdb_batch_commit_bytes: HistogramVec,
     pub rocksdb_num_active_db_handles: IntGaugeVec,
+    pub rocksdb_very_slow_batch_writes_count: IntCounterVec,
+    pub rocksdb_very_slow_batch_writes_duration_ms: IntCounterVec,
+    pub rocksdb_very_slow_puts_count: IntCounterVec,
+    pub rocksdb_very_slow_puts_duration_ms: IntCounterVec,
 }
 
 impl OperationMetrics {
@@ -376,6 +380,34 @@ impl OperationMetrics {
                 "rocksdb_num_active_db_handles",
                 "Number of active db handles",
                 &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_batch_writes_count: register_int_counter_vec_with_registry!(
+                "rocksdb_num_very_slow_batch_writes",
+                "Number of batch writes that took more than 1 second",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_batch_writes_duration_ms: register_int_counter_vec_with_registry!(
+                "rocksdb_very_slow_batch_writes_duration",
+                "Total duration of batch writes that took more than 1 second",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_puts_count: register_int_counter_vec_with_registry!(
+                "rocksdb_num_very_slow_puts",
+                "Number of puts that took more than 1 second",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_puts_duration_ms: register_int_counter_vec_with_registry!(
+                "rocksdb_very_slow_puts_duration",
+                "Total duration of puts that took more than 1 second",
+                &["cf_name"],
                 registry,
             )
             .unwrap(),

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1374,6 +1374,7 @@ impl DBBatch {
         }
         let elapsed = timer.stop_and_record();
         if elapsed > 1.0 {
+            warn!(?elapsed, ?db_name, "very slow batch write");
             self.db_metrics
                 .op_metrics
                 .rocksdb_very_slow_batch_writes_count
@@ -1905,6 +1906,7 @@ where
 
         let elapsed = timer.stop_and_record();
         if elapsed > 1.0 {
+            warn!(?elapsed, cf = ?self.cf, "very slow insert");
             self.db_metrics
                 .op_metrics
                 .rocksdb_very_slow_puts_count


### PR DESCRIPTION
We have seen situations where rocksdb throttling briefly causes all threads to block while attempting to write to a throttled table.

However, it is not clear that very rare events such as these will show up in histograms. By tracking them in counters we can see definitively how often and when these events occur.
