### PR TITLE
[move] Update error behavior on serialization boundaries

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1341,6 +1341,7 @@
                 "reject_mutable_random_on_entry_functions": false,
                 "reshare_at_same_initial_version": false,
                 "resolve_abort_locations_to_package_id": false,
+                "rethrow_serialization_type_layout_errors": false,
                 "scoring_decision_with_validity_cutoff": true,
                 "shared_object_deletion": false,
                 "simple_conservation_checks": false,

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_55.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_55.snap
@@ -58,6 +58,7 @@ feature_flags:
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
+  rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -319,3 +320,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: false
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_55.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_55.snap
@@ -59,6 +59,7 @@ feature_flags:
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
+  rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -320,3 +321,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_55.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_55.snap
@@ -64,6 +64,7 @@ feature_flags:
   enable_coin_deny_list_v2: true
   passkey_auth: true
   authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -329,3 +330,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+

--- a/external-crates/move/crates/move-vm-config/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-config/src/runtime.rs
@@ -33,6 +33,9 @@ pub struct VMConfig {
     pub error_execution_state: bool,
     // configuration for binary deserialization (modules)
     pub binary_config: BinaryConfig,
+    // Whether value serialization errors when generating type layouts should be rethrown or
+    // converted to a different error.
+    pub rethrow_serialization_type_layout_errors: bool,
 }
 
 impl Default for VMConfig {
@@ -46,6 +49,7 @@ impl Default for VMConfig {
             profiler_config: None,
             error_execution_state: true,
             binary_config: BinaryConfig::with_extraneous_bytes_check(false),
+            rethrow_serialization_type_layout_errors: false,
         }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -70,6 +70,8 @@ mod checked {
                 // Don't augment errors with execution state on-chain
                 error_execution_state: false,
                 binary_config: to_binary_config(protocol_config),
+                rethrow_serialization_type_layout_errors: protocol_config
+                    .rethrow_serialization_type_layout_errors(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -72,6 +72,8 @@ mod checked {
 
                 profiler_config: vm_profiler_config,
                 binary_config: to_binary_config(protocol_config),
+                rethrow_serialization_type_layout_errors: protocol_config
+                    .rethrow_serialization_type_layout_errors(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)

--- a/sui-execution/v1/sui-adapter/src/adapter.rs
+++ b/sui-execution/v1/sui-adapter/src/adapter.rs
@@ -72,6 +72,8 @@ mod checked {
                 // Don't augment errors with execution state on-chain
                 error_execution_state: false,
                 binary_config: to_binary_config(protocol_config),
+                rethrow_serialization_type_layout_errors: protocol_config
+                    .rethrow_serialization_type_layout_errors(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)

--- a/sui-execution/v2/sui-adapter/src/adapter.rs
+++ b/sui-execution/v2/sui-adapter/src/adapter.rs
@@ -70,6 +70,8 @@ mod checked {
                 // Don't augment errors with execution state on-chain
                 error_execution_state: false,
                 binary_config: to_binary_config(protocol_config),
+                rethrow_serialization_type_layout_errors: protocol_config
+                    .rethrow_serialization_type_layout_errors(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)


### PR DESCRIPTION
## Description 

Update the semantics around serialization errors when computing type layouts to follow the underlying layout errors more closely. 

## Test plan 

Manually tested.

