### PR TITLE
[move][move-2024] Fix a small bug in how match was handled in parsing

### DIFF
--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2303,6 +2303,7 @@ fn at_start_of_exp(context: &mut Context) -> bool {
             | Tok::Break
             | Tok::Continue
             | Tok::If
+            | Tok::Match
             | Tok::Loop
             | Tok::Return
             | Tok::While

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_break_parse.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_break_parse.move
@@ -1,0 +1,7 @@
+module a::m;
+
+public fun t(): u64 {
+    loop {
+        break match (0u64) { 0 => 0, _ => 0 }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_return_parse.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_return_parse.move
@@ -1,0 +1,5 @@
+module a::m;
+
+public fun t(): u64 {
+    return match (0u64) { 0 => 0, _ => 0 }
+}


### PR DESCRIPTION
## Description 

This adds `Tok::Match` to the `at_start_of_exp` check in the parser

## Test plan 

Added tests that failed before the fix.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
