### PR TITLE
[suiop] add title similarity detection to incident review selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,7 +2502,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
  "terminal_size",
 ]
 
@@ -12355,9 +12355,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -15275,6 +15275,7 @@ dependencies = [
  "field_names",
  "include_dir",
  "inquire",
+ "itertools 0.13.0",
  "once_cell",
  "open",
  "prettytable-rs",
@@ -15287,6 +15288,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sha2 0.10.8",
  "spinners",
+ "strsim 0.11.1",
  "strum 0.24.1",
  "tabled",
  "tempfile",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -29,6 +29,7 @@ docker-api.workspace = true
 field_names.workspace = true
 include_dir.workspace = true
 inquire.workspace = true
+itertools.workspace = true
 open = "5.1.2"
 prettytable-rs.workspace = true
 rand.workspace = true
@@ -50,7 +51,6 @@ toml_edit.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 once_cell.workspace = true
-itertools = "0.13.0"
 strsim = "0.11.1"
 
 [dev-dependencies]

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -50,6 +50,8 @@ toml_edit.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 once_cell.workspace = true
+itertools = "0.13.0"
+strsim = "0.11.1"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/suiop-cli/src/cli/incidents/mod.rs
+++ b/crates/suiop-cli/src/cli/incidents/mod.rs
@@ -61,21 +61,7 @@ pub async fn incidents_cmd(args: &IncidentsArgs) -> Result<()> {
 
             let incidents = fetch_incidents(*limit, start_time, current_time).await?;
             if *interactive {
-                println!("{:?} incidents found", incidents);
-                review_recent_incidents(
-                    incidents
-                        .into_iter()
-                        // filter on priority > P3 and any slack channel association
-                        .filter(|i| {
-                            i.priority
-                                .clone()
-                                .filter(|p| !p.name.is_empty() && p.name != "P3")
-                                .is_some()
-                                || i.slack_channel.is_some()
-                        })
-                        .collect::<Vec<_>>(),
-                )
-                .await?
+                review_recent_incidents(incidents).await?
             } else {
                 print_recent_incidents(incidents, *long, *with_priority).await?
             }

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -6,7 +6,6 @@ use chrono::Utc;
 use chrono::{DateTime, Local, NaiveDateTime};
 use colored::{ColoredString, Colorize};
 use inquire::Confirm;
-use itertools::Itertools;
 use reqwest;
 use reqwest::header::HeaderMap;
 use reqwest::header::ACCEPT;
@@ -19,7 +18,6 @@ use strsim::normalized_damerau_levenshtein;
 use tracing::debug;
 
 use crate::cli::incidents::slack::Channel;
-use crate::cli::incidents_cmd;
 use crate::cli::lib::utils::day_of_week;
 use crate::DEBUG_MODE;
 
@@ -306,7 +304,7 @@ pub async fn review_recent_incidents(incidents: Vec<Incident>) -> Result<()> {
                 excluded.extend(incident_group.clone());
             }
         } else {
-            for incident in incident_group.into_iter() {
+            for incident in incident_group.iter() {
                 incident.print(false)?;
                 let ans = Confirm::new("Keep this incident for review?")
                     .with_default(false)
@@ -382,7 +380,7 @@ fn group_by_similar_title(
     incidents: Vec<Incident>,
     threshold: f64,
 ) -> HashMap<String, Vec<Incident>> {
-    if threshold < 0.0 || threshold > 1.0 {
+    if !(0.0..=1.0).contains(&threshold) {
         panic!("Threshold must be between 0.0 and 1.0");
     }
 
@@ -408,7 +406,7 @@ fn group_by_similar_title(
         if !found {
             groups
                 .entry(incident.title.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(incident);
         }
     }

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -254,18 +254,18 @@ pub async fn print_recent_incidents(
 }
 
 pub async fn review_recent_incidents(incidents: Vec<Incident>) -> Result<()> {
-    let group_map = group_by_similar_title(incidents, 0.9);
-    // let incidents_grouped = incidents
-    // .into_iter()
-    // filter on priority > P3 and any slack channel association
-    // .filter(|i| {
-    // i.priority
-    // .clone()
-    // .filter(|p| !p.name.is_empty() && p.name != "P3")
-    // .is_some()
-    // || i.slack_channel.is_some()
-    // })
-    // .chunk_by(|i| i.title.clone());
+    let incidents_grouped = incidents
+        .into_iter()
+        // filter on priority > P3 and any slack channel association
+        .filter(|i| {
+            i.priority
+                .clone()
+                .filter(|p| !p.name.is_empty() && p.name != "P3")
+                .is_some()
+                || i.slack_channel.is_some()
+        })
+        .collect();
+    let group_map = group_by_similar_title(incidents_grouped, 0.9);
     let mut to_review = vec![];
     let mut excluded = vec![];
     debug!(

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -6,16 +6,20 @@ use chrono::Utc;
 use chrono::{DateTime, Local, NaiveDateTime};
 use colored::{ColoredString, Colorize};
 use inquire::Confirm;
+use itertools::Itertools;
 use reqwest;
 use reqwest::header::HeaderMap;
 use reqwest::header::ACCEPT;
 use reqwest::header::AUTHORIZATION;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 use std::env;
+use strsim::normalized_damerau_levenshtein;
 use tracing::debug;
 
 use crate::cli::incidents::slack::Channel;
+use crate::cli::incidents_cmd;
 use crate::cli::lib::utils::day_of_week;
 use crate::DEBUG_MODE;
 
@@ -26,7 +30,7 @@ pub struct Priority {
     color: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Incident {
     #[serde(rename = "incident_number")]
     number: u64,
@@ -118,6 +122,29 @@ impl Incident {
             Some("P4") => "P4".white(),
             _ => "".white(),
         }
+    }
+
+    fn short_fmt(&self) -> String {
+        format!(
+            "• {} {} {} {}",
+            if let Some(channel) = self.slack_channel.clone() {
+                format!("{} ({})", self.number, channel.url())
+            } else {
+                self.number.to_string()
+            },
+            self.resolved_at
+                .clone()
+                .map(|c| NaiveDateTime::parse_from_str(&c, DATE_FORMAT_IN)
+                    .expect("parsing closed date")
+                    .format(DATE_FORMAT_OUT_SHORT)
+                    .to_string())
+                .unwrap_or("".to_owned()),
+            self.title,
+            self.slack_channel
+                .clone()
+                .map(|c| c.name)
+                .unwrap_or("".to_string()),
+        )
     }
 }
 
@@ -227,18 +254,70 @@ pub async fn print_recent_incidents(
 }
 
 pub async fn review_recent_incidents(incidents: Vec<Incident>) -> Result<()> {
+    let group_map = group_by_similar_title(incidents, 0.9);
+    // let incidents_grouped = incidents
+    // .into_iter()
+    // filter on priority > P3 and any slack channel association
+    // .filter(|i| {
+    // i.priority
+    // .clone()
+    // .filter(|p| !p.name.is_empty() && p.name != "P3")
+    // .is_some()
+    // || i.slack_channel.is_some()
+    // })
+    // .chunk_by(|i| i.title.clone());
     let mut to_review = vec![];
     let mut excluded = vec![];
-    for incident in incidents {
-        incident.print(false)?;
-        let ans = Confirm::new("Keep this incident for review?")
-            .with_default(false)
-            .prompt()
-            .expect("Unexpected response");
-        if ans {
-            to_review.push(incident);
+    debug!(
+        "map: {:#?}",
+        group_map
+            .iter()
+            .map(|(k, v)| (k, v.len()))
+            .collect::<Vec<_>>()
+    );
+    for (title, incident_group) in group_map.iter() {
+        let treat_as_one = if incident_group.len() > 1 {
+            println!(
+                "There are {} incidents with a title similar to this: {}",
+                &incident_group.len(),
+                title
+            );
+            println!("All incidents with a similar title:");
+            for i in incident_group {
+                i.print(false)?;
+            }
+            Confirm::new("Treat them as one?")
+                .with_default(true)
+                .prompt()
+                .expect("Unexpected response")
         } else {
-            excluded.push(incident);
+            false
+        };
+        if treat_as_one {
+            let ans = Confirm::new("Keep these incidents for review?")
+                .with_default(false)
+                .prompt()
+                .expect("Unexpected response");
+            if ans {
+                println!("{:?} added to review", to_review);
+                to_review.extend(incident_group.clone());
+                println!("{:?} added to review", to_review);
+            } else {
+                excluded.extend(incident_group.clone());
+            }
+        } else {
+            for incident in incident_group.into_iter() {
+                incident.print(false)?;
+                let ans = Confirm::new("Keep this incident for review?")
+                    .with_default(false)
+                    .prompt()
+                    .expect("Unexpected response");
+                if ans {
+                    to_review.push(incident.clone());
+                } else {
+                    excluded.push(incident.clone());
+                }
+            }
         }
     }
     println!(
@@ -249,29 +328,6 @@ pub async fn review_recent_incidents(incidents: Vec<Incident>) -> Result<()> {
             .collect::<Vec<_>>()
             .join(", ")
     );
-
-    fn short_print(i: &Incident) -> String {
-        format!(
-            "• {} {} {} {}",
-            if let Some(channel) = i.slack_channel.clone() {
-                format!("{} ({})", i.number, channel.url())
-            } else {
-                i.number.to_string()
-            },
-            i.resolved_at
-                .clone()
-                .map(|c| NaiveDateTime::parse_from_str(&c, DATE_FORMAT_IN)
-                    .expect("parsing closed date")
-                    .format(DATE_FORMAT_OUT_SHORT)
-                    .to_string())
-                .unwrap_or("".to_owned()),
-            i.title,
-            i.slack_channel
-                .clone()
-                .map(|c| c.name)
-                .unwrap_or("".to_string()),
-        )
-    }
 
     let message = format!(
         "
@@ -287,12 +343,12 @@ Please comment in the thread to request an adjustment to the list.",
         day_of_week(),
         to_review
             .iter()
-            .map(short_print)
+            .map(Incident::short_fmt)
             .collect::<Vec<_>>()
             .join("\n"),
         excluded
             .iter()
-            .map(short_print)
+            .map(Incident::short_fmt)
             .collect::<Vec<_>>()
             .join("\n")
     );
@@ -320,4 +376,42 @@ Please comment in the thread to request an adjustment to the list.",
     }
     // post to https://slack.com/api/chat.postMessage with message
     Ok(())
+}
+
+fn group_by_similar_title(
+    incidents: Vec<Incident>,
+    threshold: f64,
+) -> HashMap<String, Vec<Incident>> {
+    if threshold < 0.0 || threshold > 1.0 {
+        panic!("Threshold must be between 0.0 and 1.0");
+    }
+
+    let mut groups: HashMap<String, Vec<Incident>> = HashMap::new();
+
+    for incident in incidents {
+        // Try to find an existing title that is similar enough
+        let mut found = false;
+        for (existing_title, group) in groups.iter_mut() {
+            if normalized_damerau_levenshtein(
+                &incident.title.chars().take(20).collect::<String>(),
+                &existing_title.chars().take(20).collect::<String>(),
+            ) >= threshold
+            {
+                // If similar, add it to this group
+                group.push(incident.clone());
+                found = true;
+                break;
+            }
+        }
+
+        // If no similar title found, add a new group
+        if !found {
+            groups
+                .entry(incident.title.clone())
+                .or_insert_with(Vec::new)
+                .push(incident);
+        }
+    }
+
+    groups
 }


### PR DESCRIPTION
## Description 

Refactor the filtering code into the review selection module. 
Use strsim to detect title similarity (only using the first 20 chars of the title for now to keep it simple)
Group similar titles and allow treating them as one atomic operation

## Test plan 

tested locally, grouped successfully. tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
