### PR TITLE
[Consensus] move transaction count limit to protocol config

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -164,7 +164,7 @@ where
         let start_time = Instant::now();
 
         let (tx_client, tx_receiver) = TransactionClient::new(context.clone());
-        let tx_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let tx_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
         let (core_signals, signals_receivers) = CoreSignals::new(context.clone());
 

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -158,9 +158,7 @@ impl BlockVerifier for SignedBlockVerifier {
         }
 
         let max_num_transactions_limit =
-            self.context
-                .protocol_config
-                .consensus_max_num_transactions_in_block() as usize;
+            self.context.protocol_config.max_num_transactions_in_block() as usize;
         if batch.len() > max_num_transactions_limit && max_num_transactions_limit > 0 {
             return Err(ConsensusError::TooManyTransactions {
                 count: batch.len(),

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -142,8 +142,45 @@ impl BlockVerifier for SignedBlockVerifier {
             });
         }
 
-        // TODO: check transaction size, total size and count.
         let batch: Vec<_> = block.transactions().iter().map(|t| t.data()).collect();
+
+        let max_transaction_size_limit =
+            self.context
+                .protocol_config
+                .consensus_max_transaction_size_bytes() as usize;
+        for t in &batch {
+            if t.len() > max_transaction_size_limit && max_transaction_size_limit > 0 {
+                return Err(ConsensusError::TransactionTooLarge {
+                    size: t.len(),
+                    limit: max_transaction_size_limit,
+                });
+            }
+        }
+
+        let max_num_transactions_limit =
+            self.context
+                .protocol_config
+                .consensus_max_num_transactions_in_block() as usize;
+        if batch.len() > max_num_transactions_limit && max_num_transactions_limit > 0 {
+            return Err(ConsensusError::TooManyTransactions {
+                count: batch.len(),
+                limit: max_num_transactions_limit,
+            });
+        }
+
+        let total_transactions_size_limit =
+            self.context
+                .protocol_config
+                .consensus_max_transactions_in_block_bytes() as usize;
+        if batch.iter().map(|t| t.len()).sum::<usize>() > total_transactions_size_limit
+            && total_transactions_size_limit > 0
+        {
+            return Err(ConsensusError::TooManyTransactionBytes {
+                size: batch.len(),
+                limit: total_transactions_size_limit,
+            });
+        }
+
         self.transaction_verifier
             .verify_batch(&self.context.protocol_config, &batch)
             .map_err(|e| ConsensusError::InvalidTransaction(format!("{e:?}")))
@@ -443,6 +480,49 @@ mod test {
             assert!(matches!(
                 verifier.verify(&signed_block),
                 Err(ConsensusError::InvalidTransaction(_))
+            ));
+        }
+
+        // Block with transaction too large.
+        {
+            let block = test_block
+                .clone()
+                .set_transactions(vec![Transaction::new(vec![4; 257 * 1024])])
+                .build();
+            let signed_block = SignedBlock::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::TransactionTooLarge { size: _, limit: _ })
+            ));
+        }
+
+        // Block with too many transactions.
+        {
+            let block = test_block
+                .clone()
+                .set_transactions((0..1000).map(|_| Transaction::new(vec![4; 8])).collect())
+                .build();
+            let signed_block = SignedBlock::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::TooManyTransactions { count: _, limit: _ })
+            ));
+        }
+
+        // Block with too many transaction bytes.
+        {
+            let block = test_block
+                .clone()
+                .set_transactions(
+                    (0..100)
+                        .map(|_| Transaction::new(vec![4; 8 * 1024]))
+                        .collect(),
+                )
+                .build();
+            let signed_block = SignedBlock::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::TooManyTransactionBytes { size: _, limit: _ })
             ));
         }
     }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -868,7 +868,7 @@ impl CoreTextFixture {
                 .with_num_commits_per_schedule(10),
         );
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let block_receiver = signal_receivers.block_broadcast_receiver();
@@ -935,7 +935,7 @@ mod test {
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
         // Create test blocks for all the authorities for 4 rounds and populate them in store
         let mut last_round_blocks = genesis_blocks(context.clone());
@@ -1045,7 +1045,7 @@ mod test {
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
         // Create test blocks for all authorities except our's (index = 0).
         let mut last_round_blocks = genesis_blocks(context.clone());
@@ -1175,7 +1175,7 @@ mod test {
             Arc::new(NoopBlockVerifier),
         );
         let (transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let mut block_receiver = signal_receivers.block_broadcast_receiver();
@@ -1288,7 +1288,7 @@ mod test {
         ));
 
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
@@ -1376,7 +1376,7 @@ mod test {
         ));
 
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
@@ -1563,7 +1563,7 @@ mod test {
         ));
 
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -325,7 +325,7 @@ mod test {
             Arc::new(NoopBlockVerifier),
         );
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let _block_receiver = signal_receivers.block_broadcast_receiver();
         let (sender, _receiver) = unbounded_channel("consensus_output");

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -24,6 +24,15 @@ pub(crate) enum ConsensusError {
     #[error("Error serializing: {0}")]
     SerializationFailure(bcs::Error),
 
+    #[error("Block contains a transaction that is too large: {size} > {limit}")]
+    TransactionTooLarge { size: usize, limit: usize },
+
+    #[error("Block contains too many transactions: {count} > {limit}")]
+    TooManyTransactions { count: usize, limit: usize },
+
+    #[error("Block contains too many transaction bytes: {size} > {limit}")]
+    TooManyTransactionBytes { size: usize, limit: usize },
+
     #[error("Unexpected block authority {0} from peer {1}")]
     UnexpectedAuthority(AuthorityIndex, AuthorityIndex),
 

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -18,10 +18,6 @@ use crate::{
 /// The maximum number of transactions pending to the queue to be pulled for block proposal
 const MAX_PENDING_TRANSACTIONS: usize = 2_000;
 
-/// Assume 20_000 TPS * 5% max stake per validator / (minimum) 4 blocks per round = 250 transactions per block maximum
-/// Using a higher limit that is 250 * 2 = 500, to account for bursty traffic and system transactions.
-const MAX_CONSUMED_TRANSACTIONS_PER_REQUEST: u64 = 500;
-
 /// The guard acts as an acknowledgment mechanism for the inclusion of the transactions to a block.
 /// When its last transaction is included to a block then `included_in_block_ack` will be signalled.
 /// If the guard is dropped without getting acknowledged that means the transactions have not been
@@ -53,9 +49,7 @@ impl TransactionConsumer {
                 .consensus_max_transactions_in_block_bytes(),
             max_consumed_transactions_per_request: context
                 .protocol_config
-                .consensus_max_num_transactions_in_block()
-                // TODO: remove below after protocol 55 has rolled out.
-                .max(MAX_CONSUMED_TRANSACTIONS_PER_REQUEST),
+                .max_num_transactions_in_block(),
             pending_transactions: None,
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1417,6 +1417,7 @@
                 "config_read_setting_impl_cost_base": null,
                 "config_read_setting_impl_cost_per_byte": null,
                 "consensus_bad_nodes_stake_threshold": null,
+                "consensus_max_num_transactions_in_block": null,
                 "consensus_max_transaction_size_bytes": null,
                 "consensus_max_transactions_in_block_bytes": null,
                 "crypto_invalid_arguments_cost": {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1531,6 +1531,11 @@ impl ProtocolConfig {
     pub fn authority_capabilities_v2(&self) -> bool {
         self.feature_flags.authority_capabilities_v2
     }
+
+    pub fn max_num_transactions_in_block(&self) -> u64 {
+        // 500 is the value used before this field is introduced.
+        self.consensus_max_num_transactions_in_block.unwrap_or(500)
+    }
 }
 
 #[cfg(not(msim))]

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1184,8 +1184,10 @@ pub struct ProtocolConfig {
     /// The maximum serialised transaction size (in bytes) accepted by consensus. That should be bigger than the
     /// `max_tx_size_bytes` with some additional headroom.
     consensus_max_transaction_size_bytes: Option<u64>,
-    /// The maximum size of transactions included in a consensus proposed block
+    /// The maximum size of transactions included in a consensus block.
     consensus_max_transactions_in_block_bytes: Option<u64>,
+    /// The maximum number of transactions included in a consensus block.
+    consensus_max_num_transactions_in_block: Option<u64>,
 
     /// The max accumulated txn execution cost per object in a Narwhal commit. Transactions
     /// in a checkpoint will be deferred once their touch shared objects hit this limit.
@@ -2016,6 +2018,8 @@ impl ProtocolConfig {
 
             consensus_max_transactions_in_block_bytes: None,
 
+            consensus_max_num_transactions_in_block: None,
+
             max_accumulated_txn_cost_per_object_in_narwhal_commit: None,
 
             max_deferral_rounds_for_congestion_control: None,
@@ -2656,6 +2660,12 @@ impl ProtocolConfig {
                 55 => {
                     // Turn on enums mainnet
                     cfg.move_binary_format_version = Some(7);
+
+                    // Assume 1KB per transaction and 500 transactions per block.
+                    cfg.consensus_max_transactions_in_block_bytes = Some(512 * 1024);
+                    // Assume 20_000 TPS * 5% max stake per validator / (minimum) 4 blocks per round = 250 transactions per block maximum
+                    // Using a higher limit that is 512, to account for bursty traffic and system transactions.
+                    cfg.consensus_max_num_transactions_in_block = Some(512);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_55.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_55.snap
@@ -310,7 +310,8 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
-consensus_max_transactions_in_block_bytes: 6291456
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 100
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
@@ -318,4 +319,3 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: false
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_55.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_55.snap
@@ -311,7 +311,8 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
-consensus_max_transactions_in_block_bytes: 6291456
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 100
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
@@ -319,4 +320,3 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_55.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_55.snap
@@ -320,7 +320,8 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
-consensus_max_transactions_in_block_bytes: 6291456
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 100
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
@@ -328,4 +329,3 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-


### PR DESCRIPTION
## Description 

1. move transaction count per block limit to protocol config.
2. reduce the transaction bytes per block limit to 512KB, based on the transaction count limit.
3. verify the limits in `BlockVerifier`

## Test plan 

Unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
