### PR TITLE
return 0 for lowest available cp on unpruned fn

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -119,10 +119,16 @@ impl ReadStore for RocksDbStore {
     }
 
     fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber, StorageError> {
-        self.checkpoint_store
+        let highest_pruned_cp = self
+            .checkpoint_store
             .get_highest_pruned_checkpoint_seq_number()
-            .map(|seq| seq + 1)
-            .map_err(Into::into)
+            .map_err(Into::<StorageError>::into)?;
+
+        if highest_pruned_cp == 0 {
+            Ok(0)
+        } else {
+            Ok(highest_pruned_cp + 1)
+        }
     }
 
     fn get_full_checkpoint_contents_by_sequence_number(
@@ -508,11 +514,17 @@ impl RestStateReader for RestReadStore {
     fn get_lowest_available_checkpoint_objects(
         &self,
     ) -> sui_types::storage::error::Result<CheckpointSequenceNumber> {
-        self.state
+        let highest_pruned_cp = self
+            .state
             .get_object_cache_reader()
             .get_highest_pruned_checkpoint()
-            .map(|seq| seq + 1)
-            .map_err(StorageError::custom)
+            .map_err(StorageError::custom)?;
+
+        if highest_pruned_cp == 0 {
+            Ok(0)
+        } else {
+            Ok(highest_pruned_cp + 1)
+        }
     }
 
     fn get_chain_identifier(


### PR DESCRIPTION
## Description 

If the fullnodes is unpruned, then we should return 0 directly for lowest available cp.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
