### PR TITLE
[walrus/sui-proxy] example of extending sui-proxy for additional use …

### DIFF
--- a/crates/sui-proxy/src/lib.rs
+++ b/crates/sui-proxy/src/lib.rs
@@ -11,6 +11,7 @@ pub mod middleware;
 pub mod peers;
 pub mod prom_to_mimir;
 pub mod remote_write;
+pub mod walrus;
 
 /// var extracts environment variables at runtime with a default fallback value
 /// if a default is not provided, the value is simply an empty string if not found

--- a/crates/sui-proxy/src/walrus.rs
+++ b/crates/sui-proxy/src/walrus.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::peers::{SuiPeer, SuiPeers};
+
+use sui_tls::Allower;
+
+/// AllowWalrus will allow walrus nodes
+#[derive(Debug, Clone, Default)]
+pub struct WalrusProvider {
+    peers: SuiPeers,
+}
+
+impl Allower for WalrusProvider {
+    fn allowed(&self, key: &Ed25519PublicKey) -> bool {
+        // Place whatever logic you need here, see the HashSetAllow in sui-tls::verifier
+        // for a specific example.
+        // eg you could do this:
+        self.peers.read().unwrap().contains_key(key)
+    }
+}
+
+impl WalrusProvider {
+    pub fn new(peers: Vec<SuiPeer>) -> Self {
+        // build our hashmap with the static pub keys. we only do this one time at binary startup.
+        let statics: HashMap<Ed25519PublicKey, SuiPeer> = peers
+            .into_iter()
+            .map(|v| (v.public_key.clone(), v))
+            .collect();
+        Self { peers: statics }
+    }
+}


### PR DESCRIPTION
## Description
this pr demos how to add additional routes to the server without changing or affecting the existing behavior of sui node.  It allows for limitless additions and configuration in distinct code paths isolated from existing behavior and will reduce the likelihood of breaking other parts of the proxy when extending the features.

## Test Plan

cargo fmt

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
