### PR TITLE
[graphql] add query epochs functionality

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.exp
@@ -1,0 +1,145 @@
+processed 17 tasks
+
+init:
+C: object(0,0)
+
+task 1, line 7:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 2, lines 9-11:
+//# advance-epoch
+Epoch advanced: 0
+
+task 3, line 12:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 4, lines 14-17:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 18:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 6, line 20:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, line 22:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 8, line 24:
+//# advance-epoch
+Epoch advanced: 3
+
+task 9, line 26:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 10, line 28:
+//# advance-epoch
+Epoch advanced: 4
+
+task 11, line 30:
+//# create-checkpoint
+Checkpoint created: 11
+
+task 12, line 32:
+//# advance-epoch
+Epoch advanced: 5
+
+task 13, lines 34-45:
+//# run-graphql 
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "nodes": [
+        {
+          "epochId": 4
+        },
+        {
+          "epochId": 5
+        }
+      ]
+    }
+  }
+}
+
+task 14, lines 47-58:
+//# run-graphql 
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "nodes": [
+        {
+          "epochId": 0
+        },
+        {
+          "epochId": 1
+        },
+        {
+          "epochId": 2
+        }
+      ]
+    }
+  }
+}
+
+task 15, lines 60-71:
+//# run-graphql --cursors {"c":5,"e":2} 
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "nodes": [
+        {
+          "epochId": 0
+        },
+        {
+          "epochId": 1
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 73-84:
+//# run-graphql --cursors {"c":11,"e":1}
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "nodes": [
+        {
+          "epochId": 2
+        },
+        {
+          "epochId": 3
+        },
+        {
+          "epochId": 4
+        },
+        {
+          "epochId": 5
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.exp
@@ -1,57 +1,33 @@
-processed 17 tasks
+processed 15 tasks
 
 init:
 C: object(0,0)
 
-task 1, line 7:
-//# create-checkpoint
-Checkpoint created: 1
-
-task 2, lines 9-11:
+task 1, line 6:
 //# advance-epoch
 Epoch advanced: 0
 
-task 3, line 12:
-//# create-checkpoint
-Checkpoint created: 3
-
-task 4, lines 14-17:
+task 2, line 8:
 //# advance-epoch
 Epoch advanced: 1
 
-task 5, line 18:
-//# create-checkpoint
-Checkpoint created: 5
-
-task 6, line 20:
+task 3, line 10:
 //# advance-epoch
 Epoch advanced: 2
 
-task 7, line 22:
-//# create-checkpoint
-Checkpoint created: 7
-
-task 8, line 24:
+task 4, line 12:
 //# advance-epoch
 Epoch advanced: 3
 
-task 9, line 26:
-//# create-checkpoint
-Checkpoint created: 9
-
-task 10, line 28:
+task 5, line 14:
 //# advance-epoch
 Epoch advanced: 4
 
-task 11, line 30:
-//# create-checkpoint
-Checkpoint created: 11
-
-task 12, line 32:
+task 6, line 16:
 //# advance-epoch
 Epoch advanced: 5
 
-task 13, lines 34-45:
+task 7, lines 18-29:
 //# run-graphql 
 Response: {
   "data": {
@@ -72,7 +48,7 @@ Response: {
   }
 }
 
-task 14, lines 47-58:
+task 8, lines 31-42:
 //# run-graphql 
 Response: {
   "data": {
@@ -96,7 +72,7 @@ Response: {
   }
 }
 
-task 15, lines 60-71:
+task 9, lines 44-55:
 //# run-graphql --cursors {"c":5,"e":2} 
 Response: {
   "data": {
@@ -117,7 +93,31 @@ Response: {
   }
 }
 
-task 16, lines 73-84:
+task 10, lines 57-68:
+//# run-graphql --cursors {"c":3,"e":4} 
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "nodes": [
+        {
+          "epochId": 0
+        },
+        {
+          "epochId": 1
+        },
+        {
+          "epochId": 2
+        }
+      ]
+    }
+  }
+}
+
+task 11, lines 70-81:
 //# run-graphql --cursors {"c":11,"e":1}
 Response: {
   "data": {
@@ -138,8 +138,57 @@ Response: {
         },
         {
           "epochId": 5
+        },
+        {
+          "epochId": 6
         }
       ]
+    }
+  }
+}
+
+task 12, lines 83-94:
+//# run-graphql --cursors {"c":0,"e":5}
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "nodes": [
+        {
+          "epochId": 0
+        }
+      ]
+    }
+  }
+}
+
+task 13, lines 96-107:
+//# run-graphql --cursors {"c":3,"e":4}
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "nodes": []
+    }
+  }
+}
+
+task 14, lines 109-120:
+//# run-graphql --cursors {"c":0,"e":0}
+Response: {
+  "data": {
+    "epochs": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "nodes": []
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.move
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 51 --simulator --accounts C
+
+// TODO: Short term hack to get around indexer epoch issue
+//# create-checkpoint
+
+//# advance-epoch
+
+// TODO: Short term hack to get around indexer epoch issue
+//# create-checkpoint
+
+//# advance-epoch
+
+
+// TODO: Short term hack to get around indexer epoch issue
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql 
+{
+    epochs(last:2) {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
+//# run-graphql 
+{
+    epochs(first:3) {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
+//# run-graphql --cursors {"c":5,"e":2} 
+{
+    epochs(before: "@{cursor_0}") {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
+//# run-graphql --cursors {"c":11,"e":1}
+{
+    epochs(after: "@{cursor_0}") {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.move
@@ -3,31 +3,15 @@
 
 //# init --protocol-version 51 --simulator --accounts C
 
-// TODO: Short term hack to get around indexer epoch issue
-//# create-checkpoint
+//# advance-epoch
 
 //# advance-epoch
 
-// TODO: Short term hack to get around indexer epoch issue
-//# create-checkpoint
+//# advance-epoch
 
 //# advance-epoch
 
-
-// TODO: Short term hack to get around indexer epoch issue
-//# create-checkpoint
-
 //# advance-epoch
-
-//# create-checkpoint
-
-//# advance-epoch
-
-//# create-checkpoint
-
-//# advance-epoch
-
-//# create-checkpoint
 
 //# advance-epoch
 
@@ -70,7 +54,59 @@
     }
 }
 
+//# run-graphql --cursors {"c":3,"e":4} 
+{
+    epochs(before: "@{cursor_0}") {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
 //# run-graphql --cursors {"c":11,"e":1}
+{
+    epochs(after: "@{cursor_0}") {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
+//# run-graphql --cursors {"c":0,"e":5}
+{
+    epochs(before: "@{cursor_0}") {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
+//# run-graphql --cursors {"c":3,"e":4}
+{
+    epochs(after: "@{cursor_0}") {
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+        }
+        nodes {
+            epochId
+        }
+    }
+}
+
+//# run-graphql --cursors {"c":0,"e":0}
 {
     epochs(after: "@{cursor_0}") {
         pageInfo {

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -1200,6 +1200,35 @@ type Epoch {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
 }
 
+type EpochConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EpochEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Epoch!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EpochEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Epoch!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Event {
 	"""
 	The Move module containing some function that when called by
@@ -3306,6 +3335,7 @@ type Query {
 	`0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	epochs(first: Int, after: String, last: Int, before: String): EpochConnection!
 	"""
 	The checkpoints that exist in the network.
 	"""

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -29,7 +29,7 @@ use super::{
     cursor::Page,
     digest::Digest,
     dry_run_result::DryRunResult,
-    epoch::Epoch,
+    epoch::{self, Epoch},
     event::{self, Event, EventFilter},
     move_type::MoveType,
     object::{self, Object, ObjectFilter},
@@ -354,6 +354,23 @@ impl Query {
         )
         .await
         .extend()
+    }
+
+    // The epochs of the network
+    async fn epochs(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<epoch::Cursor>,
+        last: Option<u64>,
+        before: Option<epoch::Cursor>,
+    ) -> Result<Connection<String, Epoch>> {
+        let Watermark { checkpoint, .. } = *ctx.data()?;
+
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        Epoch::paginate(ctx.data_unchecked(), page, checkpoint)
+            .await
+            .extend()
     }
 
     /// The checkpoints that exist in the network.

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -1205,6 +1205,35 @@ type Epoch {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
 }
 
+type EpochConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EpochEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Epoch!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EpochEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Epoch!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Event {
 	"""
 	The Move module containing some function that when called by
@@ -3311,6 +3340,7 @@ type Query {
 	`0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	epochs(first: Int, after: String, last: Int, before: String): EpochConnection!
 	"""
 	The checkpoints that exist in the network.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -1204,6 +1204,35 @@ type Epoch {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
 }
 
+type EpochConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EpochEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Epoch!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EpochEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Epoch!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Event {
 	"""
 	The Move module containing some function that when called by
@@ -3310,6 +3339,7 @@ type Query {
 	`0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	epochs(first: Int, after: String, last: Int, before: String): EpochConnection!
 	"""
 	The checkpoints that exist in the network.
 	"""
@@ -4795,4 +4825,3 @@ schema {
 	query: Query
 	mutation: Mutation
 }
-

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -1209,6 +1209,35 @@ type Epoch {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
 }
 
+type EpochConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EpochEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Epoch!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EpochEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Epoch!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Event {
 	"""
 	The Move module containing some function that when called by
@@ -3315,6 +3344,7 @@ type Query {
 	`0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	epochs(first: Int, after: String, last: Int, before: String): EpochConnection!
 	"""
 	The checkpoints that exist in the network.
 	"""
@@ -4812,4 +4842,3 @@ schema {
 	query: Query
 	mutation: Mutation
 }
-


### PR DESCRIPTION
## Description 

Implementation of paginated query for epochs in GraphQL

## Test plan 

How did you test the new or updated feature?

Added a pagination.move test under the sui-graphql-e2e-tests crate.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: 
Added support for paginated queries for epochs. This allows users to fetch epochs data in a paginated format.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
