### PR TITLE
[indexer] Use full_objects_history in reads

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.exp
@@ -1,87 +1,68 @@
-processed 13 tasks
+processed 12 tasks
 
-task 1, lines 6-19:
+task 1, lines 6-23:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5608800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 21:
-//# run Test::M1::create --args 0 @A
+task 2, line 25:
+//# run Test::M1::create --args 0
 created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3, line 23:
+task 3, line 27:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, line 25:
+task 4, line 29:
 //# advance-epoch
 Epoch advanced: 0
 
-task 5, line 27:
-//# run Test::M1::create --args 1 @A
-created: object(5,0)
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+task 5, line 31:
+//# run Test::M1::mutate --args object(2,0) 1
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
 
-task 6, lines 29-34:
+task 6, line 33:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, lines 35-40:
 //# run-graphql
 Response: {
   "data": {
     "object": {
-      "digest": "Nj3zEXbNMaKqUFUTpaTk3sMinxpRvMwq1WBDRt2L27Q"
+      "digest": "BMwy6uHLQwfAxLGdMQFWFR5faQkHUnhxDuaLdd3vngpt"
     }
   }
 }
 
-task 7, lines 36-45:
+task 8, lines 42-47:
 //# run-graphql
 Response: {
   "data": {
-    "address": {
-      "objects": {
-        "nodes": [
-          {
-            "digest": "Nj3zEXbNMaKqUFUTpaTk3sMinxpRvMwq1WBDRt2L27Q"
-          }
-        ]
-      }
+    "object": {
+      "digest": "D7Sc2kjsUCZBRvwM2ByFZPKAz3EG1m1qyjxpesN1j97f"
     }
   }
 }
 
-task 8, line 47:
-//# create-checkpoint
-Checkpoint created: 3
-
-task 9, lines 49-51:
+task 9, line 49:
 //# advance-epoch
 Epoch advanced: 1
 
-task 10, lines 52-54:
+task 10, lines 51-53:
 //# create-checkpoint
 Checkpoint created: 5
 
-task 11, lines 55-60:
+task 11, lines 54-59:
 //# run-graphql --wait-for-checkpoint-pruned 0
 Response: {
   "data": {
     "object": {
-      "digest": "Nj3zEXbNMaKqUFUTpaTk3sMinxpRvMwq1WBDRt2L27Q"
-    }
-  }
-}
-
-task 12, lines 62-71:
-//# run-graphql
-Response: {
-  "data": {
-    "address": {
-      "objects": {
-        "nodes": []
-      }
+      "digest": "BMwy6uHLQwfAxLGdMQFWFR5faQkHUnhxDuaLdd3vngpt"
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.exp
@@ -1,0 +1,87 @@
+processed 13 tasks
+
+task 1, lines 6-19:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 21:
+//# run Test::M1::create --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 23:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 25:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 27:
+//# run Test::M1::create --args 1 @A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 29-34:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "digest": "Nj3zEXbNMaKqUFUTpaTk3sMinxpRvMwq1WBDRt2L27Q"
+    }
+  }
+}
+
+task 7, lines 36-45:
+//# run-graphql
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "digest": "Nj3zEXbNMaKqUFUTpaTk3sMinxpRvMwq1WBDRt2L27Q"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 8, line 47:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 9, lines 49-51:
+//# advance-epoch
+Epoch advanced: 1
+
+task 10, lines 52-54:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 11, lines 55-60:
+//# run-graphql --wait-for-checkpoint-pruned 0
+Response: {
+  "data": {
+    "object": {
+      "digest": "Nj3zEXbNMaKqUFUTpaTk3sMinxpRvMwq1WBDRt2L27Q"
+    }
+  }
+}
+
+task 12, lines 62-71:
+//# run-graphql
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.exp
@@ -34,7 +34,7 @@ task 7, lines 35-40:
 Response: {
   "data": {
     "object": {
-      "digest": "BMwy6uHLQwfAxLGdMQFWFR5faQkHUnhxDuaLdd3vngpt"
+      "digest": "ig3beP5kc79atHUitXDvwpmZfH5AM5ZaKzaySVdJxL3"
     }
   }
 }
@@ -44,7 +44,7 @@ task 8, lines 42-47:
 Response: {
   "data": {
     "object": {
-      "digest": "D7Sc2kjsUCZBRvwM2ByFZPKAz3EG1m1qyjxpesN1j97f"
+      "digest": "HzGF2DsFWkXbAm9bhRwDC8ams4VaxqxVYEw5zwEmVyPj"
     }
   }
 }
@@ -62,7 +62,7 @@ task 11, lines 54-59:
 Response: {
   "data": {
     "object": {
-      "digest": "BMwy6uHLQwfAxLGdMQFWFR5faQkHUnhxDuaLdd3vngpt"
+      "digest": "ig3beP5kc79atHUitXDvwpmZfH5AM5ZaKzaySVdJxL3"
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.move
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M1 {
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::create --args 1 @A
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}", version: 3) {
+    digest
+  }
+}
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objects {
+      nodes {
+        digest
+      }
+    }
+  }
+}
+
+//# create-checkpoint
+
+//# advance-epoch
+
+# We must create a checkpoint so that available checkpoint range is still valid after pruning.
+//# create-checkpoint
+
+# After pruning, we can still read the object, but won't be able to read indexed data such as address owned objects.
+//# run-graphql --wait-for-checkpoint-pruned 0
+{
+  object(address: "@{obj_2_0}", version: 3) {
+    digest
+  }
+}
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objects {
+      nodes {
+        digest
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -274,9 +274,11 @@ impl TryFrom<MoveObject> for DynamicField {
         let super_ = &stored.super_;
 
         let native = match &super_.kind {
-            ObjectKind::NotIndexed(native) | ObjectKind::Indexed(native, _) => native,
+            ObjectKind::NotIndexed(native) | ObjectKind::Indexed(native, _) => native.clone(),
+            ObjectKind::Serialized(bytes) => bcs::from_bytes(bytes)
+                .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?,
 
-            ObjectKind::WrappedOrDeleted(_) => {
+            ObjectKind::WrappedOrDeleted => {
                 return Err(Error::Internal(
                     "DynamicField is wrapped or deleted.".to_string(),
                 ));

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -51,9 +51,6 @@ use sui_types::object::{
     MoveObject as NativeMoveObject, Object as NativeObject, Owner as NativeOwner,
 };
 use sui_types::TypeTag;
-
-type SerializedObject = Option<Vec<u8>>;
-
 #[derive(Clone, Debug)]
 pub(crate) struct Object {
     pub address: SuiAddress,
@@ -761,7 +758,7 @@ impl Object {
     pub(crate) fn new_serialized(
         object_id: SuiAddress,
         version: u64,
-        serialized: SerializedObject,
+        serialized: Option<Vec<u8>>,
         checkpoint_viewed_at: u64,
         root_version: u64,
     ) -> Self {
@@ -1529,13 +1526,13 @@ impl Loader<LatestAtKey> for Db {
 
 #[async_trait::async_trait]
 impl Loader<PointLookupKey> for Db {
-    type Value = SerializedObject;
+    type Value = Option<Vec<u8>>;
     type Error = Error;
 
     async fn load(
         &self,
         keys: &[PointLookupKey],
-    ) -> Result<HashMap<PointLookupKey, SerializedObject>, Error> {
+    ) -> Result<HashMap<PointLookupKey, Option<Vec<u8>>>, Error> {
         use full_objects_history::dsl as f;
 
         let id_versions: BTreeSet<_> = keys

--- a/crates/sui-indexer/src/models/obj_indices.rs
+++ b/crates/sui-indexer/src/models/obj_indices.rs
@@ -7,7 +7,7 @@ use crate::schema::objects_version;
 /// Model types related to tables that support efficient execution of queries on the `objects`,
 /// `objects_history` and `objects_snapshot` tables.
 
-#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName, Selectable)]
 #[diesel(table_name = objects_version, primary_key(object_id, object_version))]
 pub struct StoredObjectVersion {
     pub object_id: Vec<u8>,

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -421,7 +421,7 @@ impl TryFrom<CoinBalance> for Balance {
     }
 }
 
-#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName, Selectable)]
 #[diesel(table_name = full_objects_history, primary_key(object_id, object_version))]
 pub struct StoredFullHistoryObject {
     pub object_id: Vec<u8>,


### PR DESCRIPTION
## Description 

This PR queries the full_objects_history table for objects query.
It does so in a backward-compatible way. We always return data from the objects_history table if it's found, and otherwise we return from the full_objects_history table.

## Test plan 

Added e2e test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
