### PR TITLE
[bridge] let monitor handle emergecny op

### DIFF
--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -43,6 +43,10 @@ pub const BRIDGE_AUTHORITY_TOTAL_VOTING_POWER: u64 = 10000;
 
 pub const USD_MULTIPLIER: u64 = 10000; // decimal places = 4
 
+pub type IsBridgePaused = bool;
+pub const BRIDGE_PAUSED: bool = true;
+pub const BRIDGE_UNPAUSED: bool = false;
+
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct BridgeAuthority {
     pub pubkey: BridgeAuthorityPublicKey,


### PR DESCRIPTION
## Description 

as title. Note the actual usage of the watch channel hasn't been wired up in ActionExecutor. It will be in the next PR.

## Test plan 

unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
