### PR TITLE
[bridge] enable bridge on mainnet

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1293,7 +1293,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "57",
+              "maxSupportedProtocolVersion": "58",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -16,7 +16,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 57;
+const MAX_PROTOCOL_VERSION: u64 = 58;
 
 // Record history of protocol version allocations here:
 //
@@ -169,8 +169,9 @@ const MAX_PROTOCOL_VERSION: u64 = 57;
 //             Enable soft bundle on mainnet.
 // Version 55: Enable enums on mainnet.
 //             Rethrow serialization type layout errors instead of converting them.
-// Version 56: Reduce minimum number of random beacon shares.
-// Version 57: Optimize boolean binops
+// Version 56: Enable bridge on mainnet.
+// Version 57: Reduce minimum number of random beacon shares.
+// Version 58: Optimize boolean binops
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2698,10 +2699,15 @@ impl ProtocolConfig {
                     cfg.feature_flags.rethrow_serialization_type_layout_errors = true;
                 }
                 56 => {
+                    if chain == Chain::Mainnet {
+                        cfg.feature_flags.bridge = true;
+                    }
+                }
+                57 => {
                     // Reduce minimum number of random beacon shares.
                     cfg.random_beacon_reduction_lower_bound = Some(800);
                 }
-                57 => {}
+                58 => {}
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -170,6 +170,7 @@ const MAX_PROTOCOL_VERSION: u64 = 58;
 // Version 55: Enable enums on mainnet.
 //             Rethrow serialization type layout errors instead of converting them.
 // Version 56: Enable bridge on mainnet.
+//             Note: do not use version 56 for any new features.
 // Version 57: Reduce minimum number of random beacon shares.
 // Version 58: Optimize boolean binops
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_56.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_56.snap
@@ -33,6 +33,7 @@ feature_flags:
   loaded_child_object_format_type: true
   receive_objects: true
   random_beacon: true
+  bridge: true
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
@@ -306,7 +307,7 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-random_beacon_reduction_lower_bound: 800
+random_beacon_reduction_lower_bound: 1000
 random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_58.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_58.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 57
+version: 58
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_56.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_56.snap
@@ -307,7 +307,7 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-random_beacon_reduction_lower_bound: 800
+random_beacon_reduction_lower_bound: 1000
 random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_58.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_58.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 57
+version: 58
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -319,6 +319,6 @@ max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
-bridge_should_try_to_finalize_committee: false
+bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_56.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_56.snap
@@ -316,7 +316,7 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-random_beacon_reduction_lower_bound: 800
+random_beacon_reduction_lower_bound: 1000
 random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_58.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_58.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 57
+version: 58
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -42,8 +42,10 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
+  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
   consensus_choice: Mysticeti
@@ -53,12 +55,15 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -238,6 +243,8 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 52
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 10
 group_ops_bls12381_decode_scalar_cost: 52
 group_ops_bls12381_decode_g1_cost: 52
 group_ops_bls12381_decode_g2_cost: 52
@@ -273,6 +280,8 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
 bcs_per_byte_serialized_cost: 2
 bcs_legacy_min_output_size_cost: 1
 bcs_failure_cost: 52
@@ -319,6 +328,6 @@ max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
-bridge_should_try_to_finalize_committee: false
+bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 57
+  protocol_version: 58
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 57
+protocol_version: 58
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x3ae0280cc3896eddd70f543d88d4a62398eeab5b72853dc865be1311b3fc3f34"
+            id: "0xc2d14ac13258b8f3b226af594912a4827eaed07619eaeaaf1720f74b78c6e6f2"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xb30301b32b3f3f08b9c6cffd160dd8bae9f2108237e57f7d1eda342306afbdd8"
+      operation_cap_id: "0xb3614c5b6ab4f2e57b8af0a00b39b9ea844184bdada20c8bc4d9e53b890400b7"
       gas_price: 1000
       staking_pool:
-        id: "0x45aa062f714dc12f53440e11106b1eaa58601389e52bea63aa488bbdb0602f5f"
+        id: "0x2679200399733fbf4a4222193320f4ab05d5f326ce47c1c2d5c8a64abe992859"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x66679730c60cf21bdc1bb351c5a2e4af23150adff827e0b7c1a31427a0861c4d"
+          id: "0x3d94e5f7c4dfdf8b63f0ad5797322e89f1a313dc14a15b79e18a49373673da61"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xd5fbb62737bef393eb95946ca5c72bc32192209608c52d173dbb321f75f3bc4d"
+            id: "0x3331ff8dbb4c8f658ef558d404cb02446dc16336e402339999c134c3febc15f0"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x4dcb2d802f2873cf75d5f929a9077aeaa840732e10a4bb289454817adaad2b1b"
+          id: "0xf51dda855dcebc34936a2fb74dd27d4ba39901e75fdcc534d5dc676146a1bfbf"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x364c72ac84a4d20d26abe50d7e7c65bc01ef1a5a3f88509fc85e3e30f30acec0"
+      id: "0x9d39a48e84fe307a3e9fa15a2b66f8cd30859a51ad97beef7fd3f88ff445a767"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x9da0238faf8434f05889c6bf6479f45e2fd3e0ab11c07c260d281c8c29b3dbd4"
+    id: "0xa551b4b779ddfc252fbd74efd4797a123c6776c08ee3d207907e4e5da4c02981"
     size: 1
   inactive_validators:
-    id: "0x5db716cd23d05a7875a9d320b4ec900c67bce9cb5abdfe5b3d6a5dca8889fe44"
+    id: "0x52a6f271c8bbcd028e79fbe34fa42b024b9f0d0483c3a66ee57d175d60a7e32c"
     size: 0
   validator_candidates:
-    id: "0x6e27c600f65fb475111f0acf64535436a93a170d13373e5dba1cf8389cc6aff6"
+    id: "0x9b6d66c1583be2ef9870b8db59ad4c3aa6b9b08a9d3c83fd4e77af1f42ad26b6"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x9a529516ae8ef00675d997826fc1e6157de85a10f149de98f579d527c82fabc5"
+      id: "0x712bc45147bbe111cc0a6ff754eb85d35b8958a898ff63a530ec5061b322255c"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x6d57000dfb420416d7a40cbe297b59a62d4eaef0082af97fdc0d5d6259960b5c"
+      id: "0xd2a66e9d85bbffe67291d8baa77803b463a589663c850ca595cf22938560fde4"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x8ffbd55004f5ca13ab46d8e8a269bbbd3fcd52cfdff14f32e6dd0b5f01a2f3db"
+      id: "0x96e0ef506f1c7074baee3f9761a7403c4a77653a1a40f28c2228ece4aaa7f8e8"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xb4bf4e42e0f2b475234a3de4d8a904e9a43b9501a2c09a1c6469db9c0629179a"
+    id: "0x897c0e02c83865b1d4f60e98549122bc56dad7ed2f7626ad819770b45fd964f6"
   size: 0
 


### PR DESCRIPTION
## Description 

enable bridge creation on mainnet by setting bridge is true. Before this change, the value true for testnet and devnet, but not mainnet. So this only applies to mainnet.

## Test plan 


### Mainnet
* expect 56, 57, 58 all have bridge = true
* [old 57](https://github.com/MystenLabs/sui/blob/main/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_57.snap) v.s. [new 58](https://github.com/MystenLabs/sui/blob/bb25a072dac4848337c111d4fefeb0256fa36cd8/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_58.snap): https://www.diffchecker.com/AbcQx7DQ/
* [old 56](https://github.com/MystenLabs/sui/blob/main/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_56.snap) v.s. [new 57](https://github.com/MystenLabs/sui/blob/bb25a072dac4848337c111d4fefeb0256fa36cd8/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_57.snap):  https://www.diffchecker.com/E3b9mlHd/, notably random_beacon_reduction_lower_bound: 800  in new 57, which was in old 56
* [old 56](https://github.com/MystenLabs/sui/blob/main/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_56.snap) v.s [new 56](https://github.com/MystenLabs/sui/blob/bb25a072dac4848337c111d4fefeb0256fa36cd8/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_56.snap):  https://www.diffchecker.com/EkWIOCeQ/ this reverts 
[@Andrew Schran](https://mysten-labs.slack.com/team/U03TDESBNR0)
’s change of random_beacon_reduction_lower_bound , now back to 1000.

### Testnet
* unlike mainnet, bridge has been set to true months ago, so expect no change for this parameter.
* [old 57](https://github.com/MystenLabs/sui/blob/main/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_57.snap) v.s. [new 58](https://github.com/MystenLabs/sui/blob/bb25a072dac4848337c111d4fefeb0256fa36cd8/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_58.snap): https://www.diffchecker.com/bc7A5fVn/, no change
* [old 56](https://github.com/MystenLabs/sui/blob/main/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_56.snap) vs [new 57](https://github.com/MystenLabs/sui/blob/bb25a072dac4848337c111d4fefeb0256fa36cd8/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_57.snap): https://www.diffchecker.com/XaktzhpC/  no change. notably random_beacon_reduction_lower_bound: 800  in new 57, which was in old 56
* [old 56 ](https://github.com/MystenLabs/sui/blob/main/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_56.snap)v.s [new 56:](https://github.com/MystenLabs/sui/blob/bb25a072dac4848337c111d4fefeb0256fa36cd8/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_56.snap) https://www.diffchecker.com/SeNewiDN/ this reverts 
[@Andrew Schran](https://mysten-labs.slack.com/team/U03TDESBNR0)
’s change of random_beacon_reduction_lower_bound , now back to 1000.
* effectively version 56 is a no-op for testnet

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
