### PR TITLE
[move] Revise dead code detection

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value_even_when_ignored.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value_even_when_ignored.exp
@@ -1,6 +1,6 @@
 processed 4 tasks
 
-task 2, line 26:
+task 2, line 29:
 //# run 42::m::aborts0
 Error: Function execution failed with VMError: {
     major_status: ABORTED,
@@ -10,7 +10,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 1)],
 }
 
-task 3, line 28:
+task 3, line 31:
 //# run 42::m::aborts1
 Error: Function execution failed with VMError: {
     major_status: ABORTED,

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value_even_when_ignored.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value_even_when_ignored.move
@@ -12,14 +12,17 @@ module 42::m {
     macro fun macro_abort(_: X) {
         abort 2
     }
+
     // method syntax results in the macro arg being bound first before being passed to the method
     // meaning these should abort from the LHS not the macro. Even though the LHS is discarded
+    #[allow(dead_code)]
     fun aborts0() {
-        x_abort().macro_abort!();
+        x_abort().macro_abort!()
     }
 
+    #[allow(dead_code)]
     fun aborts1() {
-        X().id_abort().macro_abort!();
+        X().id_abort().macro_abort!()
     }
 }
 

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp.move
@@ -1,0 +1,117 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Op has drop {
+        LoopOpen,
+        BreakIfEven(u64), // encodes jump PC
+        Return,
+        Push(u64),
+        Add,
+        LoopClose,
+    }
+
+    fun interp(ops: vector<Op>): u64 {
+        let mut stack = vector[];
+        let mut loop_pcs = vector[];
+        let mut cur_pc = 0;
+
+        'exit: {
+            'interp: loop {
+                match (&ops[cur_pc]) {
+                    Op::LoopOpen => {
+                        loop_pcs.push_back(cur_pc + 1);
+                    },
+                    Op::BreakIfEven(new_pc) => {
+                        let top = stack[stack.length() - 1];
+                        if (top % 2 == 0) {
+                            loop_pcs.pop_back();
+                            cur_pc = *new_pc;
+                            continue 'interp
+                        }
+                    },
+                    Op::Return => {
+                        return 'exit
+                    },
+                    Op::Push(value) => {
+                        stack.push_back(*value);
+                    },
+                    Op::Add => {
+                        let n0 = stack.pop_back();
+                        let n1 = stack.pop_back();
+                        stack.push_back(n0 + n1);
+                    },
+                    Op::LoopClose => {
+                        cur_pc = loop_pcs[loop_pcs.length() - 1];
+                        continue 'interp
+                    }
+                };
+                cur_pc = cur_pc + 1;
+            }
+        };
+
+        stack.pop_back()
+    }
+
+    fun test() {
+
+        let push = vector[
+            Op::Push(1),
+            Op::Return,
+        ];
+
+        assert!(interp(push) == 1);
+
+        let add = vector[
+            Op::Push(1),
+            Op::Push(1),
+            Op::Add,
+            Op::Return,
+        ];
+
+        assert!(interp(add) == 2);
+
+        let early_break = vector[
+            Op::Push(1),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp(early_break) == 100);
+
+        let exiting = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp(exiting) == 1);
+
+        let loop_and_break = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(6),
+            Op::LoopClose,
+            Op::Return,
+        ];
+
+        assert!(interp(loop_and_break) == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp_macro.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp_macro.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp_macro.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp_macro.move
@@ -1,0 +1,118 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Op has drop {
+        LoopOpen,
+        BreakIfEven(u64), // encodes jump PC
+        Return,
+        Push(u64),
+        Add,
+        LoopClose,
+    }
+
+    macro fun interp($ops: vector<Op>): u64 {
+        let ops = $ops;
+        let mut stack = vector[];
+        let mut loop_pcs = vector[];
+        let mut cur_pc = 0;
+
+        'exit: {
+            'interp: loop {
+                match (&ops[cur_pc]) {
+                    Op::LoopOpen => {
+                        loop_pcs.push_back(cur_pc + 1);
+                    },
+                    Op::BreakIfEven(new_pc) => {
+                        let top = stack[stack.length() - 1];
+                        if (top % 2 == 0) {
+                            loop_pcs.pop_back();
+                            cur_pc = *new_pc;
+                            continue 'interp
+                        }
+                    },
+                    Op::Return => {
+                        return 'exit
+                    },
+                    Op::Push(value) => {
+                        stack.push_back(*value);
+                    },
+                    Op::Add => {
+                        let n0 = stack.pop_back();
+                        let n1 = stack.pop_back();
+                        stack.push_back(n0 + n1);
+                    },
+                    Op::LoopClose => {
+                        cur_pc = loop_pcs[loop_pcs.length() - 1];
+                        continue 'interp
+                    }
+                };
+                cur_pc = cur_pc + 1;
+            }
+        };
+
+        stack.pop_back()
+    }
+
+    fun test() {
+
+        let push = vector[
+            Op::Push(1),
+            Op::Return,
+        ];
+
+        assert!(interp!(push) == 1);
+
+        let add = vector[
+            Op::Push(1),
+            Op::Push(1),
+            Op::Add,
+            Op::Return,
+        ];
+
+        assert!(interp!(add) == 2);
+
+        let early_break = vector[
+            Op::Push(1),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp!(early_break) == 100);
+
+        let exiting = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp!(exiting) == 1);
+
+        let loop_and_break = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(6),
+            Op::LoopClose,
+            Op::Return,
+        ];
+
+        assert!(interp!(loop_and_break) == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -13,7 +13,7 @@ use crate::{
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
-use std::{collections::VecDeque, iter::Peekable};
+use std::collections::{BTreeSet, VecDeque};
 
 //**************************************************************************************************
 // Description
@@ -61,97 +61,265 @@ use std::{collections::VecDeque, iter::Peekable};
 // Context
 //**************************************************************************************************
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum ControlFlow_ {
-    AlreadyReported,
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum ControlFlowEntry {
     AbortCalled,
-    Divergent,
     InfiniteLoop,
-    NamedBlockControlCalled(BlockLabel), // tracks the name
+    GiveCalled(BlockLabel),     // tracks the name
+    ContinueCalled(BlockLabel), // tracks the name
     ReturnCalled,
-    UnreachableCode,
 }
 
-type ControlFlow = Spanned<ControlFlow_>;
+type ControlFlowSet = BTreeSet<ControlFlowEntry>;
+
+#[derive(Debug)]
+enum ControlFlow {
+    None,
+    Divergent {
+        loc: Loc,
+        set: ControlFlowSet,
+        reported: bool,
+    },
+    Possible(Loc, ControlFlowSet),
+}
+
+impl ControlFlow {
+    fn is_none(&self) -> bool {
+        match self {
+            ControlFlow::None => true,
+            ControlFlow::Divergent { .. } | ControlFlow::Possible(_, _) => false,
+        }
+    }
+
+    fn is_some(&self) -> bool {
+        match self {
+            ControlFlow::None => false,
+            ControlFlow::Divergent { .. } | ControlFlow::Possible(_, _) => true,
+        }
+    }
+
+    // Combinse control flows around branch arms:
+    // - If both are None, None
+    // - If both are Divergent, Divergent
+    // - If either is Possible, divergence is Possible
+    fn combine_arms(self, loc: Loc, other: Self) -> Self {
+        use ControlFlow as CF;
+        match (self, other) {
+            (
+                CF::Divergent {
+                    set: mut left,
+                    reported: reported_left,
+                    loc: _,
+                },
+                CF::Divergent {
+                    set: mut right,
+                    reported: reported_right,
+                    loc: _,
+                },
+            ) => {
+                left.append(&mut right);
+                CF::Divergent {
+                    loc,
+                    set: left,
+                    reported: reported_left || reported_right,
+                }
+            }
+            (CF::None, CF::None) => CF::None,
+            (
+                CF::None,
+                CF::Possible(_, set)
+                | CF::Divergent {
+                    set,
+                    reported: _,
+                    loc: _,
+                },
+            )
+            | (
+                CF::Possible(_, set)
+                | CF::Divergent {
+                    set,
+                    reported: _,
+                    loc: _,
+                },
+                CF::None,
+            ) => CF::Possible(loc, set),
+            (
+                CF::Possible(_, mut left)
+                | CF::Divergent {
+                    set: mut left,
+                    reported: _,
+                    loc: _,
+                },
+                CF::Possible(_, mut right)
+                | CF::Divergent {
+                    set: mut right,
+                    reported: _,
+                    loc: _,
+                },
+            ) => {
+                left.append(&mut right);
+                CF::Possible(loc, left)
+            }
+        }
+    }
+
+    // Combinse control flows around sequence entries (assuming `self` comes before `next`):
+    // - If `self` diverges, divergent.
+    // - If `self` is None, whatever `next` does.
+    // - If `self` is Possible, consider `next`:
+    //   - `None` means divergence is Possible
+    //   - `Divergent` means divergence is Divergence, combining sets. This code:
+    //         ...
+    //         if (cond) break 'a;
+    //         break 'b;
+    //         ...
+    //      Produces Divergent({a, b})
+    //      divergence,
+    //   - `Possible` means divergence is Possible, combining
+    fn combine_seq(self, next: Self) -> Self {
+        use ControlFlow as CF;
+        match self {
+            CF::Divergent { loc, set, reported } => CF::Divergent { loc, set, reported },
+            CF::None => next,
+            CF::Possible(loc, mut left) => match next {
+                CF::None => CF::Possible(loc, left),
+                CF::Divergent {
+                    loc,
+                    mut set,
+                    reported: _,
+                } => {
+                    set.append(&mut left);
+                    CF::Possible(loc, set)
+                }
+                CF::Possible(_, _) => CF::Possible(loc, left),
+            },
+        }
+    }
+
+    fn remove_label(mut self, label: &BlockLabel) -> Self {
+        use ControlFlow as CF;
+        match &mut self {
+            CF::None => (),
+            CF::Divergent {
+                set,
+                reported: _,
+                loc: _,
+            }
+            | CF::Possible(_, set) => {
+                set.remove(&ControlFlowEntry::GiveCalled(*label));
+                set.remove(&ControlFlowEntry::ContinueCalled(*label));
+                if set.is_empty() {
+                    return CF::None;
+                }
+            }
+        };
+        self
+    }
+
+    fn is_divergent(&self) -> bool {
+        match self {
+            ControlFlow::Divergent { .. } => true,
+            ControlFlow::None | ControlFlow::Possible(_, _) => false,
+        }
+    }
+}
 
 struct Context<'env> {
     env: &'env mut CompilationEnv,
+    // loops: Vec<BlockLabel>,
 }
 
 impl<'env> Context<'env> {
     pub fn new(env: &'env mut CompilationEnv) -> Self {
+        // let loops = vec![];
+        // Context { env , loops }
         Context { env }
     }
 
-    fn report_value_error(&mut self, sp!(site, error): ControlFlow) {
-        use ControlFlow_::*;
+    fn maybe_report_value_error(&mut self, error: &mut ControlFlow) -> bool {
+        use ControlFlow as CF;
         match error {
-            AbortCalled | Divergent | InfiniteLoop | NamedBlockControlCalled(_) | ReturnCalled => {
+            CF::Divergent {
+                loc,
+                set: _,
+                reported,
+            } if !*reported => {
+                *reported = true;
                 self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, VALUE_UNREACHABLE_MSG)));
+                    .add_diag(diag!(UnusedItem::DeadCode, (*loc, VALUE_UNREACHABLE_MSG)));
+                true
             }
-            UnreachableCode => {
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, NOT_EXECUTED_MSG)));
-            }
-            _ => (),
+            CF::Divergent { .. } | CF::None | CF::Possible(_, _) => false,
         }
     }
 
