### PR TITLE
[kv store] create new client for every request

### DIFF
--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -235,12 +235,10 @@ impl HttpKVStore {
             .with_label_values(&["http_cache", "url"])
             .inc();
 
-        let resp = self
-            .client
-            .get(url.clone())
-            .send()
-            .await
-            .into_sui_result()?;
+        let client = Client::builder()
+            .build()
+            .map_err(|e| SuiError::Storage(e.to_string()))?;
+        let resp = client.get(url.clone()).send().await.into_sui_result()?;
         trace!(
             "got response {} for url: {}, len: {:?}",
             url,

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -549,7 +549,7 @@ mod simtests {
 
         // verify that the request took approximately one round trip despite fetching 4 items,
         // i.e. test that pipelining or multiplexing is working.
-        assert!(start_time.elapsed() < Duration::from_millis(600));
+        // assert!(start_time.elapsed() < Duration::from_millis(600));
 
         assert_eq!(
             result,


### PR DESCRIPTION
## Description 

temporarily disable connection pooling for the key-value store to prevent Cloudfront from slowing down individual connections, which impacts JSON-RPC latency for pruned data

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
