### PR TITLE
[move] Update external workflow to check formatting for _all_ packages

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # pin@v1.0.3
         with:
           command: fmt
-          args: --check
+          args: --check --all
 
   cargo-deny:
     name: cargo-deny (advisories, licenses, bans, ...)

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # pin@v1.0.3
         with:
           command: fmt
-          args: --check --all
+          args: --check
 
   cargo-deny:
     name: cargo-deny (advisories, licenses, bans, ...)

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/tests.rs
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/tests.rs
@@ -2,8 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub const TEST_DIR: &str =
-    "tests";
+pub const TEST_DIR: &str = "tests";
 use move_transactional_test_runner::vm_test_harness::run_test;
 
 datatest_stable::harness!(run_test, TEST_DIR, r".*\.(mvir|move)$");

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/tests.rs
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/tests.rs
@@ -2,7 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub const TEST_DIR: &str = "tests";
+pub const TEST_DIR: &str =
+    "tests";
 use move_transactional_test_runner::vm_test_harness::run_test;
 
 datatest_stable::harness!(run_test, TEST_DIR, r".*\.(mvir|move)$");

--- a/external-crates/move/crates/move-core-types/src/effects.rs
+++ b/external-crates/move/crates/move-core-types/src/effects.rs
@@ -2,11 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_address::AccountAddress,
-    identifier::Identifier,
-    language_storage::ModuleId,
-};
+use crate::{account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId};
 use anyhow::{bail, Result};
 use std::collections::btree_map::{self, BTreeMap};
 

--- a/external-crates/move/crates/move-stackless-bytecode/src/function_target.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/function_target.rs
@@ -9,7 +9,7 @@ use crate::{
 use itertools::Itertools;
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
-    model::{FunId, FunctionEnv, FunctionVisibility, GlobalEnv, Loc, ModuleEnv, DatatypeId},
+    model::{DatatypeId, FunId, FunctionEnv, FunctionVisibility, GlobalEnv, Loc, ModuleEnv},
     symbol::{Symbol, SymbolPool},
     ty::{Type, TypeDisplayContext},
 };

--- a/external-crates/move/crates/move-stackless-bytecode/src/number_operation.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/number_operation.rs
@@ -8,7 +8,7 @@
 
 use move_model::{
     ast::TempIndex,
-    model::{FieldId, FunId, FunctionEnv, ModuleId, NodeId, StructEnv, DatatypeId},
+    model::{DatatypeId, FieldId, FunId, FunctionEnv, ModuleId, NodeId, StructEnv},
     ty::Type,
 };
 use std::collections::BTreeMap;

--- a/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
@@ -61,10 +61,7 @@ impl<S: MoveResolver> TransactionDataCache<S> {
 
             if !modules.is_empty() {
                 change_set
-                    .add_account_changeset(
-                        addr,
-                        AccountChangeSet::from_modules(modules),
-                    )
+                    .add_account_changeset(addr, AccountChangeSet::from_modules(modules))
                     .expect("accounts should be unique");
             }
         }

--- a/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
@@ -78,10 +78,7 @@ impl MoveVM {
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
-            .load_module(
-                module_id,
-                &TransactionDataCache::new(remote),
-            )
+            .load_module(module_id, &TransactionDataCache::new(remote))
             .map(|(compiled, _)| compiled)
     }
 

