### PR TITLE
[Consensus] stop proposing when propagation delay is high

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -124,7 +124,7 @@ impl Parameters {
 
     pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
         // In experiments, propagation delay is usually 0 round.
-        10
+        5
     }
 
     pub(crate) fn default_dag_state_cached_rounds() -> u32 {

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -44,6 +44,14 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_sync_last_known_own_block_timeout")]
     pub sync_last_known_own_block_timeout: Duration,
 
+    /// Interval in milliseconds to probe highest received rounds of peers.
+    #[serde(default = "Parameters::default_round_prober_interval_ms")]
+    pub round_prober_interval_ms: u64,
+
+    /// Timeout in milliseconds for a round prober request.
+    #[serde(default = "Parameters::default_round_prober_request_timeout_ms")]
+    pub round_prober_request_timeout_ms: u64,
+
     /// Proposing new block is stopped when the propagation delay is greater than this threshold.
     /// Propagation delay is the difference between the round of the last proposed block and the
     /// the highest round from this authority that is received by all validators in a quorum.
@@ -122,9 +130,17 @@ impl Parameters {
         }
     }
 
+    pub(crate) fn default_round_prober_interval_ms() -> u64 {
+        5000
+    }
+
+    pub(crate) fn default_round_prober_request_timeout_ms() -> u64 {
+        2000
+    }
+
     pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
