### PR TITLE
[GraphQL] Cache chain identifier & use ticks

### DIFF
--- a/crates/sui-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/sui-graphql-rpc/src/server/watermark_task.rs
@@ -4,6 +4,7 @@
 use crate::data::{Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::metrics::Metrics;
+use crate::types::chain_identifier::ChainIdentifier;
 use async_graphql::ServerError;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use std::mem;
@@ -11,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_indexer::schema::checkpoints;
 use tokio::sync::{watch, RwLock};
+use tokio::time::Interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -19,6 +21,7 @@ use tracing::{error, info};
 pub(crate) struct WatermarkTask {
     /// Thread-safe watermark that avoids writer starvation
     watermark: WatermarkLock,
+    chain_identifier: ChainIdentifierLock,
     db: Db,
     metrics: Metrics,
     sleep: Duration,
@@ -26,6 +29,9 @@ pub(crate) struct WatermarkTask {
     sender: watch::Sender<u64>,
     receiver: watch::Receiver<u64>,
 }
+
+#[derive(Clone, Default)]
+pub(crate) struct ChainIdentifierLock(pub(crate) Arc<RwLock<ChainIdentifier>>);
 
 pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
 
@@ -53,6 +59,7 @@ impl WatermarkTask {
 
         Self {
             watermark: Default::default(),
+            chain_identifier: Default::default(),
             db,
             metrics,
             sleep,
@@ -63,18 +70,23 @@ impl WatermarkTask {
     }
 
     pub(crate) async fn run(&self) {
+        let mut interval = tokio::time::interval(self.sleep);
+        // We start the task by first finding & setting the chain identifier
+        // so that it can be used in all requests.
+        self.get_and_cache_chain_identifier(&mut interval).await;
+
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => {
                     info!("Shutdown signal received, terminating watermark update task");
                     return;
                 },
-                _ = tokio::time::sleep(self.sleep) => {
+                _ = interval.tick() => {
                     let Watermark {checkpoint, epoch, checkpoint_timestamp_ms } = match Watermark::query(&self.db).await {
                         Ok(Some(watermark)) => watermark,
                         Ok(None) => continue,
                         Err(e) => {
-                            error!("{}", e);
+                            error!("Failed to fetch chain identifier: {}", e);
                             self.metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
                             continue;
                         }
@@ -100,9 +112,41 @@ impl WatermarkTask {
         self.watermark.clone()
     }
 
+    pub(crate) fn chain_id_lock(&self) -> ChainIdentifierLock {
+        self.chain_identifier.clone()
+    }
+
     /// Receiver for subscribing to epoch changes.
     pub(crate) fn epoch_receiver(&self) -> watch::Receiver<u64> {
         self.receiver.clone()
+    }
+
+    // Fetch the chain identifier (once) from the database and cache it.
+    async fn get_and_cache_chain_identifier(&self, interval: &mut Interval) {
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    info!("Shutdown signal received, terminating attempt to get chain identifier");
+                    return;
+                },
+                _ = interval.tick() => {
+                    // we only set the chain_identifier once.
+                    let chain = match ChainIdentifier::query(&self.db).await  {
+                        Ok(Some(chain)) => chain,
+                        Ok(None) => continue,
+                        Err(e) => {
+                            error!("{}", e);
+                            self.metrics.inc_errors(&[ServerError::new(e.to_string(), None)]);
+                            continue;
+                        }
+                    };
+
+                    let mut chain_id_lock = self.chain_identifier.0.write().await;
+                    *chain_id_lock = chain.into();
+                    return;
+                }
+            }
+        }
     }
 }
 
@@ -137,5 +181,12 @@ impl Watermark {
             checkpoint_timestamp_ms: checkpoint_timestamp_ms as u64,
             epoch: epoch as u64,
         }))
+    }
+}
+
+impl ChainIdentifierLock {
+    pub(crate) async fn read(&self) -> ChainIdentifier {
+        let w = self.0.read().await;
+        w.0.into()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/sui-graphql-rpc/src/types/chain_identifier.rs
@@ -6,27 +6,34 @@ use crate::{
     error::Error,
 };
 use async_graphql::*;
-use diesel::QueryDsl;
+use diesel::{OptionalExtension, QueryDsl};
 use sui_indexer::schema::chain_identifier;
 use sui_types::{
     digests::ChainIdentifier as NativeChainIdentifier, messages_checkpoint::CheckpointDigest,
 };
 
-pub(crate) struct ChainIdentifier;
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct ChainIdentifier(pub(crate) Option<NativeChainIdentifier>);
 
 impl ChainIdentifier {
     /// Query the Chain Identifier from the DB.
-    pub(crate) async fn query(db: &Db) -> Result<NativeChainIdentifier, Error> {
+    pub(crate) async fn query(db: &Db) -> Result<Option<NativeChainIdentifier>, Error> {
         use chain_identifier::dsl;
 
-        let digest_bytes = db
+        let Some(digest_bytes) = db
             .execute(move |conn| {
                 conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
+                    .optional()
             })
             .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?;
+            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?
+        else {
+            return Ok(None);
+        };
 
-        Self::from_bytes(digest_bytes)
+        let native_identifier = Self::from_bytes(digest_bytes)?;
+
+        Ok(Some(native_identifier))
     }
 
     /// Treat `bytes` as a checkpoint digest and extract a chain identifier from it.
@@ -34,5 +41,17 @@ impl ChainIdentifier {
         let genesis_digest = CheckpointDigest::try_from(bytes)
             .map_err(|e| Error::Internal(format!("Failed to deserialize genesis digest: {e}")))?;
         Ok(NativeChainIdentifier::from(genesis_digest))
+    }
+}
+
+impl From<Option<NativeChainIdentifier>> for ChainIdentifier {
+    fn from(chain_identifier: Option<NativeChainIdentifier>) -> Self {
+        Self(chain_identifier)
+    }
+}
+
+impl From<NativeChainIdentifier> for ChainIdentifier {
+    fn from(chain_identifier: NativeChainIdentifier) -> Self {
+        Self(Some(chain_identifier))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -55,10 +55,18 @@ impl Query {
     /// First four bytes of the network's genesis checkpoint digest (uniquely identifies the
     /// network).
     async fn chain_identifier(&self, ctx: &Context<'_>) -> Result<String> {
-        Ok(ChainIdentifier::query(ctx.data_unchecked())
-            .await
-            .extend()?
-            .to_string())
+        // we want to panic if the chain identifier is missing, as there's something wrong with
+        // the service.
+        let chain_id: ChainIdentifier = *ctx.data_unchecked();
+
+        if let Some(id) = chain_id.0 {
+            Ok(id.to_string())
+        } else {
+            Err(Error::Internal(
+                "Chain identifier not initialized.".to_string(),
+            ))
+            .extend()
+        }
     }
 
     /// Range of checkpoints that the RPC has data available for (for data


### PR DESCRIPTION
## Description 

We cache the chain identifier & use ticks instead of sleep() on the loop (to keep our queries consistently on `self.sleep` duration, instead of `self.sleep + query time`, as suggested by @amnn !

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
