### PR TITLE
Fix a few flaky tests

### DIFF
--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -181,12 +181,16 @@ async fn test_multisig_e2e() {
 #[sim_test]
 async fn test_multisig_with_zklogin_scenerios() {
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(15000)
+        // Use a long epoch duration such that it won't change epoch on its own.
+        .with_epoch_duration_ms(10000000)
         .with_default_jwks()
         .build()
         .await;
 
-    test_cluster.wait_for_epoch(Some(1)).await;
+    // Wait a bit for JWKs to be propagated.
+    test_cluster.wait_for_authenticator_state_update().await;
+    // Manually trigger epoch change to be able to test zklogin with multiple epochs.
+    test_cluster.trigger_reconfiguration().await;
 
     let rgp = test_cluster.get_reference_gas_price().await;
     let context = &test_cluster.wallet;

--- a/crates/sui-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_tests.rs
@@ -257,7 +257,6 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
         .await
         .unwrap();
     assert!(second_page.data.len() > 5);
-    assert!(!second_page.has_next_page);
 
     let mut all_txs = first_page.data.clone();
     all_txs.extend(second_page.data);

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -255,7 +255,7 @@ async fn test_withdraw_stake() {
     telemetry_subscribers::init_for_testing();
 
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(60000)
         .build()
         .await;
     let sender = test_cluster.get_address_0();
@@ -321,8 +321,8 @@ async fn test_withdraw_stake() {
     assert_eq!(1, response.balances.len());
     assert_eq!(1000000000, response.balances[0].value);
 
-    // wait for epoch.
-    tokio::time::sleep(Duration::from_millis(15000)).await;
+    // Trigger epoch change.
+    test_cluster.trigger_reconfiguration().await;
 
     // withdraw all stake
     let ops = serde_json::from_value(json!(


### PR DESCRIPTION
## Description 

This PR fixes a few flaky tests:
1. The multisig tests. If epoch duration is too small, some times it triggered epoch changes in the middle of test and the max epoch becomes insufficient.
2. The transaction e2e tesets. The query includes system transactions too, which there can be a lot more than 2 pages if enough checkpoints have passed by.
3. In rosetta with_draw_stake test, similar issue to (1), we need to manually control epoch change otherwise accidental epoch change could lead to wrong stake results.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
