### PR TITLE
[rosetta] SEBP-97 Replace coins hashmap cache with an lru cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14469,6 +14469,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper 1.4.1",
+ "lru 0.10.0",
  "move-cli",
  "move-core-types",
  "mysten-metrics",

--- a/crates/sui-rosetta/Cargo.toml
+++ b/crates/sui-rosetta/Cargo.toml
@@ -37,6 +37,7 @@ sui-keys.workspace = true
 sui-json-rpc-types.workspace = true
 mysten-metrics.workspace = true
 shared-crypto.workspace = true
+lru.workspace = true
 
 move-core-types.workspace = true
 

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use shared_crypto::intent::Intent;
 use signature::rand_core::OsRng;
 use std::collections::{BTreeMap, HashMap};
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::str::FromStr;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
@@ -750,7 +751,7 @@ async fn test_transaction(
             SuiExecutionStatus::Failure { .. }
         ));
     }
-    let coin_cache = CoinMetadataCache::new(client.clone());
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(2).unwrap());
     let ops = Operations::try_from_response(response.clone(), &coin_cache)
         .await
         .unwrap();

--- a/crates/sui-rosetta/src/unit_tests/lib_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/lib_tests.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::CoinMetadataCache;
+use anyhow::anyhow;
+use rand::prelude::IteratorRandom;
+use rand::rngs::OsRng;
+use shared_crypto::intent::Intent;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use sui_json_rpc_types::{
+    ObjectChange, SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockResponseOptions,
+};
+use sui_keys::keystore::AccountKeystore;
+use sui_move_build::BuildConfig;
+use sui_sdk::SuiClient;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::gas_coin::GAS;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
+use sui_types::transaction::{
+    InputObjectKind, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+};
+use test_cluster::TestClusterBuilder;
+
+#[tokio::test]
+async fn test_cache() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test publish
+    let addresses = network.get_addresses();
+    let sender = addresses[0];
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["..", "..", "examples", "move", "coin"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(compiled_modules_bytes, dependencies);
+        builder.finish()
+    };
+    let input_objects = pt
+        .input_objects()
+        .unwrap_or_default()
+        .iter()
+        .flat_map(|obj| {
+            if let InputObjectKind::ImmOrOwnedMoveObject((id, ..)) = obj {
+                Some(*id)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    let gas = vec![get_random_sui(&client, sender, input_objects).await];
+    let data = TransactionData::new_with_gas_coins(
+        TransactionKind::programmable(pt.clone()),
+        sender,
+        gas,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+        rgp,
+    );
+
+    let signature = keystore
+        .sign_secure(&data.sender(), &data, Intent::sui_transaction())
+        .unwrap();
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            Transaction::from_data(data.clone(), vec![signature]),
+            SuiTransactionBlockResponseOptions::full_content(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .map_err(|e| anyhow!("TX execution failed for {data:#?}, error : {e}"))
+        .unwrap();
+    let object_changes = response.object_changes.unwrap();
+    let my_coin_type = object_changes
+        .into_iter()
+        .find_map(|change| {
+            if let ObjectChange::Created { object_type, .. } = change {
+                if object_type.to_string().contains("2::coin::TreasuryCap") {
+                    let coin_tag = object_type.type_params.into_iter().next().unwrap();
+                    return Some(coin_tag);
+                }
+            }
+            None
+        })
+        .unwrap();
+
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(1).unwrap());
+
+    assert_eq!(0, coin_cache.metadata.lock().await.len());
+
+    let _ = coin_cache.get_currency(&GAS::type_tag()).await;
+
+    assert_eq!(1, coin_cache.metadata.lock().await.len());
+    assert!(coin_cache.metadata.lock().await.contains(&GAS::type_tag()));
+    assert!(!coin_cache.metadata.lock().await.contains(&my_coin_type));
+
+    let _ = coin_cache.get_currency(&my_coin_type).await;
+
+    assert_eq!(1, coin_cache.metadata.lock().await.len());
+    assert!(coin_cache.metadata.lock().await.contains(&my_coin_type));
+    assert!(!coin_cache.metadata.lock().await.contains(&GAS::type_tag()));
+}
+
+async fn get_random_sui(
+    client: &SuiClient,
+    sender: SuiAddress,
+    except: Vec<ObjectID>,
+) -> ObjectRef {
+    let coins = client
+        .read_api()
+        .get_owned_objects(
+            sender,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            /* cursor */ None,
+            /* limit */ None,
+        )
+        .await
+        .unwrap()
+        .data;
+
+    let coin_resp = coins
+        .iter()
+        .filter(|object| {
+            let obj = object.object().unwrap();
+            obj.is_gas_coin() && !except.contains(&obj.object_id)
+        })
+        .choose(&mut OsRng)
+        .unwrap();
+
+    let coin = coin_resp.object().unwrap();
+    (coin.object_id, coin.version, coin.digest)
+}

--- a/crates/sui-rosetta/tests/custom_coins_tests.rs
+++ b/crates/sui-rosetta/tests/custom_coins_tests.rs
@@ -7,6 +7,7 @@ mod rosetta_client;
 mod test_coin_utils;
 
 use serde_json::json;
+use std::num::NonZeroUsize;
 use sui_json_rpc_types::{
     SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponseOptions,
 };
@@ -222,7 +223,7 @@ async fn test_custom_coin_transfer() {
         tx.effects.as_ref().unwrap().status()
     );
     println!("Sui TX: {tx:?}");
-    let coin_cache = CoinMetadataCache::new(client);
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
     let ops2 = Operations::try_from_response(tx, &coin_cache)
         .await
         .unwrap();

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde_json::json;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use rosetta_client::start_rosetta_test_server;
@@ -175,8 +176,10 @@ async fn test_stake() {
         tx.effects.as_ref().unwrap().status()
     );
 
-    let con_cache = CoinMetadataCache::new(client);
-    let ops2 = Operations::try_from_response(tx, &con_cache).await.unwrap();
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
     assert!(
         ops2.contains(&ops),
         "Operation mismatch. expecting:{}, got:{}",
@@ -236,7 +239,7 @@ async fn test_stake_all() {
         tx.effects.as_ref().unwrap().status()
     );
 
-    let coin_cache = CoinMetadataCache::new(client);
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
     let ops2 = Operations::try_from_response(tx, &coin_cache)
         .await
         .unwrap();
@@ -354,7 +357,7 @@ async fn test_withdraw_stake() {
         tx.effects.as_ref().unwrap().status()
     );
     println!("Sui TX: {tx:?}");
-    let coin_cache = CoinMetadataCache::new(client);
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
     let ops2 = Operations::try_from_response(tx, &coin_cache)
         .await
         .unwrap();
@@ -425,7 +428,7 @@ async fn test_pay_sui() {
         tx.effects.as_ref().unwrap().status()
     );
     println!("Sui TX: {tx:?}");
-    let coin_cache = CoinMetadataCache::new(client);
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
     let ops2 = Operations::try_from_response(tx, &coin_cache)
         .await
         .unwrap();
@@ -449,7 +452,7 @@ async fn test_pay_sui_multiple_times() {
     let keystore = &test_cluster.wallet.config.keystore;
 
     let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
-    let coin_cache = CoinMetadataCache::new(client.clone());
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(2).unwrap());
 
     for i in 1..20 {
         println!("Iteration: {}", i);


### PR DESCRIPTION
## Description 

Replaces coins hashmap cache with an lru cache

## Test plan 

Unit tests
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
