### PR TITLE
Customize statis initialize move dir in simtest

### DIFF
--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -58,7 +58,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
 
                     register_package_hooks(Box::new(SuiPackageHooks {}));
                     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                    path.extend(["..", "..", "examples", "move", "basics"]);
+                    path.push(env!("SIMTEST_STATIC_INIT_MOVE"));
                     let mut build_config = BuildConfig::default();
 
                     build_config.config.install_dir = Some(TempDir::new().unwrap().into_path());

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -57,8 +57,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
                     use sui_simulator::move_package::package_hooks::register_package_hooks;
 
                     register_package_hooks(Box::new(SuiPackageHooks {}));
-                    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                    path.push(env!("SIMTEST_STATIC_INIT_MOVE"));
+                    let mut path = PathBuf::from(env!("SIMTEST_STATIC_INIT_MOVE"));
                     let mut build_config = BuildConfig::default();
 
                     build_config.config.install_dir = Some(TempDir::new().unwrap().into_path());

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -96,6 +96,10 @@ fi
 # Must supply a new temp dir - the test is deterministic and can't choose one randomly itself.
 export TMPDIR=$(mktemp -d)
 
+# Set the example move package for the simtest static initializer
+# https://github.com/MystenLabs/sui/blob/7bc276d534c6c758ac2cfefe96431c2b1318ca01/crates/sui-proc-macros/src/lib.rs#L52
+export SIMTEST_STATIC_INIT_MOVE="../../examples/move/basics"
+
 cargo ${CARGO_COMMAND[@]} \
   --config "build.rustflags = [$RUST_FLAGS]" \
   "${cargo_patch_args[@]}" \

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -98,7 +98,8 @@ export TMPDIR=$(mktemp -d)
 
 # Set the example move package for the simtest static initializer
 # https://github.com/MystenLabs/sui/blob/7bc276d534c6c758ac2cfefe96431c2b1318ca01/crates/sui-proc-macros/src/lib.rs#L52
-export SIMTEST_STATIC_INIT_MOVE="../../examples/move/basics"
+root_dir=$(git rev-parse --show-toplevel)
+export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
 cargo ${CARGO_COMMAND[@]} \
   --config "build.rustflags = [$RUST_FLAGS]" \


### PR DESCRIPTION
## Description 

So that other projects can choose their own move package for this static initialization.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
