### PR TITLE
[bridge] extend add coin e2e test to cover evm side, and a bug fix

### DIFF
--- a/bridge/evm/script/deploy_bridge.s.sol
+++ b/bridge/evm/script/deploy_bridge.s.sol
@@ -44,6 +44,8 @@ contract DeployBridge is Script {
             MockWBTC wBTC = new MockWBTC();
             MockUSDC USDC = new MockUSDC();
             MockUSDT USDT = new MockUSDT();
+            MockKA KA = new MockKA();
+            console.log("[Deployed] KA:", address(KA));
 
             // update deployConfig with mock addresses
             deployConfig.supportedTokens = new address[](5);

--- a/bridge/evm/test/mocks/MockTokens.sol
+++ b/bridge/evm/test/mocks/MockTokens.sol
@@ -57,6 +57,24 @@ contract MockUSDT is ERC20 {
     function testSkip() public {}
 }
 
+contract MockKA is ERC20 {
+    constructor() ERC20("Ka Coin", "KA") {}
+
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
+
+    function burn(address form, uint256 amount) public virtual {
+        _burn(form, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return 9;
+    }
+
+    function testSkip() public {}
+}
+
 contract WETH {
     string public name = "Wrapped Ether";
     string public symbol = "WETH";

--- a/crates/sui-bridge/abi/erc20.json
+++ b/crates/sui-bridge/abi/erc20.json
@@ -1,0 +1,358 @@
+[
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "form",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burn",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "testSkip",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+]

--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -88,6 +88,12 @@ gen_eth_events!(
 
 gen_eth_events!(EthBridgeVault, "abi/bridge_vault.json");
 
+abigen!(
+    EthERC20,
+    "abi/erc20.json",
+    event_derives(serde::Deserialize, serde::Serialize)
+);
+
 impl EthBridgeEvent {
     pub fn try_into_bridge_action(
         self,

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -1,16 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::abi::{eth_sui_bridge, EthBridgeEvent, EthSuiBridge};
+use crate::abi::{eth_sui_bridge, EthBridgeEvent, EthERC20, EthSuiBridge};
 use crate::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
 use crate::e2e_tests::test_utils::BridgeTestCluster;
-use crate::e2e_tests::test_utils::{get_signatures, BridgeTestClusterBuilder};
+use crate::e2e_tests::test_utils::{
+    get_signatures, send_eth_tx_and_get_tx_receipt, BridgeTestClusterBuilder,
+};
+use crate::eth_transaction_builder::build_eth_transaction;
 use crate::events::{
     SuiBridgeEvent, SuiToEthTokenBridgeV1, TokenTransferApproved, TokenTransferClaimed,
 };
 use crate::sui_client::SuiBridgeClient;
 use crate::sui_transaction_builder::build_add_tokens_on_sui_transaction;
-use crate::types::{BridgeAction, BridgeActionStatus, SuiToEthBridgeAction};
+use crate::types::{AddTokensOnEvmAction, BridgeAction, BridgeActionStatus, SuiToEthBridgeAction};
 use crate::utils::publish_and_register_coins_return_add_coins_on_sui_action;
 use crate::utils::EthSigner;
 use eth_sui_bridge::EthSuiBridgeEvents;
@@ -58,7 +61,7 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
     let amount = 42;
     let sui_amount = amount * 100_000_000;
 
-    initiate_bridge_eth_to_sui(&bridge_test_cluster, amount, sui_amount, TOKEN_ID_ETH, 0)
+    initiate_bridge_eth_to_sui(&bridge_test_cluster, amount, 0)
         .await
         .unwrap();
     let events = bridge_test_cluster
@@ -141,8 +144,9 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
         bridge_test_cluster.contracts().sui_bridge,
         eth_signer.clone().into(),
     );
-    let tx = eth_sui_bridge.transfer_bridged_tokens_with_signatures(signatures, message);
-    let _eth_claim_tx_receipt = tx.send().await.unwrap().await.unwrap().unwrap();
+    let call = eth_sui_bridge.transfer_bridged_tokens_with_signatures(signatures, message);
+    let eth_claim_tx_receipt = send_eth_tx_and_get_tx_receipt(call).await;
+    assert_eq!(eth_claim_tx_receipt.status.unwrap().as_u64(), 1);
     info!("Sui to Eth bridge transfer claimed");
     // Assert eth_address_1 has received ETH
     assert_eq!(
@@ -151,8 +155,10 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
     );
 }
 
+// Test add new coins on both Sui and Eth
+// Also test bridge ndoe handling `NewTokenEvent``
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn test_add_new_coins_on_sui() {
+async fn test_add_new_coins_on_sui_and_eth() {
     telemetry_subscribers::init_for_testing();
     let mut bridge_test_cluster = BridgeTestClusterBuilder::new()
         .with_eth_env(true)
@@ -163,12 +169,13 @@ async fn test_add_new_coins_on_sui() {
 
     let bridge_arg = bridge_test_cluster.get_mut_bridge_arg().await.unwrap();
 
-    // Register tokens
-    let token_id = 42;
+    // Register tokens on Sui
+    let token_id = 5;
+    let token_sui_decimal = 9; // this needs to match ka.move
     let token_price = 10000;
     let sender = bridge_test_cluster.sui_user_address();
     info!("Published new token");
-    let action = publish_and_register_coins_return_add_coins_on_sui_action(
+    let sui_action = publish_and_register_coins_return_add_coins_on_sui_action(
         bridge_test_cluster.wallet(),
         bridge_arg,
         vec![Path::new("../../bridge/move/tokens/mock/ka").into()],
@@ -177,13 +184,23 @@ async fn test_add_new_coins_on_sui() {
         1, // seq num
     )
     .await;
+    let new_token_erc_address = bridge_test_cluster.contracts().ka;
+    let eth_action = BridgeAction::AddTokensOnEvmAction(AddTokensOnEvmAction {
+        nonce: 0,
+        chain_id: BridgeChainId::EthCustom,
+        native: true,
+        token_ids: vec![token_id],
+        token_addresses: vec![new_token_erc_address],
+        token_sui_decimals: vec![token_sui_decimal],
+        token_prices: vec![token_price],
+    });
 
     info!("Starting bridge cluster");
 
     bridge_test_cluster.set_approved_governance_actions_for_next_start(vec![
-        vec![action.clone()],
-        vec![action.clone()],
-        vec![],
+        vec![sui_action.clone(), eth_action.clone()],
+        vec![sui_action.clone()],
+        vec![eth_action.clone()],
     ]);
     bridge_test_cluster.start_bridge_cluster().await;
     bridge_test_cluster
@@ -199,10 +216,14 @@ async fn test_add_new_coins_on_sui() {
             .expect("Failed to get bridge committee"),
     );
     let agg = BridgeAuthorityAggregator::new(bridge_committee);
-    let certified_action = agg
-        .request_committee_signatures(action)
+    let certified_sui_action = agg
+        .request_committee_signatures(sui_action)
         .await
-        .expect("Failed to request committee signatures");
+        .expect("Failed to request committee signatures for AddTokensOnSuiAction");
+    let certified_eth_action = agg
+        .request_committee_signatures(eth_action.clone())
+        .await
+        .expect("Failed to request committee signatures for AddTokensOnEvmAction");
 
     let tx = build_add_tokens_on_sui_transaction(
         sender,
@@ -212,18 +233,26 @@ async fn test_add_new_coins_on_sui() {
             .await
             .unwrap()
             .unwrap(),
-        certified_action,
+        certified_sui_action,
         bridge_arg,
         1000,
     )
     .unwrap();
 
     let response = bridge_test_cluster.sign_and_execute_transaction(&tx).await;
-    assert_eq!(
-        response.effects.unwrap().status(),
-        &SuiExecutionStatus::Success
-    );
-    info!("Approved new token");
+    let effects = response.effects.unwrap();
+    assert_eq!(effects.status(), &SuiExecutionStatus::Success);
+    assert!(response.events.unwrap().data.iter().any(|e| {
+        let sui_bridge_event = SuiBridgeEvent::try_from_sui_event(e).unwrap().unwrap();
+        match sui_bridge_event {
+            SuiBridgeEvent::NewTokenEvent(e) => {
+                assert_eq!(e.token_id, token_id);
+                true
+            }
+            _ => false,
+        }
+    }));
+    info!("Approved new token on Sui");
 
     // Assert new token is correctly added
     let treasury_summary = bridge_test_cluster
@@ -251,6 +280,34 @@ async fn test_add_new_coins_on_sui() {
             native_token: false,
         }
     );
+
+    // Add new token on EVM
+    let config_address = bridge_test_cluster.contracts().bridge_config;
+    let eth_signer = bridge_test_cluster.get_eth_signer().await;
+    let eth_call = build_eth_transaction(config_address, eth_signer, certified_eth_action)
+        .await
+        .unwrap();
+    let eth_receipt = send_eth_tx_and_get_tx_receipt(eth_call).await;
+    assert_eq!(eth_receipt.status.unwrap().as_u64(), 1);
+
+    // Verify new tokens are added on EVM
+    let (address, dp, price) = bridge_test_cluster
+        .eth_env()
+        .get_supported_token(token_id)
+        .await;
+    assert_eq!(address, new_token_erc_address);
+    assert_eq!(dp, 9);
+    assert_eq!(price, token_price);
+
+    initiate_bridge_erc20_to_sui(
+        &bridge_test_cluster,
+        100,
+        new_token_erc_address,
+        token_id,
+        0,
+    )
+    .await
+    .unwrap();
 }
 
 pub(crate) async fn deposit_native_eth_to_sol_contract(
@@ -313,14 +370,100 @@ async fn deposit_eth_to_sui_package(
     wallet_context.execute_transaction_may_fail(tx).await
 }
 
-pub async fn initiate_bridge_eth_to_sui(
+pub async fn initiate_bridge_erc20_to_sui(
     bridge_test_cluster: &BridgeTestCluster,
-    amount: u64,
-    sui_amount: u64,
+    amount_u64: u64,
+    token_address: EthAddress,
     token_id: u8,
     nonce: u64,
 ) -> Result<(), anyhow::Error> {
-    info!("Depositing Eth to Solidity contract");
+    let (eth_signer, eth_address) = bridge_test_cluster
+        .get_eth_signer_and_address()
+        .await
+        .unwrap();
+
+    // First, mint ERC20 tokens to the signer
+    let contract = EthERC20::new(token_address, eth_signer.clone().into());
+    let decimal = contract.decimals().await? as usize;
+    let amount = U256::from(amount_u64) * U256::exp10(decimal);
+    let sui_amount = amount.as_u64();
+    let mint_call = contract.mint(eth_address, amount);
+    let mint_tx_receipt = send_eth_tx_and_get_tx_receipt(mint_call).await;
+    assert_eq!(mint_tx_receipt.status.unwrap().as_u64(), 1);
+
+    // Second, set allowance
+    let allowance_call = contract.approve(bridge_test_cluster.contracts().sui_bridge, amount);
+    let allowance_tx_receipt = send_eth_tx_and_get_tx_receipt(allowance_call).await;
+    assert_eq!(allowance_tx_receipt.status.unwrap().as_u64(), 1);
+
+    // Third, deposit to bridge
+    let sui_recipient_address = bridge_test_cluster.sui_user_address();
+    let sui_chain_id = bridge_test_cluster.sui_chain_id();
+    let eth_chain_id = bridge_test_cluster.eth_chain_id();
+
+    info!(
+        "Depositing ERC20 (token id:{}, token_address: {}) to Solidity contract",
+        token_id, token_address
+    );
+    let contract = EthSuiBridge::new(
+        bridge_test_cluster.contracts().sui_bridge,
+        eth_signer.clone().into(),
+    );
+    let deposit_call = contract.bridge_erc20(
+        token_id,
+        amount,
+        sui_recipient_address.to_vec().into(),
+        sui_chain_id as u8,
+    );
+    let tx_receipt = send_eth_tx_and_get_tx_receipt(deposit_call).await;
+    let eth_bridge_event = tx_receipt
+        .logs
+        .iter()
+        .find_map(EthBridgeEvent::try_from_log)
+        .unwrap();
+    let EthBridgeEvent::EthSuiBridgeEvents(EthSuiBridgeEvents::TokensDepositedFilter(
+        eth_bridge_event,
+    )) = eth_bridge_event
+    else {
+        unreachable!();
+    };
+    // assert eth log matches
+    assert_eq!(eth_bridge_event.source_chain_id, eth_chain_id as u8);
+    assert_eq!(eth_bridge_event.nonce, nonce);
+    assert_eq!(eth_bridge_event.destination_chain_id, sui_chain_id as u8);
+    assert_eq!(eth_bridge_event.token_id, token_id);
+    assert_eq!(eth_bridge_event.sui_adjusted_amount, sui_amount);
+    assert_eq!(eth_bridge_event.sender_address, eth_address);
+    assert_eq!(
+        eth_bridge_event.recipient_address,
+        sui_recipient_address.to_vec()
+    );
+    info!(
+        "Deposited ERC20 (token id:{}, token_address: {}) to Solidity contract",
+        token_id, token_address
+    );
+
+    wait_for_transfer_action_status(
+        bridge_test_cluster.bridge_client(),
+        eth_chain_id,
+        nonce,
+        BridgeActionStatus::Claimed,
+    )
+    .await
+    .tap_ok(|_| {
+        info!(
+            nonce,
+            token_id, amount_u64, "Eth to Sui bridge transfer claimed"
+        );
+    })
+}
+
+pub async fn initiate_bridge_eth_to_sui(
+    bridge_test_cluster: &BridgeTestCluster,
+    amount: u64,
+    nonce: u64,
+) -> Result<(), anyhow::Error> {
+    info!("Depositing native Ether to Solidity contract, nonce: {nonce}, amount: {amount}");
     let (eth_signer, eth_address) = bridge_test_cluster
         .get_eth_signer_and_address()
         .await
@@ -329,6 +472,9 @@ pub async fn initiate_bridge_eth_to_sui(
     let sui_address = bridge_test_cluster.sui_user_address();
     let sui_chain_id = bridge_test_cluster.sui_chain_id();
     let eth_chain_id = bridge_test_cluster.eth_chain_id();
+    let token_id = TOKEN_ID_ETH;
+
+    let sui_amount = (U256::from(amount) * U256::exp10(8)).as_u64(); // DP for Ether on Sui
 
     let eth_tx = deposit_native_eth_to_sol_contract(
         &eth_signer,
@@ -338,8 +484,7 @@ pub async fn initiate_bridge_eth_to_sui(
         amount,
     )
     .await;
-    let pending_tx = eth_tx.send().await.unwrap();
-    let tx_receipt = pending_tx.await.unwrap().unwrap();
+    let tx_receipt = send_eth_tx_and_get_tx_receipt(eth_tx).await;
     let eth_bridge_event = tx_receipt
         .logs
         .iter()
@@ -474,9 +619,16 @@ async fn wait_for_transfer_action_status(
         status, chain_id as u8
     );
     loop {
+        let timer = std::time::Instant::now();
         let res = sui_bridge_client
             .get_token_transfer_action_onchain_status_until_success(chain_id as u8, nonce)
             .await;
+        info!(
+            "get_token_transfer_action_onchain_status_until_success took {:?}, status: {:?}",
+            timer.elapsed(),
+            res
+        );
+
         if res == status {
             info!(
                 "detected on chain status {:?}. chain: {:?}, nonce: {nonce}",

--- a/crates/sui-bridge/src/e2e_tests/complex.rs
+++ b/crates/sui-bridge/src/e2e_tests/complex.rs
@@ -54,7 +54,7 @@ async fn test_sui_bridge_paused() {
     assert!(!bridge_client.get_bridge_summary().await.unwrap().is_frozen);
 
     // try bridge from eth and verify it works on sui
-    initiate_bridge_eth_to_sui(&bridge_test_cluster, 10, 10 * 100_000_000, TOKEN_ID_ETH, 0)
+    initiate_bridge_eth_to_sui(&bridge_test_cluster, 10, 0)
         .await
         .unwrap();
     // verify Eth was transferred to Sui address
@@ -107,9 +107,7 @@ async fn test_sui_bridge_paused() {
     assert!(bridge_client.get_bridge_summary().await.unwrap().is_frozen);
 
     // Transfer from eth to sui should fail on Sui
-    let eth_to_sui_bridge_action =
-        initiate_bridge_eth_to_sui(&bridge_test_cluster, 10, 10 * 100_000_000, TOKEN_ID_ETH, 1)
-            .await;
+    let eth_to_sui_bridge_action = initiate_bridge_eth_to_sui(&bridge_test_cluster, 10, 1).await;
     assert!(eth_to_sui_bridge_action.is_err());
     // message should not be recorded on Sui when the bridge is paused
     let res = bridge_test_cluster

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -24,7 +24,10 @@ use std::{
     time::Duration,
 };
 use sui_types::{
-    bridge::{BRIDGE_COMMITTEE_MODULE_NAME, BRIDGE_MODULE_NAME},
+    bridge::{
+        BRIDGE_COMMITTEE_MODULE_NAME, BRIDGE_LIMITER_MODULE_NAME, BRIDGE_MODULE_NAME,
+        BRIDGE_TREASURY_MODULE_NAME,
+    },
     event::EventID,
     Identifier,
 };
@@ -166,6 +169,8 @@ fn get_sui_modules_to_watch(
     let sui_bridge_modules = vec![
         BRIDGE_MODULE_NAME.to_owned(),
         BRIDGE_COMMITTEE_MODULE_NAME.to_owned(),
+        BRIDGE_TREASURY_MODULE_NAME.to_owned(),
+        BRIDGE_LIMITER_MODULE_NAME.to_owned(),
     ];
     if let Some(cursor) = sui_bridge_module_last_processed_event_id_override {
         info!("Overriding cursor for sui bridge modules to {:?}", cursor);
@@ -315,13 +320,17 @@ mod tests {
         let store = BridgeOrchestratorTables::new(temp_dir.path());
         let bridge_module = BRIDGE_MODULE_NAME.to_owned();
         let committee_module = BRIDGE_COMMITTEE_MODULE_NAME.to_owned();
+        let treasury_module = BRIDGE_TREASURY_MODULE_NAME.to_owned();
+        let limiter_module = BRIDGE_LIMITER_MODULE_NAME.to_owned();
         // No override, no stored watermark, use None
         let sui_modules_to_watch = get_sui_modules_to_watch(&store, None);
         assert_eq!(
             sui_modules_to_watch,
             vec![
                 (bridge_module.clone(), None),
-                (committee_module.clone(), None)
+                (committee_module.clone(), None),
+                (treasury_module.clone(), None),
+                (limiter_module.clone(), None)
             ]
             .into_iter()
             .collect::<HashMap<_, _>>()
@@ -337,7 +346,9 @@ mod tests {
             sui_modules_to_watch,
             vec![
                 (bridge_module.clone(), Some(override_cursor)),
-                (committee_module.clone(), Some(override_cursor))
+                (committee_module.clone(), Some(override_cursor)),
+                (treasury_module.clone(), Some(override_cursor)),
+                (limiter_module.clone(), Some(override_cursor))
             ]
             .into_iter()
             .collect::<HashMap<_, _>>()
@@ -357,7 +368,9 @@ mod tests {
             sui_modules_to_watch,
             vec![
                 (bridge_module.clone(), Some(stored_cursor)),
-                (committee_module.clone(), None)
+                (committee_module.clone(), None),
+                (treasury_module.clone(), None),
+                (limiter_module.clone(), None)
             ]
             .into_iter()
             .collect::<HashMap<_, _>>()
@@ -376,7 +389,9 @@ mod tests {
             sui_modules_to_watch,
             vec![
                 (bridge_module.clone(), Some(override_cursor)),
-                (committee_module.clone(), Some(override_cursor))
+                (committee_module.clone(), Some(override_cursor)),
+                (treasury_module.clone(), Some(override_cursor)),
+                (limiter_module.clone(), Some(override_cursor))
             ]
             .into_iter()
             .collect::<HashMap<_, _>>()

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -34,6 +34,8 @@ pub type BridgeRecordDyanmicField = Field<
 >;
 
 pub const BRIDGE_MODULE_NAME: &IdentStr = ident_str!("bridge");
+pub const BRIDGE_TREASURY_MODULE_NAME: &IdentStr = ident_str!("treasury");
+pub const BRIDGE_LIMITER_MODULE_NAME: &IdentStr = ident_str!("limiter");
 pub const BRIDGE_COMMITTEE_MODULE_NAME: &IdentStr = ident_str!("committee");
 pub const BRIDGE_MESSAGE_MODULE_NAME: &IdentStr = ident_str!("message");
 pub const BRIDGE_CREATE_FUNCTION_NAME: &IdentStr = ident_str!("create");


### PR DESCRIPTION
## Description 

In this PR we extend e2e test `test_add_new_coins_on_sui` to `test_add_new_coins_on_sui_and_eth`, also testing
1. add new coin on Eth
2. bridge node capture the new token event without restarting

Also fixed a bug where bridge node did not listen to move events from treasury.move and limiter.move (caught by the updated e2e tests, apparently)

## Test plan 

e2e tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
