### PR TITLE
chore: [Examples] Remove sui_programmability

### DIFF
--- a/sui_programmability/examples/README.md
+++ b/sui_programmability/examples/README.md
@@ -1,2 +1,0 @@
->[!IMPORTANT]
-> These examples have moved! **Find the latest versions in the [examples](../../examples) directory** which contains up-to-date [Move](../../examples/move) and end-to-end examples!


### PR DESCRIPTION
## Description

Clean-up the `sui_programmability` directory for good. It has been a month since everything was ported to the `examples` directory.