### PR TITLE
[move-ide] Fixes auto-completion for fields

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -478,13 +478,13 @@ fn datatype_completion(
         (
             format!("{field_container}{{..}}"),
             // more than two named fields, each on a separate line
-            format!("{field_container}{{\n\t{fields_list},\n}}"),
+            format!("{field_container} {{\n\t{fields_list},\n}}"),
         )
     } else {
         (
             format!("{field_container}{{..}}"),
             // fewer than three named fields, all on the same line
-            format!("{field_container}{{{fields_list}}}"),
+            format!("{field_container} {{{fields_list}}}"),
         )
     };
     let field_completion = CompletionItem {

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -473,7 +473,7 @@ fn datatype_completion(
             }
         })
         .collect::<Vec<_>>()
-        .join(&separator);
+        .join(separator);
 
     let (label, insert_text) = if !named_fields {
         (

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -7,8 +7,8 @@ use crate::{
     symbols::{
         self, mod_ident_to_ide_string, ret_type_to_ide_str, type_args_to_ide_string,
         type_list_to_ide_string, type_to_ide_string, ChainCompletionKind, ChainInfo, CursorContext,
-        CursorDefinition, DefInfo, FunType, PrecompiledPkgDeps, SymbolicatorRunner, Symbols,
-        VariantInfo,
+        CursorDefinition, DefInfo, FunType, MemberDef, MemberDefInfo, ModuleDefs,
+        PrecompiledPkgDeps, SymbolicatorRunner, Symbols, VariantInfo,
     },
     utils,
 };
@@ -43,6 +43,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
+    vec,
 };
 use vfs::VfsPath;
 
@@ -194,50 +195,71 @@ fn get_cursor_token(buffer: &str, position: &Position) -> Option<Tok> {
     }
 }
 
