### PR TITLE
[indexer][graphql] Pruner prunes only epoch-partitioned tables

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -230,7 +230,7 @@ impl Cluster for LocalNewCluster {
             start_test_indexer(
                 Some(pg_address.clone()),
                 fullnode_url.clone(),
-                ReaderWriterConfig::writer_mode(None),
+                ReaderWriterConfig::writer_mode(None, None),
                 data_ingestion_path.clone(),
             )
             .await;

--- a/crates/sui-graphql-e2e-tests/tests/prune.exp
+++ b/crates/sui-graphql-e2e-tests/tests/prune.exp
@@ -1,0 +1,125 @@
+processed 13 tasks
+
+task 1, lines 6-25:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 27:
+//# run Test::M1::create --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 29:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 31:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 33:
+//# run Test::M1::create --args 1 @A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 35:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 37:
+//# advance-epoch
+Epoch advanced: 1
+
+task 8, line 39:
+//# run Test::M1::create --args 2 @A
+created: object(8,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 41:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 10, line 43:
+//# advance-epoch
+Epoch advanced: 2
+
+task 11, lines 45-55:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "epoch": {
+            "epochId": 0
+          },
+          "sequenceNumber": 0
+        },
+        {
+          "epoch": {
+            "epochId": 0
+          },
+          "sequenceNumber": 1
+        },
+        {
+          "epoch": {
+            "epochId": 0
+          },
+          "sequenceNumber": 2
+        },
+        {
+          "epoch": {
+            "epochId": 1
+          },
+          "sequenceNumber": 3
+        },
+        {
+          "epoch": {
+            "epochId": 1
+          },
+          "sequenceNumber": 4
+        },
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 5
+        },
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 6
+        }
+      ]
+    }
+  }
+}
+
+task 12, lines 58-68:
+//# run-graphql --wait-for-checkpoint-pruned 0
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 5
+        },
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 6
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/prune.move
+++ b/crates/sui-graphql-e2e-tests/tests/prune.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 51 --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 2
+
+//# publish
+module Test::M1 {
+    use sui::coin::Coin;
+
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    fun foo<T: key, T2: drop>(_p1: u64, value1: T, _value2: &Coin<T2>, _p2: u64): T {
+        value1
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::create --args 1 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::create --args 2 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+{
+  checkpoints {
+    nodes {
+      epoch {
+        epochId
+      }
+      sequenceNumber
+    }
+  }
+}
+
+
+//# run-graphql --wait-for-checkpoint-pruned 0
+{
+  checkpoints {
+    nodes {
+      epoch {
+        epochId
+      }
+      sequenceNumber
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -45,6 +45,7 @@ mod tests {
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
+            None,
             data_ingestion_path,
         )
         .await;
@@ -128,6 +129,7 @@ mod tests {
             ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
             None,
             data_ingestion_path,
         )

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -157,6 +157,7 @@ mod tests {
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
+            None,
             data_ingestion_path,
         )
         .await;
@@ -222,6 +223,7 @@ mod tests {
             ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
             None,
             data_ingestion_path,
         )

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -103,6 +103,12 @@ impl Indexer {
         )
         .await?;
 
+        let epochs_to_keep = epochs_to_keep.or_else(|| {
+            std::env::var("EPOCHS_TO_KEEP")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+        });
+
         if let Some(epochs_to_keep) = epochs_to_keep {
             info!(
                 "Starting indexer pruner with epochs to keep: {}",

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -50,6 +50,7 @@ impl Indexer {
             store,
             metrics,
             snapshot_config,
+            None,
             CancellationToken::new(),
         )
         .await
@@ -60,6 +61,7 @@ impl Indexer {
         store: PgIndexerStore,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
+        epochs_to_keep: Option<u64>,
         cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
         info!(
@@ -101,9 +103,6 @@ impl Indexer {
         )
         .await?;
 
-        let epochs_to_keep = std::env::var("EPOCHS_TO_KEEP")
-            .map(|s| s.parse::<u64>().ok())
-            .unwrap_or_else(|_e| None);
         if let Some(epochs_to_keep) = epochs_to_keep {
             info!(
                 "Starting indexer pruner with epochs to keep: {}",

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -37,6 +37,8 @@ impl ReaderWriterConfig {
         }
     }
 
+    /// Instantiates a config for indexer in writer mode with the given snapshot config and epochs
+    /// to keep.
     pub fn writer_mode(
         snapshot_config: Option<SnapshotLagConfig>,
         epochs_to_keep: Option<u64>,

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -21,8 +21,13 @@ use crate::store::PgIndexerStore;
 use crate::{IndexerConfig, IndexerMetrics};
 
 pub enum ReaderWriterConfig {
-    Reader { reader_mode_rpc_url: String },
-    Writer { snapshot_config: SnapshotLagConfig },
+    Reader {
+        reader_mode_rpc_url: String,
+    },
+    Writer {
+        snapshot_config: SnapshotLagConfig,
+        epochs_to_keep: Option<u64>,
+    },
 }
 
 impl ReaderWriterConfig {
@@ -32,9 +37,13 @@ impl ReaderWriterConfig {
         }
     }
 
-    pub fn writer_mode(snapshot_config: Option<SnapshotLagConfig>) -> Self {
+    pub fn writer_mode(
+        snapshot_config: Option<SnapshotLagConfig>,
+        epochs_to_keep: Option<u64>,
+    ) -> Self {
         Self::Writer {
             snapshot_config: snapshot_config.unwrap_or_default(),
+            epochs_to_keep,
         }
     }
 }
@@ -142,7 +151,10 @@ pub async fn start_test_indexer_impl(
             config.rpc_server_port = reader_mode_rpc_url.port();
             tokio::spawn(async move { Indexer::start_reader(&config, &registry, db_url).await })
         }
-        ReaderWriterConfig::Writer { snapshot_config } => {
+        ReaderWriterConfig::Writer {
+            snapshot_config,
+            epochs_to_keep,
+        } => {
             if config.reset_db {
                 crate::db::reset_database(&mut blocking_pool.get().unwrap()).unwrap();
             }
@@ -154,6 +166,7 @@ pub async fn start_test_indexer_impl(
                     store_clone,
                     indexer_metrics,
                     snapshot_config,
+                    epochs_to_keep,
                     cancel,
                 )
                 .await

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -60,7 +60,7 @@ mod ingestion_tests {
         let (pg_store, pg_handle) = start_test_indexer(
             Some(DEFAULT_DB_URL.to_owned()),
             format!("http://{}", server_url),
-            ReaderWriterConfig::writer_mode(None),
+            ReaderWriterConfig::writer_mode(None, None),
             data_ingestion_path,
         )
         .await;

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -67,6 +67,10 @@ pub struct SuiInitArgs {
     pub object_snapshot_max_checkpoint_lag: Option<usize>,
     #[clap(long = "flavor")]
     pub flavor: Option<Flavor>,
+    /// The number of epochs to keep in the database. Epochs outside of this range will be pruned by
+    /// the indexer.
+    #[clap(long = "epochs-to-keep")]
+    pub epochs_to_keep: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -165,6 +169,8 @@ pub struct RunGraphqlCommand {
     pub show_service_version: bool,
     #[clap(long, num_args(1..))]
     pub cursors: Vec<String>,
+    #[clap(long)]
+    pub wait_for_checkpoint_pruned: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -704,7 +704,7 @@ async fn start(
         start_test_indexer(
             Some(pg_address.clone()),
             fullnode_url.clone(),
-            ReaderWriterConfig::writer_mode(None),
+            ReaderWriterConfig::writer_mode(None, None),
             data_ingestion_path.clone(),
         )
         .await;


### PR DESCRIPTION
## Description 

Currently, the pruner assumes that all partitioned tables are partitioned on epoch, which is an issue since `objects_version` is not partitioned by epoch. Modify the pruner so that it will filter out non-epoch-partitioned tables, and otherwise do the same thing.

Change `EPOCHS_TO_KEEP` from an env variable to a config, so we can pass in test values through the transactional test runner, and a prune.move test to validate that we prune epoch data without any trouble.

## Test plan 

prune.move

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
