### PR TITLE
allow custom validator num in bridge tests

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -157,6 +157,7 @@ async fn test_add_new_coins_on_sui() {
     let mut bridge_test_cluster = BridgeTestClusterBuilder::new()
         .with_eth_env(true)
         .with_bridge_cluster(false)
+        .with_num_validators(3)
         .build()
         .await;
 
@@ -180,7 +181,6 @@ async fn test_add_new_coins_on_sui() {
     info!("Starting bridge cluster");
 
     bridge_test_cluster.set_approved_governance_actions_for_next_start(vec![
-        vec![action.clone()],
         vec![action.clone()],
         vec![action.clone()],
         vec![],
@@ -469,11 +469,19 @@ async fn wait_for_transfer_action_status(
 ) -> Result<(), anyhow::Error> {
     // Wait for the bridge action to be approved
     let now = std::time::Instant::now();
+    info!(
+        "Waiting for onchain status {:?}. chain: {:?}, nonce: {nonce}",
+        status, chain_id as u8
+    );
     loop {
         let res = sui_bridge_client
             .get_token_transfer_action_onchain_status_until_success(chain_id as u8, nonce)
             .await;
         if res == status {
+            info!(
+                "detected on chain status {:?}. chain: {:?}, nonce: {nonce}",
+                status, chain_id as u8
+            );
             return Ok(());
         }
         if now.elapsed().as_secs() > 60 {

--- a/crates/sui-bridge/src/e2e_tests/complex.rs
+++ b/crates/sui-bridge/src/e2e_tests/complex.rs
@@ -35,13 +35,14 @@ async fn test_sui_bridge_paused() {
     // Setup bridge test env
     let bridge_test_cluster = BridgeTestClusterBuilder::new()
         .with_eth_env(true)
+        .with_bridge_cluster(true)
+        .with_num_validators(4)
         .with_approved_governance_actions(vec![
             vec![pause_action.clone(), unpause_action.clone()],
-            vec![pause_action.clone(), unpause_action.clone()],
-            vec![pause_action.clone(), unpause_action.clone()],
+            vec![unpause_action.clone()],
+            vec![unpause_action.clone()],
             vec![],
         ])
-        .with_bridge_cluster(true)
         .build()
         .await;
 

--- a/crates/sui-bridge/src/eth_syncer.rs
+++ b/crates/sui-bridge/src/eth_syncer.rs
@@ -169,7 +169,7 @@ where
                 error!("Failed to get events from eth client after retry");
                 continue;
             };
-            tracing::info!(
+            tracing::debug!(
                 ?contract_address,
                 start_block,
                 end_block,

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -506,6 +506,7 @@ pub mod tests {
         let mut bridge_test_cluster = BridgeTestClusterBuilder::new()
             .with_eth_env(false)
             .with_bridge_cluster(false)
+            .with_num_validators(2)
             .build()
             .await;
 

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -577,6 +577,7 @@ mod tests {
         BridgeTestClusterBuilder::new()
             .with_eth_env(true)
             .with_bridge_cluster(false)
+            .with_num_validators(2)
             .build()
             .await
     }


### PR DESCRIPTION
## Description 

As title, this will make some e2e tests easier to write.
It's worth noting that surprisingly this does not help with fullnode sync up speed in the test, which is the main source of slowness in bridge e2e tests.

## Test plan 

existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
