### PR TITLE
fix(graphql): flakiness in pruning test

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/prune.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune.exp
@@ -1,4 +1,4 @@
-processed 13 tasks
+processed 12 tasks
 
 task 1, lines 6-25:
 //# publish
@@ -49,60 +49,7 @@ task 10, line 43:
 Epoch advanced: 2
 
 task 11, lines 45-55:
-//# run-graphql
-Response: {
-  "data": {
-    "checkpoints": {
-      "nodes": [
-        {
-          "epoch": {
-            "epochId": 0
-          },
-          "sequenceNumber": 0
-        },
-        {
-          "epoch": {
-            "epochId": 0
-          },
-          "sequenceNumber": 1
-        },
-        {
-          "epoch": {
-            "epochId": 0
-          },
-          "sequenceNumber": 2
-        },
-        {
-          "epoch": {
-            "epochId": 1
-          },
-          "sequenceNumber": 3
-        },
-        {
-          "epoch": {
-            "epochId": 1
-          },
-          "sequenceNumber": 4
-        },
-        {
-          "epoch": {
-            "epochId": 2
-          },
-          "sequenceNumber": 5
-        },
-        {
-          "epoch": {
-            "epochId": 2
-          },
-          "sequenceNumber": 6
-        }
-      ]
-    }
-  }
-}
-
-task 12, lines 58-68:
-//# run-graphql --wait-for-checkpoint-pruned 0
+//# run-graphql --wait-for-checkpoint-pruned 4
 Response: {
   "data": {
     "checkpoints": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune.move
@@ -42,20 +42,7 @@ module Test::M1 {
 
 //# advance-epoch
 
-//# run-graphql
-{
-  checkpoints {
-    nodes {
-      epoch {
-        epochId
-      }
-      sequenceNumber
-    }
-  }
-}
-
-
-//# run-graphql --wait-for-checkpoint-pruned 0
+//# run-graphql --wait-for-checkpoint-pruned 4
 {
   checkpoints {
     nodes {


### PR DESCRIPTION
## Description

Fix some flakiness in the `prune.move` by removing the initial checkpoints query which may witness different degrees of pruning.

## Test plan

Run the E2E tests in a loop -- previously this would trigger the failure after some time (usually fewer than 10 runs) and after this change, the same thing does not happen:

```
sui$ while true; do
  cargo nextest run -p sui-graphql-e2e-tests
done
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
