### PR TITLE
[move] Mark sui::math as deprecated

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/math.move
+++ b/crates/sui-framework/packages/sui-framework/sources/math.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// DEPRECATED, use the each integer type's individual module instead, e.g. `std::u64`
+#[deprecated(b"Use the each integer type's individual module instead, e.g. `std::u64`")]
 module sui::math {
 
     /// DEPRECATED, use `std::u64::max` instead

--- a/crates/sui-framework/packages/sui-framework/sources/math.move
+++ b/crates/sui-framework/packages/sui-framework/sources/math.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[deprecated(b"Use the each integer type's individual module instead, e.g. `std::u64`")]
+#[deprecated(note = b"Use the each integer type's individual module instead, e.g. `std::u64`")]
 module sui::math {
 
     /// DEPRECATED, use `std::u64::max` instead

--- a/crates/sui-framework/packages/sui-framework/tests/math_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/math_tests.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only]
+#[test_only, allow(deprecated_usage)]
 module sui::math_tests {
     use sui::math;
 


### PR DESCRIPTION
## Description 

- Adds the `deprecated` annotation to `sui::math`

## Test plan 

- Ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: The Move module `sui::math` has been deprecated. The individual integer modules, e.g. `std::u64`, should be used instead.
- [ ] Rust SDK:
- [ ] REST API:
