### PR TITLE
[move][move-2024] Fix match parsing by adding Match to expression start set

### DIFF
--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -102,12 +102,12 @@ impl fmt::Display for Tok {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         use Tok::*;
         let s = match *self {
-            EOF => "[end-of-file]",
-            NumValue => "[Num]",
-            NumTypedValue => "[NumTyped]",
-            ByteStringValue => "[ByteString]",
-            Identifier => "[Identifier]",
-            SyntaxIdentifier => "[SyntaxIdentifier]",
+            EOF => "<End-Of-File>",
+            NumValue => "<Number>",
+            NumTypedValue => "<TypedNumber>",
+            ByteStringValue => "<ByteString>",
+            Identifier => "<Identifier>",
+            SyntaxIdentifier => "$<Identifier>",
             Exclaim => "!",
             ExclaimEqual => "!=",
             Percent => "%",
@@ -171,12 +171,12 @@ impl fmt::Display for Tok {
             Friend => "friend",
             NumSign => "#",
             AtSign => "@",
-            RestrictedIdentifier => "r#[Identifier]",
+            RestrictedIdentifier => "r#<Identifier>",
             Mut => "mut",
             Enum => "enum",
             Type => "type",
             Match => "match",
-            BlockLabel => "'[Identifier]",
+            BlockLabel => "'<Identifier>",
             MinusGreater => "->",
             For => "for",
         };

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -409,7 +409,14 @@ where
             let loc = make_loc(context.tokens.file_hash(), current_loc, current_loc);
             let diag = diag!(
                 Syntax::UnexpectedToken,
-                (loc, format!("Unexpected '{}'. Expected {}", context.tokens.peek(), item_description))
+                (
+                    loc,
+                    format!(
+                        "Unexpected '{}'. Expected {}",
+                        context.tokens.peek(),
+                        item_description
+                    )
+                )
             );
             advance_separated_items_error(
                 context,

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -409,7 +409,7 @@ where
             let loc = make_loc(context.tokens.file_hash(), current_loc, current_loc);
             let diag = diag!(
                 Syntax::UnexpectedToken,
-                (loc, format!("Expected {}", item_description))
+                (loc, format!("Unexpected '{}'. Expected {}", context.tokens.peek(), item_description))
             );
             advance_separated_items_error(
                 context,

--- a/external-crates/move/crates/move-compiler/src/parser/token_set.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/token_set.rs
@@ -94,6 +94,7 @@ const EXP_STARTS: &[Tok] = &[
     Tok::Return,
     Tok::While,
     Tok::BlockLabel,
+    Tok::Match,
 ];
 
 pub static EXP_START_SET: Lazy<TokenSet> = Lazy::new(|| TokenSet::from(EXP_STARTS));

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_match_lhs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_match_lhs.exp
@@ -1,0 +1,17 @@
+warning[W09002]: unused variable
+  ┌─ tests/move_2024/matching/invalid_match_lhs.move:8:10
+  │
+8 │ fun test(z: &mut Maybe<u64>) {
+  │          ^ Unused parameter 'z'. Consider removing or prefixing with an underscore: '_z'
+  │
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/matching/invalid_match_lhs.move:9:9
+  │
+9 │     let { match (z) { Maybe::Just(n) => n, Maybe::Nothing => abort 0 } } = 5;
+  │         ^
+  │         │
+  │         Unexpected '{'
+  │         Expected a variable or struct name
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_match_lhs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_match_lhs.move
@@ -1,0 +1,12 @@
+module 0x42::m;
+
+public enum Maybe<T> {
+    Just(T),
+    Nothing
+}
+
+fun test(z: &mut Maybe<u64>) {
+    let { match (z) { Maybe::Just(n) => n, Maybe::Nothing => abort 0 } } = 5;
+}
+
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/matching_everywhere.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/matching_everywhere.move
@@ -1,0 +1,51 @@
+module 0x42::m;
+
+public enum Maybe<T> {
+    Just(T),
+    Nothing
+}
+
+
+fun helper(_x: u64) { abort 0 }
+
+fun test(x: &Maybe<u64>, y: Maybe<u64>): u64 {
+    helper(match (y) { Maybe::Just(n) => n, Maybe::Nothing => 0 });
+
+    let a: u64 = match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 };
+
+    let b: u64 = loop {
+        break match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 }
+    };
+
+    let c: u64 = 'a: {
+        return 'a match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 }
+    };
+
+    let d: u64 = 'a: {
+        while (true) {
+            return 'a match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 }
+        };
+        0
+    };
+
+    while (match (x) { Maybe::Just(_) => true, Maybe::Nothing => false }) {
+        break
+    };
+
+    let e = if (match (x) { Maybe::Just(_) => true, Maybe::Nothing => false, }) return 5 else 0;
+
+    let (f, g) = (
+        match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 },
+        match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 }
+    );
+
+    let h = match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 } + 1;
+
+    let i = 1 + match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 };
+
+    let j = match (x) { Maybe::Just(n) => match (x) { Maybe::Just(m) => *n + *m, Maybe::Nothing => 0 }, Maybe::Nothing => 0 };
+
+    let _q = a + b + c + d + e + f + g + h + i + j;
+
+    return match (x) { Maybe::Just(n) => *n, Maybe::Nothing => 0 }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/migration/match_okay.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/migration/match_okay.exp
@@ -10,7 +10,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/migration/match_okay.move:3:20
   │
 3 │     fun t1(t: u64, match: u64): bool {
-  │                    ^ Expected a function parameter
+  │                    ^ Unexpected 'match'. Expected a function parameter
 
 error[E01002]: unexpected token
   ┌─ tests/move_2024/migration/match_okay.move:5:5
@@ -33,7 +33,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/migration/match_okay.move:7:20
   │
 7 │     fun t2(t: u64, match: u64): bool {
-  │                    ^ Expected a function parameter
+  │                    ^ Unexpected 'match'. Expected a function parameter
 
 error[E01002]: unexpected token
   ┌─ tests/move_2024/migration/match_okay.move:8:23

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_assign.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_assign.exp
@@ -8,5 +8,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/mut_field_pun_invalid_assign.move:6:13
   │
 6 │         S { mut f } = s;
-  │             ^ Expected a field expression
+  │             ^ Unexpected 'mut'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_pack.exp
@@ -8,5 +8,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/mut_field_pun_invalid_pack.move:6:13
   │
 6 │         S { mut f }
-  │             ^ Expected a field expression
+  │             ^ Unexpected 'mut'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis_invalid.exp
@@ -8,5 +8,5 @@ error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/pattern_ellipsis_invalid.move:10:13
    │
 10 │             ..
-   │             ^ Expected a call argument expression
+   │             ^ Unexpected '..'. Expected a call argument expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_keyword_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_keyword_field.exp
@@ -2,7 +2,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/positional_struct_fields_keyword_field.move:3:23
   │
 3 │     public struct Foo(fun)
-  │                       ^ Expected a type
+  │                       ^ Unexpected 'fun'. Expected a type
 
 error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/positional_struct_fields_keyword_field.move:3:26

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/invalid_deprecation_attributes.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/invalid_deprecation_attributes.exp
@@ -26,7 +26,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/typing/invalid_deprecation_attributes.move:8:18
   │
 8 │     #[deprecated(b"This is a deprecated function")]
-  │                  ^ Expected attribute
+  │                  ^ Unexpected '<ByteString>'. Expected attribute
 
 error[E10004]: invalid usage of known attribute
    ┌─ tests/move_2024/typing/invalid_deprecation_attributes.move:11:7

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_block_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_block_expr.exp
@@ -2,7 +2,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/pack_no_fields_block_expr.move:4:22
   │
 4 │         let _s = S { let x = 0; x };
-  │                      ^ Expected a field expression
+  │                      ^ Unexpected 'let'. Expected a field expression
 
 error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/pack_no_fields_block_expr.move:4:31

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
@@ -8,7 +8,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/pack_no_fields_single_block_expr.move:4:22
   │
 4 │         let _s = S { false };
-  │                      ^ Expected a field expression
+  │                      ^ Unexpected 'false'. Expected a field expression
 
 error[E04016]: too few arguments
   ┌─ tests/move_check/expansion/pack_no_fields_single_block_expr.move:5:18
@@ -20,5 +20,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/pack_no_fields_single_block_expr.move:5:22
   │
 5 │         let _s = S { 0 };
-  │                      ^ Expected a field expression
+  │                      ^ Unexpected '<Number>'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
@@ -53,5 +53,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/pack_no_fields_single_block_other_expr.move:9:22
   │
 9 │         let _g = G { {} };
-  │                      ^ Expected a field expression
+  │                      ^ Unexpected '{'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_block_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_block_expr.exp
@@ -20,7 +20,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/unpack_assign_block_expr.move:4:13
   │
 4 │         S { let f = 0; } = S { f: 0 };
-  │             ^ Expected a field expression
+  │             ^ Unexpected 'let'. Expected a field expression
 
 error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/unpack_assign_block_expr.move:4:22

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_block_single_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_block_single_expr.exp
@@ -8,5 +8,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/expansion/unpack_assign_block_single_expr.move:4:13
   │
 4 │         S { 0 } = S { f: 0 };
-  │             ^ Expected a field expression
+  │             ^ Unexpected '<Number>'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_other_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_other_expr.exp
@@ -73,5 +73,5 @@ error[E01002]: unexpected token
    ┌─ tests/move_check/expansion/unpack_assign_other_expr.move:12:12
    │
 12 │         G {{}} = G{};
-   │            ^ Expected a field expression
+   │            ^ Unexpected '{'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_type_extra_comma.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_type_extra_comma.exp
@@ -2,5 +2,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/parser/function_type_extra_comma.move:2:12
   │
 2 │     fun fn<,T>() { } // Test a comma before the first type parameter
-  │            ^ Expected a type parameter
+  │            ^ Unexpected ','. Expected a type parameter
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
@@ -37,5 +37,5 @@ error[E01002]: unexpected token
    ┌─ tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.move:13:16
    │
 13 │         X::S { 0 } = 0;
-   │                ^ Expected a field expression
+   │                ^ Unexpected '<Number>'. Expected a field expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
@@ -26,7 +26,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:23
   │
 4 │     public struct Foo(fun)
-  │                       ^ Expected a type
+  │                       ^ Unexpected 'fun'. Expected a type
 
 error[E01002]: unexpected token
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:26

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_type_extra_comma.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_type_extra_comma.exp
@@ -2,5 +2,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/parser/struct_type_extra_comma.move:2:14
   │
 2 │     struct S<,T> { f: T } // Test a comma before the first type parameter
-  │              ^ Expected a type parameter
+  │              ^ Unexpected ','. Expected a type parameter
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_comma.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_module_member_invalid_comma.exp
@@ -2,5 +2,5 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/parser/use_module_member_invalid_comma.move:4:26
   │
 4 │     use 0x1::X::{S as XS,,};
-  │                          ^ Expected a module member alias
+  │                          ^ Unexpected ','. Expected a module member alias
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/vector_literal_unclosed_args.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/vector_literal_unclosed_args.exp
@@ -19,7 +19,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/parser/vector_literal_unclosed_args.move:5:5
   │
 5 │     }
-  │     ^ Expected a vector argument expression
+  │     ^ Unexpected '}'. Expected a vector argument expression
 
 error[E01002]: unexpected token
   ┌─ tests/move_check/parser/vector_literal_unclosed_args.move:7:1


### PR DESCRIPTION
## Description 

Match did not end up in the expression start set due to these features growing separately. Now match parses in more places.

This PR also slightly changes parsing error reporting to report what symbol was there in comma list parse failures, allowing for slightly better error reporting(?)

## Test plan 

New tests added.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
