### PR TITLE
Only spawn validator tx finalizer for newly signed tx

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -802,7 +802,7 @@ pub struct AuthorityState {
     /// Current overload status in this authority. Updated periodically.
     pub overload_info: AuthorityOverloadInfo,
 
-    validator_tx_finalizer: Option<Arc<ValidatorTxFinalizer<NetworkAuthorityClient>>>,
+    pub validator_tx_finalizer: Option<Arc<ValidatorTxFinalizer<NetworkAuthorityClient>>>,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -321,6 +321,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             config.clone(),
             usize::MAX,
             ArchiveReaderBalancer::default(),
+            None,
         )
         .await;
 

--- a/crates/sui-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/sui-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -64,3 +64,55 @@ async fn test_validator_tx_finalizer_consensus_tx() {
         node.with(|n| assert!(n.state().is_tx_already_executed(&tx_digest).unwrap()));
     }
 }
+
+#[cfg(msim)]
+#[sim_test]
+async fn test_validator_tx_finalizer_equivocation() {
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(4)
+        // Make epoch duration large enough so that reconfig is never triggered.
+        .with_epoch_duration_ms(1000 * 1000)
+        .build()
+        .await;
+    let tx_data1 = cluster
+        .test_transaction_builder()
+        .await
+        .transfer_sui(None, dbg_addr(1))
+        .build();
+    let tx1 = cluster.sign_transaction(&tx_data1);
+    let tx_data2 = cluster
+        .test_transaction_builder()
+        .await
+        .transfer_sui(None, dbg_addr(2))
+        .build();
+    let tx2 = cluster.sign_transaction(&tx_data2);
+    let tx_digest1 = *tx1.digest();
+    let tx_digest2 = *tx2.digest();
+    let auth_agg = cluster.authority_aggregator();
+    for (idx, client) in auth_agg.authority_clients.values().enumerate() {
+        if idx < 2 {
+            client.handle_transaction(tx1.clone(), None).await.unwrap();
+        } else {
+            client.handle_transaction(tx2.clone(), None).await.unwrap();
+        }
+    }
+    // It takes up to 90s for each validator to wake up and finalize the txs once.
+    // We wait for long enough and check that no validator will spawn another thread
+    // twice to try to finalize the same txs.
+    tokio::time::sleep(Duration::from_secs(200)).await;
+    for node in cluster.swarm.validator_node_handles() {
+        node.with(|n| {
+            let state = n.state();
+            assert!(!state.is_tx_already_executed(&tx_digest1).unwrap());
+            assert!(!state.is_tx_already_executed(&tx_digest2).unwrap());
+            assert_eq!(
+                state
+                    .validator_tx_finalizer
+                    .as_ref()
+                    .unwrap()
+                    .num_finalization_attempts_for_testing(),
+                1
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Description 

This PR moves the validator tx finalizer into AuthorityState, since there we have the most accurate information on whether a transaction is newly signed.
Only spawn a thread if it's newly signed.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
