### PR TITLE
introduce MeteredEthHttpProvider that meters rpc usage

### DIFF
--- a/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
+++ b/crates/sui-bridge-indexer/src/latest_eth_syncer.rs
@@ -6,7 +6,7 @@
 //! only query from that block number onwards. The syncer also keeps track of the last
 //! block on Ethereum and will only query for events up to that block number.
 
-use ethers::providers::{Http, JsonRpcClient, Middleware, Provider};
+use ethers::providers::{JsonRpcClient, Middleware, Provider};
 use ethers::types::Address as EthAddress;
 use mysten_metrics::metered_channel::{channel, Receiver, Sender};
 use mysten_metrics::spawn_logged_monitored_task;
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use sui_bridge::error::BridgeResult;
 use sui_bridge::eth_client::EthClient;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
 use sui_bridge::retry_with_max_elapsed_time;
 use sui_bridge::types::RawEthLog;
 use tokio::task::JoinHandle;
@@ -30,7 +31,7 @@ const BLOCK_QUERY_INTERVAL: Duration = Duration::from_secs(2);
 
 pub struct LatestEthSyncer<P> {
     eth_client: Arc<EthClient<P>>,
-    provider: Arc<Provider<Http>>,
+    provider: Arc<Provider<MeteredEthHttpProvier>>,
     contract_addresses: EthTargetAddresses,
 }
 
