### PR TITLE
[pick] indexer pruner: add pruner and prune unpartitioned tables (#18495)

### DIFF
--- a/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/down.sql
+++ b/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS checkpoints;
+DROP TABLE IF EXISTS pruner_cp_watermark;

--- a/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/up.sql
+++ b/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/up.sql
@@ -26,3 +26,9 @@ CREATE TABLE checkpoints
 
 CREATE INDEX checkpoints_epoch ON checkpoints (epoch, sequence_number);
 CREATE INDEX checkpoints_digest ON checkpoints USING HASH (checkpoint_digest);
+
+CREATE TABLE pruner_cp_watermark (
+    checkpoint_sequence_number  BIGINT       PRIMARY KEY,
+    min_tx_sequence_number      BIGINT       NOT NULL,
+    max_tx_sequence_number      BIGINT       NOT NULL
+)

--- a/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
@@ -23,6 +23,7 @@ CREATE TABLE tx_input_objects (
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
 );
+CREATE INDEX tx_input_objects_tx_sequence_number_index ON tx_input_objects (tx_sequence_number);
 
 CREATE TABLE tx_changed_objects (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -31,6 +32,7 @@ CREATE TABLE tx_changed_objects (
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
 );
+CREATE INDEX tx_changed_objects_tx_sequence_number_index ON tx_changed_objects (tx_sequence_number);
 
 CREATE TABLE tx_calls (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -52,3 +54,4 @@ CREATE TABLE tx_digests (
     cp_sequence_number          BIGINT       NOT NULL,
     tx_sequence_number          BIGINT       NOT NULL
 );
+CREATE INDEX tx_digests_tx_sequence_number ON tx_digests (tx_sequence_number);

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 pub mod checkpoint_handler;
 pub mod committer;
 pub mod objects_snapshot_processor;
+pub mod pruner;
 pub mod tx_processor;
 
 #[derive(Debug)]

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
+
+pub struct Pruner<S> {
+    pub store: S,
+    pub epochs_to_keep: u64,
+    pub metrics: IndexerMetrics,
+}
+
+impl<S> Pruner<S>
+where
+    S: IndexerStore + Clone + Sync + Send + 'static,
+{
+    pub fn new(store: S, epochs_to_keep: u64, metrics: IndexerMetrics) -> Self {
+        Self {
+            store,
+            epochs_to_keep,
+            metrics,
+        }
+    }
+
+    pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
+        loop {
+            if cancel.is_cancelled() {
+                info!("Pruner task cancelled.");
+                return Ok(());
+            }
+
+            let (mut min_epoch, mut max_epoch) = self.store.get_available_epoch_range().await?;
+            while min_epoch + self.epochs_to_keep > max_epoch {
+                if cancel.is_cancelled() {
+                    info!("Pruner task cancelled.");
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
+            }
+
+            for epoch in min_epoch..=max_epoch - self.epochs_to_keep {
+                if cancel.is_cancelled() {
+                    info!("Pruner task cancelled.");
+                    return Ok(());
+                }
+                info!("Pruning epoch {}", epoch);
+                self.store.prune_epoch(epoch).await.unwrap_or_else(|e| {
+                    error!("Failed to prune epoch {}: {}", epoch, e);
+                });
+                self.metrics.last_pruned_epoch.set(epoch as i64);
+                info!("Pruned epoch {}", epoch);
+            }
+        }
+    }
+}

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -19,6 +19,7 @@ use crate::build_json_rpc_server;
 use crate::errors::IndexerError;
 use crate::handlers::checkpoint_handler::new_handlers;
 use crate::handlers::objects_snapshot_processor::{ObjectsSnapshotProcessor, SnapshotLagConfig};
+use crate::handlers::pruner::Pruner;
 use crate::indexer_reader::IndexerReader;
 use crate::metrics::IndexerMetrics;
 use crate::store::IndexerStore;
@@ -97,6 +98,18 @@ impl Indexer {
             cancel.clone(),
         );
         spawn_monitored_task!(objects_snapshot_processor.start());
+
+        let epochs_to_keep = std::env::var("EPOCHS_TO_KEEP")
+            .map(|s| s.parse::<u64>().ok())
+            .unwrap_or_else(|_e| None);
+        if let Some(epochs_to_keep) = epochs_to_keep {
+            info!(
+                "Starting indexer pruner with epochs to keep: {}",
+                epochs_to_keep
+            );
+            let pruner = Pruner::new(store.clone(), epochs_to_keep, metrics.clone());
+            spawn_monitored_task!(pruner.start(CancellationToken::new()));
+        }
 
         let cancel_clone = cancel.clone();
         let (exit_sender, exit_receiver) = oneshot::channel();

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -74,6 +74,11 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
     80.0, 100.0, 200.0,
 ];
 
+const DB_UPDATE_QUERY_LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 5000.0,
+    10000.0,
+];
+
 const DB_COMMIT_LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 2.0, 3.0,
     5.0, 10.0, 20.0, 40.0, 60.0, 80.0, 100.0, 200.0,
@@ -170,9 +175,13 @@ pub struct IndexerMetrics {
     // indexer state metrics
     pub db_conn_pool_size: IntGauge,
     pub idle_db_conn: IntGauge,
-
     pub address_processor_failure: IntCounter,
     pub checkpoint_metrics_processor_failure: IntCounter,
+    // pruner metrics
+    pub last_pruned_epoch: IntGauge,
+    pub last_pruned_checkpoint: IntGauge,
+    pub last_pruned_transaction: IntGauge,
+    pub epoch_pruning_latency: Histogram,
 }
 
 impl IndexerMetrics {
@@ -703,6 +712,29 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            last_pruned_epoch: register_int_gauge_with_registry!(
+                "last_pruned_epoch",
+                "Last pruned epoch number",
+                registry,
+            )
+            .unwrap(),
+            last_pruned_checkpoint: register_int_gauge_with_registry!(
+                "last_pruned_checkpoint",
+                "Last pruned checkpoint sequence number",
+                registry,
+            )
+            .unwrap(),
+            last_pruned_transaction: register_int_gauge_with_registry!(
+                "last_pruned_transaction",
+                "Last pruned transaction sequence number",
+                registry,
+            ).unwrap(),
+            epoch_pruning_latency: register_histogram_with_registry!(
+                "epoch_pruning_latency",
+                "Time spent in pruning one epoch",
+                DB_UPDATE_QUERY_LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            ).unwrap(),
         }
     }
 }

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -9,7 +9,7 @@ use sui_types::digests::CheckpointDigest;
 use sui_types::gas::GasCostSummary;
 
 use crate::errors::IndexerError;
