### PR TITLE
fix: [GraphQL/Owner] rootVersion: UInt53

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -3033,7 +3033,7 @@ type Query {
 	state at the latest checkpoint known to the GraphQL RPC. Similarly, `Owner.asObject` will
 	return the object's version at the latest checkpoint.
 	"""
-	owner(address: SuiAddress!, rootVersion: Int): Owner
+	owner(address: SuiAddress!, rootVersion: UInt53): Owner
 	"""
 	The object corresponding to the given address at the (optionally) given version.
 	When no version is given, the latest version is returned.

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -195,13 +195,13 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         address: SuiAddress,
-        root_version: Option<u64>,
+        root_version: Option<UInt53>,
     ) -> Result<Option<Owner>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
         Ok(Some(Owner {
             address,
             checkpoint_viewed_at: checkpoint,
-            root_version,
+            root_version: root_version.map(|v| v.into()),
         }))
     }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3037,7 +3037,7 @@ type Query {
 	state at the latest checkpoint known to the GraphQL RPC. Similarly, `Owner.asObject` will
 	return the object's version at the latest checkpoint.
 	"""
-	owner(address: SuiAddress!, rootVersion: Int): Owner
+	owner(address: SuiAddress!, rootVersion: UInt53): Owner
 	"""
 	The object corresponding to the given address at the (optionally) given version.
 	When no version is given, the latest version is returned.


### PR DESCRIPTION
## Description

The PR introducing the `rootVersion` parameter to `Query.owner` raced with the PR that introduced `UInt53`. This PR fixes the race by using `UInt53` as the type for `rootVersion`.

## Test plan

```
sui-graphql-rpc$ cargo nextest run
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: `Query.owner`'s `rootVersion` parameter should accepts a `UInt53` rather than an `Int`.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
