### PR TITLE
[Move] Box type layout vectors 

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/large_enum_v58.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/large_enum_v58.exp
@@ -18,5 +18,5 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0
 task 3, lines 40-41:
 //# programmable --sender A
 //> test::m::x3()
-mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: TOO_MANY_TYPE_NODES, sub_status: None, message: None, exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/large_enum_v58.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/large_enum_v58.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests error after serializing a large enum return value
+
+//# init --addresses test=0x0 --accounts A --protocol-version 58
+
+//# publish
+
+module test::m {
+
+public enum X1 has drop  {
+    Big1(u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8),
+}
+
+public enum X2 has drop  {
+    V1(X1, X1, X1),
+    V2(X1, X1, X1),
+    V3(X1, X1, X1),
+}
+
+public enum X3 has drop {
+    X2(X2, X2, X2),
+    U64(u64),
+}
+
+entry fun x1(): X1 {
+    X1::Big1(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+}
+
+entry fun x3(): X3 {
+    X3::U64(0)
+}
+
+}
+
+//# programmable --sender A
+//> test::m::x1()
+
+//# programmable --sender A
+//> test::m::x3()

--- a/crates/sui-core/src/unit_tests/subscription_handler_tests.rs
+++ b/crates/sui-core/src/unit_tests/subscription_handler_tests.rs
@@ -85,11 +85,11 @@ impl TestEvent {
     fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: vec![
+            fields: Box::new(vec![
                 MoveFieldLayout::new(ident_str!("creator").to_owned(), MoveTypeLayout::Address),
                 MoveFieldLayout::new(
                     ident_str!("name").to_owned(),
-                    MoveTypeLayout::Struct(UTF8String::layout()),
+                    MoveTypeLayout::Struct(Box::new(UTF8String::layout())),
                 ),
                 MoveFieldLayout::new(
                     ident_str!("data").to_owned(),
@@ -97,9 +97,11 @@ impl TestEvent {
                 ),
                 MoveFieldLayout::new(
                     ident_str!("coins").to_owned(),
-                    MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Struct(GasCoin::layout()))),
+                    MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Struct(Box::new(
+                        GasCoin::layout(),
+                    )))),
                 ),
-            ],
+            ]),
         }
     }
 }
@@ -131,10 +133,10 @@ impl UTF8String {
     fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: vec![MoveFieldLayout::new(
+            fields: Box::new(vec![MoveFieldLayout::new(
                 ident_str!("bytes").to_owned(),
                 MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-            )],
+            )]),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -259,8 +259,8 @@ impl TryFrom<A::MoveTypeLayout> for MoveTypeLayout {
             TL::Address => Self::Address,
 
             TL::Vector(v) => Self::Vector(Box::new(Self::try_from(*v)?)),
-            TL::Struct(s) => Self::Struct(s.try_into()?),
-            TL::Enum(e) => Self::Enum(e.try_into()?),
+            TL::Struct(s) => Self::Struct((*s).try_into()?),
+            TL::Enum(e) => Self::Enum((*e).try_into()?),
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -474,13 +474,13 @@ mod tests {
 
     macro_rules! struct_layout {
         ($type:literal { $($name:literal : $layout:expr),* $(,)?}) => {
-            A::MoveTypeLayout::Struct(S {
+            A::MoveTypeLayout::Struct(Box::new(S {
                 type_: StructTag::from_str($type).expect("Failed to parse struct"),
-                fields: vec![$(MoveFieldLayout {
+                fields: Box::new(vec![$(MoveFieldLayout {
                     name: ident_str!($name).to_owned(),
                     layout: $layout,
-                }),*]
-            })
+                }),*])
+            }))
         }
     }
 

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -709,7 +709,7 @@ async fn get_move_struct_layout_map(
                         move_core_types::annotated_value::MoveStructLayout,
                     ),
                     IndexerError,
-                >((struct_tag, move_struct_layout))
+                >((struct_tag, *move_struct_layout))
             }
         })
         .collect::<Vec<_>>();

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -314,7 +314,7 @@ impl StoredObject {
             )),
         }?;
 
