### PR TITLE
[StateAccumulator] Remove v2 disable functionality from node config

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -186,6 +186,8 @@ pub struct NodeConfig {
     #[serde(default)]
     pub execution_cache: ExecutionCacheConfig,
 
+    // step 1 in removing the old state accumulator
+    #[serde(skip)]
     #[serde(default = "bool_true")]
     pub state_accumulator_v2: bool,
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -165,7 +165,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
   - protocol-key-pair:
@@ -330,7 +329,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
   - protocol-key-pair:
@@ -495,7 +493,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
   - protocol-key-pair:
@@ -660,7 +657,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
   - protocol-key-pair:
@@ -825,7 +821,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
   - protocol-key-pair:
@@ -990,7 +985,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
   - protocol-key-pair:
@@ -1155,7 +1149,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
-    state-accumulator-v2: true
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
 account_keys:
@@ -1165,3 +1158,4 @@ account_keys:
   - mfPjCoE6SX0Sl84MnmNS/LS+tfPpkn7I8tziuk2g0WM=
   - 5RWlYF22jS9i76zLl8jP2D3D8GC5ht+IP1dWUBGZxi8=
 genesis: "[fake genesis]"
+


### PR DESCRIPTION
## Description 

Before removing v1, we need to ensure that no one has v2 force disabled, as it would otherwise lead to a fork during upgrade due to forcing v2 to be enabled mid-epoch.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
