### PR TITLE
move: dump-bytecode-as-base64 uses Move.lock addresses

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -29,6 +29,11 @@ pub struct Build {
     /// and events.
     #[clap(long, global = true)]
     pub generate_struct_layouts: bool,
+    /// The chain ID, if resolved. Required when the dump_bytecode_as_base64 is true,
+    /// for automated address management, where package addresses are resolved for the
+    /// respective chain in the Move.lock file.
+    #[clap(skip)]
+    pub chain_id: Option<String>,
 }
 
 impl Build {
@@ -45,6 +50,7 @@ impl Build {
             self.with_unpublished_dependencies,
             self.dump_bytecode_as_base64,
             self.generate_struct_layouts,
+            self.chain_id.clone(),
         )
     }
 
@@ -54,12 +60,13 @@ impl Build {
         with_unpublished_deps: bool,
         dump_bytecode_as_base64: bool,
         generate_struct_layouts: bool,
+        chain_id: Option<String>,
     ) -> anyhow::Result<()> {
         let pkg = BuildConfig {
             config,
             run_bytecode_verifier: true,
             print_diags_to_stderr: true,
-            chain_id: None,
+            chain_id,
         }
         .build(rerooted_path)?;
         if dump_bytecode_as_base64 {

--- a/crates/sui/tests/data/depends_on_simple/Move.toml
+++ b/crates/sui/tests/data/depends_on_simple/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "depends_on_simple"
+edition = "2024.beta"
+
+[dependencies]
+simple = { local = "../simple" }
+
+[addresses]
+depends_on_simple = "0x0"

--- a/crates/sui/tests/data/depends_on_simple/sources/depends_on_simple.move
+++ b/crates/sui/tests/data/depends_on_simple/sources/depends_on_simple.move
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module depends_on_simple::depends_on_simple {}

--- a/crates/sui/tests/data/simple/Move.toml
+++ b/crates/sui/tests/data/simple/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "simple"
+edition = "2024.beta"
+
+[dependencies]
+
+[addresses]
+simple = "0x0"

--- a/crates/sui/tests/data/simple/sources/simple.move
+++ b/crates/sui/tests/data/simple/sources/simple.move
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module simple::simple {}

--- a/sdk/deepbook/test/e2e/setup.ts
+++ b/sdk/deepbook/test/e2e/setup.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execSync } from 'child_process';
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
 import type {
 	DevInspectResults,
 	SuiObjectChangeCreated,
@@ -30,10 +33,12 @@ export const DEFAULT_LOT_SIZE = 1n;
 export class TestToolbox {
 	keypair: Ed25519Keypair;
 	client: SuiClient;
+	configPath: string;
 
-	constructor(keypair: Ed25519Keypair, client: SuiClient) {
+	constructor(keypair: Ed25519Keypair, client: SuiClient, configPath: string) {
 		this.keypair = keypair;
 		this.client = client;
+		this.configPath = configPath;
 	}
 
 	address() {
@@ -64,7 +69,12 @@ export async function setupSuiClient() {
 		retryIf: (error: any) => !(error instanceof FaucetRateLimitError),
 		logger: (msg) => console.warn('Retrying requesting from faucet: ' + msg),
 	});
-	return new TestToolbox(keypair, client);
+
+	const tmpDirPath = path.join(tmpdir(), 'config-');
+	const tmpDir = await mkdtemp(tmpDirPath);
+	const configPath = path.join(tmpDir, 'client.yaml');
+	execSync(`${SUI_BIN} client --yes --client.config ${configPath}`, { encoding: 'utf-8' });
+	return new TestToolbox(keypair, client, configPath);
 }
 
 // TODO: expose these testing utils from @mysten/sui
@@ -81,7 +91,7 @@ export async function publishPackage(packagePath: string, toolbox?: TestToolbox)
 
 	const { modules, dependencies } = JSON.parse(
 		execSync(
-			`${SUI_BIN} move build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
+			`${SUI_BIN} move move --client.config ${toolbox.configPath} build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
 			{ encoding: 'utf-8' },
 		),
 	);

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -174,7 +174,7 @@ export async function publishPackage(packagePath: string, toolbox?: TestToolbox)
 
 	const { modules, dependencies } = JSON.parse(
 		execSync(
-			`${SUI_BIN} move build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
+			`${SUI_BIN} move --client.config ${toolbox.configPath} build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
 			{ encoding: 'utf-8' },
 		),
 	);
@@ -228,7 +228,7 @@ export async function upgradePackage(
 
 	const { modules, dependencies, digest } = JSON.parse(
 		execSync(
-			`${SUI_BIN} move build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
+			`${SUI_BIN} move --client.config ${toolbox.configPath} build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
 			{ encoding: 'utf-8' },
 		),
 	);


### PR DESCRIPTION
## Description 

`sui move build` does not ordinarily require a network connection because it doesn't need to know about a chain's ID. The exception is when `--dump-bytecode-as-base64` is specified: In this case, we should resolve the correct addresses for the respective chain (e.g., testnet, mainnet) from the `Move.lock` under automated address management.

Two options to fix `sui move build --dump-bytecode-as-base64` to work with automated addresses / by resolving from the `Move.lock`: 

1. Require an extra `--chain-id` flag on `sui move build`, which a user must specify along with `--dump-bytecode-as-base64`. E.g.,
```
sui move build --dump-bytecode-as-base64 --chain-id "$(sui client chain-identifier)"
``` 

OR

2. Require a network connection _only when_ `--dump-bytecode-as-base64` is set and and resolve the chain-id without requiring a flag.


This PR opts for **(2)**, but it is trivial to change the implementation and test to do **(1)** instead. **(1)** should come with an accompanying doc change though.

Context: encountered when running, e.g., 

```
execSync(`${SUI} move build --dump-bytecode-as-base64 --path ${packagePath}`
```

[as per our TS example](https://docs.sui.io/concepts/sui-move-concepts/packages/custom-policies#publishing-custom-policy). More in [thread](https://mysten-labs.slack.com/archives/C06DS8DSS7J/p1721658462735199)




## Test plan 

Added test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixed an issue where `--dump-bytecode-as-base64` did not work as expected if [package addresses are automatically managed](https://docs.sui.io/concepts/sui-move-concepts/packages/automated-address-management#adopting-automated-address-management-for-published-packages).
- [ ] Rust SDK:
- [ ] REST API:
