### PR TITLE
[Consensus] reduce commit sync fetch parallelism

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -153,7 +153,7 @@ impl Parameters {
     }
 
     pub(crate) fn default_commit_sync_parallel_fetches() -> usize {
-        20
+        8
     }
 
     pub(crate) fn default_commit_sync_batch_size() -> u32 {
@@ -168,7 +168,7 @@ impl Parameters {
     pub(crate) fn default_commit_sync_batches_ahead() -> usize {
         // This is set to be a multiple of default commit_sync_parallel_fetches to allow fetching ahead,
         // while keeping the total number of inflight fetches and unprocessed fetched commits limited.
-        80
+        32
     }
 }
 

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -19,9 +19,9 @@ round_prober_interval_ms: 5000
 round_prober_request_timeout_ms: 2000
 propagation_delay_stop_proposal_threshold: 20
 dag_state_cached_rounds: 500
-commit_sync_parallel_fetches: 20
+commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
-commit_sync_batches_ahead: 80
+commit_sync_batches_ahead: 32
 anemo:
   excessive_message_size: 8388608
 tonic:

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -711,7 +711,7 @@ mod tests {
         let parameters = Parameters {
             db_path: db_dir.path().to_path_buf(),
             dag_state_cached_rounds: 5,
-            commit_sync_parallel_fetches: 3,
+            commit_sync_parallel_fetches: 2,
             commit_sync_batch_size: 3,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()


### PR DESCRIPTION
## Description 

For validators with limited bandwidth, too much parallelism can increase fetch jitters and slow down the overall progress. Before we make the algorithm more adaptive, start with less parallelism by default.

## Test plan 

PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
