### PR TITLE
[move-ide] A fix to empty variant autocompletion

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -698,17 +698,25 @@ fn variant_completion(symbols: &Symbols, vinfo: &VariantInfo) -> Option<Completi
         })
         .collect::<Vec<_>>()
         .join(", ");
-    let insert_text = if *is_positional {
-        format!("{vname}({field_snippet})")
+    let (insert_text, insert_text_format) = if field_names.is_empty() {
+        (format!("{vname}"), InsertTextFormat::PLAIN_TEXT)
+    } else if *is_positional {
+        (
+            format!("{vname}({field_snippet})"),
+            InsertTextFormat::SNIPPET,
+        )
     } else {
-        format!("{vname}{{{field_snippet}}}")
+        (
+            format!("{vname}{{{field_snippet}}}"),
+            InsertTextFormat::SNIPPET,
+        )
     };
 
     Some(CompletionItem {
         label,
         kind: Some(CompletionItemKind::ENUM_MEMBER),
         insert_text: Some(insert_text),
-        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        insert_text_format: Some(insert_text_format),
         ..Default::default()
     })
 }

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.exp
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.exp
@@ -123,7 +123,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 5 -------------------
 use line: 22, use_col: 11
@@ -140,7 +140,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 7 -------------------
 use line: 23, use_col: 25
@@ -176,7 +176,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 10 -------------------
 use line: 25, use_col: 9
@@ -418,7 +418,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 15 -------------------
 use line: 28, use_col: 13
@@ -815,7 +815,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 29 -------------------
 use line: 25, use_col: 16
@@ -954,7 +954,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 32 -------------------
 use line: 41, use_col: 20
@@ -974,7 +974,7 @@ EnumMember 'SomeNamedVariant{}'
 EnumMember 'SomePositionalVariant()'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant{}'
+    INSERT TEXT: 'SomeVariant'
 
 -- test 34 -------------------
 use line: 55, use_col: 38


### PR DESCRIPTION
## Description 

This PR fixes autocompletion for empty enum variants. Previously the autocompletion would result in:
```
SomeEnum::EmptyVariant{}
```

After the change, autocompletion will result in:
```
SomeEnum::EmptyVariant
```


## Test plan 

All tests must pass (the change in the PR is reflected in modified expected test output)
