### PR TITLE
 [docs] Include a reference to "The Move Book" in the Write a Move Package page

### DIFF
--- a/docs/content/guides/developer/first-app/write-package.mdx
+++ b/docs/content/guides/developer/first-app/write-package.mdx
@@ -49,3 +49,4 @@ After you save the file, you have a complete Move package.
 
 - [Build and Test Packages](./build-test.mdx): Continue this example to build and test your package to get it ready for publishing.
 - [Sui Move CLI](../../../references/cli/move.mdx): Available Move commands the CLI provides.
+- [Sui Move Book](https://move-book.com/): A comprehensive guide to the Move programming language and the Sui blockchain.


### PR DESCRIPTION
## Description 

Add a link to the Sui Move book. A link also exists in the move references page, however it is beneficial to have the link in the write a move package page as well. This will help users find the right book for writing move packages for sui and can be a good follow up step to writing a basic move package.

## Test plan 

Built the docs, checked the link.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
