### PR TITLE
[Consensus] Garbage Collection - 1

### DIFF
--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -24,7 +24,6 @@ use crate::{
     },
     context::Context,
     leader_scoring::{ReputationScores, ScoringSubdag},
-    linearizer::CommitRound,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::{Store, WriteBatch},
     CommittedSubDag,
@@ -352,7 +351,7 @@ impl DagState {
     /// Gets all uncommitted blocks in a round.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
     pub(crate) fn get_uncommitted_blocks_at_round(&self, round: Round) -> Vec<VerifiedBlock> {
-        if round <= self.last_commit_round().commit_round() {
+        if round <= self.last_commit_round() {
             panic!("Round {} have committed blocks!", round);
         }
 
@@ -716,16 +715,26 @@ impl DagState {
         }
     }
 
-    /// The last (highest) committed round which is in practice the last leader's round. The commit round contains
-    /// information both about the committed leader slot and the corresponding gc round as well.
-    pub(crate) fn last_commit_round(&self) -> CommitRound {
-        let leader = self.last_commit_leader();
-        CommitRound::new(leader, self.context.protocol_config.gc_depth())
+    /// Highest round where a block is committed, which is last commit's leader round.
+    pub(crate) fn last_commit_round(&self) -> Round {
+        match &self.last_commit {
+            Some(commit) => commit.leader().round,
+            None => 0,
+        }
     }
 
     /// Last committed round per authority.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
         self.last_committed_rounds.clone()
+    }
+
+    pub(crate) fn gc_round(&self) -> Round {
+        self.last_commit_round()
+            .saturating_sub(self.context.protocol_config.gc_depth())
+    }
+
+    pub(crate) fn gc_enabled(&self) -> bool {
+        self.context.protocol_config.gc_depth() > 0
     }
 
     /// After each flush, DagState becomes persisted in storage and it expected to recover

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -728,7 +728,9 @@ impl DagState {
         self.last_committed_rounds.clone()
     }
 
-    /// The latest Garbage Collection (GC) round that is calculated based on the latest committed leader round. When GC is disabled that will return the genesis round.
+    /// The GC round is the highest round that blocks of equal or lower round are considered obsolete and no longer possible to be committed.
+    /// There is no meaning accepting any blocks with round <= gc_round. The Garbage Collection (GC) round is calculated based on the latest
+    /// committed leader round. When GC is disabled that will return the genesis round.
     pub(crate) fn gc_round(&self) -> Round {
         let gc_depth = self.context.protocol_config.gc_depth();
         if gc_depth > 0 {

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -730,8 +730,16 @@ impl DagState {
 
     /// The latest round that has been garbage collected.
     pub(crate) fn gc_round(&self) -> Round {
-        self.last_commit_round()
-            .saturating_sub(self.context.protocol_config.gc_depth())
+        let gc_depth = self.context.protocol_config.gc_depth();
+
+        if gc_depth > 0 {
+            // GC is enabled, only then calculate the diff
+            self.last_commit_round().saturating_sub(gc_depth)
+        } else {
+            // Otherwise just return genesis round. That also acts as a safety mechanism so we never attempt to truncate anything
+            // even accidentally.
+            GENESIS_ROUND
+        }
     }
 
     pub(crate) fn gc_enabled(&self) -> bool {

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -720,8 +720,7 @@ impl DagState {
     /// information both about the committed leader slot and the corresponding gc round as well.
     pub(crate) fn last_commit_round(&self) -> CommitRound {
         let leader = self.last_commit_leader();
-        let gc_depth = 50;
-        CommitRound::new(leader, gc_depth)
+        CommitRound::new(leader, self.context.protocol_config.gc_depth())
     }
 
     /// Last committed round per authority.

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -728,10 +728,9 @@ impl DagState {
         self.last_committed_rounds.clone()
     }
 
-    /// The latest round that has been garbage collected.
+    /// The latest Garbage Collection (GC) round that is calculated based on the latest committed leader round. When GC is disabled that will return the genesis round.
     pub(crate) fn gc_round(&self) -> Round {
         let gc_depth = self.context.protocol_config.gc_depth();
-
         if gc_depth > 0 {
             // GC is enabled, only then calculate the diff
             self.last_commit_round().saturating_sub(gc_depth)

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -728,6 +728,7 @@ impl DagState {
         self.last_committed_rounds.clone()
     }
 
+    /// The latest round that has been garbage collected.
     pub(crate) fn gc_round(&self) -> Round {
         self.last_commit_round()
             .saturating_sub(self.context.protocol_config.gc_depth())

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -7,66 +7,12 @@ use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
 use crate::{
-    block::{BlockAPI, Slot, VerifiedBlock},
+    block::{BlockAPI, VerifiedBlock},
     commit::{sort_sub_dag_blocks, Commit, CommittedSubDag, TrustedCommit},
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
     Round,
 };
-
-#[derive(Clone)]
-pub(crate) struct CommitRound {
-    leader: Slot,
-    gc_round: Round,
-    gc_depth: u32,
-}
-
-impl CommitRound {
-    pub fn new(leader: Slot, gc_depth: u32) -> Self {
-        Self {
-            leader,
-            gc_round: Self::calculate_gc_round(leader, gc_depth),
-            gc_depth,
-        }
-    }
-
-    pub fn commit_round(&self) -> Round {
-        self.leader.round
-    }
-
-    #[allow(unused)]
-    pub fn gc_round(&self) -> Round {
-        self.gc_round
-    }
-
-    #[allow(unused)]
-    pub fn gc_depth(&self) -> u32 {
-        self.gc_depth
-    }
-
-    /// Calculates the latest CommitRound by providing the new latest committed leader.
-    /// The method will consume the current CommitRound and return a new one.
-    #[allow(unused)]
-    fn update(self, leader: Slot) -> Self {
-        // TODO: if we ever support multiple leaders we need to relax that rule
-        assert!(
-            leader.round > self.leader.round,
-            "Attempted to update commit round for leader of same round."
-        );
-        let gc_round = Self::calculate_gc_round(leader, self.gc_depth);
-
-        CommitRound {
-            leader,
-            gc_round,
-            gc_depth: self.gc_depth,
-        }
-    }
-
-    /// Calculates the GC round given a commit round and the gc_depth
-    fn calculate_gc_round(leader: Slot, gc_depth: u32) -> Round {
-        leader.round.saturating_sub(gc_depth)
-    }
-}
 
 /// Expand a committed sequence of leader into a sequence of sub-dags.
 #[derive(Clone)]
@@ -100,7 +46,8 @@ impl Linearizer {
         let last_commit_digest = dag_state.last_commit_digest();
         let last_commit_timestamp_ms = dag_state.last_commit_timestamp_ms();
         let last_committed_rounds = dag_state.last_committed_rounds();
-        let mut _last_committed_round = dag_state.last_commit_round();
+        let gc_enabled = dag_state.gc_enabled();
+        let gc_round: Round = dag_state.gc_round();
 
         let mut to_commit = Vec::new();
         let mut committed = HashSet::new();
@@ -124,6 +71,11 @@ impl Linearizer {
                             !committed.contains(ancestor)
                                 && last_committed_rounds[ancestor.author] < ancestor.round
                         })
+                        .filter(|ancestor| {
+                            // Keep the block if GC is not enabled or it is enabled and the block is above the gc_round. We do this
+                            // to stop the recursion early and avoid going to deep when it's unnecessary.
+                            !gc_enabled || ancestor.round > gc_round
+                        })
                         .collect::<Vec<_>>(),
                 )
                 .into_iter()
@@ -139,6 +91,12 @@ impl Linearizer {
         }
 
         drop(dag_state);
+
+        // The above code should have not yielded any blocks that are <= gc_round, but just to make sure that we'll never
+        // commit anything that should be garbage collected we attempt to prune here as well.
+        if gc_enabled {
+            to_commit.retain(|block| block.round() > gc_round);
+        }
 
         // Sort the blocks of the sub-dag blocks
         sort_sub_dag_blocks(&mut to_commit);

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -47,6 +47,10 @@ impl Linearizer {
         let last_commit_timestamp_ms = dag_state.last_commit_timestamp_ms();
         let last_committed_rounds = dag_state.last_committed_rounds();
         let gc_enabled = dag_state.gc_enabled();
+        // The GC round here is calculated based on the last committed round of the leader block. The algorithm will attempt to
+        // commit blocks up to this GC round. Once this commit has been processed and written to DagState, then gc round will update
+        // and on the processing of the next commit we'll have it already updated, so no need to do any gc_round recalculations here.
+        // We just use whatever is currently in DagState.
         let gc_round: Round = dag_state.gc_round();
 
         let mut to_commit = Vec::new();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1421,6 +1421,7 @@
                 "config_read_setting_impl_cost_base": null,
                 "config_read_setting_impl_cost_per_byte": null,
                 "consensus_bad_nodes_stake_threshold": null,
+                "consensus_gc_depth": null,
                 "consensus_max_num_transactions_in_block": null,
                 "consensus_max_transaction_size_bytes": null,
                 "consensus_max_transactions_in_block_bytes": null,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2946,6 +2946,10 @@ impl ProtocolConfig {
     pub fn set_consensus_round_prober_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_round_prober = val;
     }
+
+    pub fn set_gc_depth_for_testing(&mut self, val: u32) {
+        self.consensus_gc_depth = Some(val);
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1249,6 +1249,10 @@ pub struct ProtocolConfig {
     /// This config plays the same role as `max_accumulated_txn_cost_per_object_in_narwhal_commit`
     /// but for mysticeti commits due to that mysticeti has higher commit rate.
     max_accumulated_txn_cost_per_object_in_mysticeti_commit: Option<u64>,
+
+    /// Configures the garbage collection depth for consensus. When is unset or `0` then the garbage collection
+    /// is disabled.
+    consensus_gc_depth: Option<u32>,
 }
 
 // feature flags
@@ -1595,6 +1599,9 @@ impl ProtocolConfig {
 
     pub fn validate_identifier_inputs(&self) -> bool {
         self.feature_flags.validate_identifier_inputs
+    }
+    pub fn gc_depth(&self) -> u32 {
+        self.consensus_gc_depth.unwrap_or(0)
     }
 }
 
@@ -2109,6 +2116,8 @@ impl ProtocolConfig {
             bridge_should_try_to_finalize_committee: None,
 
             max_accumulated_txn_cost_per_object_in_mysticeti_commit: None,
+
+            consensus_gc_depth: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };


### PR DESCRIPTION
## Description 

This is the fist part that implements Garbage Collection for consensus.

Compared to Narwhal/Bullshark where the GC round was calculated and driven by the consensus component it self, here the single threaded nature of the system and the fact that we do have DagState - which is shared amongst all the components - allow us to base the gc round calculations purely on the latest committed round as derived from DagState.

On this PR:
* `Linearizer` has been refactored to respect the `gc_round`. When linearizer tries to commit leader `R` , it attempts to commit everything up to the `gc_round` that has been set from leader `R-1` (as already discussed this is the desired approach).
* `DagState` is calculating the current `gc_round` based on the latest commit.
* `gc_depth` has been added as a protocol config variable
* Basic testing has been added to `Linearizer`

Next steps:

- [ ] BlockManager to respect the `gc_round` when accepting blocks and trigger clean ups for new gc rounds
- [ ] Skip blocks that are received which are `<= gc_round`
- [ ] Not propose ancestors that are `<= gc_round`
- [ ] Subscriber to ask for blocks from `gc_round` when `last_fetched_round < gc_round` for a peer to prevent us from fetching unnecessary blocks
- [ ] Implement new timestamp approach so ancestor verification is not needed 
- [ ] Re-propose GC'ed transactions (probably not all of them)
- [ ] Harden testing for GC & edge cases

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
