### PR TITLE
[trace-view] Added support for marking optimized away code lines

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -32,7 +32,7 @@ interface IRuntimeStackFrame {
  * Describes the runtime stack during trace viewing session
  * (oldest frame is at the bottom of the stack at index 0).
  */
-interface IRuntimeStack {
+export interface IRuntimeStack {
     frames: IRuntimeStackFrame[];
 }
 


### PR DESCRIPTION
## Description 

In Move, there isn't necessarily 1:1 correspondence between source code and bytecode due to compiler optimizations. In the following code example (admittedly somewhat artificial for presentation purposes), there will be no entry for `constant` variable in the bytecode as it will be optimized away via constant propagation:
```
    fun hello(param: u64): vector<u64> {
        let mut res = param;
        let constant = 42; // optimized away

        if (constant >= 42) { // optimized away and turned into straight line code
            res = 42;
        };

        vector::singleton(res)
    }
```

This PR implements a heuristic that will mark source code lines optimized away by the compiler as having grey background. We do this by analyzing source maps for a given file and marking lines that are present in the source map but not in the source file (with some exceptions, notably empty lines, lines starting with `const`, and lines that only contain right brace `}`).

At this point, the "optimized away" lines include comments (we can finesse it in the future if need be, but it does in some sense reflect the spirit of this visualization)

## Test plan 

Tested manually to see if grey lines appear and changes throughout debugging session when going to different files, and that they are reset once debug session is finished.