-        // In experiments, propagation delay is usually 0 round.
-        10
+        // Propagation delay is usually 0 round in production.
+        20
     }
 
     pub(crate) fn default_dag_state_cached_rounds() -> u32 {
@@ -166,6 +182,8 @@ impl Default for Parameters {
             max_blocks_per_fetch: Parameters::default_max_blocks_per_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
+            round_prober_interval_ms: Parameters::default_round_prober_interval_ms(),
+            round_prober_request_timeout_ms: Parameters::default_round_prober_request_timeout_ms(),
             propagation_delay_stop_proposal_threshold:
                 Parameters::default_propagation_delay_stop_proposal_threshold(),
             dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -38,6 +38,18 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_max_blocks_per_fetch")]
     pub max_blocks_per_fetch: usize,
 
+    /// Time to wait during node start up until the node has synced the last proposed block via the
+    /// network peers. When set to `0` the sync mechanism is disabled. This property is meant to be
+    /// used for amnesia recovery.
+    #[serde(default = "Parameters::default_sync_last_known_own_block_timeout")]
+    pub sync_last_known_own_block_timeout: Duration,
+
+    /// Proposing new block is stopped when the propagation delay is greater than this threshold.
+    /// Propagation delay is the difference between the round of the last proposed block and the
+    /// the highest round from this authority that is received by all validators in a quorum.
+    #[serde(default = "Parameters::default_propagation_delay_stop_proposal_threshold")]
+    pub propagation_delay_stop_proposal_threshold: u32,
+
     /// The number of rounds of blocks to be kept in the Dag state cache per authority. The larger
     /// the number the more the blocks that will be kept in memory allowing minimising any potential
     /// disk access.
@@ -69,12 +81,6 @@ pub struct Parameters {
     /// Tonic network settings.
     #[serde(default = "TonicParameters::default")]
     pub tonic: TonicParameters,
-
-    /// Time to wait during node start up until the node has synced the last proposed block via the
-    /// network peers. When set to `0` the sync mechanism is disabled. This property is meant to be
-    /// used for amnesia recovery.
-    #[serde(default = "Parameters::default_sync_last_known_own_block_timeout")]
-    pub sync_last_known_own_block_timeout: Duration,
 }
 
 impl Parameters {
@@ -95,6 +101,30 @@ impl Parameters {
 
     pub(crate) fn default_max_forward_time_drift() -> Duration {
         Duration::from_millis(500)
+    }
+
+    pub(crate) fn default_max_blocks_per_fetch() -> usize {
+        if cfg!(msim) {
+            // Exercise hitting blocks per fetch limit.
+            10
+        } else {
+            1000
+        }
+    }
+
+    pub(crate) fn default_sync_last_known_own_block_timeout() -> Duration {
+        if cfg!(msim) {
+            Duration::from_millis(500)
+        } else {
+            // Here we prioritise liveness over the complete de-risking of block equivocation. 5 seconds
+            // in the majority of cases should be good enough for this given a healthy network.
+            Duration::from_secs(5)
+        }
+    }
+
+    pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
+        // In experiments, propagation delay is usually 0 round.
+        10
     }
 
     pub(crate) fn default_dag_state_cached_rounds() -> u32 {
@@ -119,29 +149,10 @@ impl Parameters {
         }
     }
 
-    pub(crate) fn default_max_blocks_per_fetch() -> usize {
-        if cfg!(msim) {
-            // Exercise hitting blocks per fetch limit.
-            10
-        } else {
-            1000
-        }
-    }
-
     pub(crate) fn default_commit_sync_batches_ahead() -> usize {
         // This is set to be a multiple of default commit_sync_parallel_fetches to allow fetching ahead,
         // while keeping the total number of inflight fetches and unprocessed fetched commits limited.
         80
-    }
-
-    pub(crate) fn default_sync_last_known_own_block_timeout() -> Duration {
-        if cfg!(msim) {
-            Duration::from_millis(500)
-        } else {
-            // Here we prioritise liveness over the complete de-risking of block equivocation. 5 seconds
-            // in the majority of cases should be good enough for this given a healthy network.
-            Duration::from_secs(5)
-        }
     }
 }
 
@@ -152,10 +163,12 @@ impl Default for Parameters {
             leader_timeout: Parameters::default_leader_timeout(),
             min_round_delay: Parameters::default_min_round_delay(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
-            dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),
             max_blocks_per_fetch: Parameters::default_max_blocks_per_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
+            propagation_delay_stop_proposal_threshold:
+                Parameters::default_propagation_delay_stop_proposal_threshold(),
+            dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -124,7 +124,7 @@ impl Parameters {
 
     pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
         // In experiments, propagation delay is usually 0 round.
-        5
+        10
     }
 
     pub(crate) fn default_dag_state_cached_rounds() -> u32 {

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -15,7 +15,7 @@ max_blocks_per_fetch: 1000
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0
-propagation_delay_stop_proposal_threshold: 5
+propagation_delay_stop_proposal_threshold: 10
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 20
 commit_sync_batch_size: 100

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -12,6 +12,10 @@ max_forward_time_drift:
   secs: 0
   nanos: 500000000
 max_blocks_per_fetch: 1000
+sync_last_known_own_block_timeout:
+  secs: 5
+  nanos: 0
+propagation_delay_stop_proposal_threshold: 5
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 20
 commit_sync_batch_size: 100
@@ -25,6 +29,3 @@ tonic:
   connection_buffer_size: 33554432
   excessive_message_size: 16777216
   message_size_limit: 67108864
-sync_last_known_own_block_timeout:
-  secs: 5
-  nanos: 0

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -15,7 +15,9 @@ max_blocks_per_fetch: 1000
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0
-propagation_delay_stop_proposal_threshold: 10
+round_prober_interval_ms: 5000
+round_prober_request_timeout_ms: 2000
+propagation_delay_stop_proposal_threshold: 20
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 20
 commit_sync_batch_size: 100

--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -75,6 +75,15 @@ fn build_tonic_services(out_dir: &Path) {
                 .server_streaming()
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_latest_rounds")
+                .route_name("GetLatestRounds")
+                .input_type("crate::network::tonic_network::GetLatestRoundsRequest")
+                .output_type("crate::network::tonic_network::GetLatestRoundsResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     tonic_build::manual::Builder::new()
@@ -125,6 +134,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("FetchLatestBlocks")
                 .request_type("crate::network::anemo_network::FetchLatestBlocksRequest")
                 .response_type("crate::network::anemo_network::FetchLatestBlocksResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_latest_rounds")
+                .route_name("GetLatestRounds")
+                .request_type("crate::network::anemo_network::GetLatestRoundsRequest")
+                .response_type("crate::network::anemo_network::GetLatestRoundsResponse")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -259,7 +259,7 @@ where
         );
 
         let (core_dispatcher, core_thread_handle) =
-            ChannelCoreThreadDispatcher::start(core, context.clone());
+            ChannelCoreThreadDispatcher::start(context.clone(), &dag_state, core);
         let core_dispatcher = Arc::new(core_dispatcher);
         let leader_timeout_handle =
             LeaderTimeoutTask::start(core_dispatcher.clone(), &signals_receivers, context.clone());

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -416,6 +416,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         Ok(result)
     }
+
+    async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
+        fail_point_async!("consensus-rpc-response");
+
+        let mut highest_received_rounds = self.core_dispatcher.highest_received_rounds();
+        // Own blocks do not go through the core dispatcher, so they need to be set separately.
+        highest_received_rounds[self.context.own_index] = self
+            .dag_state
+            .read()
+            .get_last_block_for_authority(self.context.own_index)
+            .round();
+
+        Ok(highest_received_rounds)
+    }
 }
 
 /// Atomically counts the number of active subscriptions to the block broadcast stream,
@@ -629,6 +643,10 @@ mod tests {
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             todo!()
         }
+
+        fn highest_received_rounds(&self) -> Vec<Round> {
+            todo!()
+        }
     }
 
     #[derive(Default)]
@@ -681,6 +699,14 @@ mod tests {
             _authorities: Vec<AuthorityIndex>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn get_latest_rounds(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Round>> {
             unimplemented!("Unimplemented")
         }
     }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -640,6 +640,10 @@ mod tests {
             todo!()
         }
 
+        fn set_propagation_delay(&self, _delay: Round) -> Result<(), CoreError> {
+            todo!()
+        }
+
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             todo!()
         }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -438,7 +438,7 @@ impl SubscriptionCounter {
         *counter += 1;
         if *counter == 1 {
             self.dispatcher
-                .set_consumer_availability(true)
+                .set_subscriber_exists(true)
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
         Ok(())
@@ -449,7 +449,7 @@ impl SubscriptionCounter {
         *counter -= 1;
         if *counter == 0 {
             self.dispatcher
-                .set_consumer_availability(false)
+                .set_subscriber_exists(false)
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
         Ok(())
@@ -622,9 +622,10 @@ mod tests {
             Ok(Default::default())
         }
 
-        fn set_consumer_availability(&self, _available: bool) -> Result<(), CoreError> {
+        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
             todo!()
         }
+
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             todo!()
         }

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -274,6 +274,14 @@ mod test {
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Round>> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -812,6 +812,14 @@ mod tests {
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Round>> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -63,7 +63,10 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     /// Informs the core whether consumer of produced blocks exists.
     /// This is only used by core to decide if it should propose new blocks.
     /// It is not a guarantee that produced blocks will be accepted by peers.
-    fn set_subscriber_exists(&self, available: bool) -> Result<(), CoreError>;
+    fn set_subscriber_exists(&self, exists: bool) -> Result<(), CoreError>;
+
+    /// Sets the estimated delay to propagate a block to a quorum of peers, in number of rounds.
+    fn set_propagation_delay(&self, delay: Round) -> Result<(), CoreError>;
 
     fn set_last_known_proposed_round(&self, round: Round) -> Result<(), CoreError>;
 
@@ -88,6 +91,7 @@ struct CoreThread {
     core: Core,
     receiver: Receiver<CoreThreadCommand>,
     rx_subscriber_exists: watch::Receiver<bool>,
+    rx_propagation_delay: watch::Receiver<Round>,
     rx_last_known_proposed_round: watch::Receiver<Round>,
     context: Arc<Context>,
 }
@@ -128,10 +132,22 @@ impl CoreThread {
                 }
                 _ = self.rx_subscriber_exists.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_subscriber_exists");
+                    let should_propose_before = self.core.should_propose();
                     let available = *self.rx_subscriber_exists.borrow();
                     self.core.set_subscriber_exists(available);
-                    if available {
-                        // If a consumer becomes available, try to produce a new block to ensure liveness,
+                    if !should_propose_before && self.core.should_propose() {
+                        // If core cannnot propose before but can propose now, try to produce a new block to ensure liveness,
+                        // because block proposal could have been skipped.
+                        self.core.new_block(Round::MAX, true)?;
+                    }
+                }
+                _ = self.rx_propagation_delay.changed() => {
+                    let _scope = monitored_scope("CoreThread::loop::set_propagation_delay");
+                    let should_propose_before = self.core.should_propose();
+                    let delay = *self.rx_propagation_delay.borrow();
+                    self.core.set_propagation_delay(delay);
+                    if !should_propose_before && self.core.should_propose() {
+                        // If core cannnot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.
                         self.core.new_block(Round::MAX, true)?;
                     }
@@ -148,6 +164,7 @@ pub(crate) struct ChannelCoreThreadDispatcher {
     context: Arc<Context>,
     sender: WeakSender<CoreThreadCommand>,
     tx_subscriber_exists: Arc<watch::Sender<bool>>,
+    tx_propagation_delay: Arc<watch::Sender<Round>>,
     tx_last_known_proposed_round: Arc<watch::Sender<Round>>,
     highest_received_rounds: Arc<Vec<AtomicU32>>,
 }
@@ -173,13 +190,16 @@ impl ChannelCoreThreadDispatcher {
         let (sender, receiver) =
             channel("consensus_core_commands", CORE_THREAD_COMMANDS_CHANNEL_SIZE);
         let (tx_subscriber_exists, mut rx_subscriber_exists) = watch::channel(false);
+        let (tx_propagation_delay, mut rx_propagation_delay) = watch::channel(0);
         let (tx_last_known_proposed_round, mut rx_last_known_proposed_round) = watch::channel(0);
         rx_subscriber_exists.mark_unchanged();
+        rx_propagation_delay.mark_unchanged();
         rx_last_known_proposed_round.mark_unchanged();
         let core_thread = CoreThread {
             core,
             receiver,
             rx_subscriber_exists,
+            rx_propagation_delay,
             rx_last_known_proposed_round,
             context: context.clone(),
         };
@@ -201,6 +221,7 @@ impl ChannelCoreThreadDispatcher {
             context,
             sender: sender.downgrade(),
             tx_subscriber_exists: Arc::new(tx_subscriber_exists),
+            tx_propagation_delay: Arc::new(tx_propagation_delay),
             tx_last_known_proposed_round: Arc::new(tx_last_known_proposed_round),
             highest_received_rounds: Arc::new(highest_received_rounds),
         };
@@ -252,9 +273,15 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
-    fn set_subscriber_exists(&self, available: bool) -> Result<(), CoreError> {
+    fn set_subscriber_exists(&self, exists: bool) -> Result<(), CoreError> {
         self.tx_subscriber_exists
-            .send(available)
+            .send(exists)
+            .map_err(|e| Shutdown(e.to_string()))
+    }
+
+    fn set_propagation_delay(&self, delay: Round) -> Result<(), CoreError> {
+        self.tx_propagation_delay
+            .send(delay)
             .map_err(|e| Shutdown(e.to_string()))
     }
 
@@ -323,6 +350,10 @@ impl CoreThreadDispatcher for MockCoreThreadDispatcher {
     }
 
     fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
+        todo!()
+    }
+
+    fn set_propagation_delay(&self, _delay: Round) -> Result<(), CoreError> {
         todo!()
     }
 

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -133,8 +133,8 @@ impl CoreThread {
                 _ = self.rx_subscriber_exists.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_subscriber_exists");
                     let should_propose_before = self.core.should_propose();
-                    let available = *self.rx_subscriber_exists.borrow();
-                    self.core.set_subscriber_exists(available);
+                    let exists = *self.rx_subscriber_exists.borrow();
+                    self.core.set_subscriber_exists(exists);
                     if !should_propose_before && self.core.should_propose() {
                         // If core cannnot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -167,9 +167,10 @@ mod tests {
             todo!()
         }
 
-        fn set_consumer_availability(&self, _available: bool) -> Result<(), CoreError> {
+        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
             todo!()
         }
+
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             todo!()
         }

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -171,6 +171,10 @@ mod tests {
             todo!()
         }
 
+        fn set_propagation_delay(&self, _delay: Round) -> Result<(), CoreError> {
+            todo!()
+        }
+
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             todo!()
         }

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -174,6 +174,10 @@ mod tests {
         fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
             todo!()
         }
+
+        fn highest_received_rounds(&self) -> Vec<Round> {
+            todo!()
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -35,6 +35,7 @@ mod universal_committer;
 #[cfg(test)]
 #[path = "tests/randomized_tests.rs"]
 mod randomized_tests;
+mod round_prober;
 #[cfg(test)]
 mod test_dag;
 #[cfg(test)]

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -174,6 +174,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
     pub(crate) round_prober_quorum_gaps: IntGaugeVec,
     pub(crate) round_prober_propagation_delay: IntGauge,
+    pub(crate) round_prober_request_timeouts: IntCounter,
     pub(crate) uptime: Histogram,
 }
 
@@ -611,6 +612,11 @@ impl NodeMetrics {
             round_prober_propagation_delay: register_int_gauge_with_registry!(
                 "round_prober_propagation_delay",
                 "Round gap between own last proposed block and the low watermark of quorum round",
+                registry
+            ).unwrap(),
+            round_prober_request_timeouts: register_int_counter_with_registry!(
+                "round_prober_request_timeouts",
+                "Number of timeouts when probing against peers",
                 registry
             ).unwrap(),
             uptime: register_histogram_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -113,6 +113,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) core_add_blocks_batch_size: Histogram,
     pub(crate) core_lock_dequeued: IntCounter,
     pub(crate) core_lock_enqueued: IntCounter,
+    pub(crate) core_skipped_proposals: IntCounterVec,
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
     pub(crate) highest_accepted_round: IntGauge,
     pub(crate) accepted_blocks: IntCounterVec,
@@ -272,6 +273,12 @@ impl NodeMetrics {
             core_lock_enqueued: register_int_counter_with_registry!(
                 "core_lock_enqueued",
                 "Number of enqueued core requests",
+                registry,
+            ).unwrap(),
+            core_skipped_proposals: register_int_counter_vec_with_registry!(
+                "core_skipped_proposals",
+                "Number of proposals skipped in the Core, per reason",
+                &["reason"],
                 registry,
             ).unwrap(),
             highest_accepted_authority_round: register_int_gauge_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -171,6 +171,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: Histogram,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
+    pub(crate) round_prober_quorum_gaps: IntGaugeVec,
+    pub(crate) round_prober_propagation_delay: IntGauge,
     pub(crate) uptime: Histogram,
 }
 
@@ -591,6 +593,17 @@ impl NodeMetrics {
                 "commit_sync_fetch_once_errors",
                 "Number of errors when attempting to fetch commits and blocks from single authority during commit sync.",
                 &["error"],
+                registry
+            ).unwrap(),
+            round_prober_quorum_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_quorum_gaps",
+                "Round gaps among peers for blocks proposed from each authority",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_propagation_delay: register_int_gauge_with_registry!(
+                "round_prober_propagation_delay",
+                "Round gap between own last proposed block and the low watermark of quorum round",
                 registry
             ).unwrap(),
             uptime: register_histogram_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -172,9 +172,10 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: Histogram,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
-    pub(crate) round_prober_quorum_gaps: IntGaugeVec,
-    pub(crate) round_prober_propagation_delay: IntGauge,
-    pub(crate) round_prober_request_timeouts: IntCounter,
+    pub(crate) round_prober_quorum_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_propagation_delays: Histogram,
+    pub(crate) round_prober_last_propagation_delay: IntGauge,
+    pub(crate) round_prober_request_errors: IntCounter,
     pub(crate) uptime: Histogram,
 }
 
@@ -603,19 +604,25 @@ impl NodeMetrics {
                 &["error"],
                 registry
             ).unwrap(),
-            round_prober_quorum_gaps: register_int_gauge_vec_with_registry!(
-                "round_prober_quorum_gaps",
+            round_prober_quorum_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_quorum_round_gaps",
                 "Round gaps among peers for blocks proposed from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
-            round_prober_propagation_delay: register_int_gauge_with_registry!(
-                "round_prober_propagation_delay",
-                "Round gap between own last proposed block and the low watermark of quorum round",
+            round_prober_propagation_delays: register_histogram_with_registry!(
+                "round_prober_propagation_delays",
+                "Round gaps between the last proposed block round and the lower bound of own quorum round",
+                NUM_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
-            round_prober_request_timeouts: register_int_counter_with_registry!(
-                "round_prober_request_timeouts",
+            round_prober_last_propagation_delay: register_int_gauge_with_registry!(
+                "round_prober_last_propagation_delay",
+                "Most recent propagation delay observed by RoundProber",
+                registry
+            ).unwrap(),
+            round_prober_request_errors: register_int_counter_with_registry!(
+                "round_prober_request_errors",
                 "Number of timeouts when probing against peers",
                 registry
             ).unwrap(),

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -114,6 +114,15 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         authorities: Vec<AuthorityIndex>,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
+
+    /// Gets the latest received rounds of all authorities from the peer.
+    async fn get_latest_rounds(
+        &self,
+        peer: AuthorityIndex,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<Round>> {
+        unimplemented!("Unimplemented")
+    }
 }
 
 /// Network service for handling requests from peers.
@@ -157,6 +166,9 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         peer: AuthorityIndex,
         authorities: Vec<AuthorityIndex>,
     ) -> ConsensusResult<Vec<Bytes>>;
+
+    /// Handles the request to get the latest received rounds of all authorities.
+    async fn handle_get_latest_rounds(&self, peer: AuthorityIndex) -> ConsensusResult<Vec<Round>>;
 }
 
 /// An `AuthorityNode` holds a `NetworkManager` until shutdown.

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -120,9 +120,7 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         &self,
         peer: AuthorityIndex,
         timeout: Duration,
-    ) -> ConsensusResult<Vec<Round>> {
-        unimplemented!("Unimplemented")
-    }
+    ) -> ConsensusResult<Vec<Round>>;
 }
 
 /// Network service for handling requests from peers.

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -91,4 +91,8 @@ impl NetworkService for Mutex<TestService> {
     ) -> ConsensusResult<Vec<Bytes>> {
         unimplemented!("Unimplemented")
     }
+
+    async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
+        unimplemented!("Unimplemented")
+    }
 }

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -1143,6 +1143,18 @@ pub(crate) struct FetchLatestBlocksResponse {
     blocks: Vec<Bytes>,
 }
 
+#[derive(Clone, prost::Message)]
+pub(crate) struct GetLatestRoundsRequest {
+    #[prost(uint32, repeated, tag = "1")]
+    authorities: Vec<u32>,
+}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct GetLatestRoundsResponse {
+    #[prost(uint32, repeated, tag = "1")]
+    highest_received: Vec<u32>,
+}
+
 fn chunk_blocks(blocks: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
     let mut chunks = vec![];
     let mut chunk = vec![];

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -73,7 +73,7 @@ impl<C: NetworkClient> RoundProber<C> {
         let shutdown_notif = self.shutdown_notif.clone();
         let loop_shutdown_notif = shutdown_notif.clone();
         let prober_task = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(1));
+            let mut interval = tokio::time::interval(Duration::from_secs(2));
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
                 tokio::select! {
@@ -133,9 +133,11 @@ impl<C: NetworkClient> RoundProber<C> {
                             highest_received_rounds[peer] = rounds;
                         }
                         Ok(Err(err)) => {
+                            self.context.metrics.node_metrics.round_prober_request_timeouts.inc();
                             tracing::warn!("Failed to get latest rounds from peer {}: {:?}", peer, err);
                         }
                         Err(_) => {
+                            self.context.metrics.node_metrics.round_prober_request_timeouts.inc();
                             tracing::warn!("Timeout while getting latest rounds from peer {}", peer);
                         }
                     }

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! RoundProber periodically probes every peer for the latest rounds they received from other peers.
+//! This creates a picture of how well each authority's blocks are propagated through the network.
+//!
+//! Compared to inferring peers' accepted rounds from the DAG represented by each block, the
+//! advantage of RoundProber is that it is active even when peers are not proposing. This makes
+//! the component necessary for deciding when to disable the various optimizations that lower
+//! the network latency but can cost liveness.
+//!
+//! The source of data used by RoundProber are the `highest_received_rounds` tracked in the
+//! ChannelCoreThreadDispatcher. They are updated after verification of the blocks, but before
+//! the blocks are checked for dependencies. This should make the values more relevant to how well
+//! authorities propagate blocks, and less affected by the ancestors included in the blocks.
+
+use std::{sync::Arc, time::Duration};
+
+use consensus_config::AuthorityIndex;
+use futures::stream::{FuturesUnordered, StreamExt as _};
+use parking_lot::RwLock;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use crate::{
+    context::Context, core_thread::CoreThreadDispatcher, dag_state::DagState,
+    network::NetworkClient, BlockAPI as _, Round,
+};
+
+// Handle to control the RoundProber loop and read latest round gaps.
+pub(crate) struct RoundProberHandle {
+    prober_task: JoinHandle<()>,
+    tx_shutdown: oneshot::Sender<()>,
+}
+
+impl RoundProberHandle {
+    pub(crate) async fn stop(self) {
+        let _ = self.tx_shutdown.send(());
+        // Do not abort prober task, which waits for requests to be cancelled.
+        if let Err(e) = self.prober_task.await {
+            if e.is_panic() {
+                std::panic::resume_unwind(e.into_panic());
+            }
+        }
+    }
+}
+
+pub(crate) struct RoundProber<C: NetworkClient> {
+    context: Arc<Context>,
+    core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
+    dag_state: Arc<RwLock<DagState>>,
+    network_client: Arc<C>,
+}
+
+impl<C: NetworkClient> RoundProber<C> {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
+        dag_state: Arc<RwLock<DagState>>,
+        network_client: Arc<C>,
+    ) -> Self {
+        Self {
+            context,
+            core_thread_dispatcher,
+            dag_state,
+            network_client,
+        }
+    }
+
+    pub(crate) fn start(self) -> RoundProberHandle {
+        let (tx_shutdown, mut rx_shutdown) = oneshot::channel();
+        let prober_task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(1));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        self.probe().await;
+                    }
+                    _ = &mut rx_shutdown => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        RoundProberHandle {
+            prober_task,
+            tx_shutdown,
+        }
+    }
+
+    pub(crate) async fn probe(&self) {
+        const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+        let own_index = self.context.own_index;
+        let last_proposed_round = self
+            .dag_state
+            .read()
+            .get_last_block_for_authority(own_index)
+            .round();
+
+        let mut requests = FuturesUnordered::new();
+        for (peer, _) in self.context.committee.authorities() {
+            if peer == own_index {
+                continue;
+            }
+            let network_client = self.network_client.clone();
+            requests.push(async move {
+                let result = tokio::time::timeout(
+                    PROBE_TIMEOUT,
+                    network_client.get_latest_rounds(peer, PROBE_TIMEOUT),
+                )
+                .await;
+                (peer, result)
+            });
+        }
+
+        let mut highest_received_rounds =
+            vec![vec![0; self.context.committee.size()]; self.context.committee.size()];
+        highest_received_rounds[own_index] = self.core_thread_dispatcher.highest_received_rounds();
+        highest_received_rounds[own_index][own_index] = last_proposed_round;
+        while let Some((peer, result)) = requests.next().await {
+            match result {
+                Ok(Ok(rounds)) => {
+                    highest_received_rounds[peer] = rounds;
+                }
+                Ok(Err(err)) => {
+                    tracing::warn!("Failed to get latest rounds from peer {}: {:?}", peer, err);
+                }
+                Err(_) => {
+                    tracing::warn!("Timeout while getting latest rounds from peer {}", peer);
+                }
+            }
+        }
+
+        let quorum_rounds: Vec<_> = self
+            .context
+            .committee
+            .authorities()
+            .map(|(peer, _)| self.compute_quorum_rounds(peer, &highest_received_rounds))
+            .collect();
+        for ((low, high), (_, authority)) in quorum_rounds
+            .iter()
+            .zip(self.context.committee.authorities())
+        {
+            self.context
+                .metrics
+                .node_metrics
+                .round_prober_quorum_gaps
+                .with_label_values(&[&authority.hostname])
+                .set((high - low) as i64);
+        }
+
+        // It is possible more blocks arrive at a quorum of peers before the get_latest_rounds
+        // requests arrive.
+        // Also, use the lower watermark to increase sensitivity about block propagation issues
+        // that can reduce round rate.
+        let propagation_delay = last_proposed_round.saturating_sub(quorum_rounds[own_index].0);
+        self.context
+            .metrics
+            .node_metrics
+            .round_prober_propagation_delay
+            .set(propagation_delay as i64);
+    }
+
+    fn compute_quorum_rounds(
+        &self,
+        target_index: AuthorityIndex,
+        highest_received_rounds: &[Vec<Round>],
+    ) -> (Round, Round) {
+        let mut rounds_with_stake = highest_received_rounds
+            .iter()
+            .zip(self.context.committee.authorities())
+            .map(|(rounds, (_, authority))| (rounds[target_index], authority.stake))
+            .collect::<Vec<_>>();
+        rounds_with_stake.sort();
+
+        let mut total_stake = 0;
+        let mut low = 0;
+        let mut high = 0;
+        for (round, stake) in rounds_with_stake {
+            let reached_validator_before = total_stake >= self.context.committee.validity_threshold();
+            let reached_quorum_before = total_stake >= self.context.committee.quorum_threshold();
+            total_stake += stake;
+            if !reached_validator_before && total_stake >= self.context.committee.validity_threshold() {
+                low = round;
+            }
+            if !reached_quorum_before && total_stake >= self.context.committee.quorum_threshold() {
+                high = round;
+            }
+        }
+
+        (low, high)
+    }
+}

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -293,6 +293,14 @@ mod test {
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Round>> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1181,6 +1181,14 @@ mod tests {
 
             Ok(serialised)
         }
+
+        async fn get_latest_rounds(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Round>> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[test]

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1306,6 +1306,7 @@
                 "commit_root_state_digest": false,
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_order_end_of_epoch_last": true,
+                "consensus_round_prober": false,
                 "disable_invariant_violation_check_in_swap_loc": false,
                 "disallow_adding_abilities_on_upgrade": false,
                 "disallow_change_struct_type_params_on_upgrade": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -525,6 +525,10 @@ struct FeatureFlags {
     // Use distributed vote leader scoring strategy in consensus.
     #[serde(skip_serializing_if = "is_false")]
     consensus_distributed_vote_scoring_strategy: bool,
+
+    // Probe rounds received by peers from every authority.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_round_prober: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1578,6 +1582,10 @@ impl ProtocolConfig {
     pub fn consensus_distributed_vote_scoring_strategy(&self) -> bool {
         self.feature_flags
             .consensus_distributed_vote_scoring_strategy
+    }
+
+    pub fn consensus_round_prober(&self) -> bool {
+        self.feature_flags.consensus_round_prober
     }
 }
 
@@ -2750,6 +2758,9 @@ impl ProtocolConfig {
                 }
                 59 => {
                     cfg.max_type_to_layout_nodes = Some(512);
+
+                    // Enable round prober in consensus.
+                    cfg.feature_flags.consensus_round_prober = true;
                 }
                 // Use this template when making changes:
                 //
@@ -2910,6 +2921,10 @@ impl ProtocolConfig {
     pub fn set_consensus_distributed_vote_scoring_strategy_for_testing(&mut self, val: bool) {
         self.feature_flags
             .consensus_distributed_vote_scoring_strategy = val;
+    }
+
+    pub fn set_consensus_round_prober_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_round_prober = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_59.snap
@@ -60,6 +60,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   rethrow_serialization_type_layout_errors: true
+  consensus_round_prober: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -322,4 +323,3 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_59.snap
@@ -60,6 +60,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   rethrow_serialization_type_layout_errors: true
+  consensus_round_prober: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -322,4 +323,3 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_59.snap
@@ -66,6 +66,7 @@ feature_flags:
   authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -332,4 +333,3 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-


### PR DESCRIPTION
## Description 

Introduce `RoundProber` to gather information from each authority, on their received rounds from others. The gathered data on block propagation delays across the network are exported to metrics. The propagation delay for own blocks is used to control whether proposing blocks can happen.

## Test plan 

CI
PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