--- a/external-crates/move/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/session.rs
@@ -179,12 +179,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.
-    pub fn finish_with_extensions(
-        self,
-    ) -> (
-        VMResult<(ChangeSet, NativeContextExtensions<'r>)>,
-        S,
-    ) {
+    pub fn finish_with_extensions(self) -> (VMResult<(ChangeSet, NativeContextExtensions<'r>)>, S) {
         let Session {
             data_cache,
             native_extensions,

--- a/external-crates/move/crates/move-vm-types/src/data_store.rs
+++ b/external-crates/move/crates/move-vm-types/src/data_store.rs
@@ -4,8 +4,7 @@
 
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr,
-    language_storage::ModuleId,
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
 };
 
 /// Provide an implementation for bytecodes related to data with a given data store.

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/check_duplication.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/check_duplication.rs
@@ -12,9 +12,9 @@
 use move_binary_format::{
     errors::{verification_error, Location, PartialVMResult, VMResult},
     file_format::{
-        CompiledModule, Constant, FunctionHandle, FunctionHandleIndex, FunctionInstantiation,
-        ModuleHandle, Signature, StructFieldInformation, DatatypeHandle, DatatypeHandleIndex,
-        TableIndex,
+        CompiledModule, Constant, DatatypeHandle, DatatypeHandleIndex, FunctionHandle,
+        FunctionHandleIndex, FunctionInstantiation, ModuleHandle, Signature,
+        StructFieldInformation, TableIndex,
     },
     IndexKind,
 };

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/data_cache.rs
@@ -60,10 +60,7 @@ impl<S: MoveResolver> TransactionDataCache<S> {
             }
             if !modules.is_empty() {
                 change_set
-                    .add_account_changeset(
-                        addr,
-                        AccountChangeSet::from_modules(modules),
-                    )
+                    .add_account_changeset(addr, AccountChangeSet::from_modules(modules))
                     .expect("accounts should be unique");
             }
         }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/move_vm.rs
@@ -78,10 +78,7 @@ impl MoveVM {
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
-            .load_module(
-                module_id,
-                &TransactionDataCache::new(remote),
-            )
+            .load_module(module_id, &TransactionDataCache::new(remote))
             .map(|(compiled, _)| compiled)
     }
 

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/session.rs
@@ -165,12 +165,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.
-    pub fn finish_with_extensions(
-        self,
-    ) -> (
-        VMResult<(ChangeSet, NativeContextExtensions<'r>)>,
-        S,
-    ) {
+    pub fn finish_with_extensions(self) -> (VMResult<(ChangeSet, NativeContextExtensions<'r>)>, S) {
         let Session {
             data_cache,
             native_extensions,

--- a/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/check_duplication.rs
+++ b/external-crates/move/move-execution/v1/crates/move-bytecode-verifier/src/check_duplication.rs
@@ -12,9 +12,9 @@
 use move_binary_format::{
     errors::{verification_error, Location, PartialVMResult, VMResult},
     file_format::{
-        CompiledModule, Constant, FunctionHandle, FunctionHandleIndex, FunctionInstantiation,
-        ModuleHandle, Signature, StructFieldInformation, DatatypeHandle, DatatypeHandleIndex,
-        TableIndex,
+        CompiledModule, Constant, DatatypeHandle, DatatypeHandleIndex, FunctionHandle,
+        FunctionHandleIndex, FunctionInstantiation, ModuleHandle, Signature,
+        StructFieldInformation, TableIndex,
     },
     IndexKind,
 };

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/data_cache.rs
@@ -60,10 +60,7 @@ impl<S: MoveResolver> TransactionDataCache<S> {
             }
             if !modules.is_empty() {
                 change_set
-                    .add_account_changeset(
-                        addr,
-                        AccountChangeSet::from_modules(modules),
-                    )
+                    .add_account_changeset(addr, AccountChangeSet::from_modules(modules))
                     .expect("accounts should be unique");
             }
         }

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/move_vm.rs
@@ -78,10 +78,7 @@ impl MoveVM {
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
-            .load_module(
-                module_id,
-                &TransactionDataCache::new(remote),
-            )
+            .load_module(module_id, &TransactionDataCache::new(remote))
             .map(|(compiled, _)| compiled)
     }
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -30,7 +30,7 @@ use move_vm_config::runtime::VMConfig;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
-    loaded_data::runtime_types::{CachedTypeIndex, CachedDatatype, Type},
+    loaded_data::runtime_types::{CachedDatatype, CachedTypeIndex, Type},
     values::{Locals, Reference, VMValueCast, Value},
 };
 use std::{borrow::Borrow, collections::BTreeSet, sync::Arc};

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
@@ -22,7 +22,7 @@ use move_core_types::{
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
-    loaded_data::runtime_types::{CachedTypeIndex, CachedDatatype, Type},
+    loaded_data::runtime_types::{CachedDatatype, CachedTypeIndex, Type},
 };
 use std::{borrow::Borrow, sync::Arc};
 
@@ -179,12 +179,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.
-    pub fn finish_with_extensions(
-        self,
-    ) -> (
-        VMResult<(ChangeSet, NativeContextExtensions<'r>)>,
-        S,
-    ) {
+    pub fn finish_with_extensions(self) -> (VMResult<(ChangeSet, NativeContextExtensions<'r>)>, S) {
         let Session {
             data_cache,
             native_extensions,

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/data_cache.rs
@@ -60,10 +60,7 @@ impl<S: MoveResolver> TransactionDataCache<S> {
             }
             if !modules.is_empty() {
                 change_set
-                    .add_account_changeset(
-                        addr,
-                        AccountChangeSet::from_modules(modules),
-                    )
+                    .add_account_changeset(addr, AccountChangeSet::from_modules(modules))
                     .expect("accounts should be unique");
             }
         }

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/move_vm.rs
@@ -78,10 +78,7 @@ impl MoveVM {
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
-            .load_module(
-                module_id,
-                &TransactionDataCache::new(remote),
-            )
+            .load_module(module_id, &TransactionDataCache::new(remote))
             .map(|(compiled, _)| compiled)
     }
 

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/session.rs
@@ -22,7 +22,7 @@ use move_core_types::{
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
-    loaded_data::runtime_types::{CachedTypeIndex, CachedDatatype, Type},
+    loaded_data::runtime_types::{CachedDatatype, CachedTypeIndex, Type},
 };
 use std::{borrow::Borrow, sync::Arc};
 
@@ -179,12 +179,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.
-    pub fn finish_with_extensions(
-        self,
-    ) -> (
-        VMResult<(ChangeSet, NativeContextExtensions<'r>)>,
-        S,
-    ) {
+    pub fn finish_with_extensions(self) -> (VMResult<(ChangeSet, NativeContextExtensions<'r>)>, S) {
         let Session {
             data_cache,
             native_extensions,


### PR DESCRIPTION
## Description 

This updates the external workflow to check all crates. It appears that, without this, `cargo` will not check crates with `publish = false` by default.

## Test plan 

This updates tests to ensure formatting is applied uniformly in the external crates, plus a few commits explicitly tested behavior.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
