### PR TITLE
fix: show prior transaction warning onChange

### DIFF
--- a/apps/wallet/src/ui/app/components/address-input/index.tsx
+++ b/apps/wallet/src/ui/app/components/address-input/index.tsx
@@ -132,7 +132,7 @@ export function AddressInput({
 				</div>
 			</div>
 
-			{meta.touched && !isValidating ? (
+			{field.value && !isValidating ? (
 				<div className="mt-2.5 w-full">
 					<Alert noBorder rounded="lg" mode={meta.error || warningData ? 'issue' : 'success'}>
 						{warningData === RecipientWarningType.OBJECT ? (


### PR DESCRIPTION
## Description 

Adjusts the Send Form to show the "No prior transactions" warning onChange instead of onBlur. This helps ensure that the user sees it before moving onto the Review screen. 




https://github.com/user-attachments/assets/743c58f8-f9c5-4530-8677-6511530ee98a



