### PR TITLE
fix: handle nondeterminism in test

### DIFF
--- a/crates/sui-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/sui-e2e-tests/tests/passkey_e2e_tests.rs
@@ -303,7 +303,11 @@ async fn test_passkey_fails_to_verify_sig() {
     let test_cluster = TestClusterBuilder::new().build().await;
     let response = create_credential_and_sign_test_tx(&test_cluster, None, false, false).await;
     let mut modified_sig = response.user_sig_bytes.clone();
-    modified_sig[1] = 0x00;
+    if modified_sig[1] == 0x00 {
+        modified_sig[1] = 0x01;
+    } else {
+        modified_sig[1] = 0x00;
+    }
     let sig = GenericSignature::PasskeyAuthenticator(
         PasskeyAuthenticator::new_for_testing(
             response.authenticator_data,


### PR DESCRIPTION
## Description 

my guess is the modified signature byte is already 0 and does not need modification. fix here is to deterministically flip the byte. 
## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
