### PR TITLE
feat: Cookbook Onboard (AI Assistant) integration

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -89,6 +89,7 @@ const config = {
     },
     path.resolve(__dirname, `./src/plugins/descriptions`),
     path.resolve(__dirname, `./src/plugins/framework`),
+    path.resolve(__dirname, `./src/plugins/askcookbook`),
   ],
   presets: [
     [

--- a/docs/site/src/plugins/askcookbook/index.js
+++ b/docs/site/src/plugins/askcookbook/index.js
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// It is going to be exposed in HTTP requests anyway, so it's fine to just hardcode it here.
+const COOKBOOK_PUBLIC_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NjU5ODBiNDAwZTliZDQ2MzcwZDlhNzYiLCJpYXQiOjE3MTcxNDE2ODQsImV4cCI6MjAzMjcxNzY4NH0.0JCgi4bJ_f6ILFgEyYAP-KeCm1dzOKwH30tC3jEs2_A";
+
+async function askCookbookPlugin() {
+  return {
+    name: "askCookbook",
+    injectHtmlTags() {
+      return {
+        postBodyTags: [
+          {
+            tagName: "div",
+            attributes: {
+              id: "__cookbook",
+              "data-api-key": COOKBOOK_PUBLIC_API_KEY,
+            },
+          },
+          `
+            <script>
+              function initCookbook() {
+                try {
+                  if (window.__cookbook_script) {
+                    window.__cookbook_script.remove();
+                  }
+                  const script = document.createElement('script');
+                  script.src = 'https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js';
+                  script.async = true;
+                  document.body.appendChild(script);
+                  window.__cookbook_script = script;
+                } catch (e) {
+                  console.error("Error while initializing Cookbook:", e);
+                }
+              };
+            </script>
+          `,
+        ],
+      };
+    },
+  };
+};
+
+module.exports = askCookbookPlugin;

--- a/docs/site/src/theme/SearchBar/index.js
+++ b/docs/site/src/theme/SearchBar/index.js
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import SearchBar from "@theme-original/SearchBar";
+
+export default class SearchBarWrapper extends React.Component {
+  componentDidMount() {
+    try {
+      window.initCookbook();
+    } catch (e) {
+      // Gracefully ignore errors if something goes wrong
+      console.error("Erorr initializing Ask Cookbook", e);
+    }
+  }
+
+  render() {
+    return (
+      <>
+        <SearchBar {...this.props} />
+      </>
+    );
+  }
+}


### PR DESCRIPTION
## Description 
Cookbook's Ask Cookbook AI assistant and co-pilot is trained on all existing Sui resources (source code, docs website, etc.) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about building on Sui, acting as an enhanced and streamlined technical documentation search tool as well as Solidity and Move coding co-pilot.

Ask Cookbook AI can also access context from thousands of data sources indexed by Cookbook.dev in addition to Sui-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

![image](https://github.com/user-attachments/assets/d36e4a14-e5e1-476f-9604-9ced0f38aeb9)

### Changes
- Added the Ask Cookbook plugin to embed the Cookbook Onboard AI Assistant into the Sui docs, and included it in `docusaurus.config.js`.

### Preview
Preview link: https://sui-docs-cookbook.vercel.app/

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
