### PR TITLE
Transaction must be written before executed_effects_digests

### DIFF
--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -804,6 +804,11 @@ impl WritebackCache {
         let tx_digest = *transaction.digest();
         let effects_digest = effects.digest();
 
+        self.metrics.record_cache_write("transaction_block");
+        self.dirty
+            .pending_transaction_writes
+            .insert(tx_digest, tx_outputs.clone());
+
         // insert transaction effects before executed_effects_digests so that there
         // are never dangling entries in executed_effects_digests
         self.metrics.record_cache_write("transaction_effects");
@@ -830,11 +835,6 @@ impl WritebackCache {
         self.dirty
             .executed_effects_digests
             .insert(tx_digest, effects_digest);
-
-        self.metrics.record_cache_write("transaction_block");
-        self.dirty
-            .pending_transaction_writes
-            .insert(tx_digest, tx_outputs);
 
         self.executed_effects_digests_notify_read
             .notify(&tx_digest, &effects_digest);


### PR DESCRIPTION
This fixes a very unlikely race where:
- notify_read_executed_effects is called
- the effects are available and are returned immediately
- transaction itself has not yet been written to pending_transaction_writes
- reader thread tries to read the tx and asserts that it exists
