### PR TITLE
Delete sst files in key range in rocksdb

### DIFF
--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -265,6 +265,13 @@ where
         Ok(())
     }
 
+    fn delete_file_in_range(&self, from: &K, to: &K) -> Result<(), TypedStoreError> {
+        let mut locked = self.rows.write().unwrap();
+        locked
+            .retain(|k, _| k < &be_fix_int_ser(from).unwrap() || k >= &be_fix_int_ser(to).unwrap());
+        Ok(())
+    }
+
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let mut locked = self.rows.write().unwrap();
         locked.clear();

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -48,6 +48,9 @@ where
     /// Removes every key-value pair from the map.
     fn unsafe_clear(&self) -> Result<(), Self::Error>;
 
+    /// Removes every key-value pair from the map by deleting the underlying file.
+    fn delete_file_in_range(&self, from: &K, to: &K) -> Result<(), TypedStoreError>;
+
     /// Uses delete range on the entire key range
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError>;
 


### PR DESCRIPTION
## Description 

This PR adds a rocksdb endpoint to delete .sst files in key range in rocksdb which is useful to prune data (in certain scenarios) without compaction.
