### PR TITLE
Monitor thread stalls in sui node

### DIFF
--- a/crates/mysten-metrics/Cargo.toml
+++ b/crates/mysten-metrics/Cargo.toml
@@ -19,5 +19,4 @@ uuid.workspace = true
 parking_lot.workspace = true
 futures.workspace = true
 async-trait.workspace = true
-
 prometheus-closure-metric.workspace = true

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -11,7 +11,10 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use once_cell::sync::OnceCell;
-use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry, TextEncoder};
+use prometheus::{
+    register_histogram_with_registry, register_int_gauge_vec_with_registry, Histogram, IntGaugeVec,
+    Registry, TextEncoder,
+};
 use tap::TapFallible;
 use tracing::{warn, Span};
 
@@ -22,14 +25,16 @@ mod guards;
 pub mod histogram;
 pub mod metered_channel;
 pub mod monitored_mpsc;
+pub mod thread_stall_monitor;
 pub use guards::*;
 
 pub const TX_TYPE_SINGLE_WRITER_TX: &str = "single_writer";
 pub const TX_TYPE_SHARED_OBJ_TX: &str = "shared_object";
 
-pub const TX_LATENCY_SEC_BUCKETS: &[f64] = &[
-    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.5, 2., 2.5,
-    3., 3.5, 4., 4.5, 5., 6., 7., 8., 9., 10., 20., 30., 60., 90.,
+pub const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6,
+    0.7, 0.8, 0.9, 1., 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2., 2.5, 3., 3.5, 4., 4.5, 5.,
+    6., 7., 8., 9., 10., 15., 20., 25., 30., 60., 90.,
 ];
 
 #[derive(Debug)]
@@ -42,6 +47,7 @@ pub struct Metrics {
     pub scope_iterations: IntGaugeVec,
     pub scope_duration_ns: IntGaugeVec,
     pub scope_entrance: IntGaugeVec,
+    pub thread_stall_duration_sec: Histogram,
 }
 
 impl Metrics {
@@ -103,6 +109,12 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            thread_stall_duration_sec: register_histogram_with_registry!(
+                "thread_stall_duration_sec",
+                "Duration of thread stalls in seconds.",
+                registry,
+            )
+            .unwrap(),
         }
     }
 }
@@ -134,18 +146,18 @@ macro_rules! monitored_future {
         };
 
         async move {
-            let metrics = mysten_metrics::get_metrics();
+            let metrics = $crate::get_metrics();
 
             let _metrics_guard = if let Some(m) = metrics {
                 m.$metric.with_label_values(&[location]).inc();
-                Some(mysten_metrics::scopeguard::guard(m, |metrics| {
+                Some($crate::scopeguard::guard(m, |_| {
                     m.$metric.with_label_values(&[location]).dec();
                 }))
             } else {
                 None
             };
             let _logging_guard = if $logging_enabled {
-                Some(mysten_metrics::scopeguard::guard((), |_| {
+                Some($crate::scopeguard::guard((), |_| {
                     tracing::event!(
                         tracing::Level::$logging_level,
                         "Future {} completed",
@@ -172,28 +184,22 @@ macro_rules! monitored_future {
 #[macro_export]
 macro_rules! spawn_monitored_task {
     ($fut: expr) => {
-        tokio::task::spawn(mysten_metrics::monitored_future!(
-            tasks, $fut, "", INFO, false
-        ))
+        tokio::task::spawn($crate::monitored_future!(tasks, $fut, "", INFO, false))
     };
 }
 
 #[macro_export]
 macro_rules! spawn_logged_monitored_task {
     ($fut: expr) => {
-        tokio::task::spawn(mysten_metrics::monitored_future!(
-            tasks, $fut, "", INFO, true
-        ))
+        tokio::task::spawn($crate::monitored_future!(tasks, $fut, "", INFO, true))
     };
 
     ($fut: expr, $name: expr) => {
-        tokio::task::spawn(mysten_metrics::monitored_future!(
-            tasks, $fut, $name, INFO, true
-        ))
+        tokio::task::spawn($crate::monitored_future!(tasks, $fut, $name, INFO, true))
     };
 
     ($fut: expr, $name: expr, $logging_level: ident) => {
-        tokio::task::spawn(mysten_metrics::monitored_future!(
+        tokio::task::spawn($crate::monitored_future!(
             tasks,
             $fut,
             $name,

--- a/crates/mysten-metrics/src/thread_stall_monitor.rs
+++ b/crates/mysten-metrics/src/thread_stall_monitor.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Once;
+
+use tracing::{error, info};
+
+use crate::{get_metrics, spawn_logged_monitored_task};
+
+static THREAD_STALL_MONITOR: Once = Once::new();
+
+const MONITOR_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Monitors temporary stalls in tokio scheduling every MONITOR_INTERVAL.
+/// Logs an error and increments a metric if more than 2 * MONITOR_INTERVAL has elapsed,
+/// which means the stall lasted longer than MONITOR_INTERVAL.
+pub fn start_thread_stall_monitor() {
+    let mut called = true;
+    THREAD_STALL_MONITOR.call_once(|| {
+        called = false;
+    });
+    if called {
+        return;
+    }
+    if tokio::runtime::Handle::try_current().is_err() {
+        info!("Not running in a tokio runtime, not starting thread stall monitor.");
+        return;
+    }
+
+    spawn_logged_monitored_task!(
+        async move {
+            let Some(metrics) = get_metrics() else {
+                info!("Metrics uninitialized, not starting thread stall monitor.");
+                return;
+            };
+            let mut last_sleep_time = tokio::time::Instant::now();
+            loop {
+                tokio::time::sleep(MONITOR_INTERVAL).await;
+                let current_time = tokio::time::Instant::now();
+                let stalled_duration = current_time - last_sleep_time - MONITOR_INTERVAL;
+                last_sleep_time = current_time;
+                if stalled_duration > MONITOR_INTERVAL {
+                    metrics
+                        .thread_stall_duration_sec
+                        .observe(stalled_duration.as_secs_f64());
+                    // TODO: disable this in simulation tests with artificial thread stalls?
+                    error!(
+                        "Thread stalled for {}s. Possible causes include CPU overload or too much blocking calls.",
+                        stalled_duration.as_secs_f64()
+                    );
+                }
+            }
+        },
+        "ThreadStallMonitor"
+    );
+}

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -5,7 +5,7 @@ use crate::authority_aggregator::AuthorityAggregator;
 use crate::authority_client::AuthorityAPI;
 use crate::execution_cache::TransactionCacheRead;
 use arc_swap::ArcSwap;
-use mysten_metrics::TX_LATENCY_SEC_BUCKETS;
+use mysten_metrics::LATENCY_SEC_BUCKETS;
 use prometheus::{
     register_histogram_with_registry, register_int_counter_with_registry, Histogram, IntCounter,
     Registry,
@@ -61,7 +61,7 @@ impl ValidatorTxFinalizerMetrics {
             finalization_latency: register_histogram_with_registry!(
                 "validator_tx_finalizer_finalization_latency",
                 "Latency of transaction finalization",
-                TX_LATENCY_SEC_BUCKETS.to_vec(),
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -439,7 +439,12 @@ impl SuiNode {
 
         // Initialize metrics to track db usage before creating any stores
         DBMetrics::init(&prometheus_registry);
+
+        // Initialize Mysten metrics.
         mysten_metrics::init_metrics(&prometheus_registry);
+        // Unsupported (because of the use of static variable) and unnecessary in simtests.
+        #[cfg(not(msim))]
+        mysten_metrics::thread_stall_monitor::start_thread_stall_monitor();
 
         let genesis = config.genesis()?.clone();
 


### PR DESCRIPTION
## Description 

Assuming when tokio scheduling stalls temporarily, tasks are not woken up after sleeps. A dedicated task can be used to monitor this issue.

This mechanism will stop reporting when the system is completely frozen, which has been observed once before. This issue will require a separate std::thread to monitor, which can be added if needed in future.

## Test plan 

TODO

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
