### PR TITLE
[Consensus] make config optional

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -14,9 +14,10 @@ use serde::{Deserialize, Serialize};
 /// should not need to specify any field, except db_path.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Parameters {
-    /// The database path.
-    /// Required.
-    pub db_path: Option<PathBuf>,
+    /// Path to consensus DB for this epoch. Required when initializing consensus.
+    /// This is calculated based on user configuration for base directory.
+    #[serde(skip)]
+    pub db_path: PathBuf,
 
     /// Time to wait for parent round leader before sealing a block.
     #[serde(default = "Parameters::default_leader_timeout")]
@@ -143,7 +144,7 @@ impl Parameters {
 impl Default for Parameters {
     fn default() -> Self {
         Self {
-            db_path: None,
+            db_path: PathBuf::default(),
             leader_timeout: Parameters::default_leader_timeout(),
             min_round_delay: Parameters::default_min_round_delay(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -2,7 +2,6 @@
 source: consensus/config/tests/parameters_test.rs
 expression: parameters
 ---
-db_path: ~
 leader_timeout:
   secs: 0
   nanos: 250000000
@@ -29,4 +28,3 @@ tonic:
 sync_last_proposed_block_timeout:
   secs: 0
   nanos: 0
-

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -182,14 +182,7 @@ where
             ))
         };
 
-        let store_path = context
-            .parameters
-            .db_path
-            .as_ref()
-            .expect("DB path is not set")
-            .as_path()
-            .to_str()
-            .unwrap();
+        let store_path = context.parameters.db_path.as_path().to_str().unwrap();
         let store = Arc::new(RocksDBStore::new(store_path));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
@@ -375,7 +368,7 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let parameters = Parameters {
-            db_path: Some(temp_dir.into_path()),
+            db_path: temp_dir.into_path(),
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};
@@ -672,7 +665,7 @@ mod tests {
 
         // Cache less blocks to exercise commit sync.
         let parameters = Parameters {
-            db_path: Some(db_dir.path().to_path_buf()),
+            db_path: db_dir.path().to_path_buf(),
             dag_state_cached_rounds: 5,
             commit_sync_parallel_fetches: 3,
             commit_sync_batch_size: 3,

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -67,7 +67,7 @@ impl Context {
             AuthorityIndex::new_for_test(0),
             committee,
             Parameters {
-                db_path: Some(temp_dir.into_path()),
+                db_path: temp_dir.into_path(),
                 ..Default::default()
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -429,7 +429,7 @@ pub struct ConsensusConfig {
     pub address: Multiaddr,
     pub narwhal_config: NarwhalParameters,
 
-    pub parameters: ConsensusParameters,
+    pub parameters: Option<ConsensusParameters>,
 }
 
 impl ConsensusConfig {

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -126,7 +126,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             .expect("consensus_config should exist");
         let parameters = Parameters {
             db_path: Some(self.get_store_path(epoch)),
-            ..consensus_config.parameters.clone()
+            ..consensus_config.parameters.clone().unwrap_or_default()
         };
 
         let own_protocol_key = self.protocol_keypair.public();

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -125,7 +125,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             .consensus_config()
             .expect("consensus_config should exist");
         let parameters = Parameters {
-            db_path: Some(self.get_store_path(epoch)),
+            db_path: self.get_store_path(epoch),
             ..consensus_config.parameters.clone().unwrap_or_default()
         };
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -43,34 +43,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -208,34 +181,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -373,34 +319,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -538,34 +457,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -703,34 +595,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -868,34 +733,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
@@ -1033,34 +871,7 @@ validator_configs:
           send_certificate_rate_limit: ~
           report_batch_rate_limit: ~
           request_batches_rate_limit: ~
-      parameters:
-        db_path: ~
-        leader_timeout:
-          secs: 0
-          nanos: 250000000
-        min_round_delay:
-          secs: 0
-          nanos: 50000000
-        max_forward_time_drift:
-          secs: 0
-          nanos: 500000000
-        max_blocks_per_fetch: 1000
-        dag_state_cached_rounds: 500
-        commit_sync_parallel_fetches: 20
-        commit_sync_batch_size: 100
-        commit_sync_batches_ahead: 200
-        anemo:
-          excessive_message_size: 8388608
-        tonic:
-          keepalive_interval:
-            secs: 5
-            nanos: 0
-          connection_buffer_size: 33554432
-          excessive_message_size: 16777216
-          message_size_limit: 67108864
-        sync_last_proposed_block_timeout:
-          secs: 0
-          nanos: 0
+      parameters: ~
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~


### PR DESCRIPTION
## Description 

1. Make consensus parameters optional in node config, since it has not been populated before.
2. Make consensus_config::Parameters::db_path non optional. It is always set from the node config after integration with Sui. If empty path causes problem, it needs to be detected from Sui or within consensus.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
