### PR TITLE
fix(ci): Disable release notes check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,22 +77,24 @@ jobs:
           locked: true
       - run: cargo xlint
 
-  # release-notes-description-check:
-  #   name: release-notes-check
-  #   needs: diff
-  #   if: needs.diff.outputs.isReleaseNotesEligible == 'true'
-  #   runs-on: [ ubuntu-latest ]
-  #   steps:
-  #     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
-  #       with:
-  #         ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-  #     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # pin@v5.0.0
-  #       with:
-  #         python-version: 3.10.10
-  #     - name: Validate PR's release notes
-  #       shell: bash
-  #       run: |
-  #         GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python ./scripts/release_notes.py check
+  release-notes-description-check:
+    name: release-notes-check
+    needs: diff
+    if: needs.diff.outputs.isReleaseNotesEligible == 'true'
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # pin@v5.0.0
+        with:
+          python-version: 3.10.10
+      - name: Validate PR's release notes
+        shell: bash
+        run: |
+          # TODO: Temporarily disabled due to bug -- re-enable when fixed.
+          # GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python ./scripts/release_notes.py check
+          true
 
   move-auto-formatter-ci-test:
     needs: diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,22 +77,22 @@ jobs:
           locked: true
       - run: cargo xlint
 
-  release-notes-description-check:
-    name: release-notes-check
-    needs: diff
-    if: needs.diff.outputs.isReleaseNotesEligible == 'true'
-    runs-on: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
-        with:
-          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # pin@v5.0.0
-        with:
-          python-version: 3.10.10
-      - name: Validate PR's release notes
-        shell: bash
-        run: |
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python ./scripts/release_notes.py check
+  # release-notes-description-check:
+  #   name: release-notes-check
+  #   needs: diff
+  #   if: needs.diff.outputs.isReleaseNotesEligible == 'true'
+  #   runs-on: [ ubuntu-latest ]
+  #   steps:
+  #     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+  #       with:
+  #         ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+  #     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # pin@v5.0.0
+  #       with:
+  #         python-version: 3.10.10
+  #     - name: Validate PR's release notes
+  #       shell: bash
+  #       run: |
+  #         GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python ./scripts/release_notes.py check
 
   move-auto-formatter-ci-test:
     needs: diff


### PR DESCRIPTION
## Description

This check is not doing the right thing, for a couple of reasons. Disabling it to unblock releases.

- Firstly, it's trying to assess the suitability of release notes by looking at the commits in the PR. This does not really make sense, because it's rare for people to fill out the release notes section in the commits -- it's part of the PR description, so most of the time, it's just going to pass because it can't find any release notes, IIUC.

- Secondly, if it can't find the PR number in the commit message, a new code path was recently (a month ago) added to try and find it by querying the GitHub API for the pull request corresponding to the commit we're currently checking. However, the default commit that we check is HEAD, which is not a commit -- HEAD for the repo in CI points to wherever they just checked out that repo to, HEAD for the github API is HEAD for the remote repo, which is the tip of main, which is what caused the problem (because the PR description for a commit in main lacked the proper release notes).

The correct long-term fix is to introduce a separate command to check the release notes for a PR, using the GitHub API -- I'm sure it's possible to get the PR number that the workflow is running for, so this seems like the most straightforward way to perform the diff and pre-land check. I added the check command initially, and it's not for that -- it's for performing a local check against commits already in `main`.

I don't think that long-term fix needs to deal with the actual commits when talking to the Github API, but in case it does, it needs to use git show-ref to translate symbolic references like HEAD into something that would be understood both locally and remotely.

CI for this check should also probably not be land-blocking because we cannot guarantee that someone doesn't change the PR description between when the job runs and when they actually land. Instead, it should run periodically on `main` and we can then follow-up on PRs to add release notes.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
