### PR TITLE
Improve tx finalizer simtests

### DIFF
--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -20,7 +20,7 @@ if [ -z "$NUM_CPUS" ]; then
 fi
 
 # filter out some tests that give spurious failures.
-TEST_FILTER="(not (test(~batch_verification_tests) | test(~test_validator_tx_finalizer_)))"
+TEST_FILTER="(not (test(~batch_verification_tests)))"
 
 DATE=$(date +%s)
 SEED="$DATE"


### PR DESCRIPTION
## Description 

Introduce a timing config, and set the values differently for prod vs tests.
This allows tests to run much more quickly.
Re-enable the simtests in nightly.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
