### PR TITLE
[move-ide] Added support for variable shadowing

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -236,16 +236,15 @@ export class MoveDebugSession extends LoggingDebugSession {
         }
         const scopes: DebugProtocol.Scope[] = [];
         if (frame.locals.length > 0) {
-            const localScopeReference = this.variableHandles.create({ locals: frame.locals[0] });
-            const localScope = new Scope(`locals: ${frame.name}`, localScopeReference, false);
-            scopes.push(localScope);
-            // TODO: finish shadowed variables support
-            for (let i = 1; i < frame.locals.length; i++) {
+            for (let i = frame.locals.length - 1; i > 0; i--) {
                 const shadowedScopeReference = this.variableHandles.create({ locals: frame.locals[i] });
                 const shadowedScope = new Scope(`shadowed(${i}): ${frame.name}`, shadowedScopeReference, false);
                 scopes.push(shadowedScope);
             }
         }
+        const localScopeReference = this.variableHandles.create({ locals: frame.locals[0] });
+        const localScope = new Scope(`locals: ${frame.name}`, localScopeReference, false);
+        scopes.push(localScope);
 
         return scopes;
     }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -242,6 +242,8 @@ export class MoveDebugSession extends LoggingDebugSession {
                 scopes.push(shadowedScope);
             }
         }
+        // don't have to check if scope 0 exists as it's created whenever a new frame is created
+        // and it's never disposed of
         const localScopeReference = this.variableHandles.create({ locals: frame.locals[0] });
         const localScope = new Scope(`locals: ${frame.name}`, localScopeReference, false);
         scopes.push(localScope);

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -442,14 +442,12 @@ export class Runtime extends EventEmitter {
                 }
             }
             // trim shadowed scopes that have no live variables in them