-        Ok(ObjectRead::Exists(oref, object, Some(move_struct_layout)))
+        Ok(ObjectRead::Exists(oref, object, Some(*move_struct_layout)))
     }
 
     pub fn get_object_ref(&self) -> Result<ObjectRef, IndexerError> {

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -618,18 +618,18 @@ fn test_from_str() {
 fn test_sui_call_arg_string_type() {
     let arg1 = bcs::to_bytes("Some String").unwrap();
 
-    let string_layout = Some(MoveTypeLayout::Struct(MoveStructLayout {
+    let string_layout = Some(MoveTypeLayout::Struct(Box::new(MoveStructLayout {
         type_: StructTag {
             address: MOVE_STDLIB_ADDRESS,
             module: STD_ASCII_MODULE_NAME.into(),
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: vec![MoveFieldLayout {
+        fields: Box::new(vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }],
-    }));
+        }]),
+    })));
     let v = SuiJsonValue::from_bcs_bytes(string_layout.as_ref(), &arg1).unwrap();
 
     assert_eq!(json! {"Some String"}, v.to_json_value());
@@ -639,31 +639,31 @@ fn test_sui_call_arg_string_type() {
 fn test_sui_call_arg_option_type() {
     let arg1 = bcs::to_bytes(&Some("Some String")).unwrap();
 
-    let string_layout = MoveTypeLayout::Struct(MoveStructLayout {
+    let string_layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
         type_: StructTag {
             address: MOVE_STDLIB_ADDRESS,
             module: STD_ASCII_MODULE_NAME.into(),
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: vec![MoveFieldLayout {
+        fields: Box::new(vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }],
-    });
+        }]),
+    }));
 
-    let option_layout = MoveTypeLayout::Struct(MoveStructLayout {
+    let option_layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
         type_: StructTag {
             address: MOVE_STDLIB_ADDRESS,
             module: STD_OPTION_MODULE_NAME.into(),
             name: STD_OPTION_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: vec![MoveFieldLayout {
+        fields: Box::new(vec![MoveFieldLayout {
             name: ident_str!("vec").into(),
             layout: MoveTypeLayout::Vector(Box::new(string_layout.clone())),
-        }],
-    });
+        }]),
+    }));
 
     let v = SuiJsonValue::from_bcs_bytes(Some(option_layout).as_ref(), &arg1).unwrap();
 
@@ -680,7 +680,7 @@ fn test_sui_call_arg_option_type() {
 
 #[test]
 fn test_convert_struct() {
-    let layout = MoveTypeLayout::Struct(GasCoin::layout());
+    let layout = MoveTypeLayout::Struct(Box::new(GasCoin::layout()));
 
     let value = json!({"id":"0xf1416fe18c7baa1673187375777a7606708481311cb3548509ec91a5871c6b9a", "balance": "1000000"});
     let sui_json = SuiJsonValue::new(value).unwrap();
@@ -702,18 +702,18 @@ fn test_convert_struct() {
 fn test_convert_string_vec() {
     let test_vec = vec!["0xbbb", "test_str"];
     let bcs = bcs::to_bytes(&test_vec).unwrap();
-    let string_layout = MoveTypeLayout::Struct(MoveStructLayout {
+    let string_layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
         type_: StructTag {
             address: MOVE_STDLIB_ADDRESS,
             module: STD_ASCII_MODULE_NAME.into(),
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: vec![MoveFieldLayout {
+        fields: Box::new(vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }],
-    });
+        }]),
+    }));
 
     let layout = MoveTypeLayout::Vector(Box::new(string_layout));
 
@@ -737,31 +737,31 @@ fn test_string_vec_df_name_child_id_eq() {
         ]
     });
 
-    let string_layout = MoveTypeLayout::Struct(MoveStructLayout {
+    let string_layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
         type_: StructTag {
             address: MOVE_STDLIB_ADDRESS,
             module: STD_ASCII_MODULE_NAME.into(),
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: vec![MoveFieldLayout {
+        fields: Box::new(vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }],
-    });
+        }]),
+    }));
 
-    let layout = MoveTypeLayout::Struct(MoveStructLayout {
+    let layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
         type_: StructTag {
             address: MOVE_STDLIB_ADDRESS,
             module: STD_ASCII_MODULE_NAME.into(),
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: vec![MoveFieldLayout::new(
+        fields: Box::new(vec![MoveFieldLayout::new(
             Identifier::from_str("labels").unwrap(),
             MoveTypeLayout::Vector(Box::new(string_layout)),
-        )],
-    });
+        )]),
+    }));
 
     let sui_json = SuiJsonValue::new(name).unwrap();
     let bcs2 = sui_json.to_bcs_bytes(&layout).unwrap();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1814,6 +1814,7 @@
                 "max_type_nodes": {
                   "u64": "256"
                 },
