### PR TITLE
[move][ide] Revise IDE path information to always include all possible names.

### DIFF
--- a/external-crates/move/crates/move-compiler/src/expansion/aliases.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/aliases.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_ir_types::location::Loc;
-use move_symbol_pool::Symbol;
 
 use crate::{
     diagnostics::Diagnostic,
@@ -31,8 +30,7 @@ pub struct AliasMap {
     // macro lambdas, but those have to have a leading `$` and cannot conflict with module members
     module_members: UniqueMap<Name, MemberEntry>,
     // These are for caching resolution for IDE information.
-    all_leading_names: Option<BTreeMap<Symbol, LeadingAccessEntry>>,
-    all_module_members: Option<BTreeMap<Symbol, MemberEntry>>,
+    ide_alias_info: Option<ide::AliasAutocompleteInfo>,
     previous: Option<Box<AliasMap>>,
 }
 
@@ -109,8 +107,7 @@ impl AliasMap {
             unused: BTreeSet::new(),
             leading_access: UniqueMap::new(),
             module_members: UniqueMap::new(),
-            all_leading_names: None,
-            all_module_members: None,
+            ide_alias_info: None,
             previous: None,
         }
     }
@@ -212,8 +209,7 @@ impl AliasMap {
             unused,
             leading_access,
             module_members,
-            all_leading_names: None,
-            all_module_members: None,
+            ide_alias_info: None,
             previous: None,
         };
 
@@ -262,38 +258,25 @@ impl AliasMap {
         result
     }
 
-    /// Gets a map of all in-scope leading names, subject to shadowing, either from a cached value
-    /// or generated fresh.
-    pub fn get_all_leading_names(&mut self) -> &BTreeMap<Symbol, LeadingAccessEntry> {
-        if self.all_leading_names.is_none() {
+    /// Gets a map of all in-scope names for IDE information, subject to shadowing, either from a
+    /// cached value or generated fresh.
+    pub fn get_ide_alias_information(&mut self) -> ide::AliasAutocompleteInfo {
+        if self.ide_alias_info.is_none() {
             let mut cur: Option<&Self> = Some(self);
             let mut leading_names = BTreeMap::new();
+            let mut member_names = BTreeMap::new();
             while let Some(map) = cur {
                 for (name, entry) in map.leading_access.key_cloned_iter() {
                     leading_names.entry(name.value).or_insert(*entry);
                 }
-                cur = map.previous.as_deref();
-            }
-            self.all_leading_names = Some(leading_names);
-        }
-        self.all_leading_names.as_ref().unwrap()
-    }
-
-    /// Gets a map of all in-scope member names, subject to shadowing, either from a cached value
-    /// or generated fresh.
-    pub fn get_all_member_names(&mut self) -> &BTreeMap<Symbol, MemberEntry> {
-        if self.all_module_members.is_none() {
-            let mut cur: Option<&Self> = Some(self);
-            let mut members = BTreeMap::new();
-            while let Some(map) = cur {
                 for (name, entry) in map.module_members.key_cloned_iter() {
-                    members.entry(name.value).or_insert(*entry);
+                    member_names.entry(name.value).or_insert(*entry);
                 }
                 cur = map.previous.as_deref();
             }
-            self.all_module_members = Some(members);
+            self.ide_alias_info = Some((leading_names, member_names).into())
         }
-        self.all_module_members.as_ref().unwrap()
+        self.ide_alias_info.clone().unwrap()
     }
 }
 
@@ -307,8 +290,7 @@ impl fmt::Debug for AliasMap {
             unused,
             leading_access,
             module_members,
-            all_leading_names: _,
-            all_module_members: _,
+            ide_alias_info: _,
             previous,
         } = self;
         writeln!(f, "AliasMap(\n  unused: [")?;

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -86,6 +86,8 @@ pub trait PathExpander {
         context: &mut DefnContext,
         name_chain: P::NameAccessChain,
     ) -> Option<E::ModuleIdent>;
+
+    fn ide_autocomplete_suggestion(&mut self, context: &mut DefnContext, loc: Loc);
 }
 
 pub fn make_access_result(
@@ -216,7 +218,7 @@ impl Move2024PathExpander {
     ) -> AccessChainNameResult {
         use AccessChainFailure as NF;
         use AccessChainNameResult as NR;
-        self.ide_autocomplete_suggestion(context, &namespace, name.loc);
+        self.ide_autocomplete_suggestion(context, name.loc);
         match self.aliases.resolve(namespace, &name) {
             Some(AliasEntry::Member(_, mident, sp!(_, mem))) => {
                 // We are preserving the name's original location, rather than referring to where
@@ -477,22 +479,6 @@ impl Move2024PathExpander {
             }
         }
     }
-
-    fn ide_autocomplete_suggestion(
-        &mut self,
-        context: &mut DefnContext,
-        namespace: &NameSpace,
-        loc: Loc,
-    ) {
-        if context.env.ide_mode() {
-            let info: AliasAutocompleteInfo = match namespace {
-                NameSpace::LeadingAccess => self.aliases.get_all_leading_names().into(),
-                NameSpace::ModuleMembers => self.aliases.get_all_member_names().into(),
-            };
-            let annotation = IDEAnnotation::PathAutocompleteInfo(Box::new(info));
-            context.env.add_ide_annotation(loc, annotation)
-        }
-    }
 }
 
 impl PathExpander for Move2024PathExpander {
@@ -751,6 +737,15 @@ impl PathExpander for Move2024PathExpander {
             }
         }
     }
