### PR TITLE
chore(graphql): Align all e2e tests on protocol 51

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.exp
@@ -58,11 +58,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x6b7e8ee3f855e9c484caf53b5fef5fe958d7266d8a3a12577f4a17830e213983",
+              "address": "0xe3679305061cc482496424b6d7620aaf7547c119248c3a32d92cfd960be18f70",
               "version": 5,
               "contents": {
                 "json": {
-                  "id": "0x6b7e8ee3f855e9c484caf53b5fef5fe958d7266d8a3a12577f4a17830e213983",
+                  "id": "0xe3679305061cc482496424b6d7620aaf7547c119248c3a32d92cfd960be18f70",
                   "count": "0"
                 }
               },
@@ -86,11 +86,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x6b7e8ee3f855e9c484caf53b5fef5fe958d7266d8a3a12577f4a17830e213983",
+              "address": "0xe3679305061cc482496424b6d7620aaf7547c119248c3a32d92cfd960be18f70",
               "version": 5,
               "contents": {
                 "json": {
-                  "id": "0x6b7e8ee3f855e9c484caf53b5fef5fe958d7266d8a3a12577f4a17830e213983",
+                  "id": "0xe3679305061cc482496424b6d7620aaf7547c119248c3a32d92cfd960be18f70",
                   "count": "0"
                 }
               },
@@ -98,11 +98,11 @@ Response: {
                 "nodes": [
                   {
                     "value": {
-                      "address": "0x4198a12c0cd01da21a6cd35cc5e986d855c532676233d004105dbaa77bdfda77",
+                      "address": "0xe9da616bc3a2cadb507658554aa60744f6745a9580dd0512553cdf3a64f41618",
                       "version": 6,
                       "contents": {
                         "json": {
-                          "id": "0x4198a12c0cd01da21a6cd35cc5e986d855c532676233d004105dbaa77bdfda77",
+                          "id": "0xe9da616bc3a2cadb507658554aa60744f6745a9580dd0512553cdf3a64f41618",
                           "count": "0"
                         }
                       }
@@ -145,7 +145,7 @@ Response: {
     "object": {
       "owner": {
         "parent": {
-          "address": "0x14c69bfdef30d74f3cb7e305aead3f5d2558ca8d4a32c96b01936c7cfbb36af0"
+          "address": "0x9958869e2da5c5af828a334520a81de2bec0861e171b575db12fb4987cb27a78"
         }
       },
       "dynamicFields": {
@@ -175,11 +175,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x4198a12c0cd01da21a6cd35cc5e986d855c532676233d004105dbaa77bdfda77",
+              "address": "0xe9da616bc3a2cadb507658554aa60744f6745a9580dd0512553cdf3a64f41618",
               "version": 6,
               "contents": {
                 "json": {
-                  "id": "0x4198a12c0cd01da21a6cd35cc5e986d855c532676233d004105dbaa77bdfda77",
+                  "id": "0xe9da616bc3a2cadb507658554aa60744f6745a9580dd0512553cdf3a64f41618",
                   "count": "0"
                 }
               }
@@ -203,11 +203,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x4198a12c0cd01da21a6cd35cc5e986d855c532676233d004105dbaa77bdfda77",
+              "address": "0xe9da616bc3a2cadb507658554aa60744f6745a9580dd0512553cdf3a64f41618",
               "version": 6,
               "contents": {
                 "json": {
-                  "id": "0x4198a12c0cd01da21a6cd35cc5e986d855c532676233d004105dbaa77bdfda77",
+                  "id": "0xe9da616bc3a2cadb507658554aa60744f6745a9580dd0512553cdf3a64f41618",
                   "count": "0"
                 }
               }

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.move
@@ -15,7 +15,7 @@
 
 // Verify that Parent1 (6) -> Child1 (5) -> Child2 (6)
 
-//# init --protocol-version 45 --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/nested_dof.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/nested_dof.exp
@@ -62,11 +62,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+              "address": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
               "version": 5,
               "contents": {
                 "json": {
-                  "id": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+                  "id": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
                   "count": "0"
                 }
               },
@@ -90,11 +90,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+              "address": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
               "version": 5,
               "contents": {
                 "json": {
-                  "id": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+                  "id": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
                   "count": "0"
                 }
               },
@@ -102,11 +102,11 @@ Response: {
                 "nodes": [
                   {
                     "value": {
-                      "address": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                      "address": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                       "version": 6,
                       "contents": {
                         "json": {
-                          "id": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                          "id": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                           "count": "0"
                         }
                       }
@@ -131,11 +131,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+              "address": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
               "version": 7,
               "contents": {
                 "json": {
-                  "id": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+                  "id": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
                   "count": "1"
                 }
               },
@@ -143,11 +143,11 @@ Response: {
                 "nodes": [
                   {
                     "value": {
-                      "address": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                      "address": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                       "version": 6,
                       "contents": {
                         "json": {
-                          "id": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                          "id": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                           "count": "0"
                         }
                       }
@@ -172,11 +172,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+              "address": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
               "version": 7,
               "contents": {
                 "json": {
-                  "id": "0x73f7e04f424045e449ed940a29a191045a40089fab972a4d83d7715d06c7ecf4",
+                  "id": "0xaf22a2cb7f462efe4ee5edbad04401ebc2839fd7039c5765ab885239526e56df",
                   "count": "1"
                 }
               },
@@ -184,11 +184,11 @@ Response: {
                 "nodes": [
                   {
                     "value": {
-                      "address": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                      "address": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                       "version": 8,
                       "contents": {
                         "json": {
-                          "id": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                          "id": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                           "count": "1"
                         }
                       }
@@ -233,11 +233,11 @@ Response: {
         "nodes": [
           {
             "value": {
-              "address": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+              "address": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
               "version": 6,
               "contents": {
                 "json": {
-                  "id": "0xc01dbc5bc85403c91054fc00aceffde453d176eecd91c216cace519337f3880b",
+                  "id": "0x2a7da6bbcdab2d016824ee13cae48c2efff439e704162acb5a2eb1367bd975c7",
                   "count": "0"
                 }
               }

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/nested_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/nested_dof.move
@@ -19,7 +19,7 @@
 // Child1 (5) -> None
 // Child1 (7) -> Child2 (6)
 
-//# init --protocol-version 45 --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/chain_identifier.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/chain_identifier.exp
@@ -11,6 +11,6 @@ task 2, lines 9-12:
 //# run-graphql
 Response: {
   "data": {
-    "chainIdentifier": "8f58ad28"
+    "chainIdentifier": "3989ac57"
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/chain_identifier.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/chain_identifier.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --simulator --accounts C
+//# init --protocol-version 51 --simulator --accounts C
 
 
 //# create-checkpoint

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/no_filter.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/no_filter.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.exp
@@ -37,19 +37,19 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "digest": "AXoD3PWjAdYov3o7FaWgAqJA8RmvQrjwxGxAi2MNEujz"
+          "digest": "J7mHXcoa7LXwyjzZUWsk8zvYZjek359TM4d2hQK4LGHo"
         },
         {
-          "digest": "3nuQk9o2VVoqWbF6gS5vBTPwVLhMRbFJREDCvQJUavZ2"
+          "digest": "GzuRyvDM6ehuWCZx9ARJ2orWxUHQFYkfgEnb1a3jJvHU"
         },
         {
-          "digest": "5VAhspujQVcgJNvqe9Ed8BuFTeZdTRCCTzS6WwSZ9Dke"
+          "digest": "86VwSuYhTH7JZBP9a54RaudqRdqiEcx4QK9EC3RbiyBx"
         },
         {
-          "digest": "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"
+          "digest": "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"
         },
         {
-          "digest": "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"
+          "digest": "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.move
@@ -5,7 +5,7 @@
 // Also tests that fetching events filtered on a tx digest that has events returns the correct
 // number of page-limit-bound nodes.
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {
@@ -44,7 +44,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-    events(filter: {transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(filter: {transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -57,7 +57,7 @@ module Test::M1 {
 //# run-graphql --cursors {"tx":3,"e":1,"c":1}
 # When the tx digest and after cursor are on the same tx, we'll use the after cursor's event sequence number
 {
-    events(after: "@{cursor_0}" filter: {transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(after: "@{cursor_0}" filter: {transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -72,7 +72,7 @@ module Test::M1 {
 # we will get an empty response, since it's not possible to fetch an event
 # that isn't of the same tx sequence number
 {
-    events(after: "@{cursor_0}" filter: {transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(after: "@{cursor_0}" filter: {transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -85,7 +85,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-    events(filter: {transactionDigest: "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"}) {
+    events(filter: {transactionDigest: "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"}) {
         edges {
             cursor
             node {
@@ -97,7 +97,7 @@ module Test::M1 {
 
 //# run-graphql --cursors {"tx":4,"e":0,"c":1}
 {
-    events(after: "@{cursor_0}" filter: {transactionDigest: "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"}) {
+    events(after: "@{cursor_0}" filter: {transactionDigest: "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"}) {
         edges {
             cursor
             node {
@@ -110,7 +110,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-    events(last: 10 filter: {transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(last: 10 filter: {transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -123,7 +123,7 @@ module Test::M1 {
 //# run-graphql --cursors {"tx":3,"e":1,"c":1}
 # When the tx digest and cursor are on the same tx, we'll use the cursor's event sequence number
 {
-    events(last: 10 before: "@{cursor_0}" filter: {transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(last: 10 before: "@{cursor_0}" filter: {transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -138,7 +138,7 @@ module Test::M1 {
 # we will get an empty response, since it's not possible to fetch an event
 # that isn't of the same tx sequence number
 {
-    events(last: 10 before: "@{cursor_0}" filter: {transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(last: 10 before: "@{cursor_0}" filter: {transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -151,7 +151,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-    events(last: 10 filter: {transactionDigest: "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"}) {
+    events(last: 10 filter: {transactionDigest: "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"}) {
         edges {
             cursor
             node {
@@ -163,7 +163,7 @@ module Test::M1 {
 
 //# run-graphql --cursors {"tx":4,"e":1,"c":1}
 {
-    events(last: 10 before: "@{cursor_0}" filter: {transactionDigest: "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"}) {
+    events(last: 10 before: "@{cursor_0}" filter: {transactionDigest: "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"}) {
         edges {
             cursor
             node {
@@ -176,7 +176,7 @@ module Test::M1 {
 //# run-graphql
 # correct sender
 {
-    events(filter: {sender: "@{A}" transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(filter: {sender: "@{A}" transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -189,7 +189,7 @@ module Test::M1 {
 //# run-graphql
 # correct sender
 {
-    events(filter: {sender: "@{B}" transactionDigest: "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"}) {
+    events(filter: {sender: "@{B}" transactionDigest: "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"}) {
         edges {
             cursor
             node {
@@ -202,7 +202,7 @@ module Test::M1 {
 //# run-graphql
 # incorrect sender
 {
-    events(filter: {sender: "@{B}" transactionDigest: "8n1pk5fYM7v7tvsh4dcKxLRy8uf3he24FZCwdEKi9cSj"}) {
+    events(filter: {sender: "@{B}" transactionDigest: "4WR3NBdL6urP2e6SiUybJ4PwjGf5TjXVWQXUNa5LWmSX"}) {
         edges {
             cursor
             node {
@@ -215,7 +215,7 @@ module Test::M1 {
 //# run-graphql
 # incorrect sender
 {
-    events(filter: {sender: "@{A}" transactionDigest: "4dqR1zeomDMNHbUAZjooSZXrosPEb67gvvsUFeUSet9v"}) {
+    events(filter: {sender: "@{A}" transactionDigest: "34FkpE6XEGHr1tygReoa1inUk2Ba41QiLMQA4SnBgeQ8"}) {
         edges {
             cursor
             node {

--- a/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.exp
@@ -124,10 +124,10 @@ Response: {
           "version": 11,
           "contents": {
             "json": {
-              "id": "0x90dc651cc4aef34057af8c944f0ab8a0150295ad088edd4407a1bd4c225e18b8",
+              "id": "0xdecc5c8f1ae3f8e6bfa4493d9e9711a033e1eb00551e07854d5f08ac6dae7588",
               "count": "1",
               "wrapped": {
-                "id": "0x3330add01caca066f647d3a3df92917d0191ba9b9aaaa8d2da4d726bb3c330cf",
+                "id": "0xec73f4e0490995f1661d8248f4402b475a4f9643d309c1bb792874484cb0adbd",
                 "count": "1"
               }
             }
@@ -141,10 +141,10 @@ Response: {
           "version": 10,
           "contents": {
             "json": {
-              "id": "0x90dc651cc4aef34057af8c944f0ab8a0150295ad088edd4407a1bd4c225e18b8",
+              "id": "0xdecc5c8f1ae3f8e6bfa4493d9e9711a033e1eb00551e07854d5f08ac6dae7588",
               "count": "1",
               "wrapped": {
-                "id": "0x3330add01caca066f647d3a3df92917d0191ba9b9aaaa8d2da4d726bb3c330cf",
+                "id": "0xec73f4e0490995f1661d8248f4402b475a4f9643d309c1bb792874484cb0adbd",
                 "count": "1"
               }
             }
@@ -158,10 +158,10 @@ Response: {
           "version": 8,
           "contents": {
             "json": {
-              "id": "0x90dc651cc4aef34057af8c944f0ab8a0150295ad088edd4407a1bd4c225e18b8",
+              "id": "0xdecc5c8f1ae3f8e6bfa4493d9e9711a033e1eb00551e07854d5f08ac6dae7588",
               "count": "1",
               "wrapped": {
-                "id": "0x3330add01caca066f647d3a3df92917d0191ba9b9aaaa8d2da4d726bb3c330cf",
+                "id": "0xec73f4e0490995f1661d8248f4402b475a4f9643d309c1bb792874484cb0adbd",
                 "count": "0"
               }
             }
@@ -175,10 +175,10 @@ Response: {
           "version": 7,
           "contents": {
             "json": {
-              "id": "0x90dc651cc4aef34057af8c944f0ab8a0150295ad088edd4407a1bd4c225e18b8",
+              "id": "0xdecc5c8f1ae3f8e6bfa4493d9e9711a033e1eb00551e07854d5f08ac6dae7588",
               "count": "0",
               "wrapped": {
-                "id": "0x3330add01caca066f647d3a3df92917d0191ba9b9aaaa8d2da4d726bb3c330cf",
+                "id": "0xec73f4e0490995f1661d8248f4402b475a4f9643d309c1bb792874484cb0adbd",
                 "count": "0"
               }
             }
@@ -199,7 +199,7 @@ Response: {
           "version": 7,
           "contents": {
             "json": {
-              "id": "0xd38f2f2e8c369c5ec08b8852fac5834c2bcc25308f0205763528364354dc0369",
+              "id": "0xc6648a3386f34bd5b4757713a6d5f81852df299ef5a867de257b0c28a56f07e3",
               "count": "0"
             }
           }
@@ -212,7 +212,7 @@ Response: {
           "version": 10,
           "contents": {
             "json": {
-              "id": "0xd38f2f2e8c369c5ec08b8852fac5834c2bcc25308f0205763528364354dc0369",
+              "id": "0xc6648a3386f34bd5b4757713a6d5f81852df299ef5a867de257b0c28a56f07e3",
               "count": "1"
             }
           }
@@ -225,7 +225,7 @@ Response: {
           "version": 10,
           "contents": {
             "json": {
-              "id": "0xd38f2f2e8c369c5ec08b8852fac5834c2bcc25308f0205763528364354dc0369",
+              "id": "0xc6648a3386f34bd5b4757713a6d5f81852df299ef5a867de257b0c28a56f07e3",
               "count": "1"
             }
           }
@@ -238,7 +238,7 @@ Response: {
           "version": 7,
           "contents": {
             "json": {
-              "id": "0xd38f2f2e8c369c5ec08b8852fac5834c2bcc25308f0205763528364354dc0369",
+              "id": "0xc6648a3386f34bd5b4757713a6d5f81852df299ef5a867de257b0c28a56f07e3",
               "count": "0"
             }
           }
@@ -251,7 +251,7 @@ Response: {
           "version": 7,
           "contents": {
             "json": {
-              "id": "0xd38f2f2e8c369c5ec08b8852fac5834c2bcc25308f0205763528364354dc0369",
+              "id": "0xc6648a3386f34bd5b4757713a6d5f81852df299ef5a867de257b0c28a56f07e3",
               "count": "0"
             }
           }
@@ -271,7 +271,7 @@ Response: {
           "version": 7,
           "contents": {
             "json": {
-              "id": "0xab491044d75a8be613bd6fdc2215a0847c740b8774bc6feb9188f4b7233a37d5",
+              "id": "0x418dc1ff6ea1cdccbc2ab29974b3f233855dee9bedecfadaab0d4f906bef4295",
               "count": "0"
             }
           }
@@ -284,7 +284,7 @@ Response: {
           "version": 11,
           "contents": {
             "json": {
-              "id": "0xab491044d75a8be613bd6fdc2215a0847c740b8774bc6feb9188f4b7233a37d5",
+              "id": "0x418dc1ff6ea1cdccbc2ab29974b3f233855dee9bedecfadaab0d4f906bef4295",
               "count": "1"
             }
           }
@@ -297,7 +297,7 @@ Response: {
           "version": 7,
           "contents": {
             "json": {
-              "id": "0xab491044d75a8be613bd6fdc2215a0847c740b8774bc6feb9188f4b7233a37d5",
+              "id": "0x418dc1ff6ea1cdccbc2ab29974b3f233855dee9bedecfadaab0d4f906bef4295",
               "count": "0"
             }
           }

--- a/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses P0=0x0 --accounts A --simulator
+//# init --protocol-version 51 --addresses P0=0x0 --accounts A --simulator
 
 //# publish
 module P0::M {

--- a/crates/sui-graphql-e2e-tests/tests/stable/packages/versioning.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/packages/versioning.exp
@@ -31,14 +31,14 @@ Response: {
       "packageVersions": {
         "nodes": [
           {
-            "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+            "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
             "version": 1
           }
         ]
       }
     },
     "firstPackage": {
-      "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+      "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
       "version": 1,
       "module": {
         "functions": {
@@ -52,7 +52,7 @@ Response: {
       "packageVersions": {
         "nodes": [
           {
-            "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+            "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
             "version": 1
           }
         ]
@@ -73,11 +73,15 @@ Response: {
           "version": 1
         },
         {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
+          "version": 1
+        },
+        {
           "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
           "version": 1
         },
         {
-          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
           "version": 1
         }
       ]
@@ -116,18 +120,18 @@ Response: {
       "packageVersions": {
         "nodes": [
           {
-            "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+            "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
             "version": 1
           },
           {
-            "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+            "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
             "version": 2
           }
         ]
       }
     },
     "firstPackage": {
-      "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+      "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
       "version": 1,
       "module": {
         "functions": {
@@ -141,11 +145,11 @@ Response: {
       "packageVersions": {
         "nodes": [
           {
-            "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+            "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
             "version": 1
           },
           {
-            "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+            "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
             "version": 2
           }
         ]
@@ -166,15 +170,19 @@ Response: {
           "version": 1
         },
         {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
+          "version": 1
+        },
+        {
           "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
           "version": 1
         },
         {
-          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
           "version": 1
         },
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2
         }
       ]
@@ -216,22 +224,22 @@ Response: {
       "packageVersions": {
         "nodes": [
           {
-            "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+            "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
             "version": 1
           },
           {
-            "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+            "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
             "version": 2
           },
           {
-            "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+            "address": "0xb276a6430b37c21393e4bd594b1c6f080485243b7437141b8c54b3c46e0209d6",
             "version": 3
           }
         ]
       }
     },
     "firstPackage": {
-      "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+      "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
       "version": 1,
       "module": {
         "functions": {
@@ -245,15 +253,15 @@ Response: {
       "packageVersions": {
         "nodes": [
           {
-            "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+            "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
             "version": 1
           },
           {
-            "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+            "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
             "version": 2
           },
           {
-            "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+            "address": "0xb276a6430b37c21393e4bd594b1c6f080485243b7437141b8c54b3c46e0209d6",
             "version": 3
           }
         ]
@@ -274,19 +282,23 @@ Response: {
           "version": 1
         },
         {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
+          "version": 1
+        },
+        {
           "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
           "version": 1
         },
         {
-          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
           "version": 1
         },
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2
         },
         {
-          "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+          "address": "0xb276a6430b37c21393e4bd594b1c6f080485243b7437141b8c54b3c46e0209d6",
           "version": 3
         }
       ]
@@ -677,6 +689,17 @@ Response: {
           }
         },
         {
+          "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
+          "version": 1,
+          "previousTransactionBlock": {
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
           "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
           "version": 1,
           "previousTransactionBlock": {
@@ -692,7 +715,7 @@ Response: {
     "after": {
       "nodes": [
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2,
           "previousTransactionBlock": {
             "effects": {
@@ -703,7 +726,7 @@ Response: {
           }
         },
         {
-          "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+          "address": "0xb276a6430b37c21393e4bd594b1c6f080485243b7437141b8c54b3c46e0209d6",
           "version": 3,
           "previousTransactionBlock": {
             "effects": {
@@ -718,7 +741,7 @@ Response: {
     "between": {
       "nodes": [
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2,
           "previousTransactionBlock": {
             "effects": {
@@ -740,15 +763,15 @@ Response: {
     "packageVersions": {
       "nodes": [
         {
-          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
           "version": 1
         },
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2
         },
         {
-          "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+          "address": "0xb276a6430b37c21393e4bd594b1c6f080485243b7437141b8c54b3c46e0209d6",
           "version": 3
         }
       ]
@@ -756,11 +779,11 @@ Response: {
     "after": {
       "nodes": [
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2
         },
         {
-          "address": "0x0eae57b7a07b0548b1f6b0c309f0692828ff994e9159b541334b25582980631c",
+          "address": "0xb276a6430b37c21393e4bd594b1c6f080485243b7437141b8c54b3c46e0209d6",
           "version": 3
         }
       ]
@@ -768,11 +791,11 @@ Response: {
     "before": {
       "nodes": [
         {
-          "address": "0x175ae86f2df1eb652d57fbe9e44c7f2d67870d2b6776a4356f30930221b63b88",
+          "address": "0xfdcf4af87c644ea38970e8655a82cc59bd0d17f6970593f2e6cd82c85358abb9",
           "version": 1
         },
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2
         }
       ]
@@ -780,7 +803,7 @@ Response: {
     "between": {
       "nodes": [
         {
-          "address": "0x351bc614b36f0f522a64334e4c278d4bfe200234958870c084e0a005f041d681",
+          "address": "0xa1b89a2baa194e91b44a51975b44ef547fd543595047057faa17e3f8c8c29553",
           "version": 2
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/stable/packages/versioning.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/packages/versioning.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 P2=0x0 --accounts A --simulator
+//# init --protocol-version 51 --addresses P0=0x0 P1=0x0 P2=0x0 --accounts A --simulator
 
 //# publish --upgradeable --sender A
 module P0::m {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/kind.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/kind.exp
@@ -60,7 +60,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "78YAzuJPHbHXsqqj2GjiBibpAiWim7sha6MseSCN2Y6g",
+          "digest": "DtdkcWfVprqB3UTAsHZu4WKjTAZ9GNgCJYcpARVdwhE2",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -68,7 +68,7 @@ Response: {
           }
         },
         {
-          "digest": "9zVSnZuHjSQZKcbrwmpkUfsRTA4J9VKqSiqzNCmycPex",
+          "digest": "GSWPZuHhsJ12D7HhTQ9qwntehfjDmZDCjGYVkraPWzUW",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -76,7 +76,7 @@ Response: {
           }
         },
         {
-          "digest": "BmipCooPMB1CHeRuFHS15q4VQ14pSLoYvuuNEfNsvZBc",
+          "digest": "AmhHJvv1yZYR6q3jKHm7YwXAvaZEuDy8TWDqHPDU8sC7",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -84,7 +84,7 @@ Response: {
           }
         },
         {
-          "digest": "W3YEPxp4z4LzuwoGq4kmCBiy12xv4cNuEvwusrsxDem",
+          "digest": "GxcuVbd9wJLq89oiUK7zWsWQkGu4V481k2mGurfpkBdJ",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -92,7 +92,7 @@ Response: {
           }
         },
         {
-          "digest": "HCNwnSLqsQYEju3KoQbxpa3SD5mVG6FLcggkd2ZYxHvB",
+          "digest": "4Di8EQtt8JZ4dUhn9brM4g51Aw3Ly1JDfdqnE4ZuTQRN",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -117,7 +117,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "78YAzuJPHbHXsqqj2GjiBibpAiWim7sha6MseSCN2Y6g",
+          "digest": "DtdkcWfVprqB3UTAsHZu4WKjTAZ9GNgCJYcpARVdwhE2",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -142,7 +142,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "9zVSnZuHjSQZKcbrwmpkUfsRTA4J9VKqSiqzNCmycPex",
+          "digest": "GSWPZuHhsJ12D7HhTQ9qwntehfjDmZDCjGYVkraPWzUW",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -167,7 +167,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "BmipCooPMB1CHeRuFHS15q4VQ14pSLoYvuuNEfNsvZBc",
+          "digest": "AmhHJvv1yZYR6q3jKHm7YwXAvaZEuDy8TWDqHPDU8sC7",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -192,7 +192,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "W3YEPxp4z4LzuwoGq4kmCBiy12xv4cNuEvwusrsxDem",
+          "digest": "GxcuVbd9wJLq89oiUK7zWsWQkGu4V481k2mGurfpkBdJ",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -217,7 +217,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "HCNwnSLqsQYEju3KoQbxpa3SD5mVG6FLcggkd2ZYxHvB",
+          "digest": "4Di8EQtt8JZ4dUhn9brM4g51Aw3Ly1JDfdqnE4ZuTQRN",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/kind.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/kind.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B C D E --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B C D E --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/transaction_ids.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/transaction_ids.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/alternating.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/alternating.exp
@@ -96,7 +96,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -124,7 +124,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "Hgu3LePqrpyR8Vq3Ve4L2KmvErcdcz92u7YiiotkKJ1N",
+            "digest": "5Dm9LxmyHwUwdvUaJEiKi5VpLJTjrkuAL8Wc6B8C6icr",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -135,7 +135,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2EwyAHiMofhbM5z5ty7XT1QXs4sNZfHmZLX513Ag8sD3",
+            "digest": "2sswXsnYEQMv9TpVCGU1HzGHC7F53GTZSLcpiqSo4Hts",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -163,7 +163,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "Hgu3LePqrpyR8Vq3Ve4L2KmvErcdcz92u7YiiotkKJ1N",
+            "digest": "5Dm9LxmyHwUwdvUaJEiKi5VpLJTjrkuAL8Wc6B8C6icr",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -191,7 +191,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo4LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "4LUhoFJMmZfG71RHiRkwa9KHovrDv3S3mqUM1vu9JWKJ",
+            "digest": "2WNRvutEcWJa14edzAxogwthH6h31iDHA1HNSmyuBZFa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -219,7 +219,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2EwyAHiMofhbM5z5ty7XT1QXs4sNZfHmZLX513Ag8sD3",
+            "digest": "2sswXsnYEQMv9TpVCGU1HzGHC7F53GTZSLcpiqSo4Hts",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -230,7 +230,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo4LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "4LUhoFJMmZfG71RHiRkwa9KHovrDv3S3mqUM1vu9JWKJ",
+            "digest": "2WNRvutEcWJa14edzAxogwthH6h31iDHA1HNSmyuBZFa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -258,7 +258,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AnqDERsdbEiE26CACJa6KtJTLsggisgu7yxhMJ6mU1JZ",
+            "digest": "6zo1FuBYmF7HL7Jrf7pX87X2V6RVAZd9p84iyDKmFKM2",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -286,7 +286,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AnqDERsdbEiE26CACJa6KtJTLsggisgu7yxhMJ6mU1JZ",
+            "digest": "6zo1FuBYmF7HL7Jrf7pX87X2V6RVAZd9p84iyDKmFKM2",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/alternating.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/alternating.move
@@ -3,7 +3,7 @@
 
 // Testing behavior of alternating between a scan-limited and normal query
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/both_cursors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/both_cursors.exp
@@ -96,7 +96,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "6RKZYt946ztfY8ZVspCv8faXBzKxDcTUEHnrCyBSZ4Li",
+            "digest": "TbUMpXvLWGEA4JA7Pnay5HSMpfzdpgT9MMrqbDzcnhV",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -124,7 +124,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "6RKZYt946ztfY8ZVspCv8faXBzKxDcTUEHnrCyBSZ4Li",
+            "digest": "TbUMpXvLWGEA4JA7Pnay5HSMpfzdpgT9MMrqbDzcnhV",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -135,7 +135,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "83AZLnLVtQeUdrXGg3igLkeo94j3wTLuwY4izobLLVBT",
+            "digest": "9WRNzGahWuQZ2qgHsJsRsRWBLmVdvS3HoeCDDKzz8bmx",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -163,7 +163,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo1LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "74pdWZw8nEhvtan9aoYHAeZxGouHsj9cwBr5GcgncNAz",
+            "digest": "8sHHvATyqZbWnrxQMu5S5L7S7QZhqYT8hDCSah1enz1q",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/both_cursors.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/both_cursors.move
@@ -4,7 +4,7 @@
 // Tests paginating forwards where first and scanLimit are equal. The 1st, 3rd, 5th, and 7th through
 // 10th transactions will match the filtering criteria.
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/first.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/first.exp
@@ -96,7 +96,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+            "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -107,7 +107,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "6RKZYt946ztfY8ZVspCv8faXBzKxDcTUEHnrCyBSZ4Li",
+            "digest": "TbUMpXvLWGEA4JA7Pnay5HSMpfzdpgT9MMrqbDzcnhV",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -118,7 +118,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "83AZLnLVtQeUdrXGg3igLkeo94j3wTLuwY4izobLLVBT",
+            "digest": "9WRNzGahWuQZ2qgHsJsRsRWBLmVdvS3HoeCDDKzz8bmx",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -129,7 +129,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AWWgnnumcijVEY2YUzs4MtqzFPeLKFAbHnnjXwUyn6Gj",
+            "digest": "D2EoUZfiJDBLZoFM5fCFt1dAqJdXqR9doBJmdYWmjUwW",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -140,7 +140,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "DVVVd1cLYDpV3KHhXpirV5NFpk3DKaCuKvXXFeG2owA7",
+            "digest": "Ecn5qVzhRLR2XYSqWoN8vgRzXiZz4M7dzP2Q33iW9b5D",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -168,7 +168,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+            "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -196,7 +196,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "6RKZYt946ztfY8ZVspCv8faXBzKxDcTUEHnrCyBSZ4Li",
+            "digest": "TbUMpXvLWGEA4JA7Pnay5HSMpfzdpgT9MMrqbDzcnhV",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -224,7 +224,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "83AZLnLVtQeUdrXGg3igLkeo94j3wTLuwY4izobLLVBT",
+            "digest": "9WRNzGahWuQZ2qgHsJsRsRWBLmVdvS3HoeCDDKzz8bmx",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -268,7 +268,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AWWgnnumcijVEY2YUzs4MtqzFPeLKFAbHnnjXwUyn6Gj",
+            "digest": "D2EoUZfiJDBLZoFM5fCFt1dAqJdXqR9doBJmdYWmjUwW",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -279,7 +279,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "DVVVd1cLYDpV3KHhXpirV5NFpk3DKaCuKvXXFeG2owA7",
+            "digest": "Ecn5qVzhRLR2XYSqWoN8vgRzXiZz4M7dzP2Q33iW9b5D",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -333,7 +333,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AWWgnnumcijVEY2YUzs4MtqzFPeLKFAbHnnjXwUyn6Gj",
+            "digest": "D2EoUZfiJDBLZoFM5fCFt1dAqJdXqR9doBJmdYWmjUwW",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -344,7 +344,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "DVVVd1cLYDpV3KHhXpirV5NFpk3DKaCuKvXXFeG2owA7",
+            "digest": "Ecn5qVzhRLR2XYSqWoN8vgRzXiZz4M7dzP2Q33iW9b5D",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/first.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/first.move
@@ -4,7 +4,7 @@
 // Tests paginating forwards where first and scanLimit are equal. The 1st, 3rd, 5th, and 7th through
 // 10th transactions will match the filtering criteria.
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/last.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/last.exp
@@ -96,7 +96,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+            "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -107,7 +107,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "DiywoRFzC33smQhVf5K7AcM853XFgfgFxBGErLTEvVWi",
+            "digest": "2a2uYFbVZ7A4tYCF1Uc4XqgR4qTpttyn28bTfzCaRzFK",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -118,7 +118,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo3LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "F32vrNL7p5sa1iFeykvFQ17UYLeM1urXnSNbbGyoqDRx",
+            "digest": "J1m6m73jbeeThGM5qiXLo2EHcuypYCDbET4XXzZYPJLb",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -129,7 +129,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo5LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "3eHY9XENiqep4VvNBr3ws79TEMGhp5egGvFEymk679dc",
+            "digest": "2S2HvtQqyNMBL41HrEGLM8bwM96phPYCnjujFsr1YiUu",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -140,7 +140,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "4p5avK1cStj1xtBnvCnHgEUVVr5qnfXQ76ujUZx4ZvP8",
+            "digest": "UUNCfyvA7e3QWrmUx5ULvPfqBN3wGf6KbNfBZsyxK2Y",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -168,7 +168,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "4p5avK1cStj1xtBnvCnHgEUVVr5qnfXQ76ujUZx4ZvP8",
+            "digest": "UUNCfyvA7e3QWrmUx5ULvPfqBN3wGf6KbNfBZsyxK2Y",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -196,7 +196,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo5LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "3eHY9XENiqep4VvNBr3ws79TEMGhp5egGvFEymk679dc",
+            "digest": "2S2HvtQqyNMBL41HrEGLM8bwM96phPYCnjujFsr1YiUu",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -224,7 +224,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo3LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "F32vrNL7p5sa1iFeykvFQ17UYLeM1urXnSNbbGyoqDRx",
+            "digest": "J1m6m73jbeeThGM5qiXLo2EHcuypYCDbET4XXzZYPJLb",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -268,7 +268,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+            "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -279,7 +279,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "DiywoRFzC33smQhVf5K7AcM853XFgfgFxBGErLTEvVWi",
+            "digest": "2a2uYFbVZ7A4tYCF1Uc4XqgR4qTpttyn28bTfzCaRzFK",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/last.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/equal/last.move
@@ -3,7 +3,7 @@
 
 // Mirrors scan_limit/equal/first.move, paginating backwards where first and scanLimit are equal.
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/first.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/first.exp
@@ -164,7 +164,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -175,7 +175,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "BB6bMUxrBJX9wANzzptKnJM3bMVFKnD4xtY8DGWthaH9",
+            "digest": "FnzcnFt5xdvzBpE7nirZmBQNqVbYhRjzSjvipUo9vKqU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -186,7 +186,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoxNywiaSI6ZmFsc2V9",
           "node": {
-            "digest": "BhW3cLzaCgdRYc6jcmXB6DrQ6KaTfmYmb6vBNiu5xPhg",
+            "digest": "4r6AUqGkYrv3q7mFEJpCNYZ886XWViAcikxzBwmkwbzU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -197,7 +197,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoxOCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "FjpAF5bT173BfV6HLuBdBd2bYevsUVDeJNmYnmJYsTLb",
+            "digest": "DWxxrRhcoHYGwn8hexP36nwK4qKmKKimFkDzkTD8yefd",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -208,7 +208,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoyMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "Eq611DTcfsBjH1P9Smrv7xFYQZXNtUMgbQCUr5jo3ycJ",
+            "digest": "FV6N1Z1jHj81XzpLUA8EpdKZxdS9Gm9tkVy3hJkydtNa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -236,7 +236,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -264,7 +264,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "BB6bMUxrBJX9wANzzptKnJM3bMVFKnD4xtY8DGWthaH9",
+            "digest": "FnzcnFt5xdvzBpE7nirZmBQNqVbYhRjzSjvipUo9vKqU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -308,7 +308,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjoxNywiaSI6ZmFsc2V9",
           "node": {
-            "digest": "BhW3cLzaCgdRYc6jcmXB6DrQ6KaTfmYmb6vBNiu5xPhg",
+            "digest": "4r6AUqGkYrv3q7mFEJpCNYZ886XWViAcikxzBwmkwbzU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -336,7 +336,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjoxOCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "FjpAF5bT173BfV6HLuBdBd2bYevsUVDeJNmYnmJYsTLb",
+            "digest": "DWxxrRhcoHYGwn8hexP36nwK4qKmKKimFkDzkTD8yefd",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -364,7 +364,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjoyMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "Eq611DTcfsBjH1P9Smrv7xFYQZXNtUMgbQCUr5jo3ycJ",
+            "digest": "FV6N1Z1jHj81XzpLUA8EpdKZxdS9Gm9tkVy3hJkydtNa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/first.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/first.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/last.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/last.exp
@@ -164,7 +164,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -175,7 +175,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "BB6bMUxrBJX9wANzzptKnJM3bMVFKnD4xtY8DGWthaH9",
+            "digest": "FnzcnFt5xdvzBpE7nirZmBQNqVbYhRjzSjvipUo9vKqU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -186,7 +186,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoxNywiaSI6ZmFsc2V9",
           "node": {
-            "digest": "BhW3cLzaCgdRYc6jcmXB6DrQ6KaTfmYmb6vBNiu5xPhg",
+            "digest": "4r6AUqGkYrv3q7mFEJpCNYZ886XWViAcikxzBwmkwbzU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -197,7 +197,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoyMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "G7DhbdbJeze8e5kmVLNY6aVKckM7yfrzadaABv71ssjx",
+            "digest": "77ej41S4Cy6X9GeZB8cb1uoKW4NdLeR319g16eUPn7HW",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -225,7 +225,7 @@ Response: {
         {
           "cursor": "eyJjIjo1LCJ0IjoyMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "G7DhbdbJeze8e5kmVLNY6aVKckM7yfrzadaABv71ssjx",
+            "digest": "77ej41S4Cy6X9GeZB8cb1uoKW4NdLeR319g16eUPn7HW",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -253,7 +253,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjoxNywiaSI6ZmFsc2V9",
           "node": {
-            "digest": "BhW3cLzaCgdRYc6jcmXB6DrQ6KaTfmYmb6vBNiu5xPhg",
+            "digest": "4r6AUqGkYrv3q7mFEJpCNYZ886XWViAcikxzBwmkwbzU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 5
@@ -313,7 +313,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "BB6bMUxrBJX9wANzzptKnJM3bMVFKnD4xtY8DGWthaH9",
+            "digest": "FnzcnFt5xdvzBpE7nirZmBQNqVbYhRjzSjvipUo9vKqU",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -341,7 +341,7 @@ Response: {
         {
           "cursor": "eyJjIjo3LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/last.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/ge_page/last.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/invalid_limits.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/invalid_limits.move
@@ -3,7 +3,7 @@
 
 // For any instance where limit is 0 or scan limit is 0, we should return an empty result
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/first.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/first.exp
@@ -96,7 +96,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -107,7 +107,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "FveHd4cC5ykjtknvewFjmf6V1gHYhdkuEoUEBAV3y52h",
+            "digest": "5munzbeNFxTocEUwdJmj997KX6wWkuNsTA77rpmnxTVX",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -118,7 +118,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "Hgu3LePqrpyR8Vq3Ve4L2KmvErcdcz92u7YiiotkKJ1N",
+            "digest": "5Dm9LxmyHwUwdvUaJEiKi5VpLJTjrkuAL8Wc6B8C6icr",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -129,7 +129,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo1LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "5pVYLMHazkfshyLvmQyow1UY4vn9V481KWDxUYpX65BZ",
+            "digest": "GdMGVdYcePeZfvxBEkP9DtJSkCWdeG8u6RRDAKEfvSQx",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -140,7 +140,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2EwyAHiMofhbM5z5ty7XT1QXs4sNZfHmZLX513Ag8sD3",
+            "digest": "2sswXsnYEQMv9TpVCGU1HzGHC7F53GTZSLcpiqSo4Hts",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -151,7 +151,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo3LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "FtVAPJKNoPumPcQuyzznmZB99yhYNqdsmC7wKPj17xR3",
+            "digest": "3wwhPrETKroAXwFnHzB32EFW9KjnV7Y5t5A4wjLSLFHm",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -162,7 +162,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo4LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "4LUhoFJMmZfG71RHiRkwa9KHovrDv3S3mqUM1vu9JWKJ",
+            "digest": "2WNRvutEcWJa14edzAxogwthH6h31iDHA1HNSmyuBZFa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -173,7 +173,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo5LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "FasAf1kHei9QkZuPLBSkCdXXMtv13RbCgiywktFzx58m",
+            "digest": "AX56faYv1GsQEbKxga4hDwo7bFrJW4m5ZEUpodpfZSkC",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -184,7 +184,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AnqDERsdbEiE26CACJa6KtJTLsggisgu7yxhMJ6mU1JZ",
+            "digest": "6zo1FuBYmF7HL7Jrf7pX87X2V6RVAZd9p84iyDKmFKM2",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -195,7 +195,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "GKKT2n7jc6YyJDcckP3kXhVN5FEZJEk1fN3aFzcgRyRr",
+            "digest": "4JHfzAuHa8TFCVMBrLXm4BE17WUrXNXFAAUZ1SWZfAH5",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -223,7 +223,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -251,7 +251,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "Hgu3LePqrpyR8Vq3Ve4L2KmvErcdcz92u7YiiotkKJ1N",
+            "digest": "5Dm9LxmyHwUwdvUaJEiKi5VpLJTjrkuAL8Wc6B8C6icr",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -279,7 +279,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2EwyAHiMofhbM5z5ty7XT1QXs4sNZfHmZLX513Ag8sD3",
+            "digest": "2sswXsnYEQMv9TpVCGU1HzGHC7F53GTZSLcpiqSo4Hts",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -290,7 +290,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo4LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "4LUhoFJMmZfG71RHiRkwa9KHovrDv3S3mqUM1vu9JWKJ",
+            "digest": "2WNRvutEcWJa14edzAxogwthH6h31iDHA1HNSmyuBZFa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -318,7 +318,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AnqDERsdbEiE26CACJa6KtJTLsggisgu7yxhMJ6mU1JZ",
+            "digest": "6zo1FuBYmF7HL7Jrf7pX87X2V6RVAZd9p84iyDKmFKM2",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/first.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/first.move
@@ -5,7 +5,7 @@
 // However, because we have a scanLimit of 2, we'll be limited to filtering only two candidate
 // transactions per page, of which one will match the filtering criteria.
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/last.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/last.exp
@@ -96,7 +96,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -107,7 +107,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "FveHd4cC5ykjtknvewFjmf6V1gHYhdkuEoUEBAV3y52h",
+            "digest": "5munzbeNFxTocEUwdJmj997KX6wWkuNsTA77rpmnxTVX",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -118,7 +118,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "Hgu3LePqrpyR8Vq3Ve4L2KmvErcdcz92u7YiiotkKJ1N",
+            "digest": "5Dm9LxmyHwUwdvUaJEiKi5VpLJTjrkuAL8Wc6B8C6icr",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -129,7 +129,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo1LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "5pVYLMHazkfshyLvmQyow1UY4vn9V481KWDxUYpX65BZ",
+            "digest": "GdMGVdYcePeZfvxBEkP9DtJSkCWdeG8u6RRDAKEfvSQx",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -140,7 +140,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2EwyAHiMofhbM5z5ty7XT1QXs4sNZfHmZLX513Ag8sD3",
+            "digest": "2sswXsnYEQMv9TpVCGU1HzGHC7F53GTZSLcpiqSo4Hts",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -151,7 +151,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo3LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "FtVAPJKNoPumPcQuyzznmZB99yhYNqdsmC7wKPj17xR3",
+            "digest": "3wwhPrETKroAXwFnHzB32EFW9KjnV7Y5t5A4wjLSLFHm",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -162,7 +162,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo4LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "4LUhoFJMmZfG71RHiRkwa9KHovrDv3S3mqUM1vu9JWKJ",
+            "digest": "2WNRvutEcWJa14edzAxogwthH6h31iDHA1HNSmyuBZFa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -173,7 +173,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0Ijo5LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "FasAf1kHei9QkZuPLBSkCdXXMtv13RbCgiywktFzx58m",
+            "digest": "AX56faYv1GsQEbKxga4hDwo7bFrJW4m5ZEUpodpfZSkC",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -184,7 +184,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AnqDERsdbEiE26CACJa6KtJTLsggisgu7yxhMJ6mU1JZ",
+            "digest": "6zo1FuBYmF7HL7Jrf7pX87X2V6RVAZd9p84iyDKmFKM2",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -195,7 +195,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "GKKT2n7jc6YyJDcckP3kXhVN5FEZJEk1fN3aFzcgRyRr",
+            "digest": "4JHfzAuHa8TFCVMBrLXm4BE17WUrXNXFAAUZ1SWZfAH5",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -223,7 +223,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoxMCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AnqDERsdbEiE26CACJa6KtJTLsggisgu7yxhMJ6mU1JZ",
+            "digest": "6zo1FuBYmF7HL7Jrf7pX87X2V6RVAZd9p84iyDKmFKM2",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -251,7 +251,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo4LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "4LUhoFJMmZfG71RHiRkwa9KHovrDv3S3mqUM1vu9JWKJ",
+            "digest": "2WNRvutEcWJa14edzAxogwthH6h31iDHA1HNSmyuBZFa",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 3
@@ -279,7 +279,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2EwyAHiMofhbM5z5ty7XT1QXs4sNZfHmZLX513Ag8sD3",
+            "digest": "2sswXsnYEQMv9TpVCGU1HzGHC7F53GTZSLcpiqSo4Hts",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -307,7 +307,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "Hgu3LePqrpyR8Vq3Ve4L2KmvErcdcz92u7YiiotkKJ1N",
+            "digest": "5Dm9LxmyHwUwdvUaJEiKi5VpLJTjrkuAL8Wc6B8C6icr",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2
@@ -335,7 +335,7 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "CReUjLynvpq4dD4w6zekGxvSyBBQF2e3KG3K2Rs7oD8L",
+            "digest": "96PA4AGPof9AtfUJ7uNzZ1KwSJ5M4sF74zqB6PPC1bfN",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/last.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/le_page/last.move
@@ -5,7 +5,7 @@
 // However, because we have a scanLimit of 2, we'll be limited to filtering only two candidate
 // transactions per page, of which one will match the filtering criteria.
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/require.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/require.exp
@@ -94,7 +94,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+          "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -102,7 +102,7 @@ Response: {
           }
         },
         {
-          "digest": "DiywoRFzC33smQhVf5K7AcM853XFgfgFxBGErLTEvVWi",
+          "digest": "2a2uYFbVZ7A4tYCF1Uc4XqgR4qTpttyn28bTfzCaRzFK",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -110,7 +110,7 @@ Response: {
           }
         },
         {
-          "digest": "7MgEfj6QXfsjDFtvJSAE9FNL3RYt8Kdw21NnfuuVXkbt",
+          "digest": "3BRYWH3JGjJHgMqxciLWqEgbzntHC9KybmjG4PPWY5MQ",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -118,7 +118,7 @@ Response: {
           }
         },
         {
-          "digest": "B8mg7JvC64cnh656yuwHyXyFPULutxBECMFkCPQNStmZ",
+          "digest": "BsGrU2kopmcTQ9V5cMNBGHzxVAEwQ1Kwomq1hmShxLQv",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -126,7 +126,7 @@ Response: {
           }
         },
         {
-          "digest": "7i7Evom2DUeS1PYxKwDnLfoZpv2r6kxdGoEWxXdFA9xV",
+          "digest": "9PrjJGFwHzPcg6rSzGjtFALvDrbfSaES6z7xcLkJNkSi",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -134,7 +134,7 @@ Response: {
           }
         },
         {
-          "digest": "5HoMDKMTYX3gibs8VroZUeSC3134MroLJN7hfAVZxdPM",
+          "digest": "7XiuHRDpeiRQU1XCK2Jw1xTVa26DR1FZeoFTetRktTrN",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -142,7 +142,7 @@ Response: {
           }
         },
         {
-          "digest": "BU8q4bm7XjaZiV8cPmchVp6SsmU8cmBWNUVmFTUNAHfb",
+          "digest": "4tKiKS62YKN2PL5Cv8645DCM3A84rH86oTqcPcvo8aWd",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -150,7 +150,7 @@ Response: {
           }
         },
         {
-          "digest": "HckXhLnDYV8hfMh1p8M8r7dpEpvzp5GpG9oHzv9dmv4R",
+          "digest": "5eQQp6NR1pb9MqiwJRfCDSBuZshCarsrc3i1bGajnqPo",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -158,7 +158,7 @@ Response: {
           }
         },
         {
-          "digest": "Hvh3oJuoTeRYRU2wkTriwDsozpaay5c7dhRS7Ru3S2S5",
+          "digest": "5vMhuv1BgZTav4HJoCUPNpMcgpr9yvv7qedwNC7uQZaf",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -166,7 +166,7 @@ Response: {
           }
         },
         {
-          "digest": "ADhRGJc24AQCvUnQNgkfjnna3hsTFK51YTgq5J5VAKQr",
+          "digest": "F2f61VrBSipg6wxFcrhEnVSe67QxuPB5SCfXfd7ZF76K",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -191,7 +191,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+          "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -199,7 +199,7 @@ Response: {
           }
         },
         {
-          "digest": "DiywoRFzC33smQhVf5K7AcM853XFgfgFxBGErLTEvVWi",
+          "digest": "2a2uYFbVZ7A4tYCF1Uc4XqgR4qTpttyn28bTfzCaRzFK",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -207,7 +207,7 @@ Response: {
           }
         },
         {
-          "digest": "7MgEfj6QXfsjDFtvJSAE9FNL3RYt8Kdw21NnfuuVXkbt",
+          "digest": "3BRYWH3JGjJHgMqxciLWqEgbzntHC9KybmjG4PPWY5MQ",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -215,7 +215,7 @@ Response: {
           }
         },
         {
-          "digest": "B8mg7JvC64cnh656yuwHyXyFPULutxBECMFkCPQNStmZ",
+          "digest": "BsGrU2kopmcTQ9V5cMNBGHzxVAEwQ1Kwomq1hmShxLQv",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -223,7 +223,7 @@ Response: {
           }
         },
         {
-          "digest": "7i7Evom2DUeS1PYxKwDnLfoZpv2r6kxdGoEWxXdFA9xV",
+          "digest": "9PrjJGFwHzPcg6rSzGjtFALvDrbfSaES6z7xcLkJNkSi",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -231,7 +231,7 @@ Response: {
           }
         },
         {
-          "digest": "5HoMDKMTYX3gibs8VroZUeSC3134MroLJN7hfAVZxdPM",
+          "digest": "7XiuHRDpeiRQU1XCK2Jw1xTVa26DR1FZeoFTetRktTrN",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -239,7 +239,7 @@ Response: {
           }
         },
         {
-          "digest": "BU8q4bm7XjaZiV8cPmchVp6SsmU8cmBWNUVmFTUNAHfb",
+          "digest": "4tKiKS62YKN2PL5Cv8645DCM3A84rH86oTqcPcvo8aWd",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -247,7 +247,7 @@ Response: {
           }
         },
         {
-          "digest": "HckXhLnDYV8hfMh1p8M8r7dpEpvzp5GpG9oHzv9dmv4R",
+          "digest": "5eQQp6NR1pb9MqiwJRfCDSBuZshCarsrc3i1bGajnqPo",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -255,7 +255,7 @@ Response: {
           }
         },
         {
-          "digest": "Hvh3oJuoTeRYRU2wkTriwDsozpaay5c7dhRS7Ru3S2S5",
+          "digest": "5vMhuv1BgZTav4HJoCUPNpMcgpr9yvv7qedwNC7uQZaf",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -263,7 +263,7 @@ Response: {
           }
         },
         {
-          "digest": "ADhRGJc24AQCvUnQNgkfjnna3hsTFK51YTgq5J5VAKQr",
+          "digest": "F2f61VrBSipg6wxFcrhEnVSe67QxuPB5SCfXfd7ZF76K",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -311,7 +311,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+          "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -319,7 +319,7 @@ Response: {
           }
         },
         {
-          "digest": "DiywoRFzC33smQhVf5K7AcM853XFgfgFxBGErLTEvVWi",
+          "digest": "2a2uYFbVZ7A4tYCF1Uc4XqgR4qTpttyn28bTfzCaRzFK",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -327,7 +327,7 @@ Response: {
           }
         },
         {
-          "digest": "7MgEfj6QXfsjDFtvJSAE9FNL3RYt8Kdw21NnfuuVXkbt",
+          "digest": "3BRYWH3JGjJHgMqxciLWqEgbzntHC9KybmjG4PPWY5MQ",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -335,7 +335,7 @@ Response: {
           }
         },
         {
-          "digest": "B8mg7JvC64cnh656yuwHyXyFPULutxBECMFkCPQNStmZ",
+          "digest": "BsGrU2kopmcTQ9V5cMNBGHzxVAEwQ1Kwomq1hmShxLQv",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -343,7 +343,7 @@ Response: {
           }
         },
         {
-          "digest": "7i7Evom2DUeS1PYxKwDnLfoZpv2r6kxdGoEWxXdFA9xV",
+          "digest": "9PrjJGFwHzPcg6rSzGjtFALvDrbfSaES6z7xcLkJNkSi",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -351,7 +351,7 @@ Response: {
           }
         },
         {
-          "digest": "5HoMDKMTYX3gibs8VroZUeSC3134MroLJN7hfAVZxdPM",
+          "digest": "7XiuHRDpeiRQU1XCK2Jw1xTVa26DR1FZeoFTetRktTrN",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -359,7 +359,7 @@ Response: {
           }
         },
         {
-          "digest": "BU8q4bm7XjaZiV8cPmchVp6SsmU8cmBWNUVmFTUNAHfb",
+          "digest": "4tKiKS62YKN2PL5Cv8645DCM3A84rH86oTqcPcvo8aWd",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -367,7 +367,7 @@ Response: {
           }
         },
         {
-          "digest": "HckXhLnDYV8hfMh1p8M8r7dpEpvzp5GpG9oHzv9dmv4R",
+          "digest": "5eQQp6NR1pb9MqiwJRfCDSBuZshCarsrc3i1bGajnqPo",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -375,7 +375,7 @@ Response: {
           }
         },
         {
-          "digest": "Hvh3oJuoTeRYRU2wkTriwDsozpaay5c7dhRS7Ru3S2S5",
+          "digest": "5vMhuv1BgZTav4HJoCUPNpMcgpr9yvv7qedwNC7uQZaf",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -383,7 +383,7 @@ Response: {
           }
         },
         {
-          "digest": "ADhRGJc24AQCvUnQNgkfjnna3hsTFK51YTgq5J5VAKQr",
+          "digest": "F2f61VrBSipg6wxFcrhEnVSe67QxuPB5SCfXfd7ZF76K",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -431,7 +431,7 @@ Response: {
       },
       "nodes": [
         {
-          "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+          "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -439,7 +439,7 @@ Response: {
           }
         },
         {
-          "digest": "DiywoRFzC33smQhVf5K7AcM853XFgfgFxBGErLTEvVWi",
+          "digest": "2a2uYFbVZ7A4tYCF1Uc4XqgR4qTpttyn28bTfzCaRzFK",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -447,7 +447,7 @@ Response: {
           }
         },
         {
-          "digest": "7MgEfj6QXfsjDFtvJSAE9FNL3RYt8Kdw21NnfuuVXkbt",
+          "digest": "3BRYWH3JGjJHgMqxciLWqEgbzntHC9KybmjG4PPWY5MQ",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -455,7 +455,7 @@ Response: {
           }
         },
         {
-          "digest": "B8mg7JvC64cnh656yuwHyXyFPULutxBECMFkCPQNStmZ",
+          "digest": "BsGrU2kopmcTQ9V5cMNBGHzxVAEwQ1Kwomq1hmShxLQv",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -463,7 +463,7 @@ Response: {
           }
         },
         {
-          "digest": "7i7Evom2DUeS1PYxKwDnLfoZpv2r6kxdGoEWxXdFA9xV",
+          "digest": "9PrjJGFwHzPcg6rSzGjtFALvDrbfSaES6z7xcLkJNkSi",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 2
@@ -471,7 +471,7 @@ Response: {
           }
         },
         {
-          "digest": "5HoMDKMTYX3gibs8VroZUeSC3134MroLJN7hfAVZxdPM",
+          "digest": "7XiuHRDpeiRQU1XCK2Jw1xTVa26DR1FZeoFTetRktTrN",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -479,7 +479,7 @@ Response: {
           }
         },
         {
-          "digest": "BU8q4bm7XjaZiV8cPmchVp6SsmU8cmBWNUVmFTUNAHfb",
+          "digest": "4tKiKS62YKN2PL5Cv8645DCM3A84rH86oTqcPcvo8aWd",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -487,7 +487,7 @@ Response: {
           }
         },
         {
-          "digest": "HckXhLnDYV8hfMh1p8M8r7dpEpvzp5GpG9oHzv9dmv4R",
+          "digest": "5eQQp6NR1pb9MqiwJRfCDSBuZshCarsrc3i1bGajnqPo",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -495,7 +495,7 @@ Response: {
           }
         },
         {
-          "digest": "Hvh3oJuoTeRYRU2wkTriwDsozpaay5c7dhRS7Ru3S2S5",
+          "digest": "5vMhuv1BgZTav4HJoCUPNpMcgpr9yvv7qedwNC7uQZaf",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -503,7 +503,7 @@ Response: {
           }
         },
         {
-          "digest": "ADhRGJc24AQCvUnQNgkfjnna3hsTFK51YTgq5J5VAKQr",
+          "digest": "F2f61VrBSipg6wxFcrhEnVSe67QxuPB5SCfXfd7ZF76K",
           "effects": {
             "checkpoint": {
               "sequenceNumber": 3
@@ -592,7 +592,7 @@ Response: {
         {
           "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "HzyC8gcn4m1ymKxYSpWMaNnmbrqm4hX7UBteJ4me3LFd",
+            "digest": "6xLEAWZ7yZ4LPYkMYJ4KMegSfAovuuL86hhMdoE4aqbH",
             "effects": {
               "checkpoint": {
                 "sequenceNumber": 2

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/require.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/scan_limit/require.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 48 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {


### PR DESCRIPTION
## Description

Some of these tests are on older versions because they landed around the time of the last bump. Bringing everything in line with protocol 51.

## Test plan

```
$ cargo nextest run -p sui-graphql-e2e-tests
```

## Stack

- #19371 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
