### PR TITLE
[indexer] Introduce watermarks table

### DIFF
--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -32,7 +32,7 @@ See the [docs](https://docs.sui.io/guides/developer/getting-started/local-networ
 
 Start a local network using the `sui` binary:
 ```sh
-cargo run --bin sui -- start --with-faucet --force-regenesis 
+cargo run --bin sui -- start --with-faucet --force-regenesis
 ```
 
 If you want to run a local network with the indexer enabled (note that `libpq` is required), you can run the following command after following the steps in the next section to set up an indexer DB:
@@ -124,3 +124,9 @@ Note that you need an existing database for this to work. Using the DATABASE_URL
 # Change the RPC_CLIENT_URL to http://0.0.0.0:9000 to run indexer against local validator & fullnode
 cargo run --bin sui-indexer --features mysql-feature --no-default-features -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker --reset-db
 ```
+
+### Extending the indexer
+
+To add a new table, run `diesel migration generate your_table_name`, and modify the newly created `up.sql` and `down.sql` files.
+
+You would apply the migration with `diesel migration run`, and run the script in `./scripts/generate_indexer_schema.sh` to update the `schema.rs` file.

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS watermarks;

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
@@ -27,8 +27,8 @@ CREATE TABLE watermarks
     -- that all in-flight reads complete or timeout before it acts on an updated watermark.
     timestamp_ms                BIGINT        NOT NULL,
     -- Pruner updates this, and uses this when recovering from a crash to determine where to
-    -- continue pruning. Data below `pruned_lo` is considered pruned by the pruner. Has the same
-    -- unit as `lo`.
+    -- continue pruning. Data at and below `pruned_lo` is considered pruned by the pruner. Has the
+    -- same unit as `lo`.
     pruned_lo                   BIGINT,
     PRIMARY KEY (entity)
 );

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE watermarks
+(
+    -- The table name of group of tables governed by this watermark, i.e `epochs`, `checkpoints`,
+    -- `transactions`. For example, `transactions` governs the `transactions` table and associated
+    -- lookup tables.
+    entity                      TEXT          NOT NULL,
+    -- Inclusive upper bound epoch this entity has data for. Committer updates this field. Pruner
+    -- uses this field for per-entity epoch-level retention, and is mostly useful for pruning
+    -- unpartitioned tables.
+    epoch_hi                    BIGINT        NOT NULL,
+    -- Inclusive lower bound epoch this entity has data for. Pruner updates this field, and uses
+    -- this field in tandem with `epoch_hi` for per-entity epoch-level retention. This is mostly
+    -- useful for pruning unpartitioned tables.
+    epoch_lo                    BIGINT        NOT NULL,
+    -- Inclusive upper bound checkpoint this entity has data for. Committer updates this field. All
+    -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
+    -- committer or ingestion task refers to this on disaster recovery.
+    checkpoint_hi               BIGINT        NOT NULL,
+    -- Inclusive high watermark that the committer advances. For `checkpoints`, this represents the
+    -- checkpoint sequence number, for `transactions`, the transaction sequence number, etc.
+    hi                          BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Data before this watermark is considered
+    -- pruned by a reader.
+    lo                          BIGINT        NOT NULL,
+    -- Updated using the database's current timestamp when the pruner sees that some data needs to
+    -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
+    -- that all in-flight reads complete or timeout before it acts on an updated watermark.
+    timestamp_ms                BIGINT        NOT NULL,
+    -- Pruner updates this, and uses this when recovering from a crash to determine where to
+    -- continue pruning. Data below `pruned_lo` is considered pruned by the pruner. Has the same
+    -- unit as `lo`.
+    pruned_lo                   BIGINT,
+    PRIMARY KEY (entity)
+);

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
@@ -20,15 +20,15 @@ CREATE TABLE watermarks
     -- checkpoint sequence number, for `transactions`, the transaction sequence number, etc.
     hi                          BIGINT        NOT NULL,
     -- Inclusive low watermark that the pruner advances. Data before this watermark is considered
-    -- pruned by a reader.
+    -- pruned by a reader. The underlying data may still exist in the db instance.
     lo                          BIGINT        NOT NULL,
     -- Updated using the database's current timestamp when the pruner sees that some data needs to
     -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
     -- that all in-flight reads complete or timeout before it acts on an updated watermark.
     timestamp_ms                BIGINT        NOT NULL,
     -- Pruner updates this, and uses this when recovering from a crash to determine where to
-    -- continue pruning. Data at and below `pruned_lo` is considered pruned by the pruner. Has the
-    -- same unit as `lo`.
+    -- continue pruning. Data at and below `pruned_lo` is considered pruned by the pruner, and
+    -- should not exist in the db. Has the same unit as `lo`.
     pruned_lo                   BIGINT,
     PRIMARY KEY (entity)
 );

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
@@ -26,9 +26,9 @@ CREATE TABLE watermarks
     -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
     -- that all in-flight reads complete or timeout before it acts on an updated watermark.
     timestamp_ms                BIGINT        NOT NULL,
-    -- Pruner updates this, and uses this when recovering from a crash to determine where to
-    -- continue pruning. Data at and below `pruned_lo` is considered pruned by the pruner, and
-    -- should not exist in the db. Has the same unit as `lo`.
+    -- Column used by the pruner to track its true progress. Data at and below this watermark has
+    -- been truly pruned from the db, and should no longer exist. When recovering from a crash, the
+    -- pruner will consult this column to determine where to continue.
     pruned_lo                   BIGINT,
     PRIMARY KEY (entity)
 );

--- a/crates/sui-indexer/migrations/pg/2024-09-27-233849_add_first_tx_sequence_number_to_epochs/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-27-233849_add_first_tx_sequence_number_to_epochs/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE epochs
+DROP COLUMN first_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-27-233849_add_first_tx_sequence_number_to_epochs/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-27-233849_add_first_tx_sequence_number_to_epochs/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE epochs
+ADD COLUMN first_tx_sequence_number BIGINT;

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -192,6 +192,7 @@ impl CheckpointHandler {
                 new_epoch: IndexedEpochInfo::from_new_system_state_summary(
                     system_state_summary,
                     0, //first_checkpoint_id
+                    0, // first_tx_sequence_number
                     None,
                 ),
                 network_total_transactions: 0,
@@ -248,6 +249,7 @@ impl CheckpointHandler {
             new_epoch: IndexedEpochInfo::from_new_system_state_summary(
                 system_state_summary,
                 checkpoint_summary.sequence_number + 1, // first_checkpoint_id
+                network_tx_count_prev_epoch,
                 Some(&event),
             ),
             network_total_transactions: checkpoint_summary.network_total_transactions,

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -3,10 +3,13 @@
 
 use std::collections::HashMap;
 use std::time::Duration;
+
+use mysten_metrics::spawn_monitored_task;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use crate::errors::IndexerError;
+use crate::models::watermarks::{Watermark, WatermarkEntity, WatermarkRead};
 use crate::store::pg_partition_manager::PgPartitionManager;
 use crate::store::PgIndexerStore;
 use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
@@ -38,61 +41,53 @@ impl Pruner {
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
-        let mut last_seen_max_epoch = 0;
+        // Spawn a separate task to continuously update the watermarks for the reader. We can't
+        // reliably update watermarks while we're in the middle of a pruning operation. This is
+        // because the pruning operation itself may take a considerable amount of time, during which
+        // the system state could change significantly. Pruner prunes on the main thread to limit
+        // concurrency.
+        let store_clone = self.store.clone();
+        let epochs_to_keep = self.epochs_to_keep;
+        let cancel_clone = cancel.clone();
+        spawn_monitored_task!(update_watermarks_lower_bounds_task(
+            store_clone,
+            epochs_to_keep,
+            cancel_clone
+        ));
+
+        // Similarly, handle epoch-partitioned tables in a separate task, so that the main thread
+        // can focus on the slowest pruning operation.
+        let store_clone = self.store.clone();
+        let partition_manager = self.partition_manager.clone();
+        let cancel_clone = cancel.clone();
+        spawn_monitored_task!(prune_epoch_partitioned_tables_task(
+            store_clone,
+            partition_manager,
+            cancel_clone.clone(),
+        ));
+
+        let mut epoch_watermark =
+            get_and_update_watermarks_epoch(&self.store, self.epochs_to_keep).await?;
+        let mut last_seen_max_epoch = epoch_watermark.reader_hi();
         // The first epoch that has not yet been pruned.
         let mut next_prune_epoch = None;
         while !cancel.is_cancelled() {
-            let (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
-            if max_epoch == last_seen_max_epoch {
+            // TODO: (wlmyng) pruner advances based on the epoch table
+            if !should_prune(&epoch_watermark) {
                 tokio::time::sleep(Duration::from_secs(5)).await;
+                epoch_watermark =
+                    get_and_update_watermarks_epoch(&self.store, self.epochs_to_keep).await?;
                 continue;
             }
-            last_seen_max_epoch = max_epoch;
 
-            // Not all partitioned tables are epoch-partitioned, so we need to filter them out.
-            let table_partitions: HashMap<_, _> = self
-                .partition_manager
-                .get_table_partitions()
-                .await?
-                .into_iter()
-                .filter(|(table_name, _)| {
-                    self.partition_manager
-                        .get_strategy(table_name)
-                        .is_epoch_partitioned()
-                })
-                .collect();
+            println!("should prune, watermark: {:?}", epoch_watermark);
 
-            for (table_name, (min_partition, max_partition)) in &table_partitions {
-                if last_seen_max_epoch != *max_partition {
-                    error!(
-                        "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
-                        table_name, last_seen_max_epoch, max_partition
-                    );
-                }
+            wait_for_prune_delay(&epoch_watermark, &cancel, 1000).await?;
 
-                let epochs_to_keep = if table_name == "objects_history" {
-                    OBJECTS_HISTORY_EPOCHS_TO_KEEP
-                } else {
-                    self.epochs_to_keep
-                };
-                for epoch in *min_partition..last_seen_max_epoch.saturating_sub(epochs_to_keep - 1)
-                {
-                    if cancel.is_cancelled() {
-                        info!("Pruner task cancelled.");
-                        return Ok(());
-                    }
-                    self.partition_manager
-                        .drop_table_partition(table_name.clone(), epoch)
-                        .await?;
-                    info!(
-                        "Batch dropped table partition {} epoch {}",
-                        table_name, epoch
-                    );
-                }
-            }
+            last_seen_max_epoch = epoch_watermark.reader_hi();
 
             let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
-            let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
+            let prune_start_epoch = next_prune_epoch.unwrap_or(epoch_watermark.pruner_lo());
             for epoch in prune_start_epoch..prune_to_epoch {
                 if cancel.is_cancelled() {
                     info!("Pruner task cancelled.");
@@ -110,5 +105,189 @@ impl Pruner {
         }
         info!("Pruner task cancelled.");
         Ok(())
+    }
+}
+
+/// Check if the lowest epoch of unpruned data exceeds the retention policy.
+fn should_update_watermark(watermark: &WatermarkRead, epochs_to_keep: u64) -> bool {
+    watermark.epoch_lo + epochs_to_keep <= watermark.epoch_hi
+}
+
+/// Determine if pruning should occur based on the current watermark state. When an entity's `hi`
+/// and `lo` (`reader_lo`) watermarks are updated to reflect the latest data range, if the
+/// `reader_lo` value is at least 1 greater than `pruned_lo`, then the pruner should prune. When
+/// `lo` is updated, and `pruned_lo` is still unset, that also means the pruner should start
+/// pruning.
+fn should_prune(watermark: &WatermarkRead) -> bool {
+    match watermark.pruned_lo {
+        None => watermark.reader_lo() > 0,
+        Some(pruned_lo) => watermark.reader_lo() > pruned_lo + 1,
+    }
+}
+
+/// Fetch epoch watermark and updates lower bounds for all watermarks for readers. Refetch to get
+/// the timestamp from db.
+async fn get_and_update_watermarks_epoch(
+    store: &PgIndexerStore,
+    epochs_to_keep: u64,
+) -> IndexerResult<WatermarkRead> {
+    let watermark = store.get_available_epoch_range().await?;
+    if should_update_watermark(&watermark, epochs_to_keep) {
+        let new_epoch_bound = watermark.epoch_hi.saturating_sub(epochs_to_keep - 1);
+        let (cp, tx) = store.get_min_cp_and_tx_for_epoch(new_epoch_bound).await?;
+        store
+            .update_watermarks(Watermark::new_lower_bounds(new_epoch_bound, cp, tx))
+            .await?;
+        info!("Finished updating lower bounds for watermarks");
+        // We refetch to use the database's timestamp
+        Ok(store.get_available_epoch_range().await?)
+    } else {
+        Ok(watermark)
+    }
+}
+
+/// Fetches all entries from the `watermarks` table, and updates the lower bounds for all watermarks
+/// if the entry's epoch range exceeds the respective retention policy.
+async fn update_watermarks_lower_bounds(
+    store: &PgIndexerStore,
+    epochs_to_keep: u64,
+) -> IndexerResult<()> {
+    let watermarks = store.get_watermarks().await?;
+    let mut lower_bound_updates = vec![];
+
+    for (key, value) in watermarks.iter() {
+        let epochs_to_keep = if key.as_str() == "objects_history" {
+            OBJECTS_HISTORY_EPOCHS_TO_KEEP
+        } else {
+            epochs_to_keep
+        };
+
+        // We should update the watermarks and prepare for pruning
+        if should_update_watermark(value, epochs_to_keep) {
+            let new_inclusive_epoch_lower_bound = value.epoch_hi.saturating_sub(epochs_to_keep - 1);
+            // TODO: (wlmyng) don't rely on `checkpoints` table
+            let (cp, tx) = store
+                .get_min_cp_and_tx_for_epoch(new_inclusive_epoch_lower_bound)
+                .await?;
+            let new_lo = match key {
+                WatermarkEntity::ObjectsHistory | WatermarkEntity::Checkpoints => cp,
+                WatermarkEntity::Transactions | WatermarkEntity::Events => tx,
+                WatermarkEntity::Epochs => new_inclusive_epoch_lower_bound,
+            };
+            lower_bound_updates.push(Watermark::lower_bound(
+                *key,
+                new_inclusive_epoch_lower_bound,
+                new_lo,
+            ));
+        }
+    }
+
+    if !lower_bound_updates.is_empty() {
+        store.update_watermarks(lower_bound_updates).await?;
+        info!("Finished updating lower bounds for watermarks");
+    }
+
+    Ok(())
+}
+
+/// Pruner waits for some time before pruning to ensure that in-flight reads complete or timeout
+/// before the underlying data is pruned.
+async fn wait_for_prune_delay(
+    watermark: &WatermarkRead,
+    cancel: &CancellationToken,
+    delay_amount: i64,
+) -> IndexerResult<()> {
+    let current_time = chrono::Utc::now().timestamp_millis();
+    let delay = (watermark.timestamp_ms + delay_amount - current_time).max(0) as u64;
+
+    if delay > 0 {
+        info!("Waiting for {}ms before pruning", delay);
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(delay)) => Ok(()),
+            _ = cancel.cancelled() => {
+                info!("Pruning cancelled during delay");
+                Ok(())
+            }
+        }
+    } else {
+        Ok(())
+    }
+}
+
+/// Task to periodically query the `watermarks` table and update the lower bounds for all watermarks
+/// if the entry exceeds epoch-level retention policy.
+async fn update_watermarks_lower_bounds_task(
+    store: PgIndexerStore,
+    epochs_to_keep: u64,
+    cancel: CancellationToken,
+) -> IndexerResult<()> {
+    loop {
+        if cancel.is_cancelled() {
+            info!("Pruner watermark lower bound update task cancelled.");
+            return Ok(());
+        }
+
+        update_watermarks_lower_bounds(&store, epochs_to_keep).await?;
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+/// A task that queries `watermarks` table for the source of truth for the epoch range, and drops
+/// older partitions up to but not including `watermark.epoch_lo`.
+async fn prune_epoch_partitioned_tables_task(
+    store: PgIndexerStore,
+    partition_manager: PgPartitionManager,
+    cancel: CancellationToken,
+) -> IndexerResult<()> {
+    loop {
+        if cancel.is_cancelled() {
+            info!("Pruner prune_epoch_partitioned_tables_task cancelled.");
+            return Ok(());
+        }
+
+        let watermarks = store.get_watermarks().await?;
+
+        // Not all partitioned tables are epoch-partitioned, so we need to filter them out.
+        let table_partitions: HashMap<_, _> = partition_manager
+            .get_table_partitions()
+            .await?
+            .into_iter()
+            .filter(|(table_name, _)| {
+                partition_manager
+                    .get_strategy(table_name)
+                    .is_epoch_partitioned()
+            })
+            .collect();
+
+        // `watermarks` table is the source of truth for the epoch range. The partitions to drop are
+        // `[min_partition, watermark.epoch_lo)`
+        for (table_name, (min_partition, _)) in &table_partitions {
+            let Some(lookup) = WatermarkEntity::from_str(table_name) else {
+                println!(
+                    "could not convert table name to WatermarkEntity: {}",
+                    table_name
+                );
+                continue;
+            };
+
+            let Some(entry) = watermarks.get(&lookup) else {
+                println!("coudl not find entity in watermarks: {:?}", lookup);
+                continue;
+            };
+
+            wait_for_prune_delay(&entry, &cancel, 1000).await?;
+
+            for epoch in *min_partition..entry.epoch_lo {
+                if cancel.is_cancelled() {
+                    info!("Pruner prune_epoch_partitioned_tables_task task cancelled.");
+                    return Ok(());
+                }
+                partition_manager
+                    .drop_table_partition(table_name.clone(), epoch)
+                    .await?;
+                info!("Dropped table partition {} epoch {}", table_name, epoch);
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
     }
 }

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -125,7 +125,9 @@ fn should_prune(watermark: &WatermarkRead) -> bool {
 }
 
 /// Pruner waits for some time before pruning to ensure that in-flight reads complete or timeout
-/// before the underlying data is pruned.
+/// before the underlying data is pruned. While waiting, it is possible that the valid data range
+/// further shifts into the future. Callers of this function can still proceed with pruning because
+/// the data to prune must be much staler than any data accessible by readers.
 async fn wait_for_prune_delay(
     watermark: &WatermarkRead,
     cancel: &CancellationToken,

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -125,6 +125,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_tx_indices_chunks: Histogram,
     pub checkpoint_db_commit_latency_checkpoints: Histogram,
     pub checkpoint_db_commit_latency_epoch: Histogram,
+    pub checkpoint_db_commit_latency_watermarks: Histogram,
     pub thousand_transaction_avg_db_commit_latency: Histogram,
     pub object_db_commit_latency: Histogram,
     pub object_mutation_db_commit_latency: Histogram,
@@ -532,6 +533,13 @@ impl IndexerMetrics {
             checkpoint_db_commit_latency_epoch: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_epochs",
                 "Time spent committing epochs",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            checkpoint_db_commit_latency_watermarks: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_watermarks",
+                "Time spent committing watermarks",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-indexer/src/models/epoch.rs
+++ b/crates/sui-indexer/src/models/epoch.rs
@@ -8,7 +8,7 @@ use diesel::{Insertable, Queryable, Selectable};
 use sui_json_rpc_types::{EndOfEpochInfo, EpochInfo};
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Debug, Clone, Default, Selectable)]
 #[diesel(table_name = epochs)]
 pub struct StoredEpochInfo {
     pub epoch: i64,
@@ -32,6 +32,7 @@ pub struct StoredEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
     /// This is the system state summary at the beginning of the epoch, serialized as JSON.
     pub system_state_summary_json: Option<serde_json::Value>,
+    pub first_tx_sequence_number: Option<i64>,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -87,6 +88,7 @@ impl StoredEpochInfo {
                 serde_json::to_value(e.system_state_summary.clone()).unwrap(),
             ),
             first_checkpoint_id: e.first_checkpoint_id as i64,
+            first_tx_sequence_number: Some(e.first_tx_sequence_number as i64),
             epoch_start_timestamp: e.epoch_start_timestamp as i64,
             reference_gas_price: e.reference_gas_price as i64,
             protocol_version: e.protocol_version as i64,
@@ -107,6 +109,7 @@ impl StoredEpochInfo {
             system_state_summary_json: None,
             epoch_total_transactions: e.epoch_total_transactions.map(|v| v as i64),
             last_checkpoint_id: e.last_checkpoint_id.map(|v| v as i64),
+            first_tx_sequence_number: Some(e.first_tx_sequence_number as i64),
             epoch_end_timestamp: e.epoch_end_timestamp.map(|v| v as i64),
             storage_fund_reinvestment: e.storage_fund_reinvestment.map(|v| v as i64),
             storage_charge: e.storage_charge.map(|v| v as i64),

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -12,3 +12,4 @@ pub mod packages;
 pub mod raw_checkpoints;
 pub mod transactions;
 pub mod tx_indices;
+pub mod watermarks;

--- a/crates/sui-indexer/src/models/watermarks.rs
+++ b/crates/sui-indexer/src/models/watermarks.rs
@@ -1,0 +1,214 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::watermarks::{self};
+use diesel::prelude::*;
+
+/// Represents a row in the `watermarks` table.
+#[derive(Queryable, Insertable, Default, QueryableByName)]
+#[diesel(table_name = watermarks, primary_key(entity))]
+pub struct StoredWatermark {
+    /// The table name of group of tables governed by this watermark, i.e `epochs`, `checkpoints`,
+    /// `transactions`.
+    pub entity: String,
+    /// Upper bound epoch range to enable per-entity epoch-level retention policy. Committer
+    /// advances this along with `high`.
+    pub epoch_hi: i64,
+    /// Lower bound epoch range to enable per-entity epoch-level retention policy. Pruner advances
+    /// this.
+    pub epoch_lo: i64,
+    pub checkpoint_hi: i64,
+    /// The inclusive high watermark that the committer advances.
+    pub hi: i64,
+    /// The inclusive low watermark that the pruner advances. Data before this watermark is
+    /// considered pruned.
+    pub lo: i64,
+    /// Pruner sets this, and uses this column to determine whether to prune or wait long enough
+    /// that all in-flight reads complete or timeout before it acts on an updated watermark.
+    pub timestamp_ms: i64,
+    /// Pruner updates this, and uses this when recovering from a crash to determine where to
+    /// continue pruning. Represents the latest watermark pruned, inclusive.
+    pub pruned_lo: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub enum WatermarkEntity {
+    Checkpoints,
+    Epochs,
+    Events,
+    ObjectsHistory,
+    Transactions,
+}
+
+pub struct Watermark {
+    pub entity: WatermarkEntity,
+    pub update: WatermarkUpdate,
+}
+
+pub enum WatermarkUpdate {
+    /// The subset of fields that the committer updates.
+    UpperBound { epoch_hi: u64, hi: u64 },
+    /// The subset of fields that the pruner updates.
+    LowerBound { epoch_lo: u64, lo: u64 },
+    /// Pruner logs its progress to this field. Uses this when recovering from a crash to determine
+    /// where to continue pruning. Represents the latest watermark pruned, inclusive.
+    LowerBoundTail { pruned_lo: u64 },
+}
+
+#[derive(Eq, Hash, PartialEq)]
+pub enum WatermarkUpdateType {
+    UpperBound,
+    LowerBound,
+    LowerBoundTail,
+}
+
+#[derive(Debug)]
+pub struct WatermarkRead {
+    pub entity: WatermarkEntity,
+    pub epoch_hi: u64,
+    pub epoch_lo: u64,
+    pub hi: u64,
+    pub lo: u64,
+    pub timestamp_ms: i64,
+    pub pruned_lo: Option<u64>,
+}
+
+impl WatermarkRead {
+    /// Returns the inclusive high watermark that the reader should use.
+    pub fn reader_hi(&self) -> u64 {
+        self.hi
+    }
+
+    /// Returns the inclusive low watermark that the reader should use.
+    pub fn reader_lo(&self) -> u64 {
+        self.lo
+    }
+
+    /// Returns the lowest watermark of unpruned data that the pruner should use. If `pruned_lo` is
+    /// not set, defaults to 0. This should be at most `reader_lo - 1`, never equal to `reader_lo`
+    /// because that data should not be pruned yet.
+    pub fn pruner_lo(&self) -> u64 {
+        self.pruned_lo.unwrap_or(0)
+    }
+}
+
+impl WatermarkEntity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WatermarkEntity::Transactions => "transactions",
+            WatermarkEntity::ObjectsHistory => "objects_history",
+            WatermarkEntity::Checkpoints => "checkpoints",
+            WatermarkEntity::Epochs => "epochs",
+            WatermarkEntity::Events => "events",
+        }
+    }
+
+    pub fn from_str(entity: &str) -> Option<Self> {
+        match entity {
+            "transactions" => Some(WatermarkEntity::Transactions),
+            "objects_history" => Some(WatermarkEntity::ObjectsHistory),
+            "checkpoints" => Some(WatermarkEntity::Checkpoints),
+            "epochs" => Some(WatermarkEntity::Epochs),
+            "events" => Some(WatermarkEntity::Events),
+            _ => None,
+        }
+    }
+}
+
+impl Watermark {
+    pub fn upper_bound(entity: WatermarkEntity, epoch_hi: u64, hi: u64) -> Self {
+        Watermark {
+            entity,
+            update: WatermarkUpdate::UpperBound { epoch_hi, hi },
+        }
+    }
+
+    pub fn lower_bound(entity: WatermarkEntity, epoch_lo: u64, lo: u64) -> Self {
+        Watermark {
+            entity,
+            update: WatermarkUpdate::LowerBound { epoch_lo, lo },
+        }
+    }
+
+    pub fn new_lower_bound_tail(entity: WatermarkEntity, pruned_lo: u64) -> Self {
+        Watermark {
+            entity,
+            update: WatermarkUpdate::LowerBoundTail { pruned_lo },
+        }
+    }
+
+    pub fn new_upper_bounds(epoch_hi: u64, cp_hi: u64, tx_hi: u64) -> Vec<Watermark> {
+        vec![
+            Watermark::upper_bound(WatermarkEntity::Checkpoints, epoch_hi, cp_hi),
+            Watermark::upper_bound(WatermarkEntity::Epochs, epoch_hi, epoch_hi),
+            Watermark::upper_bound(WatermarkEntity::Events, epoch_hi, tx_hi),
+            Watermark::upper_bound(WatermarkEntity::ObjectsHistory, epoch_hi, cp_hi),
+            Watermark::upper_bound(WatermarkEntity::Transactions, epoch_hi, tx_hi),
+        ]
+    }
+
+    pub fn new_lower_bounds(epoch_lo: u64, cp_lo: u64, tx_lo: u64) -> Vec<Watermark> {
+        vec![
+            Watermark::lower_bound(WatermarkEntity::Checkpoints, epoch_lo, cp_lo),
+            Watermark::lower_bound(WatermarkEntity::Epochs, epoch_lo, epoch_lo),
+            Watermark::lower_bound(WatermarkEntity::Events, epoch_lo, tx_lo),
+            Watermark::lower_bound(WatermarkEntity::ObjectsHistory, epoch_lo, cp_lo),
+            Watermark::lower_bound(WatermarkEntity::Transactions, epoch_lo, tx_lo),
+        ]
+    }
+
+    pub fn update_type(&self) -> WatermarkUpdateType {
+        match self.update {
+            WatermarkUpdate::UpperBound { .. } => WatermarkUpdateType::UpperBound,
+            WatermarkUpdate::LowerBound { .. } => WatermarkUpdateType::LowerBound,
+            WatermarkUpdate::LowerBoundTail { .. } => WatermarkUpdateType::LowerBoundTail,
+        }
+    }
+}
+
+impl From<Watermark> for StoredWatermark {
+    fn from(watermark: Watermark) -> Self {
+        match watermark.update {
+            WatermarkUpdate::UpperBound { epoch_hi, hi } => StoredWatermark {
+                entity: watermark.entity.as_str().to_string(),
+                epoch_hi: epoch_hi as i64,
+                hi: hi as i64,
+                ..StoredWatermark::default()
+            },
+            WatermarkUpdate::LowerBound { epoch_lo, lo } => StoredWatermark {
+                entity: watermark.entity.as_str().to_string(),
+                epoch_hi: epoch_lo as i64,
+                epoch_lo: epoch_lo as i64,
+                hi: lo as i64,
+                lo: lo as i64,
+                ..StoredWatermark::default()
+            },
+            WatermarkUpdate::LowerBoundTail { pruned_lo } => StoredWatermark {
+                entity: watermark.entity.as_str().to_string(),
+                pruned_lo: Some(pruned_lo as i64),
+                ..StoredWatermark::default()
+            },
+        }
+    }
+}
+
+impl From<StoredWatermark> for WatermarkRead {
+    fn from(watermark: StoredWatermark) -> Self {
+        WatermarkRead {
+            entity: match watermark.entity.as_str() {
+                "transactions" => WatermarkEntity::Transactions,
+                "objects_history" => WatermarkEntity::ObjectsHistory,
+                "checkpoints" => WatermarkEntity::Checkpoints,
+                "epochs" => WatermarkEntity::Epochs,
+                "events" => WatermarkEntity::Events,
+                _ => unreachable!(),
+            },
+            epoch_hi: watermark.epoch_hi as u64,
+            epoch_lo: watermark.epoch_lo as u64,
+            hi: watermark.hi as u64,
+            lo: watermark.lo as u64,
+            timestamp_ms: watermark.timestamp_ms,
+            pruned_lo: watermark.pruned_lo.map(|x| x as u64),
+        }
+    }
+}

--- a/crates/sui-indexer/src/models/watermarks.rs
+++ b/crates/sui-indexer/src/models/watermarks.rs
@@ -34,7 +34,6 @@ pub struct StoredWatermark {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum WatermarkEntity {
     Checkpoints,
-    Epochs,
     Events,
     ObjectsHistory,
     Transactions,
@@ -101,7 +100,6 @@ impl WatermarkEntity {
             WatermarkEntity::Transactions => "transactions",
             WatermarkEntity::ObjectsHistory => "objects_history",
             WatermarkEntity::Checkpoints => "checkpoints",
-            WatermarkEntity::Epochs => "epochs",
             WatermarkEntity::Events => "events",
         }
     }
@@ -111,7 +109,6 @@ impl WatermarkEntity {
             "transactions" => Some(WatermarkEntity::Transactions),
             "objects_history" => Some(WatermarkEntity::ObjectsHistory),
             "checkpoints" => Some(WatermarkEntity::Checkpoints),
-            "epochs" => Some(WatermarkEntity::Epochs),
             "events" => Some(WatermarkEntity::Events),
             _ => None,
         }
@@ -143,7 +140,6 @@ impl Watermark {
     pub fn new_upper_bounds(epoch_hi: u64, cp_hi: u64, tx_hi: u64) -> Vec<Watermark> {
         vec![
             Watermark::upper_bound(WatermarkEntity::Checkpoints, epoch_hi, cp_hi),
-            Watermark::upper_bound(WatermarkEntity::Epochs, epoch_hi, epoch_hi),
             Watermark::upper_bound(WatermarkEntity::Events, epoch_hi, tx_hi),
             Watermark::upper_bound(WatermarkEntity::ObjectsHistory, epoch_hi, cp_hi),
             Watermark::upper_bound(WatermarkEntity::Transactions, epoch_hi, tx_hi),
@@ -153,7 +149,6 @@ impl Watermark {
     pub fn new_lower_bounds(epoch_lo: u64, cp_lo: u64, tx_lo: u64) -> Vec<Watermark> {
         vec![
             Watermark::lower_bound(WatermarkEntity::Checkpoints, epoch_lo, cp_lo),
-            Watermark::lower_bound(WatermarkEntity::Epochs, epoch_lo, epoch_lo),
             Watermark::lower_bound(WatermarkEntity::Events, epoch_lo, tx_lo),
             Watermark::lower_bound(WatermarkEntity::ObjectsHistory, epoch_lo, cp_lo),
             Watermark::lower_bound(WatermarkEntity::Transactions, epoch_lo, tx_lo),
@@ -202,7 +197,6 @@ impl From<StoredWatermark> for WatermarkRead {
                 "transactions" => WatermarkEntity::Transactions,
                 "objects_history" => WatermarkEntity::ObjectsHistory,
                 "checkpoints" => WatermarkEntity::Checkpoints,
-                "epochs" => WatermarkEntity::Epochs,
                 "events" => WatermarkEntity::Events,
                 _ => unreachable!(),
             },

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -62,6 +62,7 @@ diesel::table! {
         leftover_storage_fund_inflow -> Nullable<Int8>,
         epoch_commitments -> Nullable<Bytea>,
         system_state_summary_json -> Nullable<Jsonb>,
+        first_tx_sequence_number -> Nullable<Int8>,
     }
 }
 

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -367,6 +367,19 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    watermarks (entity) {
+        entity -> Text,
+        epoch_hi -> Int8,
+        epoch_lo -> Int8,
+        checkpoint_hi -> Int8,
+        hi -> Int8,
+        lo -> Int8,
+        timestamp_ms -> Int8,
+        pruned_lo -> Nullable<Int8>,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     chain_identifier,
     checkpoints,
@@ -402,4 +415,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     tx_kinds,
     tx_recipients,
     tx_senders,
+    watermarks,
 );

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -26,7 +26,7 @@ pub enum ObjectsToCommit {
 pub trait IndexerStore: Clone + Sync + Send + 'static {
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError>;
 
-    async fn get_available_epoch_range(&self) -> Result<WatermarkRead, IndexerError>;
+    async fn get_available_epoch_range(&self) -> Result<(u64, u64), IndexerError>;
 
     async fn get_watermarks(
         &self,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -124,4 +124,6 @@ pub trait IndexerStore: Clone + Sync + Send + 'static {
     async fn update_watermarks(&self, watermarks: Vec<Watermark>) -> Result<(), IndexerError>;
 
     async fn get_min_cp_and_tx_for_epoch(&self, epoch: u64) -> Result<(u64, u64), IndexerError>;
+
+    async fn get_latest_epoch(&self) -> Result<u64, IndexerError>;
 }

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -52,3 +52,42 @@ where
     })
     .await
 }
+
+pub async fn read_with_retry<'a, Q, T>(
+    pool: &ConnectionPool,
+    timeout: Duration,
+    query: Q,
+) -> Result<T, IndexerError>
+where
+    Q: for<'r> FnOnce(
+            &'r mut AsyncPgConnection,
+        ) -> ScopedBoxFuture<'a, 'r, Result<T, IndexerError>>
+        + Send,
+    Q: Clone,
+    T: 'a,
+{
+    let backoff = backoff::ExponentialBackoff {
+        max_elapsed_time: Some(timeout),
+        ..Default::default()
+    };
+    backoff::future::retry(backoff, || async {
+        let mut connection = pool.get().await.map_err(|e| backoff::Error::Transient {
+            err: IndexerError::PostgresWriteError(e.to_string()),
+            retry_after: None,
+        })?;
+
+        connection
+            .build_transaction()
+            .read_only()
+            .run(query.clone())
+            .await
+            .map_err(|e| {
+                tracing::error!("Error with reading data from DB: {:?}, retrying...", e);
+                backoff::Error::Transient {
+                    err: IndexerError::PostgresWriteError(e.to_string()),
+                    retry_after: None,
+                }
+            })
+    })
+    .await
+}

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -342,6 +342,7 @@ impl PgIndexerStore {
 
     async fn get_min_cp_and_tx_for_epoch(&self, epoch: u64) -> Result<(u64, u64), IndexerError> {
         use diesel_async::RunQueryDsl;
+        // TODO: (wlmyng) just use min and max on checkpoints
         let epoch = epoch.saturating_sub(1) as i64;
 
         let mut connection = self.pool.get().await?;

--- a/crates/sui-indexer/src/store/pg_partition_manager.rs
+++ b/crates/sui-indexer/src/store/pg_partition_manager.rs
@@ -61,6 +61,7 @@ pub struct EpochPartitionData {
 }
 
 impl EpochPartitionData {
+    /// Determine the starting checkpoint and tx sequence number for the current and next epoch.
     pub fn compose_data(epoch: EpochToCommit, last_db_epoch: StoredEpochInfo) -> Self {
         let last_epoch = last_db_epoch.epoch as u64;
         let last_epoch_start_cp = last_db_epoch.first_checkpoint_id as u64;
@@ -151,6 +152,9 @@ impl PgPartitionManager {
         }
     }
 
+    /// Detaches the latest partition and reattach it with an updated constraint by setting its
+    /// upper-bound from some max value to the latest upper bound, and then attaches a new partition
+    /// to handle the next epoch's worth of data.
     pub async fn advance_epoch(
         &self,
         table: String,

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -102,6 +102,7 @@ impl IndexedCheckpoint {
 pub struct IndexedEpochInfo {
     pub epoch: u64,
     pub first_checkpoint_id: u64,
+    pub first_tx_sequence_number: u64,
     pub epoch_start_timestamp: u64,
     pub reference_gas_price: u64,
     pub protocol_version: u64,
@@ -125,11 +126,13 @@ impl IndexedEpochInfo {
     pub fn from_new_system_state_summary(
         new_system_state_summary: SuiSystemStateSummary,
         first_checkpoint_id: u64,
+        first_tx_sequence_number: u64,
         event: Option<&SystemEpochInfoEvent>,
     ) -> IndexedEpochInfo {
         Self {
             epoch: new_system_state_summary.epoch,
             first_checkpoint_id,
+            first_tx_sequence_number,
             epoch_start_timestamp: new_system_state_summary.epoch_start_timestamp_ms,
             reference_gas_price: new_system_state_summary.reference_gas_price,
             protocol_version: new_system_state_summary.protocol_version,
@@ -169,6 +172,7 @@ impl IndexedEpochInfo {
                     - network_total_tx_num_at_last_epoch_end,
             ),
             last_checkpoint_id: Some(*last_checkpoint_summary.sequence_number()),
+            first_tx_sequence_number: network_total_tx_num_at_last_epoch_end,
             epoch_end_timestamp: Some(last_checkpoint_summary.timestamp_ms),
             storage_fund_reinvestment: Some(event.storage_fund_reinvestment),
             storage_charge: Some(event.storage_charge),


### PR DESCRIPTION
## Description 

Introduce new `update_watermarks` fn to `indexer_store` trait. Accepts a `Vec<Watermark>`, where `Watermark` is essentially an enum of `UpperBound|LowerBound|LowerBoundTail`. 

committer
1. `Watermark::new_upper_bound
2. `store.update_watermarks(watermarks)`

pruner
1. `Watermark::new_lower_bound` and `::new_lower_bound_tail`
2. `store.update_watermarks(watermarks)`

pg_indexer_store
1. one public entry point that accepts `Vec<Watermark>`
2. groups by enum variant and handles each in bulk

`watermarks` table looks like this when run with `epochs-to-keep: 1`
```
     entity      | epoch_hi | epoch_lo |   hi   |  lo  | timestamp_ms  | pruned_lo
-----------------+----------+----------+--------+------+---------------+-----------
 epochs          |        1 |        1 |      1 |    1 | 1726766890443 |
 events          |        1 |        1 | 994511 | 6764 | 1726766890443 |      4931
 checkpoints     |        1 |        1 |  12907 | 5544 | 1726766890443 |      4425
 objects_history |        1 |        1 |  12907 | 5544 | 1726766890443 |      4425
 transactions    |        1 |        1 | 994511 | 6764 | 1726766890443 |      4931
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
