### PR TITLE
[CI] do not ignore failures from Split Cluster Check in PRs

### DIFF
--- a/.github/workflows/split-cluster-bisect.yml
+++ b/.github/workflows/split-cluster-bisect.yml
@@ -1,6 +1,5 @@
 name: Split Cluster Check
-on: 
-  pull_request:
+on:
   push:
     branches:
       - main

--- a/.github/workflows/split-cluster-pr.yml
+++ b/.github/workflows/split-cluster-pr.yml
@@ -1,0 +1,29 @@
+name: Split Cluster Check
+on: 
+  pull_request:
+jobs:
+  validate-mainnet:
+    runs-on: ubuntu-ghcloud
+    steps:
+      - name: checkout code repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Run split cluster check script
+        id: mn-split-cluster-check
+        run: | 
+            SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
+            scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ github.sha }}
+
+  validate-testnet:
+    runs-on: ubuntu-ghcloud
+    steps:
+      - name: checkout code repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Run split cluster check script
+        id: tn-split-cluster-check
+        run: | 
+            SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
+            scripts/compatibility/split-cluster-check.sh origin/testnet ${{ github.sha }}


### PR DESCRIPTION
## Description 

Currently when the check runs in PR CI, the failure is ignored and bisect does not run. So the workflow succeeds when it shouldn't.
For example, https://github.com/MystenLabs/sui/actions/runs/10641580676/job/29502904956#step:3:2268

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
