### PR TITLE
fix(jsonrpc): Flaky fullnode JSON-RPC test

### DIFF
--- a/crates/sui-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_tests.rs
@@ -259,24 +259,23 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     assert!(second_page.data.len() > 5);
     assert!(!second_page.has_next_page);
 
-    let mut all_txs_rev = first_page.data.clone();
-    all_txs_rev.extend(second_page.data);
-    all_txs_rev.reverse();
+    let mut all_txs = first_page.data.clone();
+    all_txs.extend(second_page.data);
 
-    // test get 10 latest transactions paged
+    // test get 10 transactions paged
     let latest = client
         .read_api()
         .query_transaction_blocks(
             SuiTransactionBlockResponseQuery::default(),
             None,
             Some(10),
-            true,
+            false,
         )
         .await
         .unwrap();
     assert_eq!(10, latest.data.len());
-    assert_eq!(Some(all_txs_rev[9].digest), latest.next_cursor);
-    assert_eq!(all_txs_rev[0..10], latest.data);
+    assert_eq!(Some(all_txs[9].digest), latest.next_cursor);
+    assert_eq!(all_txs[0..10], latest.data);
     assert!(latest.has_next_page);
 
     // test get from address txs in ascending order


### PR DESCRIPTION
## Description

`transaction_tests::test_get_fullnode_transaction` included a flaky assertion that if you fetch 5 transactions, then the rest of the transactions, and then fetched the latest 10 transactions, the latter would match up with the suffix of the former two queries concatenated together.

This does not work in general (at least not with this test set-up), because of consensus commit transactions.

I have updated the test to check a similar property: That if you fetch 5 transactions, then the rest, and then fetch the first 10 transactions, then the prefixes match (this tests that transaction order is stable).

There are other existing tests for what happens when you query transactions in descending order.

## Test plan

This seed previously exhibited the failure, and now it succeeds.

```
sui-json-rpc-tests$ MSIM_TEST_SEED=968774516445189525 cargo simtest -- test_get_fullnode_transaction
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
