### PR TITLE
[bridge-indexer] change live task start point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13685,6 +13685,7 @@ dependencies = [
  "prometheus",
  "sui-data-ingestion-core",
  "sui-indexer-builder",
+ "sui-sdk 1.33.0",
  "sui-types",
  "tap",
  "telemetry-subscribers",

--- a/crates/sui-bridge-indexer/src/config.rs
+++ b/crates/sui-bridge-indexer/src/config.rs
@@ -8,20 +8,22 @@ use std::env;
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct IndexerConfig {
     pub remote_store_url: String,
+    pub checkpoints_path: String,
+
+    pub sui_rpc_url: String,
     pub eth_rpc_url: String,
+    pub eth_ws_url: String,
+
     #[serde(default = "default_db_url")]
     pub db_url: String,
-    pub eth_ws_url: String,
-    pub checkpoints_path: String,
     pub concurrency: u64,
-    pub bridge_genesis_checkpoint: u64,
+    /// Used as the starting checkpoint for backfill tasks when indexer starts with an empty DB.
+    pub sui_bridge_genesis_checkpoint: u64,
+    /// Used as the starting checkpoint for backfill tasks when indexer starts with an empty DB.
+    pub eth_bridge_genesis_block: u64,
     pub eth_sui_bridge_contract_address: String,
-    pub start_block: u64,
-    pub metric_url: String,
+
     pub metric_port: u16,
-    pub sui_rpc_url: Option<String>,
-    pub back_fill_lot_size: u64,
-    pub resume_from_checkpoint: Option<u64>,
 }
 
 impl sui_config::Config for IndexerConfig {}

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -1,15 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::path::PathBuf;
-use std::sync::Arc;
-
 use anyhow::Result;
 use clap::*;
-use ethers::providers::Http;
-use ethers::providers::Middleware;
-use ethers::providers::Provider;
+use std::collections::HashSet;
+use std::env;
+use std::net::IpAddr;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::Arc;
 use sui_bridge_indexer::eth_bridge_indexer::EthSubscriptionDatasource;
 use sui_bridge_indexer::eth_bridge_indexer::EthSyncDatasource;
 use tokio::task::JoinHandle;
@@ -18,6 +17,8 @@ use tracing::info;
 use mysten_metrics::metered_channel::channel;
 use mysten_metrics::spawn_logged_monitored_task;
 use mysten_metrics::start_prometheus_server;
+use sui_bridge::eth_client::EthClient;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
 use sui_bridge::metrics::BridgeMetrics;
 use sui_bridge_indexer::config::IndexerConfig;
 use sui_bridge_indexer::eth_bridge_indexer::EthDataMapper;
@@ -58,19 +59,13 @@ async fn main() -> Result<()> {
     let config = IndexerConfig::load(&config_path)?;
 
     // Init metrics server
-    let registry_service = start_prometheus_server(
-        format!("{}:{}", config.metric_url, config.metric_port,)
-            .parse()
-            .unwrap_or_else(|err| panic!("Failed to parse metric address: {}", err)),
-    );
+    let metrics_address =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), config.metric_port);
+    let registry_service = start_prometheus_server(metrics_address);
     let registry = registry_service.default_registry();
-
     mysten_metrics::init_metrics(&registry);
+    info!("Metrics server started at port {}", config.metric_port);
 
-    info!(
-        "Metrics server started at {}::{}",
-        config.metric_url, config.metric_port
-    );
     let indexer_meterics = BridgeIndexerMetrics::new(&registry);
     let ingestion_metrics = DataIngestionMetrics::new(&registry);
     let bridge_metrics = Arc::new(BridgeMetrics::new(&registry));
@@ -78,30 +73,34 @@ async fn main() -> Result<()> {
     let db_url = config.db_url.clone();
     let datastore = PgBridgePersistent::new(get_connection_pool(db_url.clone()).await);
 
-    let provider = Arc::new(
-        Provider::<Http>::try_from(config.eth_rpc_url.clone())?
-            .interval(std::time::Duration::from_millis(2000)),
+    let eth_client: Arc<EthClient<MeteredEthHttpProvier>> = Arc::new(
+        EthClient::<MeteredEthHttpProvier>::new(
+            &config.eth_rpc_url,
+            HashSet::from_iter(vec![]), // dummy
+            bridge_metrics.clone(),
+        )
+        .await?,
     );
 
-    let current_block = provider.get_block_number().await?.as_u64();
-    let subscription_end_block = u64::MAX;
-
     // Start the eth subscription indexer
-
     let eth_subscription_datasource = EthSubscriptionDatasource::new(
         config.eth_sui_bridge_contract_address.clone(),
+        eth_client.clone(),
         config.eth_ws_url.clone(),
         indexer_meterics.clone(),
-    )?;
+        config.eth_bridge_genesis_block,
+    )
+    .await?;
     let eth_subscription_indexer = IndexerBuilder::new(
         "EthBridgeSubscriptionIndexer",
         eth_subscription_datasource,
         EthDataMapper {
             metrics: indexer_meterics.clone(),
         },
+        datastore.clone(),
     )
     .with_backfill_strategy(BackfillStrategy::Disabled)
-    .build(current_block, subscription_end_block, datastore.clone());
+    .build();
     let subscription_indexer_fut = spawn_logged_monitored_task!(eth_subscription_indexer.start());
 
     // Start the eth sync data source
@@ -110,57 +109,53 @@ async fn main() -> Result<()> {
         config.eth_rpc_url.clone(),
         indexer_meterics.clone(),
         bridge_metrics.clone(),
-    )?;
+        config.eth_bridge_genesis_block,
+    )
+    .await?;
     let eth_sync_indexer = IndexerBuilder::new(
         "EthBridgeSyncIndexer",
         eth_sync_datasource,
         EthDataMapper {
             metrics: indexer_meterics.clone(),
         },
+        datastore.clone(),
     )
     .with_backfill_strategy(BackfillStrategy::Partitioned { task_size: 1000 })
     .disable_live_task()
