### PR TITLE
Remove deleted protocol fields from older snapshots to avoid spurious failures

### DIFF
--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_21.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_21.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
+assertion_line: 1578
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 21

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_44.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_44.snap
@@ -260,4 +260,3 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_50.snap
@@ -269,4 +269,3 @@ random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
 max_deferral_rounds_for_congestion_control: 10
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_44.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_44.snap
@@ -262,4 +262,3 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_50.snap
@@ -278,4 +278,3 @@ consensus_max_transactions_in_block_bytes: 6291456
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
-


### PR DESCRIPTION
- Remove bad changes from cargo insta
- Remove deleted protocol fields from older snapshots to avoid spurious failures
