### PR TITLE
[Consensus] Garbage Collection - 2

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -495,9 +495,8 @@ mod tests {
         const NUM_OF_AUTHORITIES: usize = 4;
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        if gc_depth > 0 {
-            protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
-        }
+        protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
+
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())
             .collect::<Vec<_>>();
@@ -603,9 +602,7 @@ mod tests {
         let mut boot_counters = [0; NUM_OF_AUTHORITIES];
 
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        if gc_depth > 0 {
-            protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
-        }
+        protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
 
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -432,7 +432,8 @@ impl BlockManager {
         let _s = monitored_scope("BlockManager::try_unsuspend_blocks_for_latest_gc_round");
         let gc_enabled = self.dag_state.read().gc_enabled();
         let gc_round = self.dag_state.read().gc_round();
-        let mut total_blocks_gced = 0;
+        let mut blocks_unsuspended_below_gc_round = 0;
+        let mut blocks_gc_ed = 0;
 
         if !gc_enabled {
             trace!("GC is disabled, no blocks will attempt to get unsuspended.");
@@ -446,7 +447,7 @@ impl BlockManager {
                 return;
             }
 
-            total_blocks_gced += 1;
+            blocks_gc_ed += 1;
 
             assert!(!self.suspended_blocks.contains_key(block_ref), "Block should not be suspended, as we are causally GC'ing and no suspended block should exist for a missing ancestor.");
 
@@ -458,7 +459,7 @@ impl BlockManager {
 
             unsuspended_blocks.iter().for_each(|block| {
                 if block.round() <= gc_round {
-                    total_blocks_gced += 1;
+                    blocks_unsuspended_below_gc_round += 1;
                 }
             });
 
@@ -481,8 +482,8 @@ impl BlockManager {
         }
 
         debug!(
-            "GC'ed {} blocks in gc_round {}",
-            total_blocks_gced, gc_round
+            "Total {} blocks unsuspended and total blocks {} gc'ed <= gc_round {}",
+            blocks_unsuspended_below_gc_round, blocks_gc_ed, gc_round
         );
     }
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -251,6 +251,18 @@ impl BlockManager {
 
         // If the block is <= gc_round, then we simply skip its processing as there is no meaning do any action on it or even store it.
         if gc_enabled && block.round() <= gc_round {
+            let hostname = self
+                .context
+                .committee
+                .authority(block.author())
+                .hostname
+                .as_str();
+            self.context
+                .metrics
+                .node_metrics
+                .block_manager_skipped_blocks
+                .with_label_values(&[hostname])
+                .inc();
             return TryAcceptResult::Skipped;
         }
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet}, iter, sync::Arc, time::Instant
+    collections::{BTreeMap, BTreeSet},
+    iter,
+    sync::Arc,
+    time::Instant,
 };
 
 use itertools::Itertools as _;
@@ -118,7 +121,8 @@ impl BlockManager {
             let unsuspended_blocks = self.try_unsuspend_children_blocks(block.reference());
 
             // Verify block timestamps
-            let blocks_to_accept = self.verify_block_timestamps_and_accept(iter::once(block).chain(unsuspended_blocks));
+            let blocks_to_accept = self
+                .verify_block_timestamps_and_accept(iter::once(block).chain(unsuspended_blocks));
             accepted_blocks.extend(blocks_to_accept);
         }
 
@@ -180,7 +184,10 @@ impl BlockManager {
 
                     // When gc is enabled it's possible that we indeed won't find any ancestors that are passed gc_round. That's ok. We don't need to panic here.
                     // We do want to panic if gc_enabled we and have an ancestor that is > gc_round, or gc is disabled.
-                    if gc_enabled && ancestor_ref.round > GENESIS_ROUND && ancestor_ref.round <= gc_round {
+                    if gc_enabled
+                        && ancestor_ref.round > GENESIS_ROUND
+                        && ancestor_ref.round <= gc_round
+                    {
                         debug!(
                             "Block {:?} has a missing ancestor: {:?} passed GC round {}",
                             b.reference(),
@@ -246,17 +253,13 @@ impl BlockManager {
         // then gc_round will be 0 and all ancestors will be considered.
         let ancestors = if gc_enabled {
             block
-            .ancestors()
-            .iter()
-            .filter(|ancestor| gc_round == GENESIS_ROUND || ancestor.round > gc_round)
-            .cloned()
-            .collect::<Vec<_>>()
+                .ancestors()
+                .iter()
+                .filter(|ancestor| ancestor.round == GENESIS_ROUND || ancestor.round > gc_round)
+                .cloned()
+                .collect::<Vec<_>>()
         } else {
-            block
-            .ancestors()
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
+            block.ancestors().to_vec()
         };
 
         // make sure that we have all the required ancestors in store

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -213,11 +213,18 @@ impl BlockManager {
 
         // TODO: report blocks_to_reject to peers.
         for (block_ref, block) in blocks_to_reject {
+            let hostname = self
+                .context
+                .committee
+                .authority(block_ref.author)
+                .hostname
+                .clone();
+
             self.context
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[&block_ref.author.to_string(), "accept_block"])
+                .with_label_values(&[&hostname, "accept_block", "InvalidAncestors"])
                 .inc();
             warn!("Invalid block {:?} is rejected", block);
         }

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -430,8 +430,10 @@ impl BlockManager {
     /// this action.
     pub(crate) fn try_unsuspend_blocks_for_latest_gc_round(&mut self) {
         let _s = monitored_scope("BlockManager::try_unsuspend_blocks_for_latest_gc_round");
-        let gc_enabled = self.dag_state.read().gc_enabled();
-        let gc_round = self.dag_state.read().gc_round();
+        let (gc_enabled, gc_round) = {
+            let dag_state = self.dag_state.read();
+            (dag_state.gc_enabled(), dag_state.gc_round())
+        };
         let mut blocks_unsuspended_below_gc_round = 0;
         let mut blocks_gc_ed = 0;
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    iter,
     sync::Arc,
     time::Instant,
 };
@@ -120,70 +119,8 @@ impl BlockManager {
             // If the block is accepted, try to unsuspend its children blocks if any.
             let unsuspended_blocks = self.try_unsuspend_children_blocks(block.reference());
 
-            // Try to verify the block and its children for timestamp, with ancestor blocks.
-            let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
-            let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
-            {
-                'block: for b in iter::once(block).chain(unsuspended_blocks) {
-                    let ancestors = self.dag_state.read().get_blocks(b.ancestors());
-                    assert_eq!(b.ancestors().len(), ancestors.len());
-                    let mut ancestor_blocks = vec![];
-                    'ancestor: for (ancestor_ref, found) in
-                        b.ancestors().iter().zip(ancestors.into_iter())
-                    {
-                        if let Some(found_block) = found {
-                            // This invariant should be guaranteed by DagState.
-                            assert_eq!(ancestor_ref, &found_block.reference());
-                            ancestor_blocks.push(found_block);
-                            continue 'ancestor;
-                        }
-                        // blocks_to_accept have not been added to DagState yet, but they
-                        // can appear in ancestors.
-                        if blocks_to_accept.contains_key(ancestor_ref) {
-                            ancestor_blocks.push(blocks_to_accept[ancestor_ref].clone());
-                            continue 'ancestor;
-                        }
-                        // If an ancestor is already rejected, reject this block as well.
-                        if blocks_to_reject.contains_key(ancestor_ref) {
-                            blocks_to_reject.insert(b.reference(), b);
-                            continue 'block;
-                        }
-                        panic!("Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}", b, ancestor_ref);
-                    }
-                    if let Err(e) = self.block_verifier.check_ancestors(&b, &ancestor_blocks) {
-                        warn!("Block {:?} failed to verify ancestors: {}", b, e);
-                        blocks_to_reject.insert(b.reference(), b);
-                    } else {
-                        blocks_to_accept.insert(b.reference(), b);
-                    }
-                }
-            }
-            for (block_ref, block) in blocks_to_reject {
-                let hostname = self
-                    .context
-                    .committee
-                    .authority(block_ref.author)
-                    .hostname
-                    .clone();
-
-                self.context
-                    .metrics
-                    .node_metrics
-                    .invalid_blocks
-                    .with_label_values(&[&hostname, "accept_block", "InvalidAncestors"])
-                    .inc();
-                warn!("Invalid block {:?} is rejected", block);
-            }
-
-            // TODO: report blocks_to_reject to peers.
-
-            // Insert the accepted blocks into DAG state so future blocks including them as
-            // ancestors do not get suspended.
-            let blocks_to_accept: Vec<_> = blocks_to_accept.into_values().collect();
-            self.dag_state
-                .write()
-                .accept_blocks(blocks_to_accept.clone());
-
+            // Verify block timestamps
+            let blocks_to_accept = self.verify_block_timestamps_and_accept(unsuspended_blocks);
             accepted_blocks.extend(blocks_to_accept);
         }
 
@@ -203,6 +140,92 @@ impl BlockManager {
 
         // Figure out the new missing blocks
         (accepted_blocks, missing_blocks)
+    }
+
+    // TODO: remove once timestamping is refactored to the new approach.
+    // Verifies each block's timestamp based on its ancestors, and persists in store all the valid blocks that should be accepted. Method
+    // returns the accepted and persisted blocks.
+    fn verify_block_timestamps_and_accept(
+        &mut self,
+        unsuspended_blocks: impl IntoIterator<Item = VerifiedBlock>,
+    ) -> Vec<VerifiedBlock> {
+        let gc_enabled = self.dag_state.read().gc_enabled();
+        let gc_round = self.dag_state.read().gc_round();
+        // Try to verify the block and its children for timestamp, with ancestor blocks.
+        let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
+        let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
+        {
+            'block: for b in unsuspended_blocks {
+                let ancestors = self.dag_state.read().get_blocks(b.ancestors());
+                assert_eq!(b.ancestors().len(), ancestors.len());
+                let mut ancestor_blocks = vec![];
+                'ancestor: for (ancestor_ref, found) in
+                    b.ancestors().iter().zip(ancestors.into_iter())
+                {
+                    if let Some(found_block) = found {
+                        // This invariant should be guaranteed by DagState.
+                        assert_eq!(ancestor_ref, &found_block.reference());
+                        ancestor_blocks.push(Some(found_block));
+                        continue 'ancestor;
+                    }
+                    // blocks_to_accept have not been added to DagState yet, but they
+                    // can appear in ancestors.
+                    if blocks_to_accept.contains_key(ancestor_ref) {
+                        ancestor_blocks.push(Some(blocks_to_accept[ancestor_ref].clone()));
+                        continue 'ancestor;
+                    }
+                    // If an ancestor is already rejected, reject this block as well.
+                    if blocks_to_reject.contains_key(ancestor_ref) {
+                        blocks_to_reject.insert(b.reference(), b);
+                        continue 'block;
+                    }
+
+                    // When gc is enabled it's possible that we indeed won't find any ancestors that are passed gc_round. That's ok. We don't need to panic here.
+                    // We do want to panic if gc_enabled we and have an ancestor that is > gc_round, or gc is disabled.
+                    if gc_enabled && ancestor_ref.round <= gc_round {
+                        debug!(
+                            "Block {:?} has a missing ancestor: {:?} passed GC round {}",
+                            b.reference(),
+                            ancestor_ref,
+                            gc_round
+                        );
+                        ancestor_blocks.push(None);
+                    } else {
+                        panic!("Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}", b, ancestor_ref);
+                    }
+                }
+                if let Err(e) =
+                    self.block_verifier
+                        .check_ancestors(&b, &ancestor_blocks, gc_enabled, gc_round)
+                {
+                    warn!("Block {:?} failed to verify ancestors: {}", b, e);
+                    blocks_to_reject.insert(b.reference(), b);
+                } else {
+                    blocks_to_accept.insert(b.reference(), b);
+                }
+            }
+        }
+
+        // TODO: report blocks_to_reject to peers.
+        for (block_ref, block) in blocks_to_reject {
+            self.context
+                .metrics
+                .node_metrics
+                .invalid_blocks
+                .with_label_values(&[&block_ref.author.to_string(), "accept_block"])
+                .inc();
+            warn!("Invalid block {:?} is rejected", block);
+        }
+
+        let blocks_to_accept = blocks_to_accept.values().cloned().collect::<Vec<_>>();
+
+        // Insert the accepted blocks into DAG state so future blocks including them as
+        // ancestors do not get suspended.
+        self.dag_state
+            .write()
+            .accept_blocks(blocks_to_accept.clone());
+
+        blocks_to_accept
     }
 
     /// Tries to accept the provided block. To accept a block its ancestors must have been already successfully accepted. If
@@ -295,18 +318,13 @@ impl BlockManager {
 
     /// Given an accepted block `accepted_block` it attempts to accept all the suspended children blocks assuming such exist.
     /// All the unsuspended / accepted blocks are returned as a vector in causal order.
-    fn try_unsuspend_children_blocks(
-        &mut self,
-        accepted_block: BlockRef,
-    ) -> Vec<VerifiedBlock> {
+    fn try_unsuspend_children_blocks(&mut self, accepted_block: BlockRef) -> Vec<VerifiedBlock> {
         let mut unsuspended_blocks = vec![];
-        let mut to_process_blocks = vec![accepted_block.clone()];
+        let mut to_process_blocks = vec![accepted_block];
 
         while let Some(block_ref) = to_process_blocks.pop() {
             // And try to check if its direct children can be unsuspended
-            if let Some(block_refs_with_missing_deps) =
-                self.missing_ancestors.remove(&block_ref)
-            {
+            if let Some(block_refs_with_missing_deps) = self.missing_ancestors.remove(&block_ref) {
                 for r in block_refs_with_missing_deps {
                     // For each dependency try to unsuspend it. If that's successful then we add it to the queue so
                     // we can recursively try to unsuspend its children.
@@ -377,27 +395,61 @@ impl BlockManager {
     /// Tries to unsuspend any blocks for the latest gc round. If gc round hasn't changed then no blocks will be unsuspended due to
     /// this action.
     pub(crate) fn try_unsuspend_blocks_for_latest_gc_round(&mut self) {
+        let _s = monitored_scope("BlockManager::try_unsuspend_blocks_for_latest_gc_round");
+        let gc_enabled = self.dag_state.read().gc_enabled();
         let gc_round = self.dag_state.read().gc_round();
-        let mut unsuspended_blocks = Vec::new();
+        let mut total_blocks_gced = 0;
 
-        while let Some((block_ref, children_refs)) = self.missing_ancestors.pop_first() {
+        if !gc_enabled {
+            trace!("GC is disabled, no blocks will attempt to get unsuspended.");
+            return;
+        }
+
+        while let Some((block_ref, _children_refs)) = self.missing_ancestors.first_key_value() {
             // If the first block in the missing ancestors is higher than the gc_round, then we can't unsuspend it yet. So we just put it back
             // and we terminate the iteration as any next entry will be of equal or higher round anyways.
             if block_ref.round > gc_round {
-                self.missing_ancestors.insert(block_ref, children_refs);
                 return;
             }
 
-            // If the block was in the suspended list, then remove it from there.
-            // Also there is no point trying to accept this block anyways as it doesn't matter for history.
-            let _ = self.suspended_blocks.remove(&block_ref);
+            total_blocks_gced += 1;
+
+            assert!(!self.suspended_blocks.contains_key(block_ref), "Block should not be suspended, as we are causally GC'ing and no suspended block should exist for a missing ancestor.");
+
+            // Also remove it from the missing list - we don't want to keep looking for it.
+            self.missing_blocks.remove(block_ref);
 
             // Find all the children blocks that have a dependency on this one and try to unsuspend them
-            unsuspended_blocks.extend(self.try_unsuspend_children_blocks(block_ref));
+            let unsuspended_blocks = self.try_unsuspend_children_blocks(*block_ref);
+
+            unsuspended_blocks.iter().for_each(|block| {
+                if block.round() <= gc_round {
+                    total_blocks_gced += 1;
+                }
+            });
+
+            // Now validate their timestamps and accept them
+            let accepted_blocks = self.verify_block_timestamps_and_accept(unsuspended_blocks);
+            for block in accepted_blocks {
+                let hostname = self
+                    .context
+                    .committee
+                    .authority(block.author())
+                    .hostname
+                    .as_str();
+                self.context
+                    .metrics
+                    .node_metrics
+                    .block_manager_gc_unsuspended_blocks
+                    .with_label_values(&[hostname])
+                    .inc();
+            }
         }
 
-        // Process the unsuspended blocks
-        
+        debug!(
+            "GC'ed {} blocks in gc_round {}",
+            total_blocks_gced, gc_round
+        );
     }
 
     /// Returns all the blocks that are currently missing and needed in order to accept suspended
@@ -473,6 +525,7 @@ mod tests {
         error::{ConsensusError, ConsensusResult},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
+        Round,
     };
 
     #[tokio::test]
@@ -669,7 +722,9 @@ mod tests {
         fn check_ancestors(
             &self,
             block: &VerifiedBlock,
-            _ancestors: &[VerifiedBlock],
+            _ancestors: &[Option<VerifiedBlock>],
+            _gc_enabled: bool,
+            _gc_round: Round,
         ) -> ConsensusResult<()> {
             if self.fail.contains(&block.reference()) {
                 Err(ConsensusError::InvalidBlockTimestamp {

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -151,8 +151,10 @@ impl BlockManager {
         &mut self,
         unsuspended_blocks: impl IntoIterator<Item = VerifiedBlock>,
     ) -> Vec<VerifiedBlock> {
-        let gc_enabled = self.dag_state.read().gc_enabled();
-        let gc_round = self.dag_state.read().gc_round();
+        let (gc_enabled, gc_round) = {
+            let dag_state = self.dag_state.read();
+            (dag_state.gc_enabled(), dag_state.gc_round())
+        };
         // Try to verify the block and its children for timestamp, with ancestor blocks.
         let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
         let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -11,6 +11,7 @@ use crate::{
     context::Context,
     error::{ConsensusError, ConsensusResult},
     transaction::TransactionVerifier,
+    Round,
 };
 
 pub(crate) trait BlockVerifier: Send + Sync + 'static {
@@ -26,7 +27,9 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
     fn check_ancestors(
         &self,
         block: &VerifiedBlock,
-        ancestors: &[VerifiedBlock],
+        ancestors: &[Option<VerifiedBlock>],
+        gc_enabled: bool,
+        gc_round: Round,
     ) -> ConsensusResult<()>;
 }
 
@@ -185,20 +188,44 @@ impl BlockVerifier for SignedBlockVerifier {
     fn check_ancestors(
         &self,
         block: &VerifiedBlock,
-        ancestors: &[VerifiedBlock],
+        ancestors: &[Option<VerifiedBlock>],
+        gc_enabled: bool,
+        gc_round: Round,
     ) -> ConsensusResult<()> {
-        assert_eq!(block.ancestors().len(), ancestors.len());
-        // This checks the invariant that block timestamp >= max ancestor timestamp.
-        let mut max_timestamp_ms = BlockTimestampMs::MIN;
-        for (ancestor_ref, ancestor_block) in block.ancestors().iter().zip(ancestors.iter()) {
-            assert_eq!(ancestor_ref, &ancestor_block.reference());
-            max_timestamp_ms = max_timestamp_ms.max(ancestor_block.timestamp_ms());
-        }
-        if max_timestamp_ms > block.timestamp_ms() {
-            return Err(ConsensusError::InvalidBlockTimestamp {
-                max_timestamp_ms,
-                block_timestamp_ms: block.timestamp_ms(),
-            });
+        if gc_enabled {
+            // TODO: will be removed with new timestamp calculation is in place as all these will be irrelevant.
+            // When gc is enabled we don't have gaurantees that all ancestors will be available. We'll take into account only the passed gc_round ones
+            // for the timestamp check.
+            let mut max_timestamp_ms = BlockTimestampMs::MIN;
+            for ancestor in ancestors.iter().flatten() {
+                if ancestor.round() <= gc_round {
+                    continue;
+                }
+                max_timestamp_ms = max_timestamp_ms.max(ancestor.timestamp_ms());
+                if max_timestamp_ms > block.timestamp_ms() {
+                    return Err(ConsensusError::InvalidBlockTimestamp {
+                        max_timestamp_ms,
+                        block_timestamp_ms: block.timestamp_ms(),
+                    });
+                }
+            }
+        } else {
+            assert_eq!(block.ancestors().len(), ancestors.len());
+            // This checks the invariant that block timestamp >= max ancestor timestamp.
+            let mut max_timestamp_ms = BlockTimestampMs::MIN;
+            for (ancestor_ref, ancestor_block) in block.ancestors().iter().zip(ancestors.iter()) {
+                let ancestor_block = ancestor_block
+                    .as_ref()
+                    .expect("There should never be an empty slot");
+                assert_eq!(ancestor_ref, &ancestor_block.reference());
+                max_timestamp_ms = max_timestamp_ms.max(block.timestamp_ms());
+            }
+            if max_timestamp_ms > block.timestamp_ms() {
+                return Err(ConsensusError::InvalidBlockTimestamp {
+                    max_timestamp_ms,
+                    block_timestamp_ms: block.timestamp_ms(),
+                });
+            }
         }
         Ok(())
     }
@@ -215,7 +242,9 @@ impl BlockVerifier for NoopBlockVerifier {
     fn check_ancestors(
         &self,
         _block: &VerifiedBlock,
-        _ancestors: &[VerifiedBlock],
+        _ancestors: &[Option<VerifiedBlock>],
+        _gc_enabled: bool,
+        _gc_round: Round,
     ) -> ConsensusResult<()> {
         Ok(())
     }
@@ -530,16 +559,19 @@ mod test {
         let (context, _keypairs) = Context::new_for_test(num_authorities);
         let context = Arc::new(context);
         let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
+        let gc_enabled = false;
+        let gc_round = 0;
 
         let mut ancestor_blocks = vec![];
         for i in 0..num_authorities {
             let test_block = TestBlock::new(10, i as u32)
                 .set_timestamp_ms(1000 + 100 * i as BlockTimestampMs)
                 .build();
-            ancestor_blocks.push(VerifiedBlock::new_for_test(test_block));
+            ancestor_blocks.push(Some(VerifiedBlock::new_for_test(test_block)));
         }
         let ancestor_refs = ancestor_blocks
             .iter()
+            .flatten()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
 
@@ -551,7 +583,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(verifier
-                .check_ancestors(&verified_block, &ancestor_blocks)
+                .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
                 .is_ok());
         }
 
@@ -563,7 +595,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(matches!(
-                verifier.check_ancestors(&verified_block, &ancestor_blocks),
+                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round),
                 Err(ConsensusError::InvalidBlockTimestamp {
                     max_timestamp_ms: _,
                     block_timestamp_ms: _

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -218,7 +218,7 @@ impl BlockVerifier for SignedBlockVerifier {
                     .as_ref()
                     .expect("There should never be an empty slot");
                 assert_eq!(ancestor_ref, &ancestor_block.reference());
-                max_timestamp_ms = max_timestamp_ms.max(block.timestamp_ms());
+                max_timestamp_ms = max_timestamp_ms.max(ancestor_block.timestamp_ms());
             }
             if max_timestamp_ms > block.timestamp_ms() {
                 return Err(ConsensusError::InvalidBlockTimestamp {

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -748,14 +748,8 @@ impl Core {
                     .into_iter()
                     .filter(|block| block.author() != self.context.own_index)
                     .filter(|block| {
-                        if gc_enabled {
-                            // When GC is enabled we want to include only ancestors that are:
-                            // 1) blocks of the genesis round
-                            // 2) blocks that are parents of the previous round (clock_round - 1)
-                            // 3) blocks that are parents earlier than the previous round, but higher than the gc_round
-                            return block.round() == GENESIS_ROUND
-                                || block.round() == clock_round - 1
-                                || block.round() > gc_round;
+                        if gc_enabled && gc_round > GENESIS_ROUND {
+                            return block.round() > gc_round;
                         }
                         true
                     })

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -627,6 +627,11 @@ impl Core {
                         .write()
                         .add_unscored_committed_subdags(subdags.clone());
                 }
+
+                // Try to unsuspend blocks if gc_round has advanced.
+                self.block_manager
+                    .try_unsuspend_blocks_for_latest_gc_round();
+
                 committed_subdags.extend(subdags);
             }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -725,10 +725,15 @@ impl Core {
     /// Retrieves the next ancestors to propose to form a block at `clock_round` round.
     fn ancestors_to_propose(&mut self, clock_round: Round) -> Vec<VerifiedBlock> {
         // Now take the ancestors before the clock_round (excluded) for each authority.
-        let ancestors = self
-            .dag_state
-            .read()
-            .get_last_cached_block_per_authority(clock_round);
+        let (ancestors, gc_enabled, gc_round) = {
+            let dag_state = self.dag_state.read();
+            (
+                dag_state.get_last_cached_block_per_authority(clock_round),
+                dag_state.gc_enabled(),
+                dag_state.gc_round(),
+            )
+        };
+
         assert_eq!(
             ancestors.len(),
             self.context.committee.size(),
@@ -742,6 +747,18 @@ impl Core {
                 ancestors
                     .into_iter()
                     .filter(|block| block.author() != self.context.own_index)
+                    .filter(|block| {
+                        if gc_enabled {
+                            // When GC is enabled we want to include only ancestors that are:
+                            // 1) blocks of the genesis round
+                            // 2) blocks that are parents of the previous round (clock_round - 1)
+                            // 3) blocks that are parents earlier than the previous round, but higher than the gc_round
+                            return block.round() == GENESIS_ROUND
+                                || block.round() == clock_round - 1
+                                || block.round() > gc_round;
+                        }
+                        true
+                    })
                     .flat_map(|block| {
                         if let Some(last_block_ref) = self.last_included_ancestors[block.author()] {
                             return (last_block_ref.round < block.round()).then_some(block);

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -519,7 +519,7 @@ impl NodeMetrics {
             ).unwrap(),
             block_manager_gc_unsuspended_blocks: register_int_counter_vec_with_registry!(
                 "block_manager_gc_unsuspended_blocks",
-                "The number of unsuspended blocks garbage collected by the block manager counted by block's source authority",
+                "The number of blocks unsuspended because their missing ancestors are garbage collected by the block manager, counted by block's source authority",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -516,7 +516,7 @@ impl NodeMetrics {
                 "The number of missing ancestors by ancestor authority across received blocks",
                 &["authority"],
                 registry,
-            ).unwrap(),  
+            ).unwrap(),
             block_manager_gc_unsuspended_blocks: register_int_counter_vec_with_registry!(
                 "block_manager_gc_unsuspended_blocks",
                 "The number of unsuspended blocks garbage collected by the block manager counted by block's source authority",

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -156,6 +156,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_manager_missing_blocks_by_authority: IntCounterVec,
     pub(crate) block_manager_missing_ancestors_by_authority: IntCounterVec,
     pub(crate) block_manager_gc_unsuspended_blocks: IntCounterVec,
+    pub(crate) block_manager_skipped_blocks: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
     pub(crate) subscribed_to: IntGaugeVec,
@@ -519,6 +520,12 @@ impl NodeMetrics {
             block_manager_gc_unsuspended_blocks: register_int_counter_vec_with_registry!(
                 "block_manager_gc_unsuspended_blocks",
                 "The number of unsuspended blocks garbage collected by the block manager counted by block's source authority",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            block_manager_skipped_blocks: register_int_counter_vec_with_registry!(
+                "block_manager_skipped_blocks",
+                "The number of blocks skipped by the block manager due to block round being <= gc_round",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -155,6 +155,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_manager_missing_blocks: IntGauge,
     pub(crate) block_manager_missing_blocks_by_authority: IntCounterVec,
     pub(crate) block_manager_missing_ancestors_by_authority: IntCounterVec,
+    pub(crate) block_manager_gc_unsuspended_blocks: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
     pub(crate) subscribed_to: IntGaugeVec,
@@ -512,6 +513,12 @@ impl NodeMetrics {
             block_manager_missing_ancestors_by_authority: register_int_counter_vec_with_registry!(
                 "block_manager_missing_ancestors_by_authority",
                 "The number of missing ancestors by ancestor authority across received blocks",
+                &["authority"],
+                registry,
+            ).unwrap(),  
+            block_manager_gc_unsuspended_blocks: register_int_counter_vec_with_registry!(
+                "block_manager_gc_unsuspended_blocks",
+                "The number of unsuspended blocks garbage collected by the block manager counted by block's source authority",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -8,7 +8,7 @@ use futures::StreamExt;
 use mysten_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, RwLock};
 use tokio::{task::JoinHandle, time::sleep};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::{
     block::BlockAPI as _,
@@ -72,7 +72,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         // then do not attempt to fetch any blocks from that point as they will simply be skipped. Instead
         // do attempt to fetch from the gc round.
         if gc_enabled && last_received < gc_round {
-            warn!(
+            info!(
                 "Last received block for peer {peer} is older than GC round, {last_received} < {gc_round}, fetching from GC round"
             );
             last_received = gc_round;

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -59,10 +59,14 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let authority_service = self.authority_service.clone();
-        let dag_state = self.dag_state.read();
-        let mut last_received = dag_state.get_last_block_for_authority(peer).round();
-        let gc_round = dag_state.gc_round();
-        let gc_enabled = dag_state.gc_enabled();
+        let (mut last_received, gc_round, gc_enabled) = {
+            let dag_state = self.dag_state.read();
+            (
+                dag_state.get_last_block_for_authority(peer).round(),
+                dag_state.gc_round(),
+                dag_state.gc_enabled(),
+            )
+        };
 
         // If the latest block we have accepted by an authority is older than the current gc round,
         // then do not attempt to fetch any blocks from that point as they will simply be skipped. Instead

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1612,7 +1612,7 @@ impl ProtocolConfig {
     pub fn validate_identifier_inputs(&self) -> bool {
         self.feature_flags.validate_identifier_inputs
     }
-
+    
     pub fn gc_depth(&self) -> u32 {
         self.consensus_gc_depth.unwrap_or(0)
     }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1612,7 +1612,7 @@ impl ProtocolConfig {
     pub fn validate_identifier_inputs(&self) -> bool {
         self.feature_flags.validate_identifier_inputs
     }
-    
+
     pub fn gc_depth(&self) -> u32 {
         self.consensus_gc_depth.unwrap_or(0)
     }


### PR DESCRIPTION
## Description 

This is the second part of Garbage Collection which implements the following ticked next steps as outlined on the previous PR

- [x] BlockManager to respect the gc_round when accepting blocks and trigger clean ups for new gc rounds
- [x] Skip blocks that are received which are <= gc_round
- [x] Not propose ancestors that are <= gc_round
- [x] Subscriber to ask for blocks from `gc_round` when `last_fetched_round < gc_round` for a peer to prevent us from fetching unnecessary blocks

Next steps:

- [ ] Re-propose GC'ed transactions (probably not all of them)
- [ ] Implement new timestamp approach so ancestor verification is not needed
- [ ] Harden testing for GC & edge cases

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