-            if (localsLength > 1) {
-                for (let i = localsLength - 1; i > 0; i--) {
-                    const existingVar = currentFrame.locals[i].find(runtimeVar => {
-                        return runtimeVar !== undefined;
-                    });
-                    if (!existingVar) {
-                        currentFrame.locals.pop();
-                    }
+            for (let i = localsLength - 1; i > 0; i--) {
+                const liveVar = currentFrame.locals[i].find(runtimeVar => {
+                    return runtimeVar !== undefined;
+                });
+                if (!liveVar) {
+                    currentFrame.locals.pop();
                 }
             }
         }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -433,10 +433,22 @@ export class Runtime extends EventEmitter {
         // local variable array
         const frameLocalLifetimeEnds = this.trace.localLifetimeEnds.get(currentFrame.id);
         if (frameLocalLifetimeEnds) {
-            for (let i = 0; i < currentFrame.locals.length; i++) {
+            const localsLength = currentFrame.locals.length;
+            for (let i = 0; i < localsLength; i++) {
                 for (let j = 0; j < currentFrame.locals[i].length; j++) {
                     if (frameLocalLifetimeEnds[j] === instructionEvent.pc) {
                         currentFrame.locals[i][j] = undefined;
+                    }
+                }
+            }
+            // trim shadowed scopes that have no live variables in them
+            if (localsLength > 1) {
+                for (let i = localsLength - 1; i > 0; i--) {
+                    const existingVar = currentFrame.locals[i].find(runtimeVar => {
+                        return runtimeVar !== undefined;
+                    });
+                    if (!existingVar) {
+                        currentFrame.locals.pop();
                     }
                 }
             }
@@ -555,9 +567,36 @@ function localWrite(
             + ' in function: '
             + currentFrame.name);
     }
-    // TODO: if a variable has the same name but a different index (it is shadowed)
-    // it has to be put in a different scope (e.g., locals[1], locals[2], etc.)
-    currentFrame.locals[0][localIndex] = { name, value, type };
+
+    const scopesCount = currentFrame.locals.length;
+    if (scopesCount <= 0) {
+        throw new Error("There should be at least one variable scope in functon"
+            + currentFrame.name);
+    }
+    // If a variable has the same name but a different index (it is shadowed)
+    // it has to be put in a different scope (e.g., locals[1], locals[2], etc.).
+    // Find scope already containing variable name, if any, starting from
+    // the outermost one
+    let existingVarScope = -1;
+    for (let i = scopesCount - 1; i >= 0; i--) {
+        const existingVarIndex = currentFrame.locals[i].findIndex(runtimeVar => {
+            return runtimeVar && runtimeVar.name === name;
+        });
+        if (existingVarIndex !== -1 && existingVarIndex !== localIndex) {
+            existingVarScope = i;
+            break;
+        }
+    }
+    if (existingVarScope >= 0) {
+        const shadowedScope = currentFrame.locals[existingVarScope + 1];
+        if (!shadowedScope) {
+            currentFrame.locals.push([]);
+        }
+        currentFrame.locals[existingVarScope + 1][localIndex] = { name, value, type };
+    } else {
+        // put variable in the "main" locals scope
+        currentFrame.locals[0][localIndex] = { name, value, type };
+    }
 }
 
 /**

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
@@ -27,8 +27,10 @@ const DEBUGGER_TYPE = 'move-debug';
  * Provider of on-hover information during debug session.
  */
 class MoveEvaluatableExpressionProvider {
-    // TODO: implement a more sophisticated provider that actually provides correct on-hover information
-    provideEvaluatableExpression(document: TextDocument, position: Position, token: CancellationToken) {
+    // TODO: implement a more sophisticated provider that actually provides correct on-hover information,
+    // at least for variable definitions whose locations are readily available in the source map
+    // (user can always use go-to-def to see the definition and the value)
+    provideEvaluatableExpression(_document: TextDocument, _position: Position, _token: CancellationToken) {
         // suppress debug-time on hover information for now
         return null;
     }

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
@@ -5,7 +5,13 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { StackFrame } from '@vscode/debugadapter';
-import { WorkspaceFolder, DebugConfiguration, CancellationToken } from 'vscode';
+import {
+    WorkspaceFolder,
+    DebugConfiguration,
+    CancellationToken,
+    TextDocument,
+    Position
+} from 'vscode';
 
 /**
  * Log level for the debug adapter.
@@ -16,6 +22,17 @@ const LOG_LEVEL = 'log';
  * Describes debugger configuration name defined in package.json
  */
 const DEBUGGER_TYPE = 'move-debug';
+
+/**
+ * Provider of on-hover information during debug session.
+ */
+class MoveEvaluatableExpressionProvider {
+    // TODO: implement a more sophisticated provider that actually provides correct on-hover information
+    provideEvaluatableExpression(document: TextDocument, position: Position, token: CancellationToken) {
+        // suppress debug-time on hover information for now
+        return null;
+    }
+}
 
 /**
  * Called when the extension is activated.
@@ -82,20 +99,29 @@ export function activate(context: vscode.ExtensionContext) {
 
                             editor.setDecorations(decorationType, decorationsArray);
                         }
-
                     }
                 }
             }
-        }),
-        vscode.debug.onDidTerminateDebugSession(() => {
-            // reset all decorations when the debug session is terminated
-            // to avoid showing lines for code that was optimized away
-            const editor = vscode.window.activeTextEditor;
-            if (editor) {
-                editor.setDecorations(decorationType, []);
-            }
         })
     );
+
+    // register a provider of on-hover information during debug session
+    const langSelector = { scheme: 'file', language: 'move' };
+    context.subscriptions.push(
+        vscode.languages.registerEvaluatableExpressionProvider(
+            langSelector,
+            new MoveEvaluatableExpressionProvider()
+        )
+    );
+
+    context.subscriptions.push(vscode.debug.onDidTerminateDebugSession(() => {
+        // reset all decorations when the debug session is terminated
+        // to avoid showing lines for code that was optimized away
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+            editor.setDecorations(decorationType, []);
+        }
+    }));
 }
 
 /**


### PR DESCRIPTION
## Description 

This PR adds handling of shadowed variables to the trace viewer:
- shadowed variables appear in separate scopes
- shadowed scope appears when a variable with the same name as an already existing one is declared
- shadowed scope disappears when all variables it includes stop being live

Additionally, this PR (temporarily) suppresses on-hover information that VSCode shows during debug session. The reason for it is that the default VSCode behavior in this department breaks in presence of shadowed variables

## Test plan 

Tested manually
