### PR TITLE
[Consensus] abort submitting checkpoint sigs to consensus

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2045,7 +2045,7 @@ impl AuthorityPerEpochStore {
     }
 
     /// Notifies that a synced checkpoint of sequence number `checkpoint_seq` is available. The source of the notification
-    /// is the CheckpointExecutor.
+    /// is the CheckpointExecutor. The consumer here is guaranteed to be notified in sequence order.
     pub fn notify_synced_checkpoint(&self, checkpoint_seq: CheckpointSequenceNumber) {
         let mut highest_synced_checkpoint = self.highest_synced_checkpoint.write();
         *highest_synced_checkpoint = checkpoint_seq;

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -532,6 +532,8 @@ impl CheckpointExecutor {
         let accumulator = self.accumulator.clone();
         let state = self.state.clone();
 
+        epoch_store.notify_synced_checkpoint(*checkpoint.sequence_number());
+
         pending.push_back(spawn_monitored_task!(async move {
             let epoch_store = epoch_store.clone();
             let (tx_digests, checkpoint_acc) = loop {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -124,7 +124,7 @@ impl ConsensusAdapterMetrics {
             sequencing_certificate_latency: register_histogram_vec_with_registry!(
                 "sequencing_certificate_latency",
                 "The latency for sequencing a certificate.",
-                &["position", "tx_type"],
+                &["position", "tx_type", "processed_method"],
                 SEQUENCING_CERTIFICATE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -785,10 +785,12 @@ impl ConsensusAdapter {
                     .observe(ack_start.elapsed().as_secs_f64());
             };
             match select(processed_waiter, submit_inner.boxed()).await {
-                Either::Left((processed, _submit_inner)) => processed,
+                Either::Left((_processed, _submit_inner)) => (),
                 Either::Right(((), processed_waiter)) => {
                     debug!("Submitted {transaction_keys:?} to consensus");
-                    processed_waiter.await
+                    // if tx has been processed by checkpoint state sync, then exclude from the latency calculations as this can
+                    // introduce to misleading results.
+                    guard.exclude_from_latency_observe = !processed_waiter.await;
                 }
             }
         }
@@ -843,11 +845,12 @@ impl ConsensusAdapter {
     }
 
     /// Waits for transactions to appear either to consensus output or been executed via a checkpoint (state sync).
+    /// Returns true if all transactions have been processed via consensus, false otherwise (if have been synced via checkpoint)
     async fn await_consensus_or_checkpoint(
         self: &Arc<Self>,
         transaction_keys: Vec<SequencedConsensusTransactionKey>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) {
+    ) -> bool {
         let notifications = FuturesUnordered::new();
         for transaction_key in transaction_keys {
             let transaction_digests = if let SequencedConsensusTransactionKey::External(
@@ -878,6 +881,7 @@ impl ConsensusAdapter {
                     processed = epoch_store.consensus_messages_processed_notify(vec![transaction_key]) => {
                         processed.expect("Storage error when waiting for consensus message processed");
                         self.metrics.sequencing_certificate_processed.with_label_values(&["consensus"]).inc();
+                        return true;
                     },
                     processed = epoch_store.transactions_executed_in_checkpoint_notify(transaction_digests), if !transaction_digests.is_empty() => {
                         processed.expect("Storage error when waiting for transaction executed in checkpoint");
@@ -888,10 +892,12 @@ impl ConsensusAdapter {
                         self.metrics.sequencing_certificate_processed.with_label_values(&["synced_checkpoint"]).inc();
                     }
                 }
+                false
             });
         }
 
-        notifications.collect::<Vec<()>>().await;
+        let synced_via_consensus = notifications.collect::<Vec<bool>>().await;
+        synced_via_consensus.into_iter().all(|x| x)
     }
 }
 
@@ -1017,6 +1023,7 @@ struct InflightDropGuard<'a> {
     positions_moved: Option<usize>,
     preceding_disconnected: Option<usize>,
     tx_type: &'static str,
+    exclude_from_latency_observe: bool,
 }
 
 impl<'a> InflightDropGuard<'a> {
@@ -1041,6 +1048,7 @@ impl<'a> InflightDropGuard<'a> {
             positions_moved: None,
             preceding_disconnected: None,
             tx_type,
+            exclude_from_latency_observe: false,
         }
     }
 }
@@ -1098,7 +1106,7 @@ impl<'a> Drop for InflightDropGuard<'a> {
                 self.tx_type,
                 "shared_certificate" | "owned_certificate" | "checkpoint_signature" | "soft_bundle"
             );
-            if sampled {
+            if sampled && !self.exclude_from_latency_observe {
                 self.adapter.latency_observer.report(latency);
             }
         }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -882,6 +882,8 @@ impl ConsensusAdapter {
                         self.metrics.sequencing_certificate_processed.with_label_values(&["checkpoint"]).inc();
                     }
                     processed = async {
+                        // If the transaction is a checkpoint signature, we can also wait to get notified when a checkpoint with equal or higher sequence
+                        // number has been already synced. This way we don't try to unnecessarily sequence the signature for an already verified checkpoint.
                         if let Some(checkpoint_sequence_number) = checkpoint_sequence_number {
                             epoch_store.synced_checkpoint_notify(checkpoint_sequence_number).await
                         } else {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -859,6 +859,15 @@ impl ConsensusAdapter {
                 vec![]
             };
 
+            let checkpoint_sequence_number = if let SequencedConsensusTransactionKey::External(
+                ConsensusTransactionKey::CheckpointSignature(_, checkpoint_sequence_number),
+            ) = transaction_key
+            {
+                Some(checkpoint_sequence_number)
+            } else {
+                None
+            };
+
             // We wait for each transaction individually to be processed by consensus or executed in a checkpoint. We could equally just
             // get notified in aggregate when all transactions are processed, but with this approach can get notified in a more fine-grained way
             // as transactions can be marked as processed in different ways. This is mostly a concern for the soft-bundle transactions.
@@ -871,6 +880,16 @@ impl ConsensusAdapter {
                     processed = epoch_store.transactions_executed_in_checkpoint_notify(transaction_digests), if !transaction_digests.is_empty() => {
                         processed.expect("Storage error when waiting for transaction executed in checkpoint");
                         self.metrics.sequencing_certificate_processed.with_label_values(&["checkpoint"]).inc();
+                    }
+                    processed = async {
+                        if let Some(checkpoint_sequence_number) = checkpoint_sequence_number {
+                            epoch_store.synced_checkpoint_notify(checkpoint_sequence_number).await
+                        } else {
+                            Ok(())
+                        }
+                    }, if checkpoint_sequence_number.is_some() => {
+                        processed.expect("Error when waiting for checkpoint sequence number");
+                        self.metrics.sequencing_certificate_processed.with_label_values(&["synced_checkpoint"]).inc();
                     }
                 }
             });

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -7,21 +7,27 @@ use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_handler::SequencedConsensusTransaction;
+use fastcrypto::traits::KeyPair;
 use move_core_types::{account_address::AccountAddress, ident_str};
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use sui_network::tonic;
-use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{deterministic_random_account_key, AccountKeyPair};
+use sui_types::gas::GasCostSummary;
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointSignatureMessage, CheckpointSummary, SignedCheckpointSummary,
+};
 use sui_types::multiaddr::Multiaddr;
-use sui_types::transaction::{VerifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS};
-use sui_types::utils::to_sender_signed_transaction;
+use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS;
+use sui_types::utils::{make_committee_key, to_sender_signed_transaction};
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use sui_types::{
-    base_types::ObjectID,
+    base_types::{SuiAddress, ObjectID, ExecutionDigests},
     object::Object,
-    transaction::{CallArg, CertifiedTransaction, ObjectArg, TransactionData},
+    transaction::{CallArg, CertifiedTransaction, VerifiedTransaction, ObjectArg, TransactionData},
 };
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -220,6 +226,11 @@ pub fn make_consensus_adapter_for_test(
                                 .await?,
                         );
                     }
+                } else if let SequencedConsensusTransactionKey::External(
+                    ConsensusTransactionKey::CheckpointSignature(_, checkpoint_sequence_number),
+                ) = tx.transaction.key()
+                {
+                    epoch_store.notify_synced_checkpoint(checkpoint_sequence_number);
                 } else {
                     transactions.extend(
                         epoch_store
@@ -329,6 +340,58 @@ async fn submit_multiple_transactions_to_consensus_adapter() {
         .into_iter()
         .map(|certificate| ConsensusTransaction::new_certificate_message(&state.name, certificate))
         .collect::<Vec<_>>();
+
+    let waiter = adapter
+        .submit_batch(
+            &transactions,
+            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+            &epoch_store,
+        )
+        .unwrap();
+    waiter.await.unwrap();
+}
+
+#[tokio::test]
+async fn submit_checkpoint_signature_to_consensus_adapter() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut rng = StdRng::seed_from_u64(1_100);
+    let (keys, committee) = make_committee_key(&mut rng);
+
+    // Initialize an authority
+    let state = init_state_with_objects(vec![]).await;
+    let epoch_store = state.epoch_store_for_testing();
+
+    // Make a new consensus adapter instance.
+    let adapter = make_consensus_adapter_for_test(state, HashSet::new(), false);
+
+    let checkpoint_summary = CheckpointSummary::new(
+        &ProtocolConfig::get_for_max_version_UNSAFE(),
+        1,
+        2,
+        10,
+        &CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::random()]),
+        None,
+        GasCostSummary::default(),
+        None,
+        100,
+        Vec::new(),
+    );
+
+    let authority_key = &keys[0];
+    let authority = authority_key.public().into();
+    let signed_checkpoint_summary = SignedCheckpointSummary::new(
+        committee.epoch,
+        checkpoint_summary,
+        authority_key,
+        authority,
+    );
+
+    let transactions = vec![ConsensusTransaction::new_checkpoint_signature_message(
+        CheckpointSignatureMessage {
+            summary: signed_checkpoint_summary,
+        },
+    )];
     let waiter = adapter
         .submit_batch(
             &transactions,

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -25,9 +25,9 @@ use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS;
 use sui_types::utils::{make_committee_key, to_sender_signed_transaction};
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use sui_types::{
-    base_types::{SuiAddress, ObjectID, ExecutionDigests},
+    base_types::{ExecutionDigests, ObjectID, SuiAddress},
     object::Object,
-    transaction::{CallArg, CertifiedTransaction, VerifiedTransaction, ObjectArg, TransactionData},
+    transaction::{CallArg, CertifiedTransaction, ObjectArg, TransactionData, VerifiedTransaction},
 };
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::{Receiver, Sender};


### PR DESCRIPTION
## Description 

As part of the PR https://github.com/MystenLabs/sui/pull/18398 we are skip submitting checkpoint signatures when we have received verified checkpoints. Although this prevents the node from sending unnecessarily signatures, it's still possible to unnecessarily attempt to submit a signature tx after this has reached to consensus adapter. This PR is addressing that part.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
