### PR TITLE
fix(indexer): Store JSON-RPC URL in String

### DIFF
--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -80,7 +80,7 @@ pub struct JsonRpcConfig {
     pub rpc_address: SocketAddr,
 
     #[clap(long)]
-    pub rpc_client_url: Url,
+    pub rpc_client_url: String,
 }
 
 #[derive(Args, Debug, Default, Clone)]

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -50,7 +50,7 @@ pub async fn build_json_rpc_server(
 ) -> Result<ServerHandle, IndexerError> {
     let mut builder =
         JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
-    let http_client = crate::get_http_client(config.rpc_client_url.as_str())?;
+    let http_client = crate::get_http_client(&config.rpc_client_url)?;
 
     builder.register_module(WriteApi::new(http_client.clone()))?;
     builder.register_module(IndexerApi::new(

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -110,7 +110,7 @@ pub async fn start_test_indexer_impl(
             let config = crate::config::JsonRpcConfig {
                 name_service_options: crate::config::NameServiceOptions::default(),
                 rpc_address: reader_mode_rpc_url.parse().unwrap(),
-                rpc_client_url: rpc_url.parse().unwrap(),
+                rpc_client_url: rpc_url,
             };
             tokio::spawn(async move {
                 Indexer::start_reader(&config, &registry, blocking_pool, pool).await


### PR DESCRIPTION
## Description

`Url` elides ports if they are the default port for the URL scheme, and `jsonrpsee` needs the port to be provided explicitly, and never the twain shall meet.

## Test plan

Run a local indexer talking to a mainnet DB and a public good mainnet fullnode.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
