### PR TITLE
[Indexer] Add json serialized SuiSystemStateSummary to epochs table

### DIFF
--- a/crates/sui-indexer/migrations/pg/2024-09-18-003318_epochs_add_bcs_system_state/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-18-003318_epochs_add_bcs_system_state/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE epochs DROP COLUMN system_state_summary_json;

--- a/crates/sui-indexer/migrations/pg/2024-09-18-003318_epochs_add_bcs_system_state/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-18-003318_epochs_add_bcs_system_state/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE epochs ADD COLUMN system_state_summary_json JSONB;

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -61,6 +61,7 @@ diesel::table! {
         total_stake_rewards_distributed -> Nullable<Int8>,
         leftover_storage_fund_inflow -> Nullable<Int8>,
         epoch_commitments -> Nullable<Bytea>,
+        system_state_summary_json -> Nullable<Jsonb>,
     }
 }
 


### PR DESCRIPTION
## Description 

The existing system_state column is a BCS serialization of a JSON-RPC type, which is not evolvable.
This PR adds a new column that is the JSON serialization of SuiSystemStateSummary without BCS.

It also fixes two bugs along the way:
1. We were storing the wrong version of the system state, offsetting by 1 epoch. This PR fixes it by storing the right version of the json column at the beginning of the epoch instead of at the end.
2. We were ignoring a deserialization error and swallow it in some place. Made that throw instead.

## Test plan 

Added a debug assert to see that this column is populated with the correct epoch.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
