### PR TITLE
[suiop] add date to message output

### DIFF
--- a/crates/suiop-cli/src/cli/incidents/slack.rs
+++ b/crates/suiop-cli/src/cli/incidents/slack.rs
@@ -55,7 +55,9 @@ struct SendMessageBody {
 
 impl Slack {
     pub async fn new() -> Self {
-        let token = std::env::var("SLACK_BOT_TOKEN").expect("Please set SLACK_BOT_TOKEN env var");
+        let token = std::env::var("SLACK_BOT_TOKEN").expect(
+            "Please set SLACK_BOT_TOKEN env var ('slack bot token (incidentbot)' in 1password)",
+        );
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::AUTHORIZATION,


### PR DESCRIPTION
## Description 

Add date output to make it clear when an incident was closed.
Add the slack channel url to short output.

## Test plan 

```
DEBUG=true cargo run -- i r -i --limit 1
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.54s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop i r -i --limit 1`
2024-09-05T20:52:01.898863Z  INFO suiop: Debug mode enabled
3511:0d   [FIRING:1] disk used % Infrastructure (/dev/md1 mainnet ext4 ord-mnt-rpcbig-03 localhost:9091 node-exporter /opt/sui mainnet pagerduty/nre rpc active) (https://mystenlabs.pagerduty.com/incidents/Q1OS8GCY2HHNEB)
> Keep this incident for review? Yes
Incidents marked for review: 3511
Here is the message to send in the channel: 
    
Hello everyone and happy Thursday!

We have selected the following incidents for review:
• 3511 09/05/24 [FIRING:1] disk used % Infrastructure (/dev/md1 mainnet ext4 ord-mnt-rpcbig-03 localhost:9091 node-exporter /opt/sui mainnet pagerduty/nre rpc active) 
    
and the following incidents have been excluded from review:


Please comment in the thread to request an adjustment to the list.
    
> Send this message to the #test-notifications channel? Yes
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
