### PR TITLE
indexer: split object version ingestion for perf

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -40,6 +40,7 @@ use crate::handlers::committer::start_tx_checkpoint_commit_task;
 use crate::handlers::tx_processor::IndexingPackageBuffer;
 use crate::metrics::IndexerMetrics;
 use crate::models::display::StoredDisplay;
+use crate::models::obj_indices::StoredObjectVersion;
 use crate::store::package_resolver::{IndexerStorePackageResolver, InterimPackageResolver};
 use crate::store::{IndexerStore, PgIndexerStore};
 use crate::types::{
@@ -269,6 +270,27 @@ where
         }))
     }
 
+    fn derive_object_versions(
+        object_history_changes: &TransactionObjectChangesToCommit,
+    ) -> Vec<StoredObjectVersion> {
+        let mut object_versions = vec![];
+        for changed_obj in object_history_changes.changed_objects.iter() {
+            object_versions.push(StoredObjectVersion {
+                object_id: changed_obj.object.id().to_vec(),
+                object_version: changed_obj.object.version().value() as i64,
+                cp_sequence_number: changed_obj.checkpoint_sequence_number as i64,
+            });
+        }
+        for deleted_obj in object_history_changes.deleted_objects.iter() {
+            object_versions.push(StoredObjectVersion {
+                object_id: deleted_obj.object_id.to_vec(),
+                object_version: deleted_obj.object_version as i64,
+                cp_sequence_number: deleted_obj.checkpoint_sequence_number as i64,
+            });
+        }
+        object_versions
+    }
+
     async fn index_checkpoint(
         state: Arc<S>,
         data: CheckpointData,
@@ -287,6 +309,7 @@ where
             Self::index_objects(data.clone(), &metrics, package_resolver.clone()).await?;
         let object_history_changes: TransactionObjectChangesToCommit =
             Self::index_objects_history(data.clone(), package_resolver.clone()).await?;
+        let object_versions = Self::derive_object_versions(&object_history_changes);
 
         let (checkpoint, db_transactions, db_events, db_tx_indices, db_event_indices, db_displays) = {
             let CheckpointData {
@@ -342,6 +365,7 @@ where
             display_updates: db_displays,
             object_changes,
             object_history_changes,
+            object_versions,
             packages,
             epoch,
         })

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -93,6 +93,7 @@ async fn commit_checkpoints<S>(
     let mut display_updates_batch = BTreeMap::new();
     let mut object_changes_batch = vec![];
     let mut object_history_changes_batch = vec![];
+    let mut object_versions_batch = vec![];
     let mut packages_batch = vec![];
 
     for indexed_checkpoint in indexed_checkpoint_batch {
@@ -105,6 +106,7 @@ async fn commit_checkpoints<S>(
             display_updates,
             object_changes,
             object_history_changes,
+            object_versions,
             packages,
             epoch: _,
         } = indexed_checkpoint;
@@ -116,6 +118,7 @@ async fn commit_checkpoints<S>(
         display_updates_batch.extend(display_updates.into_iter());
         object_changes_batch.push(object_changes);
         object_history_changes_batch.push(object_history_changes);
+        object_versions_batch.push(object_versions);
         packages_batch.push(packages);
     }
 
@@ -127,6 +130,10 @@ async fn commit_checkpoints<S>(
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let object_versions_batch = object_versions_batch
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
@@ -150,6 +157,7 @@ async fn commit_checkpoints<S>(
             state.persist_objects(object_changes_batch.clone()),
             state.persist_object_history(object_history_changes_batch.clone()),
             state.persist_full_objects_history(object_history_changes_batch.clone()),
+            state.persist_object_versions(object_versions_batch.clone()),
         ];
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    models::display::StoredDisplay,
+    models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent,
         IndexedObject, IndexedPackage, IndexedTransaction, TxIndex,
@@ -27,6 +27,7 @@ pub struct CheckpointDataToCommit {
     pub display_updates: BTreeMap<String, StoredDisplay>,
     pub object_changes: TransactionObjectChangesToCommit,
     pub object_history_changes: TransactionObjectChangesToCommit,
+    pub object_versions: Vec<StoredObjectVersion>,
     pub packages: Vec<IndexedPackage>,
     pub epoch: Option<EpochToCommit>,
 }

--- a/crates/sui-indexer/src/models/obj_indices.rs
+++ b/crates/sui-indexer/src/models/obj_indices.rs
@@ -4,10 +4,6 @@
 use diesel::prelude::*;
 
 use crate::schema::objects_version;
-
-use super::objects::StoredDeletedObject;
-use super::objects::StoredObject;
-
 /// Model types related to tables that support efficient execution of queries on the `objects`,
 /// `objects_history` and `objects_snapshot` tables.
 
@@ -17,24 +13,4 @@ pub struct StoredObjectVersion {
     pub object_id: Vec<u8>,
     pub object_version: i64,
     pub cp_sequence_number: i64,
-}
-
-impl From<&StoredObject> for StoredObjectVersion {
-    fn from(o: &StoredObject) -> Self {
-        Self {
-            object_id: o.object_id.clone(),
-            object_version: o.object_version,
-            cp_sequence_number: o.checkpoint_sequence_number,
-        }
-    }
-}
-
-impl From<&StoredDeletedObject> for StoredObjectVersion {
-    fn from(o: &StoredDeletedObject) -> Self {
-        Self {
-            object_id: o.object_id.clone(),
-            object_version: o.object_version,
-            cp_sequence_number: o.checkpoint_sequence_number,
-        }
-    }
 }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use crate::errors::IndexerError;
 use crate::handlers::{EpochToCommit, TransactionObjectChangesToCommit};
 use crate::models::display::StoredDisplay;
+use crate::models::obj_indices::StoredObjectVersion;
 use crate::models::objects::{StoredDeletedObject, StoredObject};
 use crate::types::{
     EventIndex, IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex,
@@ -52,6 +53,11 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn persist_full_objects_history(
         &self,
         object_changes: Vec<TransactionObjectChangesToCommit>,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_object_versions(
+        &self,
+        object_versions: Vec<StoredObjectVersion>,
     ) -> Result<(), IndexerError>;
 
     // persist objects snapshot with object changes during backfill


### PR DESCRIPTION
## Description 

objects_history has been a bottleneck of indexer ingestion / backfill, splitting objects_version and let it run in parallel.
this might have been a factor of recent backfill perf regression.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
