### PR TITLE
Integrate consensus Parameters into NodeConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12381,6 +12381,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap",
+ "consensus-config",
  "csv",
  "dirs 4.0.0",
  "fastcrypto",

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -24,6 +24,7 @@ clap.workspace = true
 object_store.workspace = true
 reqwest.workspace = true
 
+consensus-config.workspace = true
 narwhal-config.workspace = true
 sui-keys.workspace = true
 sui-protocol-config.workspace = true

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -7,7 +7,8 @@ use crate::p2p::P2pConfig;
 use crate::transaction_deny_config::TransactionDenyConfig;
 use crate::Config;
 use anyhow::Result;
-use narwhal_config::Parameters as ConsensusParameters;
+use consensus_config::Parameters as ConsensusParameters;
+use narwhal_config::Parameters as NarwhalParameters;
 use once_cell::sync::OnceCell;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
@@ -428,7 +429,9 @@ pub struct ConsensusConfig {
     /// on consensus latency estimates.
     pub submit_delay_step_override_millis: Option<u64>,
 
-    pub narwhal_config: ConsensusParameters,
+    pub narwhal_config: NarwhalParameters,
+
+    pub parameters: ConsensusParameters,
 }
 
 impl ConsensusConfig {
@@ -449,7 +452,7 @@ impl ConsensusConfig {
             .map(Duration::from_millis)
     }
 
-    pub fn narwhal_config(&self) -> &ConsensusParameters {
+    pub fn narwhal_config(&self) -> &NarwhalParameters {
         &self.narwhal_config
     }
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -407,12 +407,8 @@ pub enum ConsensusProtocol {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConsensusConfig {
-    pub address: Multiaddr,
+    // Base consensus DB path for all epochs.
     pub db_path: PathBuf,
-
-    /// Optional alternative address preferentially used by a primary to talk to its own worker.
-    /// For example, this could be used to connect to co-located workers over a private LAN address.
-    pub internal_worker_address: Option<Multiaddr>,
 
     /// Maximum number of pending transactions to submit to consensus, including those
     /// in submission wait.
@@ -429,6 +425,8 @@ pub struct ConsensusConfig {
     /// on consensus latency estimates.
     pub submit_delay_step_override_millis: Option<u64>,
 
+    // Deprecated: Narwhal specific configs.
+    pub address: Multiaddr,
     pub narwhal_config: NarwhalParameters,
 
     pub parameters: ConsensusParameters,

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -72,7 +72,6 @@ impl MysticetiManager {
         }
     }
 
-    #[allow(unused)]
     fn get_store_path(&self, epoch: EpochId) -> PathBuf {
         let mut store_path = self.storage_base_path.clone();
         store_path.push(format!("{}", epoch));
@@ -100,7 +99,7 @@ impl MysticetiManager {
 impl ConsensusManagerTrait for MysticetiManager {
     async fn start(
         &self,
-        _config: &NodeConfig,
+        config: &NodeConfig,
         epoch_store: Arc<AuthorityPerEpochStore>,
         consensus_handler_initializer: ConsensusHandlerInitializer,
         tx_validator: SuiTxValidator,
@@ -122,10 +121,10 @@ impl ConsensusManagerTrait for MysticetiManager {
             return;
         };
 
-        // TODO(mysticeti): Fill in the other fields
+        let consensus_config = config.consensus_config().expect("consensus_config should exist");
         let parameters = Parameters {
             db_path: Some(self.get_store_path(epoch)),
-            ..Default::default()
+            ..consensus_config.parameters.clone()
         };
 
         let own_protocol_key = self.protocol_keypair.public();

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -121,7 +121,9 @@ impl ConsensusManagerTrait for MysticetiManager {
             return;
         };
 
-        let consensus_config = config.consensus_config().expect("consensus_config should exist");
+        let consensus_config = config
+            .consensus_config()
+            .expect("consensus_config should exist");
         let parameters = Parameters {
             db_path: Some(self.get_store_path(epoch)),
             ..consensus_config.parameters.clone()

--- a/crates/sui-swarm-config/src/genesis_config.rs
+++ b/crates/sui-swarm-config/src/genesis_config.rs
@@ -49,7 +49,6 @@ pub struct ValidatorGenesisConfig {
     pub narwhal_primary_address: Multiaddr,
     pub narwhal_worker_address: Multiaddr,
     pub consensus_address: Multiaddr,
-    pub consensus_internal_worker_address: Option<Multiaddr>,
     #[serde(default = "default_stake")]
     pub stake: u64,
     pub name: Option<String>,
@@ -207,7 +206,6 @@ impl ValidatorGenesisConfigBuilder {
             narwhal_primary_address,
             narwhal_worker_address,
             consensus_address,
-            consensus_internal_worker_address: None,
             stake: sui_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MIST,
             name: None,
         }

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -131,12 +131,10 @@ impl ValidatorConfigBuilder {
         let network_address = validator.network_address;
         let consensus_address = validator.consensus_address;
         let consensus_db_path = config_directory.join(CONSENSUS_DB_NAME).join(key_path);
-        let internal_worker_address = validator.consensus_internal_worker_address;
         let localhost = local_ip_utils::localhost_for_testing();
         let consensus_config = ConsensusConfig {
             address: consensus_address,
             db_path: consensus_db_path,
-            internal_worker_address,
             max_pending_transactions: None,
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -154,6 +154,7 @@ impl ValidatorConfigBuilder {
                 },
                 ..Default::default()
             },
+            parameters: Default::default(),
         };
 
         let p2p_config = P2pConfig {

--- a/crates/sui-swarm-config/tests/snapshot_tests.rs
+++ b/crates/sui-swarm-config/tests/snapshot_tests.rs
@@ -133,7 +133,6 @@ fn network_config_snapshot_matches() {
         if let Some(consensus_config) = validator_config.consensus_config.as_mut() {
             consensus_config.address = Multiaddr::empty();
             consensus_config.db_path = PathBuf::from("/tmp/foo/");
-            consensus_config.internal_worker_address = Some(Multiaddr::empty());
             consensus_config
                 .narwhal_config
                 .prometheus_metrics

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -18,12 +18,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -44,6 +43,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -156,12 +183,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -182,6 +208,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -294,12 +348,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -320,6 +373,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -432,12 +513,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -458,6 +538,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -570,12 +678,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -596,6 +703,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -708,12 +843,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -734,6 +868,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -846,12 +1008,11 @@ validator_configs:
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
-      address: ""
       db-path: /tmp/foo/
-      internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
       submit-delay-step-override-millis: ~
+      address: ""
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -872,6 +1033,34 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
+      parameters:
+        db_path: ~
+        leader_timeout:
+          secs: 0
+          nanos: 250000000
+        min_round_delay:
+          secs: 0
+          nanos: 50000000
+        max_forward_time_drift:
+          secs: 0
+          nanos: 500000000
+        max_blocks_per_fetch: 1000
+        dag_state_cached_rounds: 500
+        commit_sync_parallel_fetches: 20
+        commit_sync_batch_size: 100
+        commit_sync_batches_ahead: 200
+        anemo:
+          excessive_message_size: 8388608
+        tonic:
+          keepalive_interval:
+            secs: 5
+            nanos: 0
+          connection_buffer_size: 33554432
+          excessive_message_size: 16777216
+          message_size_limit: 67108864
+        sync_last_proposed_block_timeout:
+          secs: 0
+          nanos: 0
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -976,4 +1165,3 @@ account_keys:
   - mfPjCoE6SX0Sl84MnmNS/LS+tfPpkn7I8tziuk2g0WM=
   - 5RWlYF22jS9i76zLl8jP2D3D8GC5ht+IP1dWUBGZxi8=
 genesis: "[fake genesis]"
-


### PR DESCRIPTION
## Description 

This allows setting consensus Parameters via NodeConfig.
Also, do some minor cleanups. But the bulk of the cleanup will happen when we stop supporting Narwhal.

## Test plan 

CI. Private testnet.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
