### PR TITLE
rest: discard failed dynamic field indices

### DIFF
--- a/crates/sui-core/src/rest_index.rs
+++ b/crates/sui-core/src/rest_index.rs
@@ -452,7 +452,9 @@ impl IndexStoreTables {
                         }
                         Owner::ObjectOwner(parent) => {
                             if let Some(field_info) =
-                                try_create_dynamic_field_info(object, resolver)?
+                                try_create_dynamic_field_info(object, resolver)
+                                    .ok()
+                                    .flatten()
                             {
                                 let field_key = DynamicFieldKey::new(*parent, object.id());
 


### PR DESCRIPTION
## Description

Allow dynamic field indexing to fail when building up fullnode REST indices to bring it in line with behaviour in `sui-indexer`, `sui-analytics-indexer`, and the existing fullnode indices.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
