### PR TITLE
feat: allow specifying OTEL service name with OTEL_SERVICE_NAME

### DIFF
--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -380,6 +380,7 @@ impl TelemetryConfig {
         let mut file_output = CachedOpenFile::new::<&str>(None).unwrap();
         let mut provider = None;
         let sampler = SamplingFilter::new(config.sample_rate);
+        let service_name = env::var("OTEL_SERVICE_NAME").unwrap_or("sui-node".to_owned());
 
         if config.enable_otlp_tracing {
             let trace_file = env::var("TRACE_FILE").ok();
@@ -387,7 +388,7 @@ impl TelemetryConfig {
             let config = sdk::trace::config()
                 .with_resource(Resource::new(vec![opentelemetry::KeyValue::new(
                     "service.name",
-                    "sui-node",
+                    service_name.clone(),
                 )]))
                 .with_sampler(Sampler::ParentBased(Box::new(sampler.clone())));
 
@@ -404,7 +405,7 @@ impl TelemetryConfig {
                     .with_span_processor(processor)
                     .build();
 
-                let tracer = p.tracer("sui-node");
+                let tracer = p.tracer(service_name);
                 provider = Some(p);
 
                 tracing_opentelemetry::layer().with_tracer(tracer)


### PR DESCRIPTION
## Description 

This changes allows specifying the open-telemetry service name to the `telemetry-subscribers` crate, by setting the `OTEL_SERVICE_NAME` environment variable. This defaults to sui-node, so there is no change in behaviour when unset.

As `OTEL_SERVICE_NAME` is not automatically consulted by the otel rust implementation, this uses the environment variable to perform the update in `telemetry-subscribers`.

## Test plan 

The change is minor, the code compiles, and the environment variable is spelled correctly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
