### PR TITLE
[move][move-2024] Adjust HLIR to allow reuse of labels in different scopes

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_0.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_0.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_0.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_0.move
@@ -1,0 +1,27 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum E {
+        One { a: u64, b: u64, c: u64 },
+        Two { d: u64, e: u64, f: u64 },
+    }
+
+    fun test() {
+        let e_0 = E::One { a: 0, b: 1, c: 2 };
+        let x = match (e_0) {
+            E::One { c: a, b: b, a: c } => a + c * b,
+            E::Two { .. } => abort 0,
+        };
+        assert!(x == 2);
+        let e_1 = E::Two { d: 0, e: 1, f: 2 };
+        let x = match (e_1) {
+            E::Two { e: d, f: e, d: f } => d * e + f,
+            E::One { .. } => abort 0,
+        };
+        assert!(x == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_1.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_1.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_1.move
@@ -1,0 +1,26 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum E {
+        One { a: u64, b: u64, c: u64 },
+        Two(u64, u64, u64)
+    }
+
+    fun do(e: E): u64 {
+        match (e) {
+            E::One { c: a, b: c, a: b } | E::Two(c, b, a) => a * (b + c)
+        }
+    }
+
+
+    fun test() {
+        let e_0 = E::One { a: 0, b: 1, c: 2 };
+        assert!(do(e_0) == 2);
+        let e_1 = E::Two(0, 1, 2);
+        assert!(do(e_1) == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_0.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_0.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_0.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_0.move
@@ -1,0 +1,35 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum E has drop {
+        A { a: vector<u64> },
+        B { b: vector<u64> }
+    }
+
+    #[syntax(index)]
+    fun e_index(e: &E, ndx: u64): &u64 {
+        match (e) {
+            E::A { a } => &a[ndx],
+            E::B { b } => &b[ndx],
+        }
+    }
+
+    fun test() {
+        let e = E::A { a: vector[0,1,2,3,4] };
+        assert!(e[0] == 0);
+        assert!(e[1] == 1);
+        assert!(e[2] == 2);
+        assert!(e[3] == 3);
+        assert!(e[4] == 4);
+        let e = E::B { b: vector[0,1,2,3,4] };
+        assert!(e[0] == 0);
+        assert!(e[1] == 1);
+        assert!(e[2] == 2);
+        assert!(e[3] == 3);
+        assert!(e[4] == 4);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_1.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_1.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_1.move
@@ -1,0 +1,34 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum E has drop {
+        A { a: vector<u64> },
+        B { b: vector<u64> }
+    }
+
+    #[syntax(index)]
+    fun e_index(e: &E, ndx: u64): &u64 {
+        match (e) {
+            E::A { a } | E::B { b: a } => &a[ndx],
+        }
+    }
+
+    fun test() {
+        let e = E::A { a: vector[0,1,2,3,4] };
+        assert!(e[0] == 0);
+        assert!(e[1] == 1);
+        assert!(e[2] == 2);
+        assert!(e[3] == 3);
+        assert!(e[4] == 4);
+        let e = E::B { b: vector[0,1,2,3,4] };
+        assert!(e[0] == 0);
+        assert!(e[1] == 1);
+        assert!(e[2] == 2);
+        assert!(e[3] == 3);
+        assert!(e[4] == 4);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_2.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_2.move
@@ -1,0 +1,39 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum E has drop {
+        A { a: vector<u64> },
+        B { b: vector<u64> }
+    }
+
+    fun get_vec(e: &E): &vector<u64> {
+        match (e) {
+            E::A { a } => a,
+            E::B { b } => b,
+        }
+    }
+
+    #[syntax(index)]
+    fun e_index(e: &E, ndx: u64): &u64 {
+        &e.get_vec()[ndx]
+    }
+
+    fun test() {
+        let e = E::A { a: vector[0,1,2,3,4] };
+        assert!(e[0] == 0);
+        assert!(e[1] == 1);
+        assert!(e[2] == 2);
+        assert!(e[3] == 3);
+        assert!(e[4] == 4);
+        let e = E::B { b: vector[0,1,2,3,4] };
+        assert!(e[0] == 0);
+        assert!(e[1] == 1);
+        assert!(e[2] == 2);
+        assert!(e[3] == 3);
+        assert!(e[4] == 4);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_lit_mut_bind.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_lit_mut_bind.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_lit_mut_bind.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_lit_mut_bind.move
@@ -1,0 +1,26 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+    public fun test() {
+        let x = 10;
+        let y = match (x) {
+            0 => 10,
+            mut x => {
+                x = x + 10;
+                x
+            }
+        };
+        assert!(y == 20);
+        let y = match (x) {
+            0 => 10,
+            mut y => {
+                y = y + 10;
+                y
+            }
+        };
+        assert!(y == 20);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/mut_field_alias.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/mut_field_alias.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/mut_field_alias.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/mut_field_alias.move
@@ -1,0 +1,22 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+    public enum E {
+        X { x: u64 },
+        Y { y: u64 }
+    }
+
+    public fun test() {
+        let e = E::Y { y: 1 };
+        let value = match (e) {
+            E::X { mut x } | E::Y { y: mut x } => {
+                x = x + 1;
+                x
+            }
+        };
+        assert!(value == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_0.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_0.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_0.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_0.move
@@ -1,0 +1,56 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Action has drop {
+        Stop,
+        MoveTo { x: u64, y: u64 },
+        ChangeSpeed(u64),
+    }
+
+    public fun test() {
+        // Define a list of actions
+        let actions: vector<Action> = vector[
+            Action::MoveTo { x: 10, y: 20 },
+            Action::ChangeSpeed(40),
+            Action::MoveTo { x: 10, y: 20 },
+            Action::Stop,
+            Action::ChangeSpeed(40),
+        ];
+
+        let mut total_moves = 0;
+
+        'loop_label: loop {
+            let mut i = 0;
+            while (i < actions.length()) {
+                let action = &actions[i];
+
+                match (action) {
+                    Action::MoveTo { x, y } => {
+                        'loop_label: loop {
+                            total_moves = total_moves + *x + *y;
+                            break 'loop_label
+                        };
+                    },
+                    Action::ChangeSpeed(speed) => {
+                        'loop_label: loop {
+                            total_moves = total_moves + *speed;
+                            break 'loop_label
+                        };
+                    },
+                    Action::Stop => {
+                        break 'loop_label
+                    },
+                };
+                i = i + 1;
+            };
+        };
+
+        actions.destroy!(|_| {});
+
+        assert!(total_moves == 100);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_1.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_1.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_1.move
@@ -1,0 +1,50 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Action has drop {
+        Stop,
+        MoveTo { x: u64, y: u64 },
+        ChangeSpeed(u64),
+    }
+
+    public fun test() {
+        // Define a list of actions
+        let actions: vector<Action> = vector[
+            Action::MoveTo { x: 10, y: 20 },
+            Action::ChangeSpeed(20),
+            Action::MoveTo { x: 10, y: 20 },
+            Action::Stop,
+            Action::ChangeSpeed(40),
+        ];
+
+        let mut total_moves = 0;
+
+        'loop_label: loop {
+            let mut i = 0;
+            while (i < actions.length()) {
+                let action = &actions[i];
+
+                match (action) {
+                    Action::MoveTo { x: speed, y: _ } | Action::ChangeSpeed(speed) => {
+                        'loop_label: loop {
+                            total_moves = total_moves + *speed;
+                            break 'loop_label
+                        };
+                    },
+                    Action::Stop => {
+                        break 'loop_label
+                    },
+                };
+                i = i + 1;
+            };
+        };
+
+        actions.destroy!(|_| {});
+
+        assert!(total_moves == 40);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_2.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_2.move
@@ -1,0 +1,58 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Action has copy, drop {
+        Stop,
+        MoveTo { x: u64, y: u64 },
+        ChangeSpeed(u64),
+    }
+
+    public fun speed(action: &Action): u64 {
+        match (action) {
+            Action::MoveTo { x: speed, y: _ } => *speed,
+            Action::ChangeSpeed(speed) => *speed,
+            Action::Stop => abort 0,
+        }
+    }
+
+    public fun test() {
+        // Define a list of actions
+        let actions: vector<Action> = vector[
+            Action::MoveTo { x: 10, y: 20 },
+            Action::ChangeSpeed(20),
+            Action::MoveTo { x: 10, y: 20 },
+            Action::Stop,
+            Action::ChangeSpeed(40),
+        ];
+
+        let mut total_moves = 0;
+
+        'loop_label: loop {
+            let mut i = 0;
+            while (i < actions.length()) {
+                let action = actions[i];
+
+                match (action) {
+                    action @ Action::MoveTo { .. } | action @ Action::ChangeSpeed(_) => {
+                        'loop_label: loop {
+                            total_moves = total_moves + action.speed();
+                            break 'loop_label
+                        };
+                    },
+                    Action::Stop => {
+                        break 'loop_label
+                    },
+                };
+                i = i + 1;
+            };
+        };
+
+        actions.destroy!(|_| {});
+
+        assert!(total_moves == 40);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_3.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_3.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_3.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_3.move
@@ -1,0 +1,58 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Action has copy, drop {
+        Stop,
+        MoveTo { x: u64, y: u64 },
+        ChangeSpeed(u64),
+    }
+
+    public fun speed(action: &Action): u64 {
+        match (action) {
+            Action::MoveTo { x: speed, y: _ } => *speed,
+            Action::ChangeSpeed(speed) => *speed,
+            Action::Stop => abort 0,
+        }
+    }
+
+    public fun test() {
+        // Define a list of actions
+        let actions: vector<Action> = vector[
+            Action::MoveTo { x: 10, y: 20 },
+            Action::ChangeSpeed(20),
+            Action::MoveTo { x: 10, y: 20 },
+            Action::Stop,
+            Action::ChangeSpeed(40),
+        ];
+
+        let mut total_moves = 0;
+
+        'loop_label: loop {
+            let mut i = 0;
+            while (i < actions.length()) {
+                let action = actions[i];
+
+                match (action) {
+                    action @ (Action::MoveTo { x: _, y: _ } | Action::ChangeSpeed(..)) => {
+                        'loop_label: loop {
+                            total_moves = total_moves + action.speed();
+                            break 'loop_label
+                        };
+                    },
+                    Action::Stop => {
+                        break 'loop_label
+                    },
+                };
+                i = i + 1;
+            };
+        };
+
+        actions.destroy!(|_| {});
+
+        assert!(total_moves == 40);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -10,7 +10,7 @@ use crate::{
         AbilitySet, Attribute, AttributeValue_, Attribute_, DottedUsage, Fields, Friend,
         ModuleAccess_, ModuleIdent, ModuleIdent_, Mutability, TargetKind, Value_, Visibility,
     },
-    ice,
+    ice, ice_assert,
     naming::ast::{
         self as N, BlockLabel, DatatypeTypeParameter, IndexSyntaxMethods, TParam, TParamID, Type,
         TypeName, TypeName_, Type_,
@@ -2916,14 +2916,12 @@ fn add_variant_field_types<T>(
         N::VariantFields::Defined(_, m) => m,
         N::VariantFields::Empty => {
             if !fields.is_empty() {
-                let msg = format!(
-                    "Invalid usage for empty variant '{}::{}::{}'. Empty variants do not take \
-                     any arguments.",
-                    m, n, v
+                ice_assert!(
+                    context.env,
+                    context.env.has_errors(),
+                    loc,
+                    "Empty variant with fields but no error from naming"
                 );
-                context
-                    .env
-                    .add_diag(diag!(TypeSafety::TooManyArguments, (loc, msg),));
                 return fields.map(|f, (idx, x)| (idx, (context.error_type(f.loc()), x)));
             } else {
                 return Fields::new();

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_no_drop_exhaustive_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_no_drop_exhaustive_invalid.exp
@@ -1,0 +1,12 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/matching/abc_match_no_drop_exhaustive_invalid.move:14:13
+   │
+ 3 │     public enum ABC<T> {
+   │                 --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+10 │         match (ABC::C(0)) {
+   │                --------- The type '0x42::m::ABC<u64>' does not have the ability 'drop'
+   ·
+14 │             _ => 1,
+   │             ^ Cannot ignore values without the 'drop' ability. '_' patterns discard their values
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_no_drop_exhaustive_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_no_drop_exhaustive_invalid.move
@@ -1,0 +1,18 @@
+module 0x42::m {
+
+    public enum ABC<T> {
+        A(T),
+        B,
+        C(T)
+    }
+
+    fun t0(): u64 {
+        match (ABC::C(0)) {
+            ABC::C(x) => x,
+            ABC::A(x) => x,
+            ABC::B => 0,
+            _ => 1,
+        }
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/go_match.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/go_match.move
@@ -1,0 +1,15 @@
+module 0x42::go;
+
+public enum Color has copy, store, drop {
+    Empty,
+    Black,
+    White,
+}
+
+public fun from_index(color: Color): u64 {
+    match (color) {
+        Color::White => 0,
+        Color::Black => 1,
+        _ => abort 0,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/go_repro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/go_repro.move
@@ -1,0 +1,16 @@
+module 0x42::go;
+
+public enum Colour has copy, store, drop {
+    Empty,
+    Black,
+    White,
+}
+
+public fun from_index(index: u64): Colour {
+    match (index) {
+        0 => Colour::Empty,
+        1 => Colour::Black,
+        2 => Colour::White,
+        _ => abort 0,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/if_compilation.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/if_compilation.move
@@ -1,0 +1,9 @@
+module 0x42::m;
+
+fun test(): u64 {
+    if (true) {
+        5
+    } else {
+        abort 0
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_3.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_3.exp
@@ -1,0 +1,12 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/move_2024/matching/invalid_or_binding_3.move:9:12
+  │
+9 │     match (e) {
+  │            ^ Pattern 'E::Y { y: _ }' not covered
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/matching/invalid_or_binding_3.move:10:22
+   │
+10 │         E::X { x } | E::Y { y: _, x } => *x
+   │                      ^^^^^^^^^^^^^^^^ Unbound field 'x' in '0x42::m::E::Y'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_3.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_3.move
@@ -1,0 +1,12 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y { y: u64 }
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x } | E::Y { y: _, x } => *x
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_4.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_4.exp
@@ -1,0 +1,28 @@
+error[E03019]: invalid pattern
+   ┌─ tests/move_2024/matching/invalid_or_binding_4.move:11:19
+   │
+11 │         E::X { x: y } | E::Y(x) | E::Z { z: x } => *x
+   │                   ^     ----------------------- right or-pattern does not
+   │                   │      
+   │                   left or-pattern binds variable y
+   │
+   = Both sides of an or-pattern must bind the same variables.
+
+warning[W09002]: unused variable
+   ┌─ tests/move_2024/matching/invalid_or_binding_4.move:11:19
+   │
+11 │         E::X { x: y } | E::Y(x) | E::Z { z: x } => *x
+   │                   ^ Unused local variable 'y'. Consider removing or prefixing with an underscore: '_y'
+   │
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E03019]: invalid pattern
+   ┌─ tests/move_2024/matching/invalid_or_binding_4.move:11:30
+   │
+11 │         E::X { x: y } | E::Y(x) | E::Z { z: x } => *x
+   │         -------------        ^ right or-pattern binds variable x
+   │         │                     
+   │         left or-pattern does not
+   │
+   = Both sides of an or-pattern must bind the same variables.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_4.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_4.move
@@ -1,0 +1,13 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y(u64),
+    Z { z: u64 }
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x: y } | E::Y(x) | E::Z { z: x } => *x
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_pattern.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_pattern.exp
@@ -1,0 +1,17 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/move_2024/matching/invalid_or_pattern.move:9:12
+  │
+9 │     match (e) {
+  │            ^ Pattern 'E::Y' not covered
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/matching/invalid_or_pattern.move:10:22
+   │
+ 5 │     Y
+   │     - 'Y' is declared here
+   ·
+10 │         E::X { x } | E::Y { y: _, x } => *x
+   │                      ^^^^^^^^^^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+   │
+   = Remove '{ }' arguments from this pattern
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_pattern.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_pattern.move
@@ -1,0 +1,12 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x } | E::Y { y: _, x } => *x
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types.exp
@@ -1,0 +1,11 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/matching/invalid_or_types.move:10:24
+   │
+ 4 │     X(u64),
+   │       --- Given: 'u64'
+ 5 │     Y(u32)
+   │       --- Expected: 'u32'
+   ·
+10 │         E::X(x) | E::Y(x) => *x
+   │                        ^ Invalid pattern field type
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types.move
@@ -1,0 +1,12 @@
+module 0x42::m;
+
+public enum E {
+    X(u64),
+    Y(u32)
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X(x) | E::Y(x) => *x
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_2.exp
@@ -1,0 +1,11 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/matching/invalid_or_types_2.move:10:35
+   │
+ 4 │     X { x: u64 },
+   │            --- Given: 'u64'
+ 5 │     Y { y: u64, x: u32 }
+   │                    --- Expected: 'u32'
+   ·
+10 │         E::X { x } | E::Y { y: _, x } => *x
+   │                                   ^ Invalid pattern field type
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_2.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_2.move
@@ -1,0 +1,12 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y { y: u64, x: u32 }
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x } | E::Y { y: _, x } => *x
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_3.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_3.exp
@@ -1,0 +1,11 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/matching/invalid_or_types_3.move:10:30
+   │
+ 4 │     X { x: u64 },
+   │            --- Given: 'u64'
+ 5 │     Y(u32)
+   │       --- Expected: 'u32'
+   ·
+10 │         E::X { x: y } | E::Y(y) => *y
+   │                              ^ Invalid pattern field type
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_3.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_3.move
@@ -1,0 +1,12 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y(u32)
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x: y } | E::Y(y) => *y
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_4.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_4.exp
@@ -1,0 +1,11 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/matching/invalid_or_types_4.move:11:30
+   │
+ 4 │     X { x: u64 },
+   │            --- Given: 'u64'
+ 5 │     Y(u32),
+   │       --- Expected: 'u32'
+   ·
+11 │         E::X { x: y } | E::Y(y) | E::Z { z: y } => *y
+   │                              ^ Invalid pattern field type
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_4.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_types_4.move
@@ -1,0 +1,13 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y(u32),
+    Z { z: u64 }
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x: y } | E::Y(y) | E::Z { z: y } => *y
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_raw_variant_name.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_raw_variant_name.exp
@@ -1,0 +1,33 @@
+error[E04036]: non-exhaustive pattern
+   ┌─ tests/move_2024/matching/invalid_raw_variant_name.move:10:12
+   │
+10 │     match (e) {
+   │            ^ Pattern 'E::Z { z: _ }' not covered
+
+error[E03019]: invalid pattern
+   ┌─ tests/move_2024/matching/invalid_raw_variant_name.move:11:30
+   │
+11 │         E::X { x: y } | E::Y(y) | Z { z: y } => *y
+   │                              ^    ---------- right or-pattern does not
+   │                              │     
+   │                              left or-pattern binds variable y
+   │
+   = Both sides of an or-pattern must bind the same variables.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/matching/invalid_raw_variant_name.move:11:30
+   │
+ 4 │     X { x: u64 },
+   │            --- Given: 'u64'
+ 5 │     Y(u32),
+   │       --- Expected: 'u32'
+   ·
+11 │         E::X { x: y } | E::Y(y) | Z { z: y } => *y
+   │                              ^ Invalid pattern field type
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/matching/invalid_raw_variant_name.move:11:35
+   │
+11 │         E::X { x: y } | E::Y(y) | Z { z: y } => *y
+   │                                   ^ Unexpected name access. Expected a valid 'enum' variant, 'struct', or 'const'.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_raw_variant_name.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_raw_variant_name.move
@@ -1,0 +1,13 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y(u32),
+    Z { z: u64 }
+}
+
+public fun test(e: &E): u64 {
+    match (e) {
+        E::X { x: y } | E::Y(y) | Z { z: y } => *y
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/mut_field_alias.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/mut_field_alias.move
@@ -1,0 +1,17 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y { y: u64 }
+}
+
+public fun test() {
+    let e = E::Y { y: 1 };
+    let value = match (e) {
+        E::X { mut x } | E::Y { y: mut x } => {
+            x = x + 1;
+            x
+        }
+    };
+    assert!(value == 2);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/mut_field_alias_2.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/mut_field_alias_2.move
@@ -1,0 +1,17 @@
+module 0x42::m;
+
+public enum E {
+    X { x: u64 },
+    Y { y: u64 }
+}
+
+public fun test() {
+    let e = E::Y { y: 1 };
+    let value = match (e) {
+        E::X { mut x } | E::Y { y: mut x } => {
+            x = x + 1;
+            x
+        }
+    };
+    assert!(value == 2);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/rhs_shadow_loop_label.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/rhs_shadow_loop_label.move
@@ -1,0 +1,49 @@
+module 0x42::TestLoopLabelShadowing;
+
+public enum Action has drop {
+    Stop,
+    MoveTo { x: u64, y: u64 },
+    ChangeSpeed(u64),
+}
+
+public fun test() {
+    // Define a list of actions
+    let actions: vector<Action> = vector[
+        Action::MoveTo { x: 10, y: 20 },
+        Action::ChangeSpeed(40),
+        Action::MoveTo { x: 10, y: 20 },
+        Action::Stop
+    ];
+
+    let mut total_moves = 0;
+
+    'loop_label: loop {
+        let mut i = 0;
+        while (i < actions.length()) {
+            let action = &actions[i];
+
+            match (action) {
+                Action::MoveTo { x, y } => {
+                    'loop_label: loop {
+                        total_moves = total_moves + *x + *y;
+                        break 'loop_label
+                    };
+                },
+                Action::ChangeSpeed(_) => {
+                    'loop_label: loop {
+                        break 'loop_label
+                    };
+                },
+                Action::Stop => {
+                    break 'loop_label
+                },
+                _ => {},
+            };
+            i = i + 1;
+        };
+    };
+
+    actions.destroy_empty();
+
+    assert!(total_moves == 60);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/rhs_shadow_loop_with_or.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/rhs_shadow_loop_with_or.move
@@ -1,0 +1,44 @@
+module 0x42::TestLoopLabelShadowing;
+
+public enum Action has drop {
+    Stop,
+    MoveTo { x: u64, y: u64 },
+    ChangeSpeed(u64),
+}
+
+public fun test() {
+    // Define a list of actions
+    let actions: vector<Action> = vector[
+        Action::MoveTo { x: 10, y: 20 },
+        Action::ChangeSpeed(20),
+        Action::MoveTo { x: 10, y: 20 },
+        Action::Stop
+    ];
+
+    let mut total_moves = 0;
+
+    'loop_label: loop {
+        let mut i = 0;
+        while (i < actions.length()) {
+            let action = &actions[i];
+
+            match (action) {
+                Action::MoveTo { x: speed, y: _ } | Action::ChangeSpeed(speed) => {
+                    'loop_label: loop {
+                        total_moves = total_moves + *speed;
+                        break 'loop_label
+                    };
+                },
+                Action::Stop => {
+                    break 'loop_label
+                },
+                _ => {},
+            };
+            i = i + 1;
+        };
+    };
+
+    actions.destroy_empty();
+
+    assert!(total_moves == 40);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.exp
@@ -31,12 +31,6 @@ error[E03013]: positional call mismatch
    │
    = Remove '()' arguments from this pattern
 
-error[E04017]: too many arguments
-   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:18:13
-   │
-18 │             Y::D(x, ..) => 0,
-   │             ^^^^^^^^^^^ Invalid usage for empty variant '0x42::m::Y::D'. Empty variants do not take any arguments.
-
 warning[W09002]: unused variable
    ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:18:18
    │
@@ -55,12 +49,6 @@ error[E03013]: positional call mismatch
    │             ^^^^^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
    │
    = Remove '{ }' arguments from this pattern
-
-error[E04017]: too many arguments
-   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:19:13
-   │
-19 │             Y::D{x, ..} => 0,
-   │             ^^^^^^^^^^^ Invalid usage for empty variant '0x42::m::Y::D'. Empty variants do not take any arguments.
 
 warning[W09002]: unused variable
    ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:19:18


### PR DESCRIPTION
## Description 

While name resolution and typing ensure uniquely-named labels, they can appear on the right-hand side of an `or`-pattern match, meaning they will be duplicated during match compilation. This currently causes a panic (cc @damirka ), but the revised code allows for block name reuse in different scopes in HLIR by adding them to the map for processing the body and removing them afterwards.

This also cleans up a redundant error being generated in typing, which was also being reported in naming.

## Test plan 

Several new tests, plus a bunch of other tests for match features.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
