### PR TITLE
pick(rest): discard failed dynamic field indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10235,9 +10235,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -16471,7 +16471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/crates/sui-core/src/rest_index.rs
+++ b/crates/sui-core/src/rest_index.rs
@@ -452,7 +452,9 @@ impl IndexStoreTables {
                         }
                         Owner::ObjectOwner(parent) => {
                             if let Some(field_info) =
-                                try_create_dynamic_field_info(object, resolver)?
+                                try_create_dynamic_field_info(object, resolver)
+                                    .ok()
+                                    .flatten()
                             {
                                 let field_key = DynamicFieldKey::new(*parent, object.id());
 

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,8 @@ ignore = [
     "RUSTSEC-2024-0336",
     # allow yaml-rust being unmaintained
     "RUSTSEC-2024-0320",
+    # allow unmaintained proc-macro-error used in transitive dependencies
+    "RUSTSEC-2024-0370",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## Description

Allow dynamic field indexing to fail when building up fullnode REST indices to bring it in line with behaviour in `sui-indexer`, `sui-analytics-indexer`, and the existing fullnode indices.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
