### PR TITLE
Add an option to disable fullnode pruning in test cluster

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -717,6 +717,10 @@ impl Default for AuthorityStorePruningConfig {
 }
 
 impl AuthorityStorePruningConfig {
+    pub fn set_num_epochs_to_retain(&mut self, num_epochs_to_retain: u64) {
+        self.num_epochs_to_retain = num_epochs_to_retain;
+    }
+
     pub fn set_num_epochs_to_retain_for_checkpoints(&mut self, num_epochs_to_retain: Option<u64>) {
         self.num_epochs_to_retain_for_checkpoints = num_epochs_to_retain;
     }

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -278,6 +278,7 @@ pub struct FullnodeConfigBuilder {
     policy_config: Option<PolicyConfig>,
     fw_config: Option<RemoteFirewallConfig>,
     data_ingestion_dir: Option<PathBuf>,
+    disable_pruning: bool,
 }
 
 impl FullnodeConfigBuilder {
@@ -309,6 +310,11 @@ impl FullnodeConfigBuilder {
 
     pub fn with_db_checkpoint_config(mut self, db_checkpoint_config: DBCheckpointConfig) -> Self {
         self.db_checkpoint_config = Some(db_checkpoint_config);
+        self
+    }
+
+    pub fn with_disable_pruning(mut self, disable_pruning: bool) -> Self {
+        self.disable_pruning = disable_pruning;
         self
     }
 
@@ -458,6 +464,12 @@ impl FullnodeConfigBuilder {
             ..Default::default()
         };
 
+        let mut pruning_config = AuthorityStorePruningConfig::default();
+        if self.disable_pruning {
+            pruning_config.set_num_epochs_to_retain_for_checkpoints(None);
+            pruning_config.set_num_epochs_to_retain(u64::MAX);
+        };
+
         NodeConfig {
             protocol_key_pair: AuthorityKeyPairWithPath::new(validator_config.key_pair),
             account_key_pair: KeyPairWithPath::new(validator_config.account_key_pair),
@@ -489,7 +501,7 @@ impl FullnodeConfigBuilder {
             grpc_load_shed: None,
             grpc_concurrency_limit: None,
             p2p_config,
-            authority_store_pruning_config: AuthorityStorePruningConfig::default(),
+            authority_store_pruning_config: pruning_config,
             end_of_epoch_broadcast_channel_capacity:
                 default_end_of_epoch_broadcast_channel_capacity(),
             checkpoint_executor_config,

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -58,6 +58,7 @@ pub struct SwarmBuilder<R = OsRng> {
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
     state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig,
+    disable_fullnode_pruning: bool,
 }
 
 impl SwarmBuilder {
@@ -86,6 +87,7 @@ impl SwarmBuilder {
             max_submit_position: None,
             submit_delay_step_override_millis: None,
             state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig::Global(true),
+            disable_fullnode_pruning: false,
         }
     }
 }
@@ -116,6 +118,7 @@ impl<R> SwarmBuilder<R> {
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             state_accumulator_v2_enabled_config: self.state_accumulator_v2_enabled_config,
+            disable_fullnode_pruning: self.disable_fullnode_pruning,
         }
     }
 
@@ -289,6 +292,11 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_disable_fullnode_pruning(mut self) -> Self {
+        self.disable_fullnode_pruning = true;
+        self
+    }
+
     pub fn with_submit_delay_step_override_millis(
         mut self,
         submit_delay_step_override_millis: u64,
@@ -375,7 +383,8 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             .with_run_with_range(self.fullnode_run_with_range)
             .with_policy_config(self.fullnode_policy_config)
             .with_data_ingestion_dir(ingest_data)
-            .with_fw_config(self.fullnode_fw_config);
+            .with_fw_config(self.fullnode_fw_config)
+            .with_disable_pruning(self.disable_fullnode_pruning);
 
         if let Some(spvc) = &self.fullnode_supported_protocol_versions_config {
             let supported_versions = match spvc {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -883,6 +883,7 @@ pub struct TestClusterBuilder {
     num_validators: Option<usize>,
     fullnode_rpc_port: Option<u16>,
     enable_fullnode_events: bool,
+    disable_fullnode_pruning: bool,
     validator_supported_protocol_versions_config: ProtocolVersionsConfig,
     // Default to validator_supported_protocol_versions_config, but can be overridden.
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
@@ -912,6 +913,7 @@ impl TestClusterBuilder {
             fullnode_rpc_port: None,
             num_validators: None,
             enable_fullnode_events: false,
+            disable_fullnode_pruning: false,
             validator_supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config_validators: DBCheckpointConfig::default(),
@@ -979,6 +981,11 @@ impl TestClusterBuilder {
 
     pub fn enable_fullnode_events(mut self) -> Self {
         self.enable_fullnode_events = true;
+        self
+    }
+
+    pub fn disable_fullnode_pruning(mut self) -> Self {
+        self.disable_fullnode_pruning = true;
         self
     }
 
@@ -1453,6 +1460,10 @@ impl TestClusterBuilder {
         if let Some(submit_delay_step_override_millis) = self.submit_delay_step_override_millis {
             builder =
                 builder.with_submit_delay_step_override_millis(submit_delay_step_override_millis);
+        }
+
+        if self.disable_fullnode_pruning {
+            builder = builder.with_disable_fullnode_pruning();
         }
 
         let mut swarm = builder.build();


### PR DESCRIPTION
## Description 

Currently we aggressive prine FNs by default which causes tests which depend on reading checkpoints from rest api fail

## Test plan 

Existing tests
