### PR TITLE
[indexer builder] - add completed column to progress store

### DIFF
--- a/crates/sui-bridge-indexer/src/migrations/2024-08-22-125020_progress_store_completed_column/down.sql
+++ b/crates/sui-bridge-indexer/src/migrations/2024-08-22-125020_progress_store_completed_column/down.sql
@@ -1,0 +1,2 @@
+alter table progress_store
+    drop column completed;

--- a/crates/sui-bridge-indexer/src/migrations/2024-08-22-125020_progress_store_completed_column/up.sql
+++ b/crates/sui-bridge-indexer/src/migrations/2024-08-22-125020_progress_store_completed_column/up.sql
@@ -1,0 +1,2 @@
+alter table progress_store
+    add completed bool default false not null;

--- a/crates/sui-bridge-indexer/src/models.rs
+++ b/crates/sui-bridge-indexer/src/models.rs
@@ -17,6 +17,7 @@ pub struct ProgressStore {
     pub checkpoint: i64,
     pub target_checkpoint: i64,
     pub timestamp: Option<PgTimestamp>,
+    pub completed: bool,
 }
 
 impl From<ProgressStore> for Task {
@@ -27,6 +28,7 @@ impl From<ProgressStore> for Task {
             target_checkpoint: value.target_checkpoint as u64,
             // Ok to unwrap, timestamp is defaulted to now() in database
             timestamp: value.timestamp.expect("Timestamp not set").0 as u64,
+            completed: value.completed,
         }
     }
 }

--- a/crates/sui-bridge-indexer/src/schema.rs
+++ b/crates/sui-bridge-indexer/src/schema.rs
@@ -8,6 +8,7 @@ diesel::table! {
         checkpoint -> Int8,
         target_checkpoint -> Int8,
         timestamp -> Nullable<Timestamp>,
+        completed -> Bool
     }
 }
 

--- a/crates/sui-bridge-indexer/src/sui_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/sui_bridge_indexer.rs
@@ -106,6 +106,7 @@ impl IndexerProgressStore for PgBridgePersistent {
                 target_checkpoint: i64::MAX,
                 // Timestamp is defaulted to current time in DB if None
                 timestamp: None,
+                completed: false,
             })
             .on_conflict(dsl::task_name)
             .do_update()
@@ -143,6 +144,7 @@ impl IndexerProgressStore for PgBridgePersistent {
                 target_checkpoint: target_checkpoint as i64,
                 // Timestamp is defaulted to current time in DB if None
                 timestamp: None,
+                completed: false,
             })
             .execute(&mut conn)?;
         Ok(())
@@ -155,6 +157,7 @@ impl IndexerProgressStore for PgBridgePersistent {
                 columns::checkpoint.eq(task.checkpoint as i64),
                 columns::target_checkpoint.eq(task.target_checkpoint as i64),
                 columns::timestamp.eq(now),
+                columns::completed.eq(task.completed),
             ))
             .execute(&mut conn)?;
         Ok(())

--- a/crates/sui-indexer-builder/src/lib.rs
+++ b/crates/sui-indexer-builder/src/lib.rs
@@ -10,6 +10,7 @@ pub struct Task {
     pub checkpoint: u64,
     pub target_checkpoint: u64,
     pub timestamp: u64,
+    pub completed: bool,
 }
 
 pub trait Tasks {

--- a/crates/sui-indexer-builder/tests/indexer_tests.rs
+++ b/crates/sui-indexer-builder/tests/indexer_tests.rs
@@ -34,8 +34,10 @@ async fn indexer_simple_backfill_task_test() {
     // the first one will be the live task and second one will be the backfill
     assert_eq!(10, tasks.first().unwrap().checkpoint);
     assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
+    assert!(!tasks.first().unwrap().completed);
     assert_eq!(4, tasks.last().unwrap().checkpoint);
     assert_eq!(4, tasks.last().unwrap().target_checkpoint);
+    assert!(tasks.last().unwrap().completed);
 
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
@@ -64,14 +66,19 @@ async fn indexer_partitioned_backfill_task_test() {
     // the first one will be the live task and rest will be the backfills
     assert_eq!(50, tasks.first().unwrap().checkpoint);
     assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
+    assert!(!tasks.first().unwrap().completed);
     assert_eq!(34, tasks.get(1).unwrap().checkpoint);
     assert_eq!(34, tasks.get(1).unwrap().target_checkpoint);
+    assert!(tasks.get(1).unwrap().completed);
     assert_eq!(29, tasks.get(2).unwrap().checkpoint);
     assert_eq!(29, tasks.get(2).unwrap().target_checkpoint);
+    assert!(tasks.get(2).unwrap().completed);
     assert_eq!(19, tasks.get(3).unwrap().checkpoint);
     assert_eq!(19, tasks.get(3).unwrap().target_checkpoint);
+    assert!(tasks.get(3).unwrap().completed);
     assert_eq!(9, tasks.get(4).unwrap().checkpoint);
     assert_eq!(9, tasks.get(4).unwrap().target_checkpoint);
+    assert!(tasks.get(4).unwrap().completed);
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();
@@ -95,6 +102,7 @@ async fn indexer_partitioned_task_with_data_already_in_db_test() {
             checkpoint: 30,
             target_checkpoint: 30,
             timestamp: 0,
+            completed: false,
         },
     );
     let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
@@ -131,6 +139,7 @@ async fn indexer_partitioned_task_with_data_already_in_db_test2() {
             checkpoint: 30,
             target_checkpoint: 30,
             timestamp: 0,
+            completed: false,
         },
     );
     let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
@@ -171,6 +180,7 @@ async fn resume_test() {
             checkpoint: 10,
             target_checkpoint: 30,
             timestamp: 0,
+            completed: false,
         },
     );
     let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)


### PR DESCRIPTION
## Description 

add completed column to progress store to prevent last task not being resumed after restart.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