-use crate::schema::{chain_identifier, checkpoints};
+use crate::schema::{chain_identifier, checkpoints, pruner_cp_watermark};
 use crate::types::IndexedCheckpoint;
 
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
@@ -157,5 +157,23 @@ impl TryFrom<StoredCheckpoint> for RpcCheckpoint {
             validator_signature,
             checkpoint_commitments,
         })
+    }
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = pruner_cp_watermark)]
+pub struct StoredCpTx {
+    pub checkpoint_sequence_number: i64,
+    pub min_tx_sequence_number: i64,
+    pub max_tx_sequence_number: i64,
+}
+
+impl From<&IndexedCheckpoint> for StoredCpTx {
+    fn from(c: &IndexedCheckpoint) -> Self {
+        Self {
+            checkpoint_sequence_number: c.sequence_number as i64,
+            min_tx_sequence_number: c.min_tx_sequence_number as i64,
+            max_tx_sequence_number: c.max_tx_sequence_number as i64,
+        }
     }
 }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -30,6 +30,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    pruner_cp_watermark (checkpoint_sequence_number) {
+        checkpoint_sequence_number -> Int8,
+        min_tx_sequence_number -> Int8,
+        max_tx_sequence_number -> Int8,
+    }
+}
+
+diesel::table! {
     display (object_type) {
         object_type -> Text,
         id -> Bytea,
@@ -284,6 +292,8 @@ macro_rules! for_all_tables {
         $action!(
             chain_identifier,
             checkpoints,
+            pruner_cp_watermark,
+            display,
             epochs,
             events,
             objects,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -22,6 +22,10 @@ pub enum ObjectChangeToCommit {
 pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError>;
 
+    async fn get_available_epoch_range(&self) -> Result<(u64, u64), IndexerError>;
+
+    async fn get_available_checkpoint_range(&self) -> Result<(u64, u64), IndexerError>;
+
     async fn get_latest_object_snapshot_checkpoint_sequence_number(
         &self,
     ) -> Result<Option<u64>, IndexerError>;
@@ -69,6 +73,8 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn persist_epoch(&self, epoch: EpochToCommit) -> Result<(), IndexerError>;
 
     async fn advance_epoch(&self, epoch: EpochToCommit) -> Result<(), IndexerError>;
+
+    async fn prune_epoch(&self, epoch: u64) -> Result<(), IndexerError>;
 
     async fn get_network_total_transactions_by_end_of_epoch(
         &self,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use core::result::Result::Ok;
-use diesel::dsl::max;
+use diesel::dsl::{max, min};
 use diesel::r2d2::R2D2Connection;
 use diesel::upsert::excluded;
 use diesel::ExpressionMethods;
@@ -31,6 +31,7 @@ use crate::insert_or_ignore_into;
 use crate::metrics::IndexerMetrics;
 use crate::models::checkpoints::StoredChainIdentifier;
 use crate::models::checkpoints::StoredCheckpoint;
+use crate::models::checkpoints::StoredCpTx;
 use crate::models::display::StoredDisplay;
 use crate::models::epoch::StoredEpochInfo;
 use crate::models::events::StoredEvent;
@@ -42,8 +43,8 @@ use crate::models::packages::StoredPackage;
 use crate::models::transactions::StoredTransaction;
 use crate::schema::{
     chain_identifier, checkpoints, display, epochs, events, objects, objects_history,
-    objects_snapshot, packages, transactions, tx_calls, tx_changed_objects, tx_digests,
-    tx_input_objects, tx_recipients, tx_senders,
+    objects_snapshot, packages, pruner_cp_watermark, transactions, tx_calls, tx_changed_objects,
+    tx_digests, tx_input_objects, tx_recipients, tx_senders,
 };
 use crate::types::{IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex};
 use crate::{read_only_blocking, transactional_blocking_with_retry};
@@ -62,6 +63,15 @@ macro_rules! chunk {
             .map(|c| c.collect())
             .collect::<Vec<Vec<_>>>()
     }};
+}
+
+macro_rules! prune_tx_indice_table {
+    ($table:ident, $conn:expr, $min_tx:expr, $max_tx:expr, $context_msg:expr) => {
+        diesel::delete($table::table.filter($table::tx_sequence_number.between($min_tx, $max_tx)))
+            .execute($conn)
+            .map_err(IndexerError::from)
+            .context($context_msg)?;
+    };
 }
 
 // In one DB transaction, the update could be chunked into
@@ -185,6 +195,80 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
                 .map(|v| v.map(|v| v as u64))
         })
         .context("Failed reading latest checkpoint sequence number from PostgresDB")
+    }
+
+    fn get_available_checkpoint_range(&self) -> Result<(u64, u64), IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            checkpoints::dsl::checkpoints
+                .select((
+                    min(checkpoints::sequence_number),
+                    max(checkpoints::sequence_number),
+                ))
+                .first::<(Option<i64>, Option<i64>)>(conn)
+                .map(|(min, max)| {
+                    (
+                        min.unwrap_or_default() as u64,
+                        max.unwrap_or_default() as u64,
+                    )
+                })
+        })
+        .context("Failed reading min and max checkpoint sequence numbers from PostgresDB")
+    }
+
+    fn get_prunable_epoch_range(&self) -> Result<(u64, u64), IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            epochs::dsl::epochs
+                .select((min(epochs::epoch), max(epochs::epoch)))
+                .first::<(Option<i64>, Option<i64>)>(conn)
+                .map(|(min, max)| {
+                    (
+                        min.unwrap_or_default() as u64,
+                        max.unwrap_or_default() as u64,
+                    )
+                })
+        })
+        .context("Failed reading min and max epoch numbers from PostgresDB")
+    }
+
+    fn get_min_prunable_checkpoint(&self) -> Result<u64, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            pruner_cp_watermark::dsl::pruner_cp_watermark
+                .select(min(pruner_cp_watermark::checkpoint_sequence_number))
+                .first::<Option<i64>>(conn)
+                .map(|v| v.unwrap_or_default() as u64)
+        })
+        .context("Failed reading min prunable checkpoint sequence number from PostgresDB")
+    }
+
+    fn get_checkpoint_range_for_epoch(
+        &self,
+        epoch: u64,
+    ) -> Result<(u64, Option<u64>), IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            epochs::dsl::epochs
+                .select((epochs::first_checkpoint_id, epochs::last_checkpoint_id))
+                .filter(epochs::epoch.eq(epoch as i64))
+                .first::<(i64, Option<i64>)>(conn)
+                .map(|(min, max)| (min as u64, max.map(|v| v as u64)))
+        })
+        .context("Failed reading checkpoint range from PostgresDB")
+    }
+
+    fn get_transaction_range_for_checkpoint(
+        &self,
+        checkpoint: u64,
+    ) -> Result<(u64, u64), IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            pruner_cp_watermark::dsl::pruner_cp_watermark
+                .select((
+                    pruner_cp_watermark::min_tx_sequence_number,
+                    pruner_cp_watermark::max_tx_sequence_number,
+                ))
+                .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(checkpoint as i64))
+                .first::<(i64, i64)>(conn)
+                .map(|(min, max)| (min as u64, max as u64))
+        })
+        .context("Failed reading transaction range from PostgresDB")
     }
 
     fn get_latest_object_snapshot_checkpoint_sequence_number(
@@ -496,6 +580,27 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
             .metrics
             .checkpoint_db_commit_latency_checkpoints
             .start_timer();
+
+        let stored_cp_txs = checkpoints.iter().map(StoredCpTx::from).collect::<Vec<_>>();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                for stored_cp_tx_chunk in stored_cp_txs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                    insert_or_ignore_into!(pruner_cp_watermark::table, stored_cp_tx_chunk, conn);
+                }
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            info!(
+                "Persisted {} pruner_cp_watermark rows.",
+                stored_cp_txs.len(),
+            );
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist pruner_cp_watermark with error: {}", e);
+        })?;
 
         let stored_checkpoints = checkpoints
             .iter()