+                "max_type_to_layout_nodes": null,
                 "max_value_stack_size": {
                   "u64": "1024"
                 },

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -1206,7 +1206,7 @@ impl RpcExampleProvider {
                     },
                     MoveStructLayout {
                         type_: struct_tag,
-                        fields: Vec::new(),
+                        fields: Box::new(Vec::new()),
                     },
                 )
                 .unwrap(),

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -1453,10 +1453,10 @@ impl<'l> ResolutionContext<'l> {
                 }
 
                 (
-                    MoveTypeLayout::Struct(MoveStructLayout {
+                    MoveTypeLayout::Struct(Box::new(MoveStructLayout {
                         type_,
-                        fields: resolved_fields,
-                    }),
+                        fields: Box::new(resolved_fields),
+                    })),
                     field_depth + 1,
                 )
             }
@@ -1481,10 +1481,10 @@ impl<'l> ResolutionContext<'l> {
                 }
 
                 (
-                    MoveTypeLayout::Enum(MoveEnumLayout {
+                    MoveTypeLayout::Enum(Box::new(MoveEnumLayout {
                         type_,
                         variants: resolved_variants,
-                    }),
+                    })),
                     field_depth + 1,
                 )
             }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -178,6 +178,7 @@ const MAX_PROTOCOL_VERSION: u64 = 59;
 //             Finalize bridge committee on mainnet.
 //             Switch to distributed vote scoring in consensus in devnet
 // Version 59: Validation of public inputs for Groth16 verification.
+//             Enable configuration of maximum number of type nodes in a type layout.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -860,6 +861,9 @@ pub struct ProtocolConfig {
     // than a per-byte cost. checking an object lock should not require loading an
     // entire object, just consulting an ID -> tx digest map
     obj_access_cost_verify_per_byte: Option<u64>,
+
+    // Maximal nodes which are allowed when converting to a type layout.
+    max_type_to_layout_nodes: Option<u64>,
 
     /// === Gas version. gas model ===
 
@@ -1766,6 +1770,7 @@ impl ProtocolConfig {
             max_num_transferred_move_object_ids_system_tx: Some(2048 * 16),
             max_event_emit_size: Some(250 * 1024),
             max_move_vector_len: Some(256 * 1024),
+            max_type_to_layout_nodes: None,
 
             max_back_edges_per_function: Some(10_000),
             max_back_edges_per_module: Some(10_000),
@@ -2743,7 +2748,9 @@ impl ProtocolConfig {
                             .consensus_distributed_vote_scoring_strategy = true;
                     }
                 }
-                59 => {}
+                59 => {
+                    cfg.max_type_to_layout_nodes = Some(512);
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_59.snap
@@ -137,6 +137,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
 gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_59.snap
@@ -137,6 +137,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
 gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_59.snap
@@ -143,6 +143,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
 gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50

--- a/crates/sui-types/src/balance.rs
+++ b/crates/sui-types/src/balance.rs
@@ -78,10 +78,10 @@ impl Balance {
     pub fn layout(type_param: TypeTag) -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(type_param),
-            fields: vec![MoveFieldLayout::new(
+            fields: Box::new(vec![MoveFieldLayout::new(
                 ident_str!("value").to_owned(),
                 MoveTypeLayout::U64,
-            )],
+            )]),
         }
     }
 }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -96,16 +96,16 @@ impl Coin {
     pub fn layout(type_param: TypeTag) -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(type_param.clone()),
-            fields: vec![
+            fields: Box::new(vec![
                 MoveFieldLayout::new(
                     ident_str!("id").to_owned(),
-                    MoveTypeLayout::Struct(UID::layout()),
+                    MoveTypeLayout::Struct(Box::new(UID::layout())),
                 ),
                 MoveFieldLayout::new(
                     ident_str!("balance").to_owned(),
-                    MoveTypeLayout::Struct(Balance::layout(type_param)),
+                    MoveTypeLayout::Struct(Box::new(Balance::layout(type_param))),
                 ),
-            ],
+            ]),
         }
     }
 

