### PR TITLE
[trace-view] Support for differently named variables moving forward

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -1,4 +1,5 @@
 import {
+    Handles,
     Logger,
     logger,
     LoggingDebugSession,
@@ -6,12 +7,13 @@ import {
     TerminatedEvent,
     StoppedEvent,
     Thread,
+    Scope,
     StackFrame,
     Source
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as path from 'path';
-import { Runtime, RuntimeEvents, IRuntimeStack } from './runtime';
+import { Runtime, RuntimeEvents, IRuntimeVariableScope } from './runtime';
 
 const enum LogLevel {
     Log = 'log',
@@ -66,15 +68,31 @@ interface ILaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 
 export class MoveDebugSession extends LoggingDebugSession {
 
+    /**
+     * We only even have one thread so we can hardcode its ID.
+     */
     private static THREAD_ID = 1;
 
+    /**
+     * DAP-independent runtime maintaining state during
+     * trace viewing session.
+     */
     private runtime: Runtime;
+
+    /**
+     * Handles to create variable scopes
+     * (ideally we would use numbers but DAP package does not like it)
+     *
+     */
+    private variableHandles: Handles<IRuntimeVariableScope>;
+
 
     public constructor() {
         super();
         this.setDebuggerLinesStartAt1(false);
         this.setDebuggerColumnsStartAt1(false);
         this.runtime = new Runtime();
+        this.variableHandles = new Handles<IRuntimeVariableScope>();
 
         // setup event handlers
 
@@ -99,7 +117,7 @@ export class MoveDebugSession extends LoggingDebugSession {
         response.body.supportsEvaluateForHovers = false;
 
         // make VS Code show a 'step back' button
-        response.body.supportsStepBack = true;
+        response.body.supportsStepBack = false;
 
         // make VS Code support data breakpoints
         response.body.supportsDataBreakpoints = false;
@@ -182,7 +200,7 @@ export class MoveDebugSession extends LoggingDebugSession {
 
     protected stackTraceRequest(
         response: CustomizedStackTraceResponse,
-        args: DebugProtocol.StackTraceArguments
+        _args: DebugProtocol.StackTraceArguments
     ): void {
         try {
             const runtimeStack = this.runtime.stack();
@@ -194,7 +212,7 @@ export class MoveDebugSession extends LoggingDebugSession {
                 }).reverse(),
                 totalFrames: stack_height,
                 optimized_lines: stack_height > 0
-                    ? runtimeStack.frames[stack_height - 1].sourceMap.optimized_lines
+                    ? runtimeStack.frames[stack_height - 1].sourceMap.optimizedLines
                     : []
             };
         } catch (err) {
@@ -204,12 +222,107 @@ export class MoveDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    protected nextRequest(
-        response: DebugProtocol.NextResponse,
-        args: DebugProtocol.NextArguments
+    /**
+     * Gets the scopes for a given frame.
+     *
+     * @param frameId identifier of the frame scopes are requested for.
+     * @returns an array of scopes.
+     */
+    private getScopes(frameId: number): DebugProtocol.Scope[] {
+        const runtimeStack = this.runtime.stack();
+        const frame = runtimeStack.frames.find(frame => frame.id === frameId);
+        if (!frame) {
+            throw new Error("No frame found for id: " + frameId);
+        }
+        const scopes: DebugProtocol.Scope[] = [];
+        if (frame.locals.length > 0) {
+            const localScopeReference = this.variableHandles.create({ locals: frame.locals[0] });
+            const localScope = new Scope('locals: ' + frame.name, localScopeReference, false);
+            scopes.push(localScope);
+            // TODO: finish shadowed variables support
+            for (let i = 1; i < frame.locals.length; i++) {
+                const shadowedScopeReference = this.variableHandles.create({ locals: frame.locals[i] });
+                const shadowedScope = new Scope('shadowed: ' + frame.name, shadowedScopeReference, false);
+                scopes.push(shadowedScope);
+            }
+        }
+
+        return scopes;
+    }
+
+    protected scopesRequest(
+        response: DebugProtocol.ScopesResponse,
+        args: DebugProtocol.ScopesArguments
     ): void {
         try {
-            this.runtime.step(
+            const scopes = this.getScopes(args.frameId);
+            response.body = {
+                scopes
+            };
+        } catch (err) {
+            response.success = false;
+            response.message = err instanceof Error ? err.message : String(err);
+        }
+
+        this.sendResponse(response);
+    }
+
+    /**
+     * Converts runtime variables to DAP variables.
+     *
+     * @param runtimeScope runtime variables scope,
+     * @returns an array of variables.
+     */
+    private convertRuntimeVariables(runtimeScope: IRuntimeVariableScope): DebugProtocol.Variable[] {
+        const variables: DebugProtocol.Variable[] = [];
+        const runtimeVariables = runtimeScope.locals;
+        for (let i = 0; i < runtimeVariables.length; i++) {
+            const v = runtimeVariables[i];
+            if (v) {
+                variables.push({
+                    name: v.name,
+                    type: v.type,
+                    value: v.value,
+                    variablesReference: 0
+                });
+            }
+        }
+
+        return variables;
+    }
+
+    protected variablesRequest(
+        response: DebugProtocol.VariablesResponse,
+        args: DebugProtocol.VariablesArguments
+    ): void {
+        const handle = this.variableHandles.get(args.variablesReference);
+        if (!handle) {
+            this.sendResponse(response);
+            return;
+        }
+        try {
+            const variables = this.convertRuntimeVariables(handle);
+            if (variables.length > 0) {
+                response.body = {
+                    variables
+                };
+            }
+        } catch (err) {
+            response.success = false;
+            response.message = err instanceof Error ? err.message : String(err);
+        }
+
+        this.sendResponse(response);
+    }
+
+
+    protected nextRequest(
+        response: DebugProtocol.NextResponse,
+        _args: DebugProtocol.NextArguments
+    ): void {
+        let terminate = false;
+        try {
+            terminate = this.runtime.step(
                 /* next */ true,
                 /* stopAtCloseFrame */ false,
                 /* nextLineSkip */ true
@@ -218,12 +331,15 @@ export class MoveDebugSession extends LoggingDebugSession {
             response.success = false;
             response.message = err instanceof Error ? err.message : String(err);
         }
+        if (terminate) {
+            this.sendEvent(new TerminatedEvent());
+        }
         this.sendResponse(response);
     }
 
     protected stepInRequest(
         response: DebugProtocol.StepInResponse,
-        args: DebugProtocol.StepInArguments
+        _args: DebugProtocol.StepInArguments
     ): void {
         let terminate = false;
         try {
@@ -244,27 +360,29 @@ export class MoveDebugSession extends LoggingDebugSession {
 
     protected stepOutRequest(
         response: DebugProtocol.StepOutResponse,
-        args: DebugProtocol.StepOutArguments
+        _args: DebugProtocol.StepOutArguments
     ): void {
-        let terminate = false;
         try {
-            terminate = this.runtime.stepOut();
+            const steppedOut = this.runtime.stepOut();
+            if (!steppedOut) {
+                logger.log("Cannot step out");
+            }
         } catch (err) {
             response.success = false;
             response.message = err instanceof Error ? err.message : String(err);
-        }
-        if (terminate) {
-            this.sendEvent(new TerminatedEvent());
         }
         this.sendResponse(response);
     }
 
     protected stepBackRequest(
         response: DebugProtocol.StepBackResponse,
-        args: DebugProtocol.StepBackArguments
+        _args: DebugProtocol.StepBackArguments
     ): void {
         try {
-            this.runtime.stepBack();
+            const steppedBack = this.runtime.stepBack();
+            if (!steppedBack) {
+                logger.log("Cannot step back");
+            }
         } catch (err) {
             response.success = false;
             response.message = err instanceof Error ? err.message : String(err);
@@ -274,7 +392,7 @@ export class MoveDebugSession extends LoggingDebugSession {
 
     protected continueRequest(
         response: DebugProtocol.ContinueResponse,
-        args: DebugProtocol.ContinueArguments
+        _args: DebugProtocol.ContinueArguments
     ): void {
         let terminate = false;
         try {
@@ -291,7 +409,7 @@ export class MoveDebugSession extends LoggingDebugSession {
 
     protected reverseContinueRequest(
         response: DebugProtocol.ReverseContinueResponse,
-        args: DebugProtocol.ReverseContinueArguments
+        _args: DebugProtocol.ReverseContinueArguments
     ): void {
         let terminate = false;
         try {
@@ -308,7 +426,7 @@ export class MoveDebugSession extends LoggingDebugSession {
 
     protected disconnectRequest(
         response: DebugProtocol.DisconnectResponse,
-        args: DebugProtocol.DisconnectArguments
+        _args: DebugProtocol.DisconnectArguments
     ): void {
         // Cleanup and terminate the debug session
         this.sendEvent(new TerminatedEvent());

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -237,12 +237,12 @@ export class MoveDebugSession extends LoggingDebugSession {
         const scopes: DebugProtocol.Scope[] = [];
         if (frame.locals.length > 0) {
             const localScopeReference = this.variableHandles.create({ locals: frame.locals[0] });
-            const localScope = new Scope('locals: ' + frame.name, localScopeReference, false);
+            const localScope = new Scope(`locals: ${frame.name}`, localScopeReference, false);
             scopes.push(localScope);
             // TODO: finish shadowed variables support
             for (let i = 1; i < frame.locals.length; i++) {
                 const shadowedScopeReference = this.variableHandles.create({ locals: frame.locals[i] });
-                const shadowedScope = new Scope('shadowed: ' + frame.name, shadowedScopeReference, false);
+                const shadowedScope = new Scope(`shadowed(${i}): ${frame.name}`, shadowedScopeReference, false);
                 scopes.push(shadowedScope);
             }
         }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -171,7 +171,7 @@ export class MoveDebugSession extends LoggingDebugSession {
         args: ILaunchRequestArguments
     ): Promise<void> {
         logger.setup(convertLoggerLogLevel(args.logLevel ?? LogLevel.None), false);
-        logger.log("Launching trace viewer for file: " + args.source + " and trace: " + args.traceInfo);
+        logger.log(`Launching trace viewer for file: ${args.source} and trace: ${args.traceInfo}`);
         try {
             await this.runtime.start(args.source, args.traceInfo, args.stopOnEntry || false);
         } catch (err) {
@@ -179,7 +179,7 @@ export class MoveDebugSession extends LoggingDebugSession {
             response.message = err instanceof Error ? err.message : String(err);
         }
         this.sendResponse(response);
-        this.sendEvent(new StoppedEvent("entry", MoveDebugSession.THREAD_ID));
+        this.sendEvent(new StoppedEvent('entry', MoveDebugSession.THREAD_ID));
     }
 
     protected configurationDoneRequest(
@@ -192,7 +192,7 @@ export class MoveDebugSession extends LoggingDebugSession {
     protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
         response.body = {
             threads: [
-                new Thread(MoveDebugSession.THREAD_ID, "Main Thread")
+                new Thread(MoveDebugSession.THREAD_ID, 'Main Thread')
             ]
         };
         this.sendResponse(response);
@@ -232,7 +232,7 @@ export class MoveDebugSession extends LoggingDebugSession {
         const runtimeStack = this.runtime.stack();
         const frame = runtimeStack.frames.find(frame => frame.id === frameId);
         if (!frame) {
-            throw new Error("No frame found for id: " + frameId);
+            throw new Error(`No frame found for id: ${frameId}`);
         }
         const scopes: DebugProtocol.Scope[] = [];
         if (frame.locals.length > 0) {
@@ -365,7 +365,7 @@ export class MoveDebugSession extends LoggingDebugSession {
         try {
             const steppedOut = this.runtime.stepOut();
             if (!steppedOut) {
-                logger.log("Cannot step out");
+                logger.log(`Cannot step out`);
             }
         } catch (err) {
             response.success = false;
@@ -381,7 +381,7 @@ export class MoveDebugSession extends LoggingDebugSession {
         try {
             const steppedBack = this.runtime.stepBack();
             if (!steppedBack) {
-                logger.log("Cannot step back");
+                logger.log(`Cannot step back`);
             }
         } catch (err) {
             response.success = false;

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/source_map_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/source_map_utils.ts
@@ -105,7 +105,7 @@ export function readAllSourceMaps(
             const stats = fs.statSync(filePath);
             if (stats.isDirectory()) {
                 processDirectory(filePath);
-            } else if (path.extname(f) === ".json") {
+            } else if (path.extname(f) === '.json') {
                 const sourceMap = readSourceMap(filePath, filesMap);
                 sourceMapsMap.set(JSON.stringify(sourceMap.modInfo), sourceMap);
             }
@@ -123,6 +123,7 @@ export function readAllSourceMaps(
  * @param sourceMapPath path to the source map JSON file.
  * @param filesMap map from file hash to file information.
  * @returns source map.
+ * @throws Error if with a descriptive error message if the source map cannot be read.
  */
 function readSourceMap(sourceMapPath: string, filesMap: Map<string, IFileInfo>): ISourceMap {
     const sourceMapJSON: ISrcRootObject = JSON.parse(fs.readFileSync(sourceMapPath, 'utf8'));
@@ -135,9 +136,9 @@ function readSourceMap(sourceMapPath: string, filesMap: Map<string, IFileInfo>):
     const functions = new Map<string, ISourceMapFunction>();
     const fileInfo = filesMap.get(fileHash);
     if (!fileInfo) {
-        throw new Error("Could not find file with hash: "
+        throw new Error('Could not find file with hash: '
             + fileHash
-            + " when processing source map at: "
+            + ' when processing source map at: '
             + sourceMapPath);
     }
     const allSourceMapLines = new Set<number>();

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from 'fs';
-import { ModuleInfo } from './utils';
+import { INFINITE_LIFETIME, ModuleInfo } from './utils';
 
 // Data types corresponding to trace file JSON schema.
 
@@ -13,11 +13,15 @@ interface ITraceModule {
 
 interface ITraceType {
     ref_type: string | null;
-    type_: string | { vector: string };
+    type_: string;
 }
 
 interface ITraceRuntimeValue {
     value: any;
+}
+
+interface ITraceValue {
+    RuntimeValue: ITraceRuntimeValue;
 }
 
 interface ITraceFrame {
@@ -27,7 +31,7 @@ interface ITraceFrame {
     is_native: boolean;
     locals_types: ITraceType[];
     module: ITraceModule;
-    parameters: ITraceRuntimeValue[];
+    parameters: ITraceValue[];
     return_types: ITraceType[];
     type_instantiation: string[];
 }
@@ -50,13 +54,13 @@ interface ITraceLocation {
 
 interface ITraceWriteEffect {
     location: ITraceLocation;
-    root_value_after_write: ITraceRuntimeValue;
+    root_value_after_write: ITraceValue;
 }
 
 interface ITraceReadEffect {
     location: ITraceLocation;
     moved: boolean;
-    root_value_read: ITraceRuntimeValue;
+    root_value_read: ITraceValue;
 }
 
 interface ITracePushEffect {
@@ -103,18 +107,85 @@ interface ITraceRootObject {
 // Runtime data types.
 
 /**
+ * Kind of a trace event.
+ */
+export enum TraceEventKind {
+    OpenFrame = 'OpenFrame',
+    CloseFrame = 'CloseFrame',
+    Instruction = 'Instruction',
+    Effect = 'Effect'
+}
+
+/**
  * Trace event types containing relevant data.
  */
 export type TraceEvent =
-    | { type: 'OpenFrame', id: number, name: string, modInfo: ModuleInfo }
-    | { type: 'CloseFrame', id: number }
-    | { type: 'Instruction', pc: number };
+    | {
+        type: TraceEventKind.OpenFrame,
+        id: number,
+        name: string,
+        modInfo: ModuleInfo,
+        localsTypes: string[],
+        paramValues: TraceValue[]
+    }
+    | { type: TraceEventKind.CloseFrame, id: number }
+    | { type: TraceEventKind.Instruction, pc: number }
+    | { type: TraceEventKind.Effect, effect: EventEffect };
+
+/**
+ * Kind of a location in the trace.
+ */
+export enum TraceLocKind {
+    Local = 'Local'
+    // TODO: other location types
+}
+
+/**
+ * Location in the trace.
+ */
+export type TraceLocation =
+    | { type: TraceLocKind.Local, frameId: number, localIndex: number };
+
+/**
+ * Kind of a value in the trace.
+ */
+export enum TraceValKind {
+    Runtime = 'RuntimeValue'
+    // TODO: other value types
+}
+
+/**
+ * Value in the trace.
+ */
+export type TraceValue =
+    | { type: TraceValKind.Runtime, value: string };
+
+/**
+ * Kind of an effect of an instruction.
+ */
+export enum TraceEffectKind {
+    Write = 'Write'
+    // TODO: other effect types
+}
+
+/**
+ * Effect of an instruction.
+ */
+export type EventEffect =
+    | { type: TraceEffectKind.Write, location: TraceLocation, value: TraceValue };
 
 /**
  * Execution trace consisting of a sequence of trace events.
  */
 interface ITrace {
     events: TraceEvent[];
+    /**
+     * Maps frame ID to an array of local variable lifetime ends
+     * indexed by the local variable index in the trace
+     * (variable lifetime end is PC of an instruction following
+     * the last variable access).
+     */
+    localLifetimeEnds: Map<number, number[]>;
 }
 
 
@@ -127,28 +198,126 @@ interface ITrace {
 export function readTrace(traceFilePath: string): ITrace {
     const traceJSON: ITraceRootObject = JSON.parse(fs.readFileSync(traceFilePath, 'utf8'));
     const events: TraceEvent[] = [];
+    // We compute the end of lifetime for a local variable as follows.
+    // When a given local variable is read or written in an effect, we set the end of its lifetime
+    // to INFINITE_LIFETIME. When a new instruction is executed, we set the end of its lifetime
+    // to be the PC of this instruction. The caveat here is that we must use
+    // the largest PC of all encountered instructions for this to avoid incorrectly
+    // setting the end of lifetime to a smaller PC in case of a loop.
+    //
+    // For example, consider the following code:
+    // ```
+    // while (x < foo()) {
+    //    x = x + 1;
+    // }
+    // ```
+    // In this case (simplifying a bit), `x` should be live throughout
+    // (unrolled in the trace) iterations of the loop. However, the last
+    // instruction executed after `x` is accessed for the last time
+    // will be `foo` whose PC is lower than PCs of instructions in/beyond
+    // the loop
+    const localLifetimeEnds = new Map<number, number[]>();
+    const locaLifetimeEndsMax = new Map<number, number[]>();
+    let frameIDs = [];
     for (const event of traceJSON.events) {
         if (event.OpenFrame) {
-            events.push({
-                type: 'OpenFrame',
-                id: event.OpenFrame.frame.frame_id,
-                name: event.OpenFrame.frame.function_name,
-                modInfo: {
-                    addr: event.OpenFrame.frame.module.address,
-                    name: event.OpenFrame.frame.module.name
+            const localsTypes = [];
+            const frame = event.OpenFrame.frame;
+            for (const type of frame.locals_types) {
+                localsTypes.push(type.type_);
+            }
+            // process parameters - store their values in trace and set their
+            // initial lifetimes
+            const paramValues = [];
+            const lifetimeEnds = localLifetimeEnds.get(frame.frame_id) || [];
+            for (let i = 0; i < frame.parameters.length; i++) {
+                const value = frame.parameters[i];
+                if (value) {
+                    const runtimeValue: TraceValue =
+                        { type: TraceValKind.Runtime, value: JSON.stringify(value.RuntimeValue.value) };
+                    paramValues.push(runtimeValue);
+                    lifetimeEnds[i] = INFINITE_LIFETIME;
                 }
+            }
+            localLifetimeEnds.set(frame.frame_id, lifetimeEnds);
+            events.push({
+                type: TraceEventKind.OpenFrame,
+                id: frame.frame_id,
+                name: frame.function_name,
+                modInfo: {
+                    addr: frame.module.address,
+                    name: frame.module.name
+                },
+                localsTypes,
+                paramValues,
             });
+            frameIDs.push(frame.frame_id);
         } else if (event.CloseFrame) {
             events.push({
-                type: 'CloseFrame',
+                type: TraceEventKind.CloseFrame,
                 id: event.CloseFrame.frame_id
             });
+            frameIDs.pop();
         } else if (event.Instruction) {
             events.push({
-                type: 'Instruction',
+                type: TraceEventKind.Instruction,
                 pc: event.Instruction.pc
             });
+            // Set end of lifetime for all locals to the max instruction PC ever seen
+            // for a given local (if they are live after this instructions, they will
+            // be reset to INFINITE_LIFETIME when processing subsequent effects).
+            const currentFrameID = frameIDs[frameIDs.length - 1];
+            const lifetimeEnds = localLifetimeEnds.get(currentFrameID) || [];
+            const lifetimeEndsMax = locaLifetimeEndsMax.get(currentFrameID) || [];
+            for (let i = 0; i < lifetimeEnds.length; i++) {
+                if (lifetimeEnds[i] === undefined || lifetimeEnds[i] === INFINITE_LIFETIME) {
+                    // only set new end of lifetime if it has not been set before
+                    // or if variable is live
+                    const pc = event.Instruction.pc;
+                    if (lifetimeEndsMax[i] === undefined || lifetimeEndsMax[i] < pc) {
+                        lifetimeEnds[i] = pc;
+                        lifetimeEndsMax[i] = pc;
+                    }
+                }
+            }
+            localLifetimeEnds.set(currentFrameID, lifetimeEnds);
+            locaLifetimeEndsMax.set(currentFrameID, lifetimeEndsMax);
+        } else if (event.Effect) {
+            const effect = event.Effect;
+            if (effect.Write || effect.Read) {
+                // if a local is read or written, set its end of lifetime
+                // to infinite (end of frame)
+                const location = effect.Write ? effect.Write.location : effect.Read!.location;
+                const frameId = location.Local[0];
+                const localIndex = location.Local[1];
+                const lifetimeEnds = localLifetimeEnds.get(frameId) || [];
+                lifetimeEnds[localIndex] = INFINITE_LIFETIME;
+                localLifetimeEnds.set(frameId, lifetimeEnds);
+
+                if (effect.Write) {
+                    const value = JSON.stringify(effect.Write.root_value_after_write.RuntimeValue.value);
+                    const traceValue: TraceValue = {
+                        type: TraceValKind.Runtime,
+                        value
+                    };
+                    const TraceLocation: TraceLocation = {
+                        type: TraceLocKind.Local,
+                        frameId,
+                        localIndex
+                    };
+                    events.push({
+                        type: TraceEventKind.Effect,
+                        effect: {
+                            type: TraceEffectKind.Write,
+                            location: TraceLocation,
+                            value: traceValue
+                        }
+                    });
+                }
+            }
+
+
         }
     }
-    return { events };
+    return { events, localLifetimeEnds };
 }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from 'fs';
-import { INFINITE_LIFETIME, ModuleInfo } from './utils';
+import { FRAME_LIFETIME, ModuleInfo } from './utils';
 
 // Data types corresponding to trace file JSON schema.
 
@@ -236,7 +236,7 @@ export function readTrace(traceFilePath: string): ITrace {
                     const runtimeValue: TraceValue =
                         { type: TraceValKind.Runtime, value: JSON.stringify(value.RuntimeValue.value) };
                     paramValues.push(runtimeValue);
-                    lifetimeEnds[i] = INFINITE_LIFETIME;
+                    lifetimeEnds[i] = FRAME_LIFETIME;
                 }
             }
             localLifetimeEnds.set(frame.frame_id, lifetimeEnds);
@@ -270,7 +270,7 @@ export function readTrace(traceFilePath: string): ITrace {
             const lifetimeEnds = localLifetimeEnds.get(currentFrameID) || [];
             const lifetimeEndsMax = locaLifetimeEndsMax.get(currentFrameID) || [];
             for (let i = 0; i < lifetimeEnds.length; i++) {
-                if (lifetimeEnds[i] === undefined || lifetimeEnds[i] === INFINITE_LIFETIME) {
+                if (lifetimeEnds[i] === undefined || lifetimeEnds[i] === FRAME_LIFETIME) {
                     // only set new end of lifetime if it has not been set before
                     // or if variable is live
                     const pc = event.Instruction.pc;
@@ -291,7 +291,7 @@ export function readTrace(traceFilePath: string): ITrace {
                 const frameId = location.Local[0];
                 const localIndex = location.Local[1];
                 const lifetimeEnds = localLifetimeEnds.get(frameId) || [];
-                lifetimeEnds[localIndex] = INFINITE_LIFETIME;
+                lifetimeEnds[localIndex] = FRAME_LIFETIME;
                 localLifetimeEnds.set(frameId, lifetimeEnds);
 
                 if (effect.Write) {

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/utils.ts
@@ -14,4 +14,4 @@ export interface ModuleInfo {
  * it means that it lives until the end of the current
  * frame.
  */
-export const INFINITE_LIFETIME = -1;
+export const FRAME_LIFETIME = -1;

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/utils.ts
@@ -8,3 +8,10 @@ export interface ModuleInfo {
     addr: string;
     name: string;
 }
+
+/**
+ * If end of lifetime for a local has this value,
+ * it means that it lives until the end of the current
+ * frame.
+ */
+export const INFINITE_LIFETIME = -1;


### PR DESCRIPTION
## Description 

This PR is the first in the series of PRs aiming to implement support for inspecting variables when viewing the trace (splitting this into multiple PRs to make the reviewing easier). The current focus is on primitive values (no structs/enums or references), but even with this limited focus it leaves the following work to subsequent PR:
- support for shadowed variables (a variable declared in an inner scope/block that has the same name as the one declared in the outer scope/block)
- support for moving backwards in trace

## Test plan 

Tested manually to make sure that thing work correctly
