### PR TITLE
indexer restore 2/N: restore display table

### DIFF
--- a/crates/sui-indexer/migrations/pg/2023-10-07-160139_display/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-10-07-160139_display/up.sql
@@ -1,4 +1,3 @@
--- Your SQL goes here
 CREATE TABLE display
 (
     object_type     text        PRIMARY KEY,

--- a/crates/sui-indexer/src/models/display.rs
+++ b/crates/sui-indexer/src/models/display.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
+use serde::Deserialize;
+
 use sui_types::display::DisplayVersionUpdatedEvent;
 
 use crate::schema::display;
 
-#[derive(Queryable, Insertable, Selectable, Debug, Clone)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Deserialize)]
 #[diesel(table_name = display)]
 pub struct StoredDisplay {
     pub object_type: String,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -101,4 +101,5 @@ pub trait IndexerStore: Clone + Sync + Send + 'static {
     ) -> Result<u64, IndexerError>;
 
     async fn upload_display(&self, epoch: u64) -> Result<(), IndexerError>;
+    async fn restore_display(&self, bytes: bytes::Bytes) -> Result<(), IndexerError>;
 }


### PR DESCRIPTION
## Description 
title


## Test plan 

upload table to remote and restore from remote to make sure that tables match
```
(SELECT * FROM display EXCEPT SELECT * FROM display_backup)
UNION ALL
(SELECT * FROM display_backup EXCEPT SELECT * FROM display);
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
