### PR TITLE
[move-ide] Version number consistent with marketplace

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.11",
+  "version": "1.0.10",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",


### PR DESCRIPTION
## Description 

I was a bit overeager in bumping up extension version number and this PR brings it back (to `1.0.10`) to be consistent with what should be the next version in the marketplace:

![image](https://github.com/user-attachments/assets/2b8788e9-8d35-431f-a8cc-b6653ae7023e)
