### PR TITLE
Adds configuration for playtron provider in Devnet

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -271,6 +271,7 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
         "KarrierOne".to_string(),
         "Credenza3".to_string(),
         "Playtron".to_string(),
+        "Threedos".to_string(),
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_LPSLCkC3A".to_string(), // test tenant in mysten aws
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8".to_string(), // ambrus, external partner
     ]);

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -270,6 +270,7 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
         "Microsoft".to_string(),
         "KarrierOne".to_string(),
         "Credenza3".to_string(),
+        "Playtron".to_string(),
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_LPSLCkC3A".to_string(), // test tenant in mysten aws
         "AwsTenant-region:us-east-1-tenant_id:us-east-1_qPsZxYqd8".to_string(), // ambrus, external partner
     ]);

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -124,6 +124,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch
@@ -276,6 +277,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch
@@ -428,6 +430,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch
@@ -580,6 +583,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch
@@ -732,6 +736,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch
@@ -884,6 +889,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch
@@ -1036,6 +1042,7 @@ validator_configs:
         - Kakao
         - KarrierOne
         - Microsoft
+        - Playtron
         - Slack
         - TestIssuer
         - Twitch

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -127,6 +127,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
@@ -280,6 +281,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
@@ -433,6 +435,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
@@ -586,6 +589,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
@@ -739,6 +743,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
@@ -892,6 +897,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
@@ -1045,6 +1051,7 @@ validator_configs:
         - Playtron
         - Slack
         - TestIssuer
+        - Threedos
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:


### PR DESCRIPTION
## Description 

