### PR TITLE
[core] Force enable state accumulator v2

### DIFF
--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -71,30 +71,26 @@ pub enum EpochFlag {
 
 impl EpochFlag {
     pub fn default_flags_for_new_epoch(config: &NodeConfig) -> Vec<Self> {
-        Self::default_flags_impl(&config.execution_cache, config.state_accumulator_v2)
+        Self::default_flags_impl(&config.execution_cache)
     }
 
     /// For situations in which there is no config available (e.g. setting up a downloaded snapshot).
     pub fn default_for_no_config() -> Vec<Self> {
-        Self::default_flags_impl(&Default::default(), true)
+        Self::default_flags_impl(&Default::default())
     }
 
-    fn default_flags_impl(
-        cache_config: &ExecutionCacheConfig,
-        enable_state_accumulator_v2: bool,
-    ) -> Vec<Self> {
-        let mut new_flags = vec![EpochFlag::ExecutedInEpochTable];
+    fn default_flags_impl(cache_config: &ExecutionCacheConfig) -> Vec<Self> {
+        let mut new_flags = vec![
+            EpochFlag::ExecutedInEpochTable,
+            EpochFlag::StateAccumulatorV2EnabledTestnet,
+            EpochFlag::StateAccumulatorV2EnabledMainnet,
+        ];
 
         if matches!(
             choose_execution_cache(cache_config),
             ExecutionCacheConfigType::WritebackCache
         ) {
             new_flags.push(EpochFlag::WritebackCacheEnabled);
-        }
-
-        if enable_state_accumulator_v2 {
-            new_flags.push(EpochFlag::StateAccumulatorV2EnabledTestnet);
-            new_flags.push(EpochFlag::StateAccumulatorV2EnabledMainnet);
         }
 
         new_flags


### PR DESCRIPTION
## Description 

We have removed the ability to disable state accumulator v2 previously by ignoring the config parameter (https://github.com/MystenLabs/sui/pull/18786), however if a node that had v2 disabled has been running since before this change without shutting down, the old config would still be stored in memory. This PR forces enabling of v2. Once we have reached the epoch change after all nodes are running this code, we can safely merge https://github.com/MystenLabs/sui/pull/18764.

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
