### PR TITLE
revert(18170): patch for fetching latest dynamic field state for zkloginverifysignature

### DIFF
--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -3,17 +3,13 @@
 
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
-use diesel::query_dsl::methods::FilterDsl;
-use diesel::{ExpressionMethods, OptionalExtension};
 use move_core_types::annotated_value::{self as A, MoveStruct};
-use sui_indexer::models::objects::{StoredHistoryObject, StoredObject};
-use sui_indexer::schema::objects;
+use sui_indexer::models::objects::StoredHistoryObject;
 use sui_indexer::types::OwnerType;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
 use super::available_range::AvailableRange;
 use super::cursor::{Page, Target};
-use super::move_object::MoveObjectDowncastError;
 use super::object::{self, deserialize_move_struct, Object, ObjectKind, ObjectLookup};
 use super::type_filter::ExactTypeFilter;
 use super::{
@@ -21,7 +17,7 @@ use super::{
 };
 use crate::consistency::{build_objects_query, View};
 use crate::data::package_resolver::PackageResolver;
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
 use crate::filter;
 use crate::raw_query::RawQuery;
@@ -180,59 +176,6 @@ impl DynamicField {
             },
         )
         .await?;
-
-        super_.map(Self::try_from).transpose()
-    }
-
-    /// Due to recent performance degradations, the existing `DynamicField::query` method is now
-    /// consistently timing out. This impacts features like `verify_zklogin_signature`, which
-    /// depends on resolving a dynamic field of 0x7 authenticator state. This method is a temporary
-    /// fix by fetching the data from the live `objects` table, and should only be used by
-    /// `verify_zklogin_signature`. Once we have fixed `objects_snapshot` table lag and backfilled
-    /// the `objects_version` table, this will no longer be needed.
-    pub(crate) async fn query_latest_dynamic_field(
-        db: &Db,
-        parent: SuiAddress,
-        name: DynamicFieldName,
-        kind: DynamicFieldType,
-        checkpoint_viewed_at: u64,
-    ) -> Result<Option<DynamicField>, Error> {
-        let type_ = match kind {
-            DynamicFieldType::DynamicField => name.type_.0,
-            DynamicFieldType::DynamicObject => {
-                DynamicFieldInfo::dynamic_object_field_wrapper(name.type_.0).into()
-            }
-        };
-
-        let field_id = derive_dynamic_field_id(parent, &type_, &name.bcs.0)
-            .map_err(|e| Error::Internal(format!("Failed to derive dynamic field id: {e}")))?;
-
-        let object_id = SuiAddress::from(field_id);
-
-        let Some(stored_obj): Option<StoredObject> = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    objects::dsl::objects.filter(objects::dsl::object_id.eq(object_id.into_vec()))
-                })
-                .optional()
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch dynamic field: {e}")))?
-        else {
-            return Ok(None);
-        };
-
-        let history_object = StoredHistoryObject::from(stored_obj);
-        let gql_object =
-            Object::try_from_stored_history_object(history_object, checkpoint_viewed_at, None)?;
-
-        let super_ = match MoveObject::try_from(&gql_object) {
-            Ok(object) => Some(object),
-            Err(MoveObjectDowncastError::WrappedOrDeleted) => None,
-            Err(MoveObjectDowncastError::NotAMoveObject) => {
-                return Err(Error::Internal(format!("{object_id} is not a Move object")));
-            }
-        };
 
         super_.map(Self::try_from).transpose()
     }

--- a/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
+++ b/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
@@ -78,14 +78,11 @@ pub(crate) async fn verify_zklogin_signature(
         ));
     };
 
-    // fetch on-chain JWKs from dynamic field of system object. Due to recent performance
-    // degradations, the existing `DynamicField::query` method is now consistently timing out. As a
-    // workaround, we are using the `query_latest_dynamic_field` method, which fetches object data
-    // from the live `objects` table. This can be reverted once the `objects_snapshot` lag issue is
-    // fixed and we've backfilled the `objects_version` table.
-    let df = DynamicField::query_latest_dynamic_field(
-        ctx.data_unchecked(),
+    // fetch on-chain JWKs from dynamic field of system object.
+    let df = DynamicField::query(
+        ctx,
         SUI_AUTHENTICATOR_STATE_ADDRESS.into(),
+        None,
         DynamicFieldName {
             type_: ExactTypeFilter(TypeTag::U64),
             bcs: Base64(bcs::to_bytes(&1u64).unwrap()),


### PR DESCRIPTION
## Description

This reverts commit de8ae3c38c01011ade7e8bc0de70ef7076514ed4.

This change was introduced in the absence of optimisations that are going out as part of the next GraphQL release, so reverting so that we get the fully correct behaviour again (consistent lookup).

## Test plan

Existing zkLoginVerifySignature E2E tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