-    fn report_tail_error(&mut self, sp!(site, error): ControlFlow) {
-        use ControlFlow_::*;
+    fn maybe_report_tail_error(&mut self, error: &mut ControlFlow) -> bool {
+        use ControlFlow as CF;
         match error {
-            AbortCalled | InfiniteLoop => {
+            CF::Divergent {
+                loc,
+                set: _,
+                reported,
+            } if !*reported => {
+                *reported = true;
                 self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, NOT_EXECUTED_MSG)));
+                    .add_diag(diag!(UnusedItem::DeadCode, (*loc, DIVERGENT_MSG)));
+                true
             }
-            UnreachableCode => {
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, NOT_EXECUTED_MSG)));
-            }
-            _ => (),
+            CF::Divergent { .. } | CF::None | CF::Possible(_, _) => false,
         }
     }
 
-    fn report_statement_error(&mut self, sp!(site, error): ControlFlow) {
-        use ControlFlow_::*;
+    fn maybe_report_statement_error(
+        &mut self,
+        error: &mut ControlFlow,
+        next_stmt: Option<&Loc>,
+    ) -> bool {
+        use ControlFlow as CF;
         match error {
-            AbortCalled | Divergent | InfiniteLoop | ReturnCalled => {
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, UNREACHABLE_MSG)));
+            CF::Divergent {
+                loc,
+                set: _,
+                reported,
+            } if !*reported => {
+                *reported = true;
+                let mut diag = diag!(UnusedItem::DeadCode, (*loc, DIVERGENT_MSG));
+                if let Some(next_loc) = next_stmt {
+                    diag.add_secondary_label((*next_loc, UNREACHABLE_MSG));
+                }
+                self.env.add_diag(diag);
+                true
             }
-            UnreachableCode => {
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, NOT_EXECUTED_MSG)));
-            }
-            _ => (),
+            CF::Divergent { .. } | CF::None | CF::Possible(_, _) => false,
         }
     }
 
-    fn report_statement_tail_error(&mut self, sp!(site, error): ControlFlow, tail_exp: &T::Exp) {
-        use ControlFlow_::*;
-        match error {
-            AbortCalled | Divergent | InfiniteLoop | ReturnCalled | NamedBlockControlCalled(_)
-                if matches!(tail_exp.exp.value, T::UnannotatedExp_::Unit { .. }) =>
-            {
-                self.env.add_diag(diag!(
-                    UnusedItem::TrailingSemi,
-                    (tail_exp.exp.loc, SEMI_MSG),
-                    (site, UNREACHABLE_MSG),
-                    (tail_exp.exp.loc, INFO_MSG),
-                ));
+    fn maybe_report_statement_tail_error(
+        &mut self,
+        error: &mut ControlFlow,
+        tail_exp: &T::Exp,
+    ) -> bool {
+        use ControlFlow as CF;
+        if matches!(tail_exp.exp.value, T::UnannotatedExp_::Unit { .. }) {
+            match error {
+                CF::Divergent {
+                    loc,
+                    set: _,
+                    reported,
+                } if !*reported => {
+                    *reported = true;
+                    self.env.add_diag(diag!(
+                        UnusedItem::TrailingSemi,
+                        (tail_exp.exp.loc, SEMI_MSG),
+                        (*loc, DIVERGENT_MSG),
+                        (tail_exp.exp.loc, INFO_MSG),
+                    ));
+                    true
+                }
+                CF::Divergent { .. } | CF::None | CF::Possible(_, _) => false,
             }
-            AbortCalled | Divergent | InfiniteLoop | ReturnCalled | NamedBlockControlCalled(_) => {
-                self.env.add_diag(diag!(
-                    UnusedItem::DeadCode,
-                    (tail_exp.exp.loc, NOT_EXECUTED_MSG)
-                ));
-            }
-            UnreachableCode => {
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (site, NOT_EXECUTED_MSG)));
-            }
-            _ => (),
+        } else {
+            self.maybe_report_statement_error(error, Some(&tail_exp.exp.loc))
         }
     }
 }
@@ -159,9 +327,9 @@ impl<'env> Context<'env> {
 const VALUE_UNREACHABLE_MSG: &str =
     "Expected a value. Any code surrounding or after this expression will not be reached";
 
-const UNREACHABLE_MSG: &str = "Any code after this expression will not be reached";
+const DIVERGENT_MSG: &str = "Any code after this expression will not be reached";
 
-const NOT_EXECUTED_MSG: &str =
+const UNREACHABLE_MSG: &str =
     "Unreachable code. This statement (and any following statements) will not be executed.";
 
 const SEMI_MSG: &str = "Invalid trailing ';'";
@@ -169,40 +337,44 @@ const INFO_MSG: &str =
     "A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. \
      That '()' value will not be reachable";
 
-fn exits_named_block(name: BlockLabel, cf: Option<ControlFlow>) -> bool {
-    match cf {
-        Some(sp!(_, ControlFlow_::NamedBlockControlCalled(break_name))) => name == break_name,
-        _ => false,
+fn return_called(loc: Loc) -> ControlFlow {
+    ControlFlow::Divergent {
+        loc,
+        set: BTreeSet::from([ControlFlowEntry::ReturnCalled]),
+        reported: false,
     }
 }
 
-fn already_reported(loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::AlreadyReported))
+fn abort_called(loc: Loc) -> ControlFlow {
+    ControlFlow::Divergent {
+        loc,
+        set: BTreeSet::from([ControlFlowEntry::AbortCalled]),
+        reported: false,
+    }
 }
 
-fn abort_called(loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::AbortCalled))
+fn give_called(loc: Loc, label: BlockLabel) -> ControlFlow {
+    ControlFlow::Divergent {
+        loc,
+        set: BTreeSet::from([ControlFlowEntry::GiveCalled(label)]),
+        reported: false,
+    }
 }
 
-// catch all for when we have to combine failures
-fn divergent(loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::Divergent))
+fn continue_called(loc: Loc, label: BlockLabel) -> ControlFlow {
+    ControlFlow::Divergent {
+        loc,
+        set: BTreeSet::from([ControlFlowEntry::ContinueCalled(label)]),
+        reported: false,
+    }
 }
 
-fn infinite_loop(loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::InfiniteLoop))
-}
-
-fn named_control_called(loop_name: BlockLabel, loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::NamedBlockControlCalled(loop_name)))
-}
-
-fn return_called(loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::ReturnCalled))
-}
-
-fn unreachable_code(loc: Loc) -> Option<ControlFlow> {
-    Some(sp(loc, ControlFlow_::UnreachableCode))
+fn infinite_loop(loc: Loc) -> ControlFlow {
+    ControlFlow::Divergent {
+        loc,
+        set: BTreeSet::from([ControlFlowEntry::InfiniteLoop]),
+        reported: false,
+    }
 }
 
 //**************************************************************************************************
@@ -291,90 +463,51 @@ fn body(context: &mut Context, seq: &VecDeque<T::SequenceItem>) {
 }
 
 #[growing_stack]
-fn tail(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
+fn tail(context: &mut Context, e: &T::Exp) -> ControlFlow {
+    use ControlFlow as CF;
     use T::UnannotatedExp_ as E;
     let T::Exp {
-        ty,
-        exp: sp!(eloc, e_),
+        exp: sp!(eloc, e_), ..
     } = e;
 
     match e_ {
         // -----------------------------------------------------------------------------------------
         // control flow statements
         // -----------------------------------------------------------------------------------------
-        E::IfElse(test, conseq, alt) => {
-            if let Some(test_control_flow) = value(context, test) {
-                context.report_value_error(test_control_flow);
-                return None;
-            };
-            let conseq_flow = tail(context, conseq);
-            let alt_flow = tail(context, alt);
-            if matches!(ty, sp!(_, N::Type_::Unit | N::Type_::Anything)) {
-                return None;
-            };
-            match (conseq_flow, alt_flow) {
-                (Some(cflow), Some(aflow)) => {
-                    if cflow.value == aflow.value {
-                        context.report_tail_error(sp(*eloc, cflow.value));
-                    } else {
-                        context.report_tail_error(cflow);
-                        context.report_tail_error(aflow);
-                    }
-                    None
-                }
-                _ => None,
-            }
-        }
-        E::Match(subject, arms) => {
-            if let Some(test_control_flow) = value(context, subject) {
-                context.report_value_error(test_control_flow);
-                return None;
-            };
-            let arm_somes = arms
-                .value
-                .iter()
-                .map(|sp!(_, arm)| {
-                    arm.guard
-                        .as_ref()
-                        .and_then(|guard| value(context, guard))
-                        .iter()
-                        .for_each(|flow| context.report_value_error(*flow));
-                    tail(context, &arm.rhs)
-                })
-                .collect::<Vec<_>>();
-            if matches!(ty, sp!(_, N::Type_::Unit | N::Type_::Anything))
-                || arms.value.iter().all(|sp!(_, arm)| {
-                    matches!(arm.rhs.ty, sp!(_, N::Type_::Unit | N::Type_::Anything))
-                })
-            {
-                return None;
-            };
-            if arm_somes.iter().all(|arm_opt| arm_opt.is_some()) {
-                for arm_opt in arm_somes {
-                    let sp!(aloc, arm_error) = arm_opt.unwrap();
-                    context.report_tail_error(sp(aloc, arm_error))
-                }
-            }
-            None
-        }
+        E::IfElse(test, conseq, alt) => do_if(
+            context,
+            (eloc, test, conseq, alt),
+            /* tail_pos */ true,
+            tail,
+            |context, flow| context.maybe_report_tail_error(flow),
+        ),
+        E::Match(subject, arms) => do_match(
+            context,
+            (subject, arms),
+            /* tail_pos */ true,
+            tail,
+            |context, flow| context.maybe_report_tail_error(flow),
+        ),
         E::VariantMatch(..) => {
             context
                 .env
                 .add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
-            None
+            CF::None
         }
 
-        // Whiles and loops Loops are currently moved to statement position
-        E::While(_, _, _) | E::Loop { .. } => statement(context, e),
+        // Whiles Loops are treated as statements because they cannot produce values.
+        E::While(_, _, _) => statement(context, e),
+
+        // Normal loops are treated as statements. This allows people to write infinite loops in
+        // tail positions without error. This is because if it occurs in tail position, we assume
+        // it is intentionally infinite. It is, after all not causing any dead code.
+        E::Loop { .. } => statement(context, e),
+
         E::NamedBlock(name, (_, seq)) => {
             // a named block in tail position checks for bad semicolons plus if the body exits that
             // block; if so, at least some of that code is live.
-            let body_result = tail_block(context, seq);
-            if exits_named_block(*name, body_result) {
-                None
-            } else {
-                body_result
-            }
+            let body_flow = tail_block(context, seq);
+            body_flow.remove_label(name)
         }
         E::Block((_, seq)) => tail_block(context, seq),
 
@@ -382,7 +515,7 @@ fn tail(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         //  statements
         // -----------------------------------------------------------------------------------------
         E::Return(_) | E::Abort(_) | E::Give(_, _) | E::Continue(_) => value(context, e),
-        E::Assign(_, _, _) | E::Mutate(_, _) => None,
+        E::Assign(_, _, _) | E::Mutate(_, _) => CF::None,
 
         // -----------------------------------------------------------------------------------------
         //  value-like expression
@@ -391,28 +524,32 @@ fn tail(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
     }
 }
 
-fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option<ControlFlow> {
+fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> ControlFlow {
     use T::SequenceItem_ as S;
     let last_exp = seq.iter().last();
-    let stmt_flow = statement_block(
+    let mut stmt_flow = statement_block(
         context, seq, /* stmt_pos */ false, /* skip_last */ true,
     );
-    if let (Some(control_flow), Some(sp!(_, S::Seq(last)))) = (stmt_flow, last_exp) {
-        context.report_statement_tail_error(control_flow, last);
-        None
-    } else if let Some(control_flow) = stmt_flow {
-        context.report_tail_error(control_flow);
-        None
+    if stmt_flow.is_some() {
+        // If we have statement flow and a final expression, we might have an unnecessary
+        // semicolon if `last` is just a unit value. Let's check for that.
+        if let Some(sp!(_, S::Seq(last))) = last_exp {
+            context.maybe_report_statement_tail_error(&mut stmt_flow, last);
+            stmt_flow
+        } else {
+            context.maybe_report_tail_error(&mut stmt_flow);
+            stmt_flow
+        }
     } else {
         match last_exp {
-            None => None,
+            None => ControlFlow::None,
             Some(sp!(_, S::Seq(last))) => tail(context, last),
             Some(sp!(loc, _)) => {
                 context.env.add_diag(ice!((
                     *loc,
                     "ICE last sequence item should have been an exp in dead code analysis"
                 )));
-                None
+                ControlFlow::None
             }
         }
     }
@@ -423,7 +560,8 @@ fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option<
 // -------------------------------------------------------------------------------------------------
 
 #[growing_stack]
-fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
+fn value(context: &mut Context, e: &T::Exp) -> ControlFlow {
+    use ControlFlow as CF;
     use T::UnannotatedExp_ as E;
 
     let T::Exp {
@@ -432,12 +570,11 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
 
     macro_rules! value_report {
         ($nested_value:expr) => {{
-            if let Some(control_flow) = value(context, $nested_value) {
-                context.report_value_error(control_flow);
-                already_reported(*eloc)
-            } else {
-                None
+            let mut value_flow = value(context, $nested_value);
+            if context.maybe_report_value_error(&mut value_flow) {
+                return value_flow;
             }
+            value_flow
         }};
     }
 
@@ -445,63 +582,49 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         // -----------------------------------------------------------------------------------------
         // control flow statements
         // -----------------------------------------------------------------------------------------
-        E::IfElse(test, conseq, alt) => {
-            if let Some(test_control_flow) = value(context, test) {
-                context.report_value_error(test_control_flow);
-                return already_reported(*eloc);
-            };
-            if let (Some(cflow), Some(aflow)) = (value(context, conseq), value(context, alt)) {
-                if cflow.value == aflow.value {
-                    context.report_value_error(sp(*eloc, cflow.value));
-                } else {
-                    context.report_value_error(cflow);
-                    context.report_value_error(aflow);
-                }
-                return already_reported(*eloc);
-            }
-            None
-        }
-        E::Match(subject, arms) => {
-            if let Some(test_control_flow) = value(context, subject) {
-                context.report_value_error(test_control_flow);
-                return None;
-            };
-            let arm_somes = arms
-                .value
-                .iter()
-                .map(|sp!(_, arm)| {
-                    arm.guard
-                        .as_ref()
-                        .and_then(|guard| value(context, guard))
-                        .iter()
-                        .for_each(|flow| context.report_value_error(*flow));
-                    value(context, &arm.rhs)
-                })
-                .collect::<Vec<_>>();
-            if arm_somes.iter().all(|arm_opt| arm_opt.is_some()) {
-                for arm_opt in arm_somes {
-                    let sp!(aloc, arm_error) = arm_opt.unwrap();
-                    context.report_value_error(sp(aloc, arm_error))
-                }
-            }
-            None
-        }
+        E::IfElse(test, conseq, alt) => do_if(
+            context,
+            (eloc, test, conseq, alt),
+            /* tail_pos */ false,
+            value,
+            |context, flow| context.maybe_report_value_error(flow),
+        ),
+        E::Match(subject, arms) => do_match(
+            context,
+            (subject, arms),
+            /* tail_pos */ false,
+            value,
+            |context, flow| context.maybe_report_value_error(flow),
+        ),
         E::VariantMatch(_subject, _, _arms) => {
             context
                 .env
                 .add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
-            None
+            CF::None
         }
-        E::While(..) | E::Loop { .. } => statement(context, e),
-        E::NamedBlock(name, (_, seq)) => {
-            // a named block in value position checks if the body exits that block; if so, at least
-            // some of that code is live.
-            let body_result = value_block(context, seq);
-            if exits_named_block(*name, body_result) {
-                None
+        E::While(..) => statement(context, e),
+        E::Loop {
+            name,
+            body,
+            has_break: _,
+        } => {
+            // A loop can yield values, but only through `break`. We treat the body as a statement,
+            // but then consider if it ever breaks out. If it does not, this is an infinite loop.
+            let body_flow = statement(context, body);
+            let loop_flow = if body_flow.is_none() {
+                let mut new_flow = infinite_loop(*eloc);
+                context.maybe_report_value_error(&mut new_flow);
+                new_flow
             } else {
-                body_result
-            }
+                body_flow
+            };
+            loop_flow.remove_label(name)
+        }
+        E::NamedBlock(name, (_, seq)) => {
+            // a named block checks for bad semicolons plus if the body exits that
+            // block; if so, at least some of that code is live.
+            let body_flow = value_block(context, seq);
+            body_flow.remove_label(name)
         }
         E::Block((_, seq)) => value_block(context, seq),
 
@@ -512,48 +635,44 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
 
         E::Builtin(_, args) | E::Vector(_, _, _, args) => value_report!(args),
 
-        E::Pack(_, _, _, fields) => fields
-            .iter()
-            .find_map(|(_, _, (_, (_, field_exp)))| value_report!(field_exp)),
-
-        E::PackVariant(_, _, _, _, fields) => fields
-            .iter()
-            .find_map(|(_, _, (_, (_, field_exp)))| value_report!(field_exp)),
-
-        E::ExpList(_) => {
-            use T::UnannotatedExp_ as TE;
-            if let TE::ExpList(items) = &e.exp.value {
-                for item in items {
-                    match item {
-                        T::ExpListItem::Single(exp, _) => {
-                            let next = value_report!(exp);
-                            if next.is_some() {
-                                return next;
-                            }
-                        }
-                        T::ExpListItem::Splat(_, _, _) => {
-                            context.env.add_diag(ice!((
-                                *eloc,
-                                "ICE splat exp unsupported by dead code analysis"
-                            )));
-                            return None;
-                        }
-                    }
-                }
-                None
-            } else {
-                value_report!(e)
+        E::Pack(_, _, _, fields) | E::PackVariant(_, _, _, _, fields) => {
+            let mut flow = CF::None;
+            for (_, _, (_, (_, field_exp))) in fields {
+                let field_flow = value(context, field_exp);
+                flow = flow.combine_seq(field_flow);
+                context.maybe_report_value_error(&mut flow);
             }
+            flow
         }
 
-        E::Annotate(base_exp, _)
-        | E::Dereference(base_exp)
+        E::ExpList(items) => {
+            let mut flow = CF::None;
+            for item in items {
+                match item {
+                    T::ExpListItem::Single(exp, _) => {
+                        let item_flow = value(context, exp);
+                        flow = flow.combine_seq(item_flow);
+                        context.maybe_report_value_error(&mut flow);
+                    }
+                    T::ExpListItem::Splat(_, _, _) => {
+                        context.env.add_diag(ice!((
+                            *eloc,
+                            "ICE splat exp unsupported by dead code analysis"
+                        )));
+                    }
+                }
+            }
+            flow
+        }
+
+        E::Annotate(base_exp, _) | E::Cast(base_exp, _) => value(context, base_exp),
+
+        E::Dereference(base_exp)
         | E::UnaryExp(_, base_exp)
         | E::Borrow(_, base_exp, _)
-        | E::Cast(base_exp, _)
         | E::TempBorrow(_, base_exp) => value_report!(base_exp),
 
-        E::BorrowLocal(_, _) => None,
+        E::BorrowLocal(_, _) => CF::None,
 
         // -----------------------------------------------------------------------------------------
         // value-based expressions without subexpressions -- no control flow
@@ -563,48 +682,52 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::Constant(_, _)
         | E::Move { .. }
         | E::Copy { .. }
-        | E::ErrorConstant { .. } => None,
+        | E::ErrorConstant { .. } => CF::None,
 
         // -----------------------------------------------------------------------------------------
         //  statements
         // -----------------------------------------------------------------------------------------
-        E::Return(rhs) => value_report!(rhs).or_else(|| return_called(*eloc)),
-        E::Abort(rhs) => value_report!(rhs).or_else(|| abort_called(*eloc)),
-        E::Give(name, rhs) => value_report!(rhs).or_else(|| named_control_called(*name, *eloc)),
-        E::Continue(name) => named_control_called(*name, *eloc),
-        E::Assign(_, _, _) | E::Mutate(_, _) => None, // These are unit-valued
+        E::Return(rhs) => value_report!(rhs).combine_seq(return_called(*eloc)),
+        E::Abort(rhs) => value_report!(rhs).combine_seq(abort_called(*eloc)),
+        E::Give(name, rhs) => value_report!(rhs).combine_seq(give_called(*eloc, *name)),
+        E::Continue(name) => continue_called(*eloc, *name),
+        E::Assign(_, _, _) | E::Mutate(_, _) => CF::None, // These are unit-valued
 
         E::BinopExp(_, _, _, _) => process_binops(context, e),
 
         // -----------------------------------------------------------------------------------------
         // odds and ends
         // -----------------------------------------------------------------------------------------
-        E::Use(_) | E::UnresolvedError => None,
+        E::Use(_) | E::UnresolvedError => CF::None,
     }
 }
 
-fn value_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option<ControlFlow> {
+fn value_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> ControlFlow {
     use T::SequenceItem_ as S;
     let last_exp = seq.iter().last();
-    let stmt_flow = statement_block(
+    let mut stmt_flow = statement_block(
         context, seq, /* stmt_pos */ false, /* skip_last */ true,
     );
-    if let (Some(control_flow), Some(sp!(_, S::Seq(last)))) = (stmt_flow, last_exp) {
-        context.report_statement_tail_error(control_flow, last);
-        already_reported(control_flow.loc)
-    } else if let Some(control_flow) = stmt_flow {
-        context.report_value_error(control_flow);
-        already_reported(control_flow.loc)
+    if stmt_flow.is_some() {
+        // If we have statement flow and a final expression, we might have an unnecessary
+        // semicolon if `last` is just a unit value. Let's check for that.
+        if let Some(sp!(_, S::Seq(last))) = last_exp {
+            context.maybe_report_statement_tail_error(&mut stmt_flow, last);
+            stmt_flow
+        } else {
+            context.maybe_report_value_error(&mut stmt_flow);
+            stmt_flow
+        }
     } else {
         match last_exp {
-            None => None,
+            None => ControlFlow::None,
             Some(sp!(_, S::Seq(last))) => value(context, last),
             Some(sp!(loc, _)) => {
                 context.env.add_diag(ice!((
                     *loc,
                     "ICE last sequence item should have been an exp in dead code analysis"
                 )));
-                None
+                ControlFlow::None
             }
         }
     }
@@ -615,137 +738,100 @@ fn value_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option
 // -------------------------------------------------------------------------------------------------
 
 #[growing_stack]
-fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
+fn statement(context: &mut Context, e: &T::Exp) -> ControlFlow {
+    use ControlFlow as CF;
     use T::UnannotatedExp_ as E;
     let T::Exp {
         exp: sp!(eloc, e_), ..
     } = e;
+
+    macro_rules! value_report {
+        ($nested_value:expr) => {{
+            let mut value_flow = value(context, $nested_value);
+            if context.maybe_report_value_error(&mut value_flow) {
+                return value_flow;
+            }
+            value_flow
+        }};
+    }
+
     match e_ {
         // -----------------------------------------------------------------------------------------
         // control flow statements
         // -----------------------------------------------------------------------------------------
-        E::IfElse(test, conseq, alt) => {
-            if let Some(test_control_flow) = value(context, test) {
-                context.report_value_error(test_control_flow);
-                statement(context, conseq);
-                statement(context, alt);
-                already_reported(*eloc)
-            } else {
-                // if the test was okay but the arms both diverged, we need to report that for the
-                // purpose of trailing semicolons.
-                match (statement(context, conseq), statement(context, alt)) {
-                    (Some(_), Some(_)) => divergent(*eloc),
-                    _ => None,
-                }
-            }
-        }
-        E::Match(subject, arms) => {
-            if let Some(test_control_flow) = value(context, subject) {
-                context.report_value_error(test_control_flow);
-                for sp!(_, arm) in arms.value.iter() {
-                    arm.guard
-                        .as_ref()
-                        .and_then(|guard| value(context, guard))
-                        .iter()
-                        .for_each(|flow| context.report_value_error(*flow));
-                    statement(context, &arm.rhs);
-                }
-                already_reported(*eloc)
-            } else {
-                // if the test was okay but all arms both diverged, we need to report that for the
-                // purpose of trailing semicolons.
-                let arm_somes = arms
-                    .value
-                    .iter()
-                    .map(|sp!(_, arm)| statement(context, &arm.rhs))
-                    .collect::<Vec<_>>();
-                if arm_somes.iter().all(|arm_opt| arm_opt.is_some()) {
-                    divergent(*eloc)
-                } else {
-                    None
-                }
-            }
-        }
+        // For `if` and `match`, we don't care if the arms individually diverge since we only care
+        // about the final, total view of them.
+        E::IfElse(test, conseq, alt) => do_if(
+            context,
+            (eloc, test, conseq, alt),
+            /* tail_pos */ false,
+            statement,
+            |_, _| false,
+        ),
+        E::Match(subject, arms) => do_match(
+            context,
+            (subject, arms),
+            /* tail_pos */ false,
+            statement,
+            |_, _| false,
+        ),
         E::VariantMatch(_subject, _, _arms) => {
             context
                 .env
                 .add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
-            None
+            CF::None
         }
-        E::While(_, test, body) => {
-            if let Some(test_control_flow) = value(context, test) {
-                context.report_value_error(test_control_flow);
-                already_reported(*eloc)
+        E::While(name, test, body) => {
+            let mut test_flow = value(context, test);
+            if context.maybe_report_value_error(&mut test_flow) {
+                test_flow
             } else {
-                statement(context, body);
-                // we don't know if a while loop will ever run so we drop errors for the bodies.
-                None
+                // Since a body for a While loop is only Possible, not certain, we always force it
+                // into Possible.
+                let body_flow = statement(context, body).combine_arms(*eloc, CF::None);
+                let body_flow = body_flow.remove_label(name);
+                test_flow.combine_seq(body_flow)
             }
         }
 
         E::Loop {
             name,
             body,
-            has_break,
+            has_break: _,
         } => {
-            let body_result = statement(context, body);
-            if !has_break {
+            // A loop can yield values, but only through `break`. We treat the body as a statement,
+            // but then consider if it ever breaks out. If it does not, this is an infinite loop.
+            let body_flow = statement(context, body);
+            let loop_flow = if body_flow.is_none() {
                 infinite_loop(*eloc)
-            } else if exits_named_block(*name, body_result) || *has_break {
-                // if the loop has a break, only Godel knows if it'll call it
-                None
             } else {
-                body_result
-            }
+                // Unlike values, for a loop in statement position we want to preserve if it
+                // diverges or not.
+                body_flow
+            };
+            loop_flow.remove_label(name)
         }
         E::NamedBlock(name, (_, seq)) => {
-            // a named block in statement position checks if the body exits that block; if so, at
-            // least some of that code is live.
-            let body_result = value_block(context, seq);
-            if exits_named_block(*name, body_result) {
-                None
-            } else {
-                body_result
-            }
+            // a named block checks for bad semicolons plus if the body exits that
+            // block; if so, at least some of that code is live.
+            let body_flow = statement_block(
+                context, seq, /* stmt_pos */ true, /* skip_last */ false,
+            );
+            body_flow.remove_label(name)
         }
         E::Block((_, seq)) => statement_block(
             context, seq, /* stmt_pos */ true, /* skip_last */ false,
         ),
-        E::Return(rhs) => {
-            if let Some(rhs_control_flow) = value(context, rhs) {
-                context.report_value_error(rhs_control_flow);
-                already_reported(*eloc)
-            } else {
-                return_called(*eloc)
-            }
-        }
-        E::Abort(rhs) => {
-            if let Some(rhs_control_flow) = value(context, rhs) {
-                context.report_value_error(rhs_control_flow);
-                already_reported(*eloc)
-            } else {
-                abort_called(*eloc)
-            }
-        }
-        E::Give(name, _) | E::Continue(name) => named_control_called(*name, *eloc),
+        E::Return(rhs) => value_report!(rhs).combine_seq(return_called(*eloc)),
+        E::Abort(rhs) => value_report!(rhs).combine_seq(abort_called(*eloc)),
+        E::Give(name, rhs) => value_report!(rhs).combine_seq(give_called(*eloc, *name)),
+        E::Continue(name) => continue_called(*eloc, *name),
 
         // -----------------------------------------------------------------------------------------
         //  statements with effects
         // -----------------------------------------------------------------------------------------
-        E::Assign(_, _, rhs) => {
-            if let Some(rhs_control_flow) = value(context, rhs) {
-                context.report_value_error(rhs_control_flow);
-            }
-            None
-        }
-        E::Mutate(lhs, rhs) => {
-            if let Some(rhs_control_flow) = value(context, rhs) {
-                context.report_value_error(rhs_control_flow);
-            } else if let Some(lhs_control_flow) = value(context, lhs) {
-                context.report_value_error(lhs_control_flow);
-            }
-            None
-        }
+        E::Assign(_, _, rhs) => value_report!(rhs),
+        E::Mutate(lhs, rhs) => value_report!(rhs).combine_seq(value_report!(lhs)),
 
         // -----------------------------------------------------------------------------------------
         // valued expressions -- when these occur in statement position need their children
@@ -771,7 +857,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::Copy { .. }
         | E::UnresolvedError => value(context, e),
 
-        E::Value(_) | E::Unit { .. } => None,
+        E::Value(_) | E::Unit { .. } => CF::None,
 
         // -----------------------------------------------------------------------------------------
         // odds and ends -- things we need to deal with but that don't do much
@@ -780,7 +866,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
             context
                 .env
                 .add_diag(ice!((*eloc, "ICE found unexpanded use")));
-            None
+            CF::None
         }
     }
 }
@@ -790,77 +876,65 @@ fn statement_block(
     seq: &VecDeque<T::SequenceItem>,
     stmt_pos: bool,
     skip_last: bool,
-) -> Option<ControlFlow> {
+) -> ControlFlow {
+    use ControlFlow as CF;
     use T::SequenceItem_ as S;
 
+    let seq_has_trailing_unit = has_trailing_unit(seq);
     // if we're in statement position, we need to check for a trailing semicolon error
     // this code does that by noting a trialing unit and then proceeding as if we are not in
     // statement position.
-    if stmt_pos && has_trailing_unit(seq) {
+    if stmt_pos && seq_has_trailing_unit {
         let last = seq.iter().last();
-        let result = statement_block(
+        let mut control_flow = statement_block(
             context, seq, /* stmt_pos */ false, /* skip_last */ true,
         );
-        return if let (Some(control_flow), Some(sp!(_, S::Seq(entry)))) = (result, last) {
-            context.report_statement_tail_error(control_flow, entry);
-            None
-        } else {
-            None
-        };
+        if let Some(sp!(_, S::Seq(entry))) = last {
+            context.maybe_report_statement_tail_error(&mut control_flow, entry);
+        }
+        return control_flow;
     }
 
-    let iterator = if skip_last {
-        seq.iter().skip_last().enumerate().collect::<Vec<_>>()
-    } else {
-        seq.iter().enumerate().collect::<Vec<_>>()
-    };
-    let last_ndx = usize::saturating_sub(iterator.len(), 1);
-    let locs: Vec<_> = iterator.iter().map(|(_, s)| s.loc).collect();
+    // let iterator = if skip_last {
+    //     seq.iter().skip_last().enumerate().collect::<Vec<_>>()
+    // } else {
+    //     seq.iter().enumerate().collect::<Vec<_>>()
+    // };
+    let last_ndx = usize::saturating_sub(seq.len(), 1);
+    let locs: Vec<_> = seq.iter().map(|s| s.loc).collect();
 
-    for (ndx, sp!(_, seq_item)) in iterator {
-        match seq_item {
-            S::Seq(entry) if ndx == last_ndx => {
-                // If this is the last statement, the error may indicate a trailing semicolon
-                // error. Return it to whoever is expecting it so they can report it appropriately.
-                return statement(context, entry);
-            }
-            S::Seq(entry) => {
-                let entry_result = statement(context, entry);
-                if entry_result.is_some() {
-                    context.report_statement_error(unreachable_code(locs[ndx + 1]).unwrap());
-                    return None;
+    let mut cur_flow = CF::None;
+    for (ndx, sp!(_, seq_item)) in seq.iter().enumerate() {
+        if cur_flow.is_divergent() {
+            break;
+        } else if ndx == last_ndx && skip_last {
+        } else {
+            match seq_item {
+                S::Seq(entry) => {
+                    let entry_flow = statement(context, entry);
+                    cur_flow = cur_flow.combine_seq(entry_flow);
+                    if cur_flow.is_divergent()
+                        && ndx != last_ndx
+                        && !(ndx + 1 == last_ndx && seq_has_trailing_unit)
+                    {
+                        context.maybe_report_statement_error(&mut cur_flow, Some(&locs[ndx + 1]));
+                    }
                 }
-            }
-            S::Declare(_) => (),
-            S::Bind(_, _, expr) => {
-                if let Some(control_flow) = value(context, expr) {
-                    context.report_value_error(control_flow);
-                    return None;
+                S::Declare(_) => (),
+                S::Bind(_, _, rhs) => {
+                    let entry_flow = value(context, rhs);
+                    cur_flow = cur_flow.combine_seq(entry_flow);
+                    context.maybe_report_value_error(&mut cur_flow);
                 }
             }
         }
     }
-    None
+    cur_flow
 }
 
 // -------------------------------------------------------------------------------------------------
 // Helpers
 // -------------------------------------------------------------------------------------------------
-
-struct SkipLastIterator<I: Iterator>(Peekable<I>);
-impl<I: Iterator> Iterator for SkipLastIterator<I> {
-    type Item = I::Item;
-    fn next(&mut self) -> Option<Self::Item> {
-        let item = self.0.next();
-        self.0.peek().map(|_| item.unwrap())
-    }
-}
-trait SkipLast: Iterator + Sized {
-    fn skip_last(self) -> SkipLastIterator<Self> {
-        SkipLastIterator(self.peekable())
-    }
-}
-impl<I: Iterator> SkipLast for I {}
 
 fn has_trailing_unit(seq: &VecDeque<T::SequenceItem>) -> bool {
     use T::SequenceItem_ as S;
@@ -871,68 +945,135 @@ fn has_trailing_unit(seq: &VecDeque<T::SequenceItem>) -> bool {
     }
 }
 
+fn do_if<F1, F2>(
+    context: &mut Context,
+    (loc, test, conseq, alt): (&Loc, &T::Exp, &T::Exp, &T::Exp),
+    tail_pos: bool,
+    arm_recur: F1,
+    arm_error: F2,
+) -> ControlFlow
+where
+    F1: Fn(&mut Context, &T::Exp) -> ControlFlow,
+    F2: Fn(&mut Context, &mut ControlFlow) -> bool,
+{
+    use ControlFlow as CF;
+    let mut value_flow = value(context, test);
+    if context.maybe_report_value_error(&mut value_flow) {
+        return value_flow;
+    };
+
+    let conseq_flow = arm_recur(context, conseq);
+    let alt_flow = arm_recur(context, alt);
+    if tail_pos
+        && matches!(conseq.ty, sp!(_, N::Type_::Unit | N::Type_::Anything))
+        && matches!(alt.ty, sp!(_, N::Type_::Unit | N::Type_::Anything))
+    {
+        return CF::None;
+    };
+    let mut arms_flow = conseq_flow.combine_arms(*loc, alt_flow);
+    if arm_error(context, &mut arms_flow) {
+        arms_flow
+    } else {
+        value_flow.combine_seq(arms_flow)
+    }
+}
+
+fn do_match<F1, F2>(
+    context: &mut Context,
+    (subject, arms): (&T::Exp, &Spanned<Vec<T::MatchArm>>),
+    tail_pos: bool,
+    arm_recur: F1,
+    arm_error: F2,
+) -> ControlFlow
+where
+    F1: Fn(&mut Context, &T::Exp) -> ControlFlow,
+    F2: Fn(&mut Context, &mut ControlFlow) -> bool,
+{
+    use ControlFlow as CF;
+    let mut subject_flow = value(context, subject);
+    if context.maybe_report_value_error(&mut subject_flow) {
+        return subject_flow;
+    };
+
+    let mut arm_flows = arms
+        .value
+        .iter()
+        .map(|sp!(_, arm)| {
+            if let Some(guard) = &arm.guard {
+                let mut guard_flow = value(context, guard);
+                context.maybe_report_value_error(&mut guard_flow);
+            };
+            arm_recur(context, &arm.rhs)
+        })
+        .collect::<Vec<_>>();
+    if tail_pos
+        && arms.value.iter().all(|arm| {
+            matches!(
+                arm.value.rhs.ty,
+                sp!(_, N::Type_::Unit | N::Type_::Anything)
+            )
+        })
+    {
+        return CF::None;
+    };
+    // We _must_ have at least one arm, but we already produced errors about it.
+    let arms_first = if let Some(arm) = arm_flows.pop() {
+        arm
+    } else {
+        CF::None
+    };
+    let mut arms_flow = arm_flows
+        .into_iter()
+        .fold(arms_first, |base, arm| base.combine_arms(arms.loc, arm));
+    if arm_error(context, &mut arms_flow) {
+        arms_flow
+    } else {
+        subject_flow.combine_seq(arms_flow)
+    }
+}
+
 //**************************************************************************************************
 // Binops
 //**************************************************************************************************
 
-fn process_binops(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
+fn process_binops(context: &mut Context, e: &T::Exp) -> ControlFlow {
     use T::UnannotatedExp_ as E;
-
-    enum Pn {
-        Op(BinOp_, Loc),
-        Val(Option<ControlFlow>),
-    }
 
     // ----------------------------------------
     // Convert nested binops into a PN list
 
-    let mut pn_stack = vec![];
-
     let mut work_queue = vec![e];
+    let mut value_stack: Vec<ControlFlow> = vec![];
 
     while let Some(exp) = work_queue.pop() {
         if let T::Exp {
-            exp: sp!(eloc, E::BinopExp(lhs, sp!(_, op), _, rhs)),
+            exp: sp!(_eloc, E::BinopExp(lhs, sp!(_, op), _, rhs)),
             ..
         } = exp
         {
-            pn_stack.push(Pn::Op(*op, *eloc));
-            // push on backwards so when we reverse the stack, we are in RPN order
-            work_queue.push(rhs);
-            work_queue.push(lhs);
+            match op {
+                BinOp_::Or | BinOp_::And => {
+                    // We only care about errors in the left-hand side due to laziness
+                    work_queue.push(lhs);
+                }
+                _ => {
+                    work_queue.push(rhs);
+                    work_queue.push(lhs);
+                }
+            }
         } else {
-            pn_stack.push(Pn::Val(value(context, exp)));
+            value_stack.push(value(context, exp));
         }
     }
 
     // ----------------------------------------
     // Now process as an RPN stack
 
-    let mut value_stack: Vec<Option<ControlFlow>> = vec![];
-
-    for entry in pn_stack.into_iter().rev() {
-        match entry {
-            Pn::Op(BinOp_::And, _) | Pn::Op(BinOp_::Or, _) => {
-                let test = value_stack.pop().expect("ICE binop hlir issue");
-                let _rhs = value_stack.pop().expect("ICE binop hlir issue");
-                // we only care about errors in the test, as the rhs is lazy
-                value_stack.push(test);
-            }
-            Pn::Op(_, eloc) => {
-                let lhs = value_stack.pop().expect("ICE binop hlir issue");
-                let rhs = value_stack.pop().expect("ICE binop hlir issue");
-                if let Some(control_flow) = lhs {
-                    context.report_value_error(control_flow);
-                    value_stack.push(already_reported(eloc));
-                } else if let Some(control_flow) = rhs {
-                    context.report_value_error(control_flow);
-                    value_stack.push(already_reported(eloc));
-                } else {
-                    value_stack.push(lhs);
-                }
-            }
-            Pn::Val(maybe_control_flow) => value_stack.push(maybe_control_flow),
+    while let Some(mut flow) = value_stack.pop() {
+        if flow.is_divergent() {
+            context.maybe_report_value_error(&mut flow);
+            return flow;
         }
     }
-    value_stack.pop().unwrap()
+    ControlFlow::None
 }

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -441,7 +441,7 @@ fn function_body(
         TB::Defined((_, seq)) => {
             debug_print!(context.debug.function_translation,
                          (msg format!("-- {} ----------------", _name)),
-                         (lines "body" => &seq));
+                         (lines "body" => &seq; verbose));
             let (locals, body) = function_body_defined(context, sig, loc, seq);
             debug_print!(context.debug.function_translation,
                          (msg "--------"),
@@ -946,19 +946,18 @@ fn tail(
             context.enter_named_block(name, binders.clone(), out_type.clone());
             let mut body_block = make_block!();
             let final_exp = tail_block(context, &mut body_block, Some(&out_type), seq);
-            let result = final_exp.map(|exp| {
+            if let Some(exp) = final_exp {
                 bind_value_in_block(context, binders, Some(out_type), &mut body_block, exp);
-                block.push_back(sp(
-                    eloc,
-                    S::NamedBlock {
-                        name,
-                        block: body_block,
-                    },
-                ));
-                result
-            });
+            }
+            block.push_back(sp(
+                eloc,
+                S::NamedBlock {
+                    name,
+                    block: body_block,
+                },
+            ));
             context.exit_named_block(name);
-            result
+            Some(result)
         }
         E::Block((_, seq)) => tail_block(context, block, expected_type, seq),
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/cfg_conditional.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/cfg_conditional.move
@@ -1,0 +1,9 @@
+module 0x42::m;
+
+fun test(cond: bool): u64 {
+    'a: {
+        loop {
+            if (cond) { return 'a 5 }
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/cfg_panic_0.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/cfg_panic_0.move
@@ -1,0 +1,9 @@
+module 0x42::m;
+
+fun test(): u64 {
+    'a: {
+        loop {
+            return 'a 5
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/cfg_panic_1.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/cfg_panic_1.move
@@ -1,0 +1,7 @@
+module 0x42::m;
+
+fun test(): u64 {
+    'a: {
+        return 'a 5
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/expand_test.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/expand_test.move
@@ -1,0 +1,19 @@
+module a::m {
+
+    public macro fun for_each<$T>($v: vector<$T>, $f: |$T|) {
+        let mut v = $v;
+        v.reverse();
+        let mut i = 0;
+        while (!v.is_empty()) {
+            $f(v.pop_back());
+            i = i + 1;
+        };
+        v.destroy_empty();
+    }
+
+    public fun sum(v: vector<u64>): u64 {
+        let mut sum = 0;
+        for_each!(v, |x| { sum = sum + x; });
+        sum
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/named_loop_no_value.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/cfgir/named_loop_no_value.move
@@ -1,0 +1,7 @@
+module 0x42::m;
+
+fun test(): u64 {
+    'a: {
+        return 5
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/break_outer_loop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/break_outer_loop.exp
@@ -1,0 +1,10 @@
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_2024/hlir/break_outer_loop.move:14:13
+   │
+14 │             break 'a 5;
+   │             ^^^^^^^^^^ Any code after this expression will not be reached
+15 │             break 10;
+   │             -------- Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/break_outer_loop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/break_outer_loop.move
@@ -1,0 +1,19 @@
+module 0x42::m;
+
+fun test0(): u64 {
+    'a: loop {
+        loop {
+            break 'a 5
+        }
+    }
+}
+
+fun test1(): u64 {
+    'a: loop {
+        let x = loop {
+            break 'a 5;
+            break 10;
+        };
+        let _x = x;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_guard.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_guard.exp
@@ -1,8 +1,10 @@
 warning[W09005]: dead or unreachable code
-   ┌─ tests/move_2024/hlir/dead_code_guard.move:14:30
+   ┌─ tests/move_2024/hlir/dead_code_guard.move:14:20
    │
 14 │             _ if ({return 0; true}) => 1,
-   │                              ^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │                    ^^^^^^^^  ---- Unreachable code. This statement (and any following statements) will not be executed.
+   │                    │          
+   │                    Any code after this expression will not be reached
    │
    = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_nested_block.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_nested_block.exp
@@ -1,0 +1,29 @@
+warning[W09002]: unused variable
+  ┌─ tests/move_2024/hlir/dead_code_nested_block.move:3:11
+  │
+3 │ fun test0(cond: bool): u64 {
+  │           ^^^^ Unused parameter 'cond'. Consider removing or prefixing with an underscore: '_cond'
+  │
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_2024/hlir/dead_code_nested_block.move:5:9
+  │
+5 │         return 'a 5;
+  │         ^^^^^^^^^^^ Any code after this expression will not be reached
+6 │         0
+  │         - Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_2024/hlir/dead_code_nested_block.move:13:13
+   │
+13 │             return 'a 5
+   │             ^^^^^^^^^^^ Any code after this expression will not be reached
+14 │         };
+15 │         0
+   │         - Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_nested_block.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_nested_block.move
@@ -1,0 +1,17 @@
+module 0x42::m;
+
+fun test0(cond: bool): u64 {
+    'a: {
+        return 'a 5;
+        0
+    }
+}
+
+fun test1(): u64 {
+    'a: {
+        loop {
+            return 'a 5
+        };
+        0
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/if_abort_statement.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/if_abort_statement.exp
@@ -1,0 +1,8 @@
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_2024/hlir/if_abort_statement.move:4:18
+  │
+4 │     let x: u64 = if (true) abort 0 else abort 0;
+  │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/if_abort_statement.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/if_abort_statement.move
@@ -1,0 +1,6 @@
+module 0x42::m;
+
+fun test(): u64 {
+    let x: u64 = if (true) abort 0 else abort 0;
+    x
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/labeled_control_exp_associativity_unreachable_code.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/labeled_control_exp_associativity_unreachable_code.exp
@@ -1,5 +1,5 @@
 warning[W09005]: dead or unreachable code
-   ┌─ tests/move_2024/parser/labeled_control_exp_associativity_unreachable_code.move:11:13
+   ┌─ tests/move_2024/hlir/labeled_control_exp_associativity_unreachable_code.move:11:13
    │
 11 │         1 + 'a: loop { foo() } + 2;
    │             ^^^^^^^^^^^^^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/labeled_control_exp_associativity_unreachable_code.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/labeled_control_exp_associativity_unreachable_code.move
@@ -1,0 +1,30 @@
+// tests that control structures are right associative when not immediately followed by a block
+
+// these cases type check, but have dead code
+
+module 0x42::M {
+    fun foo() {}
+    fun bar(): u64 { 0 }
+
+    fun t(): u64 { 'r: {
+        // loop
+        1 + 'a: loop { foo() } + 2;
+        1 + 'a: loop foo();
+        1 + loop 'a: { foo() } + 2;
+        'a: loop { foo() } + 1;
+
+        // return
+        return 'r 1 + 2;
+        return 'r { 1 + 2 };
+        return 'r { 1 } && false;
+        false && return 'r { 1 };
+
+        // abort
+        abort 1 + 2;
+        abort 'a: { 1 + 2 };
+        abort 'a: { 1 } && false;
+        false && abort 'a: { 1 };
+
+        0
+    } }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/nested_named_block_inner_break.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/nested_named_block_inner_break.move
@@ -1,0 +1,9 @@
+module 0x42::m;
+
+fun test() {
+    'l: loop {
+        'l: loop {
+            break 'l
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/no_dead_code_block.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/no_dead_code_block.move
@@ -1,0 +1,25 @@
+module 0x42::m;
+
+fun test0(cond: bool): u64 {
+    'a: {
+        if (cond) { return 'a 5 };
+        0
+    }
+}
+
+fun test1(cond: bool): u64 {
+    'a: {
+        loop {
+            if (cond) { return 'a 5 };
+        };
+        0
+    }
+}
+
+fun test2(cond: bool): u64 {
+    'a: loop {
+        loop {
+            if (cond) { break 'a 5 };
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/return_value.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/return_value.exp
@@ -1,0 +1,10 @@
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_2024/hlir/return_value.move:4:5
+  │
+4 │     return 5;
+  │     ^^^^^^^^ Any code after this expression will not be reached
+5 │     10
+  │     -- Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/return_value.move
@@ -1,0 +1,15 @@
+module 0x42::m;
+
+fun t0(): u64 {
+    return 5;
+    10
+}
+
+fun t1(): u64 {
+    while (false) {
+        return 5
+    };
+    10
+}
+
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp.move
@@ -1,0 +1,117 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Op has drop {
+        LoopOpen,
+        BreakIfEven(u64), // encodes jump PC
+        Return,
+        Push(u64),
+        Add,
+        LoopClose,
+    }
+
+    fun interp(ops: vector<Op>): u64 {
+        let mut stack = vector[];
+        let mut loop_pcs = vector[];
+        let mut cur_pc = 0;
+
+        'exit: {
+            'interp: loop {
+                match (&ops[cur_pc]) {
+                    Op::LoopOpen => {
+                        loop_pcs.push_back(cur_pc + 1);
+                    },
+                    Op::BreakIfEven(new_pc) => {
+                        let top = stack[stack.length() - 1];
+                        if (top % 2 == 0) {
+                            loop_pcs.pop_back();
+                            cur_pc = *new_pc;
+                            continue 'interp
+                        }
+                    },
+                    Op::Return => {
+                        return 'exit
+                    },
+                    Op::Push(value) => {
+                        stack.push_back(*value);
+                    },
+                    Op::Add => {
+                        let n0 = stack.pop_back();
+                        let n1 = stack.pop_back();
+                        stack.push_back(n0 + n1);
+                    },
+                    Op::LoopClose => {
+                        cur_pc = loop_pcs[loop_pcs.length() - 1];
+                        continue 'interp
+                    }
+                };
+                cur_pc = cur_pc + 1;
+            }
+        };
+
+        stack.pop_back()
+    }
+
+    fun test() {
+
+        let push = vector[
+            Op::Push(1),
+            Op::Return,
+        ];
+
+        assert!(interp(push) == 1);
+
+        let add = vector[
+            Op::Push(1),
+            Op::Push(1),
+            Op::Add,
+            Op::Return,
+        ];
+
+        assert!(interp(add) == 2);
+
+        let early_break = vector[
+            Op::Push(1),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp(early_break) == 100);
+
+        let exiting = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp(exiting) == 1);
+
+        let loop_and_break = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(6),
+            Op::LoopClose,
+            Op::Return,
+        ];
+
+        assert!(interp(loop_and_break) == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp_macro.move
@@ -1,0 +1,118 @@
+//# init --edition 2024.beta
+
+//# publish
+module 0x42::m {
+
+    public enum Op has drop {
+        LoopOpen,
+        BreakIfEven(u64), // encodes jump PC
+        Return,
+        Push(u64),
+        Add,
+        LoopClose,
+    }
+
+    macro fun interp($ops: vector<Op>): u64 {
+        let ops = $ops;
+        let mut stack = vector[];
+        let mut loop_pcs = vector[];
+        let mut cur_pc = 0;
+
+        'exit: {
+            'interp: loop {
+                match (&ops[cur_pc]) {
+                    Op::LoopOpen => {
+                        loop_pcs.push_back(cur_pc + 1);
+                    },
+                    Op::BreakIfEven(new_pc) => {
+                        let top = stack[stack.length() - 1];
+                        if (top % 2 == 0) {
+                            loop_pcs.pop_back();
+                            cur_pc = *new_pc;
+                            continue 'interp
+                        }
+                    },
+                    Op::Return => {
+                        return 'exit
+                    },
+                    Op::Push(value) => {
+                        stack.push_back(*value);
+                    },
+                    Op::Add => {
+                        let n0 = stack.pop_back();
+                        let n1 = stack.pop_back();
+                        stack.push_back(n0 + n1);
+                    },
+                    Op::LoopClose => {
+                        cur_pc = loop_pcs[loop_pcs.length() - 1];
+                        continue 'interp
+                    }
+                };
+                cur_pc = cur_pc + 1;
+            }
+        };
+
+        stack.pop_back()
+    }
+
+    fun test() {
+
+        let push = vector[
+            Op::Push(1),
+            Op::Return,
+        ];
+
+        assert!(interp!(push) == 1);
+
+        let add = vector[
+            Op::Push(1),
+            Op::Push(1),
+            Op::Add,
+            Op::Return,
+        ];
+
+        assert!(interp!(add) == 2);
+
+        let early_break = vector[
+            Op::Push(1),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp!(early_break) == 100);
+
+        let exiting = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(7),
+                Op::Return,
+            Op::LoopClose,
+            Op::Push(100),
+            Op::Return,
+        ];
+
+        assert!(interp!(exiting) == 1);
+
+        let loop_and_break = vector[
+            Op::Push(0),
+            Op::LoopOpen,
+                Op::Push(1),
+                Op::Add,
+                Op::BreakIfEven(6),
+            Op::LoopClose,
+            Op::Return,
+        ];
+
+        assert!(interp!(loop_and_break) == 2);
+    }
+}
+
+//# run 0x42::m::test

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/let_mut_macro_return.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/let_mut_macro_return.exp
@@ -9,18 +9,13 @@ warning[W09012]: unused 'mut' modifiers
   = This warning can be suppressed with '#[allow(unused_let_mut)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_2024/typing/let_mut_macro_return.move:7:13
-  │
-7 │             i = i + 1;
-  │             ^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09005]: dead or unreachable code
    ┌─ tests/move_2024/typing/let_mut_macro_return.move:16:35
    │
+ 7 │             i = i + 1;
+   │             --------- Unreachable code. This statement (and any following statements) will not be executed.
+   ·
 16 │         'a: { for_each!(0, 1, |_| return 'a) }
-   │                                   ^^^^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
+   │                                   ^^^^^^^^^ Any code after this expression will not be reached
    │
    = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.exp
@@ -23,16 +23,8 @@ error[E05001]: ability constraint not satisfied
  9 │     macro fun baz<$T>(): NeedsCopy<$T> { abort 0 }
    │                          ^^^^^^^^^^^^^ 'copy' constraint not satisifed
    ·
-18 │         baz!<None>(); // TODO do not complain about dead code?
+18 │         baz!<None>()
    │              ---- The type 'a::m::None' does not have the ability 'copy'
-
-warning[W09005]: dead or unreachable code
-  ┌─ tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.move:9:42
-  │
-9 │     macro fun baz<$T>(): NeedsCopy<$T> { abort 0 }
-  │                                          ^^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.move:13:9
@@ -48,4 +40,15 @@ error[E05001]: ability constraint not satisfied
    │         │    │
    │         │    The type 'a::m::None' does not have the ability 'copy'
    │         'copy' constraint not satisifed
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.move:18:9
+   │
+ 9 │     macro fun baz<$T>(): NeedsCopy<$T> { abort 0 }
+   │                          ------------- Given: 'a::m::NeedsCopy<a::m::None>'
+   ·
+17 │     fun t2() {
+   │         -- Expected: '()'
+18 │         baz!<None>()
+   │         ^^^^^^^^^^^^ Invalid return expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_types_checked_invalid_constraints_simple.move
@@ -15,7 +15,7 @@ module a::m {
     }
 
     fun t2() {
-        baz!<None>(); // TODO do not complain about dead code?
+        baz!<None>()
     }
 
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/named_block_invalid_if.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/named_block_invalid_if.exp
@@ -1,0 +1,12 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_2024/typing/named_block_invalid_if.move:4:5
+  │  
+4 │ ╭     'a: {
+5 │ │         if (cond) { return 'a 5 }
+  │ │         -------------------------
+  │ │         │           │
+  │ │         │           Found: integer. It is not compatible with the other type.
+  │ │         Found: '()'. It is not compatible with the other type.
+6 │ │     }
+  │ ╰─────^ Invalid named block
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/named_block_invalid_if.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/named_block_invalid_if.move
@@ -1,0 +1,7 @@
+module 0x42::m;
+
+fun test(cond: bool): u64 {
+    'a: {
+        if (cond) { return 'a 5 }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/control_flow/while_after_while.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/control_flow/while_after_while.move
@@ -1,0 +1,6 @@
+module 0x42::m {
+    fun main() {
+        while (true) { };
+        while (true) { };
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/nested_dead.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/nested_dead.exp
@@ -15,14 +15,6 @@ warning[W09005]: dead or unreachable code
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/liveness/nested_dead.move:8:9
-  │
-8 │         return
-  │         ^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/liveness/nested_dead.move:12:23
    │
 12 │         loop { return abort 0 }

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/nested_dead_single.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/nested_dead_single.exp
@@ -1,0 +1,8 @@
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/liveness/nested_dead_single.move:3:23
+  │
+3 │         loop { return abort 0 }
+  │                       ^^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/nested_dead_single.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/nested_dead_single.move
@@ -1,0 +1,5 @@
+module 0x8675309::m {
+    fun t0() {
+        loop { return abort 0 }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/trailing_semi_single.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/trailing_semi_single.exp
@@ -1,0 +1,12 @@
+warning[W09004]: unnecessary trailing semicolon
+  ┌─ tests/move_check/liveness/trailing_semi_single.move:3:15
+  │
+3 │         return;
+  │         ------^
+  │         │     │
+  │         │     Invalid trailing ';'
+  │         │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+  │         Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/trailing_semi_single.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/trailing_semi_single.move
@@ -1,0 +1,5 @@
+module 1::m {
+    fun main() {
+        return;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
@@ -14,11 +14,3 @@ warning[W09005]: dead or unreachable code
    │
    = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[W09005]: dead or unreachable code
-   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:9
-   │
-12 │         1 + loop foo();
-   │         ^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
-   │
-   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/return_in_binop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/return_in_binop.exp
@@ -6,11 +6,3 @@ warning[W09005]: dead or unreachable code
   │
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/parser/return_in_binop.move:4:9
-  │
-4 │         return << 0;
-  │         ^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-

--- a/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/break_unreachable.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/break_unreachable.exp
@@ -1,8 +1,10 @@
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/translated_ir_tests/move/commands/break_unreachable.move:8:9
+  ┌─ tests/move_check/translated_ir_tests/move/commands/break_unreachable.move:7:9
   │
+7 │         break;
+  │         ^^^^^ Any code after this expression will not be reached
 8 │         x = 5;
-  │         ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │         ----- Unreachable code. This statement (and any following statements) will not be executed.
   │
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return.exp
@@ -1,8 +1,10 @@
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/translated_ir_tests/move/commands/dead_return.move:4:9
+  ┌─ tests/move_check/translated_ir_tests/move/commands/dead_return.move:3:9
   │
+3 │         return 100;
+  │         ^^^^^^^^^^ Any code after this expression will not be reached
 4 │         return 0
-  │         ^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │         -------- Unreachable code. This statement (and any following statements) will not be executed.
   │
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
@@ -1,8 +1,10 @@
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/translated_ir_tests/move/commands/dead_return_local.move:4:5
+  ┌─ tests/move_check/translated_ir_tests/move/commands/dead_return_local.move:3:5
   │
+3 │     return ();
+  │     ^^^^^^^^^ Any code after this expression will not be reached
 4 │     assert!(false, 42);
-  │     ^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │     ------------------ Unreachable code. This statement (and any following statements) will not be executed.
   │
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.exp
@@ -1,8 +1,10 @@
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.move:5:3
+  ┌─ tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.move:4:3
   │
+4 │   return ();
+  │   ^^^^^^^^^ Any code after this expression will not be reached
 5 │   x = 7
-  │   ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │   ----- Unreachable code. This statement (and any following statements) will not be executed.
   │
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.exp
@@ -1,8 +1,10 @@
 warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.move:5:3
+  ┌─ tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.move:4:3
   │
+4 │   if (true) return () else return ();
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Any code after this expression will not be reached
 5 │   x = 7;
-  │   ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │   ----- Unreachable code. This statement (and any following statements) will not be executed.
   │
   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -40,11 +40,3 @@ error[E05001]: ability constraint not satisfied
   │         Cannot ignore values without the 'drop' ability. The value must be used
   │         The type '0x8675309::M::Box<0x8675309::M::R>' does not have the ability 'drop'
 
-warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9
-  │
-9 │         Box<R>{ f: R{} };
-  │         ^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-


### PR DESCRIPTION
## Description 

Dead code was written without respecting named blocks and loops, leading to false negatives in cases that should work just fine. This revises. that analysis to do the correct thing, though the implementation is still a bit rough and full of heuristics. The main idea is that instead of tracking "diverged" versus "did not", we track "might have" versus "did" and "did not." This allows us enough breathing room to avoid saying we diverged when that divergence was guarded by conditional control flow.

In writing tests, I also found an issue in how HLIR lowered named blocks, due to conflicting assumptions about how things are typed. This is fixed now, allowing this sort of code:

```
fun test(): u64 {
 'a: {
     loop { return 'a 5 }
   }
}
```

## Test plan 

A bunch of new tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
