### PR TITLE
[bridge] e2e tests optimizations

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -665,7 +665,7 @@ impl EthBridgeEnvironment {
             .arg("--block-time")
             .arg("1") // 1 second block time
             .arg("--slots-in-an-epoch")
-            .arg("1") // 3 slots in an epoch
+            .arg("1") // 1 slots in an epoch
             .spawn()
             .expect("Failed to start anvil");
 

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -180,6 +180,14 @@ impl BridgeTestClusterBuilder {
         let bridge_client = SuiBridgeClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
             .unwrap();
+        info!(
+            "Bridge committee: {:?}",
+            bridge_client
+                .get_bridge_committee()
+                .await
+                .unwrap()
+                .to_string()
+        );
         BridgeTestCluster {
             num_validators: self.num_validators,
             test_cluster,
@@ -207,7 +215,6 @@ impl BridgeTestClusterBuilder {
         test_cluster
             .trigger_reconfiguration_if_not_yet_and_assert_bridge_committee_initialized()
             .await;
-        info!("Bridge committee is finalized");
         test_cluster
     }
 
@@ -519,7 +526,7 @@ pub(crate) async fn deploy_sol_contract(
     };
 
     let serialized_config = serde_json::to_string_pretty(&deploy_config).unwrap();
-    tracing::debug!(
+    tracing::info!(
         "Serialized config written to {:?}: {:?}",
         deploy_config_path,
         serialized_config
@@ -658,7 +665,7 @@ impl EthBridgeEnvironment {
             .arg("--block-time")
             .arg("1") // 1 second block time
             .arg("--slots-in-an-epoch")
-            .arg("3") // 3 slots in an epoch
+            .arg("1") // 3 slots in an epoch
             .spawn()
             .expect("Failed to start anvil");
 
@@ -753,7 +760,7 @@ pub(crate) async fn start_bridge_cluster(
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path: authority_key_path,
             approved_governance_actions,
-            run_client: true,
+            run_client: i == 0,
             db_path: Some(db_path),
             eth: EthConfig {
                 eth_rpc_url: eth_environment.rpc_url.clone(),

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -716,13 +716,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_build_sui_transaction_for_emergency_op() {
         telemetry_subscribers::init_for_testing();
+        let num_valdiator = 2;
         let mut bridge_keys = vec![];
-        for _ in 0..=3 {
+        for _ in 0..num_valdiator {
             let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
             bridge_keys.push(kp);
         }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
+            .with_num_validators(num_valdiator)
             .build_with_bridge(bridge_keys, true)
             .await;
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -135,12 +135,6 @@ impl core::fmt::Display for BridgeCommittee {
             )?;
         }
         Ok(())
-        // if self.value() < 26 {
-        //     let c = (b'A' + self.value() as u8) as char;
-        //     f.write_str(c.to_string().as_str())
-        // } else {
-        //     write!(f, "[{:02}]", self.value())
-        // }
     }
 }
 

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -14,6 +14,7 @@ use ethers::types::Address as EthAddress;
 use ethers::types::Log;
 use ethers::types::H256;
 pub use ethers::types::H256 as EthTransactionHash;
+use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::hash::{HashFunction, Keccak256};
 use num_enum::TryFromPrimitive;
 use rand::seq::SliceRandom;
@@ -35,6 +36,7 @@ use sui_types::bridge::{
 };
 use sui_types::committee::CommitteeTrait;
 use sui_types::committee::StakeUnit;
+use sui_types::crypto::ToFromBytes;
 use sui_types::digests::{Digest, TransactionDigest};
 use sui_types::message_envelope::{Envelope, Message, VerifiedEnvelope};
 use sui_types::TypeTag;
@@ -116,6 +118,29 @@ impl BridgeCommittee {
 
     pub fn total_blocklisted_stake(&self) -> StakeUnit {
         self.total_blocklisted_stake
+    }
+}
+
+impl core::fmt::Display for BridgeCommittee {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::fmt::Result {
+        for m in self.members.values() {
+            writeln!(
+                f,
+                "pubkey: {:?}, url: {:?}, stake: {:?}, blocklisted: {}, eth address: {:x}",
+                Hex::encode(m.pubkey_bytes().as_bytes()),
+                m.base_url,
+                m.voting_power,
+                m.is_blocklisted,
+                m.pubkey_bytes().to_eth_address(),
+            )?;
+        }
+        Ok(())
+        // if self.value() < 26 {
+        //     let c = (b'A' + self.value() as u8) as char;
+        //     f.write_str(c.to_string().as_str())
+        // } else {
+        //     write!(f, "[{:02}]", self.value())
+        // }
     }
 }
 


### PR DESCRIPTION
## Description 

This PR does a few things to make e2e tests run faster:
1. instead of having every node running the client, only having one of them do so.
2. allow custom number of bridge nodes, and reduce the amount of nodes for some tests
3. reduce the epoch length to 1 slot from 3 slots

These jointly reduce the duration of the basic e2e transfer test from 100+s to 70s.


## Test plan 

existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
