### PR TITLE
[bridge] do not submit tx to sui if paused

### DIFF
--- a/crates/sui-bridge/src/metrics.rs
+++ b/crates/sui-bridge/src/metrics.rs
@@ -33,6 +33,7 @@ pub struct BridgeMetrics {
     pub(crate) action_executor_signing_queue_received_actions: IntCounter,
     pub(crate) action_executor_signing_queue_skipped_actions: IntCounter,
     pub(crate) action_executor_execution_queue_received_actions: IntCounter,
+    pub(crate) action_executor_execution_queue_skipped_actions_due_to_pausing: IntCounter,
 
     pub(crate) signer_with_cache_hit: IntCounterVec,
     pub(crate) signer_with_cache_miss: IntCounterVec,
@@ -159,6 +160,12 @@ impl BridgeMetrics {
             action_executor_execution_queue_received_actions: register_int_counter_with_registry!(
                 "bridge_action_executor_execution_queue_received_actions",
                 "Total number of received actions in action executor execution queue",
+                registry,
+            )
+            .unwrap(),
+            action_executor_execution_queue_skipped_actions_due_to_pausing: register_int_counter_with_registry!(
+                "bridge_action_executor_execution_queue_skipped_actions_due_to_pausing",
+                "Total number of skipped actions in action executor execution queue because of pausing",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

in `ActionExecutor`, use `bridge_pause_rx` to decide whether to submit tx to Sui.

## Test plan 

new unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
