### PR TITLE
:sparkles: feat: update sui-move new to use module labels

### DIFF
--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -47,22 +47,21 @@ module {name}::{name};
             w,
             r#"/*
 #[test_only]
-module {name}::{name}_tests {{
-    // uncomment this line to import the module
-    // use {name}::{name};
+module {name}::{name}_tests;
+// uncomment this line to import the module
+// use {name}::{name};
 
-    const ENotImplemented: u64 = 0;
+const ENotImplemented: u64 = 0;
 
-    #[test]
-    fun test_{name}() {{
-        // pass
-    }}
+#[test]
+fun test_{name}() {{
+    // pass
+}}
 
-    #[test, expected_failure(abort_code = ::{name}::{name}_tests::ENotImplemented)]
-    fun test_{name}_fail() {{
-        abort ENotImplemented
-    }}
-
+#[test, expected_failure(abort_code = ::{name}::{name}_tests::ENotImplemented)]
+fun test_{name}_fail() {{
+    abort ENotImplemented
+}}
 */"#,
             name = name
         )?;

--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -33,9 +33,7 @@ impl New {
             w,
             r#"/*
 /// Module: {name}
-module {name}::{name} {{
-
-}}
+module {name}::{name};
 */"#,
             name = name
         )?;
@@ -64,7 +62,7 @@ module {name}::{name}_tests {{
     fun test_{name}_fail() {{
         abort ENotImplemented
     }}
-}}
+
 */"#,
             name = name
         )?;


### PR DESCRIPTION
## Description 

Updated the sui move new command to use module labels.

## Test plan 

How did you test the new or updated feature?



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui move new` produces module templates with the new module label syntax, rather than the previous module block syntax.
- [ ] Rust SDK:
- [ ] REST API:
