### PR TITLE
Update fastcrypto pointer and bls12381 scalar length path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d75fa1706f06ecb5471b1c9bd200f7c84e277bfd#d75fa1706f06ecb5471b1c9bd200f7c84e277bfd"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d75fa1706f06ecb5471b1c9bd200f7c84e277bfd#d75fa1706f06ecb5471b1c9bd200f7c84e277bfd"
 dependencies = [
  "quote 1.0.35",
  "syn 1.0.107",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d75fa1706f06ecb5471b1c9bd200f7c84e277bfd#d75fa1706f06ecb5471b1c9bd200f7c84e277bfd"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d75fa1706f06ecb5471b1c9bd200f7c84e277bfd#d75fa1706f06ecb5471b1c9bd200f7c84e277bfd"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d75fa1706f06ecb5471b1c9bd200f7c84e277bfd#d75fa1706f06ecb5471b1c9bd200f7c84e277bfd"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,18 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-bls12-381"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
-]
-
-[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4688,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
 dependencies = [
  "quote 1.0.35",
  "syn 1.0.107",
@@ -4697,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -4716,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -4733,9 +4721,8 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=501225efbb9d069062c0ab47e7ce25a7cd5128c0#501225efbb9d069062c0ab47e7ce25a7cd5128c0"
 dependencies = [
- "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -4743,7 +4730,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "blst",
+ "bcs",
  "byte-slice-cast",
  "derive_more",
  "fastcrypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -572,10 +572,10 @@ move-abstract-interpreter = { path = "external-crates/move/crates/move-abstract-
 move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack" }
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0", features = [
     "experimental",
 ] }
 passkey-types = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -572,10 +572,10 @@ move-abstract-interpreter = { path = "external-crates/move/crates/move-abstract-
 move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack" }
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "501225efbb9d069062c0ab47e7ce25a7cd5128c0", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d75fa1706f06ecb5471b1c9bd200f7c84e277bfd" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d75fa1706f06ecb5471b1c9bd200f7c84e277bfd" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d75fa1706f06ecb5471b1c9bd200f7c84e277bfd", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d75fa1706f06ecb5471b1c9bd200f7c84e277bfd", features = [
     "experimental",
 ] }
 passkey-types = { version = "0.2.0" }

--- a/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
@@ -169,8 +169,8 @@ pub fn verify_groth16_proof_internal(
                 .groth16_verify_groth16_proof_internal_bls12381_cost_base,
             groth16_verify_groth16_proof_internal_cost_params
                 .groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input,
-            (public_proof_inputs.len() + fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE - 1)
-                / fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE,
+            (public_proof_inputs.len() + fastcrypto::groups::bls12381::SCALAR_LENGTH - 1)
+                / fastcrypto::groups::bls12381::SCALAR_LENGTH,
         ),
         BN254 => (
             groth16_verify_groth16_proof_internal_cost_params
@@ -202,7 +202,7 @@ pub fn verify_groth16_proof_internal(
     let result;
     if curve == BLS12381 {
         if public_proof_inputs.len()
-            > fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE * MAX_PUBLIC_INPUTS
+            > fastcrypto::groups::bls12381::SCALAR_LENGTH * MAX_PUBLIC_INPUTS
         {
             return Ok(NativeResult::err(cost, TOO_MANY_PUBLIC_INPUTS));
         }

--- a/sui-execution/v0/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/v0/sui-move-natives/src/crypto/groth16.rs
@@ -169,8 +169,8 @@ pub fn verify_groth16_proof_internal(
                 .groth16_verify_groth16_proof_internal_bls12381_cost_base,
             groth16_verify_groth16_proof_internal_cost_params
                 .groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input,
-            (public_proof_inputs.len() + fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE - 1)
-                / fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE,
+            (public_proof_inputs.len() + fastcrypto::groups::bls12381::SCALAR_LENGTH - 1)
+                / fastcrypto::groups::bls12381::SCALAR_LENGTH,
         ),
         BN254 => (
             groth16_verify_groth16_proof_internal_cost_params
@@ -202,7 +202,7 @@ pub fn verify_groth16_proof_internal(
     let result;
     if curve == BLS12381 {
         if public_proof_inputs.len()
-            > fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE * MAX_PUBLIC_INPUTS
+            > fastcrypto::groups::bls12381::SCALAR_LENGTH * MAX_PUBLIC_INPUTS
         {
             return Ok(NativeResult::err(cost, TOO_MANY_PUBLIC_INPUTS));
         }

--- a/sui-execution/v1/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/v1/sui-move-natives/src/crypto/groth16.rs
@@ -169,8 +169,8 @@ pub fn verify_groth16_proof_internal(
                 .groth16_verify_groth16_proof_internal_bls12381_cost_base,
             groth16_verify_groth16_proof_internal_cost_params
                 .groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input,
-            (public_proof_inputs.len() + fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE - 1)
-                / fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE,
+            (public_proof_inputs.len() + fastcrypto::groups::bls12381::SCALAR_LENGTH - 1)
+                / fastcrypto::groups::bls12381::SCALAR_LENGTH,
         ),
         BN254 => (
             groth16_verify_groth16_proof_internal_cost_params
@@ -202,7 +202,7 @@ pub fn verify_groth16_proof_internal(
     let result;
     if curve == BLS12381 {
         if public_proof_inputs.len()
-            > fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE * MAX_PUBLIC_INPUTS
+            > fastcrypto::groups::bls12381::SCALAR_LENGTH * MAX_PUBLIC_INPUTS
         {
             return Ok(NativeResult::err(cost, TOO_MANY_PUBLIC_INPUTS));
         }

--- a/sui-execution/v2/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/v2/sui-move-natives/src/crypto/groth16.rs
@@ -169,8 +169,8 @@ pub fn verify_groth16_proof_internal(
                 .groth16_verify_groth16_proof_internal_bls12381_cost_base,
             groth16_verify_groth16_proof_internal_cost_params
                 .groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input,
-            (public_proof_inputs.len() + fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE - 1)
-                / fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE,
+            (public_proof_inputs.len() + fastcrypto::groups::bls12381::SCALAR_LENGTH - 1)
+                / fastcrypto::groups::bls12381::SCALAR_LENGTH,
         ),
         BN254 => (
             groth16_verify_groth16_proof_internal_cost_params
@@ -202,7 +202,7 @@ pub fn verify_groth16_proof_internal(
     let result;
     if curve == BLS12381 {
         if public_proof_inputs.len()
-            > fastcrypto_zkp::bls12381::conversions::SCALAR_SIZE * MAX_PUBLIC_INPUTS
+            > fastcrypto::groups::bls12381::SCALAR_LENGTH * MAX_PUBLIC_INPUTS
         {
             return Ok(NativeResult::err(cost, TOO_MANY_PUBLIC_INPUTS));
         }


### PR DESCRIPTION
## Description 

Update the fastcrypto version. This includes adding Playtron and Threedos as OIDC providers.

The path to the BLS12381 scalar size has been updated in fastcrypto and will be updated in here also. The value [is](https://github.com/MystenLabs/fastcrypto/blob/5f2c63266a065996d53f98156f0412782b468597/fastcrypto-zkp/src/bls12381/conversions.rs#L21) [unchanged](https://github.com/MystenLabs/fastcrypto/blob/501225efbb9d069062c0ab47e7ce25a7cd5128c0/fastcrypto/src/groups/bls12381.rs#L57).

## Test plan 

Unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