@@ -44,7 +45,7 @@ where
 {
     pub fn new(
         eth_client: Arc<EthClient<P>>,
-        provider: Arc<Provider<Http>>,
+        provider: Arc<Provider<MeteredEthHttpProvier>>,
         contract_addresses: EthTargetAddresses,
     ) -> Self {
         Self {
@@ -92,7 +93,7 @@ where
     async fn run_event_listening_task(
         contract_address: EthAddress,
         mut start_block: u64,
-        provider: Arc<Provider<Http>>,
+        provider: Arc<Provider<MeteredEthHttpProvier>>,
         events_sender: Sender<(EthAddress, u64, Vec<RawEthLog>)>,
         eth_client: Arc<EthClient<P>>,
         metrics: BridgeIndexerMetrics,

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -10,6 +10,7 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_bridge::eth_client::EthClient;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
 use sui_bridge::metrics::BridgeMetrics;
 use sui_bridge_indexer::eth_worker::EthBridgeWorker;
 use sui_bridge_indexer::metrics::BridgeIndexerMetrics;
@@ -82,7 +83,7 @@ async fn main() -> Result<()> {
     )?;
 
     let eth_client = Arc::new(
-        EthClient::<ethers::providers::Http>::new(
+        EthClient::<MeteredEthHttpProvier>::new(
             &config.eth_rpc_url,
             HashSet::from_iter(vec![eth_worker.bridge_address()]),
             bridge_metrics.clone(),

--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -78,7 +78,7 @@ pub struct BridgeActionExecutor<C> {
     gas_object_id: ObjectID,
     store: Arc<BridgeOrchestratorTables>,
     bridge_object_arg: ObjectArg,
-    token_config_rx: tokio::sync::watch::Receiver<HashMap<u8, TypeTag>>,
+    sui_token_type_tags: Arc<ArcSwap<HashMap<u8, TypeTag>>>,
     bridge_pause_rx: tokio::sync::watch::Receiver<IsBridgePaused>,
     metrics: Arc<BridgeMetrics>,
 }
@@ -109,7 +109,7 @@ where
         key: SuiKeyPair,
         sui_address: SuiAddress,
         gas_object_id: ObjectID,
-        token_config_rx: tokio::sync::watch::Receiver<HashMap<u8, TypeTag>>,
+        sui_token_type_tags: Arc<ArcSwap<HashMap<u8, TypeTag>>>,
         bridge_pause_rx: tokio::sync::watch::Receiver<IsBridgePaused>,
         metrics: Arc<BridgeMetrics>,
     ) -> Self {
@@ -124,7 +124,7 @@ where
             gas_object_id,
             sui_address,
             bridge_object_arg,
-            token_config_rx,
+            sui_token_type_tags,
             bridge_pause_rx,
             metrics,
         }
@@ -184,7 +184,7 @@ where
                 execution_tx_clone,
                 execution_rx,
                 self.bridge_object_arg,
-                self.token_config_rx,
+                self.sui_token_type_tags,
                 self.bridge_pause_rx,
                 metrics,
             )
@@ -407,58 +407,37 @@ where
             CertifiedBridgeActionExecutionWrapper,
         >,
         bridge_object_arg: ObjectArg,
-        mut token_config_rx: tokio::sync::watch::Receiver<HashMap<u8, TypeTag>>,
+        sui_token_type_tags: Arc<ArcSwap<HashMap<u8, TypeTag>>>,
         bridge_pause_rx: tokio::sync::watch::Receiver<IsBridgePaused>,
         metrics: Arc<BridgeMetrics>,
     ) {
         info!("Starting run_onchain_execution_loop");
-        let sui_token_type_tags =
-            ArcSwap::new(Arc::new(token_config_rx.borrow_and_update().clone()));
-
-        loop {
-            tokio::select! {
-                result = token_config_rx.changed() => {
-                    match result {
-                        Ok(()) => {
-                            sui_token_type_tags.store(Arc::new(token_config_rx.borrow_and_update().clone()));
-                        }
-                        Err(_) => {
-                            panic!("Token config watch channel closed unexpectedly");
-                        }
-                    }
-                },
-                certificate_wrapper = execution_queue_receiver.recv() => {
-                    // When bridge is paused, skip execution.
-                    // Skipped actions will be picked up upon node restarting
-                    // if bridge is unpaused.
-                    if *bridge_pause_rx.borrow() {
-                        warn!("Bridge is paused, skipping execution");
-                        metrics.action_executor_execution_queue_skipped_actions_due_to_pausing.inc();
-                        continue;
-                    }
-                    match certificate_wrapper {
-                        Some(certificate_wrapper) => {
-                            Self::handle_execution_task(
-                                certificate_wrapper,
-                                &sui_client,
-                                &sui_key,
-                                &sui_address,
-                                gas_object_id,
-                                &store,
-                                &execution_queue_sender,
-                                &bridge_object_arg,
-                                &sui_token_type_tags,
-                                &metrics,
-                            )
-                            .await;
-                        },
-                        None => {
-                            panic!("Execution queue closed unexpectedly");
-                        }
-                    }
-                }
+        while let Some(certificate_wrapper) = execution_queue_receiver.recv().await {
+            // When bridge is paused, skip execution.
+            // Skipped actions will be picked up upon node restarting
+            // if bridge is unpaused.
+            if *bridge_pause_rx.borrow() {
+                warn!("Bridge is paused, skipping execution");
+                metrics
+                    .action_executor_execution_queue_skipped_actions_due_to_pausing
+                    .inc();
+                continue;
             }
+            Self::handle_execution_task(
+                certificate_wrapper,
+                &sui_client,
+                &sui_key,
+                &sui_address,
+                gas_object_id,
+                &store,
+                &execution_queue_sender,
+                &bridge_object_arg,
+                &sui_token_type_tags,
+                &metrics,
+            )
+            .await;
         }
+        panic!("Execution queue closed unexpectedly");
     }
 
     #[instrument(level = "error", skip_all, fields(action_key=?certificate_wrapper.0.data().key(), attempt_times=?certificate_wrapper.1))]
@@ -674,6 +653,7 @@ mod tests {
     use fastcrypto::traits::KeyPair;
     use prometheus::Registry;
     use std::collections::{BTreeMap, HashMap};
+    use std::str::FromStr;
     use sui_json_rpc_types::SuiTransactionBlockEffects;
     use sui_json_rpc_types::SuiTransactionBlockEvents;
     use sui_json_rpc_types::{SuiEvent, SuiTransactionBlockResponse};
@@ -690,8 +670,8 @@ mod tests {
         server::mock_handler::BridgeRequestMockHandler,
         sui_mock_client::SuiMockClient,
         test_utils::{
-            get_test_authorities_and_run_mock_bridge_server, get_test_sui_to_eth_bridge_action,
-            sign_action_with_key,
+            get_test_authorities_and_run_mock_bridge_server, get_test_eth_to_sui_bridge_action,
+            get_test_sui_to_eth_bridge_action, sign_action_with_key,
         },
         types::{BridgeCommittee, BridgeCommitteeValiditySignInfo, CertifiedBridgeAction},
     };
@@ -715,15 +695,17 @@ mod tests {
             _handles,
             gas_object_ref,
             sui_address,
-            token_tx,
+            sui_token_type_tags,
             _bridge_pause_tx,
         ) = setup().await;
         let (action_certificate, _, _) = get_bridge_authority_approved_action(
             vec![&mock0, &mock1, &mock2, &mock3],
             vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+            None,
+            true,
         );
         let action = action_certificate.data().clone();
-        let id_token_map = token_tx.borrow();
+        let id_token_map = (*sui_token_type_tags.load().clone()).clone();
         let tx_data = build_sui_transaction(
             sui_address,
             &gas_object_ref,
@@ -777,6 +759,8 @@ mod tests {
         let (action_certificate, _, _) = get_bridge_authority_approved_action(
             vec![&mock0, &mock1, &mock2, &mock3],
             vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+            None,
+            true,
         );
 
         let action = action_certificate.data().clone();
@@ -829,6 +813,8 @@ mod tests {
         let (action_certificate, _, _) = get_bridge_authority_approved_action(
             vec![&mock0, &mock1, &mock2, &mock3],
             vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+            None,
+            true,
         );
 
         let action = action_certificate.data().clone();
@@ -907,14 +893,16 @@ mod tests {
             _handles,
             gas_object_ref,
             sui_address,
-            token_tx,
+            sui_token_type_tags,
             _bridge_pause_tx,
         ) = setup().await;
-        let id_token_map = token_tx.borrow();
+        let id_token_map = (*sui_token_type_tags.load().clone()).clone();
         let (action_certificate, sui_tx_digest, sui_tx_event_index) =
             get_bridge_authority_approved_action(
                 vec![&mock0, &mock1, &mock2, &mock3],
                 vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+                None,
+                true,
             );
         let action = action_certificate.data().clone();
         mock_bridge_authority_signing_errors(
@@ -1028,7 +1016,7 @@ mod tests {
             _handles,
             _gas_object_ref,
             _sui_address,
-            _token_tx,
+            _sui_token_type_tags,
             _bridge_pause_tx,
         ) = setup().await;
 
@@ -1096,13 +1084,15 @@ mod tests {
             _handles,
             gas_object_ref,
             sui_address,
-            token_tx,
+            sui_token_type_tags,
             _bridge_pause_tx,
         ) = setup().await;
-        let id_token_map = token_tx.borrow();
+        let id_token_map = (*sui_token_type_tags.load().clone()).clone();
         let (action_certificate, _, _) = get_bridge_authority_approved_action(
             vec![&mock0, &mock1, &mock2, &mock3],
             vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+            None,
+            true,
         );
 
         let action = action_certificate.data().clone();
@@ -1179,13 +1169,15 @@ mod tests {
             _handles,
             gas_object_ref,
             sui_address,
-            token_tx,
+            sui_token_type_tags,
             bridge_pause_tx,
         ) = setup().await;
-        let id_token_map = token_tx.borrow();
+        let id_token_map: HashMap<u8, TypeTag> = (*sui_token_type_tags.load().clone()).clone();
         let (action_certificate, _, _) = get_bridge_authority_approved_action(
             vec![&mock0, &mock1, &mock2, &mock3],
             vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+            None,
+            true,
         );
 
         let action = action_certificate.data().clone();
@@ -1234,7 +1226,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Some requests come in and will fail.
+        // Some requests come in
         tx_subscription.recv().await.unwrap();
 
         // Pause the bridge
@@ -1257,6 +1249,99 @@ mod tests {
             store.get_all_pending_actions()[&action_digest],
             action.clone()
         );
+    }
+
+    #[tokio::test]
+    async fn test_action_executor_handle_new_token() {
+        let new_token_id = 255u8; // token id that does not exist
+        let new_type_tag = TypeTag::from_str("0xbeef::beef::BEEF").unwrap();
+        let (
+            _signing_tx,
+            execution_tx,
+            sui_client_mock,
+            mut tx_subscription,
+            _store,
+            secrets,
+            dummy_sui_key,
+            mock0,
+            mock1,
+            mock2,
+            mock3,
+            _handles,
+            gas_object_ref,
+            sui_address,
+            sui_token_type_tags,
+            _bridge_pause_tx,
+        ) = setup().await;
+        let mut id_token_map: HashMap<u8, TypeTag> = (*sui_token_type_tags.load().clone()).clone();
+        let (action_certificate, _, _) = get_bridge_authority_approved_action(
+            vec![&mock0, &mock1, &mock2, &mock3],
+            vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+            Some(new_token_id),
+            false, // we need an eth -> sui action that entails the new token type tag in transaction building
+        );
+
+        let action = action_certificate.data().clone();
+        let arg = DUMMY_MUTALBE_BRIDGE_OBJECT_ARG;
+        let tx_data = build_sui_transaction(
+            sui_address,
+            &gas_object_ref,
+            action_certificate.clone(),
+            arg,
+            &maplit::hashmap! {
+                new_token_id => new_type_tag.clone()
+            },
+            1000,
+        )
+        .unwrap();
+        let tx_digest = get_tx_digest(tx_data, &dummy_sui_key);
+        mock_transaction_error(
+            &sui_client_mock,
+            tx_digest,
+            BridgeError::Generic("some random error".to_string()),
+            true,
+        );
+
+        let gas_coin = GasCoin::new_for_testing(1_000_000_000_000); // dummy gas coin
+        sui_client_mock.add_gas_object_info(
+            gas_coin.clone(),
+            gas_object_ref,
+            Owner::AddressOwner(sui_address),
+        );
+        sui_client_mock.set_action_onchain_status(&action, BridgeActionStatus::Pending);
+
+        // Kick it (send to the execution queue, skipping the signing queue)
+        execution_tx
+            .send(CertifiedBridgeActionExecutionWrapper(
+                action_certificate.clone(),
+                0,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        // Nothing is sent to execute, because the token id does not exist yet
+        assert_eq!(
+            tx_subscription.try_recv().unwrap_err(),
+            tokio::sync::broadcast::error::TryRecvError::Empty
+        );
+
+        // Now insert the new token id
+        id_token_map.insert(new_token_id, new_type_tag);
+        sui_token_type_tags.store(Arc::new(id_token_map));
+
+        // Kick it again
+        execution_tx
+            .send(CertifiedBridgeActionExecutionWrapper(
+                action_certificate.clone(),
+                0,
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        // The action is sent to execution
+        assert_eq!(tx_subscription.recv().await.unwrap(), tx_digest);
     }
 
     fn mock_bridge_authority_sigs(
@@ -1298,18 +1383,24 @@ mod tests {
     fn get_bridge_authority_approved_action(
         mocks: Vec<&BridgeRequestMockHandler>,
         secrets: Vec<&BridgeAuthorityKeyPair>,
+        token_id: Option<u8>,
+        sui_to_eth: bool,
     ) -> (VerifiedCertifiedBridgeAction, TransactionDigest, u16) {
         let sui_tx_digest = TransactionDigest::random();
         let sui_tx_event_index = 1;
-        let action = get_test_sui_to_eth_bridge_action(
-            Some(sui_tx_digest),
-            Some(sui_tx_event_index),
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let action = if sui_to_eth {
+            get_test_sui_to_eth_bridge_action(
+                Some(sui_tx_digest),
+                Some(sui_tx_event_index),
+                None,
+                None,
+                None,
+                None,
+                token_id,
+            )
+        } else {
+            get_test_eth_to_sui_bridge_action(None, None, None, token_id)
+        };
 
         let sigs =
             mock_bridge_authority_sigs(mocks, &action, secrets, sui_tx_digest, sui_tx_event_index);
@@ -1385,7 +1476,7 @@ mod tests {
         Vec<tokio::task::JoinHandle<()>>,
         ObjectRef,
         SuiAddress,
-        tokio::sync::watch::Sender<HashMap<u8, TypeTag>>,
+        Arc<ArcSwap<HashMap<u8, TypeTag>>>,
         tokio::sync::watch::Sender<IsBridgePaused>,
     ) {
         telemetry_subscribers::init_for_testing();
@@ -1424,8 +1515,7 @@ mod tests {
         ))));
         let metrics = Arc::new(BridgeMetrics::new(&registry));
         let sui_token_type_tags = sui_client.get_token_id_map().await.unwrap();
-        let (token_type_tags_tx, token_type_tags_rx) =
-            tokio::sync::watch::channel(sui_token_type_tags);
+        let sui_token_type_tags = Arc::new(ArcSwap::new(Arc::new(sui_token_type_tags)));
         let (bridge_pause_tx, bridge_pause_rx) = tokio::sync::watch::channel(false);
         let executor = BridgeActionExecutor::new(
             sui_client.clone(),
@@ -1434,7 +1524,7 @@ mod tests {
             sui_key,
             sui_address,
             gas_object_ref.0,
-            token_type_tags_rx,
+            sui_token_type_tags.clone(),
             bridge_pause_rx,
             metrics,
         )
@@ -1458,7 +1548,7 @@ mod tests {
             handles,
             gas_object_ref,
             sui_address,
-            token_type_tags_tx,
+            sui_token_type_tags,
             bridge_pause_tx,
         )
     }

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 
 use crate::abi::EthBridgeEvent;
 use crate::error::{BridgeError, BridgeResult};
+use crate::metered_eth_provider::{new_metered_eth_provider, MeteredEthHttpProvier};
 use crate::metrics::BridgeMetrics;
 use crate::types::{BridgeAction, EthLog, RawEthLog};
-use ethers::providers::{Http, JsonRpcClient, Middleware, Provider};
+use ethers::providers::{JsonRpcClient, Middleware, Provider};
 use ethers::types::TxHash;
 use ethers::types::{Block, Filter};
-use tap::{Tap, TapFallible};
+use tap::TapFallible;
 
 #[cfg(test)]
 use crate::eth_mock_provider::EthMockProvider;
@@ -19,20 +20,18 @@ use ethers::types::Address as EthAddress;
 pub struct EthClient<P> {
     provider: Provider<P>,
     contract_addresses: HashSet<EthAddress>,
-    metrics: Arc<BridgeMetrics>,
 }
 
-impl EthClient<Http> {
+impl EthClient<MeteredEthHttpProvier> {
     pub async fn new(
         provider_url: &str,
         contract_addresses: HashSet<EthAddress>,
         metrics: Arc<BridgeMetrics>,
     ) -> anyhow::Result<Self> {
-        let provider = Provider::try_from(provider_url)?;
+        let provider = new_metered_eth_provider(provider_url, metrics)?;
         let self_ = Self {
             provider,
             contract_addresses,
-            metrics,
         };
         self_.describe().await?;
         Ok(self_)
@@ -46,7 +45,6 @@ impl EthClient<EthMockProvider> {
         Self {
             provider,
             contract_addresses,
-            metrics: Arc::new(BridgeMetrics::new_for_testing()),
         }
     }
 }
@@ -77,7 +75,6 @@ where
             .provider
             .get_transaction_receipt(tx_hash)
             .await
-            .tap(|_| self.metrics.eth_provider_queries.inc())
             .map_err(BridgeError::from)?
             .ok_or(BridgeError::TxNotFound)?;
         let receipt_block_num = receipt.block_number.ok_or(BridgeError::ProviderError(
@@ -115,8 +112,7 @@ where
         let block: Result<Option<Block<ethers::types::TxHash>>, ethers::prelude::ProviderError> =
             self.provider
                 .request("eth_getBlockByNumber", ("finalized", false))
-                .await
-                .tap(|_| self.metrics.eth_provider_queries.inc());
+                .await;
         let block = block?.ok_or(BridgeError::TransientProviderError(
             "Provider fails to return last finalized block".into(),
         ))?;
@@ -140,9 +136,9 @@ where
             .address(address);
         let logs = self
             .provider
+            // TODO use get_logs_paginated?
             .get_logs(&filter)
             .await
-            .tap(|_| self.metrics.eth_provider_queries.inc())
             .map_err(BridgeError::from)
             .tap_err(|e| {
                 tracing::error!(
@@ -193,7 +189,6 @@ where
             .provider
             .get_logs(&filter)
             .await
-            .tap(|_| self.metrics.eth_provider_queries.inc())
             .map_err(BridgeError::from)
             .tap_err(|e| {
                 tracing::error!(
@@ -241,7 +236,6 @@ where
             .provider
             .get_transaction_receipt(tx_hash)
             .await
-            .tap(|_| self.metrics.eth_provider_queries.inc())
             .map_err(BridgeError::from)?
             .ok_or(BridgeError::ProviderError(format!(
                 "Provide cannot find eth transaction for log: {:?})",

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -12,6 +12,7 @@ pub mod eth_client;
 pub mod eth_syncer;
 pub mod eth_transaction_builder;
 pub mod events;
+pub mod metered_eth_provider;
 pub mod metrics;
 pub mod monitor;
 pub mod node;

--- a/crates/sui-bridge/src/metered_eth_provider.rs
+++ b/crates/sui-bridge/src/metered_eth_provider.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metrics::BridgeMetrics;
+use ethers::providers::{Http, HttpClientError, JsonRpcClient, Provider};
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+use std::sync::Arc;
+use url::{ParseError, Url};
+
+#[derive(Debug, Clone)]
+pub struct MeteredEthHttpProvier {
+    inner: Http,
+    metrics: Arc<BridgeMetrics>,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl JsonRpcClient for MeteredEthHttpProvier {
+    type Error = HttpClientError;
+
+    async fn request<T: Serialize + Send + Sync + Debug, R: DeserializeOwned + Send>(
+        &self,
+        method: &str,
+        params: T,
+    ) -> Result<R, HttpClientError> {
+        self.metrics
+            .eth_rpc_queries
+            .with_label_values(&[method])
+            .inc();
+        let _guard = self
+            .metrics
+            .eth_rpc_queries_latency
+            .with_label_values(&[method])
+            .start_timer();
+        self.inner.request(method, params).await
+    }
+}
+
+impl MeteredEthHttpProvier {
+    pub fn new(url: impl Into<Url>, metrics: Arc<BridgeMetrics>) -> Self {
+        let inner = Http::new(url);
+        Self { inner, metrics }
+    }
+}
+
+pub fn new_metered_eth_provider(
+    url: &str,
+    metrics: Arc<BridgeMetrics>,
+) -> Result<Provider<MeteredEthHttpProvier>, ParseError> {
+    let http_provider = MeteredEthHttpProvier::new(Url::parse(url)?, metrics);
+    Ok(Provider::new(http_provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::providers::Middleware;
+    use prometheus::Registry;
+
+    #[tokio::test]
+    async fn test_metered_eth_provider() {
+        let metrics = Arc::new(BridgeMetrics::new(&Registry::new()));
+        let provider = new_metered_eth_provider("http://localhost:9876", metrics.clone()).unwrap();
+
+        assert_eq!(
+            metrics
+                .eth_rpc_queries
+                .get_metric_with_label_values(&["eth_blockNumber"])
+                .unwrap()
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .eth_rpc_queries_latency
+                .get_metric_with_label_values(&["eth_blockNumber"])
+                .unwrap()
+                .get_sample_count(),
+            0
+        );
+
+        provider.get_block_number().await.unwrap_err(); // the rpc cal will fail but we don't care
+
+        assert_eq!(
+            metrics
+                .eth_rpc_queries
+                .get_metric_with_label_values(&["eth_blockNumber"])
+                .unwrap()
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .eth_rpc_queries_latency
+                .get_metric_with_label_values(&["eth_blockNumber"])
+                .unwrap()
+                .get_sample_count(),
+            1
+        );
+    }
+}

--- a/crates/sui-bridge/src/metrics.rs
+++ b/crates/sui-bridge/src/metrics.rs
@@ -33,6 +33,7 @@ pub struct BridgeMetrics {
     pub(crate) action_executor_signing_queue_received_actions: IntCounter,
     pub(crate) action_executor_signing_queue_skipped_actions: IntCounter,
     pub(crate) action_executor_execution_queue_received_actions: IntCounter,
+    pub(crate) action_executor_execution_queue_skipped_actions_due_to_pausing: IntCounter,
 
     pub(crate) signer_with_cache_hit: IntCounterVec,
     pub(crate) signer_with_cache_miss: IntCounterVec,
@@ -159,6 +160,12 @@ impl BridgeMetrics {
             action_executor_execution_queue_received_actions: register_int_counter_with_registry!(
                 "bridge_action_executor_execution_queue_received_actions",
                 "Total number of received actions in action executor execution queue",
+                registry,
+            )
+            .unwrap(),
+            action_executor_execution_queue_skipped_actions_due_to_pausing: register_int_counter_with_registry!(
+                "bridge_action_executor_execution_queue_skipped_actions_due_to_pausing",
+                "Total number of skipped actions in action executor execution queue because of pausing",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge/src/metrics.rs
+++ b/crates/sui-bridge/src/metrics.rs
@@ -2,12 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntCounter,
-    IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Registry,
 };
 
-#[derive(Clone)]
+const FINE_GRAINED_LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9,
+    1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5,
+    10., 15., 20., 25., 30., 35., 40., 45., 50., 60., 70., 80., 90., 100., 120., 140., 160., 180.,
+    200., 250., 300., 350., 400.,
+];
+
+#[derive(Clone, Debug)]
 pub struct BridgeMetrics {
     pub(crate) err_build_sui_transaction: IntCounter,
     pub(crate) err_signature_aggregation: IntCounter,
@@ -38,7 +46,9 @@ pub struct BridgeMetrics {
     pub(crate) signer_with_cache_hit: IntCounterVec,
     pub(crate) signer_with_cache_miss: IntCounterVec,
 
-    pub(crate) eth_provider_queries: IntCounter,
+    pub(crate) eth_rpc_queries: IntCounterVec,
+    pub(crate) eth_rpc_queries_latency: HistogramVec,
+
     pub(crate) gas_coin_balance: IntGauge,
 }
 
@@ -175,9 +185,18 @@ impl BridgeMetrics {
                 registry,
             )
             .unwrap(),
-            eth_provider_queries: register_int_counter_with_registry!(
-                "bridge_eth_provider_queries",
-                "Total number of queries issued to eth provider",
+            eth_rpc_queries: register_int_counter_vec_with_registry!(
+                "bridge_eth_rpc_queries",
+                "Total number of queries issued to eth provider, by request type",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            eth_rpc_queries_latency: register_histogram_vec_with_registry!(
+                "bridge_eth_rpc_queries_latency",
+                "Latency of queries issued to eth provider, by request type",
+                &["type"],
+                FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -18,10 +18,9 @@ use crate::sui_client::{SuiClient, SuiClientInner};
 use crate::types::EthLog;
 use ethers::types::Address as EthAddress;
 use mysten_metrics::spawn_logged_monitored_task;
-use std::collections::HashMap;
 use std::sync::Arc;
 use sui_json_rpc_types::SuiEvent;
-use sui_types::{Identifier, TypeTag};
+use sui_types::Identifier;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
@@ -30,7 +29,6 @@ pub struct BridgeOrchestrator<C> {
     sui_events_rx: mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
     eth_events_rx: mysten_metrics::metered_channel::Receiver<(EthAddress, u64, Vec<EthLog>)>,
     store: Arc<BridgeOrchestratorTables>,
-    token_type_tags_tx: tokio::sync::watch::Sender<HashMap<u8, TypeTag>>,
     monitor_tx: mysten_metrics::metered_channel::Sender<SuiBridgeEvent>,
     metrics: Arc<BridgeMetrics>,
 }
@@ -44,7 +42,6 @@ where
         sui_events_rx: mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
         eth_events_rx: mysten_metrics::metered_channel::Receiver<(EthAddress, u64, Vec<EthLog>)>,
         store: Arc<BridgeOrchestratorTables>,
-        token_type_tags_tx: tokio::sync::watch::Sender<HashMap<u8, TypeTag>>,
         monitor_tx: mysten_metrics::metered_channel::Sender<SuiBridgeEvent>,
         metrics: Arc<BridgeMetrics>,
     ) -> Self {
@@ -53,7 +50,6 @@ where
             sui_events_rx,
             eth_events_rx,
             store,
-            token_type_tags_tx,
             monitor_tx,
             metrics,
         }
@@ -76,7 +72,6 @@ where
             store_clone,
             executor_sender_clone,
             self.sui_events_rx,
-            self.token_type_tags_tx,
             self.monitor_tx,
             metrics_clone,
         )));
@@ -101,7 +96,6 @@ where
             metrics_clone,
         )));
 
-        // TODO: spawn bridge committee change watcher task
         task_handles
     }
 
@@ -109,12 +103,10 @@ where
         store: Arc<BridgeOrchestratorTables>,
         executor_tx: mysten_metrics::metered_channel::Sender<BridgeActionExecutionWrapper>,
         mut sui_events_rx: mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
-        token_type_tags_tx: tokio::sync::watch::Sender<HashMap<u8, TypeTag>>,
         monitor_tx: mysten_metrics::metered_channel::Sender<SuiBridgeEvent>,
         metrics: Arc<BridgeMetrics>,
     ) {
         info!("Starting sui watcher task");
-        let mut latest_token_config = token_type_tags_tx.borrow().clone();
         while let Some((identifier, events)) = sui_events_rx.recv().await {
             if events.is_empty() {
                 continue;
@@ -161,30 +153,11 @@ where
                     .await
                     .expect("Sending event to monitor channel should not fail");
 
-                // Handle NewTokenEvent
-                // TODO: broadcast this event and let the downstream services handle it
-                if let SuiBridgeEvent::NewTokenEvent(e) = &bridge_event {
-                    if let std::collections::hash_map::Entry::Vacant(entry) =
-                        latest_token_config.entry(e.token_id)
-                    {
-                        entry.insert(e.type_name.clone());
-                        token_type_tags_tx
-                            .send(latest_token_config.clone())
-                            .expect("Sending token type tag should not fail");
-                    } else {
-                        // invariant
-                        assert_eq!(e.type_name, latest_token_config[&e.token_id]);
-                    }
-                    continue;
-                }
-
                 if let Some(action) = bridge_event
                     .try_into_bridge_action(sui_event.id.tx_digest, sui_event.id.event_seq as u16)
                 {
                     actions.push(action);
                 }
-
-                // TODO: handle non Action events
             }
 
             if !actions.is_empty() {
@@ -290,16 +263,12 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        events::NewTokenEvent,
         test_utils::{get_test_eth_to_sui_bridge_action, get_test_log_and_action},
         types::BridgeActionDigest,
     };
     use ethers::types::{Address as EthAddress, TxHash};
-    use maplit::hashmap;
     use prometheus::Registry;
     use std::str::FromStr;
-    use sui_types::digests::TransactionDigest;
-    use tokio::time::Duration;
 
     use super::*;
     use crate::events::init_all_struct_tags;
@@ -322,7 +291,6 @@ mod tests {
             store,
         ) = setup();
         let (executor, mut executor_requested_action_rx) = MockExecutor::new();
-        let (token_type_tags_tx, _token_type_tags_rx) = tokio::sync::watch::channel(HashMap::new());
         // start orchestrator
         let registry = Registry::new();
         let metrics = Arc::new(BridgeMetrics::new(&registry));
@@ -331,7 +299,6 @@ mod tests {
             sui_events_rx,
             eth_events_rx,
             store.clone(),
-            token_type_tags_tx,
             monitor_tx,
             metrics,
         )
@@ -372,77 +339,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sui_watcher_task_add_new_token() {
-        let (
-            sui_events_tx,
-            sui_events_rx,
-            _eth_events_tx,
-            eth_events_rx,
-            monitor_tx,
-            _monitor_rx,
-            sui_client,
-            store,
-        ) = setup();
-
-        let (executor, _executor_requested_action_rx) = MockExecutor::new();
-        let (token_type_tags_tx, mut token_type_tags_rx) =
-            tokio::sync::watch::channel(HashMap::new());
-        // start orchestrator
-        let registry = Registry::new();
-        let metrics = Arc::new(BridgeMetrics::new(&registry));
-        let _handles = BridgeOrchestrator::new(
-            Arc::new(sui_client),
-            sui_events_rx,
-            eth_events_rx,
-            store.clone(),
-            token_type_tags_tx,
-            monitor_tx,
-            metrics,
-        )
-        .run(executor)
-        .await;
-
-        let identifier = Identifier::from_str("test_sui_watcher_task_add_new_token").unwrap();
-        let type_tag = TypeTag::from_str("0xbeef::beef::BEEF").unwrap();
-        let emitted_event = crate::events::MoveNewTokenEvent {
-            token_id: 255,
-            type_name: type_tag.to_canonical_string(false),
-            native_token: false,
-            decimal_multiplier: 1000000,
-            notional_value: 100000000,
-        };
-
-        let sui_event = SuiEvent {
-            type_: NewTokenEvent.get().unwrap().clone(),
-            bcs: bcs::to_bytes(&emitted_event).unwrap(),
-            id: sui_types::event::EventID {
-                tx_digest: TransactionDigest::random(),
-                event_seq: 1,
-            },
-
-            // The following fields do not matter as of writing,
-            // but if tests start to fail, it's worth checking these fields.
-            package_id: sui_types::base_types::ObjectID::ZERO,
-            transaction_module: identifier.clone(),
-            sender: sui_types::base_types::SuiAddress::random_for_testing_only(),
-            parsed_json: serde_json::json!({"test": "test"}),
-            timestamp_ms: None,
-        };
-        sui_events_tx
-            .send((identifier.clone(), vec![sui_event.clone()]))
-            .await
-            .unwrap();
-
-        tokio::time::timeout(Duration::from_secs(3), token_type_tags_rx.changed())
-            .await
-            .unwrap()
-            .unwrap();
-
-        let res = token_type_tags_rx.borrow().clone();
-        assert_eq!(res, hashmap! {255u8 => type_tag});
-    }
-
-    #[tokio::test]
     async fn test_eth_watcher_task() {
         // Note: this test may fail beacuse of the following reasons:
         // 1. Log and BridgeAction returned from `get_test_log_and_action` are not in sync
@@ -458,7 +354,6 @@ mod tests {
             sui_client,
             store,
         ) = setup();
-        let (token_type_tags_tx, _token_type_tags_rx) = tokio::sync::watch::channel(HashMap::new());
         let (executor, mut executor_requested_action_rx) = MockExecutor::new();
         // start orchestrator
         let registry = Registry::new();
@@ -468,7 +363,6 @@ mod tests {
             sui_events_rx,
             eth_events_rx,
             store.clone(),
-            token_type_tags_tx,
             monitor_tx,
             metrics,
         )
@@ -531,7 +425,6 @@ mod tests {
             store,
         ) = setup();
         let (executor, mut executor_requested_action_rx) = MockExecutor::new();
-        let (token_type_tags_tx, _token_type_tags_rx) = tokio::sync::watch::channel(HashMap::new());
 
         let action1 = get_test_sui_to_eth_bridge_action(
             None,
@@ -543,7 +436,7 @@ mod tests {
             None,
         );
 
-        let action2 = get_test_eth_to_sui_bridge_action(None, None, None);
+        let action2 = get_test_eth_to_sui_bridge_action(None, None, None, None);
         store
             .insert_pending_actions(&vec![action1.clone(), action2.clone()])
             .unwrap();
@@ -556,7 +449,6 @@ mod tests {
             sui_events_rx,
             eth_events_rx,
             store.clone(),
-            token_type_tags_tx,
             monitor_tx,
             metrics,
         )

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -791,7 +791,7 @@ mod tests {
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // 1. Create a Eth -> Sui Transfer (recipient is sender address), approve with validator secrets and assert its status to be Claimed
-        let action = get_test_eth_to_sui_bridge_action(None, Some(usdc_amount), Some(sender));
+        let action = get_test_eth_to_sui_bridge_action(None, Some(usdc_amount), Some(sender), None);
         let usdc_object_ref = approve_action_with_validator_secrets(
             context,
             bridge_object_arg,

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -669,7 +669,7 @@ mod tests {
         let id_token_map = sui_client.get_token_id_map().await.unwrap();
 
         // 1. Test Eth -> Sui Transfer approval
-        let action = get_test_eth_to_sui_bridge_action(None, Some(usdc_amount), Some(sender));
+        let action = get_test_eth_to_sui_bridge_action(None, Some(usdc_amount), Some(sender), None);
         // `approve_action_with_validator_secrets` covers transaction building
         let usdc_object_ref = approve_action_with_validator_secrets(
             context,

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -103,6 +103,7 @@ pub fn get_test_eth_to_sui_bridge_action(
     nonce: Option<u64>,
     amount: Option<u64>,
     sui_address: Option<SuiAddress>,
+    token_id: Option<u8>,
 ) -> BridgeAction {
     BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
         eth_tx_hash: TxHash::random(),
@@ -111,7 +112,7 @@ pub fn get_test_eth_to_sui_bridge_action(
             eth_chain_id: BridgeChainId::EthCustom,
             nonce: nonce.unwrap_or_default(),
             sui_chain_id: BridgeChainId::SuiCustom,
-            token_id: TOKEN_ID_USDC,
+            token_id: token_id.unwrap_or(TOKEN_ID_USDC),
             sui_adjusted_amount: amount.unwrap_or(100_000),
             sui_address: sui_address.unwrap_or_else(SuiAddress::random_for_testing_only),
             eth_address: EthAddress::random(),

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -664,7 +664,7 @@ mod tests {
         let action = get_test_sui_to_eth_bridge_action(None, None, None, None, None, None, None);
         assert_eq!(action.approval_threshold(), 3334);
 
-        let action = get_test_eth_to_sui_bridge_action(None, None, None);
+        let action = get_test_eth_to_sui_bridge_action(None, None, None, None);
         assert_eq!(action.approval_threshold(), 3334);
 
         let action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {


### PR DESCRIPTION
## Description 

`MeteredEthHttpProvider` counts every eth rpc query and its latency. This will be useful to track the eth rpc usage.

## Test plan 

unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