Adds playtron provides to Devnet. 
Afaik, since Playtron serves only the `authorization_code` flow it cannot work with the current version of the keytool, so no need to bump fastcrypto version here, unless I am missing anything.
(Related: https://github.com/MystenLabs/fastcrypto/blob/781398d38fbf342a50e66dc0ad11d6227839bd68/fastcrypto-zkp/src/bn254/utils.rs#L88)
If I do miss something though, it looks that bumping to a later fastcrypto revision it causes dependency related error during the test execution (`cargo test -p sui-swarm-config`). Like the following:
```
error[E0433]: failed to resolve: could not find `conversions` in `bls12381`
   --> sui-execution/v1/sui-move-natives/src/crypto/groth16.rs:205:41
    |
205 |             > fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE * MAX_PUBLIC_INPUTS
    |  
```
 
 
 
## Test plan 
running localnet with 
```
cargo build --bin sui 
RUST_LOG=info target/debug/sui start --force-regenesis --with-faucet
```

and grep logs for JWK pulling for playtron and threedos ok. 

```
2024-09-11T14:51:07.219647Z  INFO node{name=k#b3fd5efb..}:jwk_updater_task{epoch=0}: sui_node: Submitting JWK to consensus: JwkId { iss: "https://oauth2.playtron.one", kid: "1fd66a18-7afd-4086-ba57-a8ca9b398406" }
2024-09-11T14:51:07.219736Z  INFO node{name=k#b3fd5efb..}:jwk_updater_task{epoch=0}: sui_node: Submitting JWK to consensus: JwkId { iss: "https://oauth2.playtron.one", kid: "7388b63c-ba03-4fe3-85e3-6717f91d55b1" }
2024-09-11T14:51:07.219789Z  INFO node{name=k#b3fd5efb..}:jwk_updater_task{epoch=0}: sui_node: Submitting JWK to consensus: JwkId { iss: "https://oauth2.playtron.one", kid: "e55421cb-cdbd-4791-a590-ad8ca798aa89" }
```

for threedos: 
```
2024-09-11T14:52:08.492045Z  INFO node{name=k#8dcff6d1..}: sui_core::authority::authority_per_epoch_store: received jwk vote from k#8dcff6d1.. for jwk (JwkId { iss: "https://auth.3dos.io", kid: "6d361dc9637a275eb585a915af26198ff0d97326ca13f4baf0e4805f72f2a9a0" }, JWK { kty: "RSA", e: "AQAB", n: "y_8hHwq7w2yE4968sbQF98iGUhnu0BwyB5khTxVPAcUnMCYdp61zYcRWml2zdY4HAfq-Nnjb_pAli6I66Vpe9IE8Gf8uGRB0oYIo2S6tYMEe0lhRaEDYVbMdQkuKxTIYMNBXSd_kCHKJM1ZUAo7uFoq_bWuzt2hRG2-79z-Ycbiw0wil0rzFHlpNBKsBLKM4GSGUwOejaL2zCiE_rjf77AvOaJLRd4I_DBYG16t8D1BkxbhkcQCmOxYGG0NqjP3z0lz-w1ALqHCNfhzczZOsgaCrbSlcTKcBTq1syAUUhQmounW7nG5clBIfPQRVH7jCoPztiJUZg6Xz1AN6V07xnw", alg: "RS256" })
2024-09-11T14:52:08.492281Z  INFO node{name=k#8dcff6d1..}: sui_core::authority::authority_per_epoch_store: received jwk vote from k#99f25ef6.. for jwk (JwkId { iss: "https://auth.3dos.io", kid: "6d361dc9637a275eb585a915af26198ff0d97326ca13f4baf0e4805f72f2a9a0" }, JWK { kty: "RSA", e: "AQAB", n: "y_8hHwq7w2yE4968sbQF98iGUhnu0BwyB5khTxVPAcUnMCYdp61zYcRWml2zdY4HAfq-Nnjb_pAli6I66Vpe9IE8Gf8uGRB0oYIo2S6tYMEe0lhRaEDYVbMdQkuKxTIYMNBXSd_kCHKJM1ZUAo7uFoq_bWuzt2hRG2-79z-Ycbiw0wil0rzFHlpNBKsBLKM4GSGUwOejaL2zCiE_rjf77AvOaJLRd4I_DBYG16t8D1BkxbhkcQCmOxYGG0NqjP3z0lz-w1ALqHCNfhzczZOsgaCrbSlcTKcBTq1syAUUhQmounW7nG5clBIfPQRVH7jCoPztiJUZg6Xz1AN6V07xnw", alg: "RS256" })
2024-09-11T14:52:08.492310Z  INFO node{name=k#8dcff6d1..}: sui_core::authority::authority_per_epoch_store: jwk became active epoch=1 round=16 jwk=(JwkId { iss: "https://auth.3dos.io", kid: "6d361dc9637a275eb585a915af26198ff0d97326ca13f4baf0e4805f72f2a9a0" }, JWK { kty: "RSA", e: "AQAB", n: "y_8hHwq7w2yE4968sbQF98iGUhnu0BwyB5khTxVPAcUnMCYdp61zYcRWml2zdY4HAfq-Nnjb_pAli6I66Vpe9IE8Gf8uGRB0oYIo2S6tYMEe0lhRaEDYVbMdQkuKxTIYMNBXSd_kCHKJM1ZUAo7uFoq_bWuzt2hRG2-79z-Ycbiw0wil0rzFHlpNBKsBLKM4GSGUwOejaL2zCiE_rjf77AvOaJLRd4I_DBYG16t8D1BkxbhkcQCmOxYGG0NqjP3z0lz-w1ALqHCNfhzczZOsgaCrbSlcTKcBTq1syAUUhQmounW7nG5clBIfPQRVH7jCoPztiJUZg6Xz1AN6V07xnw", alg: "RS256" })
2024-09-11T14:52:08.492464Z  INFO node{name=k#8dcff6d1..}: sui_core::authority::authority_per_epoch_store: received jwk vote from k#b3fd5efb.. for jwk (JwkId { iss: "https://auth.3dos.io", kid: "6d361dc9637a275eb585a915af26198ff0d97326ca13f4baf0e4805f72f2a9a0" }, JWK { kty: "RSA", e: "AQAB", n: "y_8hHwq7w2yE4968sbQF98iGUhnu0BwyB5khTxVPAcUnMCYdp61zYcRWml2zdY4HAfq-Nnjb_pAli6I66Vpe9IE8Gf8uGRB0oYIo2S6tYMEe0lhRaEDYVbMdQkuKxTIYMNBXSd_kCHKJM1ZUAo7uFoq_bWuzt2hRG2-79z-Ycbiw0wil0rzFHlpNBKsBLKM4GSGUwOejaL2zCiE_rjf77AvOaJLRd4I_DBYG16t8D1BkxbhkcQCmOxYGG0NqjP3z0lz-w1ALqHCNfhzczZOsgaCrbSlcTKcBTq1syAUUhQmounW7nG5clBIfPQRVH7jCoPztiJUZg6Xz1AN6V07xnw", alg: "RS256" })
```
```
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
