### PR TITLE
[snapshots] Add metric for number of local db checkpoints

### DIFF
--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -35,6 +35,7 @@ pub const STATE_SNAPSHOT_COMPLETED_MARKER: &str = "_STATE_SNAPSHOT_COMPLETED";
 
 pub struct DBCheckpointMetrics {
     pub first_missing_db_checkpoint_epoch: IntGauge,
+    pub num_local_db_checkpoints: IntGauge,
 }
 
 impl DBCheckpointMetrics {
@@ -43,6 +44,12 @@ impl DBCheckpointMetrics {
             first_missing_db_checkpoint_epoch: register_int_gauge_with_registry!(
                 "first_missing_db_checkpoint_epoch",
                 "First epoch for which we have no db checkpoint in remote store",
+                registry
+            )
+            .unwrap(),
+            num_local_db_checkpoints: register_int_gauge_with_registry!(
+                "num_local_db_checkpoints",
+                "Number of RocksDB checkpoints currently residing on local disk (i.e. not yet garbage collected)",
                 registry
             )
             .unwrap(),
@@ -167,6 +174,9 @@ impl DBCheckpointHandler {
         loop {
             tokio::select! {
                 _now = interval.tick() => {
+                    let local_checkpoints_by_epoch =
+                        find_all_dirs_with_epoch_prefix(&self.input_object_store, None).await?;
+                    self.metrics.num_local_db_checkpoints.set(local_checkpoints_by_epoch.len() as i64);
                     match find_missing_epochs_dirs(self.output_object_store.as_ref().unwrap(), SUCCESS_MARKER).await {
                         Ok(epochs) => {
                             self.metrics.first_missing_db_checkpoint_epoch.set(epochs.first().cloned().unwrap_or(0) as i64);
@@ -192,27 +202,28 @@ impl DBCheckpointHandler {
         info!("DB checkpoint upload disabled. DB checkpoint cleanup loop started");
         loop {
             tokio::select! {
-            _now = interval.tick() => {
-                let local_checkpoints_by_epoch =
-                    find_all_dirs_with_epoch_prefix(&self.input_object_store, None).await?;
-                let mut dirs: Vec<_> = local_checkpoints_by_epoch.iter().collect();
-                dirs.sort_by_key(|(epoch_num, _path)| *epoch_num);
-                for (_, db_path) in dirs {
-                    // If db checkpoint marked as completed, skip
-                    let local_db_path = path_to_filesystem(self.input_root_path.clone(), db_path)?;
-                    let upload_completed_path = local_db_path.join(UPLOAD_COMPLETED_MARKER);
-                    if upload_completed_path.exists() {
-                        continue;
+                _now = interval.tick() => {
+                    let local_checkpoints_by_epoch =
+                        find_all_dirs_with_epoch_prefix(&self.input_object_store, None).await?;
+                    self.metrics.num_local_db_checkpoints.set(local_checkpoints_by_epoch.len() as i64);
+                    let mut dirs: Vec<_> = local_checkpoints_by_epoch.iter().collect();
+                    dirs.sort_by_key(|(epoch_num, _path)| *epoch_num);
+                    for (_, db_path) in dirs {
+                        // If db checkpoint marked as completed, skip
+                        let local_db_path = path_to_filesystem(self.input_root_path.clone(), db_path)?;
+                        let upload_completed_path = local_db_path.join(UPLOAD_COMPLETED_MARKER);
+                        if upload_completed_path.exists() {
+                            continue;
+                        }
+                        let bytes = Bytes::from_static(b"success");
+                        let upload_completed_marker = db_path.child(UPLOAD_COMPLETED_MARKER);
+                        put(&self.input_object_store,
+                            &upload_completed_marker,
+                            bytes.clone(),
+                        )
+                        .await?;
                     }
-                    let bytes = Bytes::from_static(b"success");
-                    let upload_completed_marker = db_path.child(UPLOAD_COMPLETED_MARKER);
-                    put(&self.input_object_store,
-                        &upload_completed_marker,
-                        bytes.clone(),
-                    )
-                    .await?;
-                }
-            },
+                },
                  _ = recv.recv() => break,
             }
         }


### PR DESCRIPTION
## Description 

Because we run snapshot upload and garbage collection as a background task but we perform rocksdb checkpointing at end of epoch unconditionally for configured nodes, any failure in either the upload or garbage collection path will lead to an accumulation of old db checkpoints, which will inevitably lead to disk filling and make things more difficult to debug.

This PR adds a metric to periodically count the number of rocksdb checkpoints that exist on local disk. Except in rare cases (backfills), this number should generally be lower than 3, so we can add alerting on this for early intervention.

## Test plan 

👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
