### PR TITLE
[gql][indexer] index chain identifier into its own table

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.exp
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.exp
@@ -3,10 +3,10 @@ processed 3 tasks
 init:
 C: object(0,0)
 
-task 1 'create-checkpoint'. lines 8-8:
+task 1 'create-checkpoint'. lines 7-7:
 Checkpoint created: 1
 
-task 2 'run-graphql'. lines 10-13:
+task 2 'run-graphql'. lines 9-12:
 Response: {
   "data": {
     "chainIdentifier": "8f58ad28"

--- a/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.exp
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.exp
@@ -3,10 +3,12 @@ processed 3 tasks
 init:
 C: object(0,0)
 
-task 1 'create-checkpoint'. lines 7-7:
+task 1, line 7:
+//# create-checkpoint
 Checkpoint created: 1
 
-task 2 'run-graphql'. lines 9-12:
+task 2, lines 9-12:
+//# run-graphql
 Response: {
   "data": {
     "chainIdentifier": "8f58ad28"

--- a/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.exp
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.exp
@@ -1,0 +1,14 @@
+processed 3 tasks
+
+init:
+C: object(0,0)
+
+task 1 'create-checkpoint'. lines 8-8:
+Checkpoint created: 1
+
+task 2 'run-graphql'. lines 10-13:
+Response: {
+  "data": {
+    "chainIdentifier": "8f58ad28"
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.move
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/chain_identifier.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 48 --simulator --accounts C
+
+
+//# create-checkpoint
+
+//# run-graphql
+{
+    chainIdentifier
+}

--- a/crates/sui-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/sui-graphql-rpc/src/types/chain_identifier.rs
@@ -6,8 +6,8 @@ use crate::{
     error::Error,
 };
 use async_graphql::*;
-use diesel::{ExpressionMethods, QueryDsl};
-use sui_indexer::schema::checkpoints;
+use diesel::QueryDsl;
+use sui_indexer::schema::chain_identifier;
 use sui_types::{
     digests::ChainIdentifier as NativeChainIdentifier, messages_checkpoint::CheckpointDigest,
 };
@@ -17,15 +17,11 @@ pub(crate) struct ChainIdentifier;
 impl ChainIdentifier {
     /// Query the Chain Identifier from the DB.
     pub(crate) async fn query(db: &Db) -> Result<NativeChainIdentifier, Error> {
-        use checkpoints::dsl;
+        use chain_identifier::dsl;
 
         let digest_bytes = db
             .execute(move |conn| {
-                conn.first(move || {
-                    dsl::checkpoints
-                        .select(dsl::checkpoint_digest)
-                        .order_by(dsl::sequence_number.asc())
-                })
+                conn.first(move || dsl::chain_identifier.select(dsl::checkpoint_digest))
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?;

--- a/crates/sui-indexer/migrations/pg/2024-07-13-003534_chain_identifier/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-07-13-003534_chain_identifier/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS chain_identifier;

--- a/crates/sui-indexer/migrations/pg/2024-07-13-003534_chain_identifier/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-07-13-003534_chain_identifier/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE chain_identifier
+(
+    checkpoint_digest   BYTEA    NOT NULL,
+    PRIMARY KEY(checkpoint_digest)
+);

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -9,8 +9,14 @@ use sui_types::digests::CheckpointDigest;
 use sui_types::gas::GasCostSummary;
 
 use crate::errors::IndexerError;
-use crate::schema::{checkpoints, pruner_cp_watermark};
+use crate::schema::{chain_identifier, checkpoints, pruner_cp_watermark};
 use crate::types::IndexedCheckpoint;
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = chain_identifier)]
+pub struct StoredChainIdentifier {
+    pub checkpoint_digest: Vec<u8>,
+}
 
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = checkpoints)]

--- a/crates/sui-indexer/src/schema/mod.rs
+++ b/crates/sui-indexer/src/schema/mod.rs
@@ -45,6 +45,7 @@ mod inner {
     pub use crate::schema::mysql::packages;
     pub use crate::schema::mysql::pruner_cp_watermark;
     pub use crate::schema::mysql::transactions;
+    pub use crate::schema::mysql::tx_calls;
     pub use crate::schema::mysql::tx_changed_objects;
     pub use crate::schema::mysql::tx_digests;
     pub use crate::schema::mysql::tx_input_objects;

--- a/crates/sui-indexer/src/schema/mod.rs
+++ b/crates/sui-indexer/src/schema/mod.rs
@@ -12,6 +12,7 @@ mod pg;
 
 #[cfg(feature = "postgres-feature")]
 mod inner {
+    pub use crate::schema::pg::chain_identifier;
     pub use crate::schema::pg::checkpoints;
     pub use crate::schema::pg::display;
     pub use crate::schema::pg::epochs;
@@ -51,6 +52,7 @@ mod inner {
     pub use crate::schema::mysql::tx_senders;
 }
 
+pub use inner::chain_identifier;
 pub use inner::checkpoints;
 pub use inner::display;
 pub use inner::epochs;

--- a/crates/sui-indexer/src/schema/mod.rs
+++ b/crates/sui-indexer/src/schema/mod.rs
@@ -34,6 +34,7 @@ mod inner {
 #[cfg(feature = "mysql-feature")]
 #[cfg(not(feature = "postgres-feature"))]
 mod inner {
+    pub use crate::schema::mysql::chain_identifier;
     pub use crate::schema::mysql::checkpoints;
     pub use crate::schema::mysql::display;
     pub use crate::schema::mysql::epochs;
@@ -44,7 +45,6 @@ mod inner {
     pub use crate::schema::mysql::packages;
     pub use crate::schema::mysql::pruner_cp_watermark;
     pub use crate::schema::mysql::transactions;
-    pub use crate::schema::mysql::tx_calls;
     pub use crate::schema::mysql::tx_changed_objects;
     pub use crate::schema::mysql::tx_digests;
     pub use crate::schema::mysql::tx_input_objects;

--- a/crates/sui-indexer/src/schema/mysql.rs
+++ b/crates/sui-indexer/src/schema/mysql.rs
@@ -3,6 +3,12 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    chain_identifier (checkpoint_digest) {
+        checkpoint_digest -> Blob,
+    }
+}
+
+diesel::table! {
     checkpoints (sequence_number) {
         sequence_number -> Bigint,
         checkpoint_digest -> Blob,
@@ -227,6 +233,7 @@ diesel::table! {
 macro_rules! for_all_tables {
     ($action:path) => {
         $action!(
+            chain_identifier,
             checkpoints,
             epochs,
             events,

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -1,3 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/crates/sui-indexer/src/schema/pg.rs
+++ b/crates/sui-indexer/src/schema/pg.rs
@@ -1,6 +1,10 @@
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
 // @generated automatically by Diesel CLI.
+
+diesel::table! {
+    chain_identifier (checkpoint_digest) {
+        checkpoint_digest -> Bytea,
+    }
+}
 
 diesel::table! {
     checkpoints (sequence_number) {
@@ -284,6 +288,7 @@ diesel::table! {
 macro_rules! for_all_tables {
     ($action:path) => {
         $action!(
+            chain_identifier,
             checkpoints,
             pruner_cp_watermark,
             display,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -27,6 +27,7 @@ use crate::errors::{Context, IndexerError};
 use crate::handlers::EpochToCommit;
 use crate::handlers::TransactionObjectChangesToCommit;
 use crate::metrics::IndexerMetrics;
+use crate::models::checkpoints::StoredChainIdentifier;
 use crate::models::checkpoints::StoredCheckpoint;
 use crate::models::checkpoints::StoredCpTx;
 use crate::models::display::StoredDisplay;
@@ -39,9 +40,9 @@ use crate::models::objects::{
 use crate::models::packages::StoredPackage;
 use crate::models::transactions::StoredTransaction;
 use crate::schema::{
-    checkpoints, display, epochs, events, objects, objects_history, objects_snapshot, packages,
-    pruner_cp_watermark, transactions, tx_calls, tx_changed_objects, tx_digests, tx_input_objects,
-    tx_recipients, tx_senders,
+    chain_identifier, checkpoints, display, epochs, events, objects, objects_history,
+    objects_snapshot, packages, pruner_cp_watermark, transactions, tx_calls, tx_changed_objects,
+    tx_digests, tx_input_objects, tx_recipients, tx_senders,
 };
 use crate::types::{IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex};
 use crate::{
@@ -600,6 +601,25 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
     fn persist_checkpoints(&self, checkpoints: Vec<IndexedCheckpoint>) -> Result<(), IndexerError> {
         if checkpoints.is_empty() {
             return Ok(());
+        }
+        // If the first checkpoint has sequence number 0, we need to persist the digest as
+        // chain identifier.
+        let first_checkpoint = checkpoints.first().unwrap();
+        if first_checkpoint.sequence_number == 0 {
+            transactional_blocking_with_retry!(
+                &self.blocking_cp,
+                |conn| {
+                    let checkpoint_digest =
+                        first_checkpoint.checkpoint_digest.into_inner().to_vec();
+                    insert_or_ignore_into!(
+                        chain_identifier::table,
+                        StoredChainIdentifier { checkpoint_digest },
+                        conn
+                    );
+                    Ok::<(), IndexerError>(())
+                },
+                PG_DB_COMMIT_SLEEP_DURATION
+            )?;
         }
         let guard = self
             .metrics

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -599,12 +599,12 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
     }
 
     fn persist_checkpoints(&self, checkpoints: Vec<IndexedCheckpoint>) -> Result<(), IndexerError> {
-        if checkpoints.is_empty() {
+        let Some(first_checkpoint) = checkpoints.first() else {
             return Ok(());
-        }
+        };
+
         // If the first checkpoint has sequence number 0, we need to persist the digest as
         // chain identifier.
-        let first_checkpoint = checkpoints.first().unwrap();
         if first_checkpoint.sequence_number == 0 {
             transactional_blocking_with_retry!(
                 &self.blocking_cp,


### PR DESCRIPTION
## Description 

This PR puts chain identifier into its own table so that queries of chain identifier does not depend on the existence of checkpoint 0 in the db, which may be pruned away.

## Test plan 

Tested against devnet locally and added a gql e2e test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Added a way to always have `chainIdentifier` query return the correct chain ID even when pruning is enabled.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
