### PR TITLE
[move-compler] Added parser resilience for use declarations

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2889,6 +2889,7 @@ impl<'a> ParsingSymbolicator<'a> {
                 self.chain_symbols(function);
                 self.chain_symbols(ty);
             }
+            P::Use::Partial { .. } => (),
         }
     }
 
@@ -2928,6 +2929,7 @@ impl<'a> ParsingSymbolicator<'a> {
                     self.use_decl_member_symbols(mod_ident_str.clone(), name, alias_opt);
                 }
             }
+            P::ModuleUse::Partial { .. } => (),
         }
     }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1704,7 +1704,14 @@ fn module_use(
                 }
             }
         }
-        P::ModuleUse::Partial { .. } => (), // no members or aliases to process
+        P::ModuleUse::Partial { .. } => {
+            let mident = module_ident(&mut context.defn_context, in_mident);
+            if !context.defn_context.module_members.contains_key(&mident) {
+                context.env().add_diag(unbound_module(&mident));
+                return;
+            };
+            add_module_alias!(mident, mident.value.module.0)
+        }
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1574,6 +1574,7 @@ fn use_(
             };
             use_funs.explicit.push(explicit);
         }
+        P::Use::Partial(..) => (), // no actual module to process
     }
 }
 
@@ -1703,6 +1704,7 @@ fn module_use(
                 }
             }
         }
+        P::ModuleUse::Partial(..) => (), // no members or aliases to process
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1574,7 +1574,7 @@ fn use_(
             };
             use_funs.explicit.push(explicit);
         }
-        P::Use::Partial(..) => (), // no actual module to process
+        P::Use::Partial { .. } => (), // no actual module to process
     }
 }
 
@@ -1704,7 +1704,7 @@ fn module_use(
                 }
             }
         }
-        P::ModuleUse::Partial(..) => (), // no members or aliases to process
+        P::ModuleUse::Partial { .. } => (), // no members or aliases to process
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -109,7 +109,11 @@ pub enum Use {
     // - `some_pkg::`
     // - `some_pkg::{`
     // where first location represents `::` and the second one represents `{`
-    Partial(LeadingNameAccess, Option<Loc>, Option<Loc>),
+    Partial {
+        package: LeadingNameAccess,
+        colon_colon: Option<Loc>,
+        opening_brace: Option<Loc>,
+    },
 }
 
 #[derive(Debug, PartialEq, Clone, Eq)]
@@ -121,7 +125,10 @@ pub enum ModuleUse {
     // - `... some_mod::`
     // - `... some_mod::{`
     // where first location represents `::` and the second one represents `{`
-    Partial(Option<Loc>, Option<Loc>),
+    Partial {
+        colon_colon: Option<Loc>,
+        opening_brace: Option<Loc>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1501,9 +1508,12 @@ impl AstDebug for ModuleUse {
                     alias.map(|alias| w.write(&format!("as {}", alias.value)));
                 })
             }),
-            ModuleUse::Partial(colon_colon_loc, curly_loc) => {
-                colon_colon_loc.map(|_| w.write("::".to_string()));
-                curly_loc.map(|_| w.write("{".to_string()));
+            ModuleUse::Partial {
+                colon_colon,
+                opening_brace,
+            } => {
+                colon_colon.map(|_| w.write("::"));
+                opening_brace.map(|_| w.write("{"));
             }
         }
     }
@@ -1539,10 +1549,14 @@ impl AstDebug for Use {
                 ty.ast_debug(w);
                 w.write(format!(".{method}"));
             }
