### PR TITLE
[Metrics] add timeout and retries to metrics push task

### DIFF
--- a/crates/mysten-common/src/metrics.rs
+++ b/crates/mysten-common/src/metrics.rs
@@ -3,8 +3,10 @@
 
 use mysten_metrics::RegistryService;
 use prometheus::Encoder;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info};
+
+const DEFAULT_METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct MetricsPushClient {
     certificate: std::sync::Arc<sui_tls::SelfSignedCertificate>,
@@ -75,6 +77,7 @@ pub async fn push_metrics(
         .header(reqwest::header::CONTENT_ENCODING, "snappy")
         .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
         .body(compressed)
+        .timeout(DEFAULT_METRICS_PUSH_TIMEOUT)
         .send()
         .await?;
 


### PR DESCRIPTION
## Description 

We have observed `mainnet` validators cannot push metrics until restart. And metrics data points are dropped from some validators occasionally. Adding request timeouts and retries hopefully should mitigate some of these issues.

Interval ticks are skipped if missed, so it is ok to retry until success there. 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
