### PR TITLE
[cli] Remove indexer feature for `sui` and remove the `sui-pg` binary

### DIFF
--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: cargo build
       if: env.s3_file_exist == '' # if empty, we have not built and uploaded this binary to s3 yet
       run: |
-        if [ ${{ inputs.ref }} == 'devnet' || ${{ inputs.ref }} == 'testnet' ]; then 
+        if [[ "${{ inputs.ref }}" == 'devnet' || "${{ inputs.ref }}" == 'testnet' ]]; then
           cargo build --bin sui --features indexer
         else
           cargo build --bin sui

--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -41,7 +41,7 @@ runs:
       working-directory: ./target/debug
       run: |
         mkdir -p $PWD/target/debug
-        wget -O target/debug/sui https://sui-releases.s3.us-east-1.amazonaws.com/${{ github.sha }}/debug/sui-pg
+        wget -O target/debug/sui https://sui-releases.s3.us-east-1.amazonaws.com/${{ github.sha }}/debug/sui
         chmod +x $PWD/target/debug/sui
       shell: bash
 

--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: cargo build
       if: env.s3_file_exist == '' # if empty, we have not built and uploaded this binary to s3 yet
       run: |
-        cargo build --bin sui --features indexer
+        cargo build --bin sui
       shell: bash
 
     - name: Dowload from S3

--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -29,7 +29,11 @@ runs:
     - name: cargo build
       if: env.s3_file_exist == '' # if empty, we have not built and uploaded this binary to s3 yet
       run: |
-        cargo build --bin sui
+        if [ ${{ inputs.ref }} == 'devnet' || ${{ inputs.ref }} == 'testnet' ]; then 
+          cargo build --bin sui --features indexer
+        else
+          cargo build --bin sui
+        fi
       shell: bash
 
     - name: Dowload from S3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
         with:
           version: 9.1.1
-      - run: cargo build --bin sui --features indexer --profile dev
+      - run: cargo build --bin sui --profile dev
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,6 @@ jobs:
         if: ${{ env.s3_archive_exist == '' }}
         shell: bash
         run: |
