### PR TITLE
[move-ide] Version bump

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",


### PR DESCRIPTION
## Description 

Bump version to the next one in VScode Marketplace (currently 1.0.11) as plugin can be republished only at a higher version

