### PR TITLE
[trace-view] Added support for continue

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -149,7 +149,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendEvent(new InitializedEvent());
     }
 
-    protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments): Promise<void> {
+    protected async launchRequest(
+        response: DebugProtocol.LaunchResponse,
+        args: ILaunchRequestArguments
+    ): Promise<void> {
         logger.setup(convertLoggerLogLevel(args.logLevel ?? LogLevel.None), false);
         logger.log("Launching trace viewer for file: " + args.source + " and trace: " + args.traceInfo);
         try {
@@ -162,7 +165,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendEvent(new StoppedEvent("entry", MoveDebugSession.THREAD_ID));
     }
 
-    protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
+    protected configurationDoneRequest(
+        response: DebugProtocol.ConfigurationDoneResponse,
+        _args: DebugProtocol.ConfigurationDoneArguments
+    ): void {
         this.sendResponse(response);
     }
 
@@ -175,7 +181,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected stackTraceRequest(response: CustomizedStackTraceResponse, args: DebugProtocol.StackTraceArguments): void {
+    protected stackTraceRequest(
+        response: CustomizedStackTraceResponse,
+        args: DebugProtocol.StackTraceArguments
+    ): void {
         try {
             const runtimeStack = this.runtime.stack();
             const stack_height = runtimeStack.frames.length;
@@ -196,9 +205,16 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments): void {
+    protected nextRequest(
+        response: DebugProtocol.NextResponse,
+        args: DebugProtocol.NextArguments
+    ): void {
         try {
-            this.runtime.step(/* next */ true, /* stopAtCloseFrame */ false);
+            this.runtime.step(
+                /* next */ true,
+                /* stopAtCloseFrame */ false,
+                /* nextLineSkip */ true
+            );
         } catch (err) {
             response.success = false;
             response.message = err instanceof Error ? err.message : String(err);
@@ -206,10 +222,17 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void {
+    protected stepInRequest(
+        response: DebugProtocol.StepInResponse,
+        args: DebugProtocol.StepInArguments
+    ): void {
         let terminate = false;
         try {
-            terminate = this.runtime.step(/* next */ false, /* stopAtCloseFrame */ false);
+            terminate = this.runtime.step(
+                /* next */ false,
+                /* stopAtCloseFrame */ false,
+                /* nextLineSkip */ true
+            );
         } catch (err) {
             response.success = false;
             response.message = err instanceof Error ? err.message : String(err);
@@ -220,7 +243,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments): void {
+    protected stepOutRequest(
+        response: DebugProtocol.StepOutResponse,
+        args: DebugProtocol.StepOutArguments
+    ): void {
         let terminate = false;
         try {
             terminate = this.runtime.stepOut();
@@ -234,7 +260,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected stepBackRequest(response: DebugProtocol.StepBackResponse, args: DebugProtocol.StepBackArguments): void {
+    protected stepBackRequest(
+        response: DebugProtocol.StepBackResponse,
+        args: DebugProtocol.StepBackArguments
+    ): void {
         try {
             this.runtime.stepBack();
         } catch (err) {
@@ -244,7 +273,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments): void {
+    protected continueRequest(
+        response: DebugProtocol.ContinueResponse,
+        args: DebugProtocol.ContinueArguments
+    ): void {
         let terminate = false;
         try {
             terminate = this.runtime.continue(/* reverse */ false);
@@ -258,7 +290,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected reverseContinueRequest(response: DebugProtocol.ReverseContinueResponse, args: DebugProtocol.ReverseContinueArguments): void {
+    protected reverseContinueRequest(
+        response: DebugProtocol.ReverseContinueResponse,
+        args: DebugProtocol.ReverseContinueArguments
+    ): void {
         let terminate = false;
         try {
             terminate = this.runtime.continue(/* reverse */ true);
@@ -272,7 +307,10 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
+    protected disconnectRequest(
+        response: DebugProtocol.DisconnectResponse,
+        args: DebugProtocol.DisconnectArguments
+    ): void {
         // Cleanup and terminate the debug session
         this.sendEvent(new TerminatedEvent());
         this.sendResponse(response);

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -12,7 +12,6 @@ import {
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as path from 'path';
 import { Runtime, RuntimeEvents, IRuntimeStack } from './runtime';
-import { log } from 'console';
 
 const enum LogLevel {
     Log = 'log',

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/source_map_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/source_map_utils.ts
@@ -85,7 +85,10 @@ export interface ISourceMap {
     optimized_lines: number[]
 }
 
-export function readAllSourceMaps(directory: string, filesMap: Map<string, IFileInfo>): Map<string, ISourceMap> {
+export function readAllSourceMaps(
+    directory: string,
+    filesMap: Map<string, IFileInfo>
+): Map<string, ISourceMap> {
     const sourceMapsMap = new Map<string, ISourceMap>();
 
     const processDirectory = (dir: string) => {
@@ -184,7 +187,7 @@ function prePopulateSourceMapLines(
     sourceMapJSON: ISrcRootObject,
     fileInfo: IFileInfo,
     sourceMapLines: Set<number>
-) {
+): void {
     addLinesForLocation(sourceMapJSON.definition_location, fileInfo, sourceMapLines);
     const structMap = sourceMapJSON.struct_map;
     for (const structEntry of Object.values(structMap)) {
@@ -237,7 +240,7 @@ function addLinesForLocation(
     loc: ISrcDefinitionLocation,
     fileInfo: IFileInfo,
     sourceMapLines: Set<number>
-) {
+): void {
     const startLine = byteOffsetToLineColumn(fileInfo, loc.start).line;
     sourceMapLines.add(startLine);
     const endLine = byteOffsetToLineColumn(fileInfo, loc.end).line;


### PR DESCRIPTION
## Description 

This PR adds support for "continue" debugger action. It also makes implementation of "next" ("step over") and "step out" actions faithful to their intended semantics (i.e., executing all instruction in a function stepped over or stepped out of). These changes do not actually change the current behavior of the viewer - they are done in preparation for implementing variable value tracking and displaying.

This PR also includes a refinement of the "step out" action implementation. As also explained in the code comment, previously in the following line of code, after entering `foo` and stepping out of it, we would immediately step into `bar`, which could be quite confusing for the user:
```
assert(foo() == bar());
```

Finally, this PR also includes some formatting changes for lines that were a bit too long

## Test plan 

Tested manually
