### PR TITLE
fix(indexer): Leverage index for singleton query

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1410,6 +1410,9 @@ impl IndexerReader {
         let mut connection = self.pool.get().await?;
 
         let object = match objects::table
+            .filter(objects::object_type_package.eq(type_.address.to_vec()))
+            .filter(objects::object_type_module.eq(type_.module.to_string()))
+            .filter(objects::object_type_name.eq(type_.name.to_string()))
             .filter(objects::object_type.eq(type_.to_canonical_string(/* with_prefix */ true)))
             .first::<StoredObject>(&mut connection)
             .await


### PR DESCRIPTION
## Description

Make sure the query to fetch singleton objects in `IndexerReader` can leverage the type index on the `objects` table.

## Test plan

```
# In one session
sui$ cargo run --bin sui --features indexer \
    -- start --force-renesis --with-indexer

# In another session
sui$ curl -LX POST  "http://localhost:9124" \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "jsonrpc": "2.0",
        "method": "suix_getCoinMetadata",
        "id": 1,
        "params": ["0x2::sui::SUI"]
    }' | jq  -C .
{
  "jsonrpc": "2.0",
  "result": {
    "decimals": 9,
    "name": "Sui",
    "symbol": "SUI",
    "description": "",
    "iconUrl": null,
    "id": "0x46fe2b6c623e02dd06c74552dc9d6234cb46abb747b1e5936f699a4b2b8df2e8"
  },
  "id": 1
}
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
