### PR TITLE
[move][move-2024] Fix match compilation field ordering

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/field_ordering.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/field_ordering.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/field_ordering.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/field_ordering.move
@@ -1,0 +1,19 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m;
+
+public enum E {
+    V { zero: u64, one: u64 }
+}
+
+fun add1(n: u64): u64 { n + 1 }
+
+public fun main() {
+    let one = match (E::V { zero: 0, one: 1}) {
+        E::V { one: _, zero: one } => add1(one)
+    };
+    assert!(one == 1)
+}
+
+//# run 0x42::m::main

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -373,7 +373,12 @@ fn find_counterexample_impl(
             // recur. If we don't, we check it as a default specialization.
             if let Some((ploc, arg_types)) = matrix.first_struct_ctors() {
                 let ctor_arity = arg_types.len() as u32;
-                let fringe_binders = context.make_imm_ref_match_binders(ploc, arg_types);
+                let decl_fields = context
+                    .modules
+                    .struct_fields(&mident, &datatype_name)
+                    .unwrap();
+                let fringe_binders =
+                    context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
                 let is_positional = context
                     .modules
                     .struct_is_positional(&mident, &datatype_name);
@@ -433,7 +438,12 @@ fn find_counterexample_impl(
             if unmatched_variants.is_empty() {
                 for (ctor, (ploc, arg_types)) in ctors {
                     let ctor_arity = arg_types.len() as u32;
-                    let fringe_binders = context.make_imm_ref_match_binders(ploc, arg_types);
+                    let decl_fields = context
+                        .modules
+                        .enum_variant_fields(&mident, &datatype_name, &ctor)
+                        .unwrap();
+                    let fringe_binders =
+                        context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
                     let is_positional =
                         context
                             .modules

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/field_order_counterexample.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/field_order_counterexample.exp
@@ -1,0 +1,8 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/move_2024/matching/field_order_counterexample.move:8:12
+  │
+8 │     match (e) {
+  │            ^ Pattern 'E::V { zero: _0, one: _ }' not covered
+  │
+  = When '_0' is not 0
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/field_order_counterexample.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/field_order_counterexample.move
@@ -1,0 +1,11 @@
+module a::m;
+
+public enum E {
+    V { zero: u64, one: u64 }
+}
+
+public fun bad(e: &E) {
+    match (e) {
+        E::V { one: _, zero: 0 } => (),
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/stloc_error.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/stloc_error.move
@@ -1,0 +1,30 @@
+module a::m;
+
+public enum Proposal has store, copy, drop {
+        ConfigProposalQuorum {approved: vector<u16>, rejected: vector<u16>},
+        MpcTxProposalQuorum {approved: vector<u16>, rejected: vector<u16>},
+        MpcTxProposalSpecific { require_approval_users: vector<u16>, threshold: u16, approved: vector<u16>, rejected: vector<u16> },
+}
+
+public struct Users {}
+
+public fun quorum_approves(_users: &Users, _approved: &vector<u16>): bool { false }
+
+public(package) fun is_proposal_approved(proposal: &Proposal, users: &Users): bool {
+    match (proposal) {
+        Proposal::ConfigProposalQuorum { approved: approved, rejected: _ } => {
+            users.quorum_approves(approved)
+        },
+        Proposal::MpcTxProposalQuorum { approved:approved, rejected: _ } => {
+            users.quorum_approves(approved)
+        },
+        Proposal::MpcTxProposalSpecific {
+            require_approval_users : _,
+            threshold: threshold,
+            approved: approved,
+            rejected: _
+        } => {
+            ((approved.length() as u16) >= *threshold)
+        }
+    }
+}


### PR DESCRIPTION
## Description 

Revise match compilation that ensures misordered fields are sorted when bindings are created.

## Test plan 

Two new tests to ensure things work correctly. I will add more tests ASAP as well.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
