### PR TITLE
[bridge-indexer] batch processing checkpoints and indexing progress metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13642,6 +13642,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "mysten-metrics",
  "prometheus",
  "sui-data-ingestion-core",

--- a/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
@@ -108,6 +108,7 @@ impl Datasource<RawEthData> for EthSubscriptionDatasource {
                         eth_ws_client.get_block(block_number),
                         Duration::from_secs(30000)
                     ) else {
+                        // FIXME: why
                         panic!("Unable to get block from provider");
                     };
 

--- a/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use ethers::prelude::Transaction;
 use ethers::providers::{Http, Middleware, Provider, StreamExt, Ws};
 use ethers::types::{Address as EthAddress, Block, Filter, H256};
-use prometheus::IntGaugeVec;
+use prometheus::{IntCounterVec, IntGaugeVec};
 use sui_bridge::error::BridgeError;
 use sui_bridge::eth_client::EthClient;
 use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
@@ -108,7 +108,6 @@ impl Datasource<RawEthData> for EthSubscriptionDatasource {
                         eth_ws_client.get_block(block_number),
                         Duration::from_secs(30000)
                     ) else {
-                        // FIXME: why
                         panic!("Unable to get block from provider");
                     };
 
@@ -152,7 +151,7 @@ impl Datasource<RawEthData> for EthSubscriptionDatasource {
         &self.indexer_metrics.tasks_remaining_checkpoints
     }
 
-    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntCounterVec {
         &self.indexer_metrics.tasks_processed_checkpoints
     }
 
@@ -286,7 +285,7 @@ impl Datasource<RawEthData> for EthSyncDatasource {
         &self.indexer_metrics.tasks_remaining_checkpoints
     }
 
-    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntCounterVec {
         &self.indexer_metrics.tasks_processed_checkpoints
     }
 

--- a/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
@@ -151,6 +151,10 @@ impl Datasource<RawEthData> for EthSubscriptionDatasource {
         &self.indexer_metrics.tasks_remaining_checkpoints
     }
 
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.tasks_processed_checkpoints
+    }
+
     fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
         &self.indexer_metrics.live_task_current_checkpoint
     }
@@ -279,6 +283,10 @@ impl Datasource<RawEthData> for EthSyncDatasource {
 
     fn get_tasks_remaining_checkpoints_metric(&self) -> &IntGaugeVec {
         &self.indexer_metrics.tasks_remaining_checkpoints
+    }
+
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.tasks_processed_checkpoints
     }
 
     fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {

--- a/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use ethers::prelude::Transaction;
 use ethers::providers::{Http, Middleware, Provider, StreamExt, Ws};
 use ethers::types::{Address as EthAddress, Block, Filter, H256};
+use prometheus::IntGaugeVec;
 use sui_bridge::error::BridgeError;
 use sui_bridge::eth_client::EthClient;
 use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
@@ -145,6 +146,14 @@ impl Datasource<RawEthData> for EthSubscriptionDatasource {
     fn get_genesis_height(&self) -> u64 {
         self.genesis_block
     }
+
+    fn get_tasks_remaining_checkpoints_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.tasks_remaining_checkpoints
+    }
+
+    fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.live_task_current_checkpoint
+    }
 }
 
 pub struct EthSyncDatasource {
@@ -266,6 +275,14 @@ impl Datasource<RawEthData> for EthSyncDatasource {
 
     fn get_genesis_height(&self) -> u64 {
         self.genesis_block
+    }
+
+    fn get_tasks_remaining_checkpoints_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.tasks_remaining_checkpoints
+    }
+
+    fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.live_task_current_checkpoint
     }
 }
 

--- a/crates/sui-bridge-indexer/src/lib.rs
+++ b/crates/sui-bridge-indexer/src/lib.rs
@@ -19,6 +19,7 @@ pub mod types;
 
 pub mod eth_bridge_indexer;
 pub mod sui_bridge_indexer;
