### PR TITLE
[move-ide] Fixed a bug preventing pkg build from VSCode

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -165,6 +165,7 @@ impl DependencyCache {
                             OsStr::new("fetch"),
                             OsStr::new("origin"),
                         ])
+                        .stdin(Stdio::null())
                         .stdout(Stdio::null())
                         .stderr(Stdio::null())
                         .status()
@@ -193,6 +194,7 @@ impl DependencyCache {
                             OsStr::new("--hard"),
                             OsStr::new(&format!("origin/{}", git_rev)),
                         ])
+                        .stdin(Stdio::null())
                         .stdout(Stdio::null())
                         .stderr(Stdio::null())
                         .status()


### PR DESCRIPTION
## Description 

This PR fixes a problem recently reported in https://github.com/MystenLabs/sui/issues/18749 and https://github.com/MystenLabs/sui/issues/18983. When creating `git` commands using `Command::new(...).status()` standard input inherited from VSCode was somehow causing the child process to hang, even though the commands created did not in fact require any input. This only happened on Windows and while admittedly I do not understand the root cause (perhaps one of the reviewers can help), it does fix the problem.

## Test plan 

All existing tests must pass. Additionally, manually verified that the build no longer hangs on Windows.
