### PR TITLE
[move-compiler] Added parsing resilience for name access chains

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -705,7 +705,11 @@ fn cursor_completion_items(
                             (vec![], false)
                         }
                         P::NameAccessChain_::Path(path) => {
-                            let P::NamePath { root, entries } = path;
+                            let P::NamePath {
+                                root,
+                                entries,
+                                is_incomplete: _,
+                            } = path;
                             if root.name.loc.contains(&cursor.loc) {
                                 // This is technically unreachable because we wouldn't be at a `::`
                                 (vec![], false)

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2984,7 +2984,11 @@ impl<'a> ParsingSymbolicator<'a> {
                 };
             }
             NA::Path(path) => {
-                let P::NamePath { root, entries } = path;
+                let P::NamePath {
+                    root,
+                    entries,
+                    is_incomplete: _,
+                } = path;
                 self.root_path_entry_symbols(root);
                 if let Some(root_loc) = loc_start_to_lsp_position_opt(self.files, &root.name.loc) {
                     if let P::LeadingNameAccess_::Name(n) = root.name.value {

--- a/external-crates/move/crates/move-analyzer/tests/cursor_tests/cursor_dot_call_tests.exp
+++ b/external-crates/move/crates/move-analyzer/tests/cursor_tests/cursor_dot_call_tests.exp
@@ -124,7 +124,7 @@ cursor info:
 - module: Move2024::M2
 - definition: function baz
 - position: seq item
-- value: Bind([Var(None, Var("some_struct"))], Some(Apply(Single(PathEntry { name: "SomeStructAlias", tyargs: None, is_macro: None }))), Call(Path(NamePath { root: RootPathEntry { name: M1, tyargs: None, is_macro: None }, entries: [PathEntry { name: "snew", tyargs: None, is_macro: None }] }), []))
+- value: Bind([Var(None, Var("some_struct"))], Some(Apply(Single(PathEntry { name: "SomeStructAlias", tyargs: None, is_macro: None }))), Call(Path(NamePath { root: RootPathEntry { name: M1, tyargs: None, is_macro: None }, entries: [PathEntry { name: "snew", tyargs: None, is_macro: None }], is_incomplete: false }), []))
 
 -- test 17 @ 31:18 ------------
 expected: binding in the lhs of a let-binding
@@ -140,7 +140,7 @@ cursor info:
 - module: Move2024::M2
 - definition: function baz
 - position: exp
-- value: Call(Path(NamePath { root: RootPathEntry { name: M1, tyargs: None, is_macro: None }, entries: [PathEntry { name: "snew", tyargs: None, is_macro: None }] }), [])
+- value: Call(Path(NamePath { root: RootPathEntry { name: M1, tyargs: None, is_macro: None }, entries: [PathEntry { name: "snew", tyargs: None, is_macro: None }], is_incomplete: false }), [])
 
 -- test 19 @ 34:28 ------------
 expected: name in a dot call

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -188,7 +188,6 @@ codes!(
         InvalidName: { msg: "invalid name", severity: BlockingError },
         InvalidMacro: { msg: "invalid macro invocation", severity: BlockingError },
         InvalidMatch: { msg: "invalid 'match'", severity: BlockingError },
-        IncompleteAccessChain: { msg: "incomplete access chain", severity: BlockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -188,6 +188,7 @@ codes!(
         InvalidName: { msg: "invalid name", severity: BlockingError },
         InvalidMacro: { msg: "invalid macro invocation", severity: BlockingError },
         InvalidMatch: { msg: "invalid 'match'", severity: BlockingError },
+        IncompleteAccessChain: { msg: "incomplete access chain", severity: BlockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -864,7 +864,7 @@ fn access_chain_resolution_error(result: AccessChainNameResult) -> Diagnostic {
 
 fn access_chain_incomplete_error(loc: Loc) -> Diagnostic {
     let msg = "Incomplete name in this position. Expected an identifier after '::'";
-    diag!(NameResolution::NamePositionMismatch, (loc, msg))
+    diag!(Syntax::InvalidName, (loc, msg))
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -369,7 +369,7 @@ impl Move2024PathExpander {
                 let NamePath {
                     root,
                     entries,
-                    incomplete,
+                    is_incomplete: incomplete,
                 } = path;
                 let mut result = match self.resolve_root(context, root.name) {
                     // In Move Legacy, we always treated three-place names as fully-qualified.
@@ -478,7 +478,7 @@ impl Move2024PathExpander {
                 if incomplete {
                     result = NR::ResolutionFailure(
                         Box::new(result),
-                        NF::InvalidKind("incomplete access chain".to_string()),
+                        NF::InvalidKind("fully defined access chain".to_string()),
                     );
                 }
                 AccessChainResult {

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -366,7 +366,11 @@ impl Move2024PathExpander {
                 }
             }
             PN::Path(path) => {
-                let NamePath { root, entries } = path;
+                let NamePath {
+                    root,
+                    entries,
+                    incomplete,
+                } = path;
                 let mut result = match self.resolve_root(context, root.name) {
                     // In Move Legacy, we always treated three-place names as fully-qualified.
                     // For migration mode, if we could have gotten the correct result doing so,
@@ -471,6 +475,12 @@ impl Move2024PathExpander {
                     }
                 }
 
+                if incomplete {
+                    result = NR::ResolutionFailure(
+                        Box::new(result),
+                        NF::InvalidKind("incomplete access chain".to_string()),
+                    );
+                }
                 AccessChainResult {
                     result,
                     ptys_opt,

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -863,7 +863,7 @@ fn access_chain_resolution_error(result: AccessChainNameResult) -> Diagnostic {
 }
 
 fn access_chain_incomplete_error(loc: Loc) -> Diagnostic {
-    let msg = "Expected fully defined access chain in this position";
+    let msg = "Incomplete name in this position. Expected an identifier after '::'";
     diag!(NameResolution::NamePositionMismatch, (loc, msg))
 }
 

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -363,6 +363,8 @@ pub struct RootPathEntry {
 pub struct NamePath {
     pub root: RootPathEntry,
     pub entries: Vec<PathEntry>,
+    // if parsing of this name path was incomplete
+    pub incomplete: bool,
 }
 
 // See the NameAccess trait below for usage.
@@ -763,6 +765,7 @@ impl NameAccessChain_ {
         NamePath {
             root,
             entries: vec![],
+            incomplete: false,
         }
     }
 }
@@ -1849,7 +1852,11 @@ impl AstDebug for PathEntry {
 
 impl AstDebug for NamePath {
     fn ast_debug(&self, w: &mut AstWriter) {
-        let NamePath { root, entries } = self;
+        let NamePath {
+            root,
+            entries,
+            incomplete: _,
+        } = self;
         w.write(format!("{}::", root));
         w.list(entries, "::", |w, e| {
             e.ast_debug(w);

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -364,7 +364,7 @@ pub struct NamePath {
     pub root: RootPathEntry,
     pub entries: Vec<PathEntry>,
     // if parsing of this name path was incomplete
-    pub incomplete: bool,
+    pub is_incomplete: bool,
 }
 
 // See the NameAccess trait below for usage.
@@ -765,7 +765,7 @@ impl NameAccessChain_ {
         NamePath {
             root,
             entries: vec![],
-            incomplete: false,
+            is_incomplete: false,
         }
     }
 }
@@ -1855,13 +1855,16 @@ impl AstDebug for NamePath {
         let NamePath {
             root,
             entries,
-            incomplete: _,
+            is_incomplete,
         } = self;
         w.write(format!("{}::", root));
         w.list(entries, "::", |w, e| {
             e.ast_debug(w);
             false
         });
+        if *is_incomplete {
+            w.write("_");
+        }
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -1863,7 +1863,10 @@ impl AstDebug for NamePath {
             false
         });
         if *is_incomplete {
-            w.write("_");
+            if !entries.is_empty() {
+                w.write("::");
+            }
+            w.write("_#incomplete#_");
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -824,7 +824,13 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
             context.tokens.start_loc(),
             " after an address in a module access chain",
         )?;
-        let name = parse_identifier(context)?;
+        let name = match parse_identifier(context) {
+            Ok(ident) => ident,
+            Err(diag) => {
+                context.env.add_diag(*diag);
+                return Ok(NameAccessChain_::Path(path));
+            }
+        };
         let (mut is_macro, mut tys) =
             parse_macro_opt_and_tyargs_opt(context, tyargs_whitespace_allowed, name.loc);
         if let Some(loc) = &is_macro {

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -828,6 +828,7 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
             Ok(ident) => ident,
             Err(diag) => {
                 context.env.add_diag(*diag);
+                path.is_incomplete = true;
                 return Ok(NameAccessChain_::Path(path));
             }
         };

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -826,8 +826,10 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
         )?;
         let name = match parse_identifier(context) {
             Ok(ident) => ident,
-            Err(diag) => {
-                context.env.add_diag(*diag);
+            Err(_) => {
+                // diagnostic for this is reported in path expansion (as a parsing error) when we
+                // detect incomplete chaing (adding "default" diag here would make error reporting
+                // somewhat redundant in this case)
                 path.is_incomplete = true;
                 return Ok(NameAccessChain_::Path(path));
             }

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -197,6 +197,7 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
                 is_macro: None,
             },
         ],
+        incomplete: false,
     };
     let args_ = vec![sp(
         mloc,

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -197,7 +197,7 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
                 is_macro: None,
             },
         ],
-        incomplete: false,
+        is_incomplete: false,
     };
     let args_ = vec![sp(
         mloc,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
@@ -1,23 +1,14 @@
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
    │
-10 │         a::
-   │         ^ Expected fully defined access chain in this position, not an address
-
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:11:5
-   │
-11 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
+10 │         A
+   │         ^ Expected a type, function, or constant in this position, not an address
 
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
-14 │         a::m::
-   │         ^^^^ Expected fully defined access chain in this position, not a module
+14 │         a::
+   │         ^ Expected fully defined access chain in this position, not an address
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -31,13 +22,28 @@ error[E01002]: unexpected token
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
-18 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
+18 │         a::m::
+   │         ^^^^ Expected fully defined access chain in this position, not a module
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
    │
 19 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
+   │
+22 │         a::m::SomeEnum::
+   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5
+   │
+23 │     }
    │     ^
    │     │
    │     Unexpected '}'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
@@ -2,7 +2,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
    │
 10 │         a::
-   │         ^ Unexpected address identifier. An address identifier is not a valid expression
+   │         ^ Expected fully defined access chain in this position, not an address
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:11:5
@@ -17,7 +17,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::m::
-   │         ^^^^ Unexpected module identifier. A module identifier is not a valid expression
+   │         ^^^^ Expected fully defined access chain in this position, not a module
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -28,13 +28,11 @@ error[E01002]: unexpected token
    │     Unexpected '}'
    │     Expected an identifier
 
-error[E03022]: invalid usage position
+error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^^^ Expected a local or constant, but found enum 'SomeEnum' in current scope
-   │
-   = Enum variants with no arguments must be written as 'SomeEnum::SomeVariant'
+   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
@@ -1,0 +1,47 @@
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
+   │
+10 │         a::
+   │         ^ Unexpected address identifier. An address identifier is not a valid expression
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:11:5
+   │
+11 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
+   │
+14 │         a::m::
+   │         ^^^^ Unexpected module identifier. A module identifier is not a valid expression
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
+   │
+15 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+
+error[E03022]: invalid usage position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
+   │
+18 │         a::m::SomeEnum::
+   │         ^^^^^^^^^^^^^^^^ Expected a local or constant, but found enum 'SomeEnum' in current scope
+   │
+   = Enum variants with no arguments must be written as 'SomeEnum::SomeVariant'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
+   │
+19 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
@@ -8,7 +8,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
-   │         ^^^ Expected fully defined access chain in this position
+   │         ^^^ Incomplete name in this position. Expected an identifier after '::'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -23,7 +23,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
-   │         ^^^^^^ Expected fully defined access chain in this position
+   │         ^^^^^^ Incomplete name in this position. Expected an identifier after '::'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
@@ -38,7 +38,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^^^ Expected fully defined access chain in this position
+   │         ^^^^^^^^^^^^^^^^ Incomplete name in this position. Expected an identifier after '::'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
@@ -8,7 +8,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
-   │         ^ Expected fully defined access chain in this position, not an address
+   │         ^^^ Expected fully defined access chain in this position
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -23,7 +23,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
-   │         ^^^^ Expected fully defined access chain in this position, not a module
+   │         ^^^^^^ Expected fully defined access chain in this position
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
@@ -38,7 +38,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
+   │         ^^^^^^^^^^^^^^^^ Expected fully defined access chain in this position
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.exp
@@ -4,48 +4,21 @@ error[E03006]: unexpected name in this position
 10 │         A
    │         ^ Expected a type, function, or constant in this position, not an address
 
-error[E03006]: unexpected name in this position
+error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
    │         ^^^ Incomplete name in this position. Expected an identifier after '::'
 
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
-   │
-15 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
-
-error[E03006]: unexpected name in this position
+error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
    │         ^^^^^^ Incomplete name in this position. Expected an identifier after '::'
 
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
-   │
-19 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
-
-error[E03006]: unexpected name in this position
+error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
    │         ^^^^^^^^^^^^^^^^ Incomplete name in this position. Expected an identifier after '::'
-
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5
-   │
-23 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -73,3 +73,11 @@ error[E01002]: unexpected token
    │     Unexpected '}'
    │     Expected an identifier
 
+note[I15006]: IDE path autocomplete
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:1
+   │  
+23 │ ╭ module a::m2 {
+24 │ │     public fun foo() {}
+25 │ │ }
+   │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'Self -> a::m2', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -20,7 +20,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
    │
 10 │         a::
-   │         ^ Unexpected address identifier. An address identifier is not a valid expression
+   │         ^ Expected fully defined access chain in this position, not an address
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:11:5
@@ -41,7 +41,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::m::
-   │         ^^^^ Unexpected module identifier. A module identifier is not a valid expression
+   │         ^^^^ Expected fully defined access chain in this position, not a module
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -58,13 +58,11 @@ note[I15006]: IDE path autocomplete
 18 │         a::m::SomeEnum::
    │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
-error[E03022]: invalid usage position
+error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^^^ Expected a local or constant, but found enum 'SomeEnum' in current scope
-   │
-   = Enum variants with no arguments must be written as 'SomeEnum::SomeVariant'
+   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -1,0 +1,77 @@
+note[I15006]: IDE path autocomplete
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:1:1
+   │  
+ 1 │ ╭ module a::m {
+ 2 │ │ 
+ 3 │ │     public enum SomeEnum {
+ 4 │ │         SomeVariant,
+   · │
+20 │ │ 
+21 │ │ }
+   │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+
+note[I15006]: IDE path autocomplete
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
+   │
+10 │         a::
+   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
+   │
+10 │         a::
+   │         ^ Unexpected address identifier. An address identifier is not a valid expression
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:11:5
+   │
+11 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+
+note[I15006]: IDE path autocomplete
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
+   │
+14 │         a::m::
+   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
+   │
+14 │         a::m::
+   │         ^^^^ Unexpected module identifier. A module identifier is not a valid expression
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
+   │
+15 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+
+note[I15006]: IDE path autocomplete
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
+   │
+18 │         a::m::SomeEnum::
+   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+
+error[E03022]: invalid usage position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
+   │
+18 │         a::m::SomeEnum::
+   │         ^^^^^^^^^^^^^^^^ Expected a local or constant, but found enum 'SomeEnum' in current scope
+   │
+   = Enum variants with no arguments must be written as 'SomeEnum::SomeVariant'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
+   │
+19 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -6,42 +6,33 @@ note[I15006]: IDE path autocomplete
  3 │ │     public enum SomeEnum {
  4 │ │         SomeVariant,
    · │
-20 │ │ 
-21 │ │ }
+24 │ │ 
+25 │ │ }
    │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
    │
-10 │         a::
-   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+10 │         A
+   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
 
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
    │
-10 │         a::
-   │         ^ Expected fully defined access chain in this position, not an address
-
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:11:5
-   │
-11 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
+10 │         A
+   │         ^ Expected a type, function, or constant in this position, not an address
 
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
-14 │         a::m::
+14 │         a::
    │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
-14 │         a::m::
-   │         ^^^^ Expected fully defined access chain in this position, not a module
+14 │         a::
+   │         ^ Expected fully defined access chain in this position, not an address
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -55,14 +46,14 @@ error[E01002]: unexpected token
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
-18 │         a::m::SomeEnum::
+18 │         a::m::
    │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
-18 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
+18 │         a::m::
+   │         ^^^^ Expected fully defined access chain in this position, not a module
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
@@ -74,10 +65,31 @@ error[E01002]: unexpected token
    │     Expected an identifier
 
 note[I15006]: IDE path autocomplete
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:1
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
+   │
+22 │         a::m::SomeEnum::
+   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
+   │
+22 │         a::m::SomeEnum::
+   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5
+   │
+23 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
+
+note[I15006]: IDE path autocomplete
+   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:27:1
    │  
-23 │ ╭ module a::m2 {
-24 │ │     public fun foo() {}
-25 │ │ }
+27 │ ╭ module a::m2 {
+28 │ │     public fun foo() {}
+29 │ │ }
    │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'Self -> a::m2', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -8,13 +8,23 @@ note[I15006]: IDE path autocomplete
    · │
 24 │ │ 
 25 │ │ }
-   │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   │ ╰─^ Possible in-scope names
+   │  
+   = members: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
+   = modules: 'Self -> a::m', 'option -> std::option', or 'vector -> std::vector'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
    │
 10 │         A
-   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
+   │         ^ Possible in-scope names
+   │
+   = members: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
+   = modules: 'Self -> a::m', 'option -> std::option', or 'vector -> std::vector'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:10:9
@@ -26,7 +36,12 @@ note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
-   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   │         ^ Possible in-scope names
+   │
+   = members: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
+   = modules: 'Self -> a::m', 'option -> std::option', or 'vector -> std::vector'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
@@ -38,7 +53,12 @@ note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
-   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   │         ^ Possible in-scope names
+   │
+   = members: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
+   = modules: 'Self -> a::m', 'option -> std::option', or 'vector -> std::vector'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
@@ -50,7 +70,12 @@ note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
-   │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   │         ^ Possible in-scope names
+   │
+   = members: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'foo -> a::m::foo', 'member_complete -> a::m::member_complete', 'mod_complete -> a::m::mod_complete', 'pkg_complete -> a::m::pkg_complete', or 'variant_incomplete -> a::m::variant_incomplete'
+   = modules: 'Self -> a::m', 'option -> std::option', or 'vector -> std::vector'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
@@ -64,5 +89,10 @@ note[I15006]: IDE path autocomplete
 27 │ ╭ module a::m2 {
 28 │ │     public fun foo() {}
 29 │ │ }
-   │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'Self -> a::m2', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   │ ╰─^ Possible in-scope names
+   │  
+   = members: 'Option -> std::option::Option' or 'foo -> a::m2::foo'
+   = modules: 'Self -> a::m2', 'option -> std::option', or 'vector -> std::vector'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -32,7 +32,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
-   │         ^ Expected fully defined access chain in this position, not an address
+   │         ^^^ Expected fully defined access chain in this position
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -53,7 +53,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
-   │         ^^^^ Expected fully defined access chain in this position, not a module
+   │         ^^^^^^ Expected fully defined access chain in this position
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
@@ -74,7 +74,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^ Expected fully defined access chain in this position, not a module member
+   │         ^^^^^^^^^^^^^^^^ Expected fully defined access chain in this position
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -32,7 +32,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
-   │         ^^^ Expected fully defined access chain in this position
+   │         ^^^ Incomplete name in this position. Expected an identifier after '::'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
@@ -53,7 +53,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
-   │         ^^^^^^ Expected fully defined access chain in this position
+   │         ^^^^^^ Incomplete name in this position. Expected an identifier after '::'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
@@ -74,7 +74,7 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
-   │         ^^^^^^^^^^^^^^^^ Expected fully defined access chain in this position
+   │         ^^^^^^^^^^^^^^^^ Incomplete name in this position. Expected an identifier after '::'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.ide.exp
@@ -28,62 +28,35 @@ note[I15006]: IDE path autocomplete
 14 │         a::
    │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
-error[E03006]: unexpected name in this position
+error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:14:9
    │
 14 │         a::
    │         ^^^ Incomplete name in this position. Expected an identifier after '::'
 
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:15:5
-   │
-15 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
-
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
    │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
-error[E03006]: unexpected name in this position
+error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:18:9
    │
 18 │         a::m::
    │         ^^^^^^ Incomplete name in this position. Expected an identifier after '::'
 
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:19:5
-   │
-19 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
-
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
    │         ^ Possible in-scope names: 'Option -> std::option::Option', 'SomeEnum -> a::m::SomeEnum', 'Self -> a::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
 
-error[E03006]: unexpected name in this position
+error[E01016]: invalid name
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:22:9
    │
 22 │         a::m::SomeEnum::
    │         ^^^^^^^^^^^^^^^^ Incomplete name in this position. Expected an identifier after '::'
-
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:23:5
-   │
-23 │     }
-   │     ^
-   │     │
-   │     Unexpected '}'
-   │     Expected an identifier
 
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_2024/ide_mode/colon_colon_incomplete.move:27:1

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.move
@@ -19,3 +19,7 @@ module a::m {
     }
 
 }
+
+module a::m2 {
+    public fun foo() {}
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.move
@@ -6,6 +6,10 @@ module a::m {
 
     public fun foo() {}
 
+    public fun pkg_complete() {
+        A
+    }
+
     public fun mod_complete() {
         a::
     }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/colon_colon_incomplete.move
@@ -1,0 +1,21 @@
+module a::m {
+
+    public enum SomeEnum {
+        SomeVariant,
+    }
+
+    public fun foo() {}
+
+    public fun mod_complete() {
+        a::
+    }
+
+    public fun member_complete() {
+        a::m::
+    }
+
+    public fun variant_incomplete() {
+        a::m::SomeEnum::
+    }
+
+}


### PR DESCRIPTION
## Description 

This adds parsing resilience for name access chains needed for IDE-level auto-completion

## Test plan 

All old and new tests must pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Additional compiler errors for incomplete name access chains (e.g., `some_pkg::some_module::`) may appear in the compiler output
- [ ] Rust SDK: 
