### PR TITLE
[GraphQL] fix health check acting up on tests

### DIFF
--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -900,6 +900,8 @@ mod tests {
         let cluster =
             sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
 
+        // We wait until checkpoint 1 is indexed, to give enough time to the
+        // watermark task to pick up a valid checkpoint timestamp.
         cluster
             .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
             .await;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -901,7 +901,7 @@ mod tests {
             sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
 
         cluster
-            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
             .await;
         test_health_check_impl().await;
         cluster.cleanup_resources().await


### PR DESCRIPTION
## Description 

Waiting a bit longer (until we've indexed checkpoint 1), to give time to the watermark task to pick up the proper timestamp in tests, otherwise the timestamp has the value of 0 causing a 504. 

https://github.com/MystenLabs/sui/blob/f6dd9a8ef91612f541405d0e2f704b1895abbc37/crates/sui-graphql-rpc/src/server/builder.rs#L658 
(`checkpoint_timestamp` being 0 would always cause this to fail as `now` is a system utc timestamp).

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
