### PR TITLE
Do not request local execution from Rust SDK

### DIFF
--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -1145,7 +1145,9 @@ impl QuorumDriverApi {
                 tx_bytes.clone(),
                 signatures.clone(),
                 Some(options.clone()),
-                Some(request_type.clone()),
+                // Ignore the request type as we emulate WaitForLocalExecution below.
+                // It will default to WaitForEffectsCert on the RPC nodes.
+                None,
             )
             .await?;
 


### PR DESCRIPTION
## Description 

In the code below these lines we emulate local execution by polling the transaction.
This means that we no longer need to pass through the request type to the RPC server, otherwise if user specified WaitForLocalExecution it would still be passed through.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
