### PR TITLE
[Move/Example] Run tests in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12790,6 +12790,7 @@ dependencies = [
 name = "sui-framework-tests"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-cli",
@@ -12803,6 +12804,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-types",
  "sui-verifier-latest",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/sui-framework-tests/Cargo.toml
+++ b/crates/sui-framework-tests/Cargo.toml
@@ -8,7 +8,9 @@ license = "Apache-2.0"
 publish = false
 
 [dev-dependencies]
+futures.workspace = true
 prometheus.workspace = true
+tokio.workspace = true
 
 sui-framework.workspace = true
 sui-move = { workspace = true, features = ["unit_test"] }


### PR DESCRIPTION
## Description
Run the Move example tests in parallel, so that they don't timeout and ruin everyone's day.

## Test plan

```
sui-framework-test$ cargo nextest run -- run_examples_move_unit_tests
```

Locally, tests used to run in 180s, after this change it takes about 30 seconds.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