+
+    fn ide_autocomplete_suggestion(&mut self, context: &mut DefnContext, loc: Loc) {
+        if context.env.ide_mode() {
+            let info = self.aliases.get_ide_alias_information();
+            context
+                .env
+                .add_ide_annotation(loc, IDEAnnotation::PathAutocompleteInfo(Box::new(info)));
+        }
+    }
 }
 
 impl AccessChainNameResult {
@@ -848,48 +843,11 @@ pub struct LegacyPathExpander {
     old_alias_maps: Vec<legacy_aliases::OldAliasMap>,
 }
 
-enum LegacyPositionKind {
-    Address,
-    Module,
-    Member,
-}
-
 impl LegacyPathExpander {
     pub fn new() -> LegacyPathExpander {
         LegacyPathExpander {
             aliases: legacy_aliases::AliasMap::new(),
             old_alias_maps: vec![],
-        }
-    }
-
-    fn ide_autocomplete_suggestion(
-        &mut self,
-        context: &mut DefnContext,
-        position_kind: LegacyPositionKind,
-        loc: Loc,
-    ) {
-        if context.env.ide_mode() && context.is_source_definition {
-            let mut info = AliasAutocompleteInfo::new();
-
-            match position_kind {
-                LegacyPositionKind::Address => {
-                    for (name, addr) in context.named_address_mapping.unwrap().iter() {
-                        info.addresses.insert((*name, *addr));
-                    }
-                }
-                LegacyPositionKind::Module => {
-                    for (_, name, (_, mident)) in self.aliases.modules.iter() {
-                        info.modules.insert((*name, *mident));
-                    }
-                }
-                LegacyPositionKind::Member => {
-                    for (_, name, (_, (mident, member))) in self.aliases.members.iter() {
-                        info.members.insert((*name, *mident, *member));
-                    }
-                }
-            }
-            let annotation = IDEAnnotation::PathAutocompleteInfo(Box::new(info));
-            context.env.add_ide_annotation(loc, annotation)
         }
     }
 }
@@ -936,7 +894,7 @@ impl PathExpander for LegacyPathExpander {
                 PV::ModuleAccess(sp!(ident_loc, single_entry!(name, tyargs, is_macro)))
                     if self.aliases.module_alias_get(&name).is_some() =>
                 {
-                    self.ide_autocomplete_suggestion(context, LegacyPositionKind::Module, loc);
+                    self.ide_autocomplete_suggestion(context, loc);
                     ice_assert!(context.env, tyargs.is_none(), loc, "Found tyargs");
                     ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
                     let sp!(_, mident_) = self.aliases.module_alias_get(&name).unwrap();
@@ -1028,7 +986,7 @@ impl PathExpander for LegacyPathExpander {
                 if access == Access::Type {
                     ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
                 }
-                self.ide_autocomplete_suggestion(context, LegacyPositionKind::Member, loc);
+                self.ide_autocomplete_suggestion(context, loc);
                 let access = match self.aliases.member_alias_get(&name) {
                     Some((mident, mem)) => EN::ModuleAccess(mident, mem),
                     None => EN::Name(name),
@@ -1038,7 +996,7 @@ impl PathExpander for LegacyPathExpander {
             (Access::Term, single_entry!(name, tyargs, is_macro))
                 if is_valid_datatype_or_constant_name(name.value.as_str()) =>
             {
-                self.ide_autocomplete_suggestion(context, LegacyPositionKind::Member, loc);
+                self.ide_autocomplete_suggestion(context, loc);
                 let access = match self.aliases.member_alias_get(&name) {
                     Some((mident, mem)) => EN::ModuleAccess(mident, mem),
                     None => EN::Name(name),
@@ -1081,11 +1039,7 @@ impl PathExpander for LegacyPathExpander {
                     }
                     // Others
                     (sp!(_, LN::Name(n1)), [n2]) => {
-                        self.ide_autocomplete_suggestion(
-                            context,
-                            LegacyPositionKind::Module,
-                            n1.loc,
-                        );
+                        self.ide_autocomplete_suggestion(context, n1.loc);
                         if let Some(mident) = self.aliases.module_alias_get(n1) {
                             let n2_name = n2.name;
                             let (tyargs, is_macro) = if !(path.has_tyargs_last()) {
@@ -1115,11 +1069,7 @@ impl PathExpander for LegacyPathExpander {
                         }
                     }
                     (ln, [n2, n3]) => {
-                        self.ide_autocomplete_suggestion(
-                            context,
-                            LegacyPositionKind::Address,
-                            ln.loc,
-                        );
+                        self.ide_autocomplete_suggestion(context, ln.loc);
                         let ident_loc = make_loc(
                             ln.loc.file_hash(),
                             ln.loc.start() as usize,
@@ -1148,11 +1098,7 @@ impl PathExpander for LegacyPathExpander {
                         return None;
                     }
                     (ln, [_n1, _n2, ..]) => {
-                        self.ide_autocomplete_suggestion(
-                            context,
-                            LegacyPositionKind::Address,
-                            ln.loc,
-                        );
+                        self.ide_autocomplete_suggestion(context, ln.loc);
                         let mut diag = diag!(Syntax::InvalidName, (loc, "Too many name segments"));
                         diag.add_note("Names may only have 0, 1, or 2 segments separated by '::'");
                         context.env.add_diag(diag);
@@ -1230,6 +1176,23 @@ impl PathExpander for LegacyPathExpander {
                     }
                 }
             }
+        }
+    }
+
+    fn ide_autocomplete_suggestion(&mut self, context: &mut DefnContext, loc: Loc) {
+        if context.env.ide_mode() && context.is_source_definition {
+            let mut info = AliasAutocompleteInfo::new();
+            for (name, addr) in context.named_address_mapping.unwrap().iter() {
+                info.addresses.insert((*name, *addr));
+            }
+            for (_, name, (_, mident)) in self.aliases.modules.iter() {
+                info.modules.insert((*name, *mident));
+            }
+            for (_, name, (_, (mident, member))) in self.aliases.members.iter() {
+                info.members.insert((*name, *mident, *member));
+            }
+            let annotation = IDEAnnotation::PathAutocompleteInfo(Box::new(info));
+            context.env.add_ide_annotation(loc, annotation)
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -32,26 +32,32 @@ pub fn make_ascii_titlecase(in_s: &str) -> String {
 }
 
 /// Formats a string into an oxford list as: `format_oxford_list("or", "{}", vs);`. Calls `iter()`
-/// and `len()` on `vs`.
+/// and `len()` on `vs`. If you already have an iter, you can pass `ITER` as a first parameter.
 ///
 /// This will use `or` as the separator for the last two elements, interspersing commas as
 /// appropriate:
+///
 /// ```text
-/// format_oxford_list("or", "{}", [1]);
+/// format_oxford_list!("or", "{}", [1]);
 /// ==> "1"
 ///
-/// format_oxford_list("or", "{}", [1, 2]);
+/// format_oxford_list!("or", "{}", [1, 2]);
 /// ==> "1 or 2"
 ///
-/// format_oxford_list("or", "{}", [1, 2, 3]);
+/// format_oxford_list!("or", "{}", [1, 2, 3]);
+/// ==> "1, 2, or 3"
+///
+/// format_oxford_list!(ITER, "or", "{}", [1, 2, 3].iter());
 /// ==> "1, 2, or 3"
 ///```
-///
 macro_rules! format_oxford_list {
     ($sep:expr, $format_str:expr, $e:expr) => {{
-        let in_entries = $e;
-        let e_len = in_entries.len();
-        let mut entries = in_entries.iter();
+        let entries = $e;
+        format_oxford_list!(ITER, $sep, $format_str, entries.iter())
+    }};
+    (ITER, $sep:expr, $format_str:expr, $e:expr) => {{
+        let mut entries = $e;
+        let e_len = entries.len();
         match e_len {
             0 => String::new(),
             1 => format!($format_str, entries.next().unwrap()),

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/index_autocomplete.ide.exp
@@ -7,31 +7,56 @@ note[I15006]: IDE path autocomplete
 5 │ │     #[syntax(index)]
 6 │ │     native public fun vborrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
 7 │ │ }
-  │ ╰─^ Possible in-scope names: 'Option -> std::option::Option', 'Self -> std::vector', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  │ ╰─^ Possible in-scope names
+  │  
+  = members: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', or 'vborrow_mut -> std::vector::vborrow_mut'
+  = modules: 'Self -> std::vector', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:4:51
   │
 4 │     native public fun vborrow<Element>(v: &vector<Element>, i: u64): &Element;
-  │                                                   ^^^^^^^ Possible in-scope names: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', 'vborrow_mut -> std::vector::vborrow_mut', or 'Element'
+  │                                                   ^^^^^^^ Possible in-scope names
+  │
+  = members: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', or 'vborrow_mut -> std::vector::vborrow_mut'
+  = modules: 'Self -> std::vector', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'Element'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:4:71
   │
 4 │     native public fun vborrow<Element>(v: &vector<Element>, i: u64): &Element;
-  │                                                                       ^^^^^^^ Possible in-scope names: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', 'vborrow_mut -> std::vector::vborrow_mut', or 'Element'
+  │                                                                       ^^^^^^^ Possible in-scope names
+  │
+  = members: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', or 'vborrow_mut -> std::vector::vborrow_mut'
+  = modules: 'Self -> std::vector', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'Element'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:6:59
   │
 6 │     native public fun vborrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-  │                                                           ^^^^^^^ Possible in-scope names: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', 'vborrow_mut -> std::vector::vborrow_mut', or 'Element'
+  │                                                           ^^^^^^^ Possible in-scope names
+  │
+  = members: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', or 'vborrow_mut -> std::vector::vborrow_mut'
+  = modules: 'Self -> std::vector', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'Element'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/index_autocomplete.move:6:83
   │
 6 │     native public fun vborrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
-  │                                                                                   ^^^^^^^ Possible in-scope names: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', 'vborrow_mut -> std::vector::vborrow_mut', or 'Element'
+  │                                                                                   ^^^^^^^ Possible in-scope names
+  │
+  = members: 'Option -> std::option::Option', 'vborrow -> std::vector::vborrow', or 'vborrow_mut -> std::vector::vborrow_mut'
+  = modules: 'Self -> std::vector', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'Element'
 
 warning[W09009]: unused struct field
    ┌─ tests/move_2024/ide_mode/index_autocomplete.move:14:23

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_autocomplete.ide.exp
@@ -8,31 +8,56 @@ note[I15006]: IDE path autocomplete
 5 │ │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
 6 │ │     &mut action.inner.bar
 7 │ │ }
-  │ ╰─^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'Self -> 0x42::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  │ ╰─^ Possible in-scope names
+  │  
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:3:34
   │
 3 │ public struct Action<T> { inner: T }
-  │                                  ^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                  ^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:5:44
   │
 5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                            ^^^^^^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                            ^^^^^^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:5:51
   │
 5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                                   ^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                                   ^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:5:61
   │
 5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                                             ^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                                             ^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 error[E04009]: expected specific type
   ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:10

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_no_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_no_autocomplete.ide.exp
@@ -8,31 +8,56 @@ note[I15006]: IDE path autocomplete
 5 │ │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
 6 │ │     &mut action.inner
 7 │ │ }
-  │ ╰─^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'Self -> 0x42::m', 'option -> std::option', 'vector -> std::vector', 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  │ ╰─^ Possible in-scope names
+  │  
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:3:34
   │
 3 │ public struct Action<T> { inner: T }
-  │                                  ^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                  ^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:5:44
   │
 5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                            ^^^^^^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                            ^^^^^^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:5:51
   │
 5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                                   ^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                                   ^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:5:61
   │
 5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                                             ^ Possible in-scope names: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', 'make_action_ref -> 0x42::m::make_action_ref', or 'T'
+  │                                                             ^ Possible in-scope names
+  │
+  = members: 'Action -> 0x42::m::Action', 'Option -> std::option::Option', or 'make_action_ref -> 0x42::m::make_action_ref'
+  = modules: 'Self -> 0x42::m', 'option -> std::option', or 'vector -> std::vector'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 'T'
 
 note[I15001]: IDE dot autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:6:17

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/named_struct_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/named_struct_autocomplete.ide.exp
@@ -8,31 +8,56 @@ note[I15006]: IDE path autocomplete
    · │
 15 │ │     }
 16 │ │ }
-   │ ╰─^ Possible in-scope names: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   │ ╰─^ Possible in-scope names
+   │  
+   = members: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+   = modules: 'Self -> a::m'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:4:12
   │
 4 │         x: u64
-  │            ^^^ Possible in-scope names: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+  │            ^^^ Possible in-scope names
+  │
+  = members: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+  = modules: 'Self -> a::m'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 
 
 note[I15006]: IDE path autocomplete
   ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:8:12
   │
 8 │         a: A
-  │            ^ Possible in-scope names: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+  │            ^ Possible in-scope names
+  │
+  = members: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+  = modules: 'Self -> a::m'
+  = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+  = type params: 
 
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:12:18
    │
 12 │         let _s = B { a: A { x: 0 } };
-   │                  ^ Possible in-scope names: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+   │                  ^ Possible in-scope names
+   │
+   = members: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+   = modules: 'Self -> a::m'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 note[I15006]: IDE path autocomplete
    ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:12:25
    │
 12 │         let _s = B { a: A { x: 0 } };
-   │                         ^ Possible in-scope names: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+   │                         ^ Possible in-scope names
+   │
+   = members: 'A -> a::m::A', 'B -> a::m::B', 'foo -> a::m::foo', or 'unit_test_poison -> a::m::unit_test_poison'
+   = modules: 'Self -> a::m'
+   = addresses: 'A -> 0x41', 'B -> 0x42', 'K -> 0x19', 'M -> 0x40', 'a -> 0x44', 'b -> 0x45', 'k -> 0x19', 'std -> 0x1', or 'sui -> 0x2'
+   = type params: 
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:13:23


### PR DESCRIPTION
## Description 

This revises IDE path information to include _all_ available information, not just information based on the position of the name.

## Test plan 

A new test, plus updated other tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
