### PR TITLE
[bridge-indexer] fix duplicated task creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13693,6 +13693,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "sui-data-ingestion-core",
+ "sui-indexer-builder",
  "sui-types",
  "tap",
  "telemetry-subscribers",

--- a/crates/sui-indexer-builder/Cargo.toml
+++ b/crates/sui-indexer-builder/Cargo.toml
@@ -17,3 +17,9 @@ sui-data-ingestion-core.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
 telemetry-subscribers.workspace = true
+
+[dev-dependencies]
+sui-indexer-builder = { workspace = true, features = ["test-utils"] }
+
+[features]
+test-utils = []

--- a/crates/sui-indexer-builder/src/indexer_builder.rs
+++ b/crates/sui-indexer-builder/src/indexer_builder.rs
@@ -94,10 +94,11 @@ impl<P, D, M> Indexer<P, D, M> {
             .tap_ok(|_| {
                 tracing::info!(task_name, "Tasks updated.");
             })?;
-        // get updated tasks from storage and start workers
-        let updated_tasks = self
+
+        // get ongoing tasks from storage
+        let ongoing_tasks = self
             .storage
-            .tasks(&self.name)
+            .get_ongoing_tasks(&self.name)
             .await
             .tap_err(|e| {
                 tracing::error!(task_name, "Failed to get updated tasks: {:?}", e);
@@ -109,7 +110,7 @@ impl<P, D, M> Indexer<P, D, M> {
         // Start latest checkpoint worker
         // Tasks are ordered in checkpoint descending order, realtime update task always come first
         // tasks won't be empty here, ok to unwrap.
-        let live_task_future = match updated_tasks.live_task() {
+        let live_task_future = match ongoing_tasks.live_task() {
             Some(live_task) if !self.disable_live_task => {
                 let live_task_future = self.datasource.start_ingestion_task(
                     live_task.task_name.clone(),
@@ -123,7 +124,7 @@ impl<P, D, M> Indexer<P, D, M> {
             _ => None,
         };
 
-        let backfill_tasks = updated_tasks.backfill_tasks();
+        let backfill_tasks = ongoing_tasks.backfill_tasks();
         let storage_clone = self.storage.clone();
         let data_mapper_clone = self.data_mapper.clone();
         let datasource_clone = self.datasource.clone();
@@ -159,20 +160,20 @@ impl<P, D, M> Indexer<P, D, M> {
     where
         P: Persistent<R>,
     {
-        let tasks = self.storage.tasks(&self.name).await?;
-        let backfill_tasks = tasks.backfill_tasks();
-        let latest_backfill_task = backfill_tasks.first();
+        let ongoing_tasks = self.storage.get_ongoing_tasks(&self.name).await?;
+        let largest_checkpoint = self
+            .storage
+            .get_largest_backfill_task_target_checkpoint(&self.name)
+            .await?;
 
         // 1, create and update live task if needed
         if !self.disable_live_task {
             let from_checkpoint = max(
                 self.start_from_checkpoint,
-                latest_backfill_task
-                    .map(|t| t.target_checkpoint + 1)
-                    .unwrap_or_default(),
+                largest_checkpoint.map(|cp| cp + 1).unwrap_or_default(),
             );
 
-            match tasks.live_task() {
+            match ongoing_tasks.live_task() {
                 None => {
                     self.storage
                         .register_task(
@@ -204,43 +205,32 @@ impl<P, D, M> Indexer<P, D, M> {
             }
         }
 
-        // 2, create backfill tasks base on task config and existing tasks in the db
-        match latest_backfill_task {
-            None => {
-                // No task in database, create backfill tasks from genesis to `start_from_checkpoint`
-                if self.start_from_checkpoint != self.genesis_checkpoint {
-                    self.create_backfill_tasks(
+        // 2, if there is a gap between `largest_checkpoint` and `start_from_checkpoint`,
+        // create backfill task [largest_checkpoint + 1, start_from_checkpoint - 1]
+
+        // TODO: when there is a hole, we create one task for the hole, but ideally we should
+        // honor the partition size and create as needed.
+        let from_checkpoint = largest_checkpoint
+            .map(|cp| cp + 1)
+            .unwrap_or(self.genesis_checkpoint);
+        if from_checkpoint < self.start_from_checkpoint {
+            self.create_backfill_tasks(from_checkpoint, self.start_from_checkpoint - 1)
+                .await
+                .tap_ok(|_| {
+                    tracing::info!(
+                        "Created backfill tasks ({}-{})",
+                        from_checkpoint,
+                        self.start_from_checkpoint - 1
+                    );
+                })
+                .tap_err(|e| {
+                    tracing::error!(
+                        "Failed to create backfill tasks ({}-{}): {:?}",
                         self.genesis_checkpoint,
                         self.start_from_checkpoint - 1,
-                    )
-                    .await
-                    .tap_err(|e| {
-                        tracing::error!(
-                            "Failed to create backfill tasks ({}-{}): {:?}",
-                            self.genesis_checkpoint,
-                            self.start_from_checkpoint - 1,
-                            e
-                        );
-                    })?;
-                }
-            }
-            Some(latest_backfill_task) => {
-                if latest_backfill_task.target_checkpoint + 1 < self.start_from_checkpoint {
-                    self.create_backfill_tasks(
-                        latest_backfill_task.target_checkpoint + 1,
-                        self.start_from_checkpoint - 1,
-                    )
-                    .await
-                    .tap_err(|e| {
-                        tracing::error!(
-                            "Failed to create backfill tasks ({}-{}): {:?}",
-                            latest_backfill_task.target_checkpoint + 1,
-                            self.start_from_checkpoint - 1,
-                            e
-                        );
-                    })?;
-                }
-            }
+                        e
+                    );
+                })?;
         }
         Ok(())
     }
@@ -278,6 +268,22 @@ impl<P, D, M> Indexer<P, D, M> {
             BackfillStrategy::Disabled => Ok(()),
         }
     }
+
+    #[cfg(any(feature = "test-utils", test))]
+    pub async fn test_only_update_tasks<R>(&mut self) -> Result<(), Error>
+    where
+        P: Persistent<R>,
+    {
+        self.update_tasks().await
+    }
+
+    #[cfg(any(feature = "test-utils", test))]
+    pub fn test_only_storage<R>(&self) -> &P
+    where
+        P: Persistent<R>,
+    {
+        &self.storage
+    }
 }
 
 #[async_trait]
@@ -294,7 +300,12 @@ pub trait IndexerProgressStore: Send {
         checkpoint_number: u64,
     ) -> anyhow::Result<()>;
 
-    async fn tasks(&self, task_prefix: &str) -> Result<Vec<Task>, Error>;
+    async fn get_ongoing_tasks(&self, task_prefix: &str) -> Result<Vec<Task>, Error>;
+
+    async fn get_largest_backfill_task_target_checkpoint(
+        &self,
+        task_prefix: &str,
+    ) -> Result<Option<u64>, Error>;
 
     async fn register_task(
         &mut self,

--- a/crates/sui-indexer-builder/tests/indexer_tests.rs
+++ b/crates/sui-indexer-builder/tests/indexer_tests.rs
@@ -3,9 +3,7 @@
 
 use crate::indexer_test_utils::{InMemoryPersistent, NoopDataMapper, TestDatasource};
 use prometheus::Registry;
-use sui_indexer_builder::indexer_builder::{
-    BackfillStrategy, IndexerBuilder, IndexerProgressStore,
-};
+use sui_indexer_builder::indexer_builder::{BackfillStrategy, IndexerBuilder};
 use sui_indexer_builder::Task;
 
 mod indexer_test_utils;
@@ -19,24 +17,23 @@ async fn indexer_simple_backfill_task_test() {
     let data = (0..=10u64).collect::<Vec<_>>();
     let datasource = TestDatasource { data: data.clone() };
     let persistent = InMemoryPersistent::new();
-    let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper).build(
+    let mut indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper).build(
         5,
         0,
         persistent.clone(),
     );
-
+    indexer.test_only_update_tasks().await.unwrap();
+    let tasks = indexer
+        .test_only_storage()
+        .get_all_tasks("test_indexer")
+        .await
+        .unwrap();
+    assert_ranges(&tasks, vec![(5, i64::MAX as u64), (0, 4)]);
     indexer.start().await.unwrap();
 
     // it should have 2 task created for the indexer - a live task and a backfill task
-    let tasks = persistent.tasks("test_indexer").await.unwrap();
-    assert_eq!(2, tasks.len());
-    // the tasks should be ordered by checkpoint number,
-    // the first one will be the live task and second one will be the backfill
-    assert_eq!(10, tasks.first().unwrap().checkpoint);
-    assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
-    assert_eq!(4, tasks.last().unwrap().checkpoint);
-    assert_eq!(4, tasks.last().unwrap().target_checkpoint);
-
+    let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    assert_ranges(&tasks, vec![(10, i64::MAX as u64), (4, 4)]);
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();
@@ -52,26 +49,27 @@ async fn indexer_partitioned_backfill_task_test() {
     let data = (0..=50u64).collect::<Vec<_>>();
     let datasource = TestDatasource { data: data.clone() };
     let persistent = InMemoryPersistent::new();
-    let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
+    let mut indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
         .with_backfill_strategy(BackfillStrategy::Partitioned { task_size: 10 })
         .build(35, 0, persistent.clone());
+    indexer.test_only_update_tasks().await.unwrap();
+    let tasks = indexer
+        .test_only_storage()
+        .get_all_tasks("test_indexer")
+        .await
+        .unwrap();
+    assert_ranges(
+        &tasks,
+        vec![(35, i64::MAX as u64), (30, 34), (20, 29), (10, 19), (0, 9)],
+    );
     indexer.start().await.unwrap();
 
     // it should have 5 task created for the indexer - a live task and 4 backfill task
-    let tasks = persistent.tasks("test_indexer").await.unwrap();
-    assert_eq!(5, tasks.len());
-    // the tasks should be ordered by checkpoint number,
-    // the first one will be the live task and rest will be the backfills
-    assert_eq!(50, tasks.first().unwrap().checkpoint);
-    assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
-    assert_eq!(34, tasks.get(1).unwrap().checkpoint);
-    assert_eq!(34, tasks.get(1).unwrap().target_checkpoint);
-    assert_eq!(29, tasks.get(2).unwrap().checkpoint);
-    assert_eq!(29, tasks.get(2).unwrap().target_checkpoint);
-    assert_eq!(19, tasks.get(3).unwrap().checkpoint);
-    assert_eq!(19, tasks.get(3).unwrap().target_checkpoint);
-    assert_eq!(9, tasks.get(4).unwrap().checkpoint);
-    assert_eq!(9, tasks.get(4).unwrap().target_checkpoint);
+    let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    assert_ranges(
+        &tasks,
+        vec![(50, i64::MAX as u64), (34, 34), (29, 29), (19, 19), (9, 9)],
+    );
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();
@@ -97,17 +95,22 @@ async fn indexer_partitioned_task_with_data_already_in_db_test() {
             timestamp: 0,
         },
     );
-    let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
+    let mut indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
         .with_backfill_strategy(BackfillStrategy::Partitioned { task_size: 10 })
         .build(25, 0, persistent.clone());
+    indexer.test_only_update_tasks().await.unwrap();
+    let tasks = indexer
+        .test_only_storage()
+        .get_all_tasks("test_indexer")
+        .await
+        .unwrap();
+    assert_ranges(&tasks, vec![(31, i64::MAX as u64), (30, 30)]);
     indexer.start().await.unwrap();
 
     // it should have 2 task created for the indexer, one existing task and one live task
-    let tasks = persistent.tasks("test_indexer").await.unwrap();
+    let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    assert_ranges(&tasks, vec![(50, i64::MAX as u64), (30, 30)]);
     assert_eq!(2, tasks.len());
-    // the first one will be the live task
-    assert_eq!(50, tasks.first().unwrap().checkpoint);
-    assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();
@@ -133,26 +136,80 @@ async fn indexer_partitioned_task_with_data_already_in_db_test2() {
             timestamp: 0,
         },
     );
-    let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
+    let mut indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
         .with_backfill_strategy(BackfillStrategy::Partitioned { task_size: 10 })
         .build(35, 0, persistent.clone());
+    indexer.test_only_update_tasks().await.unwrap();
+    let tasks = indexer
+        .test_only_storage()
+        .get_all_tasks("test_indexer")
+        .await
+        .unwrap();
+    assert_ranges(&tasks, vec![(35, i64::MAX as u64), (31, 34), (30, 30)]);
     indexer.start().await.unwrap();
 
     // it should have 3 task created for the indexer, existing task, a backfill task from cp 31 to cp 34, and a live task
-    let tasks = persistent.tasks("test_indexer").await.unwrap();
-    assert_eq!(3, tasks.len());
-    // the tasks should be ordered by checkpoint number,
-    // the first one will be the live task and rest will be the backfills
-    assert_eq!(50, tasks.first().unwrap().checkpoint);
-    assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
-    assert_eq!(34, tasks.get(1).unwrap().checkpoint);
-    assert_eq!(34, tasks.get(1).unwrap().target_checkpoint);
-    assert_eq!(30, tasks.get(2).unwrap().checkpoint);
-    assert_eq!(30, tasks.get(2).unwrap().target_checkpoint);
+    let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    assert_ranges(&tasks, vec![(50, i64::MAX as u64), (34, 34), (30, 30)]);
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();
     assert_eq!(data, recorded_data);
+}
+
+// The latest backfill task is done but earlier are not.
+// `starting_from` is small or no new backfill task is created
+#[tokio::test]
+async fn indexer_partitioned_task_with_data_already_in_db_test3() {
+    telemetry_subscribers::init_for_testing();
+    let registry = Registry::new();
+    mysten_metrics::init_metrics(&registry);
+
+    let data = (0..=50u64).collect::<Vec<_>>();
+    let datasource = TestDatasource { data: data.clone() };
+    let persistent = InMemoryPersistent::new();
+    persistent.progress_store.lock().await.insert(
+        "test_indexer - backfill - 20:30".to_string(),
+        Task {
+            task_name: "test_indexer - backfill - 20:30".to_string(),
+            checkpoint: 30,
+            target_checkpoint: 30,
+            timestamp: 0,
+        },
+    );
+    persistent.progress_store.lock().await.insert(
+        "test_indexer - backfill - 10:19".to_string(),
+        Task {
+            task_name: "test_indexer - backfill - 10:19".to_string(),
+            checkpoint: 10,
+            target_checkpoint: 19,
+            timestamp: 0,
+        },
+    );
+    let mut indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
+        .with_backfill_strategy(BackfillStrategy::Partitioned { task_size: 10 })
+        .build(28, 0, persistent.clone());
+    indexer.test_only_update_tasks().await.unwrap();
+    let tasks = indexer
+        .test_only_storage()
+        .get_all_tasks("test_indexer")
+        .await
+        .unwrap();
+    assert_ranges(&tasks, vec![(31, i64::MAX as u64), (30, 30), (10, 19)]);
+    indexer.start().await.unwrap();
+
+    let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    assert_ranges(&tasks, vec![(50, i64::MAX as u64), (30, 30), (19, 19)]);
+}
+
+fn assert_ranges(desc_ordered_tasks: &[Task], ranges: Vec<(u64, u64)>) {
+    assert!(desc_ordered_tasks.len() == ranges.len());
+    let mut iter = desc_ordered_tasks.iter();
+    for (start, end) in ranges {
+        let task = iter.next().unwrap();
+        assert_eq!(start, task.checkpoint);
+        assert_eq!(end, task.target_checkpoint);
+    }
 }
 
 #[tokio::test]
@@ -173,17 +230,21 @@ async fn resume_test() {
             timestamp: 0,
         },
     );
-    let indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
+    let mut indexer = IndexerBuilder::new("test_indexer", datasource, NoopDataMapper)
         .with_backfill_strategy(BackfillStrategy::Simple)
         .build(30, 0, persistent.clone());
+    indexer.test_only_update_tasks().await.unwrap();
+    let tasks = indexer
+        .test_only_storage()
+        .get_all_tasks("test_indexer")
+        .await
+        .unwrap();
+    assert_ranges(&tasks, vec![(31, i64::MAX as u64), (10, 30)]);
     indexer.start().await.unwrap();
 
     // it should have 2 task created for the indexer, one existing task and one live task
-    let tasks = persistent.tasks("test_indexer").await.unwrap();
-    assert_eq!(2, tasks.len());
-    // the first one will be the live task
-    assert_eq!(50, tasks.first().unwrap().checkpoint);
-    assert_eq!(i64::MAX as u64, tasks.first().unwrap().target_checkpoint);
+    let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    assert_ranges(&tasks, vec![(50, i64::MAX as u64), (30, 30)]);
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();


### PR DESCRIPTION
## Description 

In function `tasks()` we return only incomplete tasks. As a result, when the latest backfill tasks are done and ignored, we mistakenly use an intermediate value as the `latest target checkpoint` and use it to fill gaps. This causes duplicated tasks. This PR fixes it:
1. rename `tasks` to `get_ongoing_tasks` for semantics
2. add `get_largest_backfill_task_target_checkpoint` and use that to determine whether there is a gap
3. simplify `update_tasks` for backfill task creation
4. add some utils functions for testing.



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
