### PR TITLE
jsonrpc: use ExecuteTransactionRequestV3 when executing a transaction

### DIFF
--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -36,8 +36,7 @@ use sui_types::messages_grpc::TransactionInfoRequest;
 use sui_types::object::{Object, ObjectRead, Owner, PastObjectRead};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::quorum_driver_types::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    QuorumDriverResponse,
+    ExecuteTransactionRequestType, ExecuteTransactionRequestV3, QuorumDriverResponse,
 };
 use sui_types::storage::ObjectStore;
 use sui_types::transaction::{
@@ -754,16 +753,13 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequest {
-                transaction: txn,
-                request_type: ExecuteTransactionRequestType::WaitForLocalExecution,
-            },
+            ExecuteTransactionRequestV3::new_v2(txn),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
             None,
         )
         .await
         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
 
-    let ExecuteTransactionResponse::EffectsCert(res) = res;
     let (
         tx,
         QuorumDriverResponse {
@@ -772,11 +768,17 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
             ..
         },
     ) = rx.recv().await.unwrap().unwrap();
-    let (cte, events, is_executed_locally) = *res;
+    let (response, is_executed_locally) = res;
     assert_eq!(*tx.digest(), digest);
-    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
+    assert_eq!(
+        response.effects.effects.digest(),
+        *certified_txn_effects.digest()
+    );
     assert!(is_executed_locally);
-    assert_eq!(events.digest(), txn_events.unwrap_or_default().digest());
+    assert_eq!(
+        response.events.unwrap_or_default().digest(),
+        txn_events.unwrap_or_default().digest()
+    );
     // verify that the node has sequenced and executed the txn
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store.clone()).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForLocalExecution: {:?}", digest, e));
@@ -786,16 +788,13 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequest {
-                transaction: txn,
-                request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
-            },
+            ExecuteTransactionRequestV3::new_v2(txn),
+            ExecuteTransactionRequestType::WaitForEffectsCert,
             None,
         )
         .await
         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
 
-    let ExecuteTransactionResponse::EffectsCert(res) = res;
     let (
         tx,
         QuorumDriverResponse {
@@ -804,10 +803,16 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
             ..
         },
     ) = rx.recv().await.unwrap().unwrap();
-    let (cte, events, is_executed_locally) = *res;
+    let (response, is_executed_locally) = res;
     assert_eq!(*tx.digest(), digest);
-    assert_eq!(cte.effects.digest(), *certified_txn_effects.digest());
-    assert_eq!(txn_events.unwrap_or_default().digest(), events.digest());
+    assert_eq!(
+        response.effects.effects.digest(),
+        *certified_txn_effects.digest()
+    );
+    assert_eq!(
+        txn_events.unwrap_or_default().digest(),
+        response.events.unwrap_or_default().digest()
+    );
     assert!(!is_executed_locally);
     fullnode
         .state()
@@ -1189,10 +1194,8 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
     let digest = *tx.digest();
     let _res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequest {
-                transaction: tx,
-                request_type: ExecuteTransactionRequestType::WaitForLocalExecution,
-            },
+            ExecuteTransactionRequestV3::new_v2(tx),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
             None,
         )
         .await

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -26,7 +26,7 @@ use sui_types::crypto::default_hash;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::quorum_driver_types::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
+    ExecuteTransactionRequestType, ExecuteTransactionRequestV3, ExecuteTransactionResponseV3,
 };
 use sui_types::signature::GenericSignature;
 use sui_types::sui_serde::BigInt;
