### PR TITLE
[Store] disable write stall on fullnodes perpetual db

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -199,6 +199,11 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub verifier_signing_config: VerifierSigningConfig,
+
+    /// If a value is set, it determines if writes to DB can stall, which can halt the whole process.
+    /// By default, write stall is enabled on validators but not on fullnodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_db_write_stall: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -458,11 +458,8 @@ impl SuiNode {
             None,
         ));
 
-        let enable_write_stall = if let Some(enable) = config.enable_db_write_stall {
-            enable
-        } else {
-            is_validator
-        };
+        // By default, only enable write stall on validators for perpetual db.
+        let enable_write_stall = config.enable_db_write_stall.unwrap_or(is_validator);
         let perpetual_tables_options = AuthorityPerpetualTablesOptions { enable_write_stall };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_path().join("store"),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
+use sui_core::authority::authority_store_tables::AuthorityPerpetualTablesOptions;
 use sui_core::authority::epoch_start_configuration::EpochFlag;
 use sui_core::authority::RandomnessRoundReceiver;
 use sui_core::authority::CHAIN_IDENTIFIER;
@@ -457,10 +458,15 @@ impl SuiNode {
             None,
         ));
 
-        let perpetual_options = default_db_options().optimize_db_for_write_throughput(4);
+        let enable_write_stall = if let Some(enable) = config.enable_db_write_stall {
+            enable
+        } else {
+            is_validator
+        };
+        let perpetual_tables_options = AuthorityPerpetualTablesOptions { enable_write_stall };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_path().join("store"),
-            Some(perpetual_options.options),
+            Some(perpetual_tables_options),
         ));
         let is_genesis = perpetual_tables
             .database_is_empty()

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -242,6 +242,7 @@ impl ValidatorConfigBuilder {
             enable_soft_bundle: true,
             enable_validator_tx_finalizer: true,
             verifier_signing_config: VerifierSigningConfig::default(),
+            enable_db_write_stall: None,
         }
     }
 
@@ -526,6 +527,7 @@ impl FullnodeConfigBuilder {
             // This is a validator specific feature.
             enable_validator_tx_finalizer: false,
             verifier_signing_config: VerifierSigningConfig::default(),
+            enable_db_write_stall: None,
         }
     }
 }

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -312,6 +312,14 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 remove_deprecated_tables: bool,
             ) -> Self {
                 let path = &path;
+                let default_cf_opt = if let Some(opt) = global_db_options_override.as_ref() {
+                    typed_store::rocks::DBOptions {
+                        options: opt.clone(),
+                        rw_options: typed_store::rocks::default_db_options().rw_options,
+                    }
+                } else {
+                    typed_store::rocks::default_db_options()
+                };
                 let (db, rwopt_cfs) = {
                     let opt_cfs = match tables_db_options_override {
                         None => [
@@ -321,7 +329,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         ],
                         Some(o) => [
                             #(
-                                (stringify!(#cf_names).to_owned(), o.to_map().get(stringify!(#cf_names)).unwrap().clone()),
+                                (stringify!(#cf_names).to_owned(), o.to_map().get(stringify!(#cf_names)).unwrap_or(&default_cf_opt).clone()),
                             )*
                         ]
                     };


### PR DESCRIPTION
## Description 

For fullnodes that do not prune the `perpetual` DB, especially `transactions` and `effects` cfs, they can run into write stalls occasionally that makes the fullnode non operational. Since fullnodes have to accept all writes from checkpoints, throttling writes do not seem to make much sense.

Write stalling on validators is left enabled.

## Test plan 

CI
Deploy to a few fullnodes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
