### PR TITLE
feat: enable ambrus aws cognito as zklogin provider

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -241,12 +241,14 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
         "Credenza3".to_string(),
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_LPSLCkC3A".to_string(),
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8".to_string(),
+        "Ambrus".to_string(),
     ]);
     let providers = BTreeSet::from([
         "Google".to_string(),
         "Facebook".to_string(),
         "Twitch".to_string(),
         "Apple".to_string(),
+        "Ambrus".to_string(),
     ]);
     map.insert(Chain::Mainnet, providers.clone());
     map.insert(Chain::Testnet, providers);

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -241,14 +241,13 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
         "Credenza3".to_string(),
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_LPSLCkC3A".to_string(),
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8".to_string(),
-        "Ambrus".to_string(),
     ]);
     let providers = BTreeSet::from([
         "Google".to_string(),
         "Facebook".to_string(),
         "Twitch".to_string(),
         "Apple".to_string(),
-        "Ambrus".to_string(),
+        "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8".to_string(),
     ]);
     map.insert(Chain::Mainnet, providers.clone());
     map.insert(Chain::Testnet, providers);

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -96,14 +96,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -235,14 +235,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -374,14 +374,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -513,14 +513,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -652,14 +652,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -791,14 +791,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -930,14 +930,14 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
       Testnet:
-        - Ambrus
         - Apple
+        - "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8"
         - Facebook
         - Google
         - Twitch
@@ -983,4 +983,3 @@ account_keys:
   - mfPjCoE6SX0Sl84MnmNS/LS+tfPpkn7I8tziuk2g0WM=
   - 5RWlYF22jS9i76zLl8jP2D3D8GC5ht+IP1dWUBGZxi8=
 genesis: "[fake genesis]"
-

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -96,11 +96,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
@@ -233,11 +235,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
@@ -370,11 +374,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
@@ -507,11 +513,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
@@ -644,11 +652,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
@@ -781,11 +791,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
@@ -918,11 +930,13 @@ validator_configs:
     jwk-fetch-interval-seconds: 3600
     zklogin-oauth-providers:
       Mainnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google
         - Twitch
       Testnet:
+        - Ambrus
         - Apple
         - Facebook
         - Google


### PR DESCRIPTION
## Description 

This adds Ambrus aws cognito as a provider in node config - once 2f+1 validators has this in default config for JWKs, its considered active on testnet/mainnet.

Relevant ZK-circuit PR which is merged : https://github.com/MystenLabs/zklogin-circuits/pull/169/files

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
