### PR TITLE
Enable random beacon on mainnet

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1293,7 +1293,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "53",
+              "maxSupportedProtocolVersion": "54",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -16,7 +16,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 53;
+const MAX_PROTOCOL_VERSION: u64 = 54;
 
 // Record history of protocol version allocations here:
 //
@@ -165,6 +165,7 @@ const MAX_PROTOCOL_VERSION: u64 = 53;
 //             Enable consensus commit prologue V3 on testnet.
 //             Turn on shared object congestion control in testnet.
 //             Update stdlib natives costs
+// Version 54: Enable random beacon on mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2632,6 +2633,13 @@ impl ProtocolConfig {
                     cfg.vector_pop_back_base_cost = Some(52);
                     cfg.vector_destroy_empty_base_cost = Some(52);
                     cfg.vector_swap_base_cost = Some(52);
+                }
+                54 => {
+                    // Enable random beacon on mainnet.
+                    cfg.feature_flags.random_beacon = true;
+                    cfg.random_beacon_reduction_lower_bound = Some(1000);
+                    cfg.random_beacon_dkg_timeout_round = Some(3000);
+                    cfg.random_beacon_min_round_interval_ms = Some(500);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_54.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_54.snap
@@ -1,0 +1,316 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 54
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  reject_mutable_random_on_entry_functions: true
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  enable_coin_deny_list_v2: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+bridge_should_try_to_finalize_committee: false
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_54.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_54.snap
@@ -1,0 +1,322 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 54
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 100
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_54.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_54.snap
@@ -1,0 +1,331 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 54
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 10
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 100
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 53
+  protocol_version: 54
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 53
+protocol_version: 54
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x68e2fb2256436f2df5a9410d9e219b97eaa5765cabd2969c23d8083836a5ba79"
+            id: "0x914faf0978a3304bc5eca36ef861f4fb5c8e2fd1d7531fac16fb59c42f2444e0"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x9af5ab9c8057218b799125d1b5cbaeb044b585ff66bd3e944a28a23f2873333e"
+      operation_cap_id: "0xdd0a37c4cb272a3ef7596ed7a3a3d39e3043ac5694ea85679401afed5a579226"
       gas_price: 1000
       staking_pool:
-        id: "0x872082092168ee3579ef4abe820d2dc56b6b1ceab95f4c894bde019aa229dccb"
+        id: "0x152174c0dc497a9ed5bf38916a6e2a83ed94f7fcac9ad3d2a394d42ac2f1535c"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x7b6a8b50a9137072addd7c6751d40f60695ca6095f37620642c6c8d108319abb"
+          id: "0x813360f00f57eeb9d7606b042e40cd894600da18cfd2b09c92850429266d27a1"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x294aab97d986bc780637eab36f9d840a1dcc5c386cc5b1fe426a2057d6d918b5"
+            id: "0x3ea0a0b3a2ed3e97a41f7a5449dd6cdabc7c352d78060257070a7644df62e0be"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xbe42bcfc164349cc63f5793998d8fdced1c3c270b44b39f20a7f6c07d9911533"
+          id: "0x6fe70da3c009c35f7f0775fbb7cf31fee9b791a06b568f9e5b6bdb962df6cd70"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x2669d3abbacd114f098a6d9beb9e58be32156043cc4a9106d9c3e6ec8ef465f0"
+      id: "0xa1a5f2a0c949249c21875d68b08c2303afddde080a701a3eb7ed47cd5994a123"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x8a232136668f3855addb49f6b94382511fa2d9b43e6bb1facfccca20b763fa2b"
+    id: "0x6d5379cad39050a7e1f6fe202e02729f1b5175ad2382019f05c564099fe0c680"
     size: 1
   inactive_validators:
-    id: "0xbadbf4e81386838963b4cd6dbc0f7ccf674483b29f2fb9cbdf8f777bc54bd411"
+    id: "0x8ec59c4f685c144a0a87b0944cd05aa177402af486357645a4c38b4c9746af88"
     size: 0
   validator_candidates:
-    id: "0x20466198424f3999e695e1de69ce4717a1e9ea2a35470c1c4d0dc4aff0a4e17e"
+    id: "0xe77fe73477351803bc9dae400aed9112bbfda929dcdc22e2a14575e40e215a9c"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x0ca591b7872ccc03715ea3acba3e36dcf7d92bf016bc7f6b270e94424508cb83"
+      id: "0x7467315914ac8e1c27eb2350a1783cdcea34b6fffe349c31e7f80f7c3543b282"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x1790455a80f35cd81783a20e3cb078b7fc6f8d6feb4825c4d23577ea7a38682d"
+      id: "0x6e650aa8265196ca0fdd9ef3c1c0e2f1d5042c74cee6a76a65316bcb3b6188fc"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x6b15ef4e5abf6d83d7689d748c6e235749e9500ad456af501740a05fa8e86660"
+      id: "0x3786047219840eac174fd6e74faa0602cea08ed146bdc3ac607a6536aff8dc2c"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x3a28788f0c093f4750c2f1766056930b486fd6154073e4fb69358d0f3296e523"
+    id: "0x0111121489c309364858942970d14ae6f85473f447a382651fb3a93938538a95"
   size: 0
 


### PR DESCRIPTION
## Description 

Enables the native randomness (random beacon) feature on sui mainnet.

## Test plan 

Extensive manual and automated testing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enables the native randomness (random beacon) feature on Sui Mainnet.
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
