### PR TITLE
[framework] Marks `sui::url` as deprecated

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/coin.move
+++ b/crates/sui-framework/packages/sui-framework/sources/coin.move
@@ -522,6 +522,7 @@ module sui::coin {
 
     // deprecated as we have CoinMetadata now
     #[allow(unused_field)]
+    #[deprecated(note = b"This event is deprecated in favor of `CoinMetadata`")]
     public struct CurrencyCreated<phantom T> has copy, drop {
         decimals: u8
     }

--- a/crates/sui-framework/packages/sui-framework/sources/coin.move
+++ b/crates/sui-framework/packages/sui-framework/sources/coin.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(deprecated_usage)]
 /// Defines the `Coin` type - platform wide representation of fungible
 /// tokens and coins. `Coin` can be described as a secure wrapper around
 /// `Balance` type.

--- a/crates/sui-framework/packages/sui-framework/sources/coin.move
+++ b/crates/sui-framework/packages/sui-framework/sources/coin.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(deprecated_usage)]
 /// Defines the `Coin` type - platform wide representation of fungible
 /// tokens and coins. `Coin` can be described as a secure wrapper around
 /// `Balance` type.
@@ -42,6 +41,7 @@ module sui::coin {
         balance: Balance<T>
     }
 
+    #[allow(deprecated_usage)]
     /// Each Coin type T created through `create_currency` function will have a
     /// unique instance of CoinMetadata<T> that stores the metadata for this coin type.
     public struct CoinMetadata<phantom T> has key, store {
@@ -211,6 +211,7 @@ module sui::coin {
 
     // === Registering new coin types and managing the coin supply ===
 
+    #[allow(deprecated_usage)]
     /// Create a new currency type `T` as and return the `TreasuryCap` for
     /// `T` to the caller. Can only be called with a `one-time-witness`
     /// type, ensuring that there's only one `TreasuryCap` per `T`.
@@ -242,6 +243,7 @@ module sui::coin {
         )
     }
 
+    #[allow(deprecated_usage)]
     /// This creates a new currency, via `create_currency`, but with an extra capability that
     /// allows for specific addresses to have their coins frozen. When an address is added to the
     /// deny list, it is immediately unable to interact with the currency's coin as input objects.
@@ -453,6 +455,7 @@ module sui::coin {
         metadata.description = description;
     }
 
+    #[allow(deprecated_usage)]
     /// Update the url of the coin in `CoinMetadata`
     public entry fun update_icon_url<T>(
         _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, url: ascii::String
@@ -478,6 +481,7 @@ module sui::coin {
         metadata.description
     }
 
+    #[allow(deprecated_usage)]
     public fun get_icon_url<T>(metadata: &CoinMetadata<T>): Option<Url> {
         metadata.icon_url
     }
@@ -531,6 +535,7 @@ module sui::coin {
     /// This creates a new currency, via `create_currency`, but with an extra capability that
     /// allows for specific addresses to have their coins frozen. Those addresses cannot interact
     /// with the coin as input objects.
+    #[allow(deprecated_usage)]
     #[deprecated(note = b"For new coins, use `create_regulated_currency_v2`. To migrate existing regulated currencies, migrate with `migrate_regulated_currency_to_v2`")]
     public fun create_regulated_currency<T: drop>(
         witness: T,

--- a/crates/sui-framework/packages/sui-framework/sources/url.move
+++ b/crates/sui-framework/packages/sui-framework/sources/url.move
@@ -1,11 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[deprecated(note = b"`sui::url` module is deprecated, use `std::string` instead")]
+#[allow(deprecated_usage)]
 /// URL: standard Uniform Resource Locator string
 module sui::url {
     use std::ascii::String;
 
+    #[deprecated(note = b"`sui::url::Url` type is deprecated, use `std::string::String` instead")]
     /// Standard Uniform Resource Locator (URL) string.
     public struct Url has store, copy, drop {
         // TODO: validate URL format

--- a/crates/sui-framework/packages/sui-framework/sources/url.move
+++ b/crates/sui-framework/packages/sui-framework/sources/url.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[deprecated(note = b"`sui::url` module is deprecated, use `std::string` instead")]
 /// URL: standard Uniform Resource Locator string
 module sui::url {
     use std::ascii::String;

--- a/crates/sui-framework/packages/sui-framework/tests/url_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/url_tests.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only, allow(deprecated_usage)]
+#[test_only]
 module sui::url_tests {
     use sui::url;
 

--- a/crates/sui-framework/packages/sui-framework/tests/url_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/url_tests.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only]
+#[test_only, allow(deprecated_usage)]
 module sui::url_tests {
     use sui::url;
 

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_const, deprecated_usage)]
+#[allow(unused_const)]
 module sui_system::validator {
     use std::bcs;
 
@@ -73,6 +73,7 @@ module sui_system::validator {
     /// Max gas price a validator can set is 100K MIST.
     const MAX_VALIDATOR_GAS_PRICE: u64 = 100_000;
 
+    #[allow(deprecated_usage)]
     public struct ValidatorMetadata has store {
         /// The Sui Address of the validator. This is the sender that created the Validator object,
         /// and also the address to send validator/coins to during withdraws.
@@ -160,6 +161,7 @@ module sui_system::validator {
         reward_amount: u64,
     }
 
+    #[allow(deprecated_usage)]
     public(package) fun new_metadata(
         sui_address: address,
         protocol_pubkey_bytes: vector<u8>,
@@ -203,6 +205,7 @@ module sui_system::validator {
         metadata
     }
 
+    #[allow(deprecated_usage)]
     public(package) fun new(
         sui_address: address,
         protocol_pubkey_bytes: vector<u8>,
@@ -429,10 +432,12 @@ module sui_system::validator {
         &self.metadata.description
     }
 
+    #[allow(deprecated_usage)]
     public fun image_url(self: &Validator): &Url {
         &self.metadata.image_url
     }
 
+    #[allow(deprecated_usage)]
     public fun project_url(self: &Validator): &Url {
         &self.metadata.project_url
     }
@@ -640,6 +645,7 @@ module sui_system::validator {
         self.metadata.description = description.to_ascii_string().to_string();
     }
 
+    #[allow(deprecated_usage)]
     /// Update image url of the validator.
     public(package) fun update_image_url(self: &mut Validator, image_url: vector<u8>) {
         assert!(
@@ -649,6 +655,7 @@ module sui_system::validator {
         self.metadata.image_url = url::new_unsafe_from_bytes(image_url);
     }
 
+    #[allow(deprecated_usage)]
     /// Update project url of the validator.
     public(package) fun update_project_url(self: &mut Validator, project_url: vector<u8>) {
         assert!(
@@ -879,7 +886,7 @@ module sui_system::validator {
     // validation in the process.
     // Note: `proof_of_possession` MUST be a valid signature using sui_address and
     // protocol_pubkey_bytes. To produce a valid PoP, run [fn test_proof_of_possession].
-    #[test_only]
+    #[test_only, allow(deprecated_usage)]
     public(package) fun new_for_testing(
         sui_address: address,
         protocol_pubkey_bytes: vector<u8>,

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -205,7 +205,6 @@ module sui_system::validator {
         metadata
     }
 
-    #[allow(deprecated_usage)]
     public(package) fun new(
         sui_address: address,
         protocol_pubkey_bytes: vector<u8>,
@@ -645,7 +644,6 @@ module sui_system::validator {
         self.metadata.description = description.to_ascii_string().to_string();
     }
 
-    #[allow(deprecated_usage)]
     /// Update image url of the validator.
     public(package) fun update_image_url(self: &mut Validator, image_url: vector<u8>) {
         assert!(
@@ -655,7 +653,6 @@ module sui_system::validator {
         self.metadata.image_url = url::new_unsafe_from_bytes(image_url);
     }
 
-    #[allow(deprecated_usage)]
     /// Update project url of the validator.
     public(package) fun update_project_url(self: &mut Validator, project_url: vector<u8>) {
         assert!(

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_const)]
+#[allow(unused_const, deprecated_usage)]
 module sui_system::validator {
     use std::bcs;
 

--- a/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
@@ -5,7 +5,7 @@
 // already tested by the other more themed tests such as `stake_tests` or
 // `rewards_distribution_tests`.
 
-#[test_only]
+#[test_only, allow(deprecated_usage)]
 module sui_system::sui_system_tests {
     use sui::test_scenario::{Self, Scenario};
     use sui::sui::SUI;

--- a/crates/sui-framework/packages/sui-system/tests/validator_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_tests.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only]
+#[test_only, allow(deprecated_usage)]
 module sui_system::validator_tests {
     use sui::bag;
     use sui::balance;

--- a/examples/move/nft/sources/testnet_nft.move
+++ b/examples/move/nft/sources/testnet_nft.move
@@ -2,20 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module examples::testnet_nft {
-    use sui::url::{Self, Url};
-    use std::string;
+    use std::string::String;
     use sui::event;
 
     /// An example NFT that can be minted by anybody
     public struct TestnetNFT has key, store {
         id: UID,
         /// Name for the token
-        name: string::String,
+        name: String,
         /// Description of the token
-        description: string::String,
+        description: String,
         /// URL for the token
-        url: Url,
-        // TODO: allow custom attributes
+        url: String,
     }
 
     // ===== Events =====
@@ -26,23 +24,23 @@ module examples::testnet_nft {
         // The creator of the NFT
         creator: address,
         // The name of the NFT
-        name: string::String,
+        name: String,
     }
 
     // ===== Public view functions =====
 
     /// Get the NFT's `name`
-    public fun name(nft: &TestnetNFT): &string::String {
+    public fun name(nft: &TestnetNFT): &String {
         &nft.name
     }
 
     /// Get the NFT's `description`
-    public fun description(nft: &TestnetNFT): &string::String {
+    public fun description(nft: &TestnetNFT): &String {
         &nft.description
     }
 
     /// Get the NFT's `url`
-    public fun url(nft: &TestnetNFT): &Url {
+    public fun url(nft: &TestnetNFT): &String {
         &nft.url
     }
 
@@ -51,17 +49,17 @@ module examples::testnet_nft {
     #[allow(lint(self_transfer))]
     /// Create a new devnet_nft
     public fun mint_to_sender(
-        name: vector<u8>,
-        description: vector<u8>,
-        url: vector<u8>,
+        name: String,
+        description: String,
+        url: String,
         ctx: &mut TxContext
     ) {
         let sender = ctx.sender();
         let nft = TestnetNFT {
             id: object::new(ctx),
-            name: string::utf8(name),
-            description: string::utf8(description),
-            url: url::new_unsafe_from_bytes(url)
+            name,
+            description,
+            url
         };
 
         event::emit(NFTMinted {
@@ -83,10 +81,10 @@ module examples::testnet_nft {
     /// Update the `description` of `nft` to `new_description`
     public fun update_description(
         nft: &mut TestnetNFT,
-        new_description: vector<u8>,
+        new_description: String,
         _: &mut TxContext
     ) {
-        nft.description = string::utf8(new_description)
+        nft.description = new_description;
     }
 
     /// Permanently delete `nft`


### PR DESCRIPTION
## Description 

We're deprecating this module for now. 

## Test plan 

Not much to test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
