### PR TITLE
my_module.move -> example.move

### DIFF
--- a/docs/content/guides/developer/first-app/build-test.mdx
+++ b/docs/content/guides/developer/first-app/build-test.mdx
@@ -47,7 +47,7 @@ Test result: OK. Total tests: 0; passed: 0; failed: 0
 
 To actually test your code, you need to add test functions. Start with adding a basic test function to the `my_module.move` file, inside the module definition:
 
-{@inject: examples/move/first_package/sources/example.move#first-test}
+{@inject: examples/move/first_package/sources/my_module.move#first-test}
 
 As the code shows, the unit test function (`test_sword_create()`) creates a dummy instance of the `TxContext` struct and assigns it to `ctx`. The function then creates a sword object using `ctx` to create a unique identifier and assigns `42` to the `magic` parameter and `7` to `strength`. Finally, the test calls the `magic` and `strength` accessor functions to verify that they return correct values.
 
@@ -89,7 +89,7 @@ One of the solutions (as suggested in the error message), is to add the `drop` a
 
 To get the test to work, we will need to use the `transfer` module, which is imported by default. Add the following lines to the end of the test function (after the `assert!` call) to transfer ownership of the `sword` to a freshly created dummy address:
 
-{@inject: examples/move/first_package/sources/example.move#test-dummy noComments}
+{@inject: examples/move/first_package/sources/my_module.move#test-dummy noComments}
 
 Run the test command again. Now the output shows a single successful test has run:
 
@@ -134,13 +134,13 @@ An instance of the `Scenario` struct contains a per-address object pool emulatin
 
 Update your `my_module.move` file to include a function callable from Sui that implements `sword` creation. With this in place, you can then add a multi-transaction test that uses the `test_scenario` module to test these new capabilities. Put this functions after the accessors (Part 5 in comments).
 
-{@inject: examples/move/first_package/sources/example.move#fun=sword_create noComments}
+{@inject: examples/move/first_package/sources/my_module.move#fun=sword_create noComments}
 
 The code of the new functions uses struct creation and Sui-internal modules (`tx_context`) in a way similar to what you have seen in the previous sections. The important part is for the function to have correct signatures.
 
 With the new function included, add another test function to make sure it behaves as expected.
 
-{@inject: examples/move/first_package/sources/example.move#fun=test_sword_transactions}
+{@inject: examples/move/first_package/sources/my_module.move#fun=test_sword_transactions}
 
 There are some details of the new testing function to pay attention to. The first thing the code does is create some addresses that represent users participating in the testing scenario. The test then creates a scenario by starting the first transaction on behalf of the initial sword owner.
 
@@ -189,26 +189,26 @@ While the `sui move` command does not support publishing explicitly, you can sti
 
 The `init` function for the module in the running example creates a `Forge` object.
 
-{@inject: examples/move/first_package/sources/example.move#fun=init noComments}
+{@inject: examples/move/first_package/sources/my_module.move#fun=init noComments}
 
 The tests you have so far call the `init` function, but the initializer function itself isn't tested to ensure it properly creates a `Forge` object. To test this functionality, add a `new_sword` function to take the forge as a parameter and to update the number of created swords at the end of the function. If this were an actual module, you'd replace the `sword_create` function with `new_sword`. To keep the existing tests from failing, however, we will keep both functions.
 
-{@inject: examples/move/first_package/sources/example.move#fun=new_sword noComments}
+{@inject: examples/move/first_package/sources/my_module.move#fun=new_sword noComments}
 
 Now, create a function to test the module initialization:
 
-{@inject: examples/move/first_package/sources/example.move#fun=test_module_init}
+{@inject: examples/move/first_package/sources/my_module.move#fun=test_module_init}
 
 As the new test function shows, the first transaction (explicitly) calls the initializer. The next transaction checks if the `Forge` object has been created and properly initialized. Finally, the admin uses the `Forge` to create a sword and transfer it to the initial owner.
 
-You can refer to the source code for the package (with all the tests and functions properly adjusted) in the [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move) module in the `sui/examples` directory. You can also use the following toggle to review the complete code.
+You can refer to the source code for the package (with all the tests and functions properly adjusted) in the [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/my_module.move) module in the `sui/examples` directory. You can also use the following toggle to review the complete code.
 
 <details>
 <summary>
 Toggle complete source code 
 </summary>
 
-{@inject: examples/move/first_package/sources/example.move}
+{@inject: examples/move/first_package/sources/my_module.move}
 
 </details>
 

--- a/docs/content/guides/developer/first-app/build-test.mdx
+++ b/docs/content/guides/developer/first-app/build-test.mdx
@@ -45,9 +45,9 @@ Running Move unit tests
 Test result: OK. Total tests: 0; passed: 0; failed: 0
 ```
 
-To actually test your code, you need to add test functions. Start with adding a basic test function to the `my_module.move` file, inside the module definition:
+To actually test your code, you need to add test functions. Start with adding a basic test function to the `example.move` file, inside the module definition:
 
-{@inject: examples/move/first_package/sources/my_module.move#first-test}
+{@inject: examples/move/first_package/sources/example.move#first-test}
 
 As the code shows, the unit test function (`test_sword_create()`) creates a dummy instance of the `TxContext` struct and assigns it to `ctx`. The function then creates a sword object using `ctx` to create a unique identifier and assigns `42` to the `magic` parameter and `7` to `strength`. Finally, the test calls the `magic` and `strength` accessor functions to verify that they return correct values.
 
@@ -63,7 +63,7 @@ After running the `test` command, however, you get a compilation error instead o
 
 ```shell
 error[E06001]: unused value without 'drop'
-   ┌─ ./sources/my_module.move:59:65
+   ┌─ ./sources/example.move:59:65
    │
  9 │       public struct Sword has key, store {
    │                     ----- To satisfy the constraint, the 'drop' ability would need to be added here
@@ -89,7 +89,7 @@ One of the solutions (as suggested in the error message), is to add the `drop` a
 
 To get the test to work, we will need to use the `transfer` module, which is imported by default. Add the following lines to the end of the test function (after the `assert!` call) to transfer ownership of the `sword` to a freshly created dummy address:
 
-{@inject: examples/move/first_package/sources/my_module.move#test-dummy noComments}
+{@inject: examples/move/first_package/sources/example.move#test-dummy noComments}
 
 Run the test command again. Now the output shows a single successful test has run:
 
@@ -132,15 +132,15 @@ The `test_scenario` module provides a scenario that emulates a series of Sui tra
 
 An instance of the `Scenario` struct contains a per-address object pool emulating Sui object storage, with helper functions provided to manipulate objects in the pool. After the first transaction finishes, subsequent test transactions start with the `test_scenario::next_tx` function. This function takes an instance of the `Scenario` struct representing the current scenario and an address of a user as arguments.
 
-Update your `my_module.move` file to include a function callable from Sui that implements `sword` creation. With this in place, you can then add a multi-transaction test that uses the `test_scenario` module to test these new capabilities. Put this functions after the accessors (Part 5 in comments).
+Update your `example.move` file to include a function callable from Sui that implements `sword` creation. With this in place, you can then add a multi-transaction test that uses the `test_scenario` module to test these new capabilities. Put this functions after the accessors (Part 5 in comments).
 
-{@inject: examples/move/first_package/sources/my_module.move#fun=sword_create noComments}
+{@inject: examples/move/first_package/sources/example.move#fun=sword_create noComments}
 
 The code of the new functions uses struct creation and Sui-internal modules (`tx_context`) in a way similar to what you have seen in the previous sections. The important part is for the function to have correct signatures.
 
 With the new function included, add another test function to make sure it behaves as expected.
 
-{@inject: examples/move/first_package/sources/my_module.move#fun=test_sword_transactions}
+{@inject: examples/move/first_package/sources/example.move#fun=test_sword_transactions}
 
 There are some details of the new testing function to pay attention to. The first thing the code does is create some addresses that represent users participating in the testing scenario. The test then creates a scenario by starting the first transaction on behalf of the initial sword owner.
 
@@ -189,26 +189,26 @@ While the `sui move` command does not support publishing explicitly, you can sti
 
 The `init` function for the module in the running example creates a `Forge` object.
 
-{@inject: examples/move/first_package/sources/my_module.move#fun=init noComments}
+{@inject: examples/move/first_package/sources/example.move#fun=init noComments}
 
 The tests you have so far call the `init` function, but the initializer function itself isn't tested to ensure it properly creates a `Forge` object. To test this functionality, add a `new_sword` function to take the forge as a parameter and to update the number of created swords at the end of the function. If this were an actual module, you'd replace the `sword_create` function with `new_sword`. To keep the existing tests from failing, however, we will keep both functions.
 
-{@inject: examples/move/first_package/sources/my_module.move#fun=new_sword noComments}
+{@inject: examples/move/first_package/sources/example.move#fun=new_sword noComments}
 
 Now, create a function to test the module initialization:
 
-{@inject: examples/move/first_package/sources/my_module.move#fun=test_module_init}
+{@inject: examples/move/first_package/sources/example.move#fun=test_module_init}
 
 As the new test function shows, the first transaction (explicitly) calls the initializer. The next transaction checks if the `Forge` object has been created and properly initialized. Finally, the admin uses the `Forge` to create a sword and transfer it to the initial owner.
 
-You can refer to the source code for the package (with all the tests and functions properly adjusted) in the [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/my_module.move) module in the `sui/examples` directory. You can also use the following toggle to review the complete code.
+You can refer to the source code for the package (with all the tests and functions properly adjusted) in the [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move) module in the `sui/examples` directory. You can also use the following toggle to review the complete code.
 
 <details>
 <summary>
 Toggle complete source code 
 </summary>
 
-{@inject: examples/move/first_package/sources/my_module.move}
+{@inject: examples/move/first_package/sources/example.move}
 
 </details>
 


### PR DESCRIPTION
## Description 
While going through the tutorial I noticed that the filename `my_module.move` is not in the sources referenced in the documentation. Probably meant `example.move`.

## Test plan 
Not relevant, I guess.

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
