### PR TITLE
[Consensus] bind to localhost if requested

### DIFF
--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -168,6 +168,18 @@ impl Multiaddr {
         Self(new_address)
     }
 
+    pub fn is_localhost_ip(&self) -> bool {
+        let Some(protocol) = self.0.iter().next() else {
+            error!("Multiaddr is empty");
+            return false;
+        };
+        match protocol {
+            multiaddr::Protocol::Ip4(addr) => addr == Ipv4Addr::LOCALHOST,
+            multiaddr::Protocol::Ip6(addr) => addr == Ipv6Addr::LOCALHOST,
+            _ => false,
+        }
+    }
+
     pub fn hostname(&self) -> Option<String> {
         for component in self.iter() {
             match component {


### PR DESCRIPTION
## Description 

This avoids external network on local cluster tests.

## Test plan 

`cargo nextest run -p sui-swarm`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
