### PR TITLE
update max objects limit to 10 when jsonrpc updates the return limit

### DIFF
--- a/sdk/typescript/src/transactions/json-rpc-resolver.ts
+++ b/sdk/typescript/src/transactions/json-rpc-resolver.ts
@@ -14,7 +14,7 @@ import { getPureBcsSchema, isTxContext, normalizedTypeToMoveTypeSignature } from
 import type { TransactionDataBuilder } from './TransactionData.js';
 
 // The maximum objects that can be fetched at once using multiGetObjects.
-const MAX_OBJECTS_PER_FETCH = 50;
+const MAX_OBJECTS_PER_FETCH = 10;
 
 // An amount of gas (in gas units) that is added to transactions as an overhead to ensure transactions do not fail.
 const GAS_SAFE_OVERHEAD = 1000n;


### PR DESCRIPTION
## Description 

When calling Transaction.build and the parameters contain more than 10 objects, jsonrpc returns Input exceeds limit of 10. The reason is that the jsonrpc request parameters previously allowed a maximum of 50 objects, but starting from 11/09, it was limited to 10.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [x] JSON-RPC: update max objects limit to 10 when jsonrpc updates the return limit,  <Input exceeds limit of 10> will be fixed
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