+pub mod sui_datasource;
 
 #[derive(Clone)]
 pub enum ProcessedTxnData {

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -25,12 +25,12 @@ use sui_bridge_indexer::eth_bridge_indexer::EthDataMapper;
 use sui_bridge_indexer::metrics::BridgeIndexerMetrics;
 use sui_bridge_indexer::postgres_manager::{get_connection_pool, read_sui_progress_store};
 use sui_bridge_indexer::sui_bridge_indexer::{PgBridgePersistent, SuiBridgeDataMapper};
+use sui_bridge_indexer::sui_datasource::SuiCheckpointDatasource;
 use sui_bridge_indexer::sui_transaction_handler::handle_sui_transactions_loop;
 use sui_bridge_indexer::sui_transaction_queries::start_sui_tx_polling_task;
 use sui_config::Config;
 use sui_data_ingestion_core::DataIngestionMetrics;
 use sui_indexer_builder::indexer_builder::{BackfillStrategy, IndexerBuilder};
-use sui_indexer_builder::sui_datasource::SuiCheckpointDatasource;
 use sui_sdk::SuiClientBuilder;
 
 #[derive(Parser, Clone, Debug)]
@@ -137,6 +137,7 @@ async fn main() -> Result<()> {
         config.checkpoints_path.clone().into(),
         config.sui_bridge_genesis_checkpoint,
         ingestion_metrics.clone(),
+        indexer_meterics.clone(),
     );
     let indexer = IndexerBuilder::new(
         "SuiBridgeIndexer",

--- a/crates/sui-bridge-indexer/src/metrics.rs
+++ b/crates/sui-bridge-indexer/src/metrics.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{
-    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry, IntCounter, IntGauge, IntGaugeVec, Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntCounter,
+    IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
 
 #[derive(Clone, Debug)]
@@ -21,7 +22,7 @@ pub struct BridgeIndexerMetrics {
     pub(crate) latest_committed_eth_block: IntGauge,
     pub(crate) last_synced_eth_block: IntGauge,
     pub(crate) tasks_remaining_checkpoints: IntGaugeVec,
-    pub(crate) tasks_processed_checkpoints: IntGaugeVec,
+    pub(crate) tasks_processed_checkpoints: IntCounterVec,
     pub(crate) live_task_current_checkpoint: IntGaugeVec,
 }
 
@@ -107,7 +108,7 @@ impl BridgeIndexerMetrics {
                 registry,
             )
             .unwrap(),
-            tasks_processed_checkpoints: register_int_gauge_vec_with_registry!(
+            tasks_processed_checkpoints: register_int_counter_vec_with_registry!(
                 "bridge_indexer_tasks_processed_checkpoints",
                 "Total processed checkpoints for each task",
                 &["task_name"],

--- a/crates/sui-bridge-indexer/src/metrics.rs
+++ b/crates/sui-bridge-indexer/src/metrics.rs
@@ -21,6 +21,7 @@ pub struct BridgeIndexerMetrics {
     pub(crate) latest_committed_eth_block: IntGauge,
     pub(crate) last_synced_eth_block: IntGauge,
     pub(crate) tasks_remaining_checkpoints: IntGaugeVec,
+    pub(crate) tasks_processed_checkpoints: IntGaugeVec,
     pub(crate) live_task_current_checkpoint: IntGaugeVec,
 }
 
@@ -101,7 +102,14 @@ impl BridgeIndexerMetrics {
             .unwrap(),
             tasks_remaining_checkpoints: register_int_gauge_vec_with_registry!(
                 "bridge_indexer_tasks_remaining_checkpoints",
-                "The remaining checkpoint for each task",
+                "The remaining checkpoints for each task",
+                &["task_name"],
+                registry,
+            )
+            .unwrap(),
+            tasks_processed_checkpoints: register_int_gauge_vec_with_registry!(
+                "bridge_indexer_tasks_processed_checkpoints",
+                "Total processed checkpoints for each task",
                 &["task_name"],
                 registry,
             )

--- a/crates/sui-bridge-indexer/src/metrics.rs
+++ b/crates/sui-bridge-indexer/src/metrics.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{
-    register_int_counter_with_registry, register_int_gauge_with_registry, IntCounter, IntGauge,
-    Registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry, IntCounter, IntGauge, IntGaugeVec, Registry,
 };
 
 #[derive(Clone, Debug)]
@@ -20,80 +20,96 @@ pub struct BridgeIndexerMetrics {
     pub(crate) last_committed_sui_checkpoint: IntGauge,
     pub(crate) latest_committed_eth_block: IntGauge,
     pub(crate) last_synced_eth_block: IntGauge,
+    pub(crate) tasks_remaining_checkpoints: IntGaugeVec,
+    pub(crate) live_task_current_checkpoint: IntGaugeVec,
 }
 
 impl BridgeIndexerMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
             total_sui_bridge_transactions: register_int_counter_with_registry!(
-                "total_sui_bridge_transactions",
+                "bridge_indexer_total_sui_bridge_transactions",
                 "Total number of sui bridge transactions",
                 registry,
             )
             .unwrap(),
             total_sui_token_deposited: register_int_counter_with_registry!(
-                "total_sui_token_deposited",
+                "bridge_indexer_total_sui_token_deposited",
                 "Total number of sui token deposited transactions",
                 registry,
             )
             .unwrap(),
             total_sui_token_transfer_approved: register_int_counter_with_registry!(
-                "total_sui_token_transfer_approved",
+                "bridge_indexer_total_sui_token_transfer_approved",
                 "Total number of sui token approved transactions",
                 registry,
             )
             .unwrap(),
             total_sui_token_transfer_claimed: register_int_counter_with_registry!(
-                "total_sui_token_transfer_claimed",
+                "bridge_indexer_total_sui_token_transfer_claimed",
                 "Total number of sui token claimed transactions",
                 registry,
             )
             .unwrap(),
             total_sui_bridge_txn_other: register_int_counter_with_registry!(
-                "total_sui_bridge_txn_other",
+                "bridge_indexer_total_sui_bridge_txn_other",
                 "Total number of other sui bridge transactions",
                 registry,
             )
             .unwrap(),
             total_eth_bridge_transactions: register_int_counter_with_registry!(
-                "total_eth_bridge_transactions",
+                "bridge_indexer_total_eth_bridge_transactions",
                 "Total number of eth bridge transactions",
                 registry,
             )
             .unwrap(),
             total_eth_token_deposited: register_int_counter_with_registry!(
-                "total_eth_token_deposited",
+                "bridge_indexer_total_eth_token_deposited",
                 "Total number of eth token deposited transactions",
                 registry,
             )
             .unwrap(),
             total_eth_token_transfer_claimed: register_int_counter_with_registry!(
-                "total_eth_token_transfer_claimed",
+                "bridge_indexer_total_eth_token_transfer_claimed",
                 "Total number of eth token claimed transactions",
                 registry,
             )
             .unwrap(),
             total_eth_bridge_txn_other: register_int_counter_with_registry!(
-                "total_eth_bridge_txn_other",
+                "bridge_indexer_total_eth_bridge_txn_other",
                 "Total number of other eth bridge transactions",
                 registry,
             )
             .unwrap(),
             last_committed_sui_checkpoint: register_int_gauge_with_registry!(
-                "last_committed_sui_checkpoint",
+                "bridge_indexer_last_committed_sui_checkpoint",
                 "The latest sui checkpoint that indexer committed to DB",
                 registry,
             )
             .unwrap(),
             latest_committed_eth_block: register_int_gauge_with_registry!(
-                "last_committed_eth_block",
+                "bridge_indexer_last_committed_eth_block",
                 "The latest eth block that indexer committed to DB",
                 registry,
             )
             .unwrap(),
             last_synced_eth_block: register_int_gauge_with_registry!(
-                "last_synced_eth_block",
+                "bridge_indexer_last_synced_eth_block",
                 "The last eth block that indexer committed to DB",
+                registry,
+            )
+            .unwrap(),
+            tasks_remaining_checkpoints: register_int_gauge_vec_with_registry!(
+                "bridge_indexer_tasks_remaining_checkpoints",
+                "The remaining checkpoint for each task",
+                &["task_name"],
+                registry,
+            )
+            .unwrap(),
+            live_task_current_checkpoint: register_int_gauge_vec_with_registry!(
+                "bridge_indexer_live_task_current_checkpoint",
+                "Current checkpoint of live task",
+                &["task_name"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge-indexer/src/sui_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/sui_bridge_indexer.rs
@@ -15,7 +15,6 @@ use sui_bridge::events::{
     MoveTokenDepositedEvent, MoveTokenTransferApproved, MoveTokenTransferClaimed,
 };
 use sui_indexer_builder::indexer_builder::{DataMapper, IndexerProgressStore, Persistent};
-use sui_indexer_builder::sui_datasource::CheckpointTxnData;
 use sui_indexer_builder::Task;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::event::Event;
@@ -27,6 +26,7 @@ use crate::metrics::BridgeIndexerMetrics;
 use crate::postgres_manager::PgPool;
 use crate::schema::progress_store::{columns, dsl};
 use crate::schema::{sui_error_transactions, token_transfer, token_transfer_data};
+use crate::sui_datasource::CheckpointTxnData;
 use crate::{
     models, schema, BridgeDataSource, ProcessedTxnData, SuiTxnError, TokenTransfer,
     TokenTransferData, TokenTransferStatus,

--- a/crates/sui-bridge-indexer/src/sui_datasource.rs
+++ b/crates/sui-bridge-indexer/src/sui_datasource.rs
@@ -19,7 +19,6 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
-use tracing::info;
 
 use crate::metrics::BridgeIndexerMetrics;
 
@@ -108,6 +107,10 @@ impl Datasource<CheckpointTxnData> for SuiCheckpointDatasource {
         &self.indexer_metrics.tasks_remaining_checkpoints
     }
 
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+        &self.indexer_metrics.tasks_processed_checkpoints
+    }
+
     fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
         &self.indexer_metrics.live_task_current_checkpoint
     }
@@ -158,7 +161,7 @@ pub type CheckpointTxnData = (CheckpointTransaction, u64, u64);
 #[async_trait]
 impl Worker for IndexerWorker<CheckpointTxnData> {
     async fn process_checkpoint(&self, checkpoint: SuiCheckpointData) -> anyhow::Result<()> {
-        info!(
+        tracing::trace!(
             "Received checkpoint [{}] {}: {}",
             checkpoint.checkpoint_summary.epoch,
             checkpoint.checkpoint_summary.sequence_number,

--- a/crates/sui-bridge-indexer/src/sui_datasource.rs
+++ b/crates/sui-bridge-indexer/src/sui_datasource.rs
@@ -4,6 +4,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use mysten_metrics::{metered_channel, spawn_monitored_task};
+use prometheus::IntCounterVec;
 use prometheus::IntGaugeVec;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -107,7 +108,7 @@ impl Datasource<CheckpointTxnData> for SuiCheckpointDatasource {
         &self.indexer_metrics.tasks_remaining_checkpoints
     }
 
-    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntCounterVec {
         &self.indexer_metrics.tasks_processed_checkpoints
     }
 

--- a/crates/sui-indexer-builder/Cargo.toml
+++ b/crates/sui-indexer-builder/Cargo.toml
@@ -15,6 +15,7 @@ mysten-metrics.workspace = true
 sui-types.workspace = true
 sui-sdk.workspace = true
 sui-data-ingestion-core.workspace = true
+futures.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-indexer-builder/src/lib.rs
+++ b/crates/sui-indexer-builder/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod indexer_builder;
-pub mod sui_datasource;
 
 #[derive(Clone, Debug)]
 pub struct Task {

--- a/crates/sui-indexer-builder/tests/indexer_test_utils.rs
+++ b/crates/sui-indexer-builder/tests/indexer_test_utils.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
+use prometheus::IntGaugeVec;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -21,6 +22,7 @@ pub struct TestDatasource<T> {
     pub data: Vec<T>,
     pub live_task_starting_checkpoint: u64,
     pub genesis_checkpoint: u64,
+    pub metric: IntGaugeVec,
 }
 
 #[async_trait]
@@ -54,6 +56,16 @@ where
 
     fn get_genesis_height(&self) -> u64 {
         self.genesis_checkpoint
+    }
+
+    fn get_tasks_remaining_checkpoints_metric(&self) -> &IntGaugeVec {
+        // This is dummy
+        &self.metric
+    }
+
+    fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
+        // This is dummy
+        &self.metric
     }
 }
 

--- a/crates/sui-indexer-builder/tests/indexer_test_utils.rs
+++ b/crates/sui-indexer-builder/tests/indexer_test_utils.rs
@@ -63,6 +63,11 @@ where
         &self.metric
     }
 
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+        // This is dummy
+        &self.metric
+    }
+
     fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
         // This is dummy
         &self.metric

--- a/crates/sui-indexer-builder/tests/indexer_test_utils.rs
+++ b/crates/sui-indexer-builder/tests/indexer_test_utils.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
-use prometheus::IntGaugeVec;
+use prometheus::{IntCounterVec, IntGaugeVec};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -22,7 +22,8 @@ pub struct TestDatasource<T> {
     pub data: Vec<T>,
     pub live_task_starting_checkpoint: u64,
     pub genesis_checkpoint: u64,
-    pub metric: IntGaugeVec,
+    pub gauge_metric: IntGaugeVec,
+    pub counter_metric: IntCounterVec,
 }
 
 #[async_trait]
@@ -60,17 +61,17 @@ where
 
     fn get_tasks_remaining_checkpoints_metric(&self) -> &IntGaugeVec {
         // This is dummy
-        &self.metric
+        &self.gauge_metric
     }
 
-    fn get_tasks_processed_checkpoints_metric(&self) -> &IntGaugeVec {
+    fn get_tasks_processed_checkpoints_metric(&self) -> &IntCounterVec {
         // This is dummy
-        &self.metric
+        &self.counter_metric
     }
 
     fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
         // This is dummy
-        &self.metric
+        &self.gauge_metric
     }
 }
 

--- a/crates/sui-indexer-builder/tests/indexer_tests.rs
+++ b/crates/sui-indexer-builder/tests/indexer_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::indexer_test_utils::{InMemoryPersistent, NoopDataMapper, TestDatasource};
-use prometheus::Registry;
+use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
 use sui_indexer_builder::indexer_builder::{BackfillStrategy, IndexerBuilder};
 use sui_indexer_builder::Task;
 
@@ -19,6 +19,7 @@ async fn indexer_simple_backfill_task_test() {
         data: data.clone(),
         live_task_starting_checkpoint: 5,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     let mut indexer = IndexerBuilder::new(
@@ -57,6 +58,7 @@ async fn indexer_partitioned_backfill_task_test() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     let mut indexer = IndexerBuilder::new(
@@ -102,6 +104,7 @@ async fn indexer_partitioned_task_with_data_already_in_db_test1() {
         data: data.clone(),
         live_task_starting_checkpoint: 31,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.data.lock().await.append(&mut (0..=30).collect());
@@ -151,6 +154,7 @@ async fn indexer_partitioned_task_with_data_already_in_db_test2() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.data.lock().await.append(&mut (0..=30).collect());
@@ -202,6 +206,7 @@ async fn indexer_partitioned_task_with_data_already_in_db_test3() {
         data: data.clone(),
         live_task_starting_checkpoint: 28,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -256,6 +261,7 @@ async fn indexer_partitioned_task_with_data_already_in_db_test4() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -314,6 +320,7 @@ async fn indexer_with_existing_live_task1() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 10,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -357,6 +364,7 @@ async fn indexer_with_existing_live_task2() {
         data: data.clone(),
         live_task_starting_checkpoint: 25,
         genesis_checkpoint: 10,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -410,6 +418,7 @@ async fn resume_test() {
         data: data.clone(),
         live_task_starting_checkpoint: 31,
         genesis_checkpoint: 0,
+        metric: new_metric(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -445,4 +454,8 @@ async fn resume_test() {
     let mut recorded_data = persistent.data.lock().await.clone();
     recorded_data.sort();
     assert_eq!((10..=50u64).collect::<Vec<_>>(), recorded_data);
+}
+
+fn new_metric(registry: &Registry) -> IntGaugeVec {
+    register_int_gauge_vec_with_registry!("whatever", "whatever", &["whatever"], registry,).unwrap()
 }

--- a/crates/sui-indexer-builder/tests/indexer_tests.rs
+++ b/crates/sui-indexer-builder/tests/indexer_tests.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::indexer_test_utils::{InMemoryPersistent, NoopDataMapper, TestDatasource};
-use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
+use prometheus::{
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
+    IntGaugeVec, Registry,
+};
 use sui_indexer_builder::indexer_builder::{BackfillStrategy, IndexerBuilder};
 use sui_indexer_builder::Task;
 
@@ -19,7 +22,8 @@ async fn indexer_simple_backfill_task_test() {
         data: data.clone(),
         live_task_starting_checkpoint: 5,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     let mut indexer = IndexerBuilder::new(
@@ -40,6 +44,7 @@ async fn indexer_simple_backfill_task_test() {
 
     // it should have 2 task created for the indexer - a live task and a backfill task
     let tasks = persistent.get_all_tasks("test_indexer").await.unwrap();
+    println!("{:?}", tasks);
     assert_ranges(&tasks, vec![(10, i64::MAX as u64), (4, 4)]);
     // the data recorded in storage should be the same as the datasource
     let mut recorded_data = persistent.data.lock().await.clone();
@@ -58,7 +63,8 @@ async fn indexer_partitioned_backfill_task_test() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     let mut indexer = IndexerBuilder::new(
@@ -104,7 +110,8 @@ async fn indexer_partitioned_task_with_data_already_in_db_test1() {
         data: data.clone(),
         live_task_starting_checkpoint: 31,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.data.lock().await.append(&mut (0..=30).collect());
@@ -154,7 +161,8 @@ async fn indexer_partitioned_task_with_data_already_in_db_test2() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.data.lock().await.append(&mut (0..=30).collect());
@@ -206,7 +214,8 @@ async fn indexer_partitioned_task_with_data_already_in_db_test3() {
         data: data.clone(),
         live_task_starting_checkpoint: 28,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -261,7 +270,8 @@ async fn indexer_partitioned_task_with_data_already_in_db_test4() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -320,7 +330,8 @@ async fn indexer_with_existing_live_task1() {
         data: data.clone(),
         live_task_starting_checkpoint: 35,
         genesis_checkpoint: 10,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -364,7 +375,8 @@ async fn indexer_with_existing_live_task2() {
         data: data.clone(),
         live_task_starting_checkpoint: 25,
         genesis_checkpoint: 10,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -418,7 +430,8 @@ async fn resume_test() {
         data: data.clone(),
         live_task_starting_checkpoint: 31,
         genesis_checkpoint: 0,
-        metric: new_metric(&registry),
+        gauge_metric: new_gauge_vec(&registry),
+        counter_metric: new_counter_vec(&registry),
     };
     let persistent = InMemoryPersistent::new();
     persistent.progress_store.lock().await.insert(
@@ -456,6 +469,12 @@ async fn resume_test() {
     assert_eq!((10..=50u64).collect::<Vec<_>>(), recorded_data);
 }
 
-fn new_metric(registry: &Registry) -> IntGaugeVec {
-    register_int_gauge_vec_with_registry!("whatever", "whatever", &["whatever"], registry,).unwrap()
+fn new_gauge_vec(registry: &Registry) -> IntGaugeVec {
+    register_int_gauge_vec_with_registry!("whatever_gauge", "whatever", &["whatever"], registry,)
+        .unwrap()
+}
+
+fn new_counter_vec(registry: &Registry) -> IntCounterVec {
+    register_int_counter_vec_with_registry!("whatever_counter", "whatever", &["whatever"], registry,)
+        .unwrap()
 }


### PR DESCRIPTION
## Description 

This PR does two things:
1. pull checkpoint batches to processed when there are multiple, rather than one-by-one. This improves the efficiency especially for write_process
2. add metrics to check indexing progress.

## Test plan 

Deployed in production.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
