### PR TITLE
[Indexer] Minor cleanup on ObjectStatus::WrappedOrDeleted

### DIFF
--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -41,7 +41,7 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
 use serde::{Deserialize, Serialize};
-use sui_indexer::models::objects::{StoredDeletedHistoryObject, StoredHistoryObject};
+use sui_indexer::models::objects::StoredHistoryObject;
 use sui_indexer::schema::{objects_history, objects_version};
 use sui_indexer::types::ObjectStatus as NativeObjectStatus;
 use sui_indexer::types::OwnerType;
@@ -83,8 +83,8 @@ pub(crate) enum ObjectKind {
     /// An object fetched from the index.
     Indexed(NativeObject, StoredHistoryObject),
     /// The object is wrapped or deleted and only partial information can be loaded from the
-    /// indexer.
-    WrappedOrDeleted(StoredDeletedHistoryObject),
+    /// indexer. The `u64` is the version of the object.
+    WrappedOrDeleted(u64),
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
@@ -754,7 +754,7 @@ impl Object {
 
         match &self.kind {
             K::NotIndexed(native) | K::Indexed(native, _) => native.version().value(),
-            K::WrappedOrDeleted(stored) => stored.object_version as u64,
+            K::WrappedOrDeleted(object_version) => *object_version,
         }
     }
 
@@ -981,12 +981,7 @@ impl Object {
             }
             NativeObjectStatus::WrappedOrDeleted => Ok(Self {
                 address,
-                kind: ObjectKind::WrappedOrDeleted(StoredDeletedHistoryObject {
-                    object_id: history_object.object_id,
-                    object_version: history_object.object_version,
-                    object_status: history_object.object_status,
-                    checkpoint_sequence_number: history_object.checkpoint_sequence_number,
-                }),
+                kind: ObjectKind::WrappedOrDeleted(history_object.object_version as u64),
                 checkpoint_viewed_at,
                 root_version: history_object.object_version as u64,
             }),

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -209,7 +209,7 @@ impl From<IndexedDeletedObject> for StoredDeletedObject {
 
 #[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects_history, primary_key(object_id, object_version, checkpoint_sequence_number))]
-pub struct StoredDeletedHistoryObject {
+pub(crate) struct StoredDeletedHistoryObject {
     pub object_id: Vec<u8>,
     pub object_version: i64,
     pub object_status: i16,


### PR DESCRIPTION
## Description 

The WrappedOrDeleted variant only needs the version, as all other information is already in the Object struct.

## Test plan 

CI
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