-          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --bin sui --release --features indexer && mv target/release/sui target/release/sui-pg
           [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release && cargo build --profile=dev --bin sui
 
       - name: Rename binaries for ${{ matrix.os }}
@@ -175,10 +174,6 @@ jobs:
             export binary=$(echo ${binary} | tr -d $'\r')
             mv ./target/release/${binary}${{ env.extention }} ${{ env.TMP_BUILD_DIR }}/${binary}${{ env.extention }}
           done
-
-          # sui-pg is a special binary that is built with the indexer feature for sui start cmd
-          export binary=$(echo "sui-pg" | tr -d $'\r')
-          mv ./target/release/${binary}${{ env.extention }} ${{ env.TMP_BUILD_DIR }}/${binary}${{ env.extention }}
 
           mv ./target/debug/sui${{ env.extention }} ${{ env.TMP_BUILD_DIR }}/sui-debug${{ env.extention }}
           tar -cvzf ./tmp/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz -C ${{ env.TMP_BUILD_DIR }} .

--- a/crates/sui-graphql-rpc/README.md
+++ b/crates/sui-graphql-rpc/README.md
@@ -68,7 +68,7 @@ For local dev, it might be useful to spin up an indexer as well. Instructions ar
 
 ## Compatibility with json-rpc
 
-`cargo run --bin sui --features indexer -- start --with-faucet --force-regenesis --with-indexer --pg-port 5432 --pg-db-name sui_indexer_v2 --with-graphql`
+`cargo run --bin sui -- start --with-faucet --force-regenesis --with-indexer --pg-port 5432 --pg-db-name sui_indexer_v2 --with-graphql`
 
 `pnpm --filter @mysten/graphql-transport test:e2e`
 

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -37,7 +37,7 @@ cargo run --bin sui -- start --with-faucet --force-regenesis
 
 If you want to run a local network with the indexer enabled (note that `libpq` is required), you can run the following command after following the steps in the next section to set up an indexer DB:
 ```sh
-cargo run --bin sui --features indexer -- start --with-faucet --force-regenesis --with-indexer --pg-port 5432 --pg-db-name sui_indexer_v2
+cargo run --bin sui -- start --with-faucet --force-regenesis --with-indexer --pg-port 5432 --pg-db-name sui_indexer_v2
 ```
 
 ### Running standalone indexer

--- a/crates/sui-rpc-loadgen/README.md
+++ b/crates/sui-rpc-loadgen/README.md
@@ -17,7 +17,7 @@ Run the following command to see available commands:
 cargo run --bin sui-rpc-loadgen -- -h
 ```
 
-To try this locally, refer to the [docs](https://docs.sui.io/guides/developer/getting-started/local-network). Recommend setting `database-url` to an env variable. Note: run `RUST_LOG="consensus=off" cargo run sui --features indexer -- start --with-faucet --force-regenesis --with-indexer` to rebuild.
+To try this locally, refer to the [docs](https://docs.sui.io/guides/developer/getting-started/local-network). Recommend setting `database-url` to an env variable. Note: run `RUST_LOG="consensus=off" cargo run sui -- start --with-faucet --force-regenesis --with-indexer` to rebuild.
 
 ### Example 1: Get All Checkpoints
 

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -7,11 +7,11 @@ fn main() {
 How to install/build the sui binary IF:
     A: you only need the basic functionality, so just faucet and no persistence (no indexer, no GraphQL service), build from source as usual (cargo build --bin sui) or download latest archive from release archives (starting from testnet v1.28.1 or devnet v1.29) and use sui binary.
     B: you need to also start an indexer (--with-indexer ), or a GraphQL service (--with-graphql), you either:
-    - download latest archive from release archives (starting from testnet v1.28.1 or devnet v1.29) and use sui-pg binary.
+    - download latest archive from release archives (starting from testnet v1.28.1 or devnet v1.29) and use sui-pg binary (note that with v1.34.0 sui-pg no longer exists in the release. Use `sui` binary instead).
   OR
-    - build from source. This requires passing the indexer feature when building the sui binary, as well as having libpq/postgresql dependencies installed (just as when using sui-test-validator):
-        - cargo build --bin sui --features indexer
-        - cargo run --features indexer --bin sui -- start --with-faucet --force-regenesis --with-indexer --with-graphql
+    - build from source. This requires to have libpq/postgresql dependencies installed (just as when using sui-test-validator):
+        - cargo build --bin sui
+        - cargo run --bin sui -- start --with-faucet --force-regenesis --with-indexer --with-graphql
 
 Running the local network:
  - (Preferred) In the simplest form, you can replace sui-test-validator with sui start --with-faucet --force-regenesis. This will create a network from a new genesis and start a faucet (127.0.0.1:9123). This will not persist state.

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -56,8 +56,8 @@ sui-cluster-test.workspace = true
 sui-execution = { path = "../../sui-execution" }
 sui-faucet.workspace = true
 sui-swarm-config.workspace = true
-sui-graphql-rpc = {workspace = true, optional = true}
-sui-indexer = { workspace = true, optional = true }
+sui-graphql-rpc = {workspace = true }
+sui-indexer = { workspace = true }
 sui-genesis-builder.workspace = true
 sui-types.workspace = true
 sui-json.workspace = true
@@ -133,4 +133,3 @@ gas-profiler = [
     "sui-types/gas-profiler",
     "sui-execution/gas-profiler",
 ]
-indexer = ["dep:sui-indexer", "dep:sui-graphql-rpc"]

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -16,8 +16,7 @@ use move_package::{lock_file::schema::ManagedPackage, BuildConfig as MoveBuildCo
 use serde_json::json;
 use sui::client_ptb::ptb::PTB;
 use sui::key_identity::{get_identity_address, KeyIdentity};
-#[cfg(feature = "indexer")]
-use sui::sui_commands::IndexerFeatureArgs;
+use sui::sui_commands::IndexerArgs;
 use sui_sdk::SuiClient;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
 use sui_types::object::Owner;
@@ -76,8 +75,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         fullnode_rpc_port: 9000,
         epoch_duration_ms: None,
         no_full_node: false,
-        #[cfg(feature = "indexer")]
-        indexer_feature_args: IndexerFeatureArgs::for_testing(),
+        indexer_feature_args: IndexerArgs::for_testing(),
     }
     .execute()
     .await;

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -2,7 +2,7 @@
 title: Connect to a Local Network
 ---
 
-Use a Sui local network to test your dApps against the latest changes to Sui, and to prepare for the next Sui release to the Devnet or Testnet network. Sui CLI provides the `sui start` command to start a local network. There are several services that can be started when using `sui start`, such as an indexer, a faucet, or a local instance of the GraphQL service (including the online GraphiQL IDE). You can use the included faucet to get test SUI to use on the local network.
+Use a Sui local network to test your dApps against the latest changes to Sui, and to prepare for the next Sui release to the Devnet or Testnet network. Sui CLI provides the `sui start` command to start a local network. There are several services that can be started when using `sui start`, such as an indexer, a faucet, or a local instance of the GraphQL service (including the web-based GraphiQL IDE). You can use the included faucet to get test SUI to use on the local network.
 
 If you haven't already, you need to [install Sui CLI](./sui-install.mdx) on your system.
 
@@ -27,7 +27,7 @@ Each time you start the network by passing `--force-regenesis`, the local networ
 To customize your local Sui network, such as starting other services or changing default ports and hosts, include additional flags or options in the `sui start` command.
 
 :::info
-Options and flags like `with-indexer`,  `with-graphql`, and related require you to use the `sui-pg` binary from the [GitHub release archive](https://github.com/MystenLabs/sui/releases), or to build the `sui` binary with the indexer feature enabled: `cargo build --bin sui --features indexer`.
+Options and flags like `with-indexer`,  `with-graphql`, and related require you to have Postgresq/libpq installed. Check out the list of possible options below to find which is the default expected DB, or how to pass a different DB.
 :::
 
 The following is a list of possible options and flags to pass to `sui start`:

--- a/sdk/graphql-transport/package.json
+++ b/sdk/graphql-transport/package.json
@@ -31,7 +31,7 @@
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"test:e2e:nowait": "vitest run e2e",
-		"test:e2e:prepare": "docker-compose down && docker-compose up -d && cargo build --bin sui --features indexer --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --features indexer --bin sui -- start --with-faucet --force-regenesis --with-indexer --pg-port 5435 --pg-db-name sui_indexer_v2 --with-graphql",
+		"test:e2e:prepare": "docker-compose down && docker-compose up -d && cargo build --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui -- start --with-faucet --force-regenesis --with-indexer --pg-port 5435 --pg-db-name sui_indexer_v2 --with-graphql",
 		"test:e2e": "wait-on http://127.0.0.1:9123 -l --timeout 180000 && vitest"
 	},
 	"repository": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -102,7 +102,7 @@
 		"test:unit": "vitest run unit __tests__",
 		"test:e2e": "wait-on http://127.0.0.1:9123 -l --timeout 180000 && vitest run e2e",
 		"test:e2e:nowait": "vitest run e2e",
-		"prepare:e2e": "docker-compose down && docker-compose up -d && cargo build --bin sui --features indexer --profile dev && cross-env RUST_LOG=warn,sui=error,anemo_tower=warn,consensus=off ../../target/debug/sui start --with-faucet --force-regenesis --with-indexer --pg-port 5435 --pg-db-name sui_indexer_v2 --with-graphql",
+		"prepare:e2e": "docker-compose down && docker-compose up -d && cargo build --bin sui --profile dev && cross-env RUST_LOG=warn,sui=error,anemo_tower=warn,consensus=off ../../target/debug/sui start --with-faucet --force-regenesis --with-indexer --pg-port 5435 --pg-db-name sui_indexer_v2 --with-graphql",
 		"prepublishOnly": "pnpm build",
 		"size": "size-limit",
 		"analyze": "size-limit --why",


### PR DESCRIPTION
## Description 

Recent improvements on GraphQL and Postgres code removed the dynamic linking to `libpq`. Due to this linking (GH actions was linking to postgres@14), we had to have a separate `sui-pg` binary that was built with the `indexer` feature such that one can have access to `sui start --with-indexer` and `--with-graphql` due to the required dependencies to Postgres. 

This PR removes the `indexer` feature, all the instances of building the binary with `--features indexer` in workflows, actions, etc, and updates the documentation (docs + sui-test-validator crate). This is possible because `libpq` is no longer a dependency that gets dynamically linked to the binary. Note that in order to use those flags, a running Postgres DB is still required just like before.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: the `indexer` feature was removed from the `sui` crate as the dynamic linking to `libpq` was removed. Therefore, the `sui-pg` binary will not be part of releases anymore. This `sui-pg` binary was used for starting a network with `--with-indexer` and `--with-graphql` flags. These commands will still work as before and it is still required to have installed a Postgres database.
If you used `sui-pg` binary previously, you can simply use `sui` binary from this version on.
- [ ] Rust SDK:
- [ ] REST API:
