### PR TITLE
refactor(graphql): Remove references to df_object_id

### DIFF
--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -5,9 +5,12 @@ use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use move_core_types::annotated_value::{self as A, MoveStruct};
+use move_core_types::language_storage::TypeTag;
 use sui_indexer::models::objects::StoredHistoryObject;
 use sui_indexer::types::OwnerType;
-use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
+use sui_types::dynamic_field::{
+    derive_dynamic_field_id, extract_id_value, DynamicFieldInfo, DynamicFieldType,
+};
 
 use super::available_range::AvailableRange;
 use super::cursor::{Page, Target};
@@ -25,7 +28,6 @@ use crate::raw_query::RawQuery;
 
 pub(crate) struct DynamicField {
     pub super_: MoveObject,
-    pub df_object_id: SuiAddress,
     pub df_kind: DynamicFieldType,
 }
 
@@ -100,36 +102,43 @@ impl DynamicField {
     /// will be from the latest version that is at most equal to its parent object's
     /// version
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
+        let resolver: &PackageResolver = ctx.data_unchecked();
+
+        // TODO(annotated-visitor): Use custom visitors to extract just the value.
+        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
+            .await
+            .extend()?;
+
+        let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
+
         if self.df_kind == DynamicFieldType::DynamicObject {
             // If `df_kind` is a DynamicObject, the object we are currently on is the field object,
-            // and we must resolve one more level down to the value object. Becuase we only have
-            // checkpoint-level granularity, we may end up reading a later version of the value
-            // object. Thus, we use the version of the field object to bound the value object at the
-            // correct version.
+            // and we must resolve one more level down to the value object.
+            let df_object_id = extract_id_value(&value_move_value)
+                .ok_or_else(|| {
+                    Error::Internal(format!(
+                        "Couldn't find ID of dynamic object field value: {value_move_value:#?}"
+                    ))
+                })
+                .extend()?;
+
+            // Because we only have checkpoint-level granularity, we may end up reading a later
+            // version of the value object. Thus, we use the version of the field object to bound
+            // the value object at the correct version.
             let obj = MoveObject::query(
                 ctx,
-                self.df_object_id,
+                df_object_id.into(),
                 Object::under_parent(self.root_version(), self.super_.super_.checkpoint_viewed_at),
             )
             .await
             .extend()?;
+
             Ok(obj.map(DynamicFieldValue::MoveObject))
         } else {
-            let resolver: &PackageResolver = ctx
-                .data()
-                .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
-                .extend()?;
-
-            let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
-                .await
-                .extend()?;
-
             // Get TypeTag of the DynamicField value from StructTag of the MoveStruct
             let type_tag = DynamicFieldInfo::try_extract_field_value(&struct_tag)
                 .map_err(|e| Error::Internal(e.to_string()))
                 .extend()?;
-
-            let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
 
             let undecorated = value_move_value.undecorate();
             let bcs = bcs::to_bytes(&undecorated)
@@ -264,38 +273,43 @@ impl TryFrom<MoveObject> for DynamicField {
     fn try_from(stored: MoveObject) -> Result<Self, Error> {
         let super_ = &stored.super_;
 
-        let (df_object_id, df_kind) = match &super_.kind {
-            ObjectKind::Indexed(_, stored) => stored
-                .df_object_id
-                .as_ref()
-                .map(|id| (id, stored.df_kind))
-                .ok_or_else(|| Error::Internal("Object is not a dynamic field.".to_string()))?,
-            _ => {
+        let native = match &super_.kind {
+            ObjectKind::NotIndexed(native) | ObjectKind::Indexed(native, _) => native,
+
+            ObjectKind::WrappedOrDeleted(_) => {
                 return Err(Error::Internal(
-                    "A WrappedOrDeleted object cannot be converted into a DynamicField."
-                        .to_string(),
-                ))
+                    "DynamicField is wrapped or deleted.".to_string(),
+                ));
             }
         };
 
-        let df_object_id = SuiAddress::from_bytes(df_object_id).map_err(|e| {
-            Error::Internal(format!("Failed to deserialize dynamic field ID: {e}."))
-        })?;
+        let Some(object) = native.data.try_as_move() else {
+            return Err(Error::Internal("DynamicField is not an object".to_string()));
+        };
 
-        let df_kind = match df_kind {
-            Some(0) => DynamicFieldType::DynamicField,
-            Some(1) => DynamicFieldType::DynamicObject,
-            Some(k) => {
-                return Err(Error::Internal(format!(
-                    "Unrecognized dynamic field kind: {k}."
-                )))
-            }
-            None => return Err(Error::Internal("No dynamic field kind.".to_string())),
+        let Some(tag) = object.type_().other() else {
+            return Err(Error::Internal("DynamicField is not a struct".to_string()));
+        };
+
+        if !DynamicFieldInfo::is_dynamic_field(tag) {
+            return Err(Error::Internal("Wrong type for DynamicField".to_string()));
+        }
+
+        let Some(name) = tag.type_params.first() else {
+            return Err(Error::Internal("No type for DynamicField name".to_string()));
+        };
+
+        let df_kind = if matches!(
+            name,
+            TypeTag::Struct(s) if DynamicFieldInfo::is_dynamic_object_field_wrapper(s)
+        ) {
+            DynamicFieldType::DynamicObject
+        } else {
+            DynamicFieldType::DynamicField
         };
 
         Ok(DynamicField {
             super_: stored,
-            df_object_id,
             df_kind,
         })
     }

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -240,7 +240,7 @@ fn extract_object_id(value: &MoveStruct) -> Option<ObjectID> {
     extract_id_value(id_value)
 }
 
-fn extract_id_value(id_value: &MoveValue) -> Option<ObjectID> {
+pub fn extract_id_value(id_value: &MoveValue) -> Option<ObjectID> {
     // the id struct has a single bytes field
     let id_bytes_value = match id_value {
         MoveValue::Struct(MoveStruct { fields, .. }) => &fields.first()?.1,


### PR DESCRIPTION
## Description

Remove references to the `df_object_id` column from GraphQL codebase, so that we can eventually remove it altogether.

## Test plan

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests --features pg_integration
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
