### PR TITLE
graphql: deprecations related to affected addresses/objects

### DIFF
--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -168,7 +168,7 @@ enum AddressTransactionBlockRelationship {
 	`SENT` which behaves identically but is named more clearly. Both filters restrict
 	transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	SIGN
 	"""
@@ -176,7 +176,11 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that sent objects to this address.
+	Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+	in favor of `AFFECTED`, which offers an easier to understand behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`AFFECTED` is introduced, whichever is later.
 	"""
 	RECV
 }
@@ -4325,7 +4329,7 @@ input TransactionBlockFilter {
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
 	"""
@@ -4333,15 +4337,28 @@ input TransactionBlockFilter {
 	"""
 	sentAddress: SuiAddress
 	"""
-	Limit to transactions that sent an object to the given address.
+	Limit to transactions that sent an object to the given address. NOTE: this input filter has
+	been deprecated in favor of `affectedAddress` which offers an easier to understand
+	behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedAddress` is introduced, whichever is later.
 	"""
 	recvAddress: SuiAddress
 	"""
-	Limit to transactions that accepted the given object as an input.
+	Limit to transactions that accepted the given object as an input. NOTE: this input filter
+	has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	inputObject: SuiAddress
 	"""
-	Limit to transactions that output a versioon of this object.
+	Limit to transactions that output a versioon of this object. NOTE: this input filter has
+	been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	changedObject: SuiAddress
 	"""

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -32,11 +32,15 @@ pub(crate) enum AddressTransactionBlockRelationship {
     /// `SENT` which behaves identically but is named more clearly. Both filters restrict
     /// transactions by their sender, only, not signers in general.
     ///
-    /// This filter will be removed after 1.36.0 (2024-10-14).
+    /// This filter will be removed with 1.36.0 (2024-10-14).
     Sign,
     /// Transactions this address has sent.
     Sent,
-    /// Transactions that sent objects to this address.
+    /// Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+    /// in favor of `AFFECTED`, which offers an easier to understand behavior.
+    ///
+    /// This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+    /// `AFFECTED` is introduced, whichever is later.
     Recv,
     /// Transactions that this address was involved in, either as the sender, sponsor, or as the
     /// owner of some object that was created, modified or transfered.

--- a/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
@@ -35,19 +35,32 @@ pub(crate) struct TransactionBlockFilter {
     /// deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
     /// Both filters restrict transactions by their sender, only, not signers in general.
     ///
-    /// This filter will be removed after 1.36.0 (2024-10-14).
+    /// This filter will be removed with 1.36.0 (2024-10-14).
     pub sign_address: Option<SuiAddress>,
 
     /// Limit to transactions that were sent by the given address.
     pub sent_address: Option<SuiAddress>,
 
-    /// Limit to transactions that sent an object to the given address.
+    /// Limit to transactions that sent an object to the given address. NOTE: this input filter has
+    /// been deprecated in favor of `affectedAddress` which offers an easier to understand
+    /// behavior.
+    ///
+    /// This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+    /// `affectedAddress` is introduced, whichever is later.
     pub recv_address: Option<SuiAddress>,
 
-    /// Limit to transactions that accepted the given object as an input.
+    /// Limit to transactions that accepted the given object as an input. NOTE: this input filter
+    /// has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+    ///
+    /// This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+    /// `affectedObject` is introduced, whichever is later.
     pub input_object: Option<SuiAddress>,
 
-    /// Limit to transactions that output a versioon of this object.
+    /// Limit to transactions that output a versioon of this object. NOTE: this input filter has
+    /// been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+    ///
+    /// This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+    /// `affectedObject` is introduced, whichever is later.
     pub changed_object: Option<SuiAddress>,
 
     /// Select transactions by their digest.

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -168,7 +168,7 @@ enum AddressTransactionBlockRelationship {
 	`SENT` which behaves identically but is named more clearly. Both filters restrict
 	transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	SIGN
 	"""
@@ -176,7 +176,11 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that sent objects to this address.
+	Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+	in favor of `AFFECTED`, which offers an easier to understand behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`AFFECTED` is introduced, whichever is later.
 	"""
 	RECV
 	"""
@@ -4335,7 +4339,7 @@ input TransactionBlockFilter {
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
 	"""
@@ -4343,15 +4347,28 @@ input TransactionBlockFilter {
 	"""
 	sentAddress: SuiAddress
 	"""
-	Limit to transactions that sent an object to the given address.
+	Limit to transactions that sent an object to the given address. NOTE: this input filter has
+	been deprecated in favor of `affectedAddress` which offers an easier to understand
+	behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedAddress` is introduced, whichever is later.
 	"""
 	recvAddress: SuiAddress
 	"""
-	Limit to transactions that accepted the given object as an input.
+	Limit to transactions that accepted the given object as an input. NOTE: this input filter
+	has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	inputObject: SuiAddress
 	"""
-	Limit to transactions that output a versioon of this object.
+	Limit to transactions that output a versioon of this object. NOTE: this input filter has
+	been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	changedObject: SuiAddress
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -172,7 +172,7 @@ enum AddressTransactionBlockRelationship {
 	`SENT` which behaves identically but is named more clearly. Both filters restrict
 	transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	SIGN
 	"""
@@ -180,7 +180,11 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that sent objects to this address.
+	Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+	in favor of `AFFECTED`, which offers an easier to understand behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`AFFECTED` is introduced, whichever is later.
 	"""
 	RECV
 }
@@ -4329,7 +4333,7 @@ input TransactionBlockFilter {
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
 	"""
@@ -4337,15 +4341,28 @@ input TransactionBlockFilter {
 	"""
 	sentAddress: SuiAddress
 	"""
-	Limit to transactions that sent an object to the given address.
+	Limit to transactions that sent an object to the given address. NOTE: this input filter has
+	been deprecated in favor of `affectedAddress` which offers an easier to understand
+	behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedAddress` is introduced, whichever is later.
 	"""
 	recvAddress: SuiAddress
 	"""
-	Limit to transactions that accepted the given object as an input.
+	Limit to transactions that accepted the given object as an input. NOTE: this input filter
+	has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	inputObject: SuiAddress
 	"""
-	Limit to transactions that output a versioon of this object.
+	Limit to transactions that output a versioon of this object. NOTE: this input filter has
+	been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	changedObject: SuiAddress
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -172,7 +172,7 @@ enum AddressTransactionBlockRelationship {
 	`SENT` which behaves identically but is named more clearly. Both filters restrict
 	transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	SIGN
 	"""
@@ -180,7 +180,11 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that sent objects to this address.
+	Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+	in favor of `AFFECTED`, which offers an easier to understand behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`AFFECTED` is introduced, whichever is later.
 	"""
 	RECV
 	"""
@@ -4339,7 +4343,7 @@ input TransactionBlockFilter {
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
 	"""
@@ -4347,15 +4351,28 @@ input TransactionBlockFilter {
 	"""
 	sentAddress: SuiAddress
 	"""
-	Limit to transactions that sent an object to the given address.
+	Limit to transactions that sent an object to the given address. NOTE: this input filter has
+	been deprecated in favor of `affectedAddress` which offers an easier to understand
+	behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedAddress` is introduced, whichever is later.
 	"""
 	recvAddress: SuiAddress
 	"""
-	Limit to transactions that accepted the given object as an input.
+	Limit to transactions that accepted the given object as an input. NOTE: this input filter
+	has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	inputObject: SuiAddress
 	"""
-	Limit to transactions that output a versioon of this object.
+	Limit to transactions that output a versioon of this object. NOTE: this input filter has
+	been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	changedObject: SuiAddress
 	"""

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1423,6 +1423,13 @@ impl PgIndexerStore {
                 .await?;
 
                 diesel::delete(
+                    tx_affected_objects::table
+                        .filter(tx_affected_objects::tx_sequence_number.between(min_tx, max_tx)),
+                )
+                .execute(conn)
+                .await?;
+
+                diesel::delete(
                     tx_senders::table
                         .filter(tx_senders::tx_sequence_number.between(min_tx, max_tx)),
                 )


### PR DESCRIPTION
## Description 

- Add deprecation notices to filters that will be superseded by `tx_affected_*`-based filters.
- Adds support for pruning `tx_affected_objects` which was missing from the PR that introduced the table.

## Test plan 

:eyes:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Adds support for pruning `tx_affected_objects`.
- [ ] JSON-RPC: 
- [x] GraphQL: Add deprecation notices to `recvAddress`, `inputObject` and `changedObject` on `TransactionBlockFilter`, and `RECV` on `AddressTransactionBlockRelationship` in preparation for their removal and replacement with `affectedAddress` and `affectedObject` queries.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