+/// Checks if the cursor is at the opening brace of a struct definition and returns
+/// auto-completion of this struct into an object if the struct has the `key` ability.
+fn object_completion(symbols: &Symbols, cursor: &CursorContext) -> (Option<CompletionItem>, bool) {
+    let mut only_custom_items = false;
+    // look for a struct definition on the line that contains `{`, check its abilities,
+    // and do auto-completion if `key` ability is present
+    let Some(CursorDefinition::Struct(sname)) = &cursor.defn_name else {
+        return (None, only_custom_items);
+    };
+    only_custom_items = true;
+    let Some(mod_ident) = cursor.module else {
+        return (None, only_custom_items);
+    };
+    let Some(mod_defs) = mod_defs(symbols, &mod_ident.value) else {
+        return (None, only_custom_items);
+    };
+    let Some(struct_def) = mod_defs.structs.get(&sname.value()) else {
+        return (None, only_custom_items);
+    };
+
+    let Some(DefInfo::Struct(_, _, _, _, abilities, ..)) =
+        symbols.def_info.get(&struct_def.name_loc)
+    else {
+        return (None, only_custom_items);
+    };
+
+    if !abilities.has_ability_(Ability_::Key) {
+        return (None, only_custom_items);
+    }
+    let obj_snippet = "\n\tid: UID,\n\t$1\n".to_string();
+    let init_completion = CompletionItem {
+        label: "id: UID".to_string(),
+        kind: Some(CompletionItemKind::SNIPPET),
+        documentation: Some(Documentation::String("Object snippet".to_string())),
+        insert_text: Some(obj_snippet),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        ..Default::default()
+    };
+    (Some(init_completion), only_custom_items)
+}
+
 /// Handle context-specific auto-completion requests with lbrace (`{`) trigger character.
 fn context_specific_lbrace(
     symbols: &Symbols,
     cursor: &CursorContext,
 ) -> (Vec<CompletionItem>, bool) {
-    let mut completions = vec![];
-    let mut only_custom_items = false;
-    // look for a struct definition on the line that contains `{`, check its abilities,
-    // and do auto-completion if `key` ability is present
-    let Some(CursorDefinition::Struct(sname)) = &cursor.defn_name else {
-        return (completions, only_custom_items);
-    };
-    only_custom_items = true;
-    let Some(mident) = cursor.module else {
-        return (completions, only_custom_items);
-    };
-    let Some(typed_ast) = symbols.typed_ast.as_ref() else {
-        return (completions, only_custom_items);
-    };
-    let Some(struct_def) = typed_ast.info.struct_definition_opt(&mident, sname) else {
-        return (completions, only_custom_items);
-    };
-    if struct_def.abilities.has_ability_(Ability_::Key) {
-        let obj_snippet = "\n\tid: UID,\n\t$1\n".to_string();
-        let init_completion = CompletionItem {
-            label: "id: UID".to_string(),
-            kind: Some(CompletionItemKind::SNIPPET),
-            documentation: Some(Documentation::String("Object snippet".to_string())),
-            insert_text: Some(obj_snippet),
-            insert_text_format: Some(InsertTextFormat::SNIPPET),
-            ..Default::default()
-        };
-        completions.push(init_completion);
+    let completions = vec![];
+    let (completion_item_opt, only_custom_items) = object_completion(symbols, cursor);
+    if let Some(completion_item) = completion_item_opt {
+        return (vec![completion_item], only_custom_items);
     }
     (completions, only_custom_items)
 }
 
-fn fun_def_info(symbols: &Symbols, mod_ident: ModuleIdent_, name: Symbol) -> Option<&DefInfo> {
-    let Some(mod_defs) = symbols
+/// Get definitions for a given module.
+fn mod_defs<'a>(symbols: &'a Symbols, mod_ident: &ModuleIdent_) -> Option<&'a ModuleDefs> {
+    symbols
         .file_mods
         .values()
         .flatten()
-        .find(|mdef| mdef.ident == mod_ident)
-    else {
+        .find(|mdef| mdef.ident == *mod_ident)
+}
+
+fn fun_def_info(symbols: &Symbols, mod_ident: ModuleIdent_, name: Symbol) -> Option<&DefInfo> {
+    let Some(mod_defs) = mod_defs(symbols, &mod_ident) else {
         return None;
     };
 
@@ -247,7 +269,7 @@ fn fun_def_info(symbols: &Symbols, mod_ident: ModuleIdent_, name: Symbol) -> Opt
     symbols.def_info(&fdef.name_loc)
 }
 
-fn lamda_snippet(sp!(_, ty): &Type, snippet_idx: &mut i32) -> Option<String> {
+fn lambda_snippet(sp!(_, ty): &Type, snippet_idx: &mut i32) -> Option<String> {
     if let Type_::Fun(vec, _) = ty {
         let arg_snippets = vec
             .iter()
@@ -289,7 +311,7 @@ fn call_completion_item(
         .zip(arg_types)
         .skip(omitted_arg_count)
         .map(|(name, ty)| {
-            lamda_snippet(ty, &mut snippet_idx).unwrap_or_else(|| {
+            lambda_snippet(ty, &mut snippet_idx).unwrap_or_else(|| {
                 let mut arg_name = name.to_string();
                 if arg_name.starts_with('$') {
                     arg_name = arg_name[1..].to_string();
@@ -412,6 +434,70 @@ fn dot_completions(
     completions
 }
 
+/// Handles auto-completion for structs and enums variants, including fields contained
+/// by the struct or variant.
+fn datatype_completion(
+    field_container: Symbol,
+    kind: CompletionItemKind,
+    field_names: &[Name],
+    named_fields: bool,
+) -> Vec<CompletionItem> {
+    let mut completions = vec![];
+    // fields on separate lines if there is more than two and if they are named
+    let separator = if field_names.len() > 2 && named_fields {
+        ",\n\t"
+    } else {
+        ", "
+    };
+    let fields_list = field_names
+        .iter()
+        .enumerate()
+        .map(|(idx, name)| {
+            if named_fields {
+                format!("{}: ${{{}}}", name, idx + 1)
+            } else {
+                format!("${{{}}}", idx + 1)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(&separator);
+    // always add a completion for the datatype itself (for type completion)
+    completions.push(completion_item(&field_container, kind));
+    if field_names.is_empty() {
+        // datatype completion is all we get
+        return completions;
+    }
+
+    let (label, insert_text) = if !named_fields {
+        (
+            format!("{field_container}(..)"),
+            // positional fields always on the same line
+            format!("{field_container}({fields_list})"),
+        )
+    } else if field_names.len() > 2 {
+        (
+            format!("{field_container}{{..}}"),
+            // more than two named fields, each on a separate line
+            format!("{field_container}{{\n\t{fields_list},\n}}"),
+        )
+    } else {
+        (
+            format!("{field_container}{{..}}"),
+            // fewer than three named fields, all on the same line
+            format!("{field_container}{{{fields_list}}}"),
+        )
+    };
+    let field_completion = CompletionItem {
+        label,
+        kind: Some(kind),
+        insert_text: Some(insert_text),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        ..Default::default()
+    };
+    completions.push(field_completion);
+    completions
+}
+
 /// Returns all possible completions for a module member (e.g., a datatype) component of a name
 /// access chain, where the prefix of this component (e.g, in `some_pkg::some_mod::`) represents a
 /// module specified in `prefix_mod_ident`. The `inside_use` parameter determines if completion is
@@ -427,12 +513,7 @@ fn module_member_completions(
 
     let mut completions = vec![];
 
-    let Some(mod_defs) = symbols
-        .file_mods
-        .values()
-        .flatten()
-        .find(|mdef| mdef.ident == prefix_mod_ident.value)
-    else {
+    let Some(mod_defs) = mod_defs(symbols, &prefix_mod_ident.value) else {
         return completions;
     };
 
@@ -503,8 +584,8 @@ fn module_member_completions(
         completions.extend(
             mod_defs
                 .structs
-                .keys()
-                .map(|sname| completion_item(sname, CompletionItemKind::STRUCT)),
+                .iter()
+                .flat_map(|(sname, member_def)| struct_completion(*sname, member_def)),
         );
         completions.extend(
             mod_defs
@@ -526,6 +607,26 @@ fn module_member_completions(
     completions
 }
 
+/// Computes completions for a struct.
+fn struct_completion(name: Symbol, member_def: &MemberDef) -> Vec<CompletionItem> {
+    let MemberDef {
+        info: MemberDefInfo::Struct {
+            field_defs,
+            positional,
+        },
+        ..
+    } = member_def
+    else {
+        return vec![completion_item(&name, CompletionItemKind::STRUCT)];
+    };
+    datatype_completion(
+        name,
+        CompletionItemKind::STRUCT,
+        &field_defs.iter().map(|d| sp(d.loc, d.name)).collect_vec(),
+        !positional,
+    )
+}
+
 /// Returns completion item if a given name/alias identifies a valid member of a given module
 /// available in the completion scope as if it was a single-length name chain.
 fn single_name_member_completion(
@@ -534,29 +635,24 @@ fn single_name_member_completion(
     member_alias: &Symbol,
     member_name: &Symbol,
     chain_kind: ChainCompletionKind,
-) -> Option<CompletionItem> {
+) -> Vec<CompletionItem> {
     use ChainCompletionKind as CT;
 
-    let Some(mod_defs) = symbols
-        .file_mods
-        .values()
-        .flatten()
-        .find(|mdef| mdef.ident == *mod_ident)
-    else {
-        return None;
+    let Some(mod_defs) = mod_defs(symbols, mod_ident) else {
+        return vec![];
     };
 
     // is it a function?
     if let Some(fdef) = mod_defs.functions.get(member_name) {
         if !(matches!(chain_kind, CT::Function) || matches!(chain_kind, CT::All)) {
-            return None;
+            return vec![];
         }
         let Some(DefInfo::Function(.., fun_type, _, type_args, arg_names, arg_types, ret_type, _)) =
             symbols.def_info(&fdef.name_loc)
         else {
-            return None;
+            return vec![];
         };
-        return Some(call_completion_item(
+        return vec![call_completion_item(
             mod_ident,
             matches!(fun_type, FunType::Macro),
             None,
@@ -566,43 +662,40 @@ fn single_name_member_completion(
             arg_types,
             ret_type,
             /* inside_use */ false,
-        ));
+        )];
     };
 
     // is it a struct?
-    if mod_defs.structs.get(member_name).is_some() {
+    if let Some(member_def) = mod_defs.structs.get(member_name) {
         if !(matches!(chain_kind, CT::Type) || matches!(chain_kind, CT::All)) {
-            return None;
+            return vec![];
         }
-        return Some(completion_item(
-            member_alias.as_str(),
-            CompletionItemKind::STRUCT,
-        ));
+        return struct_completion(*member_alias, member_def);
     }
 
     // is it an enum?
     if mod_defs.enums.get(member_name).is_some() {
         if !(matches!(chain_kind, CT::Type) || matches!(chain_kind, CT::All)) {
-            return None;
+            return vec![];
         }
-        return Some(completion_item(
+        return vec![completion_item(
             member_alias.as_str(),
             CompletionItemKind::ENUM,
-        ));
+        )];
     }
 
     // is it a const?
     if mod_defs.constants.get(member_name).is_some() {
         if !matches!(chain_kind, CT::All) {
-            return None;
+            return vec![];
         }
-        return Some(completion_item(
+        return vec![completion_item(
             member_alias.as_str(),
             CompletionItemKind::CONSTANT,
-        ));
+        )];
     }
 
-    None
+    vec![]
 }
 
 /// Returns completion items for all members of a given module as if they were single-length name
@@ -614,16 +707,14 @@ fn all_single_name_member_completions(
 ) -> Vec<CompletionItem> {
     let mut completions = vec![];
     for (member_alias, sp!(_, mod_ident), member_name) in members_info {
-        let Some(member_completion) = single_name_member_completion(
+        let member_completions = single_name_member_completion(
             symbols,
             mod_ident,
             member_alias,
             &member_name.value,
             chain_kind,
-        ) else {
-            continue;
-        };
-        completions.push(member_completion);
+        );
+        completions.extend(member_completions);
     }
     completions
 }
@@ -671,54 +762,23 @@ fn pkg_mod_identifiers(
         .collect::<BTreeSet<_>>()
 }
 
-/// Computes completion for a single enum variant.
-fn variant_completion(symbols: &Symbols, vinfo: &VariantInfo) -> Option<CompletionItem> {
-    let Some(DefInfo::Variant(_, _, vname, is_positional, field_names, ..)) =
+/// Computes completions for a single enum variant.
+fn variant_completion(symbols: &Symbols, vinfo: &VariantInfo) -> Vec<CompletionItem> {
+    let Some(DefInfo::Variant(_, _, _, positional, field_names, ..)) =
         symbols.def_info.get(&vinfo.name.loc)
     else {
-        return None;
+        return vec![completion_item(
+            vinfo.name.value.as_str(),
+            CompletionItemKind::ENUM_MEMBER,
+        )];
     };
 
-    let label = if field_names.is_empty() {
-        vname.to_string()
-    } else if *is_positional {
-        format!("{vname}()")
-    } else {
-        format!("{vname}{{}}")
-    };
-    let field_snippet = field_names
-        .iter()
-        .enumerate()
-        .map(|(snippet_idx, fname)| {
-            if *is_positional {
-                format!("${{{}}}", snippet_idx + 1)
-            } else {
-                format!("${{{}:{}}}", snippet_idx + 1, fname)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    let (insert_text, insert_text_format) = if field_names.is_empty() {
-        (format!("{vname}"), InsertTextFormat::PLAIN_TEXT)
-    } else if *is_positional {
-        (
-            format!("{vname}({field_snippet})"),
-            InsertTextFormat::SNIPPET,
-        )
-    } else {
-        (
-            format!("{vname}{{{field_snippet}}}"),
-            InsertTextFormat::SNIPPET,
-        )
-    };
-
-    Some(CompletionItem {
-        label,
-        kind: Some(CompletionItemKind::ENUM_MEMBER),
-        insert_text: Some(insert_text),
-        insert_text_format: Some(insert_text_format),
-        ..Default::default()
-    })
+    datatype_completion(
+        vinfo.name.value,
+        CompletionItemKind::ENUM_MEMBER,
+        field_names,
+        !positional,
+    )
 }
 
 /// Computes completions for variants of a given enum.
@@ -727,12 +787,7 @@ fn all_variant_completions(
     mod_ident: &ModuleIdent,
     datatype_name: Symbol,
 ) -> Vec<CompletionItem> {
-    let Some(mod_defs) = symbols
-        .file_mods
-        .values()
-        .flatten()
-        .find(|mdef| mdef.ident == mod_ident.value)
-    else {
+    let Some(mod_defs) = mod_defs(symbols, &mod_ident.value) else {
         return vec![];
     };
 
@@ -746,7 +801,7 @@ fn all_variant_completions(
 
     variants
         .iter()
-        .filter_map(|vinfo| variant_completion(symbols, vinfo))
+        .flat_map(|vinfo| variant_completion(symbols, vinfo))
         .collect_vec()
 }
 

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2290,7 +2290,7 @@ fn get_mod_outer_defs(
                     let fields_order_opt = fields_order_info
                         .variants
                         .get(&mod_ident_str)
-                        .and_then(|v| v.get(&name))
+                        .and_then(|v| v.get(name))
                         .and_then(|v| v.get(vname));
                     let (defs, types) = field_defs_and_types(
                         *name,

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -97,13 +97,10 @@ use move_compiler::{
     shared::{
         files::{FileId, MappedFiles},
         unique_map::UniqueMap,
-        Identifier, Name, NamedAddressMap,
+        Identifier, Name, NamedAddressMap, NamedAddressMaps,
     },
     typing::{
-        ast::{
-            self as T, Exp, ExpListItem, ModuleDefinition, SequenceItem, SequenceItem_,
-            UnannotatedExp_,
-        },
+        ast::{Exp, ExpListItem, ModuleDefinition, SequenceItem, SequenceItem_, UnannotatedExp_},
         visitor::TypingVisitorContext,
     },
     unit_test::filter_test_members::UNIT_TEST_POISON_FUN_NAME,
@@ -354,6 +351,27 @@ impl CallInfo {
     }
 }
 
+/// Map from struct name to field order information
+pub type StructFieldOrderInfo = BTreeMap<Symbol, BTreeMap<Symbol, usize>>;
+/// Map from enum name to variant name to field order information
+pub type VariantFieldOrderInfo = BTreeMap<Symbol, BTreeMap<Symbol, BTreeMap<Symbol, usize>>>;
+
+/// Information about field order in structs and enums
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+pub struct FieldOrderInfo {
+    structs: BTreeMap<String, StructFieldOrderInfo>,
+    variants: BTreeMap<String, VariantFieldOrderInfo>,
+}
+
+impl FieldOrderInfo {
+    pub fn new() -> Self {
+        Self {
+            structs: BTreeMap::new(),
+            variants: BTreeMap::new(),
+        }
+    }
+}
+
 /// Module-level definitions and other module-related info
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ModuleDefs {
@@ -537,8 +555,6 @@ pub struct Symbols {
     pub compiler_info: CompilerInfo,
     /// Cursor information gathered up during analysis
     pub cursor_context: Option<CursorContext>,
-    /// Typed Program
-    pub typed_ast: Option<T::Program>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -1754,10 +1770,15 @@ pub fn get_symbols(
         file_id_to_lines.insert(*file_id, lines);
     }
 
+    let mut fields_order_info = FieldOrderInfo::new();
+
+    pre_process_parsed_program(&parsed_program, &mut fields_order_info);
+
     let mut cursor_context = compute_cursor_context(&mapped_files, cursor_info);
 
     pre_process_typed_modules(
         &typed_program.modules,
+        &fields_order_info,
         &mapped_files,
         &file_id_to_lines,
         &mut mod_outer_defs,
@@ -1771,6 +1792,7 @@ pub fn get_symbols(
     if let Some(libs) = compiled_libs.clone() {
         pre_process_typed_modules(
             &libs.typing.modules,
+            &fields_order_info,
             &mapped_files,
             &file_id_to_lines,
             &mut mod_outer_defs,
@@ -1862,7 +1884,6 @@ pub fn get_symbols(
         files: mapped_files,
         compiler_info,
         cursor_context,
-        typed_ast,
     };
 
     eprintln!("get_symbols load complete");
@@ -1881,8 +1902,71 @@ fn compute_cursor_context(
     Some(CursorContext::new(loc))
 }
 
+/// Pre-process parsed program to get initial info before AST traversals
+fn pre_process_parsed_program(prog: &P::Program, fields_order_info: &mut FieldOrderInfo) {
+    prog.source_definitions.iter().for_each(|pkg_def| {
+        pre_process_parsed_pkg(pkg_def, &prog.named_address_maps, fields_order_info);
+    });
+    prog.lib_definitions.iter().for_each(|pkg_def| {
+        pre_process_parsed_pkg(pkg_def, &prog.named_address_maps, fields_order_info);
+    });
+}
+
+/// Pre-process parsed package to get initial info before AST traversals
+fn pre_process_parsed_pkg(
+    pkg_def: &P::PackageDefinition,
+    named_address_maps: &NamedAddressMaps,
+    fields_order_info: &mut FieldOrderInfo,
+) {
+    if let P::Definition::Module(mod_def) = &pkg_def.def {
+        for member in &mod_def.members {
+            let pkg_addresses = named_address_maps.get(pkg_def.named_address_map);
+            let Some(mod_ident_str) = parsing_mod_def_to_map_key(pkg_addresses, mod_def) else {
+                continue;
+            };
+            if let P::ModuleMember::Struct(sdef) = member {
+                if let P::StructFields::Named(fields) = &sdef.fields {
+                    let indexed_fields = fields
+                        .iter()
+                        .enumerate()
+                        .map(|(i, (f, _))| (f.value(), i))
+                        .collect::<BTreeMap<_, _>>();
+                    fields_order_info
+                        .structs
+                        .entry(mod_ident_str.clone())
+                        .or_default()
+                        .entry(sdef.name.value())
+                        .or_default()
+                        .extend(indexed_fields);
+                }
+            }
+            if let P::ModuleMember::Enum(edef) = member {
+                for vdef in &edef.variants {
+                    if let P::VariantFields::Named(fields) = &vdef.fields {
+                        let indexed_fields = fields
+                            .iter()
+                            .enumerate()
+                            .map(|(i, (f, _))| (f.value(), i))
+                            .collect::<BTreeMap<_, _>>();
+                        fields_order_info
+                            .variants
+                            .entry(mod_ident_str.clone())
+                            .or_default()
+                            .entry(edef.name.value())
+                            .or_default()
+                            .entry(vdef.name.value())
+                            .or_default()
+                            .extend(indexed_fields);
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn pre_process_typed_modules(
     typed_modules: &UniqueMap<ModuleIdent, ModuleDefinition>,
+    fields_order_info: &FieldOrderInfo,
     files: &MappedFiles,
     file_id_to_lines: &HashMap<usize, Vec<String>>,
     mod_outer_defs: &mut BTreeMap<String, ModuleDefs>,
@@ -1904,7 +1988,9 @@ fn pre_process_typed_modules(
         let (defs, symbols) = get_mod_outer_defs(
             &pos,
             &sp(pos, *module_ident),
+            mod_ident_str.clone(),
             module_def,
+            fields_order_info,
             files,
             file_id_to_lines,
             references,
@@ -1993,6 +2079,50 @@ pub fn expansion_mod_ident_to_map_key(mod_ident: &E::ModuleIdent_) -> String {
     }
 }
 
+/// Converts parsing AST's `LeadingNameAccess` to expansion AST's `Address` (similarly to
+/// expansion::translate::top_level_address but disregarding the name portion of `Address` as we
+/// only care about actual address here if it's available). We need this to be able to reliably
+/// compare parsing AST's module identifier with expansion/typing AST's module identifier, even in
+/// presence of module renaming (i.e., we cannot rely on module names if addresses are available).
+pub fn parsed_address(ln: P::LeadingNameAccess, pkg_addresses: &NamedAddressMap) -> E::Address {
+    let sp!(loc, ln_) = ln;
+    match ln_ {
+        P::LeadingNameAccess_::AnonymousAddress(bytes) => E::Address::anonymous(loc, bytes),
+        P::LeadingNameAccess_::GlobalAddress(name) => E::Address::NamedUnassigned(name),
+        P::LeadingNameAccess_::Name(name) => match pkg_addresses.get(&name.value).copied() {
+            Some(addr) => E::Address::anonymous(loc, addr),
+            None => E::Address::NamedUnassigned(name),
+        },
+    }
+}
+
+/// Produces module ident string of the form pkg::module to be used as a map key.
+/// It's important that these are consistent between parsing AST and typed AST.
+pub fn parsing_leading_and_mod_names_to_map_key(
+    pkg_addresses: &NamedAddressMap,
+    ln: P::LeadingNameAccess,
+    name: P::ModuleName,
+) -> String {
+    format!("{}::{}", parsed_address(ln, pkg_addresses), name).to_string()
+}
+
+/// Produces module ident string of the form pkg::module to be used as a map key.
+/// It's important that these are consistent between parsing AST and typed AST.
+pub fn parsing_mod_def_to_map_key(
+    pkg_addresses: &NamedAddressMap,
+    mod_def: &P::ModuleDefinition,
+) -> Option<String> {
+    // we assume that modules are declared using the PkgName::ModName pattern (which seems to be the
+    // standard practice) and while Move allows other ways of defining modules (i.e., with address
+    // preceding a sequence of modules), this method is now deprecated.
+    //
+    // TODO: make this function simply return String when the other way of defining modules is
+    // removed
+    mod_def
+        .address
+        .map(|a| parsing_leading_and_mod_names_to_map_key(pkg_addresses, a, mod_def.name))
+}
+
 /// Get empty symbols
 pub fn empty_symbols() -> Symbols {
     Symbols {
@@ -2003,7 +2133,6 @@ pub fn empty_symbols() -> Symbols {
         files: MappedFiles::empty(),
         compiler_info: CompilerInfo::new(),
         cursor_context: None,
-        typed_ast: None,
     }
 }
 
@@ -2011,6 +2140,7 @@ fn field_defs_and_types(
     datatype_name: Symbol,
     datatype_loc: Loc,
     fields: &E::Fields<Type>,
+    fields_order_opt: Option<&BTreeMap<Symbol, usize>>,
     mod_ident: &ModuleIdent,
     files: &MappedFiles,
     file_id_to_lines: &HashMap<usize, Vec<String>>,
@@ -2018,7 +2148,15 @@ fn field_defs_and_types(
 ) -> (Vec<FieldDef>, Vec<Type>) {
     let mut field_defs = vec![];
     let mut field_types = vec![];
-    for (floc, fname, (_, t)) in fields {
+    let mut ordered_fields = fields
+        .iter()
+        .map(|(floc, fname, (_, ftype))| (floc, fname, ftype))
+        .collect::<Vec<_>>();
+    // sort fields by order if available for correct auto-completion
+    if let Some(fields_order) = fields_order_opt {
+        ordered_fields.sort_by_key(|(_, fname, _)| fields_order.get(fname).copied());
+    }
+    for (floc, fname, ftype) in ordered_fields {
         field_defs.push(FieldDef {
             name: *fname,
             loc: floc,
@@ -2030,11 +2168,11 @@ fn field_defs_and_types(
                 mod_ident.value,
                 datatype_name,
                 *fname,
-                t.clone(),
+                ftype.clone(),
                 doc_string,
             ),
         );
-        field_types.push(t.clone());
+        field_types.push(ftype.clone());
     }
     (field_defs, field_types)
 }
@@ -2067,7 +2205,9 @@ pub fn ignored_function(name: Symbol) -> bool {
 fn get_mod_outer_defs(
     loc: &Loc,
     mod_ident: &ModuleIdent,
+    mod_ident_str: String,
     mod_def: &ModuleDefinition,
+    fields_order_info: &FieldOrderInfo,
     files: &MappedFiles,
     file_id_to_lines: &HashMap<usize, Vec<String>>,
     references: &mut References,
@@ -2087,10 +2227,15 @@ fn get_mod_outer_defs(
         let mut field_types = vec![];
         if let StructFields::Defined(pos_fields, fields) = &def.fields {
             positional = *pos_fields;
+            let fields_order_opt = fields_order_info
+                .structs
+                .get(&mod_ident_str)
+                .and_then(|s| s.get(name));
             (field_defs, field_types) = field_defs_and_types(
                 *name,
                 name_loc,
                 fields,
+                fields_order_opt,
                 mod_ident,
                 files,
                 file_id_to_lines,
@@ -2142,10 +2287,16 @@ fn get_mod_outer_defs(
         for (vname_loc, vname, vdef) in &def.variants {
             let (field_defs, field_types, positional) = match &vdef.fields {
                 VariantFields::Defined(pos_fields, fields) => {
+                    let fields_order_opt = fields_order_info
+                        .variants
+                        .get(&mod_ident_str)
+                        .and_then(|v| v.get(&name))
+                        .and_then(|v| v.get(vname));
                     let (defs, types) = field_defs_and_types(
                         *name,
                         name_loc,
                         fields,
+                        fields_order_opt,
                         mod_ident,
                         files,
                         file_id_to_lines,

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.exp
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.exp
@@ -1174,6 +1174,85 @@ EnumMember 'Variant'
 EnumMember 'Variant{..}'
     INSERT TEXT: 'Variant { ${1:field} }'
 
+-- test 35 -------------------
+use line: 78, use_col: 35
+EnumMember 'MultiFieldVariant'
+EnumMember 'MultiFieldVariant{..}'
+    INSERT TEXT: 'MultiFieldVariant {
+	${1:name1},
+	${2:name2},
+	${3:name3},
+}'
+
+-- test 36 -------------------
+use line: 82, use_col: 18
+Unit '0x1'
+Unit '0xA'
+Unit '0xCAFE'
+Unit 'Completion'
+Unit 'std'
+Module 'Self'
+Module 'option'
+Module 'vector'
+Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
+Struct 'Option'
+Constant 'SOME_CONST'
+Enum 'SomeEnum'
+Struct 'SomeStruct'
+Enum 'TargEnum'
+Method 'attr_chain()'
+    INSERT TEXT: 'attr_chain()'
+    TARGET     : '(Completion::colon_colon::attr_chain)'
+    TYPE       : 'fun ()'
+Method 'complete_chains()'
+    INSERT TEXT: 'complete_chains(${1:s})'
+    TARGET     : '(Completion::colon_colon::complete_chains)'
+    TYPE       : 'fun (SomeStruct)'
+Method 'multi_colon_colon()'
+    INSERT TEXT: 'multi_colon_colon()'
+    TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
+    TYPE       : 'fun ()'
+Method 'one_colon_colon()'
+    INSERT TEXT: 'one_colon_colon()'
+    TARGET     : '(Completion::colon_colon::one_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'sbar()'
+    INSERT TEXT: 'sbar(${1:_param1}, ${2:_param2})'
+    TARGET     : '(Completion::colon_colon::sbar)'
+    TYPE       : 'fun (u64, SomeStruct)'
+Method 'sbaz()'
+    INSERT TEXT: 'sbaz()'
+    TARGET     : '(Completion::colon_colon::sbaz)'
+    TYPE       : 'fun ()'
+Method 'single_ident()'
+    INSERT TEXT: 'single_ident()'
+    TARGET     : '(Completion::colon_colon::single_ident)'
+    TYPE       : 'fun ()'
+Method 'targ_chain()'
+    INSERT TEXT: 'targ_chain()'
+    TARGET     : '(Completion::colon_colon::targ_chain)'
+    TYPE       : 'fun ()'
+Method 'targ_type()'
+    INSERT TEXT: 'targ_type(${1:p})'
+    TARGET     : '(Completion::colon_colon::targ_type)'
+    TYPE       : 'fun <SOME_TYPE>(SOME_TYPE)'
+
 == uses.move ========================================================
 -- test 0 -------------------
 use line: 2, use_col: 9

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.exp
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.exp
@@ -2,7 +2,15 @@
 -- test 0 -------------------
 use line: 15, use_col: 68
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 
@@ -18,6 +26,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Enum 'SE'
 Constant 'SOME_CONST'
@@ -35,6 +51,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -86,6 +110,14 @@ Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
     TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
+    TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
     TARGET     : '(Completion::colon_colon::one_colon_colon)'
@@ -111,19 +143,28 @@ Method 'targ_type()'
     TARGET     : '(Completion::colon_colon::targ_type)'
     TYPE       : 'fun <SOME_TYPE>(SOME_TYPE)'
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 Constant 'SOME_CONST'
 
 -- test 4 -------------------
 use line: 21, use_col: 57
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 5 -------------------
 use line: 22, use_col: 11
@@ -135,12 +176,13 @@ Unit 'std'
 
 -- test 6 -------------------
 use line: 22, use_col: 46
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 7 -------------------
 use line: 23, use_col: 25
@@ -171,12 +213,13 @@ Unit 'std'
 
 -- test 9 -------------------
 use line: 24, use_col: 40
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 10 -------------------
 use line: 25, use_col: 9
@@ -200,6 +243,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -368,6 +419,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Enum 'SE'
 Constant 'SOME_CONST'
@@ -385,6 +444,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -413,12 +480,13 @@ Method 'targ_type()'
 
 -- test 14 -------------------
 use line: 27, use_col: 23
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 15 -------------------
 use line: 28, use_col: 13
@@ -433,6 +501,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -471,6 +547,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Enum 'SE'
 Constant 'SOME_CONST'
@@ -488,6 +572,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -526,6 +618,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Enum 'SE'
 Enum 'SomeEnum'
@@ -544,7 +644,15 @@ Keyword 'address'
 -- test 18 -------------------
 use line: 33, use_col: 37
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 
@@ -576,6 +684,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Constant 'SOME_CONST'
 Enum 'SomeEnum'
@@ -592,6 +708,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -621,14 +745,23 @@ Method 'targ_type()'
 -- test 21 -------------------
 use line: 55, use_col: 26
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 
 -- test 22 -------------------
 use line: 55, use_col: 39
-EnumMember 'Variant{}'
-    INSERT TEXT: 'Variant{${1:field}}'
+EnumMember 'Variant'
+EnumMember 'Variant{..}'
+    INSERT TEXT: 'Variant { ${1:field} }'
 
 -- test 23 -------------------
 use line: 59, use_col: 21
@@ -641,6 +774,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Enum 'SomeEnum'
 Struct 'SomeStruct'
@@ -667,6 +808,14 @@ Module 'Self'
 Module 'option'
 Module 'vector'
 Struct 'CompletionStruct'
+Enum 'EnumWithMultiFieldVariant'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'Option'
 Constant 'SOME_CONST'
 Enum 'SomeEnum'
@@ -683,6 +832,14 @@ Method 'complete_chains()'
 Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
+    TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
     TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
@@ -723,6 +880,14 @@ Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
     TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
+    TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
     TARGET     : '(Completion::colon_colon::one_colon_colon)'
@@ -748,7 +913,15 @@ Method 'targ_type()'
     TARGET     : '(Completion::colon_colon::targ_type)'
     TYPE       : 'fun <SOME_TYPE>(SOME_TYPE)'
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 Constant 'SOME_CONST'
@@ -778,6 +951,14 @@ Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon()'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
     TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct()'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant()'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
+    TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon()'
     TARGET     : '(Completion::colon_colon::one_colon_colon)'
@@ -803,19 +984,28 @@ Method 'targ_type()'
     TARGET     : '(Completion::colon_colon::targ_type)'
     TYPE       : 'fun <SOME_TYPE>(SOME_TYPE)'
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
+Struct 'MultiFieldStruct{..}'
+    INSERT TEXT: 'MultiFieldStruct {
+	${1:field1},
+	${2:field2},
+	${3:field3},
+}'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 Constant 'SOME_CONST'
 
 -- test 28 -------------------
 use line: 21, use_col: 56
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 29 -------------------
 use line: 25, use_col: 16
@@ -949,12 +1139,13 @@ Method 'sha3_256()'
 
 -- test 31 -------------------
 use line: 27, use_col: 23
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 32 -------------------
 use line: 41, use_col: 20
@@ -969,17 +1160,19 @@ Module 'uses'
 
 -- test 33 -------------------
 use line: 44, use_col: 43
-EnumMember 'SomeNamedVariant{}'
-    INSERT TEXT: 'SomeNamedVariant{${1:name1}, ${2:name2}}'
-EnumMember 'SomePositionalVariant()'
+EnumMember 'SomeNamedVariant'
+EnumMember 'SomeNamedVariant{..}'
+    INSERT TEXT: 'SomeNamedVariant { ${1:name1}, ${2:name2} }'
+EnumMember 'SomePositionalVariant'
+EnumMember 'SomePositionalVariant(..)'
     INSERT TEXT: 'SomePositionalVariant(${1}, ${2})'
 EnumMember 'SomeVariant'
-    INSERT TEXT: 'SomeVariant'
 
 -- test 34 -------------------
 use line: 55, use_col: 38
-EnumMember 'Variant{}'
-    INSERT TEXT: 'Variant{${1:field}}'
+EnumMember 'Variant'
+EnumMember 'Variant{..}'
+    INSERT TEXT: 'Variant { ${1:field} }'
 
 == uses.move ========================================================
 -- test 0 -------------------
@@ -1136,6 +1329,14 @@ Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
     TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
+    TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon'
     TARGET     : '(Completion::colon_colon::one_colon_colon)'
@@ -1161,7 +1362,9 @@ Method 'targ_type()'
     TARGET     : '(Completion::colon_colon::targ_type)'
     TYPE       : 'fun <SOME_TYPE>(SOME_TYPE)'
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 
@@ -1179,6 +1382,14 @@ Method 'multi_colon_colon()'
     INSERT TEXT: 'multi_colon_colon'
     TARGET     : '(Completion::colon_colon::multi_colon_colon)'
     TYPE       : 'fun ()'
+Method 'multi_field_struct()'
+    INSERT TEXT: 'multi_field_struct'
+    TARGET     : '(Completion::colon_colon::multi_field_struct)'
+    TYPE       : 'fun ()'
+Method 'multi_field_variant()'
+    INSERT TEXT: 'multi_field_variant'
+    TARGET     : '(Completion::colon_colon::multi_field_variant)'
+    TYPE       : 'fun ()'
 Method 'one_colon_colon()'
     INSERT TEXT: 'one_colon_colon'
     TARGET     : '(Completion::colon_colon::one_colon_colon)'
@@ -1204,7 +1415,9 @@ Method 'targ_type()'
     TARGET     : '(Completion::colon_colon::targ_type)'
     TYPE       : 'fun <SOME_TYPE>(SOME_TYPE)'
 Struct 'CompletionStruct'
+Struct 'MultiFieldStruct'
 Struct 'SomeStruct'
+Enum 'EnumWithMultiFieldVariant'
 Enum 'SomeEnum'
 Enum 'TargEnum'
 

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.ide
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_completion.ide
@@ -145,6 +145,14 @@
         {
           "use_line": 55,
           "use_col": 38
+        },
+        {
+          "use_line": 78,
+          "use_col": 35
+        },
+        {
+          "use_line": 82,
+          "use_col": 18
         }
       ],
       "uses.move": [

--- a/external-crates/move/crates/move-analyzer/tests/completion/sources/colon_colon.move
+++ b/external-crates/move/crates/move-analyzer/tests/completion/sources/colon_colon.move
@@ -63,4 +63,23 @@ module Completion::colon_colon {
     public fun attr_chain() {
         abort(SOME_CONST);
     }
+
+    public enum EnumWithMultiFieldVariant has drop {
+        MultiFieldVariant { name1: u64, name2: u64, name3: u64},
+    }
+
+    public struct MultiFieldStruct has drop {
+        field1: u64,
+        field2: u64,
+        field3: u64,
+    }
+
+    public fun multi_field_variant() {
+        EnumWithMultiFieldVariant::
+    }
+
+    public fun multi_field_struct() {
+        MultiField
+    }
+
 }

--- a/external-crates/move/crates/move-analyzer/tests/enums.exp
+++ b/external-crates/move/crates/move-analyzer/tests/enums.exp
@@ -229,8 +229,8 @@ Def: 'AnotherStruct', line: 6, def char: 18
 TypeDef: 'AnotherStruct', line: 6, char: 18
 On Hover:
 public struct Enums::struct_match::AnotherStruct has drop {
-	another_field: Enums::struct_match::SomeStruct,
-	field: u64
+	field: u64,
+	another_field: Enums::struct_match::SomeStruct
 }
 
 -- test 2 -------------------


### PR DESCRIPTION
## Description 

This PR fixes field auto-completion in two ways:
- adds support for struct fields (previously only variant fields were being auto-completed)
- named fields are now listed in their definition order (which should typically be what a developer wants)
- finesses auto-completion formatting (previously all fields where inserted on a single line, and now named fields are inserted on separate lines if there are more than two fields)
- adds a no-field auto-completion option (for when a struct or variant is used as a type and not in pack/unpack context)


## Test plan 

All tests must pass
