### PR TITLE
[suiop] add point of contact selection for incident review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15291,6 +15291,7 @@ dependencies = [
  "dirs 4.0.0",
  "docker-api",
  "field_names",
+ "futures",
  "include_dir",
  "inquire",
  "itertools 0.13.0",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -51,6 +51,7 @@ toml_edit.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 once_cell.workspace = true
+futures.workspace = true
 strsim = "0.11.1"
 
 [dev-dependencies]

--- a/crates/suiop-cli/src/cli/incidents/mod.rs
+++ b/crates/suiop-cli/src/cli/incidents/mod.rs
@@ -4,6 +4,7 @@
 mod jira;
 mod pd;
 mod slack;
+mod slack_api;
 
 use anyhow::Result;
 use chrono::{Duration, Local};

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -129,9 +129,9 @@ impl Incident {
 
     fn short_fmt(&self) -> String {
         format!(
-            "• {} {} {} {} {}",
+            "• {} {} {} {}",
             if let Some(channel) = self.slack_channel.clone() {
-                format!("{} ({})", self.number, channel.url())
+                format!("{} (<#{}>)", self.number, channel.id)
             } else {
                 self.number.to_string()
             },
@@ -143,10 +143,6 @@ impl Incident {
                     .to_string())
                 .unwrap_or("".to_owned()),
             self.title,
-            self.slack_channel
-                .clone()
-                .map(|c| c.name)
-                .unwrap_or("".to_string()),
             self.poc_users.as_ref().map_or_else(
                 || "".to_string(),
                 |u| u

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -281,7 +281,7 @@ fn request_pocs(slack: &Slack) -> Result<Vec<User>> {
         "Please select the users who are POCs for this incident",
         slack.users.clone(),
     )
-    .with_default(&vec![])
+    .with_default(&[])
     .prompt()
     .map_err(|e| anyhow::anyhow!(e))
 }

--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -17,9 +17,10 @@ use std::env;
 use strsim::normalized_damerau_levenshtein;
 use tracing::debug;
 
-use crate::cli::incidents::slack::Channel;
 use crate::cli::lib::utils::day_of_week;
 use crate::DEBUG_MODE;
+
+use super::slack_api::{Channel, User};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Priority {
@@ -36,6 +37,8 @@ pub struct Incident {
     created_at: Option<String>,
     resolved_at: Option<String>,
     html_url: String,
+    /// The slack users responsible for reporting
+    poc_users: Option<Vec<User>>,
     pub priority: Option<Priority>,
     pub slack_channel: Option<Channel>,
 }

--- a/crates/suiop-cli/src/cli/incidents/slack.rs
+++ b/crates/suiop-cli/src/cli/incidents/slack.rs
@@ -3,8 +3,9 @@
 
 use anyhow::Result;
 use futures::future::Either;
-use once_cell::sync::Lazy;
 use reqwest::{header, Client};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fs::File;
 use std::path::PathBuf;
 use tracing::debug;
@@ -14,13 +15,6 @@ use super::slack_api::get_users;
 use super::slack_api::Channel;
 use super::slack_api::User;
 
-static CHANNELS_FILEPATH: Lazy<PathBuf> = Lazy::new(|| {
-    dirs::home_dir()
-        .expect("HOME env var not set")
-        .join(".suiop")
-        .join("channels")
-});
-
 #[derive(Debug, Default)]
 pub struct Slack {
     client: Client,
@@ -28,24 +22,37 @@ pub struct Slack {
     pub users: Vec<User>,
 }
 
-pub async fn serialize_channels(channels: &Vec<Channel>) -> Result<()> {
-    let file = File::create(CHANNELS_FILEPATH.as_path())?;
-    serde_json::to_writer(file, channels)?;
+fn get_serialize_filepath(subname: &str) -> PathBuf {
+    dirs::home_dir()
+        .expect("HOME env var not set")
+        .join(".suiop")
+        .join(subname)
+}
+
+/// Serialize the obj into ~/.suiop/{subname} so we can cache it across
+/// executions
+pub fn serialize_to_file<T: Serialize>(subname: &str, obj: &Vec<T>) -> Result<()> {
+    let file = File::create(get_serialize_filepath(subname).as_path())?;
+    serde_json::to_writer(file, obj)?;
     Ok(())
 }
 
-pub async fn deserialize_channels() -> Option<Vec<Channel>> {
+/// Check if the file in ~/.suiop/{subname} is less than 1 day old
+/// and if so, deserialize the value from it.
+///
+/// Otherwise return None
+pub fn deserialize_from_file<T: DeserializeOwned>(subname: &str) -> Option<Vec<T>> {
     let mut result = None;
-    let file_path = CHANNELS_FILEPATH.as_path();
+    let file_path = get_serialize_filepath(subname);
     if let Ok(metadata) = file_path.metadata() {
         if let Ok(modified) = metadata.modified() {
             if let Ok(elapsed) = modified.elapsed() {
                 // 1 day
                 if elapsed.as_secs() < 24 * 60 * 60 {
                     if let Ok(file) = File::open(file_path) {
-                        if let Ok(channels) = serde_json::from_reader::<_, Vec<Channel>>(file) {
-                            debug!("Using cached channels");
-                            result = Some(channels);
+                        if let Ok(obj) = serde_json::from_reader::<_, Vec<T>>(file) {
+                            debug!("Using cached {}", subname);
+                            result = Some(obj);
                         }
                     }
                 }
@@ -70,14 +77,12 @@ impl Slack {
             .default_headers(headers)
             .build()
             .expect("failed to build reqwest client");
-        let channels = deserialize_channels()
-            .await
+        let channels = deserialize_from_file("channels")
             .map_or_else(
                 || {
                     Either::Left(async {
                         let channels = get_channels(&client).await.expect("Failed to get channels");
-                        serialize_channels(&channels)
-                            .await
+                        serialize_to_file("channels", &channels)
                             .expect("Failed to serialize channels");
                         channels
                     })
@@ -85,7 +90,18 @@ impl Slack {
                 |v| Either::Right(async { v }),
             )
             .await;
-        let users = get_users(&client).await.expect("Failed to get users");
+        let users = deserialize_from_file("users")
+            .map_or_else(
+                || {
+                    Either::Left(async {
+                        let users = get_users(&client).await.expect("Failed to get users");
+                        serialize_to_file("users", &users).expect("Failed to serialize users");
+                        users
+                    })
+                },
+                |u| Either::Right(async { u }),
+            )
+            .await;
         Self {
             client,
             channels,

--- a/crates/suiop-cli/src/cli/incidents/slack.rs
+++ b/crates/suiop-cli/src/cli/incidents/slack.rs
@@ -1,19 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
-use anyhow::Context;
 use anyhow::Result;
+use futures::future::Either;
 use once_cell::sync::Lazy;
 use reqwest::{header, Client};
-use serde::Deserialize;
-use serde::Serialize;
 use std::fs::File;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
-const CHANNELS_URL: &str = "https://slack.com/api/conversations.list";
+use super::slack_api::get_channels;
+use super::slack_api::get_users;
+use super::slack_api::Channel;
+use super::slack_api::User;
+
 static CHANNELS_FILEPATH: Lazy<PathBuf> = Lazy::new(|| {
     dirs::home_dir()
         .expect("HOME env var not set")
@@ -21,36 +21,38 @@ static CHANNELS_FILEPATH: Lazy<PathBuf> = Lazy::new(|| {
         .join("channels")
 });
 
+#[derive(Debug, Default)]
 pub struct Slack {
     client: Client,
     pub channels: Vec<Channel>,
+    pub users: Vec<User>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct Channel {
-    pub id: String,
-    pub name: String,
+pub async fn serialize_channels(channels: &Vec<Channel>) -> Result<()> {
+    let file = File::create(CHANNELS_FILEPATH.as_path())?;
+    serde_json::to_writer(file, channels)?;
+    Ok(())
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-struct ResponseMetadata {
-    next_cursor: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-struct ConversationsResponse {
-    ok: bool,
-    error: Option<String>,
-    channels: Option<Vec<Channel>>,
-    response_metadata: ResponseMetadata,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-struct SendMessageBody {
-    channel: String,
-    text: String,
-    ts: String,
-    mrkdwn: bool,
+pub async fn deserialize_channels() -> Option<Vec<Channel>> {
+    let mut result = None;
+    let file_path = CHANNELS_FILEPATH.as_path();
+    if let Ok(metadata) = file_path.metadata() {
+        if let Ok(modified) = metadata.modified() {
+            if let Ok(elapsed) = modified.elapsed() {
+                // 1 day
+                if elapsed.as_secs() < 24 * 60 * 60 {
+                    if let Ok(file) = File::open(file_path) {
+                        if let Ok(channels) = serde_json::from_reader::<_, Vec<Channel>>(file) {
+                            debug!("Using cached channels");
+                            result = Some(channels);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    result
 }
 
 impl Slack {
@@ -68,92 +70,31 @@ impl Slack {
             .default_headers(headers)
             .build()
             .expect("failed to build reqwest client");
-        let mut s = Self {
-            client,
-            channels: vec![],
-        };
-        s.get_channels().await.expect("Failed to get channels");
-        s
-    }
-
-    pub async fn serialize_channels(&self) -> Result<()> {
-        let file = File::create(CHANNELS_FILEPATH.as_path())?;
-        serde_json::to_writer(file, &self.channels)?;
-        Ok(())
-    }
-
-    pub async fn get_channels(&mut self) -> Result<Vec<String>> {
-        let mut channels: Vec<Channel> = vec![];
-        let file_path = CHANNELS_FILEPATH.as_path();
-        if let Ok(metadata) = file_path.metadata() {
-            if let Ok(modified) = metadata.modified() {
-                if let Ok(elapsed) = modified.elapsed() {
-                    // 1 day
-                    if elapsed.as_secs() < 24 * 60 * 60 {
-                        if let Ok(file) = File::open(file_path) {
-                            if let Ok(channels) = serde_json::from_reader::<_, Vec<Channel>>(file) {
-                                debug!("Using cached channels");
-                                self.channels = channels;
-                                return Ok(self.channels.iter().map(|c| c.name.clone()).collect());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let mut result: ConversationsResponse = self
-            .client
-            .get(CHANNELS_URL)
-            .send()
+        let channels = deserialize_channels()
             .await
-            .map_err(|e| anyhow!(e))?
-            .json()
-            .await?;
-        let new_channels = result.channels.expect("Expected channels to exist").clone();
-        channels.extend(new_channels.into_iter());
-        while let Some(cursor) = result.response_metadata.next_cursor {
-            if cursor.is_empty() {
-                break;
-            }
-            result = self
-                .client
-                .get(CHANNELS_URL)
-                .query(&[("cursor", cursor)])
-                .send()
-                .await
-                .map_err(|e| anyhow!(e))?
-                .json()
-                .await
-                .context("parsing json from channels api")?;
-            let extra_channels = result.channels.expect("Expected channels to exist").clone();
-            channels.extend(extra_channels.into_iter());
+            .map_or_else(
+                || {
+                    Either::Left(async {
+                        let channels = get_channels(&client).await.expect("Failed to get channels");
+                        serialize_channels(&channels)
+                            .await
+                            .expect("Failed to serialize channels");
+                        channels
+                    })
+                },
+                |v| Either::Right(async { v }),
+            )
+            .await;
+        let users = get_users(&client).await.expect("Failed to get users");
+        Self {
+            client,
+            channels,
+            users,
         }
-        self.channels = channels.iter().map(|c| (*c).clone()).collect();
-        self.serialize_channels().await?;
-        let names = self.channels.iter().map(|c| c.name.clone()).collect();
-        Ok(names)
     }
 
-    pub async fn send_message(&self, channel: &str, message: &str) -> Result<()> {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_millis();
-        let message_body = SendMessageBody {
-            channel: channel.to_owned(),
-            text: message.to_owned(),
-            ts: timestamp.to_string(),
-            mrkdwn: true,
-        };
-        let url = "https://slack.com/api/chat.postMessage";
-        let response = self.client.post(url).json(&message_body).send().await?;
-        let response = response.json::<serde_json::Value>().await?;
-        if response["ok"].as_bool().expect("ok was not a bool") {
-            Ok(())
-        } else {
-            Err(anyhow!("Failed to send message: {}", response))
-        }
+    pub async fn send_message(self, channel: &str, message: &str) -> Result<()> {
+        super::slack_api::send_message(&self.client, channel, message).await
     }
 }
 

--- a/crates/suiop-cli/src/cli/incidents/slack_api.rs
+++ b/crates/suiop-cli/src/cli/incidents/slack_api.rs
@@ -1,0 +1,116 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use reqwest::Client;
+use serde::Deserialize;
+use serde::Serialize;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CHANNELS_URL: &str = "https://slack.com/api/conversations.list";
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct UsersResponse {
+    ok: bool,
+    members: Vec<User>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct User {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Channel {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct ResponseMetadata {
+    next_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct ConversationsResponse {
+    ok: bool,
+    error: Option<String>,
+    channels: Option<Vec<Channel>>,
+    response_metadata: ResponseMetadata,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct SendMessageBody {
+    channel: String,
+    text: String,
+    ts: String,
+    mrkdwn: bool,
+}
+
+pub async fn get_channels(client: &Client) -> Result<Vec<Channel>> {
+    let mut channels: Vec<Channel> = vec![];
+
+    let mut result: ConversationsResponse = client
+        .get(CHANNELS_URL)
+        .send()
+        .await
+        .map_err(|e| anyhow!(e))?
+        .json()
+        .await?;
+    let new_channels = result.channels.expect("Expected channels to exist").clone();
+    channels.extend(new_channels.into_iter());
+    while let Some(cursor) = result.response_metadata.next_cursor {
+        if cursor.is_empty() {
+            break;
+        }
+        result = client
+            .get(CHANNELS_URL)
+            .query(&[("cursor", cursor)])
+            .send()
+            .await
+            .map_err(|e| anyhow!(e))?
+            .json()
+            .await
+            .context("parsing json from channels api")?;
+        let extra_channels = result.channels.expect("Expected channels to exist").clone();
+        channels.extend(extra_channels.into_iter());
+    }
+    channels = channels.iter().map(|c| (*c).clone()).collect();
+    Ok(channels)
+}
+
+pub async fn get_users(client: &Client) -> Result<Vec<User>> {
+    let url = "https://slack.com/api/users.list";
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| anyhow!(e))?
+        .json::<UsersResponse>()
+        .await?;
+
+    Ok(response.members)
+}
+pub async fn send_message(client: &Client, channel: &str, message: &str) -> Result<()> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis();
+    let message_body = SendMessageBody {
+        channel: channel.to_owned(),
+        text: message.to_owned(),
+        ts: timestamp.to_string(),
+        mrkdwn: true,
+    };
+    let url = "https://slack.com/api/chat.postMessage";
+    let response = client.post(url).json(&message_body).send().await?;
+    let response = response.json::<serde_json::Value>().await?;
+    if response["ok"].as_bool().expect("ok was not a bool") {
+        Ok(())
+    } else {
+        Err(anyhow!("Failed to send message: {}", response))
+    }
+}

--- a/crates/suiop-cli/src/cli/incidents/slack_api.rs
+++ b/crates/suiop-cli/src/cli/incidents/slack_api.rs
@@ -103,7 +103,7 @@ pub async fn get_users(client: &Client) -> Result<Vec<User>> {
     if !response.ok {
         panic!("Failed to get users");
     }
-    Ok(response.members.ok_or(anyhow::anyhow!("missing members"))?)
+    response.members.ok_or(anyhow::anyhow!("missing members"))
 }
 
 pub async fn send_message(client: &Client, channel: &str, message: &str) -> Result<()> {


### PR DESCRIPTION
## Description 

- Refactor api logic into new module
- get all users so we can select them to be points of contact
- add multiselect to allow selection of an arbitrary set of users
- generalize serde logic for caching api responses (once per day)
- improve tagging of channels to link to the actual channel
- tag associated poc users for an incident

## Test plan 

e2e functional (see [example message](https://mysten-labs.slack.com/archives/C03QJ1B6BC0/p1726147679829409))

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
