### PR TITLE
[TrafficControl] Support multi-hop forwarding

### DIFF
--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -157,47 +157,46 @@ async fn process_raw_request<L: Logger>(
     let client = match service.client_id_source {
         Some(ClientIdSource::SocketAddr) => Some(client_addr.ip()),
         Some(ClientIdSource::XForwardedFor(num_hops)) => {
-            let do_header_parse = |header: &HeaderValue| {
-                header.to_str().map(|s| {
-                    let header_contents = s.split(',').map(str::trim).collect::<Vec<_>>();
+            let do_header_parse = |header: &HeaderValue| match header.to_str() {
+                Ok(header_val) => {
+                    let header_contents = header_val.split(',').map(str::trim).collect::<Vec<_>>();
                     if num_hops == 0 {
                         error!(
-                            "x-forwarded-for: 0 specified. x-forwarded-for contents: {:?}. Please assign nonzero value for \
-                            number of hops here, or use `socket-addr` client-id-source type if requests are not being proxied \
-                            to this node. Skipping traffic controller request handling.",
-                            header_contents,
-                        );
+                                "x-forwarded-for: 0 specified. x-forwarded-for contents: {:?}. Please assign nonzero value for \
+                                number of hops here, or use `socket-addr` client-id-source type if requests are not being proxied \
+                                to this node. Skipping traffic controller request handling.",
+                                header_contents,
+                            );
                         return None;
                     }
                     let contents_len = header_contents.len();
                     let Some(client_ip) = header_contents.get(contents_len - num_hops) else {
                         error!(
-                            "x-forwarded-for header value of {:?} contains {} values, but {} hops were specificed. \
-                            Expected {} values. Skipping traffic controller request handling.",
-                            header_contents,
-                            contents_len,
-                            num_hops,
-                            num_hops + 1,
-                        );
+                                "x-forwarded-for header value of {:?} contains {} values, but {} hops were specificed. \
+                                Expected {} values. Skipping traffic controller request handling.",
+                                header_contents,
+                                contents_len,
+                                num_hops,
+                                num_hops + 1,
+                            );
                         return None;
                     };
-                    match client_ip.parse::<SocketAddr>() {
-                        Ok(addr) => Some(addr.ip()),
-                        Err(err) => {
-                            error!(
-                                "Failed to parse x-forwarded-for header value of {:?} to ip address: {:?}. \
-                                Please ensure that your proxy is configured to resolve client domains to an \
-                                IP address before writing header",
-                                s,
-                                err,
-                            );
-                            None
-                        }
-                    }
-                }).unwrap_or_else(|_| {
-                    error!("Failed to parse x-forwarded-for header value of {:?} to string", header);
+                    client_ip.parse::<IpAddr>().ok().or_else(|| {
+                        client_ip.parse::<SocketAddr>().ok().map(|socket_addr| socket_addr.ip()).or_else(|| {
+                                error!(
+                                    "Failed to parse x-forwarded-for header value of {:?} to ip address or socket. \
+                                    Please ensure that your proxy is configured to resolve client domains to an \
+                                    IP address before writing header",
+                                    client_ip,
+                                );
+                                None
+                            })
+                        })
+                }
+                Err(e) => {
+                    error!("Invalid UTF-8 in x-forwarded-for header: {:?}", e);
                     None
-                })
+                }
             };
             if let Some(header) = headers.get("x-forwarded-for") {
                 do_header_parse(header)

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -26,7 +26,7 @@ const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 pub enum ClientIdSource {
     #[default]
     SocketAddr,
-    XForwardedFor,
+    XForwardedFor(usize),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -27,15 +27,25 @@ const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 /// hops between the client and the node for requests going your infra
 /// or infra provider. Example:
 ///
+/// ```ignore
 ///     (client) -> { (global proxy) -> (regional proxy) -> (node) }
+/// ```
 ///
-/// where { <server>, ... } are controlled by the Node operator / their cloud provider.
+/// where
+///
+/// ```ignore
+///     { <server>, ... }
+/// ```
+///
+/// are controlled by the Node operator / their cloud provider.
 /// In this case, we set:
 ///
+/// ```ignore
 /// policy-config:
 ///    client-id-source:
 ///      x-forwarded-for: 2
 ///    ...
+/// ```
 ///
 /// NOTE: x-forwarded-for: 0 is a special case value that can be used by Node
 /// operators to discover the number of hops that should be configured. To use:
@@ -49,8 +59,10 @@ const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 ///     address, and is defined as 1 + the number of IP addresses in the `x-forwarded-for` that occur
 ///     **after** the known client IP address. Example:
 ///
+/// ```ignore
 ///     [<known client IP>] <--- number of hops is 1
 ///     ["1.2.3.4", <known client IP>, "5.6.7.8", "9.10.11.12"] <--- number of hops is 3
+/// ```
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ClientIdSource {

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -22,7 +22,37 @@ const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 /// protocol, such as a load balancer. Note that this is not the
 /// same as the client type (e.g a direct client vs a proxy client,
 /// as in the case of a fullnode driving requests from many clients).
+///
+/// For x-forwarded-for, the usize parameter is the number of forwarding
+/// hops between the client and the node for requests going your infra
+/// or infra provider. Example:
+///
+///     (client) -> { (global proxy) -> (regional proxy) -> (node) }
+///
+/// where { <server>, ... } are controlled by the Node operator / their cloud provider.
+/// In this case, we set:
+///
+/// policy-config:
+///    client-id-source:
+///      x-forwarded-for: 2
+///    ...
+///
+/// NOTE: x-forwarded-for: 0 is a special case value that can be used by Node
+/// operators to discover the number of hops that should be configured. To use:
+///
+/// 1. Set `x-forwarded-for: 0` for the `client-id-source` in the config.
+/// 2. Run the node and query any endpoint (AuthorityServer for validator, or json rpc for rpc node)
+///     from a known IP address.
+/// 3. Search for lines containing `x-forwarded-for` in the logs. The log lines should contain
+///    the contents of the `x-forwarded-for` header, if present, or a corresponding error if not.
+/// 4. The value for number of hops is derived from any such log line that contains your known IP
+///     address, and is defined as 1 + the number of IP addresses in the `x-forwarded-for` that occur
+///     **after** the known client IP address. Example:
+///
+///     [<known client IP>] <--- number of hops is 1
+///     ["1.2.3.4", <known client IP>, "5.6.7.8", "9.10.11.12"] <--- number of hops is 3
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
 pub enum ClientIdSource {
     #[default]
     SocketAddr,


### PR DESCRIPTION
## Description 

Sometimes there can be more than one proxy between the client and the server. In such cases, the `x-forwarded-for` header is appended with the full path of IPs, ostensibly with the client IP being the first. For this reason, we need to fix the parsing to accommodate a list of IPs. However, we additionally have the problem of knowing which IP in the list is the client IP. We cannot assume the first IP in the list is the client IP, as a malicious client could attempt to spoof by writing a junk value in `x-forwarded-for` in the request, to which the internal LBs would append. There are two possible solutions to this:

a) define a custom header and configure our gcs LBS to write to this and overwrite any existing value for that header.
b) add configuration such that the node operator defines the number of intermediate load balancers (`num_hops`) it runs.

In such a case, for a `num_hops = N`, the client IP should always be the `N`th **to last**.
To illustrate (note that for N proxies, only the IP addresses of proxy 1, ..., N-1 will be contained in the header, as proxy N 
is directly connected to the server and does not write its own IP):
```
[
  <whatever the client may have written>, 
  <actual client IP>, <-- we want this
  <1>, 
  ..., 
  <N - 1>
]
```

The first solution would require extra configuration on their infra by the node operator, and would be specific to gcs (we'd have to confirm that something similar is supported in other cloud hosting services).  So this PR implements option (2).

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
