### PR TITLE
Rename RocksDB metrics

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -85,13 +85,13 @@ pub struct ColumnFamilyMetrics {
     pub rocksdb_block_cache_capacity: IntGaugeVec,
     pub rocksdb_block_cache_usage: IntGaugeVec,
     pub rocksdb_block_cache_pinned_usage: IntGaugeVec,
-    pub rocskdb_estimate_table_readers_mem: IntGaugeVec,
+    pub rocksdb_estimate_table_readers_mem: IntGaugeVec,
     pub rocksdb_mem_table_flush_pending: IntGaugeVec,
-    pub rocskdb_compaction_pending: IntGaugeVec,
-    pub rocskdb_num_running_compactions: IntGaugeVec,
+    pub rocksdb_compaction_pending: IntGaugeVec,
+    pub rocksdb_num_running_compactions: IntGaugeVec,
     pub rocksdb_num_running_flushes: IntGaugeVec,
     pub rocksdb_estimate_oldest_key_time: IntGaugeVec,
-    pub rocskdb_background_errors: IntGaugeVec,
+    pub rocksdb_background_errors: IntGaugeVec,
     pub rocksdb_estimated_num_keys: IntGaugeVec,
 }
 
@@ -168,8 +168,8 @@ impl ColumnFamilyMetrics {
                 registry,
             )
             .unwrap(),
-            rocskdb_estimate_table_readers_mem: register_int_gauge_vec_with_registry!(
-                "rocskdb_estimate_table_readers_mem",
+            rocksdb_estimate_table_readers_mem: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimate_table_readers_mem",
                 "The estimated memory size used for reading SST tables in this column
                 family such as filters and index blocks. Note that this number does not
                 include the memory used in block cache.",
@@ -186,8 +186,8 @@ impl ColumnFamilyMetrics {
                 registry,
             )
             .unwrap(),
-            rocskdb_compaction_pending: register_int_gauge_vec_with_registry!(
-                "rocskdb_compaction_pending",
+            rocksdb_compaction_pending: register_int_gauge_vec_with_registry!(
+                "rocksdb_compaction_pending",
                 "A 1 or 0 flag indicating whether a compaction job is pending.
                 If this number is 1, it means some part of the column family requires
                 compaction in order to maintain shape of LSM tree, but the compaction
@@ -198,8 +198,8 @@ impl ColumnFamilyMetrics {
                 registry,
             )
             .unwrap(),
-            rocskdb_num_running_compactions: register_int_gauge_vec_with_registry!(
-                "rocskdb_num_running_compactions",
+            rocksdb_num_running_compactions: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_running_compactions",
                 "The number of compactions that are currently running for the column family.",
                 &["cf_name"],
                 registry,
@@ -227,8 +227,8 @@ impl ColumnFamilyMetrics {
                 registry,
             )
             .unwrap(),
-            rocskdb_background_errors: register_int_gauge_vec_with_registry!(
-                "rocskdb_background_errors",
+            rocksdb_background_errors: register_int_gauge_vec_with_registry!(
+                "rocksdb_background_errors",
                 "The accumulated number of RocksDB background errors.",
                 &["cf_name"],
                 registry,

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1050,7 +1050,7 @@ impl<K, V> DBMap<K, V> {
             );
         db_metrics
             .cf_metrics
-            .rocskdb_estimate_table_readers_mem
+            .rocksdb_estimate_table_readers_mem
             .with_label_values(&[cf_name])
             .set(
                 Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_TABLE_READERS_MEM)
@@ -1074,7 +1074,7 @@ impl<K, V> DBMap<K, V> {
             );
         db_metrics
             .cf_metrics
-            .rocskdb_compaction_pending
+            .rocksdb_compaction_pending
             .with_label_values(&[cf_name])
             .set(
                 Self::get_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
@@ -1082,7 +1082,7 @@ impl<K, V> DBMap<K, V> {
             );
         db_metrics
             .cf_metrics
-            .rocskdb_num_running_compactions
+            .rocksdb_num_running_compactions
             .with_label_values(&[cf_name])
             .set(
                 Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_COMPACTIONS)
@@ -1106,7 +1106,7 @@ impl<K, V> DBMap<K, V> {
             );
         db_metrics
             .cf_metrics
-            .rocskdb_background_errors
+            .rocksdb_background_errors
             .with_label_values(&[cf_name])
             .set(
                 Self::get_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)


### PR DESCRIPTION
Some rocksdb metric names have typos

