### PR TITLE
{suins, sui-bridge}-indexer: convert to using diesel-async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,14 +3654,14 @@ dependencies = [
 
 [[package]]
 name = "diesel-derive-enum"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b10c03b954333d05bfd5be1d8a74eae2c9ca77b86e0f1c3a1ea29c49da1d6c2"
+checksum = "81c5131a2895ef64741dad1d483f358c2a229a3a2d1b256778cdc5e146db64d4"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 1.0.107",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bb8"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "parking_lot 0.12.1",
+ "tokio",
+]
+
+[[package]]
 name = "bcrypt-pbkdf"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,6 +3665,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-async"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb799bb6f8ca6a794462125d7b8983b0c86e6c93a33a9c55934a4a5de4409d3"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "diesel-derive-enum"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,6 +4619,12 @@ dependencies = [
  "log",
  "rand 0.7.3",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fast_chemail"
@@ -9735,6 +9768,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac 0.12.1",
+ "md-5 0.10.6",
+ "memchr",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11407,6 +11469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12321,6 +12393,17 @@ dependencies = [
  "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -15179,6 +15262,7 @@ dependencies = [
  "bcs",
  "bytes",
  "diesel",
+ "diesel-async",
  "dotenvy",
  "futures",
  "move-core-types",
@@ -15826,6 +15910,32 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.8.5",
+ "socket2 0.5.6",
+ "tokio",
+ "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "whoami",
 ]
 
 [[package]]
@@ -16638,6 +16748,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13003,6 +13003,7 @@ dependencies = [
  "bin-version",
  "clap",
  "diesel",
+ "diesel-async",
  "ethers",
  "futures",
  "hex-literal 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,15 +318,10 @@ derivative = "2.2.0"
 derive-syn-parse = "0.1.5"
 derive_builder = "0.12.0"
 derive_more = "0.99.17"
-diesel = { version = "2.1.0", features = [
-    "chrono",
-    "r2d2",
-    "serde_json",
-    "64-column-tables",
-    "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-] }
-diesel-derive-enum = { version = "2.0.1" }
-diesel_migrations = { version = "2.0.0" }
+diesel = "2.2"
+diesel-derive-enum = "2.1"
+diesel_migrations = "2.2"
+diesel-async = "0.5"
 dirs = "4.0.0"
 duration-str = "0.5.0"
 ed25519 = { version = "1.5.0", features = ["pkcs8", "alloc", "zeroize"] }

--- a/crates/sui-bridge-indexer/Cargo.toml
+++ b/crates/sui-bridge-indexer/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 [dependencies]
 serde.workspace = true
 tap.workspace = true
-diesel = { workspace = true, features = ["postgres", "r2d2", "serde_json"] }
+diesel = { workspace = true, features = ["serde_json"] }
+diesel-async = { workspace = true, features = ["bb8", "postgres"] }
 ethers = { version = "2.0", features = ["rustls", "ws"] }
 rayon = "1.10.0"
 tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-bridge-indexer/Cargo.toml
+++ b/crates/sui-bridge-indexer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 serde.workspace = true
 tap.workspace = true
-diesel = { version = "2.1.4", features = ["postgres", "r2d2", "serde_json"] }
+diesel = { workspace = true, features = ["postgres", "r2d2", "serde_json"] }
 ethers = { version = "2.0", features = ["rustls", "ws"] }
 rayon = "1.10.0"
 tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
     let bridge_metrics = Arc::new(BridgeMetrics::new(&registry));
 
     let db_url = config.db_url.clone();
-    let datastore = PgBridgePersistent::new(get_connection_pool(db_url.clone()));
+    let datastore = PgBridgePersistent::new(get_connection_pool(db_url.clone()).await);
 
     let provider = Arc::new(
         Provider::<Http>::try_from(config.eth_rpc_url.clone())?
@@ -167,7 +167,7 @@ async fn start_processing_sui_checkpoints_by_querying_txns(
     indexer_metrics: BridgeIndexerMetrics,
     bridge_metrics: Arc<BridgeMetrics>,
 ) -> Result<Vec<JoinHandle<()>>> {
-    let pg_pool = get_connection_pool(db_url.clone());
+    let pg_pool = get_connection_pool(db_url.clone()).await;
     let (tx, rx) = channel(
         100,
         &mysten_metrics::get_metrics()
@@ -176,8 +176,9 @@ async fn start_processing_sui_checkpoints_by_querying_txns(
             .with_label_values(&["sui_transaction_processing_queue"]),
     );
     let mut handles = vec![];
-    let cursor =
-        read_sui_progress_store(&pg_pool).expect("Failed to read cursor from sui progress store");
+    let cursor = read_sui_progress_store(&pg_pool)
+        .await
+        .expect("Failed to read cursor from sui progress store");
     let sui_client = SuiClientBuilder::default().build(sui_rpc_url).await?;
     handles.push(spawn_logged_monitored_task!(
         start_sui_tx_polling_task(sui_client, cursor, tx, bridge_metrics),

--- a/crates/sui-bridge-indexer/src/sui_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/sui_bridge_indexer.rs
@@ -4,8 +4,11 @@
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
 use diesel::dsl::now;
-use diesel::{Connection, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper};
 use diesel::{ExpressionMethods, TextExpressionMethods};
+use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
+use diesel_async::RunQueryDsl;
 use tracing::info;
 
 use sui_bridge::events::{
@@ -48,44 +51,53 @@ impl Persistent<ProcessedTxnData> for PgBridgePersistent {
         if data.is_empty() {
             return Ok(());
         }
-        let connection = &mut self.pool.get()?;
-        connection.transaction(|conn| {
-            for d in data {
-                match d {
-                    ProcessedTxnData::TokenTransfer(t) => {
-                        diesel::insert_into(token_transfer::table)
-                            .values(&t.to_db())
-                            .on_conflict_do_nothing()
-                            .execute(conn)?;
+        let connection = &mut self.pool.get().await?;
+        connection
+            .transaction(|conn| {
+                async move {
+                    for d in data {
+                        match d {
+                            ProcessedTxnData::TokenTransfer(t) => {
+                                diesel::insert_into(token_transfer::table)
+                                    .values(&t.to_db())
+                                    .on_conflict_do_nothing()
+                                    .execute(conn)
+                                    .await?;
 
-                        if let Some(d) = t.to_data_maybe() {
-                            diesel::insert_into(token_transfer_data::table)
-                                .values(&d)
-                                .on_conflict_do_nothing()
-                                .execute(conn)?;
+                                if let Some(d) = t.to_data_maybe() {
+                                    diesel::insert_into(token_transfer_data::table)
+                                        .values(&d)
+                                        .on_conflict_do_nothing()
+                                        .execute(conn)
+                                        .await?;
+                                }
+                            }
+                            ProcessedTxnData::Error(e) => {
+                                diesel::insert_into(sui_error_transactions::table)
+                                    .values(&e.to_db())
+                                    .on_conflict_do_nothing()
+                                    .execute(conn)
+                                    .await?;
+                            }
                         }
                     }
-                    ProcessedTxnData::Error(e) => {
-                        diesel::insert_into(sui_error_transactions::table)
-                            .values(&e.to_db())
-                            .on_conflict_do_nothing()
-                            .execute(conn)?;
-                    }
+                    Ok(())
                 }
-            }
-            Ok(())
-        })
+                .scope_boxed()
+            })
+            .await
     }
 }
 
 #[async_trait]
 impl IndexerProgressStore for PgBridgePersistent {
     async fn load_progress(&self, task_name: String) -> anyhow::Result<u64> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.pool.get().await?;
         let cp: Option<models::ProgressStore> = dsl::progress_store
             .find(&task_name)
             .select(models::ProgressStore::as_select())
             .first(&mut conn)
+            .await
             .optional()?;
         Ok(cp
             .ok_or(anyhow!("Cannot found progress for task {task_name}"))?
@@ -97,7 +109,7 @@ impl IndexerProgressStore for PgBridgePersistent {
         task_name: String,
         checkpoint_number: u64,
     ) -> anyhow::Result<()> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.pool.get().await?;
         diesel::insert_into(schema::progress_store::table)
             .values(&models::ProgressStore {
                 task_name,
@@ -113,19 +125,21 @@ impl IndexerProgressStore for PgBridgePersistent {
                 columns::checkpoint.eq(checkpoint_number as i64),
                 columns::timestamp.eq(now),
             ))
-            .execute(&mut conn)?;
+            .execute(&mut conn)
+            .await?;
         Ok(())
     }
 
     async fn tasks(&self, prefix: &str) -> Result<Vec<Task>, anyhow::Error> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.pool.get().await?;
         // get all unfinished tasks
         let cp: Vec<models::ProgressStore> = dsl::progress_store
             // TODO: using like could be error prone, change the progress store schema to stare the task name properly.
             .filter(columns::task_name.like(format!("{prefix} - %")))
             .filter(columns::checkpoint.lt(columns::target_checkpoint))
             .order_by(columns::target_checkpoint.desc())
-            .load(&mut conn)?;
+            .load(&mut conn)
+            .await?;
         Ok(cp.into_iter().map(|d| d.into()).collect())
     }
 
@@ -135,7 +149,7 @@ impl IndexerProgressStore for PgBridgePersistent {
         checkpoint: u64,
         target_checkpoint: u64,
     ) -> Result<(), anyhow::Error> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.pool.get().await?;
         diesel::insert_into(schema::progress_store::table)
             .values(models::ProgressStore {
                 task_name,
@@ -144,19 +158,21 @@ impl IndexerProgressStore for PgBridgePersistent {
                 // Timestamp is defaulted to current time in DB if None
                 timestamp: None,
             })
-            .execute(&mut conn)?;
+            .execute(&mut conn)
+            .await?;
         Ok(())
     }
 
     async fn update_task(&mut self, task: Task) -> Result<(), anyhow::Error> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.pool.get().await?;
         diesel::update(dsl::progress_store.filter(columns::task_name.eq(task.task_name)))
             .set((
                 columns::checkpoint.eq(task.checkpoint as i64),
                 columns::target_checkpoint.eq(task.target_checkpoint as i64),
                 columns::timestamp.eq(now),
             ))
-            .execute(&mut conn)?;
+            .execute(&mut conn)
+            .await?;
         Ok(())
     }
 }

--- a/crates/sui-bridge-indexer/src/sui_transaction_handler.rs
+++ b/crates/sui-bridge-indexer/src/sui_transaction_handler.rs
@@ -47,7 +47,7 @@ pub async fn handle_sui_transactions_loop(
         if !data.is_empty() {
             // unwrap: token_transfers is not empty
             let last_ckp = txns.last().map(|tx| tx.checkpoint).unwrap_or_default();
-            while let Err(err) = write(&pg_pool, data.clone()) {
+            while let Err(err) = write(&pg_pool, data.clone()).await {
                 error!("Failed to write sui transactions to DB: {:?}", err);
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
@@ -57,7 +57,7 @@ pub async fn handle_sui_transactions_loop(
 
         // update sui progress store using the latest cursor
         if let Some(cursor) = cursor {
-            while let Err(err) = update_sui_progress_store(&pg_pool, cursor) {
+            while let Err(err) = update_sui_progress_store(&pg_pool, cursor).await {
                 error!("Failed to update sui progress tore DB: {:?}", err);
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -19,7 +19,7 @@ bin-version.workspace = true
 chrono.workspace = true
 clap.workspace = true
 const-str.workspace = true
-diesel.workspace = true
+diesel = { workspace = true, features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 either.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 fastcrypto-zkp.workspace = true

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -16,8 +16,8 @@ chrono.workspace = true
 serde_with.workspace = true
 clap.workspace = true
 tap.workspace = true
-diesel = { workspace = true, optional = true }
-diesel-derive-enum = { workspace = true, optional = true }
+diesel = { workspace = true, features = ["chrono", "r2d2", "serde_json"] }
+diesel-derive-enum.workspace = true
 futures.workspace = true
 itertools.workspace = true
 jsonrpsee.workspace = true

--- a/crates/suins-indexer/Cargo.toml
+++ b/crates/suins-indexer/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 version.workspace = true
 
 [dependencies]
-diesel = { workspace = true, features = ["postgres", "r2d2", "serde_json"] }
+diesel = { workspace = true, features = ["serde_json"] }
+diesel-async = { workspace = true, features = ["bb8", "postgres"] }
 sui-data-ingestion-core.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/suins-indexer/Cargo.toml
+++ b/crates/suins-indexer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 version.workspace = true
 
 [dependencies]
-diesel = { version = "2.1.4", features = ["postgres", "r2d2", "serde_json"] }
+diesel = { workspace = true, features = ["postgres", "r2d2", "serde_json"] }
 sui-data-ingestion-core.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/suins-indexer/src/lib.rs
+++ b/crates/suins-indexer/src/lib.rs
@@ -5,22 +5,29 @@ pub mod indexer;
 pub mod models;
 pub mod schema;
 
-use diesel::pg::PgConnection;
-use diesel::r2d2::{ConnectionManager, Pool};
 use dotenvy::dotenv;
 use std::env;
 
-pub type PgConnectionPool = diesel::r2d2::Pool<ConnectionManager<PgConnection>>;
-pub type PgPoolConnection = diesel::r2d2::PooledConnection<ConnectionManager<PgConnection>>;
+use diesel_async::pooled_connection::bb8::Pool;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::AsyncPgConnection;
 
-pub fn get_connection_pool() -> PgConnectionPool {
+pub type PgConnectionPool =
+    diesel_async::pooled_connection::bb8::Pool<diesel_async::AsyncPgConnection>;
+pub type PgPoolConnection<'a> =
+    diesel_async::pooled_connection::bb8::PooledConnection<'a, AsyncPgConnection>;
+
+pub async fn get_connection_pool() -> PgConnectionPool {
+    //Pool<AsyncPgConnection> {
     dotenv().ok();
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let manager = ConnectionManager::<PgConnection>::new(database_url);
+
+    let manager =
+        AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new(database_url);
 
     Pool::builder()
-        .test_on_check_out(true)
         .build(manager)
+        .await
         .expect("Could not build Postgres DB connection pool")
 }


### PR DESCRIPTION
## Description 

This PR begins the journey of migrating our DB connections from sync to async by using `diesel-async`. Some of the motivation for such a change: 

- pure rust impl (no C FFI dep that needs to be present at compile and runtime)
- using a proper async connection won't block the async runtime, which can lead to poor tail latencies (since the thread can't be reused while waiting on blocking io)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
