### PR TITLE
feat(graphql)!: deprecate tx signer filters

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/sent.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/sent.exp
@@ -1,0 +1,345 @@
+processed 5 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-11:
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-15:
+//# programmable --sender B --inputs 2000000 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 17:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 19-87:
+//# run-graphql
+Response: {
+  "data": {
+    "bySentAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996024000"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "bySignAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996024000"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "bothAddresses": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996024000"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "differentAddresses": {
+      "nodes": []
+    },
+    "compoundBySentAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996024000"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "compoundBySignAddress": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996024000"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "compoundBothAddresses": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": {
+              "nodes": [
+                {
+                  "inputState": null,
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "1000000"
+                      }
+                    }
+                  }
+                },
+                {
+                  "inputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "300000000000000"
+                      }
+                    }
+                  },
+                  "outputState": {
+                    "asMoveObject": {
+                      "asCoin": {
+                        "coinBalance": "299999996024000"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "compoundDifferentAddresses": {
+      "nodes": []
+    },
+    "sentViaAddress": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "effects": {
+              "objectChanges": {
+                "nodes": [
+                  {
+                    "inputState": null,
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "1000000"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "inputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "300000000000000"
+                        }
+                      }
+                    },
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "299999996024000"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "signViaAddress": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "effects": {
+              "objectChanges": {
+                "nodes": [
+                  {
+                    "inputState": null,
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "1000000"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "inputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "300000000000000"
+                        }
+                      }
+                    },
+                    "outputState": {
+                      "asMoveObject": {
+                        "asCoin": {
+                          "coinBalance": "299999996024000"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/sent.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/filters/sent.move
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator
+
+// Confirm that the new `sentAddress` behaves like `signAddress`, and how the
+// two filters interact with each other.
+
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 2000000 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+query {
+  bySentAddress: transactionBlocks(filter: { sentAddress: "@{A}" }) {
+    nodes { ...CoinBalances }
+  }
+
+  bySignAddress: transactionBlocks(filter: { signAddress: "@{A}" }) {
+    nodes { ...CoinBalances }
+  }
+
+  bothAddresses: transactionBlocks(filter: { sentAddress: "@{A}", signAddress: "@{A}" }) {
+    nodes { ...CoinBalances }
+  }
+
+  differentAddresses: transactionBlocks(filter: { sentAddress: "@{A}", signAddress: "@{B}" }) {
+    nodes { ...CoinBalances }
+  }
+
+  compoundBySentAddress: transactionBlocks(filter: { sentAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
+    nodes { ...CoinBalances }
+  }
+
+  compoundBySignAddress: transactionBlocks(filter: { signAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
+    nodes { ...CoinBalances }
+  }
+
+  compoundBothAddresses: transactionBlocks(filter: {
+    sentAddress: "@{A}",
+    signAddress: "@{A}",
+    kind: PROGRAMMABLE_TX,
+  }) {
+    nodes { ...CoinBalances }
+  }
+
+  compoundDifferentAddresses: transactionBlocks(filter: {
+    sentAddress: "@{A}",
+    signAddress: "@{B}",
+    kind: PROGRAMMABLE_TX,
+  }) {
+    nodes { ...CoinBalances }
+  }
+
+  sentViaAddress: address(address: "@{A}") {
+    transactionBlocks(relation: SENT) {
+      nodes { ...CoinBalances }
+    }
+  }
+
+  signViaAddress: address(address: "@{A}") {
+    transactionBlocks(relation: SIGN) {
+      nodes { ...CoinBalances }
+    }
+  }
+}
+
+fragment CoinBalances on TransactionBlock {
+  effects {
+    objectChanges {
+      nodes {
+        inputState { ...CoinBalance }
+        outputState { ...CoinBalance }
+      }
+    }
+  }
+}
+
+fragment CoinBalance on Object {
+  asMoveObject { asCoin { coinBalance } }
+}

--- a/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_address.move
+++ b/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_address.move
@@ -61,7 +61,7 @@
   }
 
   # For contrast, the transactions that A is the sender for
-  sentByA: transactionBlocks(filter: { kind: PROGRAMMABLE_TX, signAddress: "@{A}" }) {
+  sentByA: transactionBlocks(filter: { kind: PROGRAMMABLE_TX, sentAddress: "@{A}" }) {
     nodes { ...CoinBalances }
   }
 

--- a/crates/sui-graphql-rpc/examples/address/transaction_block_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/address/transaction_block_connection.graphql
@@ -7,7 +7,7 @@
 # and budget.
 query transaction_block_with_relation_filter {
   address(address: "0x2") {
-    transactionBlocks(relation: SIGN, filter: { function: "0x2" }) {
+    transactionBlocks(relation: SENT, filter: { function: "0x2" }) {
       nodes {
         sender {
           address

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -97,7 +97,7 @@ type Address implements IOwner {
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the additional
-	`AddressTransactionBlockRelationship` filter, which defaults to `SIGN`.
+	`AddressTransactionBlockRelationship` filter, which defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when gathering a page of
 	results. It is required for queries that apply more than two complex filters (on function,
@@ -160,13 +160,21 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sign, sent, received, or paid.
+The possible relationship types for a transaction block: sent, or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed either as a sender or as a sponsor.
+	Transactions this address has sent. NOTE: this input filter has been deprecated in favor of
+	`SENT` which behaves identically but is named more clearly. Both filters restrict
+	transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	SIGN
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
 	"""
 	Transactions that sent objects to this address.
 	"""
@@ -4313,9 +4321,17 @@ input TransactionBlockFilter {
 	"""
 	beforeCheckpoint: UInt53
 	"""
-	Limit to transactions that were signed by the given address.
+	Limit to transactions that were sent by the given address. NOTE: this input filter has been
+	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
+	Both filters restrict transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 	"""
 	Limit to transactions that sent an object to the given address.
 	"""

--- a/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
@@ -124,7 +124,7 @@ impl TransactionBlockFilter {
         let missing_implicit_sender = missing_implicit_sender && self.affected_address.is_none();
 
         missing_implicit_sender
-            .then_some(self.sent_address)
+            .then_some(self.sent_address.or(self.sign_address))
             .flatten()
     }
 
@@ -133,6 +133,7 @@ impl TransactionBlockFilter {
     pub(crate) fn has_filters(&self) -> bool {
         let has_filters = self.function.is_some()
             || self.kind.is_some()
+            || self.sign_address.is_some()
             || self.sent_address.is_some()
             || self.recv_address.is_some()
             || self.input_object.is_some()

--- a/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
@@ -31,8 +31,15 @@ pub(crate) struct TransactionBlockFilter {
     #[cfg(feature = "staging")]
     pub affected_address: Option<SuiAddress>,
 
-    /// Limit to transactions that were signed by the given address.
+    /// Limit to transactions that were sent by the given address. NOTE: this input filter has been
+    /// deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
+    /// Both filters restrict transactions by their sender, only, not signers in general.
+    ///
+    /// This filter will be removed after 1.36.0 (2024-10-14).
     pub sign_address: Option<SuiAddress>,
+
+    /// Limit to transactions that were sent by the given address.
+    pub sent_address: Option<SuiAddress>,
 
     /// Limit to transactions that sent an object to the given address.
     pub recv_address: Option<SuiAddress>,
@@ -69,7 +76,8 @@ impl TransactionBlockFilter {
 
             #[cfg(feature = "staging")]
             affected_address: intersect!(affected_address, intersect::by_eq)?,
-            sign_address: intersect!(sign_address, intersect::by_eq)?,
+            sign_address: intersect!(sent_address, intersect::by_eq)?,
+            sent_address: intersect!(sent_address, intersect::by_eq)?,
             recv_address: intersect!(recv_address, intersect::by_eq)?,
             input_object: intersect!(input_object, intersect::by_eq)?,
             changed_object: intersect!(changed_object, intersect::by_eq)?,
@@ -116,7 +124,7 @@ impl TransactionBlockFilter {
         let missing_implicit_sender = missing_implicit_sender && self.affected_address.is_none();
 
         missing_implicit_sender
-            .then_some(self.sign_address)
+            .then_some(self.sent_address)
             .flatten()
     }
 
@@ -125,7 +133,7 @@ impl TransactionBlockFilter {
     pub(crate) fn has_filters(&self) -> bool {
         let has_filters = self.function.is_some()
             || self.kind.is_some()
-            || self.sign_address.is_some()
+            || self.sent_address.is_some()
             || self.recv_address.is_some()
             || self.input_object.is_some()
             || self.changed_object.is_some()
@@ -153,10 +161,16 @@ impl TransactionBlockFilter {
             )
             // If SystemTx, sender if specified must be 0x0. Conversely, if sender is 0x0, kind must be SystemTx.
             || matches!(
-                (self.kind, self.sign_address),
+                (self.kind, self.sent_address),
                 (Some(kind), Some(signer))
                     if (kind == TransactionBlockKindInput::SystemTx)
                         != (signer == SuiAddress::from(NativeSuiAddress::ZERO))
+            )
+            // Temporary while we deprecate `sign_address` in favor of `sent_address`.
+            || matches!(
+                (self.sign_address, self.sent_address),
+                (Some(signer), Some(sent))
+                    if signer != sent
             )
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
@@ -76,7 +76,7 @@ impl TransactionBlockFilter {
 
             #[cfg(feature = "staging")]
             affected_address: intersect!(affected_address, intersect::by_eq)?,
-            sign_address: intersect!(sent_address, intersect::by_eq)?,
+            sign_address: intersect!(sign_address, intersect::by_eq)?,
             sent_address: intersect!(sent_address, intersect::by_eq)?,
             recv_address: intersect!(recv_address, intersect::by_eq)?,
             input_object: intersect!(input_object, intersect::by_eq)?,

--- a/crates/sui-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -305,7 +305,7 @@ fn min_option<T: Ord>(xs: impl IntoIterator<Item = Option<T>>) -> Option<T> {
 /// Constructs a `RawQuery` as a join over all relevant side tables, filtered on their own filter
 /// condition, plus optionally a sender, plus optionally tx/cp bounds.
 pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -> Option<RawQuery> {
-    let sender = filter.sign_address;
+    let sender = filter.sent_address.or(filter.sign_address);
 
     let mut subqueries = vec![];
 

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -97,7 +97,7 @@ type Address implements IOwner {
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the additional
-	`AddressTransactionBlockRelationship` filter, which defaults to `SIGN`.
+	`AddressTransactionBlockRelationship` filter, which defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when gathering a page of
 	results. It is required for queries that apply more than two complex filters (on function,
@@ -160,13 +160,21 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sign, sent, received, or paid.
+The possible relationship types for a transaction block: sent, or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed either as a sender or as a sponsor.
+	Transactions this address has sent. NOTE: this input filter has been deprecated in favor of
+	`SENT` which behaves identically but is named more clearly. Both filters restrict
+	transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	SIGN
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
 	"""
 	Transactions that sent objects to this address.
 	"""
@@ -4323,9 +4331,17 @@ input TransactionBlockFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
-	Limit to transactions that were signed by the given address.
+	Limit to transactions that were sent by the given address. NOTE: this input filter has been
+	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
+	Both filters restrict transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 	"""
 	Limit to transactions that sent an object to the given address.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -101,7 +101,7 @@ type Address implements IOwner {
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the additional
-	`AddressTransactionBlockRelationship` filter, which defaults to `SIGN`.
+	`AddressTransactionBlockRelationship` filter, which defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when gathering a page of
 	results. It is required for queries that apply more than two complex filters (on function,
@@ -164,13 +164,21 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sign, sent, received, or paid.
+The possible relationship types for a transaction block: sent, or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed either as a sender or as a sponsor.
+	Transactions this address has sent. NOTE: this input filter has been deprecated in favor of
+	`SENT` which behaves identically but is named more clearly. Both filters restrict
+	transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	SIGN
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
 	"""
 	Transactions that sent objects to this address.
 	"""
@@ -4317,9 +4325,17 @@ input TransactionBlockFilter {
 	"""
 	beforeCheckpoint: UInt53
 	"""
-	Limit to transactions that were signed by the given address.
+	Limit to transactions that were sent by the given address. NOTE: this input filter has been
+	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
+	Both filters restrict transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 	"""
 	Limit to transactions that sent an object to the given address.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -101,7 +101,7 @@ type Address implements IOwner {
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the additional
-	`AddressTransactionBlockRelationship` filter, which defaults to `SIGN`.
+	`AddressTransactionBlockRelationship` filter, which defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when gathering a page of
 	results. It is required for queries that apply more than two complex filters (on function,
@@ -164,13 +164,21 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sign, sent, received, or paid.
+The possible relationship types for a transaction block: sent, or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed either as a sender or as a sponsor.
+	Transactions this address has sent. NOTE: this input filter has been deprecated in favor of
+	`SENT` which behaves identically but is named more clearly. Both filters restrict
+	transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	SIGN
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
 	"""
 	Transactions that sent objects to this address.
 	"""
@@ -4327,9 +4335,17 @@ input TransactionBlockFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
-	Limit to transactions that were signed by the given address.
+	Limit to transactions that were sent by the given address. NOTE: this input filter has been
+	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
+	Both filters restrict transactions by their sender, only, not signers in general.
+	
+	This filter will be removed after 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 	"""
 	Limit to transactions that sent an object to the given address.
 	"""


### PR DESCRIPTION
## Description

`TransactionBlockFilter.signAddress` and `AddressTransactionBlockFilter.SIGN` both claim to support filtering by sender and sponsor, but this is not true, they only support sender, and they should not be adapted to also filter by sponsor because we rely on the there being only one sender per transaction to ensure filters that combine sender with something else remain both space and time efficient.

## Test plan

Existing tests and CI, plus some new tests to make sure the new filter options work, and interactions between the old and new filters work.

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Deprecates `TransactionBlockFilter.signAddress`, replacing it with `TransactionBlockFilter.sentAddress` which behaves identically. Similarly `AddressTransactionBlockRelationship.SIGN` is deprecated and replaced by `AddressTransactionBlockRelationship.SENT`.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
