### PR TITLE
[sui bridge] use base64 for encoding serde and jsonrpc schema 

### DIFF
--- a/crates/sui-bridge-cli/src/main.rs
+++ b/crates/sui-bridge-cli/src/main.rs
@@ -328,26 +328,18 @@ async fn main() -> anyhow::Result<()> {
                     continue;
                 };
                 let eth_address = BridgeAuthorityPublicKeyBytes::from(&pubkey).to_eth_address();
-                let Ok(url) = from_utf8(&http_rest_url) else {
-                    println!(
-                        "Invalid bridge http url for validator: {}: {:?}",
-                        sui_address, http_rest_url
-                    );
-                    continue;
-                };
-                let url = url.to_string();
 
                 let name = names.get(&sui_address).unwrap();
                 if ping {
                     let client_clone = client.clone();
-                    ping_tasks.push(client_clone.get(url.clone()).send());
+                    ping_tasks.push(client_clone.get(http_rest_url.clone()).send());
                 }
                 authorities.push((
                     name,
                     sui_address,
                     pubkey,
                     eth_address,
-                    url,
+                    http_rest_url,
                     voting_power,
                     blocklisted,
                 ));

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -7,7 +7,6 @@ use core::panic;
 use fastcrypto::traits::ToFromBytes;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
-use std::str::from_utf8;
 use std::time::Duration;
 use sui_json_rpc_api::BridgeReadApiClient;
 use sui_json_rpc_types::DevInspectResults;
@@ -231,24 +230,17 @@ where
         // TODO: move this to MoveTypeBridgeCommittee
         for (_, member) in move_type_bridge_committee.members {
             let MoveTypeCommitteeMember {
-                sui_address,
+                sui_address: _,
                 bridge_pubkey_bytes,
                 voting_power,
                 http_rest_url,
                 blocklisted,
             } = member;
             let pubkey = BridgeAuthorityPublicKey::from_bytes(&bridge_pubkey_bytes)?;
-            let base_url = from_utf8(&http_rest_url).unwrap_or_else(|_e| {
-                warn!(
-                    "Bridge authority address: {}, pubkey: {:?} has invalid http url: {:?}",
-                    sui_address, bridge_pubkey_bytes, http_rest_url
-                );
-                ""
-            });
             authorities.push(BridgeAuthority {
                 pubkey,
                 voting_power,
-                base_url: base_url.into(),
+                base_url: http_rest_url,
                 is_blocklisted: blocklisted,
             });
         }

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -418,9 +418,7 @@ pub struct MoveTypeCommitteeMember {
     #[serde_as(as = "Base64")]
     pub bridge_pubkey_bytes: Vec<u8>,
     pub voting_power: u64,
-    #[schemars(with = "Base64")]
-    #[serde_as(as = "Base64")]
-    pub http_rest_url: Vec<u8>,
+    pub http_rest_url: String,
     pub blocklisted: bool,
 }
 

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -26,6 +26,7 @@ use crate::{
     error::SuiError,
     id::UID,
 };
+use fastcrypto::encoding::Base64;
 
 pub type BridgeInnerDynamicField = Field<u64, BridgeInnerV1>;
 pub type BridgeRecordDyanmicField = Field<
@@ -413,8 +414,12 @@ pub struct BridgeTreasurySummary {
 #[serde(rename_all = "camelCase")]
 pub struct MoveTypeCommitteeMember {
     pub sui_address: SuiAddress,
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Base64")]
     pub bridge_pubkey_bytes: Vec<u8>,
     pub voting_power: u64,
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Base64")]
     pub http_rest_url: Vec<u8>,
     pub blocklisted: bool,
 }


### PR DESCRIPTION
## Description 

when using jsonrpc to fetch the `bridge_pubkey_bytes` the `Vec<u8>` are verbosely displayed:
```
curl suix_getLatestBridge
         {
            "suiAddress": "0xce2039cd80188004f995cdfe1360b31d4118bd4257febee958b6c6dcd861131d",
            "bridgePubkeyBytes": [
              2,
              76,
              184,
              43,
              243,
              119,
              91,
              211,
              113,
              87,
              ...
            ]
 }
```

In comparison, it is much easier to parse the bytes when they are automatically encode to b64, eg:
https://github.com/MystenLabs/sui/blob/ef4639cc7095820e7ff8471bf77fa2a46a81a719/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs#L225-L227



## Test plan 

I'll test against a testnet rpc node

looks like usages of `bridge_pubkey_bytes` and `http_rest_url` are not around serialization/deserialization, so this shouldn't have an effect outside of jsonrpc. 

https://github.com/MystenLabs/sui/blob/ef4639cc7095820e7ff8471bf77fa2a46a81a719/crates/sui-bridge/src/sui_client.rs#L235-L240

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
