### PR TITLE
[GraphQL] Fix more tests failing due to not waiting long enough

### DIFF
--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -66,7 +66,7 @@ mod tests {
                 .await;
 
         cluster
-            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
             .await;
 
         let query = r#"
@@ -850,7 +850,7 @@ mod tests {
             sui_graphql_rpc::test_infra::cluster::start_cluster(ConnectionConfig::default(), None)
                 .await;
         cluster
-            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
             .await;
         // timeout test includes mutation timeout, which requies a [SuiClient] to be able to run
         // the test, and a transaction. [WalletContext] gives access to everything that's needed.


### PR DESCRIPTION
## Description 

Tweaked some more tests that would randomly fail because of trying to retrieve data too early.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
