### PR TITLE
[Bridge Node] Introduce new onchain authentication key

### DIFF
--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -552,6 +552,7 @@ pub fn build_committee_register_transaction(
     gas_object_ref: &ObjectRef,
     bridge_object_arg: ObjectArg,
     bridge_authority_pub_key_bytes: Vec<u8>,
+    bridge_authority_network_pub_key_bytes: Option<Vec<u8>>,
     bridge_url: &str,
     ref_gas_price: u64,
     gas_budget: u64,
@@ -564,6 +565,11 @@ pub fn build_committee_register_transaction(
             bcs::to_bytes(&bridge_authority_pub_key_bytes).unwrap(),
         ))
         .unwrap();
+    let bridge_network_pubkey = builder
+        .input(CallArg::Pure(
+            bcs::to_bytes(&bridge_authority_network_pub_key_bytes).unwrap(),
+        ))
+        .unwrap();
     let url = builder
         .input(CallArg::Pure(bcs::to_bytes(bridge_url.as_bytes()).unwrap()))
         .unwrap();
@@ -572,7 +578,13 @@ pub fn build_committee_register_transaction(
         BRIDGE_MODULE_NAME.into(),
         Identifier::from_str("committee_registration").unwrap(),
         vec![],
-        vec![bridge, system_state, bridge_pubkey, url],
+        vec![
+            bridge,
+            system_state,
+            bridge_pubkey,
+            bridge_network_pubkey,
+            url,
+        ],
     );
     let data = TransactionData::new_programmable(
         validator_address,

--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -173,12 +173,19 @@ module bridge::bridge {
         bridge: &mut Bridge,
         system_state: &mut SuiSystemState,
         bridge_pubkey_bytes: vector<u8>,
+        bridge_network_pubkey_bytes: Option<vector<u8>>,
         http_rest_url: vector<u8>,
         ctx: &TxContext
     ) {
         load_inner_mut(bridge)
             .committee
-            .register(system_state, bridge_pubkey_bytes, http_rest_url, ctx);
+            .register(
+                system_state, 
+                bridge_pubkey_bytes,
+                bridge_network_pubkey_bytes,
+                http_rest_url, 
+                ctx,
+            );
     }
 
     public fun update_node_url(bridge: &mut Bridge, new_url: vector<u8>, ctx: &TxContext) {

--- a/crates/sui-framework/packages/bridge/tests/bridge_env.move
+++ b/crates/sui-framework/packages/bridge/tests/bridge_env.move
@@ -131,6 +131,7 @@ module bridge::bridge_env {
     public struct ValidatorInfo has drop {
         validator: address,
         key_pair: KeyPair,
+        network_key_pair: KeyPair,
         stake_amount: u64,
     }
 
@@ -150,6 +151,7 @@ module bridge::bridge_env {
         ValidatorInfo {
             validator,
             key_pair: secp256k1_keypair_from_seed(seed),
+            network_key_pair: secp256k1_keypair_from_seed(seed),
             stake_amount,
         }
     }
@@ -331,6 +333,7 @@ module bridge::bridge_env {
                     bridge.committee_registration(
                         &mut system_state,
                         *validator.key_pair.public_key(),
+                        option::some(*validator.network_key_pair.public_key()),
                         b"",
                         scenario.ctx(),
                     );

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -174,6 +174,9 @@ pub enum SuiValidatorCommand {
         /// Path to Bridge Authority Key file.
         #[clap(long)]
         bridge_authority_key_path: PathBuf,
+        /// Path to Bridge Authority Network Key file.
+        #[clap(long)]
+        bridge_authority_network_key_path: Option<PathBuf>,
         /// Bridge authority URL which clients collects action signatures from.
         #[clap(long)]
         bridge_authority_url: String,
@@ -505,6 +508,7 @@ impl SuiValidatorCommand {
             }
             SuiValidatorCommand::RegisterBridgeCommittee {
                 bridge_authority_key_path,
+                bridge_authority_network_key_path,
                 bridge_authority_url,
                 print_unsigned_transaction_only,
                 validator_address,
@@ -523,6 +527,13 @@ impl SuiValidatorCommand {
                     SuiKeyPair::Secp256k1(key) => key,
                     _ => unreachable!("we required secp256k1 key in `read_key`"),
                 };
+                // Read bridge network keypair
+                let ecdsa_network_keypair = bridge_authority_network_key_path.map(|path| {
+                    match read_key(&bridge_authority_network_key_path, true)? {
+                        SuiKeyPair::Secp256k1(key) => key,
+                        _ => unreachable!("we required secp256k1 key in `read_key`"),
+                    }
+                });
                 let address = check_address(
                     context.active_address()?,
                     validator_address,
@@ -559,6 +570,7 @@ impl SuiValidatorCommand {
                     &gas.object_ref(),
                     bridge,
                     ecdsa_keypair.public().as_bytes().to_vec(),
+                    ecdsa_network_keypair.map(|keypair| public().as_bytes().to_vec()),
                     &bridge_authority_url,
                     gas_price,
                     gas_budget,


### PR DESCRIPTION
## Description 

Introducing new onchain ECDSA key to be used for client authentication schemes. Can provide more details on demand

## Test plan 

Included tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
