### PR TITLE
[rocksdb] add metric for pending compaction bytes and memtable flushes

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -88,6 +88,7 @@ pub struct ColumnFamilyMetrics {
     pub rocksdb_estimate_table_readers_mem: IntGaugeVec,
     pub rocksdb_mem_table_flush_pending: IntGaugeVec,
     pub rocksdb_compaction_pending: IntGaugeVec,
+    pub rocksdb_estimate_pending_compaction_bytes: IntGaugeVec,
     pub rocksdb_num_running_compactions: IntGaugeVec,
     pub rocksdb_num_running_flushes: IntGaugeVec,
     pub rocksdb_estimate_oldest_key_time: IntGaugeVec,
@@ -194,6 +195,14 @@ impl ColumnFamilyMetrics {
                 is pending because the desired compaction job is either waiting for
                 other dependent compactions to be finished or waiting for an available
                 compaction thread.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimate_pending_compaction_bytes: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimate_pending_compaction_bytes",
+                "Estimated total number of bytes compaction needs to rewrite to get all levels down
+                to under target size. Not valid for other compactions than level-based.",
                 &["cf_name"],
                 registry,
             )

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -77,6 +77,7 @@ impl SamplingInterval {
 pub struct ColumnFamilyMetrics {
     pub rocksdb_total_sst_files_size: IntGaugeVec,
     pub rocksdb_total_blob_files_size: IntGaugeVec,
+    pub rocksdb_current_size_active_mem_tables: IntGaugeVec,
     pub rocksdb_size_all_mem_tables: IntGaugeVec,
     pub rocksdb_num_snapshots: IntGaugeVec,
     pub rocksdb_oldest_snapshot_time: IntGaugeVec,
@@ -86,6 +87,7 @@ pub struct ColumnFamilyMetrics {
     pub rocksdb_block_cache_usage: IntGaugeVec,
     pub rocksdb_block_cache_pinned_usage: IntGaugeVec,
     pub rocksdb_estimate_table_readers_mem: IntGaugeVec,
+    pub rocksdb_num_immutable_mem_tables: IntGaugeVec,
     pub rocksdb_mem_table_flush_pending: IntGaugeVec,
     pub rocksdb_compaction_pending: IntGaugeVec,
     pub rocksdb_estimate_pending_compaction_bytes: IntGaugeVec,
@@ -94,6 +96,7 @@ pub struct ColumnFamilyMetrics {
     pub rocksdb_estimate_oldest_key_time: IntGaugeVec,
     pub rocksdb_background_errors: IntGaugeVec,
     pub rocksdb_estimated_num_keys: IntGaugeVec,
+    pub rocksdb_base_level: IntGaugeVec,
 }
 
 impl ColumnFamilyMetrics {
@@ -109,6 +112,13 @@ impl ColumnFamilyMetrics {
             rocksdb_total_blob_files_size: register_int_gauge_vec_with_registry!(
                 "rocksdb_total_blob_files_size",
                 "The storage size occupied by the blob files in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_current_size_active_mem_tables: register_int_gauge_vec_with_registry!(
+                "rocksdb_current_size_active_mem_tables",
+                "The current approximate size of active memtable (bytes).",
                 &["cf_name"],
                 registry,
             )
@@ -178,6 +188,13 @@ impl ColumnFamilyMetrics {
                 registry,
             )
             .unwrap(),
+            rocksdb_num_immutable_mem_tables: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_immutable_mem_tables",
+                "The number of immutable memtables that have not yet been flushed.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
             rocksdb_mem_table_flush_pending: register_int_gauge_vec_with_registry!(
                 "rocksdb_mem_table_flush_pending",
                 "A 1 or 0 flag indicating whether a memtable flush is pending.
@@ -243,7 +260,13 @@ impl ColumnFamilyMetrics {
                 registry,
             )
             .unwrap(),
-
+            rocksdb_base_level: register_int_gauge_vec_with_registry!(
+                "rocksdb_base_level",
+                "The number of level to which L0 data will be compacted.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
         }
     }
 }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -985,6 +985,14 @@ impl<K, V> DBMap<K, V> {
             );
         db_metrics
             .cf_metrics
+            .rocksdb_current_size_active_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::CUR_SIZE_ACTIVE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
             .rocksdb_size_all_mem_tables
             .with_label_values(&[cf_name])
             .set(
@@ -1065,6 +1073,14 @@ impl<K, V> DBMap<K, V> {
             );
         db_metrics
             .cf_metrics
+            .rocksdb_num_immutable_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::NUM_IMMUTABLE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
             .rocksdb_mem_table_flush_pending
             .with_label_values(&[cf_name])
             .set(
@@ -1117,6 +1133,14 @@ impl<K, V> DBMap<K, V> {
             .with_label_values(&[cf_name])
             .set(
                 Self::get_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_base_level
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::BASE_LEVEL)
                     .unwrap_or(METRICS_ERROR),
             );
     }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -704,7 +704,7 @@ impl MetricConf {
         }
     }
 }
-const CF_METRICS_REPORT_PERIOD_MILLIS: u64 = 1000;
+const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;
 const METRICS_ERROR: i64 = -1;
 
 /// An interface to a rocksDB database, keyed by a columnfamily
@@ -740,7 +740,7 @@ impl<K, V> DBMap<K, V> {
         if !is_deprecated {
             tokio::task::spawn(async move {
                 let mut interval =
-                    tokio::time::interval(Duration::from_millis(CF_METRICS_REPORT_PERIOD_MILLIS));
+                    tokio::time::interval(Duration::from_secs(CF_METRICS_REPORT_PERIOD_SECS));
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
@@ -1077,6 +1077,14 @@ impl<K, V> DBMap<K, V> {
             .with_label_values(&[cf_name])
             .set(
                 Self::get_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_pending_compaction_bytes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_PENDING_COMPACTION_BYTES)
                     .unwrap_or(METRICS_ERROR),
             );
         db_metrics


### PR DESCRIPTION
## Description 

Also, increase the interval where the metric is sampled. In comments, it says reading some metrics may impact live serving traffic.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
