### PR TITLE
feat(indexer): index tx_affected_objects

### DIFF
--- a/crates/sui-indexer/migrations/pg/2024-09-19-121113_tx_affected_objects/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-19-121113_tx_affected_objects/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS tx_affected_objects;

--- a/crates/sui-indexer/migrations/pg/2024-09-19-121113_tx_affected_objects/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-19-121113_tx_affected_objects/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE tx_affected_objects (
+    tx_sequence_number          BIGINT       NOT NULL,
+    affected                    BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(affected, tx_sequence_number)
+);
+
+CREATE INDEX tx_affected_objects_tx_sequence_number_index ON tx_affected_objects (tx_sequence_number);
+CREATE INDEX tx_affected_objects_sender ON tx_affected_objects (sender, affected, tx_sequence_number);

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -289,6 +289,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    tx_affected_objects (affected, tx_sequence_number) {
+        tx_sequence_number -> Int8,
+        affected -> Bytea,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
     tx_calls_fun (package, module, func, tx_sequence_number) {
         tx_sequence_number -> Int8,
         package -> Bytea,
@@ -384,6 +392,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     pruner_cp_watermark,
     transactions,
     tx_affected_addresses,
+    tx_affected_objects,
     tx_calls_fun,
     tx_calls_mod,
     tx_calls_pkg,


### PR DESCRIPTION
## Description

Similar to #19355, introduce `tx_affected_objects` table -- a combination of `tx_input_objects` and `tx_changed_objects` which will both eventually be removed in favour of the new table.

## Test plan

```
sui$ cargo build -p sui-indexer
```

Tests based on reading this field will be included with the PR introducing changes to GraphQL.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Index the objects affected by a transaction (either because they are an input object or are changed by the transaction).
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
