### PR TITLE
feat(rust-sdk): Simulate WaitForLocalExecution

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -180,6 +180,10 @@ impl SuiTransactionBlockResponseOptions {
         }
     }
 
+    #[deprecated(
+        since = "1.31",
+        note = "Balance and object changes no longer require local execution"
+    )]
     pub fn require_local_execution(&self) -> bool {
         self.show_balance_changes || self.show_object_changes
     }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -181,7 +181,7 @@ impl SuiTransactionBlockResponseOptions {
     }
 
     #[deprecated(
-        since = "1.31",
+        since = "1.31.0",
         note = "Balance and object changes no longer require local execution"
     )]
     pub fn require_local_execution(&self) -> bool {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -181,7 +181,7 @@ impl SuiTransactionBlockResponseOptions {
     }
 
     #[deprecated(
-        since = "1.31.0",
+        since = "1.33.0",
         note = "Balance and object changes no longer require local execution"
     )]
     pub fn require_local_execution(&self) -> bool {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -9,6 +9,7 @@ use jsonrpsee::core::client::Subscription;
 use std::collections::BTreeMap;
 use std::future;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 use sui_json_rpc_types::DevInspectArgs;
 use sui_json_rpc_types::SuiData;
@@ -39,7 +40,9 @@ use sui_types::sui_serde::BigInt;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::transaction::{Transaction, TransactionData, TransactionKind};
 
-const WAIT_FOR_LOCAL_EXECUTION_RETRY_COUNT: u8 = 3;
+const WAIT_FOR_LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(60);
+const WAIT_FOR_LOCAL_EXECUTION_DELAY: Duration = Duration::from_millis(200);
+const WAIT_FOR_LOCAL_EXECUTION_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The main read API structure with functions for retrieving data about different objects and transactions
 #[derive(Debug)]
@@ -1133,39 +1136,49 @@ impl QuorumDriverApi {
     ) -> SuiRpcResult<SuiTransactionBlockResponse> {
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
         let request_type = request_type.unwrap_or_else(|| options.default_execution_request_type());
-        let mut retry_count = 0;
-        let start = Instant::now();
-        while retry_count < WAIT_FOR_LOCAL_EXECUTION_RETRY_COUNT {
-            let response: SuiTransactionBlockResponse = self
-                .api
-                .http
-                .execute_transaction_block(
-                    tx_bytes.clone(),
-                    signatures.clone(),
-                    Some(options.clone()),
-                    Some(request_type.clone()),
-                )
-                .await?;
 
-            match request_type {
-                ExecuteTransactionRequestType::WaitForEffectsCert => {
-                    return Ok(response);
-                }
-                ExecuteTransactionRequestType::WaitForLocalExecution => {
-                    if let Some(true) = response.confirmed_local_execution {
-                        return Ok(response);
-                    } else {
-                        // If fullnode executed the cert in the network but did not confirm local
-                        // execution, it must have timed out and hence we could retry.
-                        retry_count += 1;
-                    }
+        let start = Instant::now();
+        let response = self
+            .api
+            .http
+            .execute_transaction_block(
+                tx_bytes.clone(),
+                signatures.clone(),
+                Some(options.clone()),
+                Some(request_type.clone()),
+            )
+            .await?;
+
+        if let ExecuteTransactionRequestType::WaitForEffectsCert = request_type {
+            return Ok(response);
+        }
+
+        // JSON-RPC ignores WaitForLocalExecution, so simulate it by polling for the transaction.
+        let mut poll_response = tokio::time::timeout(WAIT_FOR_LOCAL_EXECUTION_TIMEOUT, async {
+            // Apply a short delay to give state sync a chance to catch up
+            tokio::time::sleep(WAIT_FOR_LOCAL_EXECUTION_DELAY).await;
+
+            let mut interval = tokio::time::interval(WAIT_FOR_LOCAL_EXECUTION_INTERVAL);
+            loop {
+                interval.tick().await;
+
+                if let Ok(poll_response) = self
+                    .api
+                    .http
+                    .get_transaction_block(*tx.digest(), Some(options.clone()))
+                    .await
+                {
+                    break poll_response;
                 }
             }
-        }
-        Err(Error::FailToConfirmTransactionStatus(
-            *tx.digest(),
-            start.elapsed().as_secs(),
-        ))
+        })
+        .await
+        .map_err(|_| {
+            Error::FailToConfirmTransactionStatus(*tx.digest(), start.elapsed().as_secs())
+        })?;
+
+        poll_response.confirmed_local_execution = Some(true);
+        Ok(poll_response)
     }
 }
 

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -1155,7 +1155,7 @@ impl QuorumDriverApi {
 
         // JSON-RPC ignores WaitForLocalExecution, so simulate it by polling for the transaction.
         let mut poll_response = tokio::time::timeout(WAIT_FOR_LOCAL_EXECUTION_TIMEOUT, async {
-            // Apply a short delay to give state sync a chance to catch up
+            // Apply a short delay to give the full node a chance to catch up.
             tokio::time::sleep(WAIT_FOR_LOCAL_EXECUTION_DELAY).await;
 
             let mut interval = tokio::time::interval(WAIT_FOR_LOCAL_EXECUTION_INTERVAL);


### PR DESCRIPTION
## Description

If transaction execution requires waiting for local execution, then simulate it by polling, to account for the fact that fullnodes will soon start to ignore this parameter.

## Test plan

Run the programmable transaction SDK example:

```
sui-sdk$ cargo run --example programmable_transactions_api
```

Run the tic-tac-toe E2E example:

```
examples/tic-tac-toe/cli$ env $(cat testnet.env) \
  cargo run -- new $(sui client active-address)
                                  |   |
                               ---+---+---
                                  |   |
                               ---+---+---
                                  |   |

 -> X: <ADDRESS>
    O: <ADDRESS>
 GAME: <GAME>

examples/tic-tac-toe/cli$ env $(cat testnet.env) \
  cargo run -- move -r 0 -c 0 $GAME

...
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [X] Rust SDK: Adds support for simulating `WaitForLocalExecution` in the client, using polling, as the flag will be ignored by fullnodes shortly.
- [ ] REST API:
