### PR TITLE
Replace forge install with soldeer

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Foundry Dependencies
         working-directory: bridge/evm
         run: |
-          forge install https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable@v5.0.1 https://github.com/foundry-rs/forge-std@v1.3.0 https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades --no-git --no-commit
+          forge soldeer update
       - name: cargo test
         run: |
           cargo nextest run --profile ci -E 'package(sui-bridge)'
@@ -114,7 +114,7 @@ jobs:
       - name: Install Foundry Dependencies
         working-directory: bridge/evm
         run: |
-          forge install https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable@v5.0.1 https://github.com/foundry-rs/forge-std@v1.3.0 https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades --no-git --no-commit
+          forge soldeer update
       - name: Check Bridge EVM Unit Tests
         shell: bash
         working-directory: bridge/evm

--- a/bridge/evm/.gitignore
+++ b/bridge/evm/.gitignore
@@ -10,5 +10,4 @@ out*/
 lcov.info
 broadcast/**/31337
 
-lib/*
-
+dependencies

--- a/bridge/evm/README.md
+++ b/bridge/evm/README.md
@@ -1,6 +1,6 @@
 # 🏄‍♂️ Quick Start
 
-This project leverages [Foundry](https://github.com/foundry-rs/foundry) to manage dependencies, contract compilation, testing, deployment, and on chain interactions via Solidity scripting.
+This project leverages [Foundry](https://github.com/foundry-rs/foundry) to manage dependencies (via soldeer), contract compilation, testing, deployment, and on chain interactions via Solidity scripting.
 
 #### Environment configuration
 
@@ -14,7 +14,7 @@ Duplicate rename the `.env.example` file to `.env`. You'll need accounts and api
 To install the project dependencies, run: 
 
 ```bash
-forge install https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable@v5.0.1 https://github.com/foundry-rs/forge-std@v1.3.0 https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades --no-git --no-commit
+forge soldeer update
 ```
 
 #### Compilation
@@ -28,8 +28,7 @@ forge compile
 #### Testing
 
 ```bash
-forge clean
-forge test --ffi
+forge test
 ```
 
 #### Coverage
@@ -45,15 +44,13 @@ forge coverage
 > The file should be named `<chainID>.json` and should have the same fields and in the same order (alphabetical) as the `example.json`.
 
 ```bash
-forge clean
-forge script script/deploy_bridge.s.sol --rpc-url <<alias>> --broadcast --verify --ffi
+forge script script/deploy_bridge.s.sol --rpc-url <<alias>> --broadcast --verify
 ```
 
 **Local deployment**
 
 ```bash
-forge clean
-forge script script/deploy_bridge.s.sol --fork-url anvil --broadcast --ffi
+forge script script/deploy_bridge.s.sol --fork-url anvil --broadcast
 ```
 
 All deployments are saved in the `broadcast` directory.

--- a/bridge/evm/foundry.toml
+++ b/bridge/evm/foundry.toml
@@ -3,20 +3,31 @@ src = 'contracts'
 test = 'test'
 no_match_test = "testSkip"
 out = 'out'
-libs = ['lib']
+libs = ['dependencies']
 solc = "0.8.20"
 build_info = true
 extra_output = ["storageLayout"]
 fs_permissions = [{ access = "read", path = "/"}]
 gas_reports = ["SuiBridge"]
+ffi = true
+
 [fmt] 
 line_length = 100
+
 [fuzz]
 runs = 1000
+
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"
 anvil = "http://localhost:8545"
+
 [etherscan]
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
+
+[dependencies]
+forge-std = "1.9.2"
+openzeppelin-foundry-upgrades = "0.3.1"
+"@openzeppelin-contracts-upgradeable" = "5.0.1"
+"@openzeppelin-contracts" = "5.0.1"

--- a/bridge/evm/remappings.txt
+++ b/bridge/evm/remappings.txt
@@ -1,5 +1,8 @@
-@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/
-@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
-@openzeppelin/openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades/src/
-ds-test/=lib/forge-std/lib/ds-test/src/
-forge-std/=lib/openzeppelin-foundry-upgrades/lib/forge-std/src/
+@forge-std=dependencies/forge-std-1.9.2/src
+@openzeppelin/foundry-upgrades=dependencies/openzeppelin-foundry-upgrades-0.3.1/src
+@openzeppelin/contracts=dependencies/@openzeppelin-contracts-5.0.1
+@openzeppelin/contracts-upgradeable=dependencies/@openzeppelin-contracts-upgradeable-5.0.1
+@forge-std-1.9.2=dependencies/forge-std-1.9.2
+@openzeppelin-foundry-upgrades-0.3.1=dependencies/openzeppelin-foundry-upgrades-0.3.1
+@openzeppelin-contracts-upgradeable-5.0.1=dependencies/@openzeppelin-contracts-upgradeable-5.0.1
+@openzeppelin-contracts-5.0.1=dependencies/@openzeppelin-contracts-5.0.1

--- a/bridge/evm/soldeer.lock
+++ b/bridge/evm/soldeer.lock
@@ -1,0 +1,24 @@
+
+[[dependencies]]
+name = "forge-std"
+version = "1.9.2"
+source = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_2_06-08-2024_17:31:25_forge-std-1.9.2.zip"
+checksum = "20fd008c7c69b6c737cc0284469d1c76497107bc3e004d8381f6d8781cb27980"
+
+[[dependencies]]
+name = "openzeppelin-foundry-upgrades"
+version = "0.3.1"
+source = "https://soldeer-revisions.s3.amazonaws.com/openzeppelin-foundry-upgrades/0_3_1_25-06-2024_18:12:33_openzeppelin-foundry-upgrades.zip"
+checksum = "16a43c67b7c62e4a638b669b35f7b19c98a37278811fe910750b62b6e6fdffa7"
+
+[[dependencies]]
+name = "@openzeppelin-contracts-upgradeable"
+version = "5.0.1"
+source = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts-upgradeable/5_0_1_22-01-2024_13:15:10_contracts-upgradeable.zip"
+checksum = "cca37ad1d376a5c3954d1c2a8d2675339f182eee535caa7ba7ebf8d589a2c19a"
+
+[[dependencies]]
+name = "@openzeppelin-contracts"
+version = "5.0.1"
+source = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_0_1_22-01-2024_13:14:01_contracts.zip"
+checksum = "c256cbf6f5f38d3b65c7528bbffb530d0bdb818a20c9d5b61235a829202d7df7"


### PR DESCRIPTION
## Description 

Replacing the dependency management from manual forge install to use the recommended Soldeer dependancy management tool. 

## Test plan 

CI checks will test this update

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
