### PR TITLE
[bridge] Handle url change in bridge node

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -85,6 +85,7 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
         .expect("Recipient should have received ETH coin now")
         .clone();
     assert_eq!(eth_coin.balance, sui_amount);
+    info!("Eth to sui bridge transfer finished");
 
     // Now let the recipient send the coin back to ETH
     let eth_address_1 = EthAddress::random();

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -108,6 +108,8 @@ async fn start_client_components(
     let sui_token_type_tags = sui_client.get_token_id_map().await.unwrap();
     let (token_type_tags_tx, token_type_tags_rx) = tokio::sync::watch::channel(sui_token_type_tags);
 
+    let (monitor_tx, monitor_rx) = tokio::sync::broadcast::channel(1000);
+
     let bridge_action_executor = BridgeActionExecutor::new(
         sui_client.clone(),
         Arc::new(bridge_auth_agg),
@@ -116,6 +118,7 @@ async fn start_client_components(
         client_config.sui_address,
         client_config.gas_object_ref.0,
         token_type_tags_rx,
+        monitor_rx,
         metrics.clone(),
     )
     .await;
@@ -126,6 +129,7 @@ async fn start_client_components(
         eth_events_rx,
         store.clone(),
         token_type_tags_tx,
+        monitor_tx,
         metrics,
     );
 


### PR DESCRIPTION
## Description 

1. added a broadcast monitor event channel that broadcasts url change event (more in followup PRs)
2. in action executor, handle this event by fetching the latest committee onchain

TODO: add an e2e test for this scenario

## Test plan 

unit test for the onchain committee retrieval function

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
