### PR TITLE
Add storage gap variable to the CommitteeUpgradeable contract

### DIFF
--- a/bridge/evm/contracts/utils/CommitteeUpgradeable.sol
+++ b/bridge/evm/contracts/utils/CommitteeUpgradeable.sol
@@ -20,6 +20,8 @@ abstract contract CommitteeUpgradeable is
     /* ========== STATE VARIABLES ========== */
 
     bool private _upgradeAuthorized;
+    // upgradeablity storage gap
+    uint256[50] private __gap;
 
     /* ========== INITIALIZER ========== */
 


### PR DESCRIPTION
## Description 

In the case the `CommitteeUpgradeable` contract needs to include more storage variables, a storage gap variable is needed to reserve storage slots  so the child contract state is not overwritten. 

## Test plan 

Contract upgrade unit tests