### PR TITLE
[replay] Fix issue when replaying transactions taht query existence of dynamic fields before creating it

### DIFF
--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -635,6 +635,12 @@ impl LocalExec {
                 error!("Object {id} {version} {digest} was deleted on RPC server.");
                 Ok(None)
             }
+            // This is a child object which was not found in the store (e.g., due to exists
+            // check before creating the dynamic field).
+            Err(ReplayEngineError::ObjectVersionNotFound { id, version }) => {
+                info!("Object {id} {version} not found on RPC server -- this may have been pruned or never existed.");
+                Ok(None)
+            }
             Err(err) => Err(ReplayEngineError::SuiRpcError {
                 err: err.to_string(),
             }),


### PR DESCRIPTION
## Description 

This fixes a bug in the replay tool where if the transaction checked for the existence of the dynamic field before creating it, we would fail to be able to replay the transaction locally since the replay tool was not properly handling the underlying error.

## Test plan 

Tested manually on a failing transaction.

