### PR TITLE
[rosetta] Adds raw input option for the transformation to operations object in block endpoints

### DIFF
--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -52,7 +52,8 @@ pub async fn transaction(
                 .with_input()
                 .with_events()
                 .with_effects()
-                .with_balance_changes(),
+                .with_balance_changes()
+                .with_raw_input(),
         )
         .await?;
     let hash = response.digest;

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -121,7 +121,8 @@ impl CheckpointBlockProvider {
                         .with_input()
                         .with_effects()
                         .with_balance_changes()
-                        .with_events(),
+                        .with_events()
+                        .with_raw_input(),
                 )
                 .await?;
             for tx in transaction_responses.into_iter() {


### PR DESCRIPTION
## Description 

Transaction response now include raw input to be parsed during the transformation to the Oparations object, so in case of a pay coin operation we can get the currency type.

## Test plan 

Covered by the tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
