### PR TITLE
[light-client] Fix light client rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4177,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4948,6 +4948,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -5807,6 +5822,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -6705,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "serde",
 ]
@@ -8393,6 +8424,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "neptune"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8860,7 +8908,38 @@ dependencies = [
  "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.7.4",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "object_store"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper 1.4.1",
+ "itertools 0.13.0",
+ "md-5 0.10.6",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.8.5",
+ "reqwest 0.12.5",
+ "ring 0.17.3",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "snafu 0.8.4",
  "tokio",
  "tracing",
  "url",
@@ -8942,10 +9021,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -10668,6 +10785,7 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -10677,11 +10795,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -10694,7 +10814,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service",
@@ -12133,7 +12255,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
  "doc-comment",
- "snafu-derive",
+ "snafu-derive 0.7.4",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
+dependencies = [
+ "snafu-derive 0.8.4",
 ]
 
 [[package]]
@@ -12146,6 +12277,18 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -12167,7 +12310,7 @@ dependencies = [
  "futures",
  "glob",
  "log",
- "object_store",
+ "object_store 0.10.2",
  "regex",
  "reqwest 0.12.5",
  "reqwest-middleware",
@@ -12696,7 +12839,7 @@ dependencies = [
  "move-core-types",
  "mysten-metrics",
  "num_enum 0.6.1",
- "object_store",
+ "object_store 0.10.2",
  "parquet",
  "prometheus",
  "serde",
@@ -12750,7 +12893,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "num_enum 0.6.1",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -13024,7 +13167,7 @@ dependencies = [
  "insta",
  "move-vm-config",
  "narwhal-config",
- "object_store",
+ "object_store 0.10.2",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -13087,7 +13230,7 @@ dependencies = [
  "nonempty",
  "num-bigint 0.4.4",
  "num_cpus",
- "object_store",
+ "object_store 0.10.2",
  "once_cell",
  "parking_lot 0.12.1",
  "pprof",
@@ -13178,7 +13321,7 @@ dependencies = [
  "futures",
  "mysten-metrics",
  "notify",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -13206,7 +13349,7 @@ dependencies = [
  "futures",
  "mysten-metrics",
  "notify",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -13643,7 +13786,7 @@ dependencies = [
  "move-core-types",
  "mysten-metrics",
  "ntest",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "rayon",
  "regex",
@@ -13886,8 +14029,12 @@ dependencies = [
  "bcs",
  "bytes",
  "clap",
+ "env_logger",
+ "log",
  "move-binary-format",
  "move-core-types",
+ "object_store 0.11.0",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -13899,6 +14046,7 @@ dependencies = [
  "sui-sdk 1.34.0",
  "sui-types",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -14681,7 +14829,7 @@ dependencies = [
  "indicatif",
  "integer-encoding",
  "num_enum 0.6.1",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "serde",
  "serde_json",
@@ -14796,7 +14944,7 @@ dependencies = [
  "mysten-metrics",
  "num_cpus",
  "num_enum 0.6.1",
- "object_store",
+ "object_store 0.10.2",
  "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
@@ -14971,7 +15119,7 @@ dependencies = [
  "itertools 0.10.5",
  "move-core-types",
  "num_cpus",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "ron",
  "serde",
@@ -15251,7 +15399,7 @@ dependencies = [
  "mysten-metrics",
  "mysten-service",
  "notify",
- "object_store",
+ "object_store 0.10.2",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -15438,6 +15586,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -15893,6 +16062,16 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,21 +4950,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5822,22 +5807,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -8424,23 +8393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "neptune"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8908,38 +8860,7 @@ dependencies = [
  "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
- "snafu 0.7.4",
- "tokio",
- "tracing",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "object_store"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "hyper 1.4.1",
- "itertools 0.13.0",
- "md-5 0.10.6",
- "parking_lot 0.12.1",
- "percent-encoding",
- "quick-xml",
- "rand 0.8.5",
- "reqwest 0.12.5",
- "ring 0.17.3",
- "rustls-pemfile 2.1.2",
- "serde",
- "serde_json",
- "snafu 0.8.4",
+ "snafu",
  "tokio",
  "tracing",
  "url",
@@ -9021,48 +8942,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -10785,7 +10668,6 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -10795,13 +10677,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -10814,9 +10694,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service",
@@ -12255,16 +12133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
  "doc-comment",
- "snafu-derive 0.7.4",
-]
-
-[[package]]
-name = "snafu"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
-dependencies = [
- "snafu-derive 0.8.4",
+ "snafu-derive",
 ]
 
 [[package]]
@@ -12277,18 +12146,6 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -12310,7 +12167,7 @@ dependencies = [
  "futures",
  "glob",
  "log",
- "object_store 0.10.2",
+ "object_store",
  "regex",
  "reqwest 0.12.5",
  "reqwest-middleware",
@@ -12839,7 +12696,7 @@ dependencies = [
  "move-core-types",
  "mysten-metrics",
  "num_enum 0.6.1",
- "object_store 0.10.2",
+ "object_store",
  "parquet",
  "prometheus",
  "serde",
@@ -12893,7 +12750,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "num_enum 0.6.1",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -13167,7 +13024,7 @@ dependencies = [
  "insta",
  "move-vm-config",
  "narwhal-config",
- "object_store 0.10.2",
+ "object_store",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -13230,7 +13087,7 @@ dependencies = [
  "nonempty",
  "num-bigint 0.4.4",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "once_cell",
  "parking_lot 0.12.1",
  "pprof",
@@ -13321,7 +13178,7 @@ dependencies = [
  "futures",
  "mysten-metrics",
  "notify",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -13349,7 +13206,7 @@ dependencies = [
  "futures",
  "mysten-metrics",
  "notify",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -13786,7 +13643,7 @@ dependencies = [
  "move-core-types",
  "mysten-metrics",
  "ntest",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "rayon",
  "regex",
@@ -14033,7 +13890,7 @@ dependencies = [
  "log",
  "move-binary-format",
  "move-core-types",
- "object_store 0.11.0",
+ "object_store",
  "reqwest 0.12.5",
  "serde",
  "serde_json",
@@ -14829,7 +14686,7 @@ dependencies = [
  "indicatif",
  "integer-encoding",
  "num_enum 0.6.1",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "serde",
  "serde_json",
@@ -14944,7 +14801,7 @@ dependencies = [
  "mysten-metrics",
  "num_cpus",
  "num_enum 0.6.1",
- "object_store 0.10.2",
+ "object_store",
  "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
@@ -15119,7 +14976,7 @@ dependencies = [
  "itertools 0.10.5",
  "move-core-types",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "ron",
  "serde",
@@ -15399,7 +15256,7 @@ dependencies = [
  "mysten-metrics",
  "mysten-service",
  "notify",
- "object_store 0.10.2",
+ "object_store",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -15586,27 +15443,6 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -16062,16 +15898,6 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13896,7 +13896,6 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "sui-config",
- "sui-json",
  "sui-json-rpc-types",
  "sui-package-resolver",
  "sui-rest-api",

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -99,10 +99,6 @@ impl SuiJsonValue {
         Ok(Self(json_value))
     }
 
-    pub fn new_unchecked(json_value: JsonValue) -> Result<SuiJsonValue, anyhow::Error> {
-        Ok(Self(json_value))
-    }
-
     fn check_value(json_value: &JsonValue) -> Result<(), anyhow::Error> {
         match json_value {
             // No checks needed for Bool and String
@@ -396,7 +392,7 @@ fn json_value_to_sui_address(value: &JsonValue) -> anyhow::Result<SuiAddress> {
     }
 }
 
-pub fn move_value_to_json(move_value: &MoveValue) -> Option<JsonValue> {
+fn move_value_to_json(move_value: &MoveValue) -> Option<JsonValue> {
     Some(match move_value {
         MoveValue::Vector(values) => JsonValue::Array(
             values

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -99,6 +99,10 @@ impl SuiJsonValue {
         Ok(Self(json_value))
     }
 
+    pub fn new_unchecked(json_value: JsonValue) -> Result<SuiJsonValue, anyhow::Error> {
+        Ok(Self(json_value))
+    }
+
     fn check_value(json_value: &JsonValue) -> Result<(), anyhow::Error> {
         match json_value {
             // No checks needed for Bool and String
@@ -392,7 +396,7 @@ fn json_value_to_sui_address(value: &JsonValue) -> anyhow::Result<SuiAddress> {
     }
 }
 
-fn move_value_to_json(move_value: &MoveValue) -> Option<JsonValue> {
+pub fn move_value_to_json(move_value: &MoveValue) -> Option<JsonValue> {
     Some(match move_value {
         MoveValue::Vector(values) => JsonValue::Array(
             values

--- a/crates/sui-light-client/.gitignore
+++ b/crates/sui-light-client/.gitignore
@@ -1,0 +1,1 @@
+checkpoints_dir/*

--- a/crates/sui-light-client/Cargo.toml
+++ b/crates/sui-light-client/Cargo.toml
@@ -32,8 +32,8 @@ sui-sdk.workspace = true
 move-binary-format.workspace = true
 sui-json-rpc-types.workspace = true
 sui-package-resolver.workspace = true
+url.workspace = true
+reqwest.workspace = true
+object_store.workspace = true
 env_logger = "0.11.5"
-object_store = {version = "0.11.0", features = ["http", "aws", "gcp"]}
-url = "2.5.2"
 log = "0.4.22"
-reqwest = "0.12.5"

--- a/crates/sui-light-client/Cargo.toml
+++ b/crates/sui-light-client/Cargo.toml
@@ -27,7 +27,6 @@ serde_json.workspace = true
 sui-types.workspace = true
 sui-config.workspace = true
 sui-rest-api.workspace = true
-sui-json.workspace = true
 sui-sdk.workspace = true
 move-binary-format.workspace = true
 sui-json-rpc-types.workspace = true

--- a/crates/sui-light-client/Cargo.toml
+++ b/crates/sui-light-client/Cargo.toml
@@ -32,3 +32,8 @@ sui-sdk.workspace = true
 move-binary-format.workspace = true
 sui-json-rpc-types.workspace = true
 sui-package-resolver.workspace = true
+env_logger = "0.11.5"
+object_store = {version = "0.11.0", features = ["http", "aws", "gcp"]}
+url = "2.5.2"
+log = "0.4.22"
+reqwest = "0.12.5"

--- a/crates/sui-light-client/example_config/light_client.yaml
+++ b/crates/sui-light-client/example_config/light_client.yaml
@@ -1,3 +1,5 @@
-full_node_url: "http://ord-mnt-rpcbig-06.mainnet.sui.io:9000"
+full_node_url: "https://fullnode.mainnet.sui.io:443"
 checkpoint_summary_dir: "checkpoints_dir"
 genesis_filename: "genesis.blob"
+object_store_url: "https://checkpoints.mainnet.sui.io"
+graphql_url: "https://sui-mainnet.mystenlabs.com/graphql"

--- a/crates/sui-light-client/src/main.rs
+++ b/crates/sui-light-client/src/main.rs
@@ -431,12 +431,14 @@ async fn get_verified_effects_and_events(
     let options = SuiTransactionBlockResponseOptions::new();
     let seq = read_api
         .get_transaction_with_options(tid, options)
-        .await.map_err(|e| anyhow!(format!("Cannot get transaction: {e}")))?
+        .await
+        .map_err(|e| anyhow!(format!("Cannot get transaction: {e}")))?
         .checkpoint
         .ok_or(anyhow!("Transaction not found"))?;
 
     // Download the full checkpoint for this sequence number
-    let full_check_point = get_full_checkpoint(config, seq).await
+    let full_check_point = get_full_checkpoint(config, seq)
+        .await
         .map_err(|e| anyhow!(format!("Cannot get full checkpoint: {e}")))?;
 
     // Load the list of stored checkpoints
@@ -477,10 +479,10 @@ async fn get_verified_effects_and_events(
         // Since we did not find a small committee checkpoint we use the genesis
         let mut genesis_path = config.checkpoint_summary_dir.clone();
         genesis_path.push(&config.genesis_filename);
-        Genesis::load(&genesis_path)?.committee()
+        Genesis::load(&genesis_path)?
+            .committee()
             .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?
     };
-
 
     info!("Extracting effects and events for TID: {}", tid);
     extract_verified_effects_and_events(&full_check_point, &committee, tid)

--- a/crates/sui-light-client/src/main.rs
+++ b/crates/sui-light-client/src/main.rs
@@ -4,7 +4,7 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 use move_core_types::account_address::AccountAddress;
-use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiTransactionBlockResponseOptions};
 
 use sui_rest_api::{CheckpointData, Client};
 use sui_types::{
@@ -26,8 +26,15 @@ use sui_package_resolver::{Package, PackageStore, Resolver};
 use sui_sdk::SuiClientBuilder;
 
 use clap::{Parser, Subcommand};
-use std::{fs, io::Write, path::PathBuf, str::FromStr};
+use std::{cell::RefCell, collections::HashMap, fs, io::Write, path::PathBuf, str::FromStr, sync::Mutex};
 use std::{io::Read, sync::Arc};
+
+use log::{info, warn};
+use object_store::parse_url;
+use object_store::path::Path;
+use serde_json::json;
+use serde_json::Value;
+use url::Url;
 
 /// A light client for the Sui blockchain
 #[derive(Parser, Debug)]
@@ -43,11 +50,12 @@ struct Args {
 
 struct RemotePackageStore {
     config: Config,
+    cache: Mutex<HashMap<AccountAddress, Arc<Package>>>,
 }
 
 impl RemotePackageStore {
     pub fn new(config: Config) -> Self {
-        Self { config }
+        Self { config , cache: Mutex::new(HashMap::new()) }
     }
 }
 
@@ -56,9 +64,23 @@ impl PackageStore for RemotePackageStore {
     /// Read package contents. Fails if `id` is not an object, not a package, or is malformed in
     /// some way.
     async fn fetch(&self, id: AccountAddress) -> ResolverResult<Arc<Package>> {
+
+
+        // Check if we have it in the cache
+        if let Some(package) = self.cache.lock().unwrap().get(&id) {
+            info!("Fetch Package: {} cache hit", id);
+            return Ok(package.clone());
+        }
+
+        info!("Fetch Package: {}", id);
+
         let object = get_verified_object(&self.config, id.into()).await.unwrap();
-        let package = Package::read_from_object(&object).unwrap();
-        Ok(Arc::new(package))
+        let package = Arc::new(Package::read_from_object(&object).unwrap());
+
+        // Add to the cache
+        self.cache.lock().unwrap().insert(id, package.clone());
+
+        Ok(package)
     }
 }
 
@@ -93,12 +115,45 @@ struct Config {
 
     //  Genesis file name
     genesis_filename: PathBuf,
+
+    /// Object store url
+    object_store_url: String,
+
+    /// GraphQL endpoint
+    graphql_url: String,
 }
 
-impl Config {
-    pub fn rest_url(&self) -> &str {
-        &self.full_node_url
-    }
+async fn query_last_checkpoint_of_epoch(config: &Config, epoch_id: u64) -> anyhow::Result<u64> {
+
+    // GraphQL query to get the last checkpoint of an epoch
+    let query = json!({
+        "query": "query ($epochID: Int) { epoch(id: $epochID) { epochId checkpoints(last: 1) { nodes { sequenceNumber } } } }",
+        "variables": { "epochID": epoch_id }
+    });
+
+    // Submit the query by POSTing to the GraphQL endpoint
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(
+            &config.graphql_url
+        )
+        .header("Content-Type", "application/json")
+        .body(query.to_string())
+        .send()
+        .await
+        .expect("Cannot connect to graphql")
+        .text()
+        // .json::<HashMap<String, String>>()
+        .await
+        .expect("Cannot parse response");
+
+    // Parse the JSON response to get the last checkpoint of the epoch
+    let v: Value = serde_json::from_str(resp.as_str()).expect("Incorrect JSON response");
+    let checkpoint_number = v["data"]["epoch"]["checkpoints"]["nodes"][0]["sequenceNumber"]
+        .as_u64()
+        .unwrap();
+
+    Ok(checkpoint_number)
 }
 
 // The list of checkpoints at the end of each epoch
@@ -182,11 +237,19 @@ fn write_checkpoint_list(
 
 async fn download_checkpoint_summary(
     config: &Config,
-    seq: u64,
+    checkpoint_number: u64,
 ) -> anyhow::Result<CertifiedCheckpointSummary> {
     // Download the checkpoint from the server
-    let client = Client::new(config.rest_url());
-    client.get_checkpoint_summary(seq).await.map_err(Into::into)
+
+    let url = Url::parse(&config.object_store_url)?;
+    let (dyn_store, _store_path) = parse_url(&url).unwrap();
+    let path = Path::from(format!("{}.chk", checkpoint_number));
+    let response = dyn_store.get(&path).await?;
+    let bytes = response.bytes().await?;
+    let (_, blob) = bcs::from_bytes::<(u8, CheckpointData)>(&bytes)?;
+
+    info!("Downloaded checkpoint summary: {}", checkpoint_number);
+    Ok(blob.checkpoint_summary)
 }
 
 /// Run binary search to for each end of epoch checkpoint that is missing
@@ -202,73 +265,58 @@ async fn sync_checkpoint_list_to_latest(config: &Config) -> anyhow::Result<()> {
     // Download the latest in list checkpoint
     let summary = download_checkpoint_summary(config, *latest_in_list).await?;
     let mut last_epoch = summary.epoch();
-    let mut last_checkpoint_seq = summary.sequence_number;
 
     // Download the very latest checkpoint
-    let client = Client::new(config.rest_url());
-    let latest = client.get_latest_checkpoint().await?;
+    let client = SuiClientBuilder::default()
+        .build(config.full_node_url.as_str())
+        .await
+        .expect("Cannot connect to full node");
+
+    let latest_seq = client
+        .read_api()
+        .get_latest_checkpoint_sequence_number()
+        .await?;
+    let latest = download_checkpoint_summary(config, latest_seq).await?;
 
     // Binary search to find missing checkpoints
     while last_epoch + 1 < latest.epoch() {
-        let mut start = last_checkpoint_seq;
-        let mut end = latest.sequence_number;
-
         let target_epoch = last_epoch + 1;
-        // Print target
-        println!("Target Epoch: {}", target_epoch);
-        let mut found_summary = None;
+        let target_last_checkpoint_number =
+            query_last_checkpoint_of_epoch(config, target_epoch).await?;
 
-        while start < end {
-            let mid = (start + end) / 2;
-            let summary = download_checkpoint_summary(config, mid).await?;
+        // Add to the list
+        checkpoints_list
+            .checkpoints
+            .push(target_last_checkpoint_number);
+        write_checkpoint_list(config, &checkpoints_list)?;
 
-            // print summary epoch and seq
-            println!(
-                "Epoch: {} Seq: {}: {}",
-                summary.epoch(),
-                summary.sequence_number,
-                summary.end_of_epoch_data.is_some()
-            );
+        // Update
+        last_epoch = target_epoch;
 
-            if summary.epoch() == target_epoch && summary.end_of_epoch_data.is_some() {
-                found_summary = Some(summary);
-                break;
-            }
-
-            if summary.epoch() <= target_epoch {
-                start = mid + 1;
-            } else {
-                end = mid;
-            }
-        }
-
-        if let Some(summary) = found_summary {
-            // Note: Do not write summary to file, since we must only persist
-            //       checkpoints that have been verified by the previous committee
-
-            // Add to the list
-            checkpoints_list.checkpoints.push(summary.sequence_number);
-            write_checkpoint_list(config, &checkpoints_list)?;
-
-            // Update
-            last_epoch = summary.epoch();
-            last_checkpoint_seq = summary.sequence_number;
-        }
+        println!(
+            "Last Epoch: {} Last Checkpoint: {}",
+            target_epoch, target_last_checkpoint_number
+        );
     }
 
     Ok(())
 }
 
 async fn check_and_sync_checkpoints(config: &Config) -> anyhow::Result<()> {
-    sync_checkpoint_list_to_latest(config).await?;
+    sync_checkpoint_list_to_latest(config)
+        .await
+        .map_err(|e| anyhow!(format!("Cannot refresh list: {e}")))?;
 
     // Get the local checkpoint list
-    let checkpoints_list: CheckpointsList = read_checkpoint_list(config)?;
+    let checkpoints_list: CheckpointsList = read_checkpoint_list(config)
+        .map_err(|e| anyhow!(format!("Cannot read checkpoint list: {e}")))?;
 
     // Load the genesis committee
     let mut genesis_path = config.checkpoint_summary_dir.clone();
     genesis_path.push(&config.genesis_filename);
-    let genesis_committee = Genesis::load(&genesis_path)?.committee()?;
+    let genesis_committee = Genesis::load(&genesis_path)?
+        .committee()
+        .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?;
 
     // Check the signatures of all checkpoints
     // And download any missing ones
@@ -281,10 +329,13 @@ async fn check_and_sync_checkpoints(config: &Config) -> anyhow::Result<()> {
 
         // If file exists read the file otherwise download it from the server
         let summary = if checkpoint_path.exists() {
-            read_checkpoint(config, *ckp_id)?
+            read_checkpoint(config, *ckp_id)
+                .map_err(|e| anyhow!(format!("Cannot read checkpoint: {e}")))?
         } else {
             // Download the checkpoint from the server
-            let summary = download_checkpoint_summary(config, *ckp_id).await?;
+            let summary = download_checkpoint_summary(config, *ckp_id)
+                .await
+                .map_err(|e| anyhow!(format!("Cannot download summary: {e}")))?;
             summary.clone().try_into_verified(&prev_committee)?;
             // Write the checkpoint summary to a file
             write_checkpoint(config, &summary)?;
@@ -317,11 +368,16 @@ async fn check_and_sync_checkpoints(config: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn get_full_checkpoint(config: &Config, seq: u64) -> anyhow::Result<CheckpointData> {
-    // Downloading the checkpoint from the server
-    let client: Client = Client::new(config.rest_url());
-    let full_checkpoint = client.get_full_checkpoint(seq).await?;
-
+async fn get_full_checkpoint(
+    config: &Config,
+    checkpoint_number: u64,
+) -> anyhow::Result<CheckpointData> {
+    let url = Url::parse(&config.object_store_url)?;
+    let (dyn_store, _store_path) = parse_url(&url).unwrap();
+    let path = Path::from(format!("{}.chk", checkpoint_number));
+    let response = dyn_store.get(&path).await?;
+    let bytes = response.bytes().await?;
+    let (_, full_checkpoint) = bcs::from_bytes::<(u8, CheckpointData)>(&bytes)?;
     Ok(full_checkpoint)
 }
 
@@ -427,17 +483,31 @@ async fn get_verified_effects_and_events(
 }
 
 async fn get_verified_object(config: &Config, id: ObjectID) -> anyhow::Result<Object> {
-    let client: Client = Client::new(config.rest_url());
-    let object = client.get_object(id).await?;
+
+    let sui_client: Arc<sui_sdk::SuiClient> = Arc::new(
+        SuiClientBuilder::default()
+            .build(config.full_node_url.as_str())
+            .await
+            .unwrap(),
+    );
+
+    info!("Getting object: {}", id);
+
+    let read_api = sui_client.read_api();
+    let object_json = read_api.get_object_with_options(id, SuiObjectDataOptions::bcs_lossless()).await?;
+    let object = object_json.into_object().expect("Cannot make into object data");
+    let object : Object = object.try_into().expect("Cannot reconstruct object");
 
     // Need to authenticate this object
-    let (effects, _) = get_verified_effects_and_events(config, object.previous_transaction).await?;
+    let (effects, _) = get_verified_effects_and_events(config,
+        object.previous_transaction).await?;
 
     // check that this object ID, version and hash is in the effects
+    let target_object_ref = object.compute_object_reference();
     effects
         .all_changed_objects()
         .iter()
-        .find(|object_ref| object_ref.0 == object.compute_object_reference())
+        .find(|object_ref| object_ref.0 == target_object_ref)
         .ok_or(anyhow!("Object not found"))?;
 
     Ok(object)
@@ -445,6 +515,8 @@ async fn get_verified_object(config: &Config, id: ObjectID) -> anyhow::Result<Ob
 
 #[tokio::main]
 pub async fn main() {
+    env_logger::init();
+
     // Command line arguments and config loading
     let args = Args::parse();
 

--- a/crates/sui-light-client/src/proof.rs
+++ b/crates/sui-light-client/src/proof.rs
@@ -14,7 +14,6 @@ use sui_types::{
     transaction::Transaction,
 };
 
-
 /// Define aspect of Sui state that need to be certified in a proof
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct ProofTarget {

--- a/crates/sui-light-client/src/proof.rs
+++ b/crates/sui-light-client/src/proof.rs
@@ -3,6 +3,7 @@
 
 use anyhow::anyhow;
 
+use serde::{Deserialize, Serialize};
 use sui_types::{
     base_types::ObjectRef,
     committee::Committee,
@@ -13,8 +14,9 @@ use sui_types::{
     transaction::Transaction,
 };
 
-/// Define aspect of Sui state that needs to be certified in a proof
-#[derive(Default)]
+
+/// Define aspect of Sui state that need to be certified in a proof
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct ProofTarget {
     /// Objects that need to be certified.
     pub objects: Vec<(ObjectRef, Object)>,
@@ -58,6 +60,7 @@ impl ProofTarget {
 
 /// Part of a proof that provides evidence relating to a specific transaction to
 /// certify objects and events.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransactionProof {
     /// Checkpoint contents including this transaction.
     pub checkpoint_contents: CheckpointContents,
@@ -74,6 +77,7 @@ pub struct TransactionProof {
 
 /// A proof for specific targets. It certifies a checkpoint summary and optionally includes
 /// transaction evidence to certify objects and events.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Proof {
     /// Targets of the proof are a committee, objects, or events that need to be certified.
     pub targets: ProofTarget,


### PR DESCRIPTION
## Description 

Modernise the RPC used in the light client:
- Use GraphQL to get the end-of-epoch checkpoint.
- Use the supported Rust SDK to get objects and other info.
- Use a generic object store, by default provided by Mysten, for the full checkpoint data.
- Add a cache to package loader since we observed the same package downloaded multiple times.

## Test plan 

Existing unit tests, and manual CLI invocations.