### PR TITLE
[Consensus] consider tx processed either via consensus or checkpoint when submit

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -251,6 +251,10 @@ pub struct ExecutionComponents {
     metrics: Arc<ResolverMetrics>,
 }
 
+#[cfg(test)]
+#[path = "../unit_tests/authority_per_epoch_store_tests.rs"]
+pub mod authority_per_epoch_store_tests;
+
 pub struct AuthorityPerEpochStore {
     /// The name of this authority.
     pub(crate) name: AuthorityName,
@@ -1983,8 +1987,8 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    /// Get notified when a transaction gets executed as part of a checkpoint execution.
-    pub async fn transaction_executed_in_checkpoint_notify(
+    /// Get notified when transactions get executed as part of a checkpoint execution.
+    pub async fn transactions_executed_in_checkpoint_notify(
         &self,
         digests: Vec<TransactionDigest>,
     ) -> Result<(), SuiError> {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -50,8 +50,8 @@ use sui_simulator::anemo::PeerId;
 use sui_simulator::narwhal_network::connectivity::ConnectionStatus;
 use sui_types::base_types::AuthorityName;
 use sui_types::fp_ensure;
-use sui_types::messages_consensus::ConsensusTransaction;
 use sui_types::messages_consensus::ConsensusTransactionKind;
+use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKey};
 use tokio::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -79,6 +79,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_certificate_authority_position: Histogram,
     pub sequencing_certificate_positions_moved: Histogram,
     pub sequencing_certificate_preceding_disconnected: Histogram,
+    pub sequencing_certificate_processed: IntCounterVec,
     pub sequencing_in_flight_semaphore_wait: IntGauge,
     pub sequencing_in_flight_submissions: IntGauge,
     pub sequencing_estimated_latency: IntGauge,
@@ -146,6 +147,12 @@ impl ConsensusAdapterMetrics {
                 "The number of authorities that were hashed to an earlier position that were filtered out due to being disconnected when submitting to consensus.",
                 SEQUENCING_CERTIFICATE_POSITION_BUCKETS.to_vec(),
                 registry,
+            ).unwrap(),
+            sequencing_certificate_processed: register_int_counter_vec_with_registry!(
+                "sequencing_certificate_processed",
+                "The number of certificates that have been processed either by consensus or checkpoint.",
+                &["source"],
+                registry
             ).unwrap(),
             sequencing_in_flight_semaphore_wait: register_int_gauge_with_registry!(
                 "sequencing_in_flight_semaphore_wait",
@@ -277,7 +284,7 @@ pub struct ConsensusAdapter {
     consensus_throughput_profiler: ArcSwapOption<ConsensusThroughputProfiler>,
     /// A structure to register metrics
     metrics: ConsensusAdapterMetrics,
-    /// Semaphore limiting parallel submissions to narwhal
+    /// Semaphore limiting parallel submissions to consensus
     submit_semaphore: Semaphore,
     latency_observer: LatencyObserver,
     protocol_config: ProtocolConfig,
@@ -715,29 +722,29 @@ impl ConsensusAdapter {
             "soft_bundle"
         };
 
-        let processed_waiter = epoch_store
-            .consensus_messages_processed_notify(transaction_keys.clone())
-            .boxed();
+        let mut guard = InflightDropGuard::acquire(&self, tx_type);
 
-        pin_mut!(processed_waiter);
-
+        // Create the waiter until the node's turn comes to submit to consensus
         let (await_submit, position, positions_moved, preceding_disconnected) =
             self.await_submit_delay(epoch_store.committee(), &transactions[..]);
 
-        let mut guard = InflightDropGuard::acquire(&self, tx_type);
+        // Create the waiter until the transaction is processed by consensus or via checkpoint
+        let processed_via_consensus_or_checkpoint =
+            self.await_consensus_or_checkpoint(transaction_keys.clone(), epoch_store);
+        pin_mut!(processed_via_consensus_or_checkpoint);
+
         let processed_waiter = tokio::select! {
             // We need to wait for some delay until we submit transaction to the consensus
-            _ = await_submit => Some(processed_waiter),
+            _ = await_submit => Some(processed_via_consensus_or_checkpoint),
 
             // If epoch ends, don't wait for submit delay
             _ = epoch_store.user_certs_closed_notify() => {
                 warn!(epoch = ?epoch_store.epoch(), "Epoch ended, skipping submission delay");
-                Some(processed_waiter)
+                Some(processed_via_consensus_or_checkpoint)
             }
 
-            // If transaction is received by consensus while we wait, we are done.
-            processed = &mut processed_waiter => {
-                processed.expect("Storage error when waiting for consensus message processed");
+            // If transaction is received by consensus or checkpoint while we wait, we are done.
+            _ = &mut processed_via_consensus_or_checkpoint => {
                 None
             }
         };
@@ -769,6 +776,7 @@ impl ConsensusAdapter {
         } else {
             None
         };
+
         if let Some(processed_waiter) = processed_waiter {
             debug!("Submitting {:?} to consensus", transaction_keys);
 
@@ -844,7 +852,6 @@ impl ConsensusAdapter {
                     processed_waiter.await
                 }
             }
-            .expect("Storage error when waiting for consensus message processed");
         }
         debug!("{transaction_keys:?} processed by consensus");
 
@@ -894,6 +901,39 @@ impl ConsensusAdapter {
             .sequencing_certificate_success
             .with_label_values(&[tx_type])
             .inc();
+    }
+
+    /// Waits for transactions to appear either to consensus output or been executed via a checkpoint (state sync).
+    async fn await_consensus_or_checkpoint(
+        self: &Arc<Self>,
+        transaction_keys: Vec<SequencedConsensusTransactionKey>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) {
+        // Filter only the transaction digests to check for occurance executed checkpoint.
+        let transaction_digests = transaction_keys
+            .iter()
+            .flat_map(|key| {
+                if let SequencedConsensusTransactionKey::External(
+                    ConsensusTransactionKey::Certificate(digest),
+                ) = key
+                {
+                    Some(*digest)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        tokio::select! {
+            processed = epoch_store.consensus_messages_processed_notify(transaction_keys) => {
+                processed.expect("Storage error when waiting for consensus message processed");
+                self.metrics.sequencing_certificate_processed.with_label_values(&["consensus"]).inc();
+            },
+            processed = epoch_store.transaction_executed_in_checkpoint_notify(transaction_digests) => {
+                processed.expect("Storage error when waiting for transaction executed in checkpoint");
+                self.metrics.sequencing_certificate_processed.with_label_values(&["checkpoint"]).inc();
+            }
+        }
     }
 }
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -929,7 +929,7 @@ impl ConsensusAdapter {
                 processed.expect("Storage error when waiting for consensus message processed");
                 self.metrics.sequencing_certificate_processed.with_label_values(&["consensus"]).inc();
             },
-            processed = epoch_store.transaction_executed_in_checkpoint_notify(transaction_digests) => {
+            processed = epoch_store.transactions_executed_in_checkpoint_notify(transaction_digests) => {
                 processed.expect("Storage error when waiting for transaction executed in checkpoint");
                 self.metrics.sequencing_certificate_processed.with_label_values(&["checkpoint"]).inc();
             }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -912,13 +912,13 @@ impl ConsensusAdapter {
     ) {
         let notifications = FuturesUnordered::new();
         for transaction_key in transaction_keys {
-            let transaction_digest = if let SequencedConsensusTransactionKey::External(
+            let transaction_digests = if let SequencedConsensusTransactionKey::External(
                 ConsensusTransactionKey::Certificate(digest),
             ) = transaction_key
             {
-                Some(digest)
+                vec![digest]
             } else {
-                None
+                vec![]
             };
 
             notifications.push(async move {
@@ -927,7 +927,7 @@ impl ConsensusAdapter {
                         processed.expect("Storage error when waiting for consensus message processed");
                         self.metrics.sequencing_certificate_processed.with_label_values(&["consensus"]).inc();
                     },
-                    processed = epoch_store.transactions_executed_in_checkpoint_notify(vec![transaction_digest.unwrap()]), if transaction_digest.is_some() => {
+                    processed = epoch_store.transactions_executed_in_checkpoint_notify(transaction_digests), if !transaction_digests.is_empty() => {
                         processed.expect("Storage error when waiting for transaction executed in checkpoint");
                         self.metrics.sequencing_certificate_processed.with_label_values(&["checkpoint"]).inc();
                     }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -921,6 +921,9 @@ impl ConsensusAdapter {
                 vec![]
             };
 
+            // We wait for each transaction individually to be processed by consensus or executed in a checkpoint. We could equally just
+            // get notified in aggregate when all transactions are processed, but with this approach can get notified in a more fine-grained way
+            // as transactions can be marked as processed in different ways. This is mostly a concern for the soft-bundle transactions.
             notifications.push(async move {
                 tokio::select! {
                     processed = epoch_store.consensus_messages_processed_notify(vec![transaction_key]) => {

--- a/crates/sui-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use sui_types::base_types::TransactionDigest;
+use tokio::time::timeout;
+
+#[tokio::test]
+async fn test_insert_finalized_transactions() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+
+    let digests = vec![
+        TransactionDigest::random(),
+        TransactionDigest::random(),
+        TransactionDigest::random(),
+    ];
+    let checkpoint_sequence = 10;
+
+    let result = store.insert_finalized_transactions(&digests, checkpoint_sequence);
+
+    // Assert that the method returns Ok
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_notify_read_executed_transactions_to_checkpoint() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let checkpoint_sequence_1 = 10;
+    let checkpoint_sequence_2 = 12;
+
+    let txes_to_be_notified = vec![
+        TransactionDigest::random(),
+        TransactionDigest::random(),
+        TransactionDigest::random(),
+    ];
+
+    // Insert only the first transaction already
+    store
+        .insert_finalized_transactions(
+            vec![txes_to_be_notified[0]].as_slice(),
+            checkpoint_sequence_1,
+        )
+        .expect("Should not fail");
+
+    // Now register to get notified for the addition of some of the above transactions
+    let txes_to_be_notified_cloned = txes_to_be_notified.clone();
+    let handle = tokio::spawn(async move {
+        let notify = store.transactions_executed_in_checkpoint_notify(txes_to_be_notified_cloned);
+        notify.await
+    });
+
+    // Now insert the rest of the transactions
+    let store = authority_state.epoch_store_for_testing();
+    store
+        .insert_finalized_transactions(&txes_to_be_notified[1..], checkpoint_sequence_2)
+        .expect("Should not fail");
+
+    // We should get notified about all the transactions having been executed via checkpoints
+    let _ = timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("Should not timeout")
+        .expect("Should not fail");
+
+    // And the transactions should be found into the table
+    let result = store
+        .multi_get_transaction_checkpoint(txes_to_be_notified.as_slice())
+        .expect("Should not fail");
+    assert_eq!(result.len(), txes_to_be_notified.len());
+
+    assert_eq!(result[0].unwrap(), checkpoint_sequence_1);
+    assert_eq!(result[1].unwrap(), checkpoint_sequence_2);
+    assert_eq!(result[2].unwrap(), checkpoint_sequence_2);
+}

--- a/crates/sui-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -8,24 +8,6 @@ use sui_types::base_types::TransactionDigest;
 use tokio::time::timeout;
 
 #[tokio::test]
-async fn test_insert_finalized_transactions() {
-    let authority_state = TestAuthorityBuilder::new().build().await;
-    let store = authority_state.epoch_store_for_testing();
-
-    let digests = vec![
-        TransactionDigest::random(),
-        TransactionDigest::random(),
-        TransactionDigest::random(),
-    ];
-    let checkpoint_sequence = 10;
-
-    let result = store.insert_finalized_transactions(&digests, checkpoint_sequence);
-
-    // Assert that the method returns Ok
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
 async fn test_notify_read_executed_transactions_to_checkpoint() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use crate::checkpoints::CheckpointServiceNoop;
@@ -105,7 +107,7 @@ pub async fn test_certificates(
 
 pub fn make_consensus_adapter_for_test(
     state: Arc<AuthorityState>,
-    process_via_checkpoint: bool,
+    process_via_checkpoint: HashSet<TransactionDigest>,
     execute: bool,
 ) -> Arc<ConsensusAdapter> {
     let metrics = ConsensusAdapterMetrics::new_test();
@@ -113,7 +115,7 @@ pub fn make_consensus_adapter_for_test(
     #[derive(Clone)]
     struct SubmitDirectly {
         state: Arc<AuthorityState>,
-        process_via_checkpoint: bool,
+        process_via_checkpoint: HashSet<TransactionDigest>,
         execute: bool,
     }
 
@@ -129,14 +131,32 @@ pub fn make_consensus_adapter_for_test(
                 .map(|txn| SequencedConsensusTransaction::new_test(txn.clone()))
                 .collect();
 
-            if self.process_via_checkpoint {
-                let checkpoint_service = Arc::new(CheckpointServiceNoop {});
-                for tx in sequenced_transactions {
-                    if let Some(tx) = tx.transaction.executable_transaction_digest() {
+            let checkpoint_service = Arc::new(CheckpointServiceNoop {});
+            let mut transactions = Vec::new();
+            let mut executed_via_checkpoint = 0;
+
+            for tx in sequenced_transactions {
+                if let Some(transaction_digest) = tx.transaction.executable_transaction_digest() {
+                    if self.process_via_checkpoint.contains(&transaction_digest) {
                         epoch_store
-                            .insert_finalized_transactions(vec![tx].as_slice(), 10)
+                            .insert_finalized_transactions(vec![transaction_digest].as_slice(), 10)
                             .expect("Should not fail");
+                        executed_via_checkpoint += 1;
                     } else {
+                        transactions.extend(
+                            epoch_store
+                                .process_consensus_transactions_for_tests(
+                                    vec![tx],
+                                    &checkpoint_service,
+                                    self.state.get_object_cache_reader().as_ref(),
+                                    &self.state.metrics,
+                                    true,
+                                )
+                                .await?,
+                        );
+                    }
+                } else {
+                    transactions.extend(
                         epoch_store
                             .process_consensus_transactions_for_tests(
                                 vec![tx],
@@ -145,24 +165,21 @@ pub fn make_consensus_adapter_for_test(
                                 &self.state.metrics,
                                 true,
                             )
-                            .await?;
-                    }
+                            .await?,
+                    );
                 }
-            } else {
-                let transactions = epoch_store
-                    .process_consensus_transactions_for_tests(
-                        sequenced_transactions,
-                        &Arc::new(CheckpointServiceNoop {}),
-                        self.state.get_object_cache_reader().as_ref(),
-                        &self.state.metrics,
-                        true,
-                    )
-                    .await?;
-                if self.execute {
-                    self.state
-                        .transaction_manager()
-                        .enqueue(transactions, epoch_store);
-                }
+            }
+
+            assert_eq!(
+                executed_via_checkpoint,
+                self.process_via_checkpoint.len(),
+                "Some transactions were not executed via checkpoint"
+            );
+
+            if self.execute {
+                self.state
+                    .transaction_manager()
+                    .enqueue(transactions, epoch_store);
             }
             Ok(())
         }
@@ -203,7 +220,7 @@ async fn submit_transaction_to_consensus_adapter() {
     let epoch_store = state.epoch_store_for_testing();
 
     // Make a new consensus adapter instance.
-    let adapter = make_consensus_adapter_for_test(state.clone(), true, false);
+    let adapter = make_consensus_adapter_for_test(state.clone(), HashSet::new(), false);
 
     // Submit the transaction and ensure the adapter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).
@@ -211,6 +228,45 @@ async fn submit_transaction_to_consensus_adapter() {
     let waiter = adapter
         .submit(
             transaction.clone(),
+            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+            &epoch_store,
+        )
+        .unwrap();
+    waiter.await.unwrap();
+}
+
+#[tokio::test]
+async fn submit_multiple_transactions_to_consensus_adapter() {
+    telemetry_subscribers::init_for_testing();
+
+    // Initialize an authority with a (owned) gas object and a shared object; then
+    // make a test certificate.
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let certificates = test_certificates(&state, shared_object).await;
+    let epoch_store = state.epoch_store_for_testing();
+
+    // Mark the first two transactions to be "executed via checkpoint" and the other two to appear via consensus output.
+    assert_eq!(certificates.len(), 4);
+
+    let mut process_via_checkpoint = HashSet::new();
+    process_via_checkpoint.insert(*certificates[0].digest());
+    process_via_checkpoint.insert(*certificates[1].digest());
+
+    // Make a new consensus adapter instance.
+    let adapter = make_consensus_adapter_for_test(state.clone(), process_via_checkpoint, false);
+
+    // Submit the transaction and ensure the adapter reports success to the caller. Note
+    // that consensus may drop some transactions (so we may need to resubmit them).
+    let transactions = certificates
+        .into_iter()
+        .map(|certificate| ConsensusTransaction::new_certificate_message(&state.name, certificate))
+        .collect::<Vec<_>>();
+    let waiter = adapter
+        .submit_batch(
+            &transactions,
             Some(&epoch_store.get_reconfig_state_read_lock_guard()),
             &epoch_store,
         )

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1677,7 +1677,7 @@ async fn test_handle_soft_bundle_certificates() {
 
     // Create a server with mocked consensus.
     // This ensures transactions submitted to consensus will get processed.
-    let adapter = make_consensus_adapter_for_test(authority.clone(), true);
+    let adapter = make_consensus_adapter_for_test(authority.clone(), false, true);
     let server = AuthorityServer::new_for_test_with_consensus_adapter(authority.clone(), adapter);
     let _metrics = server.metrics.clone();
     let server_handle = server.spawn_for_test().await.unwrap();

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1677,7 +1677,7 @@ async fn test_handle_soft_bundle_certificates() {
 
     // Create a server with mocked consensus.
     // This ensures transactions submitted to consensus will get processed.
-    let adapter = make_consensus_adapter_for_test(authority.clone(), false, true);
+    let adapter = make_consensus_adapter_for_test(authority.clone(), HashSet::new(), true);
     let server = AuthorityServer::new_for_test_with_consensus_adapter(authority.clone(), adapter);
     let _metrics = server.metrics.clone();
     let server_handle = server.spawn_for_test().await.unwrap();


### PR DESCRIPTION
## Description 

This PR introduces logic to consider a transaction as processed when one of the following conditions is met:

1. It has been sequenced through consensus.
2. It has been executed via a checkpoint (state sync).

Under typical circumstances, transactions are expected to be marked as processed primarily through the consensus path. However, the checkpoint execution path proves beneficial when a node faces difficulties syncing with the consensus DAG but can still follow the state sync. This approach prevents transactions from remaining as inflight and, more importantly, avoids redundant submission through the consensus path, as these transactions are likely to be obsolete.

## Test plan 

CI/Private Testnet

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
