### PR TITLE
Add support for overriding ProtocolConfig fields by env variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11621,6 +11621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-env"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
 name = "serde-name"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14278,6 +14288,7 @@ dependencies = [
  "move-vm-config",
  "schemars",
  "serde",
+ "serde-env",
  "serde_with 3.9.0",
  "sui-protocol-config-macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -439,6 +439,7 @@ rustyline-derive = "0.7.0"
 schemars = { version = "0.8.21", features = ["either"] }
 scopeguard = "1.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
+serde-env = "0.2.0"
 serde-name = "0.2.1"
 serde-reflection = "0.3.6"
 serde_json = { version = "1.0.95", features = ["preserve_order"] }

--- a/crates/sui-protocol-config-macros/src/lib.rs
+++ b/crates/sui-protocol-config-macros/src/lib.rs
@@ -224,6 +224,66 @@ pub fn accessors_macro(input: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
+#[proc_macro_derive(ProtocolConfigOverride)]
+pub fn protocol_config_override_macro(input: TokenStream) -> TokenStream {
+    // Parse the input TokenStream.
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    // Create a new struct name by appending "Optional".
+    let struct_name = &ast.ident;
+    let optional_struct_name =
+        syn::Ident::new(&format!("{}Optional", struct_name), struct_name.span());
+
+    // Extract the fields from the struct
+    let fields = match &ast.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields_named) => &fields_named.named,
+            _ => panic!("ProtocolConfig must have named fields"),
+        },
+        _ => panic!("ProtocolConfig must be a struct"),
+    };
+
+    // Create new fields with types wrapped in Option
+    let optional_fields = fields.iter().map(|field| {
+        let field_name = &field.ident;
+        let field_type = &field.ty;
+        quote! {
+            #field_name: Option<#field_type>
+        }
+    });
+
+    // Generate the function to update the original struct
+    let update_fields = fields.iter().map(|field| {
+        let field_name = &field.ident;
+        quote! {
+            if let Some(value) = self.#field_name {
+                tracing::warn!(
+                    "ProtocolConfig field \"{}\" has been overridden with the value: {value:?}",
+                    stringify!(#field_name),
+                );
+                config.#field_name = value;
+            }
+        }
+    });
+
+    // Generate the new struct definition and the update function
+    let output = quote! {
+        #[derive(serde::Deserialize, Debug)]
+        pub struct #optional_struct_name {
+            #(#optional_fields,)*
+        }
+
+        impl #optional_struct_name {
+            pub fn apply_to(self, config: &mut #struct_name) {
+                #(#update_fields)*
+            }
+        }
+    };
+
+    // Convert the generated code into a TokenStream and return it
+    TokenStream::from(output)
+}
+
 #[proc_macro_derive(ProtocolConfigFeatureFlagsGetters)]
 pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/sui-protocol-config-macros/src/lib.rs
+++ b/crates/sui-protocol-config-macros/src/lib.rs
@@ -226,7 +226,6 @@ pub fn accessors_macro(input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(ProtocolConfigOverride)]
 pub fn protocol_config_override_macro(input: TokenStream) -> TokenStream {
-    // Parse the input TokenStream.
     let ast = parse_macro_input!(input as DeriveInput);
 
     // Create a new struct name by appending "Optional".
@@ -243,7 +242,7 @@ pub fn protocol_config_override_macro(input: TokenStream) -> TokenStream {
         _ => panic!("ProtocolConfig must be a struct"),
     };
 
-    // Create new fields with types wrapped in Option
+    // Create new fields with types wrapped in Option.
     let optional_fields = fields.iter().map(|field| {
         let field_name = &field.ident;
         let field_type = &field.ty;
@@ -252,7 +251,7 @@ pub fn protocol_config_override_macro(input: TokenStream) -> TokenStream {
         }
     });
 
-    // Generate the function to update the original struct
+    // Generate the function to update the original struct.
     let update_fields = fields.iter().map(|field| {
         let field_name = &field.ident;
         quote! {
@@ -266,7 +265,7 @@ pub fn protocol_config_override_macro(input: TokenStream) -> TokenStream {
         }
     });
 
-    // Generate the new struct definition and the update function
+    // Generate the new struct definition.
     let output = quote! {
         #[derive(serde::Deserialize, Debug)]
         pub struct #optional_struct_name {
@@ -280,7 +279,6 @@ pub fn protocol_config_override_macro(input: TokenStream) -> TokenStream {
         }
     };
 
-    // Convert the generated code into a TokenStream and return it
     TokenStream::from(output)
 }
 

--- a/crates/sui-protocol-config/Cargo.toml
+++ b/crates/sui-protocol-config/Cargo.toml
@@ -18,6 +18,7 @@ schemars.workspace = true
 insta.workspace = true
 clap.workspace = true
 move-vm-config.workspace = true
+serde-env.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -11,7 +11,9 @@ use clap::*;
 use move_vm_config::verifier::VerifierConfig;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use sui_protocol_config_macros::{ProtocolConfigAccessors, ProtocolConfigFeatureFlagsGetters};
+use sui_protocol_config_macros::{
+    ProtocolConfigAccessors, ProtocolConfigFeatureFlagsGetters, ProtocolConfigOverride,
+};
 use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
@@ -255,7 +257,7 @@ pub struct Error(pub String);
 
 // TODO: There are quite a few non boolean values in the feature flags. We should move them out.
 /// Records on/off feature flags that may vary at each protocol version.
-#[derive(Default, Clone, Serialize, Debug, ProtocolConfigFeatureFlagsGetters)]
+#[derive(Default, Clone, Serialize, Deserialize, Debug, ProtocolConfigFeatureFlagsGetters)]
 struct FeatureFlags {
     // Add feature flags here, e.g.:
     // new_protocol_feature: bool,
@@ -526,7 +528,7 @@ fn is_empty(b: &BTreeSet<String>) -> bool {
 }
 
 /// Ordering mechanism for transactions in one Narwhal consensus output.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Debug)]
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum ConsensusTransactionOrdering {
     /// No ordering. Transactions are processed in the order they appear in the consensus output.
     #[default]
@@ -542,7 +544,7 @@ impl ConsensusTransactionOrdering {
 }
 
 // The config for per object congestion control in consensus handler.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Debug)]
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum PerObjectCongestionControlMode {
     #[default]
     None, // No congestion control.
@@ -557,7 +559,7 @@ impl PerObjectCongestionControlMode {
 }
 
 // Configuration options for consensus algorithm.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Debug)]
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum ConsensusChoice {
     #[default]
     Narwhal,
@@ -572,7 +574,7 @@ impl ConsensusChoice {
 }
 
 // Configuration options for consensus network.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Debug)]
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum ConsensusNetwork {
     #[default]
     Anemo,
@@ -617,7 +619,7 @@ impl ConsensusNetwork {
 /// return `None` if the field is not defined at that version.
 /// - If you want a customized getter, you can add a method in the impl.
 #[skip_serializing_none]
-#[derive(Clone, Serialize, Debug, ProtocolConfigAccessors)]
+#[derive(Clone, Serialize, Debug, ProtocolConfigAccessors, ProtocolConfigOverride)]
 pub struct ProtocolConfig {
     pub version: ProtocolVersion,
 
@@ -1593,7 +1595,7 @@ impl ProtocolConfig {
         let mut ret = Self::get_for_version_impl(version, chain);
         ret.version = version;
 
-        CONFIG_OVERRIDE.with(|ovr| {
+        ret = CONFIG_OVERRIDE.with(|ovr| {
             if let Some(override_fn) = &*ovr.borrow() {
                 warn!(
                     "overriding ProtocolConfig settings with custom settings (you should not see this log outside of tests)"
@@ -1602,7 +1604,17 @@ impl ProtocolConfig {
             } else {
                 ret
             }
-        })
+        });
+
+        if std::env::var("SUI_PROTOCOL_CONFIG_OVERRIDE_ENABLE").is_ok() {
+            warn!("overriding ProtocolConfig settings with custom settings; this may break non-local networks");
+            let overrides: ProtocolConfigOptional =
+                serde_env::from_env_with_prefix("SUI_PROTOCOL_CONFIG_OVERRIDE")
+                    .expect("failed to parse ProtocolConfig override env variables");
+            overrides.apply_to(&mut ret);
+        }
+
+        ret
     }
 
     /// Get the value ProtocolConfig that are in effect during the given protocol version.


### PR DESCRIPTION
For use in local networks, or possibly for emergency response.

Tested with:
`SUI_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1 SUI_PROTOCOL_CONFIG_OVERRIDE_min_checkpoint_interval_ms=1000 RUST_LOG=warn cargo run --bin sui start --no-full-node --force-regenesis`