### PR TITLE
Revert "Migrate users of mysten_metrics Histogram to prometheus Histogram (#19043)"

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -8,6 +8,7 @@ use crate::authority_client::{
 };
 use crate::safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase};
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
+use mysten_metrics::histogram::Histogram;
 use mysten_metrics::{monitored_future, spawn_monitored_task, GaugeGuard, MonitorCancellation};
 use mysten_network::config::Config;
 use std::convert::AsRef;
@@ -39,9 +40,8 @@ use tracing::{debug, error, info, instrument, trace, trace_span, warn, Instrumen
 use crate::epoch::committee_store::CommitteeStore;
 use crate::stake_aggregator::{InsertResult, MultiStakeAggregator, StakeAggregator};
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
-    IntCounterVec, IntGauge, Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry, IntCounter, IntCounterVec, IntGauge, Registry,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::string::ToString;
@@ -179,16 +179,16 @@ impl AuthAggMetrics {
                 registry,
             )
             .unwrap(),
-            remaining_tasks_when_reaching_cert_quorum: register_histogram_with_registry!(
+            remaining_tasks_when_reaching_cert_quorum: mysten_metrics::histogram::Histogram::new_in_registry(
                 "auth_agg_remaining_tasks_when_reaching_cert_quorum",
                 "Number of remaining tasks when reaching certificate quorum",
                 registry,
-            ).unwrap(),
-            remaining_tasks_when_cert_broadcasting_post_quorum_timeout: register_histogram_with_registry!(
+            ),
+            remaining_tasks_when_cert_broadcasting_post_quorum_timeout: mysten_metrics::histogram::Histogram::new_in_registry(
                 "auth_agg_remaining_tasks_when_cert_broadcasting_post_quorum_timeout",
                 "Number of remaining tasks when post quorum certificate broadcasting times out",
                 registry,
-            ).unwrap()
+            )
         }
     }
 
@@ -1667,7 +1667,7 @@ where
         let metrics = self.metrics.clone();
         metrics
             .remaining_tasks_when_reaching_cert_quorum
