### PR TITLE
[CI] allow specifying branch / commit in coverage workflow

### DIFF
--- a/.github/workflows/cargo-llvm-cov.yml
+++ b/.github/workflows/cargo-llvm-cov.yml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: '0 9 * * *' # UTC timing is every day at 1am PST
   workflow_dispatch:
+    inputs:
+      sui_repo_ref:
+        description: "Branch / commit to test"
+        type: string
+        required: false
+        default: ''
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,6 +46,9 @@ jobs:
         run: rustup update stable
         
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+            ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+
       - uses: bmwill/rust-cache@v1
 
       - name: Install cargo-llvm-cov
@@ -80,8 +89,10 @@ jobs:
     steps:
     - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # Pin v4.1.1
 
-    - name: Checkout sui repo main branch
+    - name: Checkout sui repo
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v3.0.3
+      with:
+        ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
     
     - name: Get sui commit
       env:


### PR DESCRIPTION
## Description 

This allows rerunning the workflow with a past commit.

## Test plan 

https://github.com/MystenLabs/sui/actions/runs/10530504701/job/29180577939#step:3:3

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
