### PR TITLE
[bridge] add network key + /metrics/network_key rest endpoint

### DIFF
--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -30,7 +30,7 @@ use sui_types::base_types::ObjectRef;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::bridge::BridgeChainId;
 use sui_types::crypto::KeypairTraits;
-use sui_types::crypto::SuiKeyPair;
+use sui_types::crypto::{get_key_pair_from_rng, NetworkKeyPair, SuiKeyPair};
 use sui_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
 use sui_types::event::EventID;
 use sui_types::object::Owner;
@@ -93,7 +93,7 @@ pub struct SuiConfig {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BridgeNodeConfig {
     /// The port that the server listens on.
@@ -114,6 +114,13 @@ pub struct BridgeNodeConfig {
     pub sui: SuiConfig,
     /// Eth configuration
     pub eth: EthConfig,
+    /// Network key used for metrics pushing
+    #[serde(default = "default_ed25519_key_pair")]
+    pub network_key_pair: NetworkKeyPair,
+}
+
+pub fn default_ed25519_key_pair() -> NetworkKeyPair {
+    get_key_pair_from_rng(&mut rand::rngs::OsRng).1
 }
 
 impl Config for BridgeNodeConfig {}

--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -116,7 +116,7 @@ pub struct BridgeNodeConfig {
     pub eth: EthConfig,
     /// Network key used for metrics pushing
     #[serde(default = "default_ed25519_key_pair")]
-    pub network_key_pair: NetworkKeyPair,
+    pub metrics_key_pair: NetworkKeyPair,
 }
 
 pub fn default_ed25519_key_pair() -> NetworkKeyPair {

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -3,6 +3,7 @@
 
 use crate::abi::EthBridgeCommittee;
 use crate::abi::EthBridgeConfig;
+use crate::config::default_ed25519_key_pair;
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::events::*;
@@ -768,12 +769,12 @@ pub(crate) async fn start_bridge_cluster(
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: None,
             },
+            network_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
-        let config_clone = config.clone();
         handles.push(
             run_bridge_node(
-                config_clone,
+                config,
                 BridgeNodePublicMetadata::empty_for_testing(),
                 Registry::new(),
             )

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -769,7 +769,7 @@ pub(crate) async fn start_bridge_cluster(
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: None,
             },
-            network_key_pair: default_ed25519_key_pair(),
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         handles.push(

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let metadata =
-        BridgeNodePublicMetadata::new(VERSION.into(), config.network_key_pair.public().clone());
+        BridgeNodePublicMetadata::new(VERSION.into(), config.metrics_key_pair.public().clone());
 
     Ok(run_bridge_node(config, metadata, prometheus_registry)
         .await?

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use fastcrypto::traits::KeyPair;
 use mysten_metrics::start_prometheus_server;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -43,7 +44,10 @@ async fn main() -> anyhow::Result<()> {
         .with_env()
         .with_prom_registry(&prometheus_registry)
         .init();
-    let metadata = BridgeNodePublicMetadata::new(VERSION.into());
+
+    let metadata =
+        BridgeNodePublicMetadata::new(VERSION.into(), config.network_key_pair.public().clone());
+
     Ok(run_bridge_node(config, metadata, prometheus_registry)
         .await?
         .await?)

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -433,7 +433,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: false,
             db_path: None,
-            network_key_pair: default_ed25519_key_pair(),
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(
@@ -497,7 +497,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: true,
             db_path: Some(db_path),
-            network_key_pair: default_ed25519_key_pair(),
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(
@@ -572,7 +572,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: true,
             db_path: Some(db_path),
-            network_key_pair: default_ed25519_key_pair(),
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -240,6 +240,7 @@ mod tests {
     use prometheus::Registry;
 
     use super::*;
+    use crate::config::default_ed25519_key_pair;
     use crate::config::BridgeNodeConfig;
     use crate::config::EthConfig;
     use crate::config::SuiConfig;
@@ -432,6 +433,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: false,
             db_path: None,
+            network_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(
@@ -495,6 +497,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: true,
             db_path: Some(db_path),
+            network_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(
@@ -569,6 +572,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: true,
             db_path: Some(db_path),
+            network_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -20,13 +20,13 @@ use axum::{
 };
 use axum::{http::StatusCode, routing::get, Router};
 use ethers::types::Address as EthAddress;
+use fastcrypto::ed25519::Ed25519PublicKey;
 use fastcrypto::{
     encoding::{Encoding, Hex},
     traits::ToFromBytes,
 };
 use std::sync::Arc;
 use std::{net::SocketAddr, str::FromStr};
-use sui_types::crypto::{get_key_pair_from_rng, NetworkKeyPair};
 use sui_types::{bridge::BridgeChainId, TypeTag};
 use tracing::{info, instrument};
 
@@ -39,7 +39,7 @@ pub(crate) mod mock_handler;
 pub const APPLICATION_JSON: &str = "application/json";
 
 pub const PING_PATH: &str = "/ping";
-pub const NETWORK_KEY_PATH: &str = "/metrics/network_key";
+pub const METRICS_KEY_PATH: &str = "/metrics_pub_key";
 
 // Important: for BridgeActions, the paths need to match the ones in bridge_client.rs
 pub const ETH_TO_SUI_TX_PATH: &str = "/sign/bridge_tx/eth/sui/:tx_hash/:event_index";
@@ -65,25 +65,21 @@ pub const ADD_TOKENS_ON_EVM_PATH: &str =
 #[derive(serde::Serialize)]
 pub struct BridgeNodePublicMetadata {
     pub version: Option<String>,
-    pub network_key_pair: Option<Arc<NetworkKeyPair>>,
-}
-
-fn default_ed25519_key_pair() -> NetworkKeyPair {
-    get_key_pair_from_rng(&mut rand::rngs::OsRng).1
+    pub metrics_pubkey: Option<Arc<Ed25519PublicKey>>,
 }
 
 impl BridgeNodePublicMetadata {
-    pub fn new(version: String) -> Self {
+    pub fn new(version: String, metrics_pubkey: Ed25519PublicKey) -> Self {
         Self {
             version: Some(version),
-            network_key_pair: Some(default_ed25519_key_pair().into()),
+            metrics_pubkey: Some(metrics_pubkey.into()),
         }
     }
 
     pub fn empty_for_testing() -> Self {
         Self {
             version: None,
-            network_key_pair: None,
+            metrics_pubkey: None,
         }
     }
 }
@@ -114,7 +110,7 @@ pub(crate) fn make_router(
     Router::new()
         .route("/", get(health_check))
         .route(PING_PATH, get(ping))
-        .route(NETWORK_KEY_PATH, get(metrics_network_key_fetch))
+        .route(METRICS_KEY_PATH, get(metrics_key_fetch))
         .route(ETH_TO_SUI_TX_PATH, get(handle_eth_tx_hash))
         .route(SUI_TO_ETH_TX_PATH, get(handle_sui_tx_digest))
         .route(
@@ -171,14 +167,14 @@ async fn ping(
     Ok(Json(metadata))
 }
 
-async fn metrics_network_key_fetch(
+async fn metrics_key_fetch(
     State((_handler, _metrics, metadata)): State<(
         Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
         Arc<BridgeMetrics>,
         Arc<BridgeNodePublicMetadata>,
     )>,
-) -> Result<Json<Option<Arc<NetworkKeyPair>>>, BridgeError> {
-    Ok(Json(metadata.network_key_pair.clone()))
+) -> Result<Json<Option<Arc<Ed25519PublicKey>>>, BridgeError> {
+    Ok(Json(metadata.metrics_pubkey.clone()))
 }
 
 #[instrument(level = "error", skip_all, fields(tx_hash_hex=tx_hash_hex, event_idx=event_idx))]

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -193,7 +193,7 @@ pub fn generate_bridge_node_config_and_write_to_file(
         approved_governance_actions: vec![],
         run_client,
         db_path: None,
-        network_key_pair: default_ed25519_key_pair(),
+        metrics_key_pair: default_ed25519_key_pair(),
     };
     if run_client {
         config.sui.bridge_client_key_path = Some(PathBuf::from("/path/to/your/bridge_client_key"));

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -4,9 +4,7 @@
 use crate::abi::{
     EthBridgeCommittee, EthBridgeConfig, EthBridgeLimiter, EthBridgeVault, EthSuiBridge,
 };
-use crate::config::BridgeNodeConfig;
-use crate::config::EthConfig;
-use crate::config::SuiConfig;
+use crate::config::{default_ed25519_key_pair, BridgeNodeConfig, EthConfig, SuiConfig};
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::server::APPLICATION_JSON;
@@ -195,6 +193,7 @@ pub fn generate_bridge_node_config_and_write_to_file(
         approved_governance_actions: vec![],
         run_client,
         db_path: None,
+        network_key_pair: default_ed25519_key_pair(),
     };
     if run_client {
         config.sui.bridge_client_key_path = Some(PathBuf::from("/path/to/your/bridge_client_key"));


### PR DESCRIPTION
## Description 

adds a ed25519 network key to the `BridgeNodePublicMetadata`.

I'm also adding a new api endpoint, `/metrics/network_key` which returns only the network key, this isn't necessary, as `/ping` already returns this info, I'm open to removing it.

## Test plan 

tested locally: 
```
$ curl localhost:9191/ping      
{"version":"1.31.0-e244466d3d18","network_key_pair":"nxuXbFTndKX4sbtmbyTBtvb0vFRL+ImjDoZifaWok+8="}%                                               
$ curl localhost:9191/metrics/network_key              
"nxuXbFTndKX4sbtmbyTBtvb0vFRL+ImjDoZifaWok+8="%                                                 
```

