### PR TITLE
[object store] Disable more timeouts

### DIFF
--- a/crates/sui-config/src/object_storage_config.rs
+++ b/crates/sui-config/src/object_storage_config.rs
@@ -105,6 +105,13 @@ fn default_object_store_connection_limit() -> usize {
     20
 }
 
+fn no_timeout_options() -> ClientOptions {
+    ClientOptions::new()
+        .with_timeout_disabled()
+        .with_connect_timeout_disabled()
+        .with_pool_idle_timeout(std::time::Duration::from_secs(300))
+}
+
 impl ObjectStoreConfig {
     fn new_local_fs(&self) -> Result<Arc<DynObjectStore>, anyhow::Error> {
         info!(directory=?self.directory, object_store_type="File", "Object Store");
@@ -125,7 +132,9 @@ impl ObjectStoreConfig {
 
         info!(bucket=?self.bucket, object_store_type="S3", "Object Store");
 
-        let mut builder = AmazonS3Builder::new().with_imdsv1_fallback();
+        let mut builder = AmazonS3Builder::new()
+            .with_client_options(no_timeout_options())
+            .with_imdsv1_fallback();
 
         if self.aws_virtual_hosted_style_request {
             builder = builder.with_virtual_hosted_style_request(true);
@@ -183,10 +192,7 @@ impl ObjectStoreConfig {
             builder = builder.with_service_account_path(account);
         }
 
-        let mut client_options = ClientOptions::new()
-            .with_timeout_disabled()
-            .with_connect_timeout_disabled()
-            .with_pool_idle_timeout(std::time::Duration::from_secs(300));
+        let mut client_options = no_timeout_options();
         if let Some(google_project_id) = &self.google_project_id {
             let x_project_header = HeaderName::from_static("x-goog-user-project");
             let iam_req_header = HeaderName::from_static("userproject");
@@ -210,7 +216,7 @@ impl ObjectStoreConfig {
         info!(bucket=?self.bucket, account=?self.azure_storage_account,
           object_store_type="Azure", "Object Store");
 
-        let mut builder = MicrosoftAzureBuilder::new();
+        let mut builder = MicrosoftAzureBuilder::new().with_client_options(no_timeout_options());
 
         if let Some(bucket) = &self.bucket {
             builder = builder.with_container_name(bucket);

--- a/crates/sui-storage/src/object_store/http/s3.rs
+++ b/crates/sui-storage/src/object_store/http/s3.rs
@@ -23,7 +23,9 @@ pub(crate) struct S3Client {
 impl S3Client {
     pub fn new(endpoint: &str) -> Result<Self> {
         let mut builder = ClientBuilder::new();
-        builder = builder.user_agent(DEFAULT_USER_AGENT);
+        builder = builder
+            .user_agent(DEFAULT_USER_AGENT)
+            .pool_idle_timeout(None);
         let client = builder.https_only(false).build()?;
 
         Ok(Self {


### PR DESCRIPTION
## Description 

Followup to https://github.com/MystenLabs/sui/pull/19470 which does the same for AWS and Azure object stores, as well as on the http downloader side. Note that most timeouts are disabled by default when using reqwest ClientBuilder directly, as we do on the http downloader side (`--no-sign-request`), so hopefully these changes are non-controversial. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
