### PR TITLE
[bridge-indexer] Integrate progress saving policy

### DIFF
--- a/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
@@ -154,10 +154,6 @@ impl Datasource<RawEthData> for EthSubscriptionDatasource {
     fn get_tasks_processed_checkpoints_metric(&self) -> &IntCounterVec {
         &self.indexer_metrics.tasks_processed_checkpoints
     }
-
-    fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
-        &self.indexer_metrics.live_task_current_checkpoint
-    }
 }
 
 pub struct EthSyncDatasource {
@@ -287,10 +283,6 @@ impl Datasource<RawEthData> for EthSyncDatasource {
 
     fn get_tasks_processed_checkpoints_metric(&self) -> &IntCounterVec {
         &self.indexer_metrics.tasks_processed_checkpoints
-    }
-
-    fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
-        &self.indexer_metrics.live_task_current_checkpoint
     }
 }
 

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -24,7 +24,10 @@ use sui_bridge_indexer::config::IndexerConfig;
 use sui_bridge_indexer::eth_bridge_indexer::EthDataMapper;
 use sui_bridge_indexer::metrics::BridgeIndexerMetrics;
 use sui_bridge_indexer::postgres_manager::{get_connection_pool, read_sui_progress_store};
-use sui_bridge_indexer::storage::PgBridgePersistent;
+use sui_bridge_indexer::storage::{
+    OutOfOrderSaveAfterDurationPolicy, PgBridgePersistent, ProgressSavingPolicy,
+    SaveAfterDurationPolicy,
+};
 use sui_bridge_indexer::sui_bridge_indexer::SuiBridgeDataMapper;
 use sui_bridge_indexer::sui_datasource::SuiCheckpointDatasource;
 use sui_bridge_indexer::sui_transaction_handler::handle_sui_transactions_loop;
@@ -72,7 +75,20 @@ async fn main() -> Result<()> {
     let bridge_metrics = Arc::new(BridgeMetrics::new(&registry));
 
     let db_url = config.db_url.clone();
-    let datastore = PgBridgePersistent::new(get_connection_pool(db_url.clone()).await);
+    let datastore = PgBridgePersistent::new(
+        get_connection_pool(db_url.clone()).await,
+        ProgressSavingPolicy::SaveAfterDuration(SaveAfterDurationPolicy::new(
+            tokio::time::Duration::from_secs(30),
+        )),
+        indexer_meterics.clone(),
+    );
+    let datastore_with_out_of_order_source = PgBridgePersistent::new(
+        get_connection_pool(db_url.clone()).await,
+        ProgressSavingPolicy::OutOfOrderSaveAfterDuration(OutOfOrderSaveAfterDurationPolicy::new(
+            tokio::time::Duration::from_secs(30),
+        )),
+        indexer_meterics.clone(),
+    );
 
     let eth_client: Arc<EthClient<MeteredEthHttpProvier>> = Arc::new(
         EthClient::<MeteredEthHttpProvier>::new(
@@ -119,7 +135,7 @@ async fn main() -> Result<()> {
         EthDataMapper {
             metrics: indexer_meterics.clone(),
         },
-        datastore.clone(),
+        datastore,
     )
     .with_backfill_strategy(BackfillStrategy::Partitioned { task_size: 1000 })
     .disable_live_task()
@@ -146,7 +162,7 @@ async fn main() -> Result<()> {
         SuiBridgeDataMapper {
             metrics: indexer_meterics.clone(),
         },
-        datastore,
+        datastore_with_out_of_order_source,
     )
     .build();
     indexer.start().await?;

--- a/crates/sui-bridge-indexer/src/metrics.rs
+++ b/crates/sui-bridge-indexer/src/metrics.rs
@@ -23,7 +23,7 @@ pub struct BridgeIndexerMetrics {
     pub(crate) last_synced_eth_block: IntGauge,
     pub(crate) tasks_remaining_checkpoints: IntGaugeVec,
     pub(crate) tasks_processed_checkpoints: IntCounterVec,
-    pub(crate) live_task_current_checkpoint: IntGaugeVec,
+    pub(crate) tasks_current_checkpoints: IntGaugeVec,
 }
 
 impl BridgeIndexerMetrics {
@@ -115,9 +115,9 @@ impl BridgeIndexerMetrics {
                 registry,
             )
             .unwrap(),
-            live_task_current_checkpoint: register_int_gauge_vec_with_registry!(
-                "bridge_indexer_live_task_current_checkpoint",
-                "Current checkpoint of live task",
+            tasks_current_checkpoints: register_int_gauge_vec_with_registry!(
+                "bridge_indexer_tasks_current_checkpoints",
+                "Current checkpoint for each task",
                 &["task_name"],
                 registry,
             )

--- a/crates/sui-indexer-builder/tests/indexer_test_utils.rs
+++ b/crates/sui-indexer-builder/tests/indexer_test_utils.rs
@@ -68,11 +68,6 @@ where
         // This is dummy
         &self.counter_metric
     }
-
-    fn get_live_task_checkpoint_metric(&self) -> &IntGaugeVec {
-        // This is dummy
-        &self.gauge_metric
-    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -119,15 +114,18 @@ impl<T: Send + Sync> IndexerProgressStore for InMemoryPersistent<T> {
     async fn save_progress(
         &mut self,
         task_name: String,
-        checkpoint_number: u64,
-    ) -> anyhow::Result<()> {
+        checkpoint_numbers: &[u64],
+        _start_checkpoint_number: u64,
+        _target_checkpoint_number: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        let checkpoint_number = *checkpoint_numbers.last().unwrap();
         self.progress_store
             .lock()
             .await
             .get_mut(&task_name)
             .unwrap()
             .checkpoint = checkpoint_number;
-        Ok(())
+        Ok(Some(checkpoint_number))
     }
 
     async fn get_ongoing_tasks(&self, task_prefix: &str) -> Result<Vec<Task>, Error> {


### PR DESCRIPTION
## Description 

This PR integrates `ProgressSavingPolicy`. Basically, sui data sources use `OutOfOrderSaveAfterDuration` and eth data sources use `SaveAfterDuration`.

Also changed metric `live_task_current_checkpoint` to `tasks_current_checkpoints` to track all tasks in `save_progress`

## Test plan 

production deployment

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
