### PR TITLE
Revert "Remove RandomnessStateUpdate" from ConsensusTransactionKind

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2535,6 +2535,10 @@ impl AuthorityPerEpochStore {
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::RandomnessStateUpdate(_round, _bytes),
+                ..
+            }) => {}
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::RandomnessDkgMessage(authority, _bytes),
                 ..
             }) => {
@@ -3604,6 +3608,13 @@ impl AuthorityPerEpochStore {
                     );
                 }
                 Ok(ConsensusCertificateResult::ConsensusMessage)
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::RandomnessStateUpdate(_, _),
+                ..
+            }) => {
+                // These are always generated as System transactions (handled below).
+                panic!("process_consensus_transaction called with external RandomnessStateUpdate");
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::RandomnessDkgMessage(authority, bytes),

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -87,7 +87,8 @@ impl SuiTxValidator {
 
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::NewJWKFetched(_, _, _)
-                | ConsensusTransactionKind::CapabilityNotificationV2(_) => {}
+                | ConsensusTransactionKind::CapabilityNotificationV2(_)
+                | ConsensusTransactionKind::RandomnessStateUpdate(_, _) => {}
             }
         }
 

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -253,27 +253,26 @@ impl AuthorityCapabilitiesV2 {
     }
 }
 
-#[repr(u8)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConsensusTransactionKind {
-    CertifiedTransaction(Box<CertifiedTransaction>) = 0,
-    CheckpointSignature(Box<CheckpointSignatureMessage>) = 1,
-    EndOfPublish(AuthorityName) = 2,
+    CertifiedTransaction(Box<CertifiedTransaction>),
+    CheckpointSignature(Box<CheckpointSignatureMessage>),
+    EndOfPublish(AuthorityName),
 
-    CapabilityNotification(AuthorityCapabilitiesV1) = 3,
+    CapabilityNotification(AuthorityCapabilitiesV1),
 
-    NewJWKFetched(AuthorityName, JwkId, JWK) = 4,
-    RandomnessStateUpdate(u64, Vec<u8>) = 5, // deprecated
+    NewJWKFetched(AuthorityName, JwkId, JWK),
+    RandomnessStateUpdate(u64, Vec<u8>), // deprecated
     // DKG is used to generate keys for use in the random beacon protocol.
     // `RandomnessDkgMessage` is sent out at start-of-epoch to initiate the process.
     // Contents are a serialized `fastcrypto_tbls::dkg::Message`.
-    RandomnessDkgMessage(AuthorityName, Vec<u8>) = 6,
+    RandomnessDkgMessage(AuthorityName, Vec<u8>),
     // `RandomnessDkgConfirmation` is the second DKG message, sent as soon as a threshold amount of
     // `RandomnessDkgMessages` have been received locally, to complete the key generation process.
     // Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
-    RandomnessDkgConfirmation(AuthorityName, Vec<u8>) = 7,
+    RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
 
-    CapabilityNotificationV2(AuthorityCapabilitiesV2) = 8,
+    CapabilityNotificationV2(AuthorityCapabilitiesV2),
 }
 
 impl ConsensusTransactionKind {

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -261,10 +261,9 @@ pub enum ConsensusTransactionKind {
     EndOfPublish(AuthorityName) = 2,
 
     CapabilityNotification(AuthorityCapabilitiesV1) = 3,
-    CapabilityNotificationV2(AuthorityCapabilitiesV2) = 8,
 
     NewJWKFetched(AuthorityName, JwkId, JWK) = 4,
-
+    RandomnessStateUpdate(u64, Vec<u8>) = 5, // deprecated
     // DKG is used to generate keys for use in the random beacon protocol.
     // `RandomnessDkgMessage` is sent out at start-of-epoch to initiate the process.
     // Contents are a serialized `fastcrypto_tbls::dkg::Message`.
@@ -273,6 +272,8 @@ pub enum ConsensusTransactionKind {
     // `RandomnessDkgMessages` have been received locally, to complete the key generation process.
     // Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
     RandomnessDkgConfirmation(AuthorityName, Vec<u8>) = 7,
+
+    CapabilityNotificationV2(AuthorityCapabilitiesV2) = 8,
 }
 
 impl ConsensusTransactionKind {
@@ -517,6 +518,9 @@ impl ConsensusTransaction {
                     id.clone(),
                     key.clone(),
                 )))
+            }
+            ConsensusTransactionKind::RandomnessStateUpdate(_, _) => {
+                unreachable!("there should never be a RandomnessStateUpdate with SequencedConsensusTransactionKind::External")
             }
             ConsensusTransactionKind::RandomnessDkgMessage(authority, _) => {
                 ConsensusTransactionKey::RandomnessDkgMessage(*authority)


### PR DESCRIPTION
## Description 

It turns out BCS serializes enum purely based on the variant order. The discriminant / tag does not matter. https://github.com/diem/bcs/blob/master/README.md#externally-tagged-enumerations

Also revert tagging of the enum since it is no longer useful.

## Test plan 

SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet scripts/compatibility/split-cluster-check.sh origin/testnet a6336e6390b31379c7d41ef0d6fba4f966fad00c

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
