### PR TITLE
[docs] restore old move-bytecode-template readme content

### DIFF
--- a/sdk/move-bytecode-template/README.md
+++ b/sdk/move-bytecode-template/README.md
@@ -8,6 +8,32 @@ This crate builds a WASM binary for the `move-language/move-binary-format` allow
 serialization and deserialization in various environments. The main target for this package is
 "web".
 
+## Build locally
+
+To build the binary, you need to have Rust installed and then the `wasm-pack`. The installation script [can be found here](https://rustwasm.github.io/wasm-pack/).
+
+Building for test (nodejs) environment - required for tests.
+```
+pnpm build:dev
+```
+
+Building for web environment.
+```
+pnpm build:release
+```
+
+## Running tests
+
+Local tests can only be run on the `dev` build. To run tests, follow these steps:
+
+```
+pnpm build:dev
+pnpm test
+```
+
+## Build Artifacts
+Once the build is complete, you can find the build artifacts in the `pkg` subdirectory, including the wasm file
+
 ## Applications
 
 This package is a perfect fit for the following applications:


### PR DESCRIPTION
## Description 

Restore old readme content that includes build instructions and how to run tests. The instruction should give a developer new to the repo a clearer idea of how to integrate the wasm file into their web application

## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
