### PR TITLE
Fix protocol config after patching 1.33

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2757,13 +2757,11 @@ impl ProtocolConfig {
                     }
                 }
                 59 => {
-                    // Leave empty, used by 1.33 path.
+                    // Enable round prober in consensus.
+                    cfg.feature_flags.consensus_round_prober = true;
                 }
                 60 => {
                     cfg.max_type_to_layout_nodes = Some(512);
-
-                    // Enable round prober in consensus.
-                    cfg.feature_flags.consensus_round_prober = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_59.snap
@@ -60,6 +60,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   rethrow_serialization_type_layout_errors: true
+  consensus_round_prober: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_59.snap
@@ -60,6 +60,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   rethrow_serialization_type_layout_errors: true
+  consensus_round_prober: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_59.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_59.snap
@@ -66,6 +66,7 @@ feature_flags:
   authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
## Description 

Now protocol version 59 will be dominant on `testnet`, update protocol config on `main`.

## Test plan 
```
eugene@eugene-dev ~/code/sui/scripts/compatibility (tmw/config-fix) $ ./check-protocol-compatibility.sh testnet
....

running 1 test
test test::snapshot_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.48s
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
