### PR TITLE
[pick #18710][Disassembler] Fix string contraction logic

### DIFF
--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -452,7 +452,9 @@ impl<'a> Disassembler<'a> {
         if s.len() <= PREVIEW_LEN + 2 {
             s.to_string()
         } else {
-            format!("{}..", &s[..PREVIEW_LEN])
+            let mut preview: String = s.chars().take(PREVIEW_LEN).collect();
+            preview.push_str("..");
+            preview
         }
     }
 


### PR DESCRIPTION
## Description

Always pick whole UTF8 characters.

## Test plan

Tested against a package containing a UTF8 constant.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Bugfix for fetching package information over JSONRPC from fullnodes, where a package containing UTF8 string constants could fail to disassemble.
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
