### PR TITLE
reduce default db connection pool size

### DIFF
--- a/crates/sui-indexer/src/db.rs
+++ b/crates/sui-indexer/src/db.rs
@@ -24,7 +24,7 @@ const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/pg");
 
 #[derive(Args, Debug, Clone)]
 pub struct ConnectionPoolConfig {
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 20)]
     #[arg(env = "DB_POOL_SIZE")]
     pub pool_size: u32,
     #[arg(long, value_parser = parse_duration, default_value = "30")]


### PR DESCRIPTION
## Description 

Reduce default db connection pool size for indexers. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
