### PR TITLE
(feat)Indexer: Add `raw_transaction_sigs` column and switch `raw_transaction` to BCS serialize TransactionData

### DIFF
--- a/crates/sui-indexer/migrations/pg/2024-09-21-003749_transactions_raw_bcs/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-21-003749_transactions_raw_bcs/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE transactions DROP COLUMN raw_transactions_sigs;

--- a/crates/sui-indexer/migrations/pg/2024-09-21-003749_transactions_raw_bcs/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-21-003749_transactions_raw_bcs/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions ADD COLUMN raw_transaction_sigs bytea;

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -29,7 +29,10 @@ use crate::types::IndexerResult;
 pub struct StoredTransaction {
     pub tx_sequence_number: i64,
     pub transaction_digest: Vec<u8>,
+    /// BCS serialized TransactionData
     pub raw_transaction: Vec<u8>,
+    /// BCS serialized Vec<GenericSignature>
+    pub raw_transaction_sigs: Vec<u8>,
     pub raw_effects: Vec<u8>,
     pub checkpoint_sequence_number: i64,
     pub timestamp_ms: i64,
@@ -78,7 +81,10 @@ impl From<&IndexedTransaction> for StoredTransaction {
         StoredTransaction {
             tx_sequence_number: tx.tx_sequence_number as i64,
             transaction_digest: tx.tx_digest.into_inner().to_vec(),
-            raw_transaction: bcs::to_bytes(&tx.sender_signed_data).unwrap(),
+            raw_transaction: bcs::to_bytes(&tx.sender_signed_data.inner().intent_message.value)
+                .unwrap(),
+            raw_transaction_sigs: bcs::to_bytes(&tx.sender_signed_data.inner().tx_signatures)
+                .unwrap(),
             raw_effects: bcs::to_bytes(&tx.effects).unwrap(),
             checkpoint_sequence_number: tx.checkpoint_sequence_number as i64,
             object_changes: tx

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -268,6 +268,7 @@ diesel::table! {
         tx_sequence_number -> Int8,
         transaction_digest -> Bytea,
         raw_transaction -> Bytea,
+        raw_transaction_sigs -> Bytea,
         raw_effects -> Bytea,
         checkpoint_sequence_number -> Int8,
         timestamp_ms -> Int8,


### PR DESCRIPTION
## Description 

Adds one column for  `raw_transaction_sigs` representing the BCS bytes of `Vec<GenericSignature>`. 
Switches from BCS serializing `SenderSignedData` to `TransactionData` for `raw_transaction`.
## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