--- a/crates/sui-types/src/id.rs
+++ b/crates/sui-types/src/id.rs
@@ -61,10 +61,10 @@ impl UID {
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: vec![MoveFieldLayout::new(
+            fields: Box::new(vec![MoveFieldLayout::new(
                 ident_str!("id").to_owned(),
-                MoveTypeLayout::Struct(ID::layout()),
-            )],
+                MoveTypeLayout::Struct(Box::new(ID::layout())),
+            )]),
         }
     }
 }
@@ -86,10 +86,10 @@ impl ID {
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: vec![MoveFieldLayout::new(
+            fields: Box::new(vec![MoveFieldLayout::new(
                 ident_str!("bytes").to_owned(),
                 MoveTypeLayout::Address,
-            )],
+            )]),
         }
     }
 }

--- a/crates/sui-types/src/layout_resolver.rs
+++ b/crates/sui-types/src/layout_resolver.rs
@@ -38,7 +38,7 @@ pub fn get_layout_from_struct_tag(
 
 pub fn into_struct_layout(layout: A::MoveDatatypeLayout) -> Result<A::MoveStructLayout, SuiError> {
     match layout {
-        A::MoveDatatypeLayout::Struct(s) => Ok(s),
+        A::MoveDatatypeLayout::Struct(s) => Ok(*s),
         A::MoveDatatypeLayout::Enum(e) => Err(SuiError::ObjectSerializationError {
             error: format!("Expected struct layout but got an enum {e:?}"),
         }),

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -314,7 +314,7 @@ impl MoveObject {
             }
         })?;
         match layout {
-            MoveTypeLayout::Struct(l) => Ok(l),
+            MoveTypeLayout::Struct(l) => Ok(*l),
             _ => unreachable!(
                 "We called build_with_types on Struct type, should get a struct layout"
             ),

--- a/crates/sui-types/src/object/balance_traversal.rs
+++ b/crates/sui-types/src/object/balance_traversal.rs
@@ -255,7 +255,7 @@ mod tests {
         layout_(
             &format!("0x2::coin::Coin<{tag}>"),
             vec![
-                ("id", A::MoveTypeLayout::Struct(UID::layout())),
+                ("id", A::MoveTypeLayout::Struct(Box::new(UID::layout()))),
                 ("balance", bal_t(tag)),
             ],
         )
@@ -285,7 +285,10 @@ mod tests {
             .map(|(name, layout)| A::MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
             .collect();
 
-        A::MoveTypeLayout::Struct(A::MoveStructLayout { type_, fields })
+        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+            type_,
+            fields: Box::new(fields),
+        }))
     }
 
     /// BCS encode Move value.

--- a/crates/sui-types/src/object/bounded_visitor.rs
+++ b/crates/sui-types/src/object/bounded_visitor.rs
@@ -205,7 +205,7 @@ impl Visitor for BoundedVisitor {
         let tag = driver.struct_layout().type_.clone().into();
 
         self.debit_type_size(&tag)?;
-        for field in &driver.struct_layout().fields {
+        for field in driver.struct_layout().fields.iter() {
             self.debit(field.name.len())?;
         }
 
@@ -469,7 +469,10 @@ mod tests {
             .map(|(name, layout)| A::MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
             .collect();
 
-        A::MoveTypeLayout::Struct(A::MoveStructLayout { type_, fields })
+        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+            type_,
+            fields: Box::new(fields),
+        }))
     }
 
     /// BCS encode Move value.

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/large_enum.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/large_enum.exp
@@ -1,11 +1,15 @@
-processed 4 tasks
+processed 5 tasks
 
-task 2, line 34:
+task 2, line 43:
 //# run 0x42::m::x1
 return values: |0|{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 
-task 3, line 36:
+task 3, line 45:
 //# run 0x42::m::x3
+return values: |1|{ 0 }
+
+task 4, line 47:
+//# run 0x42::m::x4
 Error: Function execution failed with VMError: {
     major_status: VERIFICATION_ERROR,
     sub_status: None,

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/large_enum.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/large_enum.move
@@ -21,6 +21,11 @@ public enum X3 {
     U64(u64),
 }
 
+public enum X4 {
+    X2(X3, X3, X3),
+    U64(u64),
+}
+
 entry fun x1(): X1 {
     X1::Big(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
 }
@@ -29,8 +34,14 @@ entry fun x3(): X3 {
     X3::U64(0)
 }
 
+entry fun x4(): X4 {
+    X4::U64(0)
+}
+
 }
 
 //# run 0x42::m::x1
 
 //# run 0x42::m::x3
+
+//# run 0x42::m::x4

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -50,15 +50,15 @@ pub enum MoveValue {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MoveStructLayout(pub Vec<MoveTypeLayout>);
+pub struct MoveStructLayout(pub Box<Vec<MoveTypeLayout>>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MoveEnumLayout(pub Vec<Vec<MoveTypeLayout>>);
+pub struct MoveEnumLayout(pub Box<Vec<Vec<MoveTypeLayout>>>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MoveDatatypeLayout {
-    Struct(MoveStructLayout),
-    Enum(MoveEnumLayout),
+    Struct(Box<MoveStructLayout>),
+    Enum(Box<MoveEnumLayout>),
 }
 
 impl MoveDatatypeLayout {
@@ -86,7 +86,7 @@ pub enum MoveTypeLayout {
     #[serde(rename(serialize = "vector", deserialize = "vector"))]
     Vector(Box<MoveTypeLayout>),
     #[serde(rename(serialize = "struct", deserialize = "struct"))]
-    Struct(MoveStructLayout),
+    Struct(Box<MoveStructLayout>),
     #[serde(rename(serialize = "signer", deserialize = "signer"))]
     Signer,
 
@@ -98,7 +98,7 @@ pub enum MoveTypeLayout {
     #[serde(rename(serialize = "u256", deserialize = "u256"))]
     U256,
     #[serde(rename(serialize = "enum", deserialize = "enum"))]
-    Enum(MoveEnumLayout),
+    Enum(Box<MoveEnumLayout>),
 }
 
 impl MoveValue {
@@ -192,7 +192,7 @@ impl MoveStruct {
             type_: type_.clone(),
             fields: vals
                 .into_iter()
-                .zip(fields)
+                .zip(fields.iter())
                 .map(|(v, l)| (l.name.clone(), v.decorate(&l.layout)))
                 .collect(),
         }
@@ -228,7 +228,7 @@ impl MoveVariant {
             tag,
             fields: fields
                 .into_iter()
-                .zip(v_layout)
+                .zip(v_layout.iter())
                 .map(|(v, l)| (l.name.clone(), v.decorate(&l.layout)))
                 .collect(),
             variant_name: v_name.clone(),
@@ -246,7 +246,7 @@ impl MoveVariant {
 
 impl MoveStructLayout {
     pub fn new(types: Vec<MoveTypeLayout>) -> Self {
-        Self(types)
+        Self(Box::new(types))
     }
 
     pub fn fields(&self) -> &[MoveTypeLayout] {
@@ -254,7 +254,7 @@ impl MoveStructLayout {
     }
 
     pub fn into_fields(self) -> Vec<MoveTypeLayout> {
-        self.0
+        *self.0
     }
 }
 

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -689,7 +689,10 @@ fn struct_layout_(rep: &str, fields: Vec<(&str, MoveTypeLayout)>) -> MoveTypeLay
         .map(|(name, layout)| MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
         .collect();
 
-    MoveTypeLayout::Struct(MoveStructLayout { type_, fields })
+    MoveTypeLayout::Struct(Box::new(MoveStructLayout {
+        type_,
+        fields: Box::new(fields),
+    }))
 }
 
 /// Create a variant value for test purposes.
@@ -723,7 +726,7 @@ fn enum_layout_(rep: &str, variants: Vec<(&str, Vec<(&str, MoveTypeLayout)>)>) -
         })
         .collect();
 
-    MoveTypeLayout::Enum(MoveEnumLayout { type_, variants })
+    MoveTypeLayout::Enum(Box::new(MoveEnumLayout { type_, variants }))
 }
 
 /// BCS encode Move value.

--- a/external-crates/move/crates/move-vm-config/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-config/src/runtime.rs
@@ -36,6 +36,9 @@ pub struct VMConfig {
     // Whether value serialization errors when generating type layouts should be rethrown or
     // converted to a different error.
     pub rethrow_serialization_type_layout_errors: bool,
+    /// Maximal nodes which are allowed when converting to layout. This includes the types of
+    /// fields for struct types.
+    pub max_type_to_layout_nodes: Option<u64>,
 }
 
 impl Default for VMConfig {
@@ -50,6 +53,7 @@ impl Default for VMConfig {
             error_execution_state: true,
             binary_config: BinaryConfig::with_extraneous_bytes_check(false),
             rethrow_serialization_type_layout_errors: false,
+            max_type_to_layout_nodes: Some(512),
         }
     }
 }

--- a/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
@@ -3306,7 +3306,7 @@ impl<'a, 'b> serde::Serialize for AnnotatedValue<'a, 'b, MoveTypeLayout, ValueIm
 
             (MoveTypeLayout::Struct(struct_layout), ValueImpl::Container(Container::Struct(r))) => {
                 (AnnotatedValue {
-                    layout: struct_layout,
+                    layout: &**struct_layout,
                     val: &*r.borrow(),
                 })
                 .serialize(serializer)
@@ -3314,7 +3314,7 @@ impl<'a, 'b> serde::Serialize for AnnotatedValue<'a, 'b, MoveTypeLayout, ValueIm
 
             (MoveTypeLayout::Enum(enum_layout), ValueImpl::Container(Container::Variant(r))) => {
                 (AnnotatedValue {
-                    layout: enum_layout,
+                    layout: &**enum_layout,
                     val: &*r.borrow(),
                 })
                 .serialize(serializer)
@@ -3483,12 +3483,12 @@ impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayout> {
             L::Signer => AccountAddress::deserialize(deserializer).map(Value::signer),
 
             L::Struct(struct_layout) => Ok(SeedWrapper {
-                layout: struct_layout,
+                layout: &**struct_layout,
             }
             .deserialize(deserializer)?),
 
             L::Enum(enum_layout) => Ok(SeedWrapper {
-                layout: enum_layout,
+                layout: &**enum_layout,
             }
             .deserialize(deserializer)?),
 
@@ -4138,10 +4138,11 @@ impl ValueImpl {
             (L::Bool, ValueImpl::Bool(x)) => MoveValue::Bool(*x),
             (L::Address, ValueImpl::Address(x)) => MoveValue::Address(*x),
 
-            (L::Enum(MoveEnumLayout(variants)), ValueImpl::Container(Container::Variant(r))) => {
+            (L::Enum(enum_layout), ValueImpl::Container(Container::Variant(r))) => {
+                let MoveEnumLayout(variants) = &**enum_layout;
                 let (tag, values) = &*r.borrow();
                 let tag = *tag;
-                let field_layouts = &variants[tag as usize];
+                let field_layouts = &variants.as_slice()[tag as usize];
                 let mut fields = vec![];
                 for (v, field_layout) in values.iter().zip(field_layouts) {
                     fields.push(v.as_move_value(field_layout));

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
@@ -2186,17 +2186,14 @@ impl Loader {
             Type::Vector(ty) => R::MoveTypeLayout::Vector(Box::new(
                 self.type_to_type_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Datatype(gidx) => R::MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(
-                *gidx,
-                &[],
-                count,
-                depth,
-            )?),
+            Type::Datatype(gidx) => R::MoveTypeLayout::Struct(Box::new(
+                self.struct_gidx_to_type_layout(*gidx, &[], count, depth)?,
+            )),
             Type::DatatypeInstantiation(struct_inst) => {
                 let (gidx, ty_args) = &**struct_inst;
-                R::MoveTypeLayout::Struct(
+                R::MoveTypeLayout::Struct(Box::new(
                     self.struct_gidx_to_type_layout(*gidx, ty_args, count, depth)?,
-                )
+                ))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
@@ -2289,14 +2286,14 @@ impl Loader {
             Type::Vector(ty) => A::MoveTypeLayout::Vector(Box::new(
                 self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Datatype(gidx) => A::MoveTypeLayout::Struct(
+            Type::Datatype(gidx) => A::MoveTypeLayout::Struct(Box::new(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, &[], count, depth)?,
-            ),
+            )),
             Type::DatatypeInstantiation(struct_inst) => {
                 let (gidx, ty_args) = &**struct_inst;
-                A::MoveTypeLayout::Struct(
+                A::MoveTypeLayout::Struct(Box::new(
                     self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, count, depth)?,
-                )
+                ))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
@@ -2188,17 +2188,14 @@ impl Loader {
             Type::Vector(ty) => R::MoveTypeLayout::Vector(Box::new(
                 self.type_to_type_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Datatype(gidx) => R::MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(
-                *gidx,
-                &[],
-                count,
-                depth,
-            )?),
+            Type::Datatype(gidx) => R::MoveTypeLayout::Struct(Box::new(
+                self.struct_gidx_to_type_layout(*gidx, &[], count, depth)?,
+            )),
             Type::DatatypeInstantiation(struct_inst) => {
                 let (gidx, ty_args) = &**struct_inst;
-                R::MoveTypeLayout::Struct(
+                R::MoveTypeLayout::Struct(Box::new(
                     self.struct_gidx_to_type_layout(*gidx, ty_args, count, depth)?,
-                )
+                ))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
@@ -2291,14 +2288,14 @@ impl Loader {
             Type::Vector(ty) => A::MoveTypeLayout::Vector(Box::new(
                 self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Datatype(gidx) => A::MoveTypeLayout::Struct(
+            Type::Datatype(gidx) => A::MoveTypeLayout::Struct(Box::new(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, &[], count, depth)?,
-            ),
+            )),
             Type::DatatypeInstantiation(struct_inst) => {
                 let (gidx, ty_args) = &**struct_inst;
-                A::MoveTypeLayout::Struct(
+                A::MoveTypeLayout::Struct(Box::new(
                     self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, count, depth)?,
-                )
+                ))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/loader.rs
@@ -2157,17 +2157,14 @@ impl Loader {
             Type::Vector(ty) => R::MoveTypeLayout::Vector(Box::new(
                 self.type_to_type_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Datatype(gidx) => R::MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(
-                *gidx,
-                &[],
-                count,
-                depth,
-            )?),
+            Type::Datatype(gidx) => R::MoveTypeLayout::Struct(Box::new(
+                self.struct_gidx_to_type_layout(*gidx, &[], count, depth)?,
+            )),
             Type::DatatypeInstantiation(struct_inst) => {
                 let (gidx, ty_args) = &**struct_inst;
-                R::MoveTypeLayout::Struct(
+                R::MoveTypeLayout::Struct(Box::new(
                     self.struct_gidx_to_type_layout(*gidx, ty_args, count, depth)?,
-                )
+                ))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
@@ -2260,14 +2257,14 @@ impl Loader {
             Type::Vector(ty) => A::MoveTypeLayout::Vector(Box::new(
                 self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Datatype(gidx) => A::MoveTypeLayout::Struct(
+            Type::Datatype(gidx) => A::MoveTypeLayout::Struct(Box::new(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, &[], count, depth)?,
-            ),
+            )),
             Type::DatatypeInstantiation(struct_inst) => {
                 let (gidx, ty_args) = &**struct_inst;
-                A::MoveTypeLayout::Struct(
+                A::MoveTypeLayout::Struct(Box::new(
                     self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, count, depth)?,
-                )
+                ))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -72,6 +72,7 @@ mod checked {
                 binary_config: to_binary_config(protocol_config),
                 rethrow_serialization_type_layout_errors: protocol_config
                     .rethrow_serialization_type_layout_errors(),
+                max_type_to_layout_nodes: protocol_config.max_type_to_layout_nodes_as_option(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -74,6 +74,7 @@ mod checked {
                 binary_config: to_binary_config(protocol_config),
                 rethrow_serialization_type_layout_errors: protocol_config
                     .rethrow_serialization_type_layout_errors(),
+                max_type_to_layout_nodes: protocol_config.max_type_to_layout_nodes_as_option(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)

--- a/sui-execution/v1/sui-adapter/src/adapter.rs
+++ b/sui-execution/v1/sui-adapter/src/adapter.rs
@@ -74,6 +74,7 @@ mod checked {
                 binary_config: to_binary_config(protocol_config),
                 rethrow_serialization_type_layout_errors: protocol_config
                     .rethrow_serialization_type_layout_errors(),
+                max_type_to_layout_nodes: protocol_config.max_type_to_layout_nodes_as_option(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)

--- a/sui-execution/v2/sui-adapter/src/adapter.rs
+++ b/sui-execution/v2/sui-adapter/src/adapter.rs
@@ -72,6 +72,7 @@ mod checked {
                 binary_config: to_binary_config(protocol_config),
                 rethrow_serialization_type_layout_errors: protocol_config
                     .rethrow_serialization_type_layout_errors(),
+                max_type_to_layout_nodes: protocol_config.max_type_to_layout_nodes_as_option(),
             },
         )
         .map_err(|_| SuiError::ExecutionInvariantViolation)


### PR DESCRIPTION
## Description 

Boxes fields in the `MoveTypeLayout` to make the enum size smaller for type layouts. 

## Test plan 

Added test to check size of the enums + make sure existing tests pass. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Increase the maximum type layout size in the VM. Most users should not notice this change.  
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
