### PR TITLE
indexer: move partition dropping to pruner

### DIFF
--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -3,27 +3,41 @@
 
 use std::time::Duration;
 
+use diesel::r2d2::R2D2Connection;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
+use crate::errors::IndexerError;
+use crate::store::pg_partition_manager::PgPartitionManager;
 use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
 
-pub struct Pruner<S> {
+use super::checkpoint_handler::CheckpointHandler;
+
+pub struct Pruner<S, T: R2D2Connection + 'static> {
     pub store: S,
+    pub partition_manager: PgPartitionManager<T>,
     pub epochs_to_keep: u64,
     pub metrics: IndexerMetrics,
 }
 
-impl<S> Pruner<S>
+impl<S, T> Pruner<S, T>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
+    T: R2D2Connection + 'static,
 {
-    pub fn new(store: S, epochs_to_keep: u64, metrics: IndexerMetrics) -> Self {
-        Self {
+    pub fn new(
+        store: S,
+        epochs_to_keep: u64,
+        metrics: IndexerMetrics,
+    ) -> Result<Self, IndexerError> {
+        let blocking_cp = CheckpointHandler::<S, T>::pg_blocking_cp(store.clone()).unwrap();
+        let partition_manager = PgPartitionManager::new(blocking_cp.clone())?;
+        Ok(Self {
             store,
+            partition_manager,
             epochs_to_keep,
             metrics,
-        }
+        })
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
@@ -43,12 +57,38 @@ where
                 (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
             }
 
-            for epoch in min_epoch..=max_epoch - self.epochs_to_keep {
+            let table_partitions = self.partition_manager.get_table_partitions()?;
+            let table_names = table_partitions.keys().cloned().collect::<Vec<_>>();
+            for (table_name, (min_partition, max_partition)) in table_partitions {
+                if max_epoch != max_partition {
+                    error!(
+                        "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
+                        table_name, max_epoch, max_partition
+                    );
+                }
+                // drop partitions if pruning is enabled afterwards, where all epochs before min_epoch
+                // would have been pruned already if the pruner was running.
+                for epoch in min_partition..min_epoch {
+                    self.partition_manager
+                        .drop_table_partition(table_name.clone(), epoch)?;
+                    info!(
+                        "Batch dropped table partition {} epoch {}",
+                        table_name, epoch
+                    );
+                }
+            }
+
+            for epoch in min_epoch..max_epoch.saturating_sub(self.epochs_to_keep - 1) {
                 if cancel.is_cancelled() {
                     info!("Pruner task cancelled.");
                     return Ok(());
                 }
                 info!("Pruning epoch {}", epoch);
+                for table_name in table_names.clone() {
+                    self.partition_manager
+                        .drop_table_partition(table_name.clone(), epoch)?;
+                    info!("Dropped table partition {} epoch {}", table_name, epoch);
+                }
                 self.store.prune_epoch(epoch).await.unwrap_or_else(|e| {
                     error!("Failed to prune epoch {}: {}", epoch, e);
                 });

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -117,7 +117,8 @@ impl Indexer {
                 "Starting indexer pruner with epochs to keep: {}",
                 epochs_to_keep
             );
-            let pruner = Pruner::new(store.clone(), epochs_to_keep, metrics.clone());
+            assert!(epochs_to_keep > 0, "Epochs to keep must be positive");
+            let pruner: Pruner<S, T> = Pruner::new(store.clone(), epochs_to_keep, metrics.clone())?;
             spawn_monitored_task!(pruner.start(CancellationToken::new()));
         }
 

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -7,7 +7,7 @@ pub use pg_indexer_store::PgIndexerStore;
 pub mod indexer_store;
 pub mod package_resolver;
 mod pg_indexer_store;
-mod pg_partition_manager;
+pub mod pg_partition_manager;
 
 pub mod diesel_macro {
     thread_local! {

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -993,7 +993,7 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                 if let Some(last_epoch) = &epoch.last_epoch {
                     let last_epoch_id = last_epoch.epoch;
                     let last_epoch = StoredEpochInfo::from_epoch_end_info(last_epoch);
-                    info!(last_epoch_id, "Persisting epoch end data: {:?}", last_epoch);
+                    info!(last_epoch_id, "Persisting epoch end data.");
                     on_conflict_do_update!(
                         epochs::table,
                         vec![last_epoch],
@@ -1073,14 +1073,12 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                 let epoch_partition_data =
                     EpochPartitionData::compose_data(epoch_to_commit, last_epoch);
                 let table_partitions = self.partition_manager.get_table_partitions()?;
-                for (table, (first_partition, last_partition)) in table_partitions {
+                for (table, (_, last_partition)) in table_partitions {
                     let guard = self.metrics.advance_epoch_latency.start_timer();
-                    self.partition_manager.advance_and_prune_epoch_partition(
+                    self.partition_manager.advance_epoch(
                         table.clone(),
-                        first_partition,
                         last_partition,
                         &epoch_partition_data,
-                        self.config.epochs_to_keep,
                     )?;
                     let elapsed = guard.stop_and_record();
                     info!(


### PR DESCRIPTION
## Description 

split epoch advance and partition dropping, and move partition dropping to pruner so that all pruning tasks are in sync and tracked by pruner watermark table.

## Test plan 

local run and verify that
- partition dropping still works
- pruning are indeed in sync and accurately tracked by `pruner_watermark_cp` table

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
