### PR TITLE
feat: [Source Validation] Check linkage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14037,6 +14037,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-sdk 1.32.0",
  "sui-types",
+ "thiserror",
  "tracing",
 ]
 
@@ -14475,6 +14476,7 @@ dependencies = [
  "rand 0.8.5",
  "sui-json-rpc-types",
  "sui-move-build",
+ "sui-package-management",
  "sui-sdk 1.32.0",
  "sui-test-transaction-builder",
  "sui-types",

--- a/crates/sui-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_index_test.rs
@@ -631,7 +631,7 @@ async fn publish_managed_coin_package(
     let compiled_package = compile_managed_coin_package();
     let all_module_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let params = rpc_params![
         ctx.get_wallet_address(),

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -24,7 +24,7 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
         let compiled_package = compile_basics_package();
         let all_module_bytes =
             compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-        let dependencies = compiled_package.get_dependency_original_package_ids();
+        let dependencies = compiled_package.get_dependency_storage_package_ids();
 
         let params = rpc_params![
             ctx.get_wallet_address(),

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2806,7 +2806,7 @@ pub fn build_package(
     let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
     let digest = compiled_package.get_package_digest(with_unpublished_deps);
     let modules = compiled_package.get_package_bytes(with_unpublished_deps);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
     (digest.to_vec(), modules, dependencies)
 }
 
@@ -2826,7 +2826,7 @@ pub async fn build_and_try_publish_test_package(
 
     let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
     let all_module_bytes = compiled_package.get_package_bytes(with_unpublished_deps);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();

--- a/crates/sui-json-rpc-tests/tests/balance_changes_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/balance_changes_tests.rs
@@ -26,7 +26,7 @@ async fn test_dry_run_publish_with_mocked_coin() -> Result<(), anyhow::Error> {
         .into_iter()
         .map(|b| b.to_vec().unwrap())
         .collect::<Vec<_>>();
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let mut builder = ProgrammableTransactionBuilder::new();
     builder.publish_immutable(compiled_modules_bytes, dependencies);

--- a/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
@@ -192,7 +192,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         BuildConfig::new_for_testing().build(Path::new("../../examples/move/basics"))?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
@@ -453,7 +453,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let compiled_package = BuildConfig::new_for_testing().build(&path)?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
@@ -537,7 +537,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let compiled_package = BuildConfig::default().build(&path)?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .publish(

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -352,22 +352,6 @@ impl CompiledPackage {
         self.dependency_ids.published.values().cloned().collect()
     }
 
-    /// Return the set of Object IDs corresponding to this package's transitive dependencies'
-    /// original package IDs.
-    pub fn get_dependency_original_package_ids(&self) -> Vec<ObjectID> {
-        let mut ids: BTreeSet<_> = self
-            .package
-            .deps_compiled_units
-            .iter()
-            .map(|(_, m)| ObjectID::from(*m.unit.module.address()))
-            .collect();
-
-        // `0x0` is not a real dependency ID -- it means that the package has unpublished
-        // dependencies.
-        ids.remove(&ObjectID::ZERO);
-        ids.into_iter().collect()
-    }
-
     pub fn get_package_digest(&self, with_unpublished_deps: bool) -> [u8; 32] {
         let hash_modules = true;
         MovePackage::compute_digest_for_modules_and_deps(
@@ -394,14 +378,6 @@ impl CompiledPackage {
         self.get_package_bytes(with_unpublished_deps)
             .iter()
             .map(|b| Base64::from_bytes(b))
-            .collect()
-    }
-
-    pub fn get_package_dependencies_hex(&self) -> Vec<String> {
-        self.dependency_ids
-            .published
-            .values()
-            .map(|object_id| object_id.to_hex_uncompressed())
             .collect()
     }
 

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -75,12 +75,11 @@ impl Build {
                 check_unpublished_dependencies(&pkg.dependency_ids.unpublished)?;
             }
 
-            let package_dependencies = pkg.get_package_dependencies_hex();
             println!(
                 "{}",
                 json!({
                     "modules": pkg.get_package_base64(with_unpublished_deps),
-                    "dependencies": json!(package_dependencies),
+                    "dependencies": pkg.get_dependency_storage_package_ids(),
                     "digest": pkg.get_package_digest(with_unpublished_deps),
                 })
             )

--- a/crates/sui-oracle/tests/integration_tests.rs
+++ b/crates/sui-oracle/tests/integration_tests.rs
@@ -466,7 +466,7 @@ async fn publish_package(
 ) -> ObjectID {
     let compiled_package = BuildConfig::new_for_testing().build(path).unwrap();
     let all_module_bytes = compiled_package.get_package_bytes(false);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
     let gas = client
         .coin_read_api()
         .get_coins(sender, None, None, Some(1))

--- a/crates/sui-package-management/Cargo.toml
+++ b/crates/sui-package-management/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 sui-json-rpc-types.workspace = true

--- a/crates/sui-package-management/src/lib.rs
+++ b/crates/sui-package-management/src/lib.rs
@@ -25,10 +25,18 @@ pub enum LockCommand {
     Upgrade,
 }
 
-#[derive(Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum PublishedAtError {
+    #[error("The 'published-at' field in Move.toml or Move.lock is invalid: {0:?}")]
     Invalid(String),
+
+    #[error("The 'published-at' field is not present in Move.toml or Move.lock")]
     NotPresent,
+
+    #[error(
+        "Conflicting 'published-at' addresses between Move.toml -- {id_manifest} -- and \
+         Move.lock -- {id_lock}"
+    )]
     Conflict {
         id_lock: ObjectID,
         id_manifest: ObjectID,

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -144,7 +144,7 @@ async fn test_publish_and_move_call() {
     let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
     let compiled_modules_bytes =
         compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
-    let dependencies = compiled_package.get_dependency_original_package_ids();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -34,7 +34,7 @@ use sui_move_build::{BuildConfig, SuiPackageHooks};
 use sui_sdk::rpc_types::SuiTransactionBlockEffects;
 use sui_sdk::types::base_types::ObjectID;
 use sui_sdk::SuiClientBuilder;
-use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
+use sui_source_validation::{BytecodeSourceVerifier, ValidationMode};
 
 pub const HOST_PORT_ENV: &str = "HOST_PORT";
 pub const SUI_SOURCE_VALIDATION_VERSION_HEADER: &str = "x-sui-source-validation-version";
@@ -172,11 +172,7 @@ pub async fn verify_package(
     let compiled_package = build_config.build(package_path.as_ref())?;
 
     BytecodeSourceVerifier::new(client.read_api())
-        .verify_package(
-            &compiled_package,
-            /* verify_deps */ false,
-            SourceMode::Verify,
-        )
+        .verify(&compiled_package, ValidationMode::root())
         .await
         .map_err(|e| anyhow!("Network {network}: {e}"))?;
 

--- a/crates/sui-source-validation/Cargo.toml
+++ b/crates/sui-source-validation/Cargo.toml
@@ -17,9 +17,10 @@ tracing.workspace = true
 futures.workspace = true
 
 sui-json-rpc-types.workspace = true
+sui-move-build.workspace = true
+sui-package-management.workspace = true
 sui-types.workspace = true
 sui-sdk.workspace = true
-sui-move-build.workspace = true
 
 move-binary-format.workspace = true
 move-bytecode-source-map.workspace = true

--- a/crates/sui-source-validation/src/error.rs
+++ b/crates/sui-source-validation/src/error.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use sui_json_rpc_types::SuiRawMoveObject;
+use sui_package_management::PublishedAtError;
 use sui_sdk::error::Error as SdkError;
 use sui_types::{base_types::ObjectID, error::SuiObjectResponseError};
 
@@ -20,6 +21,9 @@ pub enum Error {
     #[error("Could not read a dependency's on-chain object: {0:?}")]
     DependencyObjectReadFailure(SdkError),
 
+    #[error("On-chain package {0} is empty")]
+    EmptyOnChainPackage(AccountAddress),
+
     #[error("Invalid module {name} with error: {message}")]
     InvalidModuleFailure { name: String, message: String },
 
@@ -28,6 +32,12 @@ pub enum Error {
         address: AccountAddress,
         module: Symbol,
     },
+
+    #[error("Source package depends on {0} which is not in the linkage table.")]
+    MissingDependencyInLinkageTable(AccountAddress),
+
+    #[error("On-chain package depends on {0} which is not a source dependency.")]
+    MissingDependencyInSourcePackage(AccountAddress),
 
     #[error(
         "Local dependency did not match its on-chain version at {address}::{package}::{module}"
@@ -49,6 +59,9 @@ pub enum Error {
 
     #[error("On-chain version of dependency {package}::{module} was not found.")]
     OnChainDependencyNotFound { package: Symbol, module: Symbol },
+
+    #[error("{0}. Please supply an explicit on-chain address for the package")]
+    PublishedAt(#[from] PublishedAtError),
 
     #[error("Dependency object does not exist or was deleted: {0:?}")]
     SuiObjectRefFailure(SuiObjectResponseError),

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -6,9 +6,8 @@ use futures::future;
 use move_binary_format::CompiledModule;
 use move_compiler::compiled_unit::NamedCompiledModule;
 use move_core_types::account_address::AccountAddress;
-use move_package::compilation::compiled_package::CompiledPackage as MoveCompiledPackage;
 use move_symbol_pool::Symbol;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use sui_move_build::CompiledPackage;
 use sui_sdk::apis::ReadApi;
 use sui_sdk::error::Error as SdkError;
@@ -22,17 +21,21 @@ mod toolchain;
 #[cfg(test)]
 mod tests;
 
-/// How to handle package source during bytecode verification.
-#[derive(PartialEq, Eq)]
-pub enum SourceMode {
-    /// Don't verify source.
-    Skip,
+/// Details of what to verify
+pub enum ValidationMode {
+    /// Validate only the dependencies
+    Deps,
 
-    /// Verify source at the address specified in its manifest.
-    Verify,
+    /// Validate the root package, and its linkage.
+    Root {
+        /// Additionally validate the dependencies, and make sure the runtime and storage IDs in
+        /// dependency source code matches the root package's on-chain linkage table.
+        deps: bool,
 
-    /// Verify source at an overridden address (only works if the package is not published)
-    VerifyAt(AccountAddress),
+        /// Look for the root package on-chain at the specified address, rather than the address in
+        /// its manifest.
+        at: Option<AccountAddress>,
+    },
 }
 
 pub struct BytecodeSourceVerifier<'a> {
@@ -41,119 +44,332 @@ pub struct BytecodeSourceVerifier<'a> {
 
 /// Map package addresses and module names to package names and bytecode.
 type LocalModules = HashMap<(AccountAddress, Symbol), (Symbol, CompiledModule)>;
-/// Map package addresses and modules names to bytecode (package names are gone in the on-chain
-/// representation).
-type OnChainModules = HashMap<(AccountAddress, Symbol), CompiledModule>;
+
+#[derive(Default)]
+struct OnChainRepresentation {
+    /// Storage IDs from the root package's on-chain linkage table. This will only be present if
+    /// root package verification was requested, in which case the keys from this mapping must
+    /// match the source package's dependencies.
+    on_chain_dependencies: Option<HashSet<AccountAddress>>,
+
+    /// Map package addresses and module names to bytecode (package names are gone in the on-chain
+    /// representation).
+    modules: HashMap<(AccountAddress, Symbol), CompiledModule>,
+}
+
+impl ValidationMode {
+    /// Only verify that source dependencies match their on-chain versions.
+    pub fn deps() -> Self {
+        Self::Deps
+    }
+
+    /// Only verify that the root package matches its on-chain version (requires that the root
+    /// package is published with its address available in the manifest).
+    pub fn root() -> Self {
+        Self::Root {
+            deps: false,
+            at: None,
+        }
+    }
+
+    /// Only verify that the root package matches its on-chain version, but override the location
+    /// to look for the root package to `address`.
+    pub fn root_at(address: AccountAddress) -> Self {
+        Self::Root {
+            deps: false,
+            at: Some(address),
+        }
+    }
+
+    /// Verify both the root package and its dependencies (requires that the root package is
+    /// published with its address available in the manifest).
+    pub fn root_and_deps() -> Self {
+        Self::Root {
+            deps: true,
+            at: None,
+        }
+    }
+
+    /// Verify both the root package and its dependencies, but override the location to look for
+    /// the root package to `address`.
+    pub fn root_and_deps_at(address: AccountAddress) -> Self {
+        Self::Root {
+            deps: true,
+            at: Some(address),
+        }
+    }
+
+    /// Should we verify dependencies?
+    fn verify_deps(&self) -> bool {
+        matches!(self, Self::Deps | Self::Root { deps: true, .. })
+    }
+
+    /// If the root package needs to be verified, what address should it be fetched from?
+    fn root_address(&self, package: &CompiledPackage) -> Result<Option<AccountAddress>, Error> {
+        match self {
+            Self::Root { at: Some(addr), .. } => Ok(Some(*addr)),
+            Self::Root { at: None, .. } => Ok(Some(*package.published_at.clone()?)),
+            Self::Deps => Ok(None),
+        }
+    }
+
+    /// All the on-chain addresses that we need to fetch to build on-chain addresses.
+    fn on_chain_addresses(&self, package: &CompiledPackage) -> Result<Vec<AccountAddress>, Error> {
+        let mut addrs = vec![];
+
+        if let Some(addr) = self.root_address(package)? {
+            addrs.push(addr);
+        }
+
+        if self.verify_deps() {
+            addrs.extend(dependency_addresses(package));
+        }
+
+        Ok(addrs)
+    }
+
+    /// On-chain representation of the package and dependencies compiled to `package`, including
+    /// linkage information.
+    async fn on_chain(
+        &self,
+        package: &CompiledPackage,
+        verifier: &BytecodeSourceVerifier<'_>,
+    ) -> Result<OnChainRepresentation, AggregateError> {
+        let mut on_chain = OnChainRepresentation::default();
+        let mut errs: Vec<Error> = vec![];
+
+        let root = self.root_address(package)?;
+        let addrs = self.on_chain_addresses(package)?;
+
+        let resps =
+            future::join_all(addrs.iter().copied().map(|a| verifier.pkg_for_address(a))).await;
+
+        for (storage_id, pkg) in addrs.into_iter().zip(resps) {
+            let SuiRawMovePackage {
+                module_map,
+                linkage_table,
+                ..
+            } = pkg?;
+
+            let mut modules = module_map
+                .into_iter()
+                .map(|(name, bytes)| {
+                    let Ok(module) = CompiledModule::deserialize_with_defaults(&bytes) else {
+                        return Err(Error::OnChainDependencyDeserializationError {
+                            address: storage_id,
+                            module: name.into(),
+                        });
+                    };
+
+                    Ok::<_, Error>((Symbol::from(name), module))
+                })
+                .peekable();
+
+            let runtime_id = match modules.peek() {
+                Some(Ok((_, module))) => *module.self_id().address(),
+
+                Some(Err(_)) => {
+                    // SAFETY: The error type does not implement `Clone` so we need to take the
+                    // error by value. We do that by calling `next` to take the value we just
+                    // peeked, which we know is an error type.
+                    errs.push(modules.next().unwrap().unwrap_err());
+                    continue;
+                }
+
+                None => {
+                    errs.push(Error::EmptyOnChainPackage(storage_id));
+                    continue;
+                }
+            };
+
+            for module in modules {
+                match module {
+                    Ok((name, module)) => {
+                        on_chain.modules.insert((runtime_id, name), module);
+                    }
+
+                    Err(e) => {
+                        errs.push(e);
+                        continue;
+                    }
+                }
+            }
+
+            if root.is_some_and(|r| r == storage_id) {
+                on_chain.on_chain_dependencies = Some(HashSet::from_iter(
+                    linkage_table.into_values().map(|info| *info.upgraded_id),
+                ));
+            }
+        }
+
+        Ok(on_chain)
+    }
+
+    /// Local representation of the modules in `package`. If the validation mode requires verifying
+    /// dependencies, then the dependencies' modules are also included in the output.
+    ///
+    /// For the purposes of this function, a module is considered a dependency if it is from a
+    /// different source package, and that source package has already been published. Conversely, a
+    /// module that is from a different source package, but that has not been published is
+    /// considered part of the root package.
+    ///
+    /// If the validation mode requires verifying the root package at a specific address, then the
+    /// modules from the root package will be expected at address `0x0` and this address will be
+    /// substituted with the specified address.
+    fn local(&self, package: &CompiledPackage) -> Result<LocalModules, Error> {
+        let package = &package.package;
+        let root_package = package.compiled_package_info.package_name;
+        let mut map = LocalModules::new();
+
+        if self.verify_deps() {
+            let deps_compiled_units =
+                units_for_toolchain(&package.deps_compiled_units).map_err(|e| {
+                    Error::CannotCheckLocalModules {
+                        package: package.compiled_package_info.package_name,
+                        message: e.to_string(),
+                    }
+                })?;
+
+            for (package, local_unit) in deps_compiled_units {
+                let m = &local_unit.unit;
+                let module = m.name;
+                let address = m.address.into_inner();
+
+                // Skip modules with on 0x0 because they are treated as part of the root package,
+                // even if they are a source dependency.
+                if address == AccountAddress::ZERO {
+                    continue;
+                }
+
+                map.insert((address, module), (package, m.module.clone()));
+            }
+        }
+
+        let Self::Root { at, .. } = self else {
+            return Ok(map);
+        };
+
+        // Potentially rebuild according to the toolchain that the package was originally built
+        // with.
+        let root_compiled_units = units_for_toolchain(
+            &package
+                .root_compiled_units
+                .iter()
+                .map(|u| ("root".into(), u.clone()))
+                .collect(),
+        )
+        .map_err(|e| Error::CannotCheckLocalModules {
+            package: package.compiled_package_info.package_name,
+            message: e.to_string(),
+        })?;
+
+        // Add the root modules, potentially remapping 0x0 if we have been supplied an address to
+        // substitute with.
+        for (_, local_unit) in root_compiled_units {
+            let m = &local_unit.unit;
+            let module = m.name;
+            let address = m.address.into_inner();
+
+            let (address, compiled_module) = if let Some(root_address) = at {
+                (*root_address, substitute_root_address(m, *root_address)?)
+            } else if address == AccountAddress::ZERO {
+                return Err(Error::InvalidModuleFailure {
+                    name: module.to_string(),
+                    message: "Can't verify unpublished source".to_string(),
+                });
+            } else {
+                (address, m.module.clone())
+            };
+
+            map.insert((address, module), (root_package, compiled_module));
+        }
+
+        // If we have a root address to substitute, we need to find unpublished dependencies that
+        // would have gone into the root package as well.
+        if let Some(root_address) = at {
+            for (package, local_unit) in &package.deps_compiled_units {
+                let m = &local_unit.unit;
+                let module = m.name;
+                let address = m.address.into_inner();
+
+                if address != AccountAddress::ZERO {
+                    continue;
+                }
+
+                map.insert(
+                    (*root_address, module),
+                    (*package, substitute_root_address(m, *root_address)?),
+                );
+            }
+        }
+
+        Ok(map)
+    }
+}
 
 impl<'a> BytecodeSourceVerifier<'a> {
     pub fn new(rpc_client: &'a ReadApi) -> Self {
         BytecodeSourceVerifier { rpc_client }
     }
 
-    /// Helper wrapper to verify that all local Move package dependencies' and root bytecode matches
-    /// the bytecode at the address specified on the Sui network we are publishing to.
-    pub async fn verify_package_root_and_deps(
+    /// Verify that the `compiled_package` matches its on-chain representation.
+    ///
+    /// See [`ValidationMode`] for more details on what is verified.
+    pub async fn verify(
         &self,
-        compiled_package: &CompiledPackage,
-        root_on_chain_address: AccountAddress,
+        package: &CompiledPackage,
+        mode: ValidationMode,
     ) -> Result<(), AggregateError> {
-        self.verify_package(
-            compiled_package,
-            /* verify_deps */ true,
-            SourceMode::VerifyAt(root_on_chain_address),
-        )
-        .await
-    }
-
-    /// Helper wrapper to verify that all local Move package root bytecode matches
-    /// the bytecode at the address specified on the Sui network we are publishing to.
-    pub async fn verify_package_root(
-        &self,
-        compiled_package: &CompiledPackage,
-        root_on_chain_address: AccountAddress,
-    ) -> Result<(), AggregateError> {
-        self.verify_package(
-            compiled_package,
-            /* verify_deps */ false,
-            SourceMode::VerifyAt(root_on_chain_address),
-        )
-        .await
-    }
-
-    /// Helper wrapper to verify that all local Move package dependencies' matches
-    /// the bytecode at the address specified on the Sui network we are publishing to.
-    pub async fn verify_package_deps(
-        &self,
-        compiled_package: &CompiledPackage,
-    ) -> Result<(), AggregateError> {
-        self.verify_package(
-            compiled_package,
-            /* verify_deps */ true,
-            SourceMode::Skip,
-        )
-        .await
-    }
-
-    /// Verify that all local Move package dependencies' and/or root bytecode matches the bytecode
-    /// at the address specified on the Sui network we are publishing to.  If `verify_deps` is true,
-    /// the dependencies are verified.  If `root_on_chain_address` is specified, the root is
-    /// verified against a package at `root_on_chain_address`.
-    pub async fn verify_package(
-        &self,
-        compiled_package: &CompiledPackage,
-        verify_deps: bool,
-        source_mode: SourceMode,
-    ) -> Result<(), AggregateError> {
-        let mut on_chain_pkgs = vec![];
-        match &source_mode {
-            SourceMode::Skip => (),
-            // On-chain address for matching root package cannot be zero
-            SourceMode::VerifyAt(AccountAddress::ZERO) => {
-                return Err(Error::ZeroOnChainAddresSpecifiedFailure.into())
+        if matches!(
+            mode,
+            ValidationMode::Root {
+                at: Some(AccountAddress::ZERO),
+                ..
             }
-            SourceMode::VerifyAt(root_address) => on_chain_pkgs.push(*root_address),
-            SourceMode::Verify => {
-                on_chain_pkgs.extend(compiled_package.published_at.as_ref().map(|id| **id))
-            }
-        };
-
-        if verify_deps {
-            on_chain_pkgs.extend(
-                compiled_package
-                    .dependency_ids
-                    .published
-                    .values()
-                    .map(|id| **id),
-            );
+        ) {
+            return Err(Error::ZeroOnChainAddresSpecifiedFailure.into());
         }
 
-        let local_modules = local_modules(&compiled_package.package, verify_deps, source_mode)?;
-        let mut on_chain_modules = self.on_chain_modules(on_chain_pkgs.into_iter()).await?;
+        let local = mode.local(package)?;
+        let mut chain = mode.on_chain(package, self).await?;
+        let mut errs = vec![];
 
-        let mut errors = Vec::new();
-        for ((address, module), (package, local_module)) in local_modules {
-            let Some(on_chain_module) = on_chain_modules.remove(&(address, module)) else {
-                errors.push(Error::OnChainDependencyNotFound { package, module });
+        // Check that the transitive dependencies listed on chain match the dependencies listed in
+        // source code. Ignore 0x0 becaus this signifies an unpublished dependency.
+        if let Some(on_chain_deps) = &mut chain.on_chain_dependencies {
+            for dependency_id in dependency_addresses(package) {
+                if dependency_id != AccountAddress::ZERO && !on_chain_deps.remove(&dependency_id) {
+                    errs.push(Error::MissingDependencyInLinkageTable(dependency_id));
+                }
+            }
+        }
+
+        for on_chain_dep_id in chain.on_chain_dependencies.take().into_iter().flatten() {
+            errs.push(Error::MissingDependencyInSourcePackage(on_chain_dep_id));
+        }
+
+        // Check that the contents of bytecode matches between modules.
+        for ((address, module), (package, local_module)) in local {
+            let Some(on_chain_module) = chain.modules.remove(&(address, module)) else {
+                errs.push(Error::OnChainDependencyNotFound { package, module });
                 continue;
             };
 
-            // compare local bytecode to on-chain bytecode to ensure integrity of our
-            // dependencies
             if local_module != on_chain_module {
-                errors.push(Error::ModuleBytecodeMismatch {
+                errs.push(Error::ModuleBytecodeMismatch {
                     address,
                     package,
                     module,
-                });
+                })
             }
         }
 
-        if let Some(((address, module), _)) = on_chain_modules.into_iter().next() {
-            errors.push(Error::LocalDependencyNotFound { address, module });
+        for (address, module) in chain.modules.into_keys() {
+            errs.push(Error::LocalDependencyNotFound { address, module });
         }
 
-        if !errors.is_empty() {
-            return Err(AggregateError(errors));
+        if !errs.is_empty() {
+            return Err(AggregateError(errs));
         }
 
         Ok(())
@@ -190,37 +406,6 @@ impl<'a> BytecodeSourceVerifier<'a> {
             }
         }
     }
-
-    async fn on_chain_modules(
-        &self,
-        addresses: impl Iterator<Item = AccountAddress> + Clone,
-    ) -> Result<OnChainModules, AggregateError> {
-        let resp = future::join_all(addresses.clone().map(|addr| self.pkg_for_address(addr))).await;
-        let mut map = OnChainModules::new();
-        let mut err = vec![];
-
-        for (storage_id, pkg) in addresses.zip(resp) {
-            let SuiRawMovePackage { module_map, .. } = pkg?;
-            for (name, bytes) in module_map {
-                let Ok(module) = CompiledModule::deserialize_with_defaults(&bytes) else {
-                    err.push(Error::OnChainDependencyDeserializationError {
-                        address: storage_id,
-                        module: name.into(),
-                    });
-                    continue;
-                };
-
-                let runtime_id = *module.self_id().address();
-                map.insert((runtime_id, Symbol::from(name)), module);
-            }
-        }
-
-        if !err.is_empty() {
-            return Err(AggregateError(err));
-        }
-
-        Ok(map)
-    }
 }
 
 fn substitute_root_address(
@@ -248,115 +433,7 @@ fn substitute_root_address(
     Ok(module)
 }
 
-fn local_modules(
-    compiled_package: &MoveCompiledPackage,
-    include_deps: bool,
-    source_mode: SourceMode,
-) -> Result<LocalModules, Error> {
-    let mut map = LocalModules::new();
-
-    if include_deps {
-        // Compile dependencies with prior compilers if needed.
-        let deps_compiled_units = units_for_toolchain(&compiled_package.deps_compiled_units)
-            .map_err(|e| Error::CannotCheckLocalModules {
-                package: compiled_package.compiled_package_info.package_name,
-                message: e.to_string(),
-            })?;
-
-        for (package, local_unit) in deps_compiled_units {
-            let m = &local_unit.unit;
-            let module = m.name;
-            let address = m.address.into_inner();
-            if address == AccountAddress::ZERO {
-                continue;
-            }
-
-            map.insert((address, module), (package, m.module.clone()));
-        }
-    }
-
-    let root_package = compiled_package.compiled_package_info.package_name;
-    match source_mode {
-        SourceMode::Skip => { /* nop */ }
-
-        // Include the root compiled units, at their current addresses.
-        SourceMode::Verify => {
-            // Compile root modules with prior compiler if needed.
-            let root_compiled_units = {
-                let root_compiled_units = compiled_package
-                    .root_compiled_units
-                    .iter()
-                    .map(|u| ("root".into(), u.clone()))
-                    .collect::<Vec<_>>();
-
-                units_for_toolchain(&root_compiled_units).map_err(|e| {
-                    Error::CannotCheckLocalModules {
-                        package: compiled_package.compiled_package_info.package_name,
-                        message: e.to_string(),
-                    }
-                })?
-            };
-
-            for (_, local_unit) in root_compiled_units {
-                let m = &local_unit.unit;
-
-                let module = m.name;
-                let address = m.address.into_inner();
-                if address == AccountAddress::ZERO {
-                    return Err(Error::InvalidModuleFailure {
-                        name: module.to_string(),
-                        message: "Can't verify unpublished source".to_string(),
-                    });
-                }
-
-                map.insert((address, module), (root_package, m.module.clone()));
-            }
-        }
-
-        // Include the root compiled units, and any unpublished dependencies with their
-        // addresses substituted
-        SourceMode::VerifyAt(root_address) => {
-            // Compile root modules with prior compiler if needed.
-            let root_compiled_units = {
-                let root_compiled_units = compiled_package
-                    .root_compiled_units
-                    .iter()
-                    .map(|u| ("root".into(), u.clone()))
-                    .collect::<Vec<_>>();
-
-                units_for_toolchain(&root_compiled_units).map_err(|e| {
-                    Error::CannotCheckLocalModules {
-                        package: compiled_package.compiled_package_info.package_name,
-                        message: e.to_string(),
-                    }
-                })?
-            };
-
-            for (_, local_unit) in root_compiled_units {
-                let m = &local_unit.unit;
-
-                let module = m.name;
-                map.insert(
-                    (root_address, module),
-                    (root_package, substitute_root_address(m, root_address)?),
-                );
-            }
-
-            for (package, local_unit) in &compiled_package.deps_compiled_units {
-                let m = &local_unit.unit;
-                let module = m.name;
-                let address = m.address.into_inner();
-                if address != AccountAddress::ZERO {
-                    continue;
-                }
-
-                map.insert(
-                    (root_address, module),
-                    (*package, substitute_root_address(m, root_address)?),
-                );
-            }
-        }
-    }
-
-    Ok(map)
+/// The on-chain addresses for a source package's dependencies
+fn dependency_addresses(package: &CompiledPackage) -> impl Iterator<Item = AccountAddress> + '_ {
+    package.dependency_ids.published.values().map(|id| **id)
 }

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -22,7 +22,7 @@ use sui_types::{
 use test_cluster::TestClusterBuilder;
 
 use crate::toolchain::CURRENT_COMPILER_VERSION;
-use crate::{BytecodeSourceVerifier, SourceMode};
+use crate::{BytecodeSourceVerifier, ValidationMode};
 
 #[tokio::test]
 async fn successful_verification() -> anyhow::Result<()> {
@@ -54,30 +54,27 @@ async fn successful_verification() -> anyhow::Result<()> {
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api());
 
-    // Skip deps and root
-    verifier
-        .verify_package(&a_pkg, /* verify_deps */ false, SourceMode::Skip)
-        .await
-        .unwrap();
-
     // Verify root without updating the address
     verifier
-        .verify_package(&b_pkg, /* verify_deps */ false, SourceMode::Verify)
+        .verify(&b_pkg, ValidationMode::root())
         .await
         .unwrap();
 
     // Verify deps but skip root
-    verifier.verify_package_deps(&a_pkg).await.unwrap();
+    verifier
+        .verify(&a_pkg, ValidationMode::deps())
+        .await
+        .unwrap();
 
     // Skip deps but verify root
     verifier
-        .verify_package_root(&a_pkg, a_ref.0.into())
+        .verify(&a_pkg, ValidationMode::root_at(a_ref.0.into()))
         .await
         .unwrap();
 
     // Verify both deps and root
     verifier
-        .verify_package_root_and_deps(&a_pkg, a_ref.0.into())
+        .verify(&a_pkg, ValidationMode::root_and_deps_at(a_ref.0.into()))
         .await
         .unwrap();
 
@@ -103,7 +100,7 @@ async fn successful_verification_unpublished_deps() -> anyhow::Result<()> {
 
     // Verify the root package which now includes dependency modules
     verifier
-        .verify_package_root(&a_pkg, a_ref.0.into())
+        .verify(&a_pkg, ValidationMode::root_at(a_ref.0.into()))
         .await
         .unwrap();
 
@@ -136,11 +133,8 @@ async fn successful_verification_module_ordering() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
-
-    let verify_deps = false;
-    verifier
-        .verify_package(&z_pkg, verify_deps, SourceMode::Verify)
+    BytecodeSourceVerifier::new(client.read_api())
+        .verify(&z_pkg, ValidationMode::root())
         .await
         .unwrap();
 
@@ -176,14 +170,16 @@ async fn successful_verification_upgrades() -> anyhow::Result<()> {
     let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     // Verify the upgraded package b-v2 as the root.
-    let verify_deps = false;
     verifier
-        .verify_package(&b_pkg, verify_deps, SourceMode::Verify)
+        .verify(&b_pkg, ValidationMode::root())
         .await
         .unwrap();
 
     // Verify the upgraded package b-v2 as a dep of e.
-    verifier.verify_package_deps(&e_pkg).await.unwrap();
+    verifier
+        .verify(&e_pkg, ValidationMode::deps())
+        .await
+        .unwrap();
 
     Ok(())
 }
@@ -208,12 +204,13 @@ async fn fail_verification_bad_address() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
-
     let expected = expect!["On-chain address cannot be zero"];
     expected.assert_eq(
-        &verifier
-            .verify_package_root_and_deps(&a_pkg, AccountAddress::ZERO)
+        &BytecodeSourceVerifier::new(client.read_api())
+            .verify(
+                &a_pkg,
+                ValidationMode::root_and_deps_at(AccountAddress::ZERO),
+            )
             .await
             .unwrap_err()
             .to_string(),
@@ -234,14 +231,13 @@ async fn fail_to_verify_unpublished_root() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     // Trying to verify the root package, which hasn't been published -- this is going to fail
     // because there is no on-chain package to verify against.
     let expected = expect!["Invalid module b with error: Can't verify unpublished source"];
     expected.assert_eq(
-        &verifier
-            .verify_package(&b_pkg, /* verify_deps */ false, SourceMode::Verify)
+        &BytecodeSourceVerifier::new(client.read_api())
+            .verify(&b_pkg, ValidationMode::root())
             .await
             .unwrap_err()
             .to_string(),
@@ -320,7 +316,7 @@ async fn package_not_found() -> anyhow::Result<()> {
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api());
 
-    let Err(err) = verifier.verify_package_deps(&a_pkg).await else {
+    let Err(err) = verifier.verify(&a_pkg, ValidationMode::deps()).await else {
         panic!("Expected verification to fail");
     };
 
@@ -331,7 +327,7 @@ async fn package_not_found() -> anyhow::Result<()> {
     let package_root = AccountAddress::random();
     stable_addrs.insert(SuiAddress::from(package_root), "<id>");
     let Err(err) = verifier
-        .verify_package_root_and_deps(&a_pkg, package_root)
+        .verify(&a_pkg, ValidationMode::root_and_deps_at(package_root))
         .await
     else {
         panic!("Expected verification to fail");
@@ -345,7 +341,10 @@ async fn package_not_found() -> anyhow::Result<()> {
 
     let package_root = AccountAddress::random();
     stable_addrs.insert(SuiAddress::from(package_root), "<id>");
-    let Err(err) = verifier.verify_package_root(&a_pkg, package_root).await else {
+    let Err(err) = verifier
+        .verify(&a_pkg, ValidationMode::root_at(package_root))
+        .await
+    else {
         panic!("Expected verification to fail");
     };
 
@@ -368,13 +367,12 @@ async fn dependency_is_an_object() -> anyhow::Result<()> {
         let a_src = copy_published_package(&a_pkg_fixtures, "a", SuiAddress::ZERO).await?;
         compile_package(a_src)
     };
-    let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
+    let client = context.get_client().await?;
     let expected = expect!["Dependency ID contains a Sui object, not a Move package: 0x0000000000000000000000000000000000000000000000000000000000000005"];
     expected.assert_eq(
-        &verifier
-            .verify_package_deps(&a_pkg)
+        &BytecodeSourceVerifier::new(client.read_api())
+            .verify(&a_pkg, ValidationMode::deps())
             .await
             .unwrap_err()
             .to_string(),
@@ -401,10 +399,12 @@ async fn module_not_found_on_chain() -> anyhow::Result<()> {
         let a_src = copy_published_package(&a_pkg_fixtures, "a", SuiAddress::ZERO).await?;
         compile_package(a_src)
     };
-    let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
-    let Err(err) = verifier.verify_package_deps(&a_pkg).await else {
+    let client = context.get_client().await?;
+    let Err(err) = BytecodeSourceVerifier::new(client.read_api())
+        .verify(&a_pkg, ValidationMode::deps())
+        .await
+    else {
         panic!("Expected verification to fail");
     };
 
@@ -437,9 +437,10 @@ async fn module_not_found_locally() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
-
-    let Err(err) = verifier.verify_package_deps(&a_pkg).await else {
+    let Err(err) = BytecodeSourceVerifier::new(client.read_api())
+        .verify(&a_pkg, ValidationMode::deps())
+        .await
+    else {
         panic!("Expected verification to fail");
     };
 
@@ -492,19 +493,89 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
     let client = context.get_client().await?;
     let verifier = BytecodeSourceVerifier::new(client.read_api());
 
-    let Err(err) = verifier.verify_package_deps(&a_pkg).await else {
+    let Err(err) = verifier.verify(&a_pkg, ValidationMode::deps()).await else {
         panic!("Expected verification to fail");
     };
 
     let expected = expect!["Local dependency did not match its on-chain version at <b_id>::b::c"];
     expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
-    let Err(err) = verifier.verify_package_root(&a_pkg, a_addr.into()).await else {
+    let Err(err) = verifier
+        .verify(&a_pkg, ValidationMode::root_at(a_addr.into()))
+        .await
+    else {
         panic!("Expected verification to fail");
     };
 
     let expected = expect!["Local dependency did not match its on-chain version at <a_addr>::a::a"];
     expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn linkage_differs() -> anyhow::Result<()> {
+    let mut cluster = TestClusterBuilder::new().build().await;
+    let context = &mut cluster.wallet;
+
+    let b_v1_fixtures = tempfile::tempdir()?;
+    let (b_v1, b_cap) = {
+        let b_src = copy_published_package(&b_v1_fixtures, "b", SuiAddress::ZERO).await?;
+        publish_package(context, b_src).await
+    };
+
+    let b_v2_fixtures = tempfile::tempdir()?;
+    let b_v2 = {
+        let b_src =
+            copy_upgraded_package(&b_v2_fixtures, "b-v2", b_v1.0.into(), SuiAddress::ZERO).await?;
+        upgrade_package(context, b_v1.0, b_cap.0, b_src).await
+    };
+
+    // Publish b-v2 a second time, to create a third version of the package that is othewise
+    // byte-for-byte identical with the second version;
+    let b_v3_fixtures = tempfile::tempdir()?;
+    let b_v3 = {
+        let b_src =
+            copy_upgraded_package(&b_v3_fixtures, "b-v2", b_v2.0.into(), SuiAddress::ZERO).await?;
+        upgrade_package(context, b_v2.0, b_cap.0, b_src).await
+    };
+
+    // Publish E pointing at v2 of B.
+    let e_v1_fixtures = tempfile::tempdir()?;
+    let (e_v1, _) = {
+        copy_upgraded_package(&e_v1_fixtures, "b-v2", b_v2.0.into(), b_v1.0.into()).await?;
+        let e_src = copy_published_package(&e_v1_fixtures, "e", SuiAddress::ZERO).await?;
+        publish_package(context, e_src).await
+    };
+
+    // Compile E pointing at v3 of B, which is byte-for-byte identical with v2, but nevertheless
+    // has a different address.
+    let e_v2_fixtures = tempfile::tempdir()?;
+    let e_pkg = {
+        copy_upgraded_package(&e_v2_fixtures, "b-v2", b_v3.0.into(), b_v1.0.into()).await?;
+        let e_src = copy_published_package(&e_v2_fixtures, "e", e_v1.0.into()).await?;
+        compile_package(e_src)
+    };
+
+    let client = context.get_client().await?;
+    let stable_ids = HashMap::from_iter([
+        (b_v1.0.into(), "<b1>"),
+        (b_v2.0.into(), "<b2>"),
+        (b_v3.0.into(), "<b3>"),
+    ]);
+
+    let error = BytecodeSourceVerifier::new(client.read_api())
+        .verify(&e_pkg, ValidationMode::root())
+        .await
+        .unwrap_err()
+        .to_string();
+
+    let expected = expect![[r#"
+        Multiple source verification errors found:
+
+        - Source package depends on <b3> which is not in the linkage table.
+        - On-chain package depends on <b2> which is not a source dependency."#]];
+    expected.assert_eq(&sanitize_id(error, &stable_ids));
 
     Ok(())
 }
@@ -547,9 +618,10 @@ async fn multiple_failures() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
-
-    let Err(err) = verifier.verify_package_deps(&d_pkg).await else {
+    let Err(err) = BytecodeSourceVerifier::new(client.read_api())
+        .verify(&d_pkg, ValidationMode::deps())
+        .await
+    else {
         panic!("Expected verification to fail");
     };
 
@@ -585,10 +657,12 @@ async fn successful_versioned_dependency_verification() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     // Verify versioned dependency
-    verifier.verify_package_deps(&a_pkg).await.unwrap();
+    BytecodeSourceVerifier::new(client.read_api())
+        .verify(&a_pkg, ValidationMode::deps())
+        .await
+        .unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Source validation additionally checks that dependencies in the linkage table of the on-chain package match the published dependencies from the source package.

Previously it was possible to construct a scenario where source verification would succeed even though a package's representation on-chain did not exactly match, because one of the dependencies mismatched on version but between two versions that were themselves identical.

## Test plan

New tests exercising the scenario mentioned above:

```
sui-source-validation$ cargo nextest run -- linkage_differs
```

## Stack

- #18956 
- #18959
- #18978
- #18960 
- #18962

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui client verify-source` now also confirms a package's linkage table matches its source dependencies. 
- [ ] Rust SDK:
- [ ] REST API:
