### PR TITLE
[indexer] Adjust transactions queries to the latest db schema

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::Result;
 use diesel::dsl::sql;
+use diesel::sql_types::Bool;
 use diesel::TextExpressionMethods;
 use diesel::{
-    BoolExpressionMethods, ExpressionMethods, JoinOnDsl, NullableExpressionMethods,
-    OptionalExtension, QueryDsl, SelectableHelper,
+    ExpressionMethods, JoinOnDsl, NullableExpressionMethods, OptionalExtension, QueryDsl,
+    SelectableHelper,
 };
 use itertools::Itertools;
 use std::sync::Arc;


### PR DESCRIPTION
## Description 

Some pg-backed jsonrpc methods got left in the dust as the indexer db schema became more specialized for graphql. This PR revisits read queries in `indexer_reader` and updates them to make use of the recent changes. This PR specifically addresses tx and events queries, which assumes that there is still an index to support queries by `transaction_digest`. Instead, we need to use the `tx_digests` lookup table for the `tx_sequence_number`, and use that to key into the transactions and events tables.

## Test plan 

manual :eye:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