-            Use::Partial(addr, colon_colon_loc, curly_loc) => {
-                colon_colon_loc.map(|_| w.write("::".to_string()));
-                curly_loc.map(|_| w.write("{".to_string()));
-                w.write(&format!("{}::", addr));
+            Use::Partial {
+                package,
+                colon_colon,
+                opening_brace,
+            } => {
+                w.write(package.to_string());
+                colon_colon.map(|_| w.write("::"));
+                opening_brace.map(|_| w.write("{"));
             }
         }
         w.write(";")

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -4142,16 +4142,15 @@ fn parse_use_decl(
                     opening_brace: None,
                 }
             } else {
+                // add `;` to stop set to limit number of eaten tokens if the list is parsed
+                // incorrectly
+                context.stop_set.add(Tok::Semicolon);
                 match context.tokens.peek() {
                     Tok::LBrace => {
                         let lbrace_loc = context.tokens.current_token_loc();
                         let parse_inner = |ctxt: &mut Context<'_, '_, '_>| {
-                            let (name, _, use_) = parse_use_module(ctxt)?;
-                            Ok((name, use_))
+                            parse_use_module(ctxt).map(|(name, _, use_)| (name, use_))
                         };
-                        // add `;` to stop set to limit number of eaten tokens if the list is parsed
-                        // incorrectly
-                        context.stop_set.add(Tok::Semicolon);
                         let use_decls = parse_comma_list(
                             context,
                             Tok::LBrace,
@@ -4176,9 +4175,6 @@ fn parse_use_decl(
                         use_
                     }
                     _ => {
-                        // add `;` to stop set to limit number of eaten tokens if the module use is
-                        // parsed incorrectly
-                        context.stop_set.add(Tok::Semicolon);
                         let use_ = match parse_use_module(context) {
                             Ok((name, end_loc, use_)) => {
                                 let loc = make_loc(

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -4140,7 +4140,11 @@ fn parse_use_decl(
                 " after an address in a use declaration",
             ) {
                 context.env.add_diag(*diag);
-                Use::Partial(address, None, None)
+                Use::Partial {
+                    package: address,
+                    colon_colon: None,
+                    opening_brace: None,
+                }
             } else {
                 match context.tokens.peek() {
                     Tok::LBrace => {
@@ -4167,7 +4171,11 @@ fn parse_use_decl(
                         );
                         if use_decls.is_empty() && module_uses_to_parse_exist {
                             // we failed to parse a non-empty list
-                            Use::Partial(address, Some(colon_colon_loc), Some(lbrace_loc))
+                            Use::Partial {
+                                package: address,
+                                colon_colon: Some(colon_colon_loc),
+                                opening_brace: Some(lbrace_loc),
+                            }
                         } else {
                             Use::NestedModuleUses(address, use_decls)
                         }
@@ -4187,7 +4195,11 @@ fn parse_use_decl(
                         }
                         Err(diag) => {
                             context.env.add_diag(*diag);
-                            Use::Partial(address, Some(colon_colon_loc), None)
+                            Use::Partial {
+                                package: address,
+                                colon_colon: Some(colon_colon_loc),
+                                opening_brace: None,
+                            }
                         }
                     },
                 }
@@ -4220,7 +4232,10 @@ fn parse_use_module(
             let colon_colon_loc = context.tokens.current_token_loc();
             if let Err(diag) = consume_token(context.tokens, Tok::ColonColon) {
                 context.env.add_diag(*diag);
-                ModuleUse::Partial(None, None)
+                ModuleUse::Partial {
+                    colon_colon: None,
+                    opening_brace: None,
+                }
             } else {
                 match context.tokens.peek() {
                     Tok::LBrace => {
@@ -4243,7 +4258,10 @@ fn parse_use_module(
                         );
                         if sub_uses.is_empty() && sub_uses_to_parse_exist {
                             // we failed to parse a non-empty list
-                            ModuleUse::Partial(Some(colon_colon_loc), Some(lbrace_loc))
+                            ModuleUse::Partial {
+                                colon_colon: Some(colon_colon_loc),
+                                opening_brace: Some(lbrace_loc),
+                            }
                         } else {
                             ModuleUse::Members(sub_uses)
                         }
@@ -4252,7 +4270,10 @@ fn parse_use_module(
                         Ok(m) => ModuleUse::Members(vec![m]),
                         Err(diag) => {
                             context.env.add_diag(*diag);
-                            ModuleUse::Partial(Some(colon_colon_loc), None)
+                            ModuleUse::Partial {
+                                colon_colon: Some(colon_colon_loc),
+                                opening_brace: None,
+                            }
                         }
                     },
                 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_incomplete.exp
@@ -1,0 +1,77 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/ide_mode/use_incomplete.move:5:9
+  │
+5 │         let _tmp = 42; // reset parser to see if the next line compiles
+  │         ^^^
+  │         │
+  │         Unexpected 'let'
+  │         Expected an identifier
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:11:9
+   │
+11 │         let _tmp = 42; // reset parser to see if the next line compiles
+   │         ^^^
+   │         │
+   │         Unexpected 'let'
+   │         Expected ',' or '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:11:22
+   │
+10 │         use a::m2::{foo
+   │                    - To match this '{'
+11 │         let _tmp = 42; // reset parser to see if the next line compiles
+   │                      ^ Expected '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:17:9
+   │
+17 │         let _tmp = 42; // reset parser to see if the next lines compile
+   │         ^^^
+   │         │
+   │         Unexpected 'let'
+   │         Expected ',' or '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:17:22
+   │
+16 │         use a::m2::{foo, bar
+   │                    - To match this '{'
+17 │         let _tmp = 42; // reset parser to see if the next lines compile
+   │                      ^ Expected '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:24:9
+   │
+24 │         let _tmp = 42; // reset parser to see if the next lines compile
+   │         ^^^
+   │         │
+   │         Unexpected 'let'
+   │         Expected ',' or '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:24:22
+   │
+23 │         use a::{m2::{foo, bar
+   │                     - To match this '{'
+24 │         let _tmp = 42; // reset parser to see if the next lines compile
+   │                      ^ Expected '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:32:9
+   │
+32 │         let _tmp = 42; // reset parser to see if the next lines compile
+   │         ^^^
+   │         │
+   │         Unexpected 'let'
+   │         Expected ',' or '}'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/ide_mode/use_incomplete.move:32:22
+   │
+31 │         use a::{m2::{foo, bar}, m3
+   │                - To match this '{'
+32 │         let _tmp = 42; // reset parser to see if the next lines compile
+   │                      ^ Expected '}'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_incomplete.move
@@ -1,0 +1,49 @@
+module a::m {
+
+    public fun test1() {
+        use a::m2::
+        let _tmp = 42; // reset parser to see if the next line compiles
+        m2::foo();
+    }
+
+    public fun test2() {
+        use a::m2::{foo
+        let _tmp = 42; // reset parser to see if the next line compiles
+        foo();
+    }
+
+    public fun test3() {
+        use a::m2::{foo, bar
+        let _tmp = 42; // reset parser to see if the next lines compile
+        foo();
+        bar();
+    }
+
+    public fun test4() {
+        use a::{m2::{foo, bar
+        let _tmp = 42; // reset parser to see if the next lines compile
+        foo();
+        bar();
+
+    }
+
+    public fun test5() {
+        use a::{m2::{foo, bar}, m3
+        let _tmp = 42; // reset parser to see if the next lines compile
+        m3::baz();
+        foo();
+        bar();
+    }
+}
+
+module a::m2 {
+
+    public fun foo() {}
+
+    public fun bar() {}
+}
+
+module a::m3 {
+
+    public fun baz() {}
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_close_brace.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_close_brace.exp
@@ -1,16 +1,16 @@
 error[E01002]: unexpected token
   ┌─ tests/move_check/parser/use_module_member_invalid_missing_close_brace.move:6:5
   │
-4 │     use 0x1::X::{S as XS
-  │                 - To match this '{'
+4 │     use 0x42::M::{S as XS
+  │                  - To match this '{'
 5 │ 
-6 │     fun foo() {
+6 │     fun foo() {}
   │     ^ Expected '}'
 
 error[E01002]: unexpected token
   ┌─ tests/move_check/parser/use_module_member_invalid_missing_close_brace.move:6:5
   │
-6 │     fun foo() {
+6 │     fun foo() {}
   │     ^^^
   │     │
   │     Unexpected 'fun'

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_close_brace.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_close_brace.move
@@ -1,9 +1,11 @@
 
 module 0x42::M {
 
-    use 0x1::X::{S as XS
+    use 0x42::M::{S as XS
 
-    fun foo() {
+    fun foo() {}
 
-    }
+    struct S has drop {}
+
+    fun bar(_p: XS) {}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_semicolon.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_semicolon.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/use_module_member_invalid_missing_semicolon.move:5:1
+  ┌─ tests/move_check/parser/use_module_member_invalid_missing_semicolon.move:6:5
   │
-5 │ }
-  │ ^
-  │ │
-  │ Unexpected '}'
-  │ Expected ';'
+6 │     fun foo() {}
+  │     ^^^
+  │     │
+  │     Unexpected 'fun'
+  │     Expected ';'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_semicolon.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_missing_semicolon.move
@@ -1,5 +1,11 @@
 
 module 0x42::M {
 
-    use 0x1::X::{S as XS,}
+    use 0x42::M::{S as XS,}
+
+    fun foo() {}
+
+    struct S has drop {}
+
+    fun bar(_p: XS) {}
 }


### PR DESCRIPTION
## Description 

This PR adds parsing resilience when parsing use declarations. The idea is to recognize partially parsed statements (examples below and also in the new test) to enable auto-completion in the IDE.
```
        use a::m2::
        use a::m2::{foo
        use a::m2::{foo, bar
        use a::{m2::{foo, bar
        use a::{m2::{foo, bar}, m3
```

## Test plan 

New and all tests must pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Additional compiler errors for incomplete name access chains (such as `use some_pkg::some_module::`) might appear in the compiler output.
- [ ] Rust SDK:
- [ ] REST API:
