### PR TITLE
Rosetta/coin metadata cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14251,6 +14251,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper 1.4.1",
+ "move-cli",
  "move-core-types",
  "mysten-metrics",
  "once_cell",

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -84,7 +84,7 @@ async fn get_balances(
             async move {
                 (
                     currency.clone(),
-                    get_account_balances(&ctx, address, &coin_type).await,
+                    get_account_balances(ctx, address, &coin_type).await,
                 )
             }
         });

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -80,7 +80,7 @@ async fn get_balances(
         get_sub_account_balances(account_type, &ctx.client, address).await
     } else if !currencies.is_empty() {
         let balance_futures = currencies.iter().map(|currency| {
-            let coin_type = currency.coin_type.clone();
+            let coin_type = currency.metadata.clone().unwrap().coin_type.clone();
             async move {
                 (
                     currency.clone(),
@@ -93,7 +93,7 @@ async fn get_balances(
         for (currency, balance_result) in balances {
             match balance_result {
                 Ok(value) => amounts.push(Amount::new(value, Some(currency))),
-                Err(_e) => return Err(Error::InvalidInput(format!("{:?}", currency.coin_type))),
+                Err(_e) => return Err(Error::InvalidInput(format!("{:?}", currency.metadata.unwrap().coin_type))),
             }
         }
         Ok(amounts)

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -35,10 +35,10 @@ pub async fn balance(
     let mut retry_attempts = 5;
     while retry_attempts > 0 {
         let balances_first = get_balances(&ctx, &request, address, currencies.clone()).await?;
-        let checkpoint1 = get_checkpoint(&ctx).await.unwrap();
-        let mut checkpoint2 = get_checkpoint(&ctx).await.unwrap();
+        let checkpoint1 = get_checkpoint(&ctx).await?;
+        let mut checkpoint2 = get_checkpoint(&ctx).await?;
         while checkpoint2 <= checkpoint1 {
-            checkpoint2 = get_checkpoint(&ctx).await.unwrap();
+            checkpoint2 = get_checkpoint(&ctx).await?;
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         let balances_second = get_balances(&ctx, &request, address, currencies.clone()).await?;

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -93,7 +93,12 @@ async fn get_balances(
         for (currency, balance_result) in balances {
             match balance_result {
                 Ok(value) => amounts.push(Amount::new(value, Some(currency))),
-                Err(_e) => return Err(Error::InvalidInput(format!("{:?}", currency.metadata.unwrap().coin_type))),
+                Err(_e) => {
+                    return Err(Error::InvalidInput(format!(
+                        "{:?}",
+                        currency.metadata.unwrap().coin_type
+                    )))
+                }
             }
         }
         Ok(amounts)

--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -6,6 +6,7 @@ use axum::{Extension, Json};
 use axum_extra::extract::WithRejection;
 use tracing::debug;
 
+use crate::operations::Operations;
 use crate::types::{
     BlockRequest, BlockResponse, BlockTransactionRequest, BlockTransactionResponse, Transaction,
     TransactionIdentifier,
@@ -57,7 +58,7 @@ pub async fn transaction(
         .await?;
     let hash = response.digest;
 
-    let operations = response.try_into()?;
+    let operations = Operations::try_from_response(response, &context.coin_metadata_cache).await?;
 
     let transaction = Transaction {
         transaction_identifier: TransactionIdentifier { hash },

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -16,7 +16,7 @@ use sui_json_rpc_types::{
     SuiTransactionBlockResponseOptions,
 };
 use sui_sdk::rpc_types::SuiExecutionStatus;
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::{DefaultHash, SignatureScheme, ToFromBytes};
 use sui_types::error::SuiError;
 use sui_types::signature::{GenericSignature, VerifyParams};
@@ -198,7 +198,6 @@ pub async fn preprocess(
     let internal_operation = request.operations.into_internal()?;
     let sender = internal_operation.sender();
     let budget = request.metadata.and_then(|m| m.budget);
-
     Ok(ConstructionPreprocessResponse {
         options: Some(MetadataOptions {
             internal_operation,
@@ -239,6 +238,12 @@ pub async fn metadata(
     let option = request.options.ok_or(Error::MissingMetadata)?;
     let budget = option.budget;
     let sender = option.internal_operation.sender();
+    let currency = match &option.internal_operation {
+        InternalOperation::PayCoin { currency, .. } => Some(currency.clone()),
+        _ => None,
+    };
+    let coin_type = currency.as_ref().map(|c| c.metadata.coin_type.clone());
+
     let mut gas_price = context
         .client
         .governance_api()
@@ -252,6 +257,20 @@ pub async fn metadata(
         InternalOperation::PaySui { amounts, .. } => {
             let amount = amounts.iter().sum::<u64>();
             (Some(amount), vec![])
+        }
+        InternalOperation::PayCoin { amounts, .. } => {
+            let amount = amounts.iter().sum::<u64>();
+            let coin_objs: Vec<ObjectRef> = context
+                .client
+                .coin_read_api()
+                .select_coins(sender, coin_type, amount.into(), vec![])
+                .await
+                .ok()
+                .unwrap_or_default()
+                .iter()
+                .map(|coin| coin.object_ref())
+                .collect();
+            (Some(0), coin_objs) // amount is 0 for gas coin
         }
         InternalOperation::Stake { amount, .. } => (*amount, vec![]),
         InternalOperation::WithdrawStake { sender, stake_ids } => {
@@ -313,6 +332,7 @@ pub async fn metadata(
                     gas_price,
                     // MAX BUDGET
                     budget: 50_000_000_000,
+                    currency: currency.clone(),
                 })?;
 
             let dry_run = context
@@ -329,7 +349,7 @@ pub async fn metadata(
         }
     };
 
-    // Try select coins for required amounts
+    // Try select gas coins for required amounts
     let coins = if let Some(amount) = total_required_amount {
         let total_amount = amount + budget;
         context
@@ -369,6 +389,7 @@ pub async fn metadata(
             total_coin_value,
             gas_price,
             budget,
+            currency,
         },
         suggested_fee: vec![Amount::new(budget as i128, None)],
     })

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -370,7 +370,7 @@ pub async fn metadata(
             gas_price,
             budget,
         },
-        suggested_fee: vec![Amount::new(budget as i128)],
+        suggested_fee: vec![Amount::new(budget as i128, None)],
     })
 }
 

--- a/crates/sui-rosetta/src/lib.rs
+++ b/crates/sui-rosetta/src/lib.rs
@@ -29,9 +29,9 @@ pub mod types;
 pub static SUI: Lazy<Currency> = Lazy::new(|| Currency {
     symbol: "SUI".to_string(),
     decimals: 9,
-    metadata: Some(CurrencyMetadata {
+    metadata: CurrencyMetadata {
         coin_type: SUI_COIN_TYPE.to_string(),
-    }),
+    },
 });
 
 pub struct RosettaOnlineServer {

--- a/crates/sui-rosetta/src/lib.rs
+++ b/crates/sui-rosetta/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::net::SocketAddr;
+use std::string::ToString;
 use std::sync::Arc;
 
 use axum::routing::post;
@@ -9,7 +10,7 @@ use axum::{Extension, Router};
 use once_cell::sync::Lazy;
 use tracing::info;
 
-use sui_sdk::SuiClient;
+use sui_sdk::{SuiClient, SUI_COIN_TYPE};
 
 use crate::errors::Error;
 use crate::state::{CheckpointBlockProvider, OnlineServerContext};
@@ -26,6 +27,7 @@ mod state;
 pub mod types;
 
 pub static SUI: Lazy<Currency> = Lazy::new(|| Currency {
+    coin_type: SUI_COIN_TYPE.to_string(),
     symbol: "SUI".to_string(),
     decimals: 9,
 });

--- a/crates/sui-rosetta/src/lib.rs
+++ b/crates/sui-rosetta/src/lib.rs
@@ -14,7 +14,7 @@ use sui_sdk::{SuiClient, SUI_COIN_TYPE};
 
 use crate::errors::Error;
 use crate::state::{CheckpointBlockProvider, OnlineServerContext};
-use crate::types::{Currency, SuiEnv};
+use crate::types::{Currency, CurrencyMetadata, SuiEnv};
 
 /// This lib implements the Rosetta online and offline server defined by the [Rosetta API Spec](https://www.rosetta-api.org/docs/Reference.html)
 mod account;
@@ -27,9 +27,11 @@ mod state;
 pub mod types;
 
 pub static SUI: Lazy<Currency> = Lazy::new(|| Currency {
-    coin_type: SUI_COIN_TYPE.to_string(),
     symbol: "SUI".to_string(),
     decimals: 9,
+    metadata: Some(CurrencyMetadata {
+        coin_type: SUI_COIN_TYPE.to_string(),
+    }),
 });
 
 pub struct RosettaOnlineServer {

--- a/crates/sui-rosetta/src/lib.rs
+++ b/crates/sui-rosetta/src/lib.rs
@@ -128,7 +128,7 @@ impl CoinMetadataCache {
 
     pub async fn get_currency(&self, type_tag: &TypeTag) -> Result<Currency, Error> {
         let mut cache = self.metadata.lock().await;
-        if !cache.contains_key(&type_tag) {
+        if !cache.contains_key(type_tag) {
             let metadata = self
                 .client
                 .coin_read_api()
@@ -145,6 +145,6 @@ impl CoinMetadataCache {
             };
             cache.insert(type_tag.clone(), ccy);
         }
-        cache.get(&type_tag).cloned().ok_or(MissingMetadata)
+        cache.get(type_tag).cloned().ok_or(MissingMetadata)
     }
 }

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -380,7 +380,7 @@ impl Operations {
                 ),
                 SuiCommand::MoveCall(m) if Self::is_stake_call(m) => {
                     stake_call(inputs, &known_results, m)?.map(|(amount, validator)| {
-                        let amount = amount.map(|amount| Amount::new(-(amount as i128)));
+                        let amount = amount.map(|amount| Amount::new(-(amount as i128), None));
                         operations.push(Operation {
                             operation_identifier: Default::default(),
                             type_: OperationType::Stake,
@@ -672,7 +672,7 @@ impl Operation {
             type_: OperationType::Genesis,
             status: Some(OperationStatus::Success),
             account: Some(sender.into()),
-            amount: Some(Amount::new(coin.value().into())),
+            amount: Some(Amount::new(coin.value().into(), None)),
             coin_change: Some(CoinChange {
                 coin_identifier: CoinIdentifier {
                     identifier: CoinID {
@@ -692,7 +692,7 @@ impl Operation {
             type_: OperationType::PaySui,
             status,
             account: Some(address.into()),
-            amount: Some(Amount::new(amount)),
+            amount: Some(Amount::new(amount, None)),
             coin_change: None,
             metadata: None,
         }
@@ -704,7 +704,7 @@ impl Operation {
             type_: OperationType::SuiBalanceChange,
             status,
             account: Some(addr.into()),
-            amount: Some(Amount::new(amount)),
+            amount: Some(Amount::new(amount, None)),
             coin_change: None,
             metadata: None,
         }
@@ -715,7 +715,7 @@ impl Operation {
             type_: OperationType::Gas,
             status: Some(OperationStatus::Success),
             account: Some(addr.into()),
-            amount: Some(Amount::new(amount)),
+            amount: Some(Amount::new(amount, None)),
             coin_change: None,
             metadata: None,
         }
@@ -726,7 +726,7 @@ impl Operation {
             type_: OperationType::StakeReward,
             status,
             account: Some(addr.into()),
-            amount: Some(Amount::new(amount)),
+            amount: Some(Amount::new(amount, None)),
             coin_change: None,
             metadata: None,
         }
@@ -737,7 +737,7 @@ impl Operation {
             type_: OperationType::StakePrinciple,
             status,
             account: Some(addr.into()),
-            amount: Some(Amount::new(amount)),
+            amount: Some(Amount::new(amount, None)),
             coin_change: None,
             metadata: None,
         }

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -534,7 +534,7 @@ impl Operations {
             .fold(balances, |mut balances, balance_change| {
                 // Rosetta only care about address owner
                 if let Owner::AddressOwner(owner) = balance_change.owner {
-                    if balances.is_empty() && balance_change.coin_type == GAS::type_tag() {
+                    if balances.is_empty() || balance_change.coin_type == GAS::type_tag() {
                         *balances.entry((owner, SUI.clone())).or_default() += balance_change.amount;
                     } else {
                         for (key, _) in balances.iter() {

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -95,8 +95,14 @@ impl From<SuiAddress> for AccountIdentifier {
     }
 }
 
+fn default_currency_metadata() -> Option<CurrencyMetadata> {
+    Some(CurrencyMetadata {
+        coin_type: default_currency_coin_type()
+    })
+}
+
 fn default_currency_coin_type() -> String {
-    SUI.clone().coin_type
+    SUI.clone().metadata.unwrap().coin_type
 }
 
 fn default_currency() -> Currency {
@@ -110,7 +116,8 @@ where
     let opt: Option<Vec<Currency>> = Option::deserialize(deserializer)?;
     match opt {
         Some(vec) if vec.is_empty() => Ok(vec![default_currency()]),
-        Some(vec) if vec[0].coin_type.is_empty() => Ok(vec![default_currency()]),
+        Some(vec) if vec[0].metadata.is_none() => Ok(vec![default_currency()]),
+        Some(vec) if vec[0].metadata.clone().unwrap().coin_type.is_empty() => Ok(vec![default_currency()]),
         Some(vec) => Ok(vec),
         None => Ok(vec![default_currency()]),
     }
@@ -118,11 +125,18 @@ where
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Currency {
-    #[serde(default = "default_currency_coin_type")]
-    pub coin_type: String,
     pub symbol: String,
     pub decimals: u64,
+    #[serde(default = "default_currency_metadata")]
+    pub metadata: Option<CurrencyMetadata>,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct CurrencyMetadata {
+    #[serde(default = "default_currency_coin_type")]
+    pub coin_type: String,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct AccountBalanceRequest {
     pub network_identifier: NetworkIdentifier,

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -97,7 +97,7 @@ impl From<SuiAddress> for AccountIdentifier {
 
 fn default_currency_metadata() -> Option<CurrencyMetadata> {
     Some(CurrencyMetadata {
-        coin_type: default_currency_coin_type()
+        coin_type: default_currency_coin_type(),
     })
 }
 
@@ -117,7 +117,9 @@ where
     match opt {
         Some(vec) if vec.is_empty() => Ok(vec![default_currency()]),
         Some(vec) if vec[0].metadata.is_none() => Ok(vec![default_currency()]),
-        Some(vec) if vec[0].metadata.clone().unwrap().coin_type.is_empty() => Ok(vec![default_currency()]),
+        Some(vec) if vec[0].metadata.clone().unwrap().coin_type.is_empty() => {
+            Ok(vec![default_currency()])
+        }
         Some(vec) => Ok(vec),
         None => Ok(vec![default_currency()]),
     }

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -95,6 +95,10 @@ impl From<SuiAddress> for AccountIdentifier {
     }
 }
 
+fn default_currency_coin_type() -> String {
+    SUI.clone().coin_type
+}
+
 fn default_currency() -> Currency {
     SUI.clone()
 }
@@ -114,6 +118,7 @@ where
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Currency {
+    #[serde(default = "default_currency_coin_type")]
     pub coin_type: String,
     pub symbol: String,
     pub decimals: u64,
@@ -171,10 +176,10 @@ pub struct SubBalance {
 }
 
 impl Amount {
-    pub fn new(value: i128) -> Self {
+    pub fn new(value: i128, currency: Option<Currency>) -> Self {
         Self {
             value,
-            currency: SUI.clone(),
+            currency: currency.unwrap_or(default_currency()),
             metadata: None,
         }
     }
@@ -183,7 +188,7 @@ impl Amount {
 
         Self {
             value,
-            currency: SUI.clone(),
+            currency: default_currency(),
             metadata: Some(AmountMetadata { sub_balances }),
         }
     }

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -629,6 +629,7 @@ async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
         total_coin_value: 0,
         gas_price: rgp,
         budget: rgp * TEST_ONLY_GAS_UNIT_FOR_STAKING,
+        currency: None,
     };
     let parsed_data = ops.clone().into_internal()?.try_into_data(metadata)?;
     assert_eq!(ops, Operations::try_from(parsed_data)?);

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -3,6 +3,7 @@
 
 use crate::operations::Operations;
 use crate::types::{ConstructionMetadata, OperationStatus, OperationType};
+use crate::CoinMetadataCache;
 use anyhow::anyhow;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -749,8 +750,8 @@ async fn test_transaction(
             SuiExecutionStatus::Failure { .. }
         ));
     }
-
-    let ops = response.clone().try_into().unwrap();
+    let coin_cache = CoinMetadataCache::new(client.clone());
+    let ops = Operations::try_from_response(response.clone(), &coin_cache).unwrap();
     let balances_from_ops = extract_balance_changes_from_ops(ops);
 
     // get actual balance changed after transaction

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -751,7 +751,9 @@ async fn test_transaction(
         ));
     }
     let coin_cache = CoinMetadataCache::new(client.clone());
-    let ops = Operations::try_from_response(response.clone(), &coin_cache).unwrap();
+    let ops = Operations::try_from_response(response.clone(), &coin_cache)
+        .await
+        .unwrap();
     let balances_from_ops = extract_balance_changes_from_ops(ops);
 
     // get actual balance changed after transaction

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -27,7 +27,7 @@ use sui_sdk::rpc_types::{
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
-use sui_types::gas_coin::GasCoin;
+use sui_types::gas_coin::{GasCoin, GAS};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::transaction::{
@@ -779,11 +779,15 @@ fn extract_balance_changes_from_ops(ops: Operations) -> HashMap<SuiAddress, i128
                     OperationType::SuiBalanceChange
                     | OperationType::Gas
                     | OperationType::PaySui
+                    | OperationType::PayCoin
                     | OperationType::StakeReward
                     | OperationType::StakePrinciple
                     | OperationType::Stake => {
                         if let (Some(addr), Some(amount)) = (op.account, op.amount) {
-                            *changes.entry(addr.address).or_default() += amount.value
+                            // Todo: amend this method and tests to cover other coin types too (eg. test_publish_and_move_call also mints MY_COIN)
+                            if amount.currency.metadata.coin_type == GAS::type_().to_string() {
+                                *changes.entry(addr.address).or_default() += amount.value
+                            }
                         }
                     }
                     _ => {}

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -8,10 +8,11 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{CallArg, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER};
 
 use crate::operations::Operations;
-use crate::types::ConstructionMetadata;
+use crate::types::{ConstructionMetadata, OperationType};
+use crate::SUI;
 
 #[tokio::test]
-async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
+async fn test_operation_data_parsing_pay_sui() -> Result<(), anyhow::Error> {
     let gas = (
         ObjectID::random(),
         SequenceNumber::new(),
@@ -37,6 +38,9 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
     );
 
     let ops: Operations = data.clone().try_into()?;
+    ops.0
+        .iter()
+        .for_each(|op| assert_eq!(op.type_, OperationType::PaySui));
     let metadata = ConstructionMetadata {
         sender,
         coins: vec![gas],
@@ -44,6 +48,63 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
         total_coin_value: 0,
         gas_price,
         budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        currency: None,
+    };
+    let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
+    assert_eq!(data, parsed_data);
+
+    Ok(())
+}
+#[tokio::test]
+async fn test_operation_data_parsing_pay_coin() -> Result<(), anyhow::Error> {
+    let gas = (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::random(),
+    );
+
+    let coin = (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::random(),
+    );
+
+    let sender = SuiAddress::random_for_testing_only();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay(
+                vec![coin],
+                vec![SuiAddress::random_for_testing_only()],
+                vec![10000],
+            )
+            .unwrap();
+        // the following is important in order to be able to transfer the coin type info between the various flow steps
+        builder.pure(serde_json::to_string(&SUI.clone())?)?;
+        builder.finish()
+    };
+    let gas_price = 10;
+    let data = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        pt,
+        TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        gas_price,
+    );
+
+    let ops: Operations = data.clone().try_into()?;
+    ops.0
+        .iter()
+        .for_each(|op| assert_eq!(op.type_, OperationType::PayCoin));
+    let metadata = ConstructionMetadata {
+        sender,
+        coins: vec![gas],
+        objects: vec![coin],
+        total_coin_value: 0,
+        gas_price,
+        budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        currency: Some(SUI.clone()),
     };
     let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
     assert_eq!(data, parsed_data);

--- a/crates/sui-rosetta/src/unit_tests/types_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/types_tests.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::types::{AccountBalanceRequest, Amount, Currency, CurrencyMetadata};
+use serde_json::json;
+
+#[tokio::test]
+async fn test_currency_defaults() {
+    let expected = Currency {
+        symbol: "SUI".to_string(),
+        decimals: 9,
+        metadata: CurrencyMetadata {
+            coin_type: "0x2::sui::SUI".to_string(),
+        },
+    };
+
+    let currency: Currency = serde_json::from_value(json!(
+        {
+            "symbol": "SUI",
+            "decimals": 9,
+        }
+    ))
+    .unwrap();
+    assert_eq!(expected, currency);
+
+    let amount: Amount = serde_json::from_value(json!(
+        {
+            "value": "1000000000",
+        }
+    ))
+    .unwrap();
+    assert_eq!(expected, amount.currency);
+
+    let account_balance_request: AccountBalanceRequest = serde_json::from_value(json!(
+        {
+            "network_identifier": {
+                "blockchain": "sui",
+                "network": "mainnet"
+            },
+            "account_identifier": {
+                "address": "0xadc3a0bb21840f732435f8b649e99df6b29cd27854dfa4b020e3bee07ea09b96"
+            }
+        }
+    ))
+    .unwrap();
+    assert_eq!(
+        expected,
+        account_balance_request.currencies.0.clone().pop().unwrap()
+    );
+
+    let account_balance_request: AccountBalanceRequest = serde_json::from_value(json!(
+        {
+            "network_identifier": {
+                "blockchain": "sui",
+                "network": "mainnet"
+            },
+            "account_identifier": {
+                "address": "0xadc3a0bb21840f732435f8b649e99df6b29cd27854dfa4b020e3bee07ea09b96"
+            },
+            "currencies": []
+        }
+    ))
+    .unwrap();
+    assert_eq!(
+        expected,
+        account_balance_request.currencies.0.clone().pop().unwrap()
+    );
+}

--- a/crates/sui-rosetta/tests/custom_coins.rs
+++ b/crates/sui-rosetta/tests/custom_coins.rs
@@ -3,11 +3,11 @@ mod rosetta_client;
 #[path = "custom_coins/test_coin_utils.rs"]
 mod test_coin_utils;
 
-use sui_rosetta::SUI;
 use sui_rosetta::types::{
     AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, NetworkIdentifier,
     SuiEnv,
 };
+use sui_rosetta::SUI;
 use test_cluster::TestClusterBuilder;
 use test_coin_utils::{init_package, mint};
 
@@ -61,11 +61,17 @@ async fn test_custom_coin_balance() {
         currencies: vec![sui_currency, test_coin_currency],
     };
 
-    println!("request: {}", serde_json::to_string_pretty(&request).unwrap());
+    println!(
+        "request: {}",
+        serde_json::to_string_pretty(&request).unwrap()
+    );
     let response: AccountBalanceResponse = rosetta_client
         .call(RosettaEndpoint::Balance, &request)
         .await;
-    println!("response: {}", serde_json::to_string_pretty(&response).unwrap());
+    println!(
+        "response: {}",
+        serde_json::to_string_pretty(&response).unwrap()
+    );
     assert_eq!(response.balances.len(), 2);
     assert_eq!(response.balances[0].value, SUI_BALANCE as i128);
     assert_eq!(response.balances[0].currency.coin_type, "0x2::sui::SUI");

--- a/crates/sui-rosetta/tests/custom_coins.rs
+++ b/crates/sui-rosetta/tests/custom_coins.rs
@@ -29,6 +29,7 @@ async fn test_custom_coin_balance() {
     let address1 = test_cluster.get_address_1();
     let address2 = test_cluster.get_address_2();
     let balances_to = vec![(COIN1_BALANCE, address1), (COIN2_BALANCE, address2)];
+    let coin_type = init_ret.coin_tag.to_canonical_string(true);
 
     let _mint_res = mint(&client, keystore, init_ret, balances_to)
         .await
@@ -48,6 +49,7 @@ async fn test_custom_coin_balance() {
         },
         block_identifier: Default::default(),
         currencies: vec![Currency {
+            coin_type,
             symbol: "TEST_COIN".to_string(),
             decimals: 6,
         }],

--- a/crates/sui-rosetta/tests/custom_coins.rs
+++ b/crates/sui-rosetta/tests/custom_coins.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[allow(dead_code)]
 mod rosetta_client;
 #[path = "custom_coins/test_coin_utils.rs"]

--- a/crates/sui-rosetta/tests/custom_coins/test_coin/Move.toml
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin/Move.toml
@@ -1,37 +1,9 @@
 [package]
 name = "test_coin"
 edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
-# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
-# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
 
-# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
-# Revision can be a branch, a tag, and a commit hash.
-# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
-
-# For local dependencies use `local = path`. Path is relative to the package root
-# Local = { local = "../path/to" }
-
-# To resolve a version conflict and force a specific version for dependency
-# override use `override = true`
-# Override = { local = "../conflicting/version", override = true }
-
 [addresses]
 test_coin = "0x0"
-
-# Named addresses will be accessible in Move as `@name`. They're also exported:
-# for example, `std = "0x1"` is exported by the Standard Library.
-# alice = "0xA11CE"
-
-[dev-dependencies]
-# The dev-dependencies section allows overriding dependencies for `--test` and
-# `--dev` modes. You can introduce test-only dependencies here.
-# Local = { local = "../path/to/dev-build" }
-
-[dev-addresses]
-# The dev-addresses section allows overwriting named addresses for the `--test`
-# and `--dev` modes.
-# alice = "0xB0B"
-

--- a/crates/sui-rosetta/tests/custom_coins/test_coin/sources/test_coin.move
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin/sources/test_coin.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Module: test_coin
 module test_coin::test_coin {
 

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 use std::str::FromStr;
 

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
@@ -148,7 +148,7 @@ pub async fn init_package(
         )
         .await?;
 
-    let gas_data = select_gas(&client, sender, None, None, vec![], None).await?;
+    let gas_data = select_gas(client, sender, None, None, vec![], None).await?;
     let tx_data = client
         .transaction_builder()
         .tx_data(
@@ -214,7 +214,7 @@ pub async fn mint(
     balances_to: Vec<(u64, SuiAddress)>,
 ) -> Result<SuiTransactionBlockResponse> {
     let treasury_cap_owner = init_ret.owner;
-    let gas_data = select_gas(&client, treasury_cap_owner, None, None, vec![], None).await?;
+    let gas_data = select_gas(client, treasury_cap_owner, None, None, vec![], None).await?;
 
     let mut ptb = ProgrammableTransactionBuilder::new();
 

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
@@ -189,10 +189,6 @@ pub async fn init_package(
         } = change
         {
             if object_type.to_string().contains("2::coin::TreasuryCap") {
-                // let TypeTag::Struct(coin_tag) = object_type.type_params.into_iter().next().unwrap()
-                // else {
-                //     return None;
-                // };
                 let Owner::AddressOwner(owner) = owner else {
                     return None;
                 };

--- a/crates/sui-rosetta/tests/custom_coins_tests.rs
+++ b/crates/sui-rosetta/tests/custom_coins_tests.rs
@@ -6,10 +6,7 @@ mod rosetta_client;
 #[path = "custom_coins/test_coin_utils.rs"]
 mod test_coin_utils;
 
-use sui_rosetta::types::{
-    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, NetworkIdentifier,
-    SuiEnv,
-};
+use sui_rosetta::types::{AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, CurrencyMetadata, NetworkIdentifier, SuiEnv};
 use sui_rosetta::SUI;
 use test_cluster::TestClusterBuilder;
 use test_coin_utils::{init_package, mint};
@@ -48,9 +45,11 @@ async fn test_custom_coin_balance() {
 
     let sui_currency = SUI.clone();
     let test_coin_currency = Currency {
-        coin_type: coin_type.clone(),
         symbol: "TEST_COIN".to_string(),
         decimals: 6,
+        metadata: Some(CurrencyMetadata {
+            coin_type: coin_type.clone(),
+        }),
     };
 
     // Verify initial balance and stake
@@ -77,7 +76,7 @@ async fn test_custom_coin_balance() {
     );
     assert_eq!(response.balances.len(), 2);
     assert_eq!(response.balances[0].value, SUI_BALANCE as i128);
-    assert_eq!(response.balances[0].currency.coin_type, "0x2::sui::SUI");
+    assert_eq!(response.balances[0].currency.clone().metadata.unwrap().coin_type, "0x2::sui::SUI");
     assert_eq!(response.balances[1].value, COIN1_BALANCE as i128);
-    assert_eq!(response.balances[1].currency.coin_type, coin_type);
+    assert_eq!(response.balances[1].currency.clone().metadata.unwrap().coin_type, coin_type);
 }

--- a/crates/sui-rosetta/tests/custom_coins_tests.rs
+++ b/crates/sui-rosetta/tests/custom_coins_tests.rs
@@ -6,7 +6,10 @@ mod rosetta_client;
 #[path = "custom_coins/test_coin_utils.rs"]
 mod test_coin_utils;
 
-use sui_rosetta::types::{AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, CurrencyMetadata, NetworkIdentifier, SuiEnv};
+use sui_rosetta::types::{
+    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, CurrencyMetadata,
+    NetworkIdentifier, SuiEnv,
+};
 use sui_rosetta::SUI;
 use test_cluster::TestClusterBuilder;
 use test_coin_utils::{init_package, mint};
@@ -76,7 +79,23 @@ async fn test_custom_coin_balance() {
     );
     assert_eq!(response.balances.len(), 2);
     assert_eq!(response.balances[0].value, SUI_BALANCE as i128);
-    assert_eq!(response.balances[0].currency.clone().metadata.unwrap().coin_type, "0x2::sui::SUI");
+    assert_eq!(
+        response.balances[0]
+            .currency
+            .clone()
+            .metadata
+            .unwrap()
+            .coin_type,
+        "0x2::sui::SUI"
+    );
     assert_eq!(response.balances[1].value, COIN1_BALANCE as i128);
-    assert_eq!(response.balances[1].currency.clone().metadata.unwrap().coin_type, coin_type);
+    assert_eq!(
+        response.balances[1]
+            .currency
+            .clone()
+            .metadata
+            .unwrap()
+            .coin_type,
+        coin_type
+    );
 }

--- a/crates/sui-rosetta/tests/custom_coins_tests.rs
+++ b/crates/sui-rosetta/tests/custom_coins_tests.rs
@@ -6,6 +6,7 @@ mod rosetta_client;
 #[path = "custom_coins/test_coin_utils.rs"]
 mod test_coin_utils;
 
+use sui_rosetta::types::Currencies;
 use sui_rosetta::types::{
     AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, CurrencyMetadata,
     NetworkIdentifier, SuiEnv,
@@ -50,9 +51,9 @@ async fn test_custom_coin_balance() {
     let test_coin_currency = Currency {
         symbol: "TEST_COIN".to_string(),
         decimals: 6,
-        metadata: Some(CurrencyMetadata {
+        metadata: CurrencyMetadata {
             coin_type: coin_type.clone(),
-        }),
+        },
     };
 
     // Verify initial balance and stake
@@ -63,7 +64,7 @@ async fn test_custom_coin_balance() {
             sub_account: None,
         },
         block_identifier: Default::default(),
-        currencies: vec![sui_currency, test_coin_currency],
+        currencies: Currencies(vec![sui_currency, test_coin_currency]),
     };
 
     println!(
@@ -80,22 +81,12 @@ async fn test_custom_coin_balance() {
     assert_eq!(response.balances.len(), 2);
     assert_eq!(response.balances[0].value, SUI_BALANCE as i128);
     assert_eq!(
-        response.balances[0]
-            .currency
-            .clone()
-            .metadata
-            .unwrap()
-            .coin_type,
+        response.balances[0].currency.clone().metadata.coin_type,
         "0x2::sui::SUI"
     );
     assert_eq!(response.balances[1].value, COIN1_BALANCE as i128);
     assert_eq!(
-        response.balances[1]
-            .currency
-            .clone()
-            .metadata
-            .unwrap()
-            .coin_type,
+        response.balances[1].currency.clone().metadata.coin_type,
         coin_type
     );
 }

--- a/crates/sui-rosetta/tests/custom_coins_tests.rs
+++ b/crates/sui-rosetta/tests/custom_coins_tests.rs
@@ -16,6 +16,7 @@ use sui_rosetta::types::{
     AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, CurrencyMetadata,
     NetworkIdentifier, SuiEnv,
 };
+use sui_rosetta::CoinMetadataCache;
 use sui_rosetta::SUI;
 use test_cluster::TestClusterBuilder;
 use test_coin_utils::{init_package, mint};
@@ -169,8 +170,10 @@ async fn test_custom_coin_transfer() {
         tx.effects.as_ref().unwrap().status()
     );
     println!("Sui TX: {tx:?}");
-
-    let ops2 = Operations::try_from(tx).unwrap();
+    let coin_cache = CoinMetadataCache::new(client);
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
     assert!(
         ops2.contains(&ops),
         "Operation mismatch. expecting:{}, got:{}",

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -146,7 +146,7 @@ async fn test_stake() {
             "operation_identifier":{"index":0},
             "type":"Stake",
             "account": { "address" : sender.to_string() },
-            "amount" : { "value": "-1000000000" , "currency": { "symbol": "SUI", "decimals": 9}},
+            "amount" : { "value": "-1000000000" },
             "metadata": { "Stake" : {"validator": validator.to_string()} }
         }]
     ))
@@ -273,7 +273,7 @@ async fn test_withdraw_stake() {
             "operation_identifier":{"index":0},
             "type":"Stake",
             "account": { "address" : sender.to_string() },
-            "amount" : { "value": "-1000000000" , "currency": { "symbol": "SUI", "decimals": 9}},
+            "amount" : { "value": "-1000000000" },
             "metadata": { "Stake" : {"validator": validator.to_string()} }
         }]
     ))
@@ -388,12 +388,12 @@ async fn test_pay_sui() {
             "operation_identifier":{"index":0},
             "type":"PaySui",
             "account": { "address" : recipient.to_string() },
-            "amount" : { "value": "1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+            "amount" : { "value": "1000000000" }
         },{
             "operation_identifier":{"index":1},
             "type":"PaySui",
             "account": { "address" : sender.to_string() },
-            "amount" : { "value": "-1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+            "amount" : { "value": "-1000000000" }
         }]
     ))
     .unwrap();
@@ -448,12 +448,12 @@ async fn test_pay_sui_multiple_times() {
                 "operation_identifier":{"index":0},
                 "type":"PaySui",
                 "account": { "address" : recipient.to_string() },
-                "amount" : { "value": "1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+                "amount" : { "value": "1000000000" }
             },{
                 "operation_identifier":{"index":1},
                 "type":"PaySui",
                 "account": { "address" : sender.to_string() },
-                "amount" : { "value": "-1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+                "amount" : { "value": "-1000000000" }
             }]
         ))
         .unwrap();

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -9,8 +9,9 @@ use rosetta_client::start_rosetta_test_server;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_keys::keystore::AccountKeystore;
 use sui_rosetta::operations::Operations;
+use sui_rosetta::types::Currencies;
 use sui_rosetta::types::{
-    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, NetworkIdentifier,
+    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, NetworkIdentifier,
     SubAccount, SubAccountType, SuiEnv,
 };
 use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
@@ -46,7 +47,7 @@ async fn test_get_staked_sui() {
             sub_account: None,
         },
         block_identifier: Default::default(),
-        currencies: vec![],
+        currencies: Currencies(vec![Currency::default()]),
     };
 
     let response: AccountBalanceResponse = rosetta_client
@@ -67,7 +68,7 @@ async fn test_get_staked_sui() {
             }),
         },
         block_identifier: Default::default(),
-        currencies: vec![],
+        currencies: Currencies(vec![Currency::default()]),
     };
     let response: AccountBalanceResponse = rosetta_client
         .call(RosettaEndpoint::Balance, &request)

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use serde_json::json;
+use std::time::Duration;
 
 use rosetta_client::start_rosetta_test_server;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -176,7 +176,7 @@ async fn test_stake() {
     );
 
     let con_cache = CoinMetadataCache::new(client);
-    let ops2 = Operations::try_from_response(tx, &con_cache).unwrap();
+    let ops2 = Operations::try_from_response(tx, &con_cache).await.unwrap();
     assert!(
         ops2.contains(&ops),
         "Operation mismatch. expecting:{}, got:{}",
@@ -237,7 +237,9 @@ async fn test_stake_all() {
     );
 
     let coin_cache = CoinMetadataCache::new(client);
-    let ops2 = Operations::try_from_response(tx, &coin_cache).unwrap();
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
     assert!(
         ops2.contains(&ops),
         "Operation mismatch. expecting:{}, got:{}",
@@ -353,7 +355,9 @@ async fn test_withdraw_stake() {
     );
     println!("Sui TX: {tx:?}");
     let coin_cache = CoinMetadataCache::new(client);
-    let ops2 = Operations::try_from_response(tx, &coin_cache).unwrap();
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
     assert!(
         ops2.contains(&ops),
         "Operation mismatch. expecting:{}, got:{}",
@@ -422,7 +426,9 @@ async fn test_pay_sui() {
     );
     println!("Sui TX: {tx:?}");
     let coin_cache = CoinMetadataCache::new(client);
-    let ops2 = Operations::try_from_response(tx, &coin_cache).unwrap();
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
     assert!(
         ops2.contains(&ops),
         "Operation mismatch. expecting:{}, got:{}",
@@ -481,7 +487,9 @@ async fn test_pay_sui_multiple_times() {
             &SuiExecutionStatus::Success,
             tx.effects.as_ref().unwrap().status()
         );
-        let ops2 = Operations::try_from_response(tx, &coin_cache).unwrap();
+        let ops2 = Operations::try_from_response(tx, &coin_cache)
+            .await
+            .unwrap();
         assert!(
             ops2.contains(&ops),
             "Operation mismatch. expecting:{}, got:{}",

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -67,12 +67,26 @@ async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult
             "operation_identifier":{"index":0},
             "type":"PaySui",
             "account": { "address" : recipient.to_string() },
-            "amount" : { "value": "1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+            "amount" : {
+                "value": "1000000000",
+                "currency": {
+                        "symbol": "SUI",
+                        "decimals": 9,
+                        "coin_type": "0x2::sui::SUI"
+                }
+            },
         },{
             "operation_identifier":{"index":1},
             "type":"PaySui",
             "account": { "address" : sender.to_string() },
-            "amount" : { "value": "-1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+            "amount" : {
+                "value": "-1000000000",
+                "currency": {
+                        "symbol": "SUI",
+                        "decimals": 9,
+                        "coin_type": "0x2::sui::SUI"
+                }
+            },
         }]
     ))
     .unwrap();

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -67,9 +67,7 @@ async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult
             "operation_identifier":{"index":0},
             "type":"PaySui",
             "account": { "address" : recipient.to_string() },
-            "amount" : {
-                "value": "1000000000",
-            },
+            "amount" : { "value": "1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
         },{
             "operation_identifier":{"index":1},
             "type":"PaySui",

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -69,11 +69,6 @@ async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult
             "account": { "address" : recipient.to_string() },
             "amount" : {
                 "value": "1000000000",
-                "currency": {
-                        "symbol": "SUI",
-                        "decimals": 9,
-                        "coin_type": "0x2::sui::SUI"
-                }
             },
         },{
             "operation_identifier":{"index":1},
@@ -82,9 +77,8 @@ async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult
             "amount" : {
                 "value": "-1000000000",
                 "currency": {
-                        "symbol": "SUI",
-                        "decimals": 9,
-                        "coin_type": "0x2::sui::SUI"
+                    "symbol": "SUI",
+                    "decimals": 9,
                 }
             },
         }]

--- a/crates/sui-rosetta/tests/rosetta_client.rs
+++ b/crates/sui-rosetta/tests/rosetta_client.rs
@@ -20,8 +20,8 @@ use sui_rosetta::types::{
     AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, ConstructionCombineRequest,
     ConstructionCombineResponse, ConstructionMetadataRequest, ConstructionMetadataResponse,
     ConstructionPayloadsRequest, ConstructionPayloadsResponse, ConstructionPreprocessRequest,
-    ConstructionPreprocessResponse, ConstructionSubmitRequest, NetworkIdentifier, Signature,
-    SignatureType, SubAccount, SubAccountType, SuiEnv, TransactionIdentifierResponse,
+    ConstructionPreprocessResponse, ConstructionSubmitRequest, Currencies, NetworkIdentifier,
+    Signature, SignatureType, SubAccount, SubAccountType, SuiEnv, TransactionIdentifierResponse,
 };
 use sui_rosetta::{RosettaOfflineServer, RosettaOnlineServer};
 use sui_sdk::SuiClient;
@@ -192,7 +192,7 @@ impl RosettaClient {
                 sub_account,
             },
             block_identifier: Default::default(),
-            currencies: vec![],
+            currencies: Currencies(vec![]),
         };
         self.call(RosettaEndpoint::Balance, &request).await
     }


### PR DESCRIPTION
## Description 

Adds a Currency cache in order to get information about the coin types when processing transfer transactions.
Also removes wrong balance change info about SUI that is created due to the lack of the coin type when processing the transaction commands in specific cases.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
