### PR TITLE
[move][tracing] Document flag for generating traces from `sui move test`

### DIFF
--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -20,7 +20,7 @@ pub struct Disassemble {
     module_path: PathBuf,
 
     /// Whether to display the disassembly in raw Debug format
-    #[clap(long = "Xdebug")]
+    #[clap(long = "Xdebug", hide = true)]
     debug: bool,
 
     #[clap(short = 'i', long = "interactive")]

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -69,7 +69,8 @@ pub struct Test {
     #[clap(name = "rand-num-iters", long = "rand-num-iters")]
     pub rand_num_iters: Option<u64>,
 
-    // Enable tracing for tests
+    /// Enable tracing for tests. A separate trace file will be created for each test. If `PATH` is
+    /// provided, the trace will be written to the `PATH` directory.
     #[clap(long = "trace-execution", value_name = "PATH")]
     pub trace_execution: Option<Option<String>>,
 }


### PR DESCRIPTION
## Description 

Add documentation for the `trace-execution` flag for `sui move test`, and also made the `-Xdebug` flag for the disassembler hidden. 

## Test plan 

recompiled and manually checked. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
