### PR TITLE
[Metric Checker] Take specific percentiles for range queries

### DIFF
--- a/crates/sui-metric-checker/src/lib.rs
+++ b/crates/sui-metric-checker/src/lib.rs
@@ -24,6 +24,9 @@ pub enum QueryType {
         end: String,
         // Query resolution step width as float number of seconds
         step: f64,
+        // The result of the query is the percentile of the data points.
+        // Valid values are [1, 100].
+        percentile: u8,
     },
 }
 
@@ -186,6 +189,7 @@ mod tests {
                   start: "now-1h"
                   end: "now"
                   step: 60.0
+                  percentile: 50
                 validate_result:
                   threshold: 3.0
                   failure_condition: Greater
@@ -199,6 +203,7 @@ mod tests {
                 start: "now-1h".to_string(),
                 end: "now".to_string(),
                 step: 60.0,
+                percentile: 50,
             },
             validate_result: Some(QueryResultValidation {
                 threshold: 3.0,

--- a/crates/sui-metric-checker/src/main.rs
+++ b/crates/sui-metric-checker/src/main.rs
@@ -78,7 +78,12 @@ async fn main() -> Result<(), anyhow::Error> {
                 })
                 .await
             }
-            QueryType::Range { start, end, step } => {
+            QueryType::Range {
+                start,
+                end,
+                step,
+                percentile,
+            } => {
                 retry(backoff.clone(), || async {
                     range_query(
                         &auth_header,
@@ -87,6 +92,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(&start)?,
                         timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(&end)?,
                         step,
+                        percentile,
                     )
                     .await
                     .map_err(backoff::Error::transient)


### PR DESCRIPTION
## Description 

This allows the following:
1. Check p95 or even p99 in the time range for p50 latency and TPS.
2. Check p50 in the time range for p95 latency.

Config will be modified separately.

## Test plan 

Nightly run

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