@@ -980,6 +1085,107 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
         Ok(())
     }
 
+    fn prune_checkpoints_table(&self, cp: u64) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::delete(
+                    checkpoints::table.filter(checkpoints::sequence_number.eq(cp as i64)),
+                )
+                .execute(conn)
+                .map_err(IndexerError::from)
+                .context("Failed to prune checkpoints table")?;
+
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
+    fn prune_epochs_table(&self, epoch: u64) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::delete(epochs::table.filter(epochs::epoch.eq(epoch as i64)))
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context("Failed to prune epochs table")?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
+    fn prune_tx_indices_table(&self, min_tx: u64, max_tx: u64) -> Result<(), IndexerError> {
+        let (min_tx, max_tx) = (min_tx as i64, max_tx as i64);
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                prune_tx_indice_table!(
+                    tx_senders,
+                    conn,
+                    min_tx,
+                    max_tx,
+                    "Failed to prune tx_senders table"
+                );
+                prune_tx_indice_table!(
+                    tx_recipients,
+                    conn,
+                    min_tx,
+                    max_tx,
+                    "Failed to prune tx_recipients table"
+                );
+                prune_tx_indice_table![
+                    tx_input_objects,
+                    conn,
+                    min_tx,
+                    max_tx,
+                    "Failed to prune tx_input_objects table"
+                ];
+                prune_tx_indice_table![
+                    tx_changed_objects,
+                    conn,
+                    min_tx,
+                    max_tx,
+                    "Failed to prune tx_changed_objects table"
+                ];
+                prune_tx_indice_table![
+                    tx_calls,
+                    conn,
+                    min_tx,
+                    max_tx,
+                    "Failed to prune tx_calls table"
+                ];
+                prune_tx_indice_table![
+                    tx_digests,
+                    conn,
+                    min_tx,
+                    max_tx,
+                    "Failed to prune tx_digests table"
+                ];
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
+    fn prune_cp_tx_table(&self, cp: u64) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::delete(
+                    pruner_cp_watermark::table
+                        .filter(pruner_cp_watermark::checkpoint_sequence_number.eq(cp as i64)),
+                )
+                .execute(conn)
+                .map_err(IndexerError::from)
+                .context("Failed to prune pruner_cp_watermark table")?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
     fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
@@ -1044,6 +1250,16 @@ impl<T: R2D2Connection + 'static> PgIndexerStore<T> {
 impl<T: R2D2Connection> IndexerStore for PgIndexerStore<T> {
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError> {
         self.execute_in_blocking_worker(|this| this.get_latest_checkpoint_sequence_number())
+            .await
+    }
+
+    async fn get_available_epoch_range(&self) -> Result<(u64, u64), IndexerError> {
+        self.execute_in_blocking_worker(|this| this.get_prunable_epoch_range())
+            .await
+    }
+
+    async fn get_available_checkpoint_range(&self) -> Result<(u64, u64), IndexerError> {
+        self.execute_in_blocking_worker(|this| this.get_available_checkpoint_range())
             .await
     }
 
@@ -1422,6 +1638,75 @@ impl<T: R2D2Connection> IndexerStore for PgIndexerStore<T> {
     async fn advance_epoch(&self, epoch: EpochToCommit) -> Result<(), IndexerError> {
         self.execute_in_blocking_worker(move |this| this.advance_epoch(epoch))
             .await
+    }
+
+    async fn prune_epoch(&self, epoch: u64) -> Result<(), IndexerError> {
+        let (mut min_cp, max_cp) = match self.get_checkpoint_range_for_epoch(epoch)? {
+            (min_cp, Some(max_cp)) => Ok((min_cp, max_cp)),
+            _ => Err(IndexerError::PostgresReadError(format!(
+                "Failed to get checkpoint range for epoch {}",
+                epoch
+            ))),
+        }?;
+
+        // NOTE: for disaster recovery, min_cp is the min cp of the current epoch, which is likely
+        // partially pruned already. min_prunable_cp is the min cp to be pruned.
+        // By std::cmp::max, we will resume the pruning process from the next checkpoint, instead of
+        // the first cp of the current epoch.
+        let min_prunable_cp = self.get_min_prunable_checkpoint()?;
+        min_cp = std::cmp::max(min_cp, min_prunable_cp);
+        for cp in min_cp..=max_cp {
+            // NOTE: the order of pruning tables is crucial:
+            // 1. prune checkpoints table, checkpoints table is the source table of available range,
+            // we prune it first to make sure that we always have full data for checkpoints within the available range;
+            // 2. then prune tx_* tables;
+            // 3. then prune pruner_cp_watermark table, which is the checkpoint pruning watermark table and also tx seq source
+            // of a checkpoint to prune tx_* tables;
+            // 4. lastly we prune epochs table when all checkpoints of the epoch have been pruned.
+            info!(
+                "Pruning checkpoint {} of epoch {} (min_prunable_cp: {})",
+                cp, epoch, min_prunable_cp
+            );
+            self.execute_in_blocking_worker(move |this| this.prune_checkpoints_table(cp))
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!("Failed to prune checkpoint {}: {}", cp, e);
+                });
+
+            let (min_tx, max_tx) = self.get_transaction_range_for_checkpoint(cp)?;
+            self.execute_in_blocking_worker(move |this| {
+                this.prune_tx_indices_table(min_tx, max_tx)
+            })
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("Failed to prune transactions for cp {}: {}", cp, e);
+            });
+            info!(
+                "Pruned transactions for checkpoint {} from tx {} to tx {}",
+                cp, min_tx, max_tx
+            );
+            self.metrics.last_pruned_transaction.set(max_tx as i64);
+
+            self.execute_in_blocking_worker(move |this| this.prune_cp_tx_table(cp))
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!(
+                        "Failed to prune pruner_cp_watermark table for cp {}: {}",
+                        cp,
+                        e
+                    );
+                });
+            info!("Pruned checkpoint {} of epoch {}", cp, epoch);
+            self.metrics.last_pruned_checkpoint.set(cp as i64);
+        }
+
+        // NOTE: prune epochs table last, otherwise get_checkpoint_range_for_epoch would fail.
+        self.execute_in_blocking_worker(move |this| this.prune_epochs_table(epoch))
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("Failed to prune epoch table for epoch {}: {}", epoch, e);
+            });
+        Ok(())
     }
 
     async fn get_network_total_transactions_by_end_of_epoch(

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -45,6 +45,8 @@ pub struct IndexedCheckpoint {
     pub successful_tx_num: usize,
     pub end_of_epoch_data: Option<EndOfEpochData>,
     pub end_of_epoch: bool,
+    pub min_tx_sequence_number: u64,
+    pub max_tx_sequence_number: u64,
 }
 
 impl IndexedCheckpoint {
@@ -57,6 +59,9 @@ impl IndexedCheckpoint {
             + checkpoint.epoch_rolling_gas_cost_summary.storage_cost as i64
             - checkpoint.epoch_rolling_gas_cost_summary.storage_rebate as i64;
         let tx_digests = contents.iter().map(|t| t.transaction).collect::<Vec<_>>();
+        let max_tx_sequence_number = checkpoint.network_total_transactions - 1;
+        // NOTE: + 1u64 first to avoid subtraction with overflow
+        let min_tx_sequence_number = max_tx_sequence_number + 1u64 - tx_digests.len() as u64;
         let auth_sig = &checkpoint.auth_sig().signature;
         Self {
             sequence_number: checkpoint.sequence_number,
@@ -78,6 +83,8 @@ impl IndexedCheckpoint {
             timestamp_ms: checkpoint.timestamp_ms,
             validator_signature: auth_sig.clone(),
             checkpoint_commitments: checkpoint.checkpoint_commitments.clone(),
+            min_tx_sequence_number,
+            max_tx_sequence_number,
         }
     }
 }


### PR DESCRIPTION
a separate pruner that use `epochs` table and `cp_tx` table to track progress of pruning and handle disaster recovery;
and `checkpoints` table as available range data source.

local run and verify via local client
- progress tracking via epoch, cp, and tx

![epoch_progress](https://github.com/MystenLabs/sui/assets/106119108/f628c7b5-add7-4198-94e3-f2542dfd7890)

![tx_cp_progress](https://github.com/MystenLabs/sui/assets/106119108/4395ff7d-b79b-4a6d-aec6-243ac5c86c22)

- verify on checkpoints & tx_ tables
  - make sure that the checkpoints table is indeed latest cp_tx cp + 1

![check_cp](https://github.com/MystenLabs/sui/assets/106119108/13de7129-16b6-44e9-a922-c487100cb152)
  - make sure that all cp < min_tx in cp_tx have been pruned

![check_tx](https://github.com/MystenLabs/sui/assets/106119108/0708e667-135a-44be-be77-b1eb667ba640)

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