@@ -75,11 +75,10 @@ impl TransactionExecutionApi {
         tx_bytes: Base64,
         signatures: Vec<Base64>,
         opts: Option<SuiTransactionBlockResponseOptions>,
-        request_type: Option<ExecuteTransactionRequestType>,
     ) -> Result<
         (
+            ExecuteTransactionRequestV3,
             SuiTransactionBlockResponseOptions,
-            ExecuteTransactionRequestType,
             SuiAddress,
             Vec<InputObjectKind>,
             Transaction,
@@ -89,12 +88,7 @@ impl TransactionExecutionApi {
         SuiRpcInputError,
     > {
         let opts = opts.unwrap_or_default();
-        let request_type = match (request_type, opts.require_local_execution()) {
-            (Some(ExecuteTransactionRequestType::WaitForEffectsCert), true) => {
-                Err(SuiRpcInputError::InvalidExecuteTransactionRequestType)?
-            }
-            (t, _) => t.unwrap_or_else(|| opts.default_execution_request_type()),
-        };
+
         let tx_data: TransactionData = self.convert_bytes(tx_bytes)?;
         let sender = tx_data.sender();
         let input_objs = tx_data.input_objects().unwrap_or_default();
@@ -118,9 +112,18 @@ impl TransactionExecutionApi {
         } else {
             None
         };
+
+        let request = ExecuteTransactionRequestV3 {
+            transaction: txn.clone(),
+            include_events: opts.show_events,
+            include_input_objects: opts.show_balance_changes || opts.show_object_changes,
+            include_output_objects: opts.show_balance_changes || opts.show_object_changes,
+            include_auxiliary_data: false,
+        };
+
         Ok((
+            request,
             opts,
-            request_type,
             sender,
             input_objs,
             txn,
@@ -136,25 +139,24 @@ impl TransactionExecutionApi {
         opts: Option<SuiTransactionBlockResponseOptions>,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> Result<SuiTransactionBlockResponse, Error> {
-        let (opts, request_type, sender, input_objs, txn, transaction, raw_transaction) =
-            self.prepare_execute_transaction_block(tx_bytes, signatures, opts, request_type)?;
+        let request_type =
+            request_type.unwrap_or(ExecuteTransactionRequestType::WaitForEffectsCert);
+        let (request, opts, sender, input_objs, txn, transaction, raw_transaction) =
+            self.prepare_execute_transaction_block(tx_bytes, signatures, opts)?;
         let digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let orch_timer = self.metrics.orchestrator_latency_ms.start_timer();
-        let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction_block(
-            ExecuteTransactionRequest {
-                transaction: txn,
-                request_type,
-            },
-            None,
-        ))
+        let (response, is_executed_locally) = spawn_monitored_task!(
+            transaction_orchestrator.execute_transaction_block(request, request_type, None)
+        )
         .await?
         .map_err(Error::from)?;
         drop(orch_timer);
 
         self.handle_post_orchestration(
             response,
+            is_executed_locally,
             opts,
             digest,
             input_objs,
@@ -167,7 +169,8 @@ impl TransactionExecutionApi {
 
     async fn handle_post_orchestration(
         &self,
-        response: ExecuteTransactionResponse,
+        response: ExecuteTransactionResponseV3,
+        is_executed_locally: bool,
         opts: SuiTransactionBlockResponseOptions,
         digest: TransactionDigest,
         input_objs: Vec<InputObjectKind>,
@@ -176,49 +179,57 @@ impl TransactionExecutionApi {
         sender: SuiAddress,
     ) -> Result<SuiTransactionBlockResponse, Error> {
         let _post_orch_timer = self.metrics.post_orchestrator_latency_ms.start_timer();
-        let ExecuteTransactionResponse::EffectsCert(cert) = response;
-        let (effects, transaction_events, is_executed_locally) = *cert;
-        let mut events: Option<SuiTransactionBlockEvents> = None;
-        if opts.show_events {
-            let epoch_store = self.state.load_epoch_store_one_call_per_task();
-            let backing_package_store = self.state.get_backing_package_store();
-            let mut layout_resolver = epoch_store
-                .executor()
-                .type_layout_resolver(Box::new(backing_package_store.as_ref()));
-            events = Some(SuiTransactionBlockEvents::try_from(
-                transaction_events,
-                digest,
-                None,
-                layout_resolver.as_mut(),
-            )?);
-        }
 
-        let object_cache = ObjectProviderCache::new(self.state.clone());
-        let balance_changes = if opts.show_balance_changes && is_executed_locally {
-            Some(
-                get_balance_changes_from_effect(&object_cache, &effects.effects, input_objs, None)
-                    .await?,
-            )
-        } else {
-            None
+        let events = match response.events {
+            Some(events) if opts.show_events => {
+                let epoch_store = self.state.load_epoch_store_one_call_per_task();
+                let backing_package_store = self.state.get_backing_package_store();
+                let mut layout_resolver = epoch_store
+                    .executor()
+                    .type_layout_resolver(Box::new(backing_package_store.as_ref()));
+                Some(SuiTransactionBlockEvents::try_from(
+                    events,
+                    digest,
+                    None,
+                    layout_resolver.as_mut(),
+                )?)
+            }
+            _ => None,
         };
-        let object_changes = if opts.show_object_changes && is_executed_locally {
-            Some(
-                get_object_changes(
-                    &object_cache,
-                    sender,
-                    effects.effects.modified_at_versions(),
-                    effects.effects.all_changed_objects(),
-                    effects.effects.all_removed_objects(),
+
+        let object_cache = response.output_objects.map(|output_objects| {
+            ObjectProviderCache::new_with_output_objects(self.state.clone(), output_objects)
+        });
+
+        let balance_changes = match &object_cache {
+            Some(object_cache) if opts.show_balance_changes => Some(
+                get_balance_changes_from_effect(
+                    object_cache,
+                    &response.effects.effects,
+                    input_objs,
+                    None,
                 )
                 .await?,
-            )
-        } else {
-            None
+            ),
+            _ => None,
+        };
+
+        let object_changes = match &object_cache {
+            Some(object_cache) if opts.show_object_changes => Some(
+                get_object_changes(
+                    object_cache,
+                    sender,
+                    response.effects.effects.modified_at_versions(),
+                    response.effects.effects.all_changed_objects(),
+                    response.effects.effects.all_removed_objects(),
+                )
+                .await?,
+            ),
+            _ => None,
         };
 
         let raw_effects = if opts.show_raw_effects {
-            bcs::to_bytes(&effects.effects)?
+            bcs::to_bytes(&response.effects.effects)?
         } else {
             vec![]
         };
@@ -227,7 +238,9 @@ impl TransactionExecutionApi {
             digest,
             transaction,
             raw_transaction,
-            effects: opts.show_effects.then_some(effects.effects.try_into()?),
+            effects: opts
+                .show_effects
+                .then_some(response.effects.effects.try_into()?),
             events,
             object_changes,
             balance_changes,

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -608,9 +608,6 @@ describe('GraphQL SuiClient compatibility', () => {
 				},
 			})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 
-		// Deleted gas coin isn't included in changes when executing transaction block
-		rpc.objectChanges?.pop();
-
 		expect(graphql).toEqual(rpc);
 	});
 


### PR DESCRIPTION
    This patch deprecates the `WaitForLocalExecution` request type that was
    previously relied upon to calculate object and balance changes. Instead
    the new `ExecuteTransactionRequestV3` functionality is used to request
    output object data directly from the validators so that we no longer
    need to rely on waiting for local execution.

    The `WaitForLocalExecution` feature still exists and will still properly
    wait to return a response to a client until after the transaction is
    executed locally in order to retain the Read-after-Write semantics that
    some clients may presently rely on.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