-            .observe(remaining_tasks.len() as f64);
+            .report(remaining_tasks.len() as u64);
         if !remaining_tasks.is_empty() {
             // Use best efforts to send the cert to remaining validators.
             spawn_monitored_task!(async move {
@@ -1677,7 +1677,7 @@ where
                         _ = &mut timeout => {
                             debug!(?tx_digest, "Timed out in post quorum cert broadcasting: {:?}. Remaining tasks: {:?}", timeout_after_quorum, remaining_tasks.len());
                             metrics.cert_broadcasting_post_quorum_timeout.inc();
-                            metrics.remaining_tasks_when_cert_broadcasting_post_quorum_timeout.observe(remaining_tasks.len() as f64);
+                            metrics.remaining_tasks_when_cert_broadcasting_post_quorum_timeout.report(remaining_tasks.len() as u64);
                             break;
                         }
                         res = remaining_tasks.next() => {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -4,11 +4,12 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use mysten_metrics::histogram::Histogram as MystenHistogram;
 use mysten_metrics::spawn_monitored_task;
 use narwhal_worker::LazyNarwhalClient;
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, Histogram, IntCounter, IntCounterVec, Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry, IntCounter,
+    IntCounterVec, Registry,
 };
 use std::{
     io,
@@ -165,14 +166,14 @@ impl AuthorityServer {
 
 pub struct ValidatorServiceMetrics {
     pub signature_errors: IntCounter,
-    pub tx_verification_latency: Histogram,
-    pub cert_verification_latency: Histogram,
-    pub consensus_latency: Histogram,
-    pub handle_transaction_latency: Histogram,
-    pub submit_certificate_consensus_latency: Histogram,
-    pub handle_certificate_consensus_latency: Histogram,
-    pub handle_certificate_non_consensus_latency: Histogram,
-    pub handle_soft_bundle_certificates_consensus_latency: Histogram,
+    pub tx_verification_latency: MystenHistogram,
+    pub cert_verification_latency: MystenHistogram,
+    pub consensus_latency: MystenHistogram,
+    pub handle_transaction_latency: MystenHistogram,
+    pub submit_certificate_consensus_latency: MystenHistogram,
+    pub handle_certificate_consensus_latency: MystenHistogram,
+    pub handle_certificate_non_consensus_latency: MystenHistogram,
+    pub handle_soft_bundle_certificates_consensus_latency: MystenHistogram,
 
     num_rejected_tx_in_epoch_boundary: IntCounter,
     num_rejected_cert_in_epoch_boundary: IntCounter,
@@ -193,62 +194,46 @@ impl ValidatorServiceMetrics {
                 registry,
             )
             .unwrap(),
-            tx_verification_latency: register_histogram_with_registry!(
+            tx_verification_latency: MystenHistogram::new_in_registry(
                 "validator_service_tx_verification_latency",
                 "Latency of verifying a transaction",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            cert_verification_latency: register_histogram_with_registry!(
+            ),
+            cert_verification_latency: MystenHistogram::new_in_registry(
                 "validator_service_cert_verification_latency",
                 "Latency of verifying a certificate",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            consensus_latency: register_histogram_with_registry!(
+            ),
+            consensus_latency: MystenHistogram::new_in_registry(
                 "validator_service_consensus_latency",
                 "Time spent between submitting a shared obj txn to consensus and getting result",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            handle_transaction_latency: register_histogram_with_registry!(
+            ),
+            handle_transaction_latency: MystenHistogram::new_in_registry(
                 "validator_service_handle_transaction_latency",
                 "Latency of handling a transaction",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            handle_certificate_consensus_latency: register_histogram_with_registry!(
+            ),
+            handle_certificate_consensus_latency: MystenHistogram::new_in_registry(
                 "validator_service_handle_certificate_consensus_latency",
                 "Latency of handling a consensus transaction certificate",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            submit_certificate_consensus_latency: register_histogram_with_registry!(
+            ),
+            submit_certificate_consensus_latency: MystenHistogram::new_in_registry(
                 "validator_service_submit_certificate_consensus_latency",
                 "Latency of submit_certificate RPC handler",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            handle_certificate_non_consensus_latency: register_histogram_with_registry!(
+            ),
+            handle_certificate_non_consensus_latency: MystenHistogram::new_in_registry(
                 "validator_service_handle_certificate_non_consensus_latency",
                 "Latency of handling a non-consensus transaction certificate",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
+            ),
+            handle_soft_bundle_certificates_consensus_latency: MystenHistogram::new_in_registry(
                 "validator_service_handle_soft_bundle_certificates_consensus_latency",
                 "Latency of handling a consensus soft bundle",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
+            ),
             num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
                 "validator_service_num_rejected_tx_in_epoch_boundary",
                 "Number of rejected transaction during epoch transitioning",

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use mysten_metrics::histogram::Histogram;
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_with_registry,
-    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
+    register_int_counter_with_registry, register_int_gauge_with_registry, IntCounter, IntGauge,
+    Registry,
 };
 use std::sync::Arc;
 
@@ -14,11 +15,11 @@ pub struct CheckpointExecutorMetrics {
     pub checkpoint_exec_errors: IntCounter,
     pub checkpoint_exec_epoch: IntGauge,
     pub checkpoint_exec_inflight: IntGauge,
-    pub checkpoint_exec_latency: Histogram,
-    pub checkpoint_prepare_latency: Histogram,
+    pub checkpoint_exec_latency_us: Histogram,
+    pub checkpoint_prepare_latency_us: Histogram,
     pub checkpoint_transaction_count: Histogram,
-    pub checkpoint_contents_age: Histogram,
-    pub last_executed_checkpoint_age: Histogram,
+    pub checkpoint_contents_age_ms: Histogram,
+    pub last_executed_checkpoint_age_ms: Histogram,
 }
 
 impl CheckpointExecutorMetrics {
@@ -60,38 +61,31 @@ impl CheckpointExecutorMetrics {
                 registry
             )
             .unwrap(),
-            checkpoint_exec_latency: register_histogram_with_registry!(
-                "checkpoint_exec_latency",
-                "Latency of executing a checkpoint from enqueue to all effects available",
+            checkpoint_exec_latency_us: Histogram::new_in_registry(
+                "checkpoint_exec_latency_us",
+                "Latency of executing a checkpoint from enqueue to all effects available, in microseconds",
                 registry,
-            )
-            .unwrap(),
-            checkpoint_prepare_latency: register_histogram_with_registry!(
-                "checkpoint_prepare_latency",
-                "Latency of preparing a checkpoint to enqueue for execution",
+            ),
+            checkpoint_prepare_latency_us: Histogram::new_in_registry(
+                "checkpoint_prepare_latency_us",
+                "Latency of preparing a checkpoint to enqueue for execution, in microseconds",
                 registry,
-            )
-            .unwrap(),
-            checkpoint_transaction_count: register_histogram_with_registry!(
+            ),
+            checkpoint_transaction_count: Histogram::new_in_registry(
                 "checkpoint_transaction_count",
                 "Number of transactions in the checkpoint",
                 registry,
-            )
-            .unwrap(),
-            checkpoint_contents_age: register_histogram_with_registry!(
-                "checkpoint_contents_age",
+            ),
+            checkpoint_contents_age_ms: Histogram::new_in_registry(
+                "checkpoint_contents_age_ms",
                 "Age of checkpoints when they arrive for execution",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            last_executed_checkpoint_age: register_histogram_with_registry!(
-                "last_executed_checkpoint_age",
+            ),
+            last_executed_checkpoint_age_ms: Histogram::new_in_registry(
+                "last_executed_checkpoint_age_ms",
                 "Age of the last executed checkpoint",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry
-            )
-            .unwrap(),
+            ),
         };
         Arc::new(this)
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -327,7 +327,7 @@ impl CheckpointExecutor {
                             sequence_number = ?checkpoint.sequence_number,
                             "Received checkpoint summary from state sync"
                         );
-                        checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age);
+                        checkpoint.report_checkpoint_age_ms(&self.metrics.checkpoint_contents_age_ms);
                     },
                     Err(RecvError::Lagged(num_skipped)) => {
                         debug!(
@@ -411,7 +411,7 @@ impl CheckpointExecutor {
         self.metrics
             .last_executed_checkpoint_timestamp_ms
             .set(checkpoint.timestamp_ms as i64);
-        checkpoint.report_checkpoint_age(&self.metrics.last_executed_checkpoint_age);
+        checkpoint.report_checkpoint_age_ms(&self.metrics.last_executed_checkpoint_age_ms);
     }
 
     /// Post processing and plumbing after we executed a checkpoint. This function is guaranteed
@@ -741,9 +741,7 @@ async fn execute_checkpoint(
 
     let tx_count = execution_digests.len();
     debug!("Number of transactions in the checkpoint: {:?}", tx_count);
-    metrics
-        .checkpoint_transaction_count
-        .observe(tx_count as f64);
+    metrics.checkpoint_transaction_count.report(tx_count as u64);
 
     let checkpoint_acc = execute_transactions(
         execution_digests,
@@ -1246,8 +1244,8 @@ async fn execute_transactions(
 
     let prepare_elapsed = prepare_start.elapsed();
     metrics
-        .checkpoint_prepare_latency
-        .observe(prepare_elapsed.as_secs_f64());
+        .checkpoint_prepare_latency_us
+        .report(prepare_elapsed.as_micros() as u64);
     if checkpoint.sequence_number % CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL == 0 {
         info!(
             "Checkpoint preparation for execution took {:?}",
@@ -1276,8 +1274,8 @@ async fn execute_transactions(
 
     let exec_elapsed = exec_start.elapsed();
     metrics
-        .checkpoint_exec_latency
-        .observe(exec_elapsed.as_secs_f64());
+        .checkpoint_exec_latency_us
+        .report(exec_elapsed.as_micros() as u64);
     if checkpoint.sequence_number % CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL == 0 {
         info!("Checkpoint execution took {:?}", exec_elapsed);
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -74,12 +74,12 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
 
         let checkpoint_timestamp = summary.timestamp_ms;
         let checkpoint_seq = summary.sequence_number;
-        self.metrics.checkpoint_creation_latency.observe(
+        self.metrics.checkpoint_creation_latency_ms.observe(
             summary
                 .timestamp()
                 .elapsed()
                 .unwrap_or_default()
-                .as_secs_f64(),
+                .as_millis() as u64,
         );
 
         let highest_verified_checkpoint = checkpoint_store

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use mysten_metrics::histogram::Histogram;
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
-    Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntCounter,
+    IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
 use std::sync::Arc;
 
@@ -21,11 +21,11 @@ pub struct CheckpointMetrics {
     pub last_skipped_checkpoint_signature_submission: IntGauge,
     pub last_ignored_checkpoint_signature_received: IntGauge,
     pub highest_accumulated_epoch: IntGauge,
-    pub checkpoint_creation_latency: Histogram,
+    pub checkpoint_creation_latency_ms: Histogram,
     pub remote_checkpoint_forks: IntCounter,
     pub split_brain_checkpoint_forks: IntCounter,
-    pub last_created_checkpoint_age: Histogram,
-    pub last_certified_checkpoint_age: Histogram,
+    pub last_created_checkpoint_age_ms: Histogram,
+    pub last_certified_checkpoint_age_ms: Histogram,
 }
 
 impl CheckpointMetrics {
@@ -43,18 +43,16 @@ impl CheckpointMetrics {
                 registry
             )
             .unwrap(),
-            last_created_checkpoint_age: register_histogram_with_registry!(
-                "last_created_checkpoint_age",
+            last_created_checkpoint_age_ms: Histogram::new_in_registry(
+                "last_created_checkpoint_age_ms",
                 "Age of the last created checkpoint",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry
-            ).unwrap(),
-            last_certified_checkpoint_age: register_histogram_with_registry!(
-                "last_certified_checkpoint_age",
+            ),
+            last_certified_checkpoint_age_ms: Histogram::new_in_registry(
+                "last_certified_checkpoint_age_ms",
                 "Age of the last certified checkpoint",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry
-            ).unwrap(),
+            ),
             checkpoint_errors: register_int_counter_with_registry!(
                 "checkpoint_errors",
                 "Checkpoints errors count",
@@ -111,12 +109,11 @@ impl CheckpointMetrics {
                 registry
             )
             .unwrap(),
-            checkpoint_creation_latency: register_histogram_with_registry!(
-                "checkpoint_creation_latency",
+            checkpoint_creation_latency_ms: Histogram::new_in_registry(
+                "checkpoint_creation_latency_ms",
                 "Latency from consensus commit timstamp to local checkpoint creation in milliseconds",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            ),
             remote_checkpoint_forks: register_int_counter_with_registry!(
                 "remote_checkpoint_forks",
                 "Number of remote checkpoints that forked from local checkpoints",

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1511,7 +1511,7 @@ impl CheckpointBuilder {
                 timestamp_ms,
                 matching_randomness_rounds,
             );
-            summary.report_checkpoint_age(&self.metrics.last_created_checkpoint_age);
+            summary.report_checkpoint_age_ms(&self.metrics.last_created_checkpoint_age_ms);
             if last_checkpoint_of_epoch {
                 info!(
                     checkpoint_seq = sequence_number,
@@ -1894,7 +1894,7 @@ impl CheckpointAggregator {
                         .set(current.summary.sequence_number as i64);
                     current
                         .summary
-                        .report_checkpoint_age(&self.metrics.last_certified_checkpoint_age);
+                        .report_checkpoint_age_ms(&self.metrics.last_certified_checkpoint_age_ms);
                     result.push(summary.into_inner());
                     self.current = None;
                     continue 'outer;

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -74,7 +74,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_certificate_success: IntCounterVec,
     pub sequencing_certificate_failures: IntCounterVec,
     pub sequencing_certificate_inflight: IntGaugeVec,
-    pub sequencing_acknowledge_latency: HistogramVec,
+    pub sequencing_acknowledge_latency: mysten_metrics::histogram::HistogramVec,
     pub sequencing_certificate_latency: HistogramVec,
     pub sequencing_certificate_authority_position: Histogram,
     pub sequencing_certificate_positions_moved: Histogram,
@@ -116,13 +116,12 @@ impl ConsensusAdapterMetrics {
                 registry,
             )
                 .unwrap(),
-            sequencing_acknowledge_latency: register_histogram_vec_with_registry!(
+            sequencing_acknowledge_latency: mysten_metrics::histogram::HistogramVec::new_in_registry(
                 "sequencing_acknowledge_latency",
                 "The latency for acknowledgement from sequencing engine. The overall sequencing latency is measured by the sequencing_certificate_latency metric",
                 &["retry", "tx_type"],
-                SEQUENCING_CERTIFICATE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            ),
             sequencing_certificate_latency: register_histogram_vec_with_registry!(
                 "sequencing_certificate_latency",
                 "The latency for sequencing a certificate.",
@@ -836,7 +835,7 @@ impl ConsensusAdapter {
                 self.metrics
                     .sequencing_acknowledge_latency
                     .with_label_values(&[&bucket, tx_type])
-                    .observe(ack_start.elapsed().as_secs_f64());
+                    .report(ack_start.elapsed().as_millis() as u64);
             };
             match select(processed_waiter, submit_inner.boxed()).await {
                 Either::Left((processed, _submit_inner)) => processed,

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{
-    register_histogram_vec_with_registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_with_registry, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_with_registry, HistogramVec, IntCounter,
+    IntCounterVec, IntGauge, Registry,
 };
+
+use mysten_metrics::histogram::Histogram;
 
 const FINALITY_LATENCY_SEC_BUCKETS: &[f64] = &[
     0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85,
@@ -67,11 +68,11 @@ impl QuorumDriverMetrics {
                 registry,
             )
             .unwrap(),
-            attempt_times_ok_response: register_histogram_with_registry!(
+            attempt_times_ok_response: Histogram::new_in_registry(
                 "quorum_driver_attempt_times_ok_response",
                 "Total attempt times of ok response",
                 registry,
-            ).unwrap(),
+            ),
             current_requests_in_flight: register_int_gauge_with_registry!(
                 "current_requests_in_flight",
                 "Current number of requests being processed in QuorumDriver",
@@ -108,11 +109,11 @@ impl QuorumDriverMetrics {
                 registry,
             )
             .unwrap(),
-            transaction_retry_count: register_histogram_with_registry!(
+            transaction_retry_count: Histogram::new_in_registry(
                 "quorum_driver_transaction_retry_count",
                 "Histogram of transaction retry count",
                 registry,
-            ).unwrap(),
+            ),
             current_transactions_in_retry: register_int_gauge_with_registry!(
                 "current_transactions_in_retry",
                 "Current number of transactions in retry loop in QuorumDriver",

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -127,7 +127,7 @@ impl<A: Clone> QuorumDriver<A> {
                     }
                     self.metrics
                         .transaction_retry_count
-                        .observe(task.retry_times as f64);
+                        .report(task.retry_times as u64);
                 }
             })
             .map_err(|e| SuiError::QuorumDriverCommunicationError {
@@ -210,7 +210,7 @@ impl<A: Clone> QuorumDriver<A> {
                 self.metrics.total_ok_responses.inc();
                 self.metrics
                     .attempt_times_ok_response
-                    .observe(total_attempts as f64);
+                    .report(total_attempts as u64);
                 Ok((transaction.clone(), resp.clone()))
             }
             Err(err) => {

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -4,11 +4,9 @@
 
 use crate::authority_client::AuthorityAPI;
 use crate::epoch::committee_store::CommitteeStore;
+use mysten_metrics::histogram::{Histogram, HistogramVec};
 use prometheus::core::GenericCounter;
-use prometheus::{
-    register_histogram_vec_with_registry, register_int_counter_vec_with_registry, Histogram,
-    HistogramVec, IntCounterVec, Registry,
-};
+use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -68,14 +66,12 @@ impl SafeClientMetricsBase {
                 registry,
             )
             .unwrap(),
-            latency: register_histogram_vec_with_registry!(
+            latency: HistogramVec::new_in_registry(
                 "safe_client_latency",
                 "RPC latency observed by safe client aggregator, group by address and method",
                 &["address", "method"],
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
+            ),
         }
     }
 }

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -16,13 +16,13 @@ use crate::quorum_driver::{QuorumDriverHandler, QuorumDriverHandlerBuilder, Quor
 use futures::future::{select, Either, Future};
 use futures::FutureExt;
 use mysten_common::sync::notify_read::NotifyRead;
+use mysten_metrics::histogram::{Histogram, HistogramVec};
 use mysten_metrics::{add_server_timing, spawn_logged_monitored_task, spawn_monitored_task};
 use mysten_metrics::{TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use prometheus::core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge};
 use prometheus::{
-    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry, Histogram, Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Registry,
 };
 use std::net::SocketAddr;
 use std::ops::Deref;
@@ -625,30 +625,24 @@ impl TransactionOrchestratorMetrics {
             req_in_flight.with_label_values(&[TX_TYPE_SINGLE_WRITER_TX]);
         let req_in_flight_shared_object = req_in_flight.with_label_values(&[TX_TYPE_SHARED_OBJ_TX]);
 
-        let request_latency = register_histogram_vec_with_registry!(
+        let request_latency = HistogramVec::new_in_registry(
             "tx_orchestrator_request_latency",
             "Time spent in processing one Transaction Orchestrator request",
             &["tx_type"],
-            mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
             registry,
-        )
-        .unwrap();
-        let wait_for_finality_latency = register_histogram_vec_with_registry!(
+        );
+        let wait_for_finality_latency = HistogramVec::new_in_registry(
             "tx_orchestrator_wait_for_finality_latency",
             "Time spent in waiting for one Transaction Orchestrator request gets finalized",
             &["tx_type"],
-            mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
             registry,
-        )
-        .unwrap();
-        let local_execution_latency = register_histogram_vec_with_registry!(
+        );
+        let local_execution_latency = HistogramVec::new_in_registry(
             "tx_orchestrator_local_execution_latency",
             "Time spent in waiting for one Transaction Orchestrator gets locally executed",
             &["tx_type"],
-            mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
             registry,
-        )
-        .unwrap();
+        );
 
         Self {
             total_req_received_single_writer,

--- a/crates/sui-json-rpc-api/src/lib.rs
+++ b/crates/sui-json-rpc-api/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use mysten_metrics::histogram::Histogram;
+
 pub use bridge::BridgeReadApiClient;
 pub use bridge::BridgeReadApiOpenRpc;
 pub use bridge::BridgeReadApiServer;
@@ -21,8 +23,6 @@ pub use move_utils::MoveUtilsClient;
 pub use move_utils::MoveUtilsOpenRpc;
 pub use move_utils::MoveUtilsServer;
 use once_cell::sync::Lazy;
-use prometheus::register_histogram_with_registry;
-use prometheus::Histogram;
 use prometheus::{register_int_counter_with_registry, IntCounter};
 pub use read::ReadApiClient;
 pub use read::ReadApiOpenRpc;
@@ -114,190 +114,165 @@ pub struct JsonRpcMetrics {
 impl JsonRpcMetrics {
     pub fn new(registry: &prometheus::Registry) -> Self {
         Self {
-            get_objects_limit: register_histogram_with_registry!(
+            get_objects_limit: Histogram::new_in_registry(
                 "json_rpc_get_objects_limit",
                 "The input limit for multi_get_objects, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            get_objects_result_size: register_histogram_with_registry!(
+            ),
+            get_objects_result_size: Histogram::new_in_registry(
                 "json_rpc_get_objects_result_size",
                 "The return size for multi_get_objects",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_objects_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_objects_result_size_total",
                 "The total return size for multi_get_objects",
                 registry
             )
             .unwrap(),
-            get_tx_blocks_limit: register_histogram_with_registry!(
+            get_tx_blocks_limit: Histogram::new_in_registry(
                 "json_rpc_get_tx_blocks_limit",
                 "The input limit for get_tx_blocks, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            get_tx_blocks_result_size: register_histogram_with_registry!(
+            ),
+            get_tx_blocks_result_size: Histogram::new_in_registry(
                 "json_rpc_get_tx_blocks_result_size",
                 "The return size for get_tx_blocks",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_tx_blocks_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_tx_blocks_result_size_total",
                 "The total return size for get_tx_blocks",
                 registry
             )
             .unwrap(),
-            get_checkpoints_limit: register_histogram_with_registry!(
+            get_checkpoints_limit: Histogram::new_in_registry(
                 "json_rpc_get_checkpoints_limit",
                 "The input limit for get_checkpoints, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            get_checkpoints_result_size: register_histogram_with_registry!(
+            ),
+            get_checkpoints_result_size: Histogram::new_in_registry(
                 "json_rpc_get_checkpoints_result_size",
                 "The return size for get_checkpoints",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_checkpoints_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_checkpoints_result_size_total",
                 "The total return size for get_checkpoints",
                 registry
             )
             .unwrap(),
-            get_owned_objects_limit: register_histogram_with_registry!(
+            get_owned_objects_limit: Histogram::new_in_registry(
                 "json_rpc_get_owned_objects_limit",
                 "The input limit for get_owned_objects, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            get_owned_objects_result_size: register_histogram_with_registry!(
+            ),
+            get_owned_objects_result_size: Histogram::new_in_registry(
                 "json_rpc_get_owned_objects_result_size",
                 "The return size for get_owned_objects",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_owned_objects_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_owned_objects_result_size_total",
                 "The total return size for get_owned_objects",
                 registry
             )
             .unwrap(),
-            get_coins_limit: register_histogram_with_registry!(
+            get_coins_limit: Histogram::new_in_registry(
                 "json_rpc_get_coins_limit",
                 "The input limit for get_coins, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            get_coins_result_size: register_histogram_with_registry!(
+            ),
+            get_coins_result_size: Histogram::new_in_registry(
                 "json_rpc_get_coins_result_size",
                 "The return size for get_coins",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_coins_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_coins_result_size_total",
                 "The total return size for get_coins",
                 registry
             )
             .unwrap(),
-            get_dynamic_fields_limit: register_histogram_with_registry!(
+            get_dynamic_fields_limit: Histogram::new_in_registry(
                 "json_rpc_get_dynamic_fields_limit",
                 "The input limit for get_dynamic_fields, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            get_dynamic_fields_result_size: register_histogram_with_registry!(
+            ),
+            get_dynamic_fields_result_size: Histogram::new_in_registry(
                 "json_rpc_get_dynamic_fields_result_size",
                 "The return size for get_dynamic_fields",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_dynamic_fields_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_dynamic_fields_result_size_total",
                 "The total return size for get_dynamic_fields",
                 registry
             )
             .unwrap(),
-            query_tx_blocks_limit: register_histogram_with_registry!(
+            query_tx_blocks_limit: Histogram::new_in_registry(
                 "json_rpc_query_tx_blocks_limit",
                 "The input limit for query_tx_blocks, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            query_tx_blocks_result_size: register_histogram_with_registry!(
+            ),
+            query_tx_blocks_result_size: Histogram::new_in_registry(
                 "json_rpc_query_tx_blocks_result_size",
                 "The return size for query_tx_blocks",
                 registry,
-            )
-            .unwrap(),
+            ),
             query_tx_blocks_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_query_tx_blocks_result_size_total",
                 "The total return size for query_tx_blocks",
                 registry
             )
             .unwrap(),
-            query_events_limit: register_histogram_with_registry!(
+            query_events_limit: Histogram::new_in_registry(
                 "json_rpc_query_events_limit",
                 "The input limit for query_events, after applying the cap",
                 registry,
-            )
-            .unwrap(),
-            query_events_result_size: register_histogram_with_registry!(
+            ),
+            query_events_result_size: Histogram::new_in_registry(
                 "json_rpc_query_events_result_size",
                 "The return size for query_events",
                 registry,
-            )
-            .unwrap(),
+            ),
             query_events_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_query_events_result_size_total",
                 "The total return size for query_events",
                 registry
             )
             .unwrap(),
-            get_stake_sui_result_size: register_histogram_with_registry!(
+            get_stake_sui_result_size: Histogram::new_in_registry(
                 "json_rpc_get_stake_sui_result_size",
                 "The return size for get_stake_sui",
                 registry,
-            )
-            .unwrap(),
+            ),
             get_stake_sui_result_size_total: register_int_counter_with_registry!(
                 "json_rpc_get_stake_sui_result_size_total",
                 "The total return size for get_stake_sui",
                 registry
             )
             .unwrap(),
-            get_stake_sui_latency: register_histogram_with_registry!(
+            get_stake_sui_latency: Histogram::new_in_registry(
                 "get_stake_sui_latency",
                 "The latency of get stake sui, in ms",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            get_delegated_sui_latency: register_histogram_with_registry!(
+            ),
+            get_delegated_sui_latency: Histogram::new_in_registry(
                 "get_delegated_sui_latency",
                 "The latency of get delegated sui, in ms",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            orchestrator_latency_ms: register_histogram_with_registry!(
+            ),
+            orchestrator_latency_ms: Histogram::new_in_registry(
                 "json_rpc_orchestrator_latency",
                 "The latency of submitting transaction via transaction orchestrator, in ms",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
-            post_orchestrator_latency_ms: register_histogram_with_registry!(
+            ),
+            post_orchestrator_latency_ms: Histogram::new_in_registry(
                 "json_rpc_post_orchestrator_latency",
                 "The latency of response processing after transaction orchestrator, in ms",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
+            ),
         }
     }
 

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -373,7 +373,7 @@ impl CoinReadInternal for CoinReadInternalImpl {
         one_coin_type_only: bool,
     ) -> RpcInterimResult<CoinPage> {
         let limit = cap_page_limit(limit);
-        self.metrics.get_coins_limit.observe(limit as f64);
+        self.metrics.get_coins_limit.report(limit as u64);
         let state = self.get_state();
         let mut data = spawn_monitored_task!(async move {
             state.get_owned_coins(owner, cursor, limit + 1, one_coin_type_only)
@@ -383,9 +383,7 @@ impl CoinReadInternal for CoinReadInternalImpl {
         let has_next_page = data.len() > limit;
         data.truncate(limit);
 
-        self.metrics
-            .get_coins_result_size
-            .observe(data.len() as f64);
+        self.metrics.get_coins_result_size.report(data.len() as u64);
         self.metrics
             .get_coins_result_size_total
             .inc_by(data.len() as u64);

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -54,7 +54,7 @@ impl GovernanceReadApi {
 
         self.metrics
             .get_stake_sui_result_size
-            .observe(result.len() as f64);
+            .report(result.len() as u64);
         self.metrics
             .get_stake_sui_result_size_total
             .inc_by(result.len() as u64);

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -148,7 +148,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         with_tracing!(async move {
             let limit =
                 validate_limit(limit, *QUERY_MAX_RESULT_LIMIT).map_err(SuiRpcInputError::from)?;
-            self.metrics.get_owned_objects_limit.observe(limit as f64);
+            self.metrics.get_owned_objects_limit.report(limit as u64);
             let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
             let options = options.unwrap_or_default();
             let mut objects = self
@@ -179,7 +179,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
 
             self.metrics
                 .get_owned_objects_result_size
-                .observe(data.len() as f64);
+                .report(data.len() as u64);
             self.metrics
                 .get_owned_objects_result_size_total
                 .inc_by(data.len() as u64);
@@ -202,7 +202,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
     ) -> RpcResult<TransactionBlocksPage> {
         with_tracing!(async move {
             let limit = cap_page_limit(limit);
-            self.metrics.query_tx_blocks_limit.observe(limit as f64);
+            self.metrics.query_tx_blocks_limit.report(limit as u64);
             let descending = descending_order.unwrap_or_default();
             let opts = query.options.unwrap_or_default();
 
@@ -241,7 +241,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
 
             self.metrics
                 .query_tx_blocks_result_size
-                .observe(data.len() as f64);
+                .report(data.len() as u64);
             self.metrics
                 .query_tx_blocks_result_size_total
                 .inc_by(data.len() as u64);
@@ -264,7 +264,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         with_tracing!(async move {
             let descending = descending_order.unwrap_or_default();
             let limit = cap_page_limit(limit);
-            self.metrics.query_events_limit.observe(limit as f64);
+            self.metrics.query_events_limit.report(limit as u64);
             // Retrieve 1 extra item for next cursor
             let mut data = self
                 .state
@@ -282,7 +282,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             let next_cursor = data.last().map_or(cursor, |e| Some(e.id));
             self.metrics
                 .query_events_result_size
-                .observe(data.len() as f64);
+                .report(data.len() as u64);
             self.metrics
                 .query_events_result_size_total
                 .inc_by(data.len() as u64);
@@ -333,7 +333,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
     ) -> RpcResult<DynamicFieldPage> {
         with_tracing!(async move {
             let limit = cap_page_limit(limit);
-            self.metrics.get_dynamic_fields_limit.observe(limit as f64);
+            self.metrics.get_dynamic_fields_limit.report(limit as u64);
             let mut data = self
                 .state
                 .get_dynamic_fields(parent_object_id, cursor, limit + 1)
@@ -343,7 +343,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             let next_cursor = data.last().cloned().map_or(cursor, |c| Some(c.0));
             self.metrics
                 .get_dynamic_fields_result_size
-                .observe(data.len() as f64);
+                .report(data.len() as u64);
             self.metrics
                 .get_dynamic_fields_result_size_total
                 .inc_by(data.len() as u64);

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -210,7 +210,7 @@ impl ReadApi {
         }
         self.metrics
             .get_tx_blocks_limit
-            .observe(digests.len() as f64);
+            .report(digests.len() as u64);
 
         let opts = opts.unwrap_or_default();
 
@@ -466,7 +466,7 @@ impl ReadApi {
 
         self.metrics
             .get_tx_blocks_result_size
-            .observe(converted_tx_block_resps.len() as f64);
+            .report(converted_tx_block_resps.len() as u64);
         self.metrics
             .get_tx_blocks_result_size_total
             .inc_by(converted_tx_block_resps.len() as u64);
@@ -543,7 +543,7 @@ impl ReadApiServer for ReadApi {
             if object_ids.len() <= *QUERY_MAX_RESULT_LIMIT {
                 self.metrics
                     .get_objects_limit
-                    .observe(object_ids.len() as f64);
+                    .report(object_ids.len() as u64);
                 let mut futures = vec![];
                 for object_id in object_ids {
                     futures.push(self.get_object(object_id, options.clone()));
@@ -567,7 +567,7 @@ impl ReadApiServer for ReadApi {
 
                 self.metrics
                     .get_objects_result_size
-                    .observe(objects.len() as f64);
+                    .report(objects.len() as u64);
                 self.metrics
                     .get_objects_result_size_total
                     .inc_by(objects.len() as u64);
@@ -964,7 +964,7 @@ impl ReadApiServer for ReadApi {
             let state = self.state.clone();
             let kv_store = self.transaction_kv_store.clone();
 
-            self.metrics.get_checkpoints_limit.observe(limit as f64);
+            self.metrics.get_checkpoints_limit.report(limit as u64);
 
             let mut data = spawn_monitored_task!(Self::get_checkpoints_internal(
                 state,
@@ -988,7 +988,7 @@ impl ReadApiServer for ReadApi {
 
             self.metrics
                 .get_checkpoints_result_size
-                .observe(data.len() as f64);
+                .report(data.len() as u64);
             self.metrics
                 .get_checkpoints_result_size_total
                 .inc_by(data.len() as u64);

--- a/crates/sui-network/src/state_sync/metrics.rs
+++ b/crates/sui-network/src/state_sync/metrics.rs
@@ -1,10 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{
-    register_histogram_with_registry, register_int_gauge_with_registry, Histogram, IntGauge,
-    Registry,
-};
+use mysten_metrics::histogram::Histogram;
+use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::sync::Arc;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tap::Pipe;
@@ -86,13 +84,11 @@ impl Inner {
             )
             .unwrap(),
 
-            checkpoint_summary_age_ms: register_histogram_with_registry!(
+            checkpoint_summary_age_ms: Histogram::new_in_registry(
                 "checkpoint_summary_age_ms",
                 "Age of checkpoints summaries when they arrive and are verified.",
-                mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            )
-            .unwrap(),
+            ),
         }
         .pipe(Arc::new)
     }

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1089,7 +1089,7 @@ where
 
         debug!(checkpoint_seq = ?checkpoint.sequence_number(), "verified checkpoint summary");
         if let Some(checkpoint_summary_age_metric) = metrics.checkpoint_summary_age_metric() {
-            checkpoint.report_checkpoint_age(checkpoint_summary_age_metric);
+            checkpoint.report_checkpoint_age_ms(checkpoint_summary_age_metric);
         }
 
         current = checkpoint.clone();

--- a/crates/sui-oracle/src/lib.rs
+++ b/crates/sui-oracle/src/lib.rs
@@ -525,7 +525,7 @@ impl OnChainDataUploader {
                 self.metrics
                     .uploaded_values
                     .with_label_values(&[&data_point.feed_name])
-                    .observe(data_point.value as f64);
+                    .observe(data_point.value);
             } else {
                 self.metrics
                     .upload_data_errors
@@ -538,9 +538,7 @@ impl OnChainDataUploader {
         let storage_rebate = effects.gas_cost_summary().storage_rebate;
         let computation_cost = effects.gas_cost_summary().computation_cost;
         let net_gas_usage = effects.gas_cost_summary().net_gas_usage();
-        self.metrics
-            .computation_gas_used
-            .observe(computation_cost as f64);
+        self.metrics.computation_gas_used.observe(computation_cost);
         self.metrics.total_gas_cost.inc_by(gas_usage);
         self.metrics.total_gas_rebate.inc_by(storage_rebate);
 
@@ -662,7 +660,7 @@ impl OnChainDataReader {
                         self.metrics
                             .downloaded_values
                             .with_label_values(&[feed_name])
-                            .observe(value * METRICS_MULTIPLIER);
+                            .observe((value * METRICS_MULTIPLIER) as u64);
                         self.metrics
                             .download_successes
                             .with_label_values(&[feed_name, &object_id.to_string()])

--- a/crates/sui-oracle/src/metrics.rs
+++ b/crates/sui-oracle/src/metrics.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{
-    register_histogram_vec_with_registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry, Histogram,
-    HistogramVec, IntCounter, IntCounterVec, Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry, IntCounter,
+    IntCounterVec, Registry,
 };
+
+use mysten_metrics::histogram::{Histogram, HistogramVec};
 
 #[derive(Clone)]
 pub struct OracleMetrics {
@@ -77,20 +78,18 @@ impl OracleMetrics {
                 registry,
             )
             .unwrap(),
-            uploaded_values: register_histogram_vec_with_registry!(
+            uploaded_values: HistogramVec::new_in_registry(
                 "oracle_uploaded_values",
                 "Values uploaded on chain",
                 &["feed"],
                 registry,
-            )
-            .unwrap(),
-            downloaded_values: register_histogram_vec_with_registry!(
+            ),
+            downloaded_values: HistogramVec::new_in_registry(
                 "oracle_downloaded_values",
                 "Values downloaded on chain",
                 &["feed"],
                 registry,
-            )
-            .unwrap(),
+            ),
             total_gas_cost: register_int_counter_with_registry!(
                 "oracle_total_gas_cost",
                 "Total number of gas used, before gas rebate",
@@ -103,12 +102,11 @@ impl OracleMetrics {
                 registry,
             )
             .unwrap(),
-            computation_gas_used: register_histogram_with_registry!(
+            computation_gas_used: Histogram::new_in_registry(
                 "oracle_computation_gas_used",
                 "computation gas used",
                 registry,
-            )
-            .unwrap(),
+            ),
             total_data_points_uploaded: register_int_counter_with_registry!(
                 "oracle_total_data_points_uploaded",
                 "Total number of data points uploaded",

--- a/narwhal/primary/src/consensus/bullshark.rs
+++ b/narwhal/primary/src/consensus/bullshark.rs
@@ -204,7 +204,7 @@ impl Bullshark {
 
         self.metrics
             .committed_certificates
-            .observe(total_committed_certificates as f64);
+            .report(total_committed_certificates);
 
         Ok((Outcome::Commit, committed_sub_dags))
     }

--- a/narwhal/primary/src/consensus/metrics.rs
+++ b/narwhal/primary/src/consensus/metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use mysten_metrics::histogram::Histogram as MystenHistogram;
 use prometheus::{
     default_registry, register_histogram_with_registry, register_int_counter_vec_with_registry,
     register_int_counter_with_registry, register_int_gauge_vec_with_registry,
@@ -27,7 +28,7 @@ pub struct ConsensusMetrics {
     /// The latency between two successful commit rounds
     pub commit_rounds_latency: Histogram,
     /// The number of certificates committed per commit round
-    pub committed_certificates: Histogram,
+    pub committed_certificates: MystenHistogram,
     /// The time it takes for a certificate from the moment it gets created
     /// up to the moment it gets committed.
     pub certificate_commit_latency: Histogram,
@@ -85,11 +86,11 @@ impl ConsensusMetrics {
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
-            committed_certificates: register_histogram_with_registry!(
+            committed_certificates: MystenHistogram::new_in_registry(
                 "committed_certificates",
                 "The number of certificates committed on a commit round",
                 registry
-            ).unwrap(),
+            ),
             certificate_commit_latency: register_histogram_with_registry!(
                 "certificate_commit_latency",
                 "The time it takes for a certificate from the moment it gets created up to the moment it gets committed.",


### PR DESCRIPTION
This reverts commit ed69f7cce7ac200a849647c5d8efa7113969d44a.

Need to revert this as it breaks health checks for services behind LB