-    .build(current_block, config.start_block, datastore.clone());
+    .build();
     let sync_indexer_fut = spawn_logged_monitored_task!(eth_sync_indexer.start());
 
-    if let Some(sui_rpc_url) = config.sui_rpc_url.clone() {
-        // Todo: impl datasource for sui RPC datasource
-        start_processing_sui_checkpoints_by_querying_txns(
-            sui_rpc_url,
-            db_url.clone(),
-            indexer_meterics.clone(),
-            bridge_metrics,
-        )
-        .await?;
-    } else {
-        let sui_checkpoint_datasource = SuiCheckpointDatasource::new(
-            config.remote_store_url,
-            config.concurrency as usize,
-            config.checkpoints_path.clone().into(),
-            ingestion_metrics.clone(),
-        );
-        let indexer = IndexerBuilder::new(
-            "SuiBridgeIndexer",
-            sui_checkpoint_datasource,
-            SuiBridgeDataMapper {
-                metrics: indexer_meterics.clone(),
-            },
-        )
-        .build(
-            config
-                .resume_from_checkpoint
-                .unwrap_or(config.bridge_genesis_checkpoint),
-            config.bridge_genesis_checkpoint,
-            datastore,
-        );
-        indexer.start().await?;
-    }
+    let sui_client = Arc::new(
+        SuiClientBuilder::default()
+            .build(config.sui_rpc_url.clone())
+            .await?,
+    );
+    let sui_checkpoint_datasource = SuiCheckpointDatasource::new(
+        config.remote_store_url,
+        sui_client,
+        config.concurrency as usize,
+        config.checkpoints_path.clone().into(),
+        config.sui_bridge_genesis_checkpoint,
+        ingestion_metrics.clone(),
+    );
+    let indexer = IndexerBuilder::new(
+        "SuiBridgeIndexer",
+        sui_checkpoint_datasource,
+        SuiBridgeDataMapper {
+            metrics: indexer_meterics.clone(),
+        },
+        datastore,
+    )
+    .build();
+    indexer.start().await?;
+
     // These tasks should not finish
     subscription_indexer_fut.await.unwrap().unwrap();
     sync_indexer_fut.await.unwrap().unwrap();
     Ok(())
 }
 
+#[allow(unused)]
 async fn start_processing_sui_checkpoints_by_querying_txns(
     sui_rpc_url: String,
     db_url: String,

--- a/crates/sui-indexer-builder/Cargo.toml
+++ b/crates/sui-indexer-builder/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { workspace = true, features = ["full"] }
 async-trait.workspace = true
 mysten-metrics.workspace = true
 sui-types.workspace = true
+sui-sdk.workspace = true
 sui-data-ingestion-core.workspace = true
 tracing.workspace = true
 prometheus.workspace = true

--- a/crates/sui-indexer-builder/tests/indexer_test_utils.rs
+++ b/crates/sui-indexer-builder/tests/indexer_test_utils.rs
@@ -19,6 +19,8 @@ use sui_indexer_builder::Task;
 
 pub struct TestDatasource<T> {
     pub data: Vec<T>,
+    pub live_task_starting_checkpoint: u64,
+    pub genesis_checkpoint: u64,
 }
 
 #[async_trait]
@@ -44,6 +46,14 @@ where
             }
             Ok(())
         }))
+    }
+
+    async fn get_live_task_starting_checkpoint(&self) -> Result<u64, Error> {
+        Ok(self.live_task_starting_checkpoint)
+    }
+
+    fn get_genesis_height(&self) -> u64 {
+        self.genesis_checkpoint
     }
 }
 
@@ -126,6 +136,7 @@ impl<T: Send + Sync> IndexerProgressStore for InMemoryPersistent<T> {
             .await
             .values()
             .filter(|task| task.task_name.starts_with(task_prefix))
+            .filter(|task| task.target_checkpoint.ne(&(i64::MAX as u64)))
             .max_by(|t1, t2| t1.target_checkpoint.cmp(&t2.target_checkpoint))
             .map(|t| t.target_checkpoint))
     }


### PR DESCRIPTION
## Description 
1. now the live task's starting height is always `get_live_task_starting_checkpoint`. See the comment for more consideration. Previously we used a value in config to determine.
2. add `fn get_live_task_starting_checkpoint` and `fn get_genesis_height` to `DataSource` trait. Therefore each datasource implements their own method to pick these values to determine task ranges, as opposed to we do it on `main.rs` today.
3. clean up `fn build` for `IndexerBuilder` by moving existing parameters to elsewhere.
4. remove unused parameters in indexer config

## Test plan 

tests and more tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
