### PR TITLE
[framework] Formatting: collections and dynamic fields 4/N

### DIFF
--- a/crates/sui-framework/docs/sui-framework/dynamic_field.md
+++ b/crates/sui-framework/docs/sui-framework/dynamic_field.md
@@ -191,10 +191,7 @@ type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
-    <a href="../sui-framework/object.md#0x2_object">object</a>: &UID,
-    name: Name,
-): &Value {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &UID, name: Name): &Value {
     <b>let</b> object_addr = <a href="../sui-framework/object.md#0x2_object">object</a>.to_address();
     <b>let</b> hash = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
     <b>let</b> field = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>, hash);
@@ -260,10 +257,7 @@ type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
-    <a href="../sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID,
-    name: Name,
-): Value {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID, name: Name): Value {
     <b>let</b> object_addr = <a href="../sui-framework/object.md#0x2_object">object</a>.to_address();
     <b>let</b> hash = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
     <b>let</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove_child_object">remove_child_object</a>&lt;<a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, hash);
@@ -293,10 +287,7 @@ Returns true if and only if the <code><a href="../sui-framework/object.md#0x2_ob
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(
-    <a href="../sui-framework/object.md#0x2_object">object</a>: &UID,
-    name: Name,
-): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &UID, name: Name): bool {
     <b>let</b> object_addr = <a href="../sui-framework/object.md#0x2_object">object</a>.to_address();
     <b>let</b> hash = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
     <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_has_child_object">has_child_object</a>(object_addr, hash)
@@ -325,7 +316,7 @@ Removes the dynamic field if it exists. Returns the <code>some(Value)</code> if 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove_if_exists">remove_if_exists</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
     <a href="../sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID,
-    name: Name
+    name: Name,
 ): Option&lt;Value&gt; {
     <b>if</b> (<a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>, name)) {
         <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(<a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">remove</a>(<a href="../sui-framework/object.md#0x2_object">object</a>, name))
@@ -446,7 +437,10 @@ May abort with <code><a href="../sui-framework/dynamic_field.md#0x2_dynamic_fiel
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b> + drop + store&gt;(parent: <b>address</b>, k: K): <b>address</b>;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b> + drop + store&gt;(
+    parent: <b>address</b>,
+    k: K,
+): <b>address</b>;
 </code></pre>
 
 
@@ -516,7 +510,10 @@ we need two versions to return a reference or a mutable reference
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID, id: <b>address</b>): &<b>mut</b> Child;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(
+    <a href="../sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID,
+    id: <b>address</b>,
+): &<b>mut</b> Child;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/sui-framework/dynamic_object_field.md
+++ b/crates/sui-framework/docs/sui-framework/dynamic_object_field.md
@@ -107,10 +107,7 @@ specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
-    <a href="../sui-framework/object.md#0x2_object">object</a>: &UID,
-    name: Name,
-): &Value {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &UID, name: Name): &Value {
     borrow_impl!(<a href="../sui-framework/object.md#0x2_object">object</a>, name)
 }
 </code></pre>
@@ -199,10 +196,7 @@ Returns true if and only if the <code><a href="../sui-framework/object.md#0x2_ob
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(
-    <a href="../sui-framework/object.md#0x2_object">object</a>: &UID,
-    name: Name,
-): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &UID, name: Name): bool {
     <b>let</b> key = <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
     field::exists_with_type&lt;<a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>, key)
 }
@@ -258,10 +252,7 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b> + drop + store&gt;(
-    <a href="../sui-framework/object.md#0x2_object">object</a>: &UID,
-    name: Name,
-): Option&lt;ID&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b> + drop + store&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>: &UID, name: Name): Option&lt;ID&gt; {
     <b>let</b> key = <a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a> { name };
     <b>if</b> (!field::exists_with_type&lt;<a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>, key)) <b>return</b> <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     <b>let</b> (_field, value_addr) = field::field_info&lt;<a href="../sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="../sui-framework/object.md#0x2_object">object</a>, key);

--- a/crates/sui-framework/docs/sui-framework/priority_queue.md
+++ b/crates/sui-framework/docs/sui-framework/priority_queue.md
@@ -119,7 +119,7 @@ Create a new priority queue from the input entry vectors.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(<b>mut</b> entries: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../sui-framework/priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt;) : <a href="../sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(<b>mut</b> entries: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../sui-framework/priority_queue.md#0x2_priority_queue_Entry">Entry</a>&lt;T&gt;&gt;): <a href="../sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt; {
     <b>let</b> len = entries.length();
     <b>let</b> <b>mut</b> i = len / 2;
     // Max heapify from the first node that is a parent (node at len / 2).
@@ -151,7 +151,7 @@ Pop the entry with the highest priority value.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_pop_max">pop_max</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;) : (<a href="../move-stdlib/u64.md#0x1_u64">u64</a>, T) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_pop_max">pop_max</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;): (<a href="../move-stdlib/u64.md#0x1_u64">u64</a>, T) {
     <b>let</b> len = pq.entries.length();
     <b>assert</b>!(len &gt; 0, <a href="../sui-framework/priority_queue.md#0x2_priority_queue_EPopFromEmptyHeap">EPopFromEmptyHeap</a>);
     // Swap the max element <b>with</b> the last element in the entries and remove the max element.
@@ -184,7 +184,7 @@ Insert a new entry into the queue.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_insert">insert</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="../sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T&gt;, priority: <a href="../move-stdlib/u64.md#0x1_u64">u64</a>, value: T) {
-    pq.entries.push_back(<a href="../sui-framework/priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value});
+    pq.entries.push_back(<a href="../sui-framework/priority_queue.md#0x2_priority_queue_Entry">Entry</a> { priority, value });
     <b>let</b> index = pq.entries.length() - 1;
     <a href="../sui-framework/priority_queue.md#0x2_priority_queue_restore_heap_recursive">restore_heap_recursive</a>(&<b>mut</b> pq.entries, index);
 }

--- a/crates/sui-framework/docs/sui-framework/table_vec.md
+++ b/crates/sui-framework/docs/sui-framework/table_vec.md
@@ -95,7 +95,7 @@ Create an empty TableVec.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/table_vec.md#0x2_table_vec_empty">empty</a>&lt;Element: store&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui-framework/table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt; {
     <a href="../sui-framework/table_vec.md#0x2_table_vec_TableVec">TableVec</a> {
-        contents: <a href="../sui-framework/table.md#0x2_table_new">table::new</a>(ctx)
+        contents: <a href="../sui-framework/table.md#0x2_table_new">table::new</a>(ctx),
     }
 }
 </code></pre>
@@ -364,7 +364,9 @@ Aborts if <code>i</code> or <code>j</code> is out of bounds.
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/table_vec.md#0x2_table_vec_swap">swap</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="../sui-framework/table_vec.md#0x2_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: <a href="../move-stdlib/u64.md#0x1_u64">u64</a>, j: <a href="../move-stdlib/u64.md#0x1_u64">u64</a>) {
     <b>assert</b>!(t.<a href="../sui-framework/table_vec.md#0x2_table_vec_length">length</a>() &gt; i, <a href="../sui-framework/table_vec.md#0x2_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>);
     <b>assert</b>!(t.<a href="../sui-framework/table_vec.md#0x2_table_vec_length">length</a>() &gt; j, <a href="../sui-framework/table_vec.md#0x2_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>);
-    <b>if</b> (i == j) { <b>return</b> };
+    <b>if</b> (i == j) {
+        <b>return</b>
+    };
     <b>let</b> element_i = t.contents.remove(i);
     <b>let</b> element_j = t.contents.remove(j);
     t.contents.add(j, element_i);

--- a/crates/sui-framework/docs/sui-framework/vec_map.md
+++ b/crates/sui-framework/docs/sui-framework/vec_map.md
@@ -182,7 +182,7 @@ Create an empty <code><a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">V
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_empty">empty</a>&lt;K: <b>copy</b>, V&gt;(): <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_empty">empty</a>&lt;K: <b>copy</b>, V&gt;(): <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt; {
     <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a> { contents: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[] }
 }
 </code></pre>
@@ -208,7 +208,7 @@ Aborts if <code>key</code> is already bound in <code>self</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_insert">insert</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: K, value: V) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_insert">insert</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: K, value: V) {
     <b>assert</b>!(!self.<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">contains</a>(&key), <a href="../sui-framework/vec_map.md#0x2_vec_map_EKeyAlreadyExists">EKeyAlreadyExists</a>);
     self.contents.push_back(<a href="../sui-framework/vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value })
 }
@@ -234,7 +234,7 @@ Remove the entry <code>key</code> |-> <code>value</code> from self. Aborts if <c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">remove</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): (K, V) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">remove</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): (K, V) {
     <b>let</b> idx = self.<a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx">get_idx</a>(key);
     <b>let</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value } = self.contents.<a href="../sui-framework/vec_map.md#0x2_vec_map_remove">remove</a>(idx);
     (key, value)
@@ -261,7 +261,7 @@ Pop the most recently inserted entry from the map. Aborts if the map is empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_pop">pop</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;): (K, V) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_pop">pop</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;): (K, V) {
     <b>assert</b>!(!self.contents.<a href="../sui-framework/vec_map.md#0x2_vec_map_is_empty">is_empty</a>(), <a href="../sui-framework/vec_map.md#0x2_vec_map_EMapEmpty">EMapEmpty</a>);
     <b>let</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_Entry">Entry</a> { key, value } = self.contents.pop_back();
     (key, value)
@@ -289,7 +289,7 @@ Aborts if <code>key</code> is not bound in <code>self</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get_mut">get_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): &<b>mut</b> V {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get_mut">get_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): &<b>mut</b> V {
     <b>let</b> idx = self.<a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx">get_idx</a>(key);
     <b>let</b> entry = &<b>mut</b> self.contents[idx];
     &<b>mut</b> entry.value
@@ -317,7 +317,7 @@ Aborts if <code>key</code> is not bound in <code>self</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get">get</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): &V {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get">get</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): &V {
     <b>let</b> idx = self.<a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx">get_idx</a>(key);
     <b>let</b> entry = &self.contents[idx];
     &entry.value
@@ -346,7 +346,7 @@ Only works for a "copyable" value as references cannot be stored in <code><a hre
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_try_get">try_get</a>&lt;K: <b>copy</b>, V: <b>copy</b>&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): Option&lt;V&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_try_get">try_get</a>&lt;K: <b>copy</b>, V: <b>copy</b>&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): Option&lt;V&gt; {
     <b>if</b> (self.<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">contains</a>(key)) {
         <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(*<a href="../sui-framework/vec_map.md#0x2_vec_map_get">get</a>(self, key))
     } <b>else</b> {
@@ -400,7 +400,7 @@ Return the number of entries in <code>self</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_size">size</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;): <a href="../move-stdlib/u64.md#0x1_u64">u64</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_size">size</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;): <a href="../move-stdlib/u64.md#0x1_u64">u64</a> {
     self.contents.length()
 }
 </code></pre>
@@ -425,7 +425,7 @@ Return true if <code>self</code> has 0 elements, false otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_is_empty">is_empty</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_is_empty">is_empty</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;): bool {
     self.<a href="../sui-framework/vec_map.md#0x2_vec_map_size">size</a>() == 0
 }
 </code></pre>
@@ -521,10 +521,7 @@ and are *not* sorted.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_from_keys_values">from_keys_values</a>&lt;K: <b>copy</b>, V&gt;(
-    <b>mut</b> keys: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;,
-    <b>mut</b> values: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;V&gt;,
-): <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_from_keys_values">from_keys_values</a>&lt;K: <b>copy</b>, V&gt;(<b>mut</b> keys: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;, <b>mut</b> values: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;V&gt;): <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt; {
     <b>assert</b>!(keys.length() == values.length(), <a href="../sui-framework/vec_map.md#0x2_vec_map_EUnequalLengths">EUnequalLengths</a>);
     keys.reverse();
     values.reverse();
@@ -591,7 +588,7 @@ Note that map entries are stored in insertion order, *not* sorted by key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): Option&lt;<a href="../move-stdlib/u64.md#0x1_u64">u64</a>&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): Option&lt;<a href="../move-stdlib/u64.md#0x1_u64">u64</a>&gt; {
     <b>let</b> <b>mut</b> i = 0;
     <b>let</b> n = <a href="../sui-framework/vec_map.md#0x2_vec_map_size">size</a>(self);
     <b>while</b> (i &lt; n) {
@@ -625,7 +622,7 @@ Note that map entries are stored in insertion order, *not* sorted by key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx">get_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K,V&gt;, key: &K): <a href="../move-stdlib/u64.md#0x1_u64">u64</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx">get_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K, V&gt;, key: &K): <a href="../move-stdlib/u64.md#0x1_u64">u64</a> {
     <b>let</b> idx_opt = self.<a href="../sui-framework/vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>(key);
     <b>assert</b>!(idx_opt.is_some(), <a href="../sui-framework/vec_map.md#0x2_vec_map_EKeyDoesNotExist">EKeyDoesNotExist</a>);
     idx_opt.destroy_some()

--- a/crates/sui-framework/packages/sui-framework/sources/bag.move
+++ b/crates/sui-framework/packages/sui-framework/sources/bag.move
@@ -21,92 +21,92 @@
 /// `sui::dynamic_field` while preventing accidentally stranding field values. A `UID` can be
 /// deleted, even if it has dynamic fields associated with it, but a bag, on the other hand, must be
 /// empty to be destroyed.
-module sui::bag {
-    use sui::dynamic_field as field;
+module sui::bag;
 
-    // Attempted to destroy a non-empty bag
-    const EBagNotEmpty: u64 = 0;
+use sui::dynamic_field as field;
 
-    public struct Bag has key, store {
-        /// the ID of this bag
-        id: UID,
-        /// the number of key-value pairs in the bag
-        size: u64,
+// Attempted to destroy a non-empty bag
+const EBagNotEmpty: u64 = 0;
+
+public struct Bag has key, store {
+    /// the ID of this bag
+    id: UID,
+    /// the number of key-value pairs in the bag
+    size: u64,
+}
+
+/// Creates a new, empty bag
+public fun new(ctx: &mut TxContext): Bag {
+    Bag {
+        id: object::new(ctx),
+        size: 0,
     }
+}
 
-    /// Creates a new, empty bag
-    public fun new(ctx: &mut TxContext): Bag {
-        Bag {
-            id: object::new(ctx),
-            size: 0,
-        }
-    }
+/// Adds a key-value pair to the bag `bag: &mut Bag`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the bag already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: store>(bag: &mut Bag, k: K, v: V) {
+    field::add(&mut bag.id, k, v);
+    bag.size = bag.size + 1;
+}
 
-    /// Adds a key-value pair to the bag `bag: &mut Bag`
-    /// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the bag already has an entry with
-    /// that key `k: K`.
-    public fun add<K: copy + drop + store, V: store>(bag: &mut Bag, k: K, v: V) {
-        field::add(&mut bag.id, k, v);
-        bag.size = bag.size + 1;
-    }
+#[syntax(index)]
+/// Immutable borrows the value associated with the key in the bag `bag: &Bag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow<K: copy + drop + store, V: store>(bag: &Bag, k: K): &V {
+    field::borrow(&bag.id, k)
+}
 
-    #[syntax(index)]
-    /// Immutable borrows the value associated with the key in the bag `bag: &Bag`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
-    /// that key `k: K`.
-    /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
-    /// the value does not have the specified type.
-    public fun borrow<K: copy + drop + store, V: store>(bag: &Bag, k: K): &V {
-        field::borrow(&bag.id, k)
-    }
+#[syntax(index)]
+/// Mutably borrows the value associated with the key in the bag `bag: &mut Bag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow_mut<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): &mut V {
+    field::borrow_mut(&mut bag.id, k)
+}
 
-    #[syntax(index)]
-    /// Mutably borrows the value associated with the key in the bag `bag: &mut Bag`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
-    /// that key `k: K`.
-    /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
-    /// the value does not have the specified type.
-    public fun borrow_mut<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): &mut V {
-        field::borrow_mut(&mut bag.id, k)
-    }
+/// Mutably borrows the key-value pair in the bag `bag: &mut Bag` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun remove<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): V {
+    let v = field::remove(&mut bag.id, k);
+    bag.size = bag.size - 1;
+    v
+}
 
-    /// Mutably borrows the key-value pair in the bag `bag: &mut Bag` and returns the value.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
-    /// that key `k: K`.
-    /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
-    /// the value does not have the specified type.
-    public fun remove<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): V {
-        let v = field::remove(&mut bag.id, k);
-        bag.size = bag.size - 1;
-        v
-    }
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &Bag`
+public fun contains<K: copy + drop + store>(bag: &Bag, k: K): bool {
+    field::exists_<K>(&bag.id, k)
+}
 
-    /// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &Bag`
-    public fun contains<K: copy + drop + store>(bag: &Bag, k: K): bool {
-        field::exists_<K>(&bag.id, k)
-    }
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &Bag`
+/// with an assigned value of type `V`
+public fun contains_with_type<K: copy + drop + store, V: store>(bag: &Bag, k: K): bool {
+    field::exists_with_type<K, V>(&bag.id, k)
+}
 
-    /// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &Bag`
-    /// with an assigned value of type `V`
-    public fun contains_with_type<K: copy + drop + store, V: store>(bag: &Bag, k: K): bool {
-        field::exists_with_type<K, V>(&bag.id, k)
-    }
+/// Returns the size of the bag, the number of key-value pairs
+public fun length(bag: &Bag): u64 {
+    bag.size
+}
 
-    /// Returns the size of the bag, the number of key-value pairs
-    public fun length(bag: &Bag): u64 {
-        bag.size
-    }
+/// Returns true iff the bag is empty (if `length` returns `0`)
+public fun is_empty(bag: &Bag): bool {
+    bag.size == 0
+}
 
-    /// Returns true iff the bag is empty (if `length` returns `0`)
-    public fun is_empty(bag: &Bag): bool {
-        bag.size == 0
-    }
-
-    /// Destroys an empty bag
-    /// Aborts with `EBagNotEmpty` if the bag still contains values
-    public fun destroy_empty(bag: Bag) {
-        let Bag { id, size } = bag;
-        assert!(size == 0, EBagNotEmpty);
-        id.delete()
-    }
+/// Destroys an empty bag
+/// Aborts with `EBagNotEmpty` if the bag still contains values
+public fun destroy_empty(bag: Bag) {
+    let Bag { id, size } = bag;
+    assert!(size == 0, EBagNotEmpty);
+    id.delete()
 }

--- a/crates/sui-framework/packages/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dynamic_field.move
@@ -8,167 +8,163 @@
 /// the `copy`, `drop`, and `store` abilities, e.g. an integer, a boolean, or a string.
 /// This gives Sui programmers the flexibility to extend objects on-the-fly, and it also serves as a
 /// building block for core collection types
-module sui::dynamic_field {
+module sui::dynamic_field;
 
-    /// The object already has a dynamic field with this name (with the value and type specified)
-    const EFieldAlreadyExists: u64 = 0;
-    /// Cannot load dynamic field.
-    /// The object does not have a dynamic field with this name (with the value and type specified)
-    const EFieldDoesNotExist: u64 = 1;
-    /// The object has a field with that name, but the value type does not match
-    const EFieldTypeMismatch: u64 = 2;
-    /// Failed to serialize the field's name
-    const EBCSSerializationFailure: u64 = 3;
-    /// The object added as a dynamic field was previously a shared object
-    const ESharedObjectOperationNotSupported: u64 = 4;
+/// The object already has a dynamic field with this name (with the value and type specified)
+const EFieldAlreadyExists: u64 = 0;
+/// Cannot load dynamic field.
+/// The object does not have a dynamic field with this name (with the value and type specified)
+const EFieldDoesNotExist: u64 = 1;
+/// The object has a field with that name, but the value type does not match
+const EFieldTypeMismatch: u64 = 2;
+/// Failed to serialize the field's name
+const EBCSSerializationFailure: u64 = 3;
+/// The object added as a dynamic field was previously a shared object
+const ESharedObjectOperationNotSupported: u64 = 4;
 
-    /// Internal object used for storing the field and value
-    public struct Field<Name: copy + drop + store, Value: store> has key {
-        /// Determined by the hash of the object ID, the field name value and it's type,
-        /// i.e. hash(parent.id || name || Name)
-        id: UID,
-        /// The value for the name of this field
-        name: Name,
-        /// The value bound to this field
-        value: Value,
-    }
-
-    /// Adds a dynamic field to the object `object: &mut UID` at field specified by `name: Name`.
-    /// Aborts with `EFieldAlreadyExists` if the object already has that field with that name.
-    public fun add<Name: copy + drop + store, Value: store>(
-        // we use &mut UID in several spots for access control
-        object: &mut UID,
-        name: Name,
-        value: Value,
-    ) {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        assert!(!has_child_object(object_addr, hash), EFieldAlreadyExists);
-        let field = Field {
-            id: object::new_uid_from_hash(hash),
-            name,
-            value,
-        };
-        add_child_object(object_addr, field)
-    }
-
-    /// Immutably borrows the `object`s dynamic field with the name specified by `name: Name`.
-    /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
-    /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
-    /// type.
-    public fun borrow<Name: copy + drop + store, Value: store>(
-        object: &UID,
-        name: Name,
-    ): &Value {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        let field = borrow_child_object<Field<Name, Value>>(object, hash);
-        &field.value
-    }
-
-    /// Mutably borrows the `object`s dynamic field with the name specified by `name: Name`.
-    /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
-    /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
-    /// type.
-    public fun borrow_mut<Name: copy + drop + store, Value: store>(
-        object: &mut UID,
-        name: Name,
-    ): &mut Value {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        let field = borrow_child_object_mut<Field<Name, Value>>(object, hash);
-        &mut field.value
-    }
-
-    /// Removes the `object`s dynamic field with the name specified by `name: Name` and returns the
-    /// bound value.
-    /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
-    /// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
-    /// type.
-    public fun remove<Name: copy + drop + store, Value: store>(
-        object: &mut UID,
-        name: Name,
-    ): Value {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        let Field { id, name: _, value } = remove_child_object<Field<Name, Value>>(object_addr, hash);
-        id.delete();
-        value
-    }
-
-    /// Returns true if and only if the `object` has a dynamic field with the name specified by
-    /// `name: Name` but without specifying the `Value` type
-    public fun exists_<Name: copy + drop + store>(
-        object: &UID,
-        name: Name,
-    ): bool {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        has_child_object(object_addr, hash)
-    }
-
-    /// Removes the dynamic field if it exists. Returns the `some(Value)` if it exists or none otherwise.
-    public fun remove_if_exists<Name: copy + drop + store, Value: store>(
-        object: &mut UID,
-        name: Name
-    ): Option<Value> {
-        if (exists_<Name>(object, name)) {
-            option::some(remove(object, name))
-        } else {
-            option::none()
-        }
-    }
-
-    /// Returns true if and only if the `object` has a dynamic field with the name specified by
-    /// `name: Name` with an assigned value of type `Value`.
-    public fun exists_with_type<Name: copy + drop + store, Value: store>(
-        object: &UID,
-        name: Name,
-    ): bool {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        has_child_object_with_ty<Field<Name, Value>>(object_addr, hash)
-    }
-
-    public(package) fun field_info<Name: copy + drop + store>(
-        object: &UID,
-        name: Name,
-    ): (&UID, address) {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        let Field { id, name: _, value } = borrow_child_object<Field<Name, ID>>(object, hash);
-        (id, value.to_address())
-    }
-
-    public(package) fun field_info_mut<Name: copy + drop + store>(
-        object: &mut UID,
-        name: Name,
-    ): (&mut UID, address) {
-        let object_addr = object.to_address();
-        let hash = hash_type_and_key(object_addr, name);
-        let Field { id, name: _, value } = borrow_child_object_mut<Field<Name, ID>>(object, hash);
-        (id, value.to_address())
-    }
-
-    /// May abort with `EBCSSerializationFailure`.
-    public(package) native fun hash_type_and_key<K: copy + drop + store>(parent: address, k: K): address;
-
-    public(package) native fun add_child_object<Child: key>(parent: address, child: Child);
-
-    /// throws `EFieldDoesNotExist` if a child does not exist with that ID
-    /// or throws `EFieldTypeMismatch` if the type does not match,
-    /// and may also abort with `EBCSSerializationFailure`
-    /// we need two versions to return a reference or a mutable reference
-    public(package) native fun borrow_child_object<Child: key>(object: &UID, id: address): &Child;
-
-    public(package) native fun borrow_child_object_mut<Child: key>(object: &mut UID, id: address): &mut Child;
-
-    /// throws `EFieldDoesNotExist` if a child does not exist with that ID
-    /// or throws `EFieldTypeMismatch` if the type does not match,
-    /// and may also abort with `EBCSSerializationFailure`.
-    public(package) native fun remove_child_object<Child: key>(parent: address, id: address): Child;
-
-    public(package) native fun has_child_object(parent: address, id: address): bool;
-
-    public(package) native fun has_child_object_with_ty<Child: key>(parent: address, id: address): bool;
+/// Internal object used for storing the field and value
+public struct Field<Name: copy + drop + store, Value: store> has key {
+    /// Determined by the hash of the object ID, the field name value and it's type,
+    /// i.e. hash(parent.id || name || Name)
+    id: UID,
+    /// The value for the name of this field
+    name: Name,
+    /// The value bound to this field
+    value: Value,
 }
+
+/// Adds a dynamic field to the object `object: &mut UID` at field specified by `name: Name`.
+/// Aborts with `EFieldAlreadyExists` if the object already has that field with that name.
+public fun add<Name: copy + drop + store, Value: store>(
+    // we use &mut UID in several spots for access control
+    object: &mut UID,
+    name: Name,
+    value: Value,
+) {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    assert!(!has_child_object(object_addr, hash), EFieldAlreadyExists);
+    let field = Field {
+        id: object::new_uid_from_hash(hash),
+        name,
+        value,
+    };
+    add_child_object(object_addr, field)
+}
+
+/// Immutably borrows the `object`s dynamic field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
+public fun borrow<Name: copy + drop + store, Value: store>(object: &UID, name: Name): &Value {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    let field = borrow_child_object<Field<Name, Value>>(object, hash);
+    &field.value
+}
+
+/// Mutably borrows the `object`s dynamic field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
+public fun borrow_mut<Name: copy + drop + store, Value: store>(
+    object: &mut UID,
+    name: Name,
+): &mut Value {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    let field = borrow_child_object_mut<Field<Name, Value>>(object, hash);
+    &mut field.value
+}
+
+/// Removes the `object`s dynamic field with the name specified by `name: Name` and returns the
+/// bound value.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
+public fun remove<Name: copy + drop + store, Value: store>(object: &mut UID, name: Name): Value {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    let Field { id, name: _, value } = remove_child_object<Field<Name, Value>>(object_addr, hash);
+    id.delete();
+    value
+}
+
+/// Returns true if and only if the `object` has a dynamic field with the name specified by
+/// `name: Name` but without specifying the `Value` type
+public fun exists_<Name: copy + drop + store>(object: &UID, name: Name): bool {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    has_child_object(object_addr, hash)
+}
+
+/// Removes the dynamic field if it exists. Returns the `some(Value)` if it exists or none otherwise.
+public fun remove_if_exists<Name: copy + drop + store, Value: store>(
+    object: &mut UID,
+    name: Name,
+): Option<Value> {
+    if (exists_<Name>(object, name)) {
+        option::some(remove(object, name))
+    } else {
+        option::none()
+    }
+}
+
+/// Returns true if and only if the `object` has a dynamic field with the name specified by
+/// `name: Name` with an assigned value of type `Value`.
+public fun exists_with_type<Name: copy + drop + store, Value: store>(
+    object: &UID,
+    name: Name,
+): bool {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    has_child_object_with_ty<Field<Name, Value>>(object_addr, hash)
+}
+
+public(package) fun field_info<Name: copy + drop + store>(
+    object: &UID,
+    name: Name,
+): (&UID, address) {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    let Field { id, name: _, value } = borrow_child_object<Field<Name, ID>>(object, hash);
+    (id, value.to_address())
+}
+
+public(package) fun field_info_mut<Name: copy + drop + store>(
+    object: &mut UID,
+    name: Name,
+): (&mut UID, address) {
+    let object_addr = object.to_address();
+    let hash = hash_type_and_key(object_addr, name);
+    let Field { id, name: _, value } = borrow_child_object_mut<Field<Name, ID>>(object, hash);
+    (id, value.to_address())
+}
+
+/// May abort with `EBCSSerializationFailure`.
+public(package) native fun hash_type_and_key<K: copy + drop + store>(
+    parent: address,
+    k: K,
+): address;
+
+public(package) native fun add_child_object<Child: key>(parent: address, child: Child);
+
+/// throws `EFieldDoesNotExist` if a child does not exist with that ID
+/// or throws `EFieldTypeMismatch` if the type does not match,
+/// and may also abort with `EBCSSerializationFailure`
+/// we need two versions to return a reference or a mutable reference
+public(package) native fun borrow_child_object<Child: key>(object: &UID, id: address): &Child;
+
+public(package) native fun borrow_child_object_mut<Child: key>(
+    object: &mut UID,
+    id: address,
+): &mut Child;
+
+/// throws `EFieldDoesNotExist` if a child does not exist with that ID
+/// or throws `EFieldTypeMismatch` if the type does not match,
+/// and may also abort with `EBCSSerializationFailure`.
+public(package) native fun remove_child_object<Child: key>(parent: address, id: address): Child;
+
+public(package) native fun has_child_object(parent: address, id: address): bool;
+
+public(package) native fun has_child_object_with_ty<Child: key>(parent: address, id: address): bool;

--- a/crates/sui-framework/packages/sui-framework/sources/dynamic_object_field.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dynamic_object_field.move
@@ -5,195 +5,185 @@
 /// unlike, `sui::dynamic_field` the values bound to these dynamic fields _must_ be objects
 /// themselves. This allows for the objects to still exist within in storage, which may be important
 /// for external tools. The difference is otherwise not observable from within Move.
-module sui::dynamic_object_field {
-    use sui::dynamic_field::{
-        Self as field,
-        add_child_object,
-        borrow_child_object,
-        borrow_child_object_mut,
-        remove_child_object,
-    };
+module sui::dynamic_object_field;
 
-    // Internal object used for storing the field and the name associated with the value
-    // The separate type is necessary to prevent key collision with direct usage of dynamic_field
-    public struct Wrapper<Name> has copy, drop, store {
-        name: Name,
-    }
+use sui::dynamic_field::{
+    Self as field,
+    add_child_object,
+    borrow_child_object,
+    borrow_child_object_mut,
+    remove_child_object
+};
 
-    /// Adds a dynamic object field to the object `object: &mut UID` at field specified by `name: Name`.
-    /// Aborts with `EFieldAlreadyExists` if the object already has that field with that name.
-    public fun add<Name: copy + drop + store, Value: key + store>(
-        // we use &mut UID in several spots for access control
-        object: &mut UID,
-        name: Name,
-        value: Value,
-    ) {
-        add_impl!(object, name, value)
-    }
+// Internal object used for storing the field and the name associated with the value
+// The separate type is necessary to prevent key collision with direct usage of dynamic_field
+public struct Wrapper<Name> has copy, drop, store {
+    name: Name,
+}
 
-    /// Immutably borrows the `object`s dynamic object field with the name specified by `name: Name`.
-    /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
-    /// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
-    /// specified type.
-    public fun borrow<Name: copy + drop + store, Value: key + store>(
-        object: &UID,
-        name: Name,
-    ): &Value {
-        borrow_impl!(object, name)
-    }
+/// Adds a dynamic object field to the object `object: &mut UID` at field specified by `name: Name`.
+/// Aborts with `EFieldAlreadyExists` if the object already has that field with that name.
+public fun add<Name: copy + drop + store, Value: key + store>(
+    // we use &mut UID in several spots for access control
+    object: &mut UID,
+    name: Name,
+    value: Value,
+) {
+    add_impl!(object, name, value)
+}
 
-    /// Mutably borrows the `object`s dynamic object field with the name specified by `name: Name`.
-    /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
-    /// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
-    /// specified type.
-    public fun borrow_mut<Name: copy + drop + store, Value: key + store>(
-        object: &mut UID,
-        name: Name,
-    ): &mut Value {
-        borrow_mut_impl!(object, name)
-    }
+/// Immutably borrows the `object`s dynamic object field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
+public fun borrow<Name: copy + drop + store, Value: key + store>(object: &UID, name: Name): &Value {
+    borrow_impl!(object, name)
+}
 
-    /// Removes the `object`s dynamic object field with the name specified by `name: Name` and returns
-    /// the bound object.
-    /// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
-    /// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
-    /// specified type.
-    public fun remove<Name: copy + drop + store, Value: key + store>(
-        object: &mut UID,
-        name: Name,
-    ): Value {
-        remove_impl!(object, name)
-    }
+/// Mutably borrows the `object`s dynamic object field with the name specified by `name: Name`.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
+public fun borrow_mut<Name: copy + drop + store, Value: key + store>(
+    object: &mut UID,
+    name: Name,
+): &mut Value {
+    borrow_mut_impl!(object, name)
+}
 
-    /// Returns true if and only if the `object` has a dynamic object field with the name specified by
-    /// `name: Name`.
-    public fun exists_<Name: copy + drop + store>(
-        object: &UID,
-        name: Name,
-    ): bool {
-        let key = Wrapper { name };
-        field::exists_with_type<Wrapper<Name>, ID>(object, key)
-    }
+/// Removes the `object`s dynamic object field with the name specified by `name: Name` and returns
+/// the bound object.
+/// Aborts with `EFieldDoesNotExist` if the object does not have a field with that name.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
+public fun remove<Name: copy + drop + store, Value: key + store>(
+    object: &mut UID,
+    name: Name,
+): Value {
+    remove_impl!(object, name)
+}
 
-    /// Returns true if and only if the `object` has a dynamic field with the name specified by
-    /// `name: Name` with an assigned value of type `Value`.
-    public fun exists_with_type<Name: copy + drop + store, Value: key + store>(
-        object: &UID,
-        name: Name,
-    ): bool {
-        exists_with_type_impl!<_, Value>(object, name)
-    }
+/// Returns true if and only if the `object` has a dynamic object field with the name specified by
+/// `name: Name`.
+public fun exists_<Name: copy + drop + store>(object: &UID, name: Name): bool {
+    let key = Wrapper { name };
+    field::exists_with_type<Wrapper<Name>, ID>(object, key)
+}
 
-    /// Returns the ID of the object associated with the dynamic object field
-    /// Returns none otherwise
-    public fun id<Name: copy + drop + store>(
-        object: &UID,
-        name: Name,
-    ): Option<ID> {
-        let key = Wrapper { name };
-        if (!field::exists_with_type<Wrapper<Name>, ID>(object, key)) return option::none();
-        let (_field, value_addr) = field::field_info<Wrapper<Name>>(object, key);
-        option::some(value_addr.to_id())
-    }
+/// Returns true if and only if the `object` has a dynamic field with the name specified by
+/// `name: Name` with an assigned value of type `Value`.
+public fun exists_with_type<Name: copy + drop + store, Value: key + store>(
+    object: &UID,
+    name: Name,
+): bool {
+    exists_with_type_impl!<_, Value>(object, name)
+}
 
-    public(package) fun internal_add<Name: copy + drop + store, Value: key>(
-        // we use &mut UID in several spots for access control
-        object: &mut UID,
-        name: Name,
-        value: Value,
-    ) {
-        add_impl!(object, name, value)
-    }
+/// Returns the ID of the object associated with the dynamic object field
+/// Returns none otherwise
+public fun id<Name: copy + drop + store>(object: &UID, name: Name): Option<ID> {
+    let key = Wrapper { name };
+    if (!field::exists_with_type<Wrapper<Name>, ID>(object, key)) return option::none();
+    let (_field, value_addr) = field::field_info<Wrapper<Name>>(object, key);
+    option::some(value_addr.to_id())
+}
 
-    public(package) fun internal_borrow<Name: copy + drop + store, Value: key>(
-        object: &UID,
-        name: Name,
-    ): &Value {
-        borrow_impl!(object, name)
-    }
+public(package) fun internal_add<Name: copy + drop + store, Value: key>(
+    // we use &mut UID in several spots for access control
+    object: &mut UID,
+    name: Name,
+    value: Value,
+) {
+    add_impl!(object, name, value)
+}
 
-    public(package) fun internal_borrow_mut<Name: copy + drop + store, Value: key>(
-        object: &mut UID,
-        name: Name,
-    ): &mut Value {
-        borrow_mut_impl!(object, name)
-    }
+public(package) fun internal_borrow<Name: copy + drop + store, Value: key>(
+    object: &UID,
+    name: Name,
+): &Value {
+    borrow_impl!(object, name)
+}
 
-    public(package) fun internal_remove<Name: copy + drop + store, Value: key>(
-        object: &mut UID,
-        name: Name,
-    ): Value {
-        remove_impl!(object, name)
-    }
+public(package) fun internal_borrow_mut<Name: copy + drop + store, Value: key>(
+    object: &mut UID,
+    name: Name,
+): &mut Value {
+    borrow_mut_impl!(object, name)
+}
 
-    public(package) fun internal_exists_with_type<Name: copy + drop + store, Value: key>(
-        object: &UID,
-        name: Name,
-    ): bool {
-        exists_with_type_impl!<_, Value>(object, name)
-    }
+public(package) fun internal_remove<Name: copy + drop + store, Value: key>(
+    object: &mut UID,
+    name: Name,
+): Value {
+    remove_impl!(object, name)
+}
 
-    macro fun add_impl<$Name: copy + drop + store, $Value: key>(
-        // we use &mut UID in several spots for access control
-        $object: &mut UID,
-        $name: $Name,
-        $value: $Value,
-    ) {
-        let object = $object;
-        let name = $name;
-        let value = $value;
-        let key = Wrapper { name };
-        let id = object::id(&value);
-        field::add(object, key, id);
-        let (field, _) = field::field_info<Wrapper<$Name>>(object, key);
-        add_child_object(field.to_address(), value);
-    }
+public(package) fun internal_exists_with_type<Name: copy + drop + store, Value: key>(
+    object: &UID,
+    name: Name,
+): bool {
+    exists_with_type_impl!<_, Value>(object, name)
+}
 
-    macro fun borrow_impl<$Name: copy + drop + store, $Value: key>(
-        $object: &UID,
-        $name: $Name,
-    ): &$Value {
-        let object = $object;
-        let name = $name;
-        let key = Wrapper { name };
-        let (field, value_id) = field::field_info<Wrapper<$Name>>(object, key);
-        borrow_child_object<$Value>(field, value_id)
-    }
+macro fun add_impl<$Name: copy + drop + store, $Value: key>(
+    // we use &mut UID in several spots for access control
+    $object: &mut UID,
+    $name: $Name,
+    $value: $Value,
+) {
+    let object = $object;
+    let name = $name;
+    let value = $value;
+    let key = Wrapper { name };
+    let id = object::id(&value);
+    field::add(object, key, id);
+    let (field, _) = field::field_info<Wrapper<$Name>>(object, key);
+    add_child_object(field.to_address(), value);
+}
 
-    macro fun borrow_mut_impl<$Name: copy + drop + store, $Value: key>(
-        $object: &mut UID,
-        $name: $Name,
-    ): &mut $Value {
-        let object = $object;
-        let name = $name;
-        let key = Wrapper { name };
-        let (field, value_id) = field::field_info_mut<Wrapper<$Name>>(object, key);
-        borrow_child_object_mut<$Value>(field, value_id)
-    }
+macro fun borrow_impl<$Name: copy + drop + store, $Value: key>(
+    $object: &UID,
+    $name: $Name,
+): &$Value {
+    let object = $object;
+    let name = $name;
+    let key = Wrapper { name };
+    let (field, value_id) = field::field_info<Wrapper<$Name>>(object, key);
+    borrow_child_object<$Value>(field, value_id)
+}
 
-    macro fun remove_impl<$Name: copy + drop + store, $Value: key>(
-        $object: &mut UID,
-        $name: $Name,
-    ): $Value {
-        let object = $object;
-        let name = $name;
-        let key = Wrapper { name };
-        let (field, value_id) = field::field_info<Wrapper<$Name>>(object, key);
-        let value = remove_child_object<$Value>(field.to_address(), value_id);
-        field::remove<Wrapper<$Name>, ID>(object, key);
-        value
-    }
+macro fun borrow_mut_impl<$Name: copy + drop + store, $Value: key>(
+    $object: &mut UID,
+    $name: $Name,
+): &mut $Value {
+    let object = $object;
+    let name = $name;
+    let key = Wrapper { name };
+    let (field, value_id) = field::field_info_mut<Wrapper<$Name>>(object, key);
+    borrow_child_object_mut<$Value>(field, value_id)
+}
 
-    macro fun exists_with_type_impl<$Name: copy + drop + store, $Value: key>(
-        $object: &UID,
-        $name: $Name,
-    ): bool {
-        let object = $object;
-        let name = $name;
-        let key = Wrapper { name };
-        if (!field::exists_with_type<Wrapper<$Name>, ID>(object, key)) return false;
-        let (field, value_id) = field::field_info<Wrapper<$Name>>(object, key);
-        field::has_child_object_with_ty<$Value>(field.to_address(), value_id)
-    }
+macro fun remove_impl<$Name: copy + drop + store, $Value: key>(
+    $object: &mut UID,
+    $name: $Name,
+): $Value {
+    let object = $object;
+    let name = $name;
+    let key = Wrapper { name };
+    let (field, value_id) = field::field_info<Wrapper<$Name>>(object, key);
+    let value = remove_child_object<$Value>(field.to_address(), value_id);
+    field::remove<Wrapper<$Name>, ID>(object, key);
+    value
+}
 
+macro fun exists_with_type_impl<$Name: copy + drop + store, $Value: key>(
+    $object: &UID,
+    $name: $Name,
+): bool {
+    let object = $object;
+    let name = $name;
+    let key = Wrapper { name };
+    if (!field::exists_with_type<Wrapper<$Name>, ID>(object, key)) return false;
+    let (field, value_id) = field::field_info<Wrapper<$Name>>(object, key);
+    field::has_child_object_with_ty<$Value>(field.to_address(), value_id)
 }

--- a/crates/sui-framework/packages/sui-framework/sources/linked_table.move
+++ b/crates/sui-framework/packages/sui-framework/sources/linked_table.move
@@ -3,197 +3,197 @@
 
 /// Similar to `sui::table` but the values are linked together, allowing for ordered insertion and
 /// removal
-module sui::linked_table {
-    use sui::dynamic_field as field;
+module sui::linked_table;
 
-    // Attempted to destroy a non-empty table
-    const ETableNotEmpty: u64 = 0;
-    // Attempted to remove the front or back of an empty table
-    const ETableIsEmpty: u64 = 1;
+use sui::dynamic_field as field;
 
-    public struct LinkedTable<K: copy + drop + store, phantom V: store> has key, store {
-        /// the ID of this table
-        id: UID,
-        /// the number of key-value pairs in the table
-        size: u64,
-        /// the front of the table, i.e. the key of the first entry
-        head: Option<K>,
-        /// the back of the table, i.e. the key of the last entry
-        tail: Option<K>,
+// Attempted to destroy a non-empty table
+const ETableNotEmpty: u64 = 0;
+// Attempted to remove the front or back of an empty table
+const ETableIsEmpty: u64 = 1;
+
+public struct LinkedTable<K: copy + drop + store, phantom V: store> has key, store {
+    /// the ID of this table
+    id: UID,
+    /// the number of key-value pairs in the table
+    size: u64,
+    /// the front of the table, i.e. the key of the first entry
+    head: Option<K>,
+    /// the back of the table, i.e. the key of the last entry
+    tail: Option<K>,
+}
+
+public struct Node<K: copy + drop + store, V: store> has store {
+    /// the previous key
+    prev: Option<K>,
+    /// the next key
+    next: Option<K>,
+    /// the value being stored
+    value: V,
+}
+
+/// Creates a new, empty table
+public fun new<K: copy + drop + store, V: store>(ctx: &mut TxContext): LinkedTable<K, V> {
+    LinkedTable {
+        id: object::new(ctx),
+        size: 0,
+        head: option::none(),
+        tail: option::none(),
     }
+}
 
-    public struct Node<K: copy + drop + store, V: store> has store {
-        /// the previous key
-        prev: Option<K>,
-        /// the next key
-        next: Option<K>,
-        /// the value being stored
-        value: V
-    }
+/// Returns the key for the first element in the table, or None if the table is empty
+public fun front<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): &Option<K> {
+    &table.head
+}
 
-    /// Creates a new, empty table
-    public fun new<K: copy + drop + store, V: store>(ctx: &mut TxContext): LinkedTable<K, V> {
-        LinkedTable {
-            id: object::new(ctx),
-            size: 0,
-            head: option::none(),
-            tail: option::none(),
-        }
-    }
+/// Returns the key for the last element in the table, or None if the table is empty
+public fun back<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): &Option<K> {
+    &table.tail
+}
 
-    /// Returns the key for the first element in the table, or None if the table is empty
-    public fun front<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): &Option<K> {
-        &table.head
-    }
+/// Inserts a key-value pair at the front of the table, i.e. the newly inserted pair will be
+/// the first element in the table
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun push_front<K: copy + drop + store, V: store>(
+    table: &mut LinkedTable<K, V>,
+    k: K,
+    value: V,
+) {
+    let old_head = table.head.swap_or_fill(k);
+    if (table.tail.is_none()) table.tail.fill(k);
+    let prev = option::none();
+    let next = if (old_head.is_some()) {
+        let old_head_k = old_head.destroy_some();
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, old_head_k).prev = option::some(k);
+        option::some(old_head_k)
+    } else {
+        option::none()
+    };
+    field::add(&mut table.id, k, Node { prev, next, value });
+    table.size = table.size + 1;
+}
 
-    /// Returns the key for the last element in the table, or None if the table is empty
-    public fun back<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): &Option<K> {
-        &table.tail
-    }
+/// Inserts a key-value pair at the back of the table, i.e. the newly inserted pair will be
+/// the last element in the table
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun push_back<K: copy + drop + store, V: store>(
+    table: &mut LinkedTable<K, V>,
+    k: K,
+    value: V,
+) {
+    if (table.head.is_none()) table.head.fill(k);
+    let old_tail = table.tail.swap_or_fill(k);
+    let prev = if (old_tail.is_some()) {
+        let old_tail_k = old_tail.destroy_some();
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, old_tail_k).next = option::some(k);
+        option::some(old_tail_k)
+    } else {
+        option::none()
+    };
+    let next = option::none();
+    field::add(&mut table.id, k, Node { prev, next, value });
+    table.size = table.size + 1;
+}
 
-    /// Inserts a key-value pair at the front of the table, i.e. the newly inserted pair will be
-    /// the first element in the table
-    /// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
-    /// that key `k: K`.
-    public fun push_front<K: copy + drop + store, V: store>(
-        table: &mut LinkedTable<K, V>,
-        k: K,
-        value: V,
-    ) {
-        let old_head = table.head.swap_or_fill(k);
-        if (table.tail.is_none()) table.tail.fill(k);
-        let prev = option::none();
-        let next = if (old_head.is_some()) {
-            let old_head_k = old_head.destroy_some();
-            field::borrow_mut<K, Node<K, V>>(&mut table.id, old_head_k).prev = option::some(k);
-            option::some(old_head_k)
-        } else {
-            option::none()
-        };
-        field::add(&mut table.id, k, Node { prev, next, value });
-        table.size = table.size + 1;
-    }
+#[syntax(index)]
+/// Immutable borrows the value associated with the key in the table `table: &LinkedTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &V {
+    &field::borrow<K, Node<K, V>>(&table.id, k).value
+}
 
-    /// Inserts a key-value pair at the back of the table, i.e. the newly inserted pair will be
-    /// the last element in the table
-    /// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
-    /// that key `k: K`.
-    public fun push_back<K: copy + drop + store, V: store>(
-        table: &mut LinkedTable<K, V>,
-        k: K,
-        value: V,
-    ) {
-        if (table.head.is_none()) table.head.fill(k);
-        let old_tail = table.tail.swap_or_fill(k);
-        let prev = if (old_tail.is_some()) {
-            let old_tail_k = old_tail.destroy_some();
-            field::borrow_mut<K, Node<K, V>>(&mut table.id, old_tail_k).next = option::some(k);
-            option::some(old_tail_k)
-        } else {
-            option::none()
-        };
-        let next = option::none();
-        field::add(&mut table.id, k, Node { prev, next, value });
-        table.size = table.size + 1;
-    }
+#[syntax(index)]
+/// Mutably borrows the value associated with the key in the table `table: &mut LinkedTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow_mut<K: copy + drop + store, V: store>(
+    table: &mut LinkedTable<K, V>,
+    k: K,
+): &mut V {
+    &mut field::borrow_mut<K, Node<K, V>>(&mut table.id, k).value
+}
 
-    #[syntax(index)]
-    /// Immutable borrows the value associated with the key in the table `table: &LinkedTable<K, V>`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun borrow<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &V {
-        &field::borrow<K, Node<K, V>>(&table.id, k).value
-    }
+/// Borrows the key for the previous entry of the specified key `k: K` in the table
+/// `table: &LinkedTable<K, V>`. Returns None if the entry does not have a predecessor.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`
+public fun prev<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &Option<K> {
+    &field::borrow<K, Node<K, V>>(&table.id, k).prev
+}
 
-    #[syntax(index)]
-    /// Mutably borrows the value associated with the key in the table `table: &mut LinkedTable<K, V>`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun borrow_mut<K: copy + drop + store, V: store>(
-        table: &mut LinkedTable<K, V>,
-        k: K,
-    ): &mut V {
-        &mut field::borrow_mut<K, Node<K, V>>(&mut table.id, k).value
-    }
+/// Borrows the key for the next entry of the specified key `k: K` in the table
+/// `table: &LinkedTable<K, V>`. Returns None if the entry does not have a predecessor.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`
+public fun next<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &Option<K> {
+    &field::borrow<K, Node<K, V>>(&table.id, k).next
+}
 
-    /// Borrows the key for the previous entry of the specified key `k: K` in the table
-    /// `table: &LinkedTable<K, V>`. Returns None if the entry does not have a predecessor.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`
-    public fun prev<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &Option<K> {
-        &field::borrow<K, Node<K, V>>(&table.id, k).prev
-    }
+/// Removes the key-value pair in the table `table: &mut LinkedTable<K, V>` and returns the value.
+/// This splices the element out of the ordering.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`. Note: this is also what happens when the table is empty.
+public fun remove<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>, k: K): V {
+    let Node<K, V> { prev, next, value } = field::remove(&mut table.id, k);
+    table.size = table.size - 1;
+    if (prev.is_some()) {
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, *prev.borrow()).next = next
+    };
+    if (next.is_some()) {
+        field::borrow_mut<K, Node<K, V>>(&mut table.id, *next.borrow()).prev = prev
+    };
+    if (table.head.borrow() == &k) table.head = next;
+    if (table.tail.borrow() == &k) table.tail = prev;
+    value
+}
 
-    /// Borrows the key for the next entry of the specified key `k: K` in the table
-    /// `table: &LinkedTable<K, V>`. Returns None if the entry does not have a predecessor.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`
-    public fun next<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): &Option<K> {
-        &field::borrow<K, Node<K, V>>(&table.id, k).next
-    }
+/// Removes the front of the table `table: &mut LinkedTable<K, V>` and returns the value.
+/// Aborts with `ETableIsEmpty` if the table is empty
+public fun pop_front<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>): (K, V) {
+    assert!(table.head.is_some(), ETableIsEmpty);
+    let head = *table.head.borrow();
+    (head, table.remove(head))
+}
 
-    /// Removes the key-value pair in the table `table: &mut LinkedTable<K, V>` and returns the value.
-    /// This splices the element out of the ordering.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`. Note: this is also what happens when the table is empty.
-    public fun remove<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>, k: K): V {
-        let Node<K, V> { prev, next, value } = field::remove(&mut table.id, k);
-        table.size = table.size - 1;
-        if (prev.is_some()) {
-            field::borrow_mut<K, Node<K, V>>(&mut table.id, *prev.borrow()).next = next
-        };
-        if (next.is_some()) {
-            field::borrow_mut<K, Node<K, V>>(&mut table.id, *next.borrow()).prev = prev
-        };
-        if (table.head.borrow() == &k) table.head = next;
-        if (table.tail.borrow() == &k) table.tail = prev;
-        value
-    }
+/// Removes the back of the table `table: &mut LinkedTable<K, V>` and returns the value.
+/// Aborts with `ETableIsEmpty` if the table is empty
+public fun pop_back<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>): (K, V) {
+    assert!(table.tail.is_some(), ETableIsEmpty);
+    let tail = *table.tail.borrow();
+    (tail, table.remove(tail))
+}
 
-    /// Removes the front of the table `table: &mut LinkedTable<K, V>` and returns the value.
-    /// Aborts with `ETableIsEmpty` if the table is empty
-    public fun pop_front<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>): (K, V) {
-        assert!(table.head.is_some(), ETableIsEmpty);
-        let head = *table.head.borrow();
-        (head, table.remove(head))
-    }
+/// Returns true iff there is a value associated with the key `k: K` in table
+/// `table: &LinkedTable<K, V>`
+public fun contains<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): bool {
+    field::exists_with_type<K, Node<K, V>>(&table.id, k)
+}
 
-    /// Removes the back of the table `table: &mut LinkedTable<K, V>` and returns the value.
-    /// Aborts with `ETableIsEmpty` if the table is empty
-    public fun pop_back<K: copy + drop + store, V: store>(table: &mut LinkedTable<K, V>): (K, V) {
-        assert!(table.tail.is_some(), ETableIsEmpty);
-        let tail = *table.tail.borrow();
-        (tail, table.remove(tail))
-    }
+/// Returns the size of the table, the number of key-value pairs
+public fun length<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): u64 {
+    table.size
+}
 
-    /// Returns true iff there is a value associated with the key `k: K` in table
-    /// `table: &LinkedTable<K, V>`
-    public fun contains<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, k: K): bool {
-        field::exists_with_type<K, Node<K, V>>(&table.id, k)
-    }
+/// Returns true iff the table is empty (if `length` returns `0`)
+public fun is_empty<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): bool {
+    table.size == 0
+}
 
-    /// Returns the size of the table, the number of key-value pairs
-    public fun length<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): u64 {
-        table.size
-    }
+/// Destroys an empty table
+/// Aborts with `ETableNotEmpty` if the table still contains values
+public fun destroy_empty<K: copy + drop + store, V: store>(table: LinkedTable<K, V>) {
+    let LinkedTable { id, size, head: _, tail: _ } = table;
+    assert!(size == 0, ETableNotEmpty);
+    id.delete()
+}
 
-    /// Returns true iff the table is empty (if `length` returns `0`)
-    public fun is_empty<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>): bool {
-        table.size == 0
-    }
-
-    /// Destroys an empty table
-    /// Aborts with `ETableNotEmpty` if the table still contains values
-    public fun destroy_empty<K: copy + drop + store, V: store>(table: LinkedTable<K, V>) {
-        let LinkedTable { id, size, head: _, tail: _ } = table;
-        assert!(size == 0, ETableNotEmpty);
-        id.delete()
-    }
-
-    /// Drop a possibly non-empty table.
-    /// Usable only if the value type `V` has the `drop` ability
-    public fun drop<K: copy + drop + store, V: drop + store>(table: LinkedTable<K, V>) {
-        let LinkedTable { id, size: _, head: _, tail: _ } = table;
-        id.delete()
-    }
+/// Drop a possibly non-empty table.
+/// Usable only if the value type `V` has the `drop` ability
+public fun drop<K: copy + drop + store, V: drop + store>(table: LinkedTable<K, V>) {
+    let LinkedTable { id, size: _, head: _, tail: _ } = table;
+    id.delete()
 }

--- a/crates/sui-framework/packages/sui-framework/sources/object_bag.move
+++ b/crates/sui-framework/packages/sui-framework/sources/object_bag.move
@@ -5,98 +5,98 @@
 /// `sui::bag`, the values bound to these dynamic fields _must_ be objects themselves. This allows
 /// for the objects to still exist in storage, which may be important for external tools.
 /// The difference is otherwise not observable from within Move.
-module sui::object_bag {
-    use sui::dynamic_object_field as ofield;
+module sui::object_bag;
 
-    // Attempted to destroy a non-empty bag
-    const EBagNotEmpty: u64 = 0;
+use sui::dynamic_object_field as ofield;
 
-    public struct ObjectBag has key, store {
-        /// the ID of this bag
-        id: UID,
-        /// the number of key-value pairs in the bag
-        size: u64,
+// Attempted to destroy a non-empty bag
+const EBagNotEmpty: u64 = 0;
+
+public struct ObjectBag has key, store {
+    /// the ID of this bag
+    id: UID,
+    /// the number of key-value pairs in the bag
+    size: u64,
+}
+
+/// Creates a new, empty bag
+public fun new(ctx: &mut TxContext): ObjectBag {
+    ObjectBag {
+        id: object::new(ctx),
+        size: 0,
     }
+}
 
-    /// Creates a new, empty bag
-    public fun new(ctx: &mut TxContext): ObjectBag {
-        ObjectBag {
-            id: object::new(ctx),
-            size: 0,
-        }
-    }
+/// Adds a key-value pair to the bag `bag: &mut ObjectBag`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the bag already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K, v: V) {
+    ofield::add(&mut bag.id, k, v);
+    bag.size = bag.size + 1;
+}
 
-    /// Adds a key-value pair to the bag `bag: &mut ObjectBag`
-    /// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the bag already has an entry with
-    /// that key `k: K`.
-    public fun add<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K, v: V) {
-        ofield::add(&mut bag.id, k, v);
-        bag.size = bag.size + 1;
-    }
+#[syntax(index)]
+/// Immutably borrows the value associated with the key in the bag `bag: &ObjectBag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow<K: copy + drop + store, V: key + store>(bag: &ObjectBag, k: K): &V {
+    ofield::borrow(&bag.id, k)
+}
 
-    #[syntax(index)]
-    /// Immutably borrows the value associated with the key in the bag `bag: &ObjectBag`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
-    /// that key `k: K`.
-    /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
-    /// the value does not have the specified type.
-    public fun borrow<K: copy + drop + store, V: key + store>(bag: &ObjectBag, k: K): &V {
-        ofield::borrow(&bag.id, k)
-    }
+#[syntax(index)]
+/// Mutably borrows the value associated with the key in the bag `bag: &mut ObjectBag`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun borrow_mut<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): &mut V {
+    ofield::borrow_mut(&mut bag.id, k)
+}
 
-    #[syntax(index)]
-    /// Mutably borrows the value associated with the key in the bag `bag: &mut ObjectBag`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
-    /// that key `k: K`.
-    /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
-    /// the value does not have the specified type.
-    public fun borrow_mut<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): &mut V {
-        ofield::borrow_mut(&mut bag.id, k)
-    }
+/// Mutably borrows the key-value pair in the bag `bag: &mut ObjectBag` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
+/// that key `k: K`.
+/// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
+/// the value does not have the specified type.
+public fun remove<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): V {
+    let v = ofield::remove(&mut bag.id, k);
+    bag.size = bag.size - 1;
+    v
+}
 
-    /// Mutably borrows the key-value pair in the bag `bag: &mut ObjectBag` and returns the value.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
-    /// that key `k: K`.
-    /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but
-    /// the value does not have the specified type.
-    public fun remove<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): V {
-        let v = ofield::remove(&mut bag.id, k);
-        bag.size = bag.size - 1;
-        v
-    }
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &ObjectBag`
+public fun contains<K: copy + drop + store>(bag: &ObjectBag, k: K): bool {
+    ofield::exists_<K>(&bag.id, k)
+}
 
-    /// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &ObjectBag`
-    public fun contains<K: copy + drop + store>(bag: &ObjectBag, k: K): bool {
-        ofield::exists_<K>(&bag.id, k)
-    }
+/// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &ObjectBag`
+/// with an assigned value of type `V`
+public fun contains_with_type<K: copy + drop + store, V: key + store>(bag: &ObjectBag, k: K): bool {
+    ofield::exists_with_type<K, V>(&bag.id, k)
+}
 
-    /// Returns true iff there is an value associated with the key `k: K` in the bag `bag: &ObjectBag`
-    /// with an assigned value of type `V`
-    public fun contains_with_type<K: copy + drop + store, V: key + store>(bag: &ObjectBag, k: K): bool {
-        ofield::exists_with_type<K, V>(&bag.id, k)
-    }
+/// Returns the size of the bag, the number of key-value pairs
+public fun length(bag: &ObjectBag): u64 {
+    bag.size
+}
 
-    /// Returns the size of the bag, the number of key-value pairs
-    public fun length(bag: &ObjectBag): u64 {
-        bag.size
-    }
+/// Returns true iff the bag is empty (if `length` returns `0`)
+public fun is_empty(bag: &ObjectBag): bool {
+    bag.size == 0
+}
 
-    /// Returns true iff the bag is empty (if `length` returns `0`)
-    public fun is_empty(bag: &ObjectBag): bool {
-        bag.size == 0
-    }
+/// Destroys an empty bag
+/// Aborts with `EBagNotEmpty` if the bag still contains values
+public fun destroy_empty(bag: ObjectBag) {
+    let ObjectBag { id, size } = bag;
+    assert!(size == 0, EBagNotEmpty);
+    id.delete()
+}
 
-    /// Destroys an empty bag
-    /// Aborts with `EBagNotEmpty` if the bag still contains values
-    public fun destroy_empty(bag: ObjectBag) {
-        let ObjectBag { id, size } = bag;
-        assert!(size == 0, EBagNotEmpty);
-        id.delete()
-    }
-
-    /// Returns the ID of the object associated with the key if the bag has an entry with key `k: K`
-    /// Returns none otherwise
-    public fun value_id<K: copy + drop + store>(bag: &ObjectBag, k: K): Option<ID> {
-        ofield::id(&bag.id, k)
-    }
+/// Returns the ID of the object associated with the key if the bag has an entry with key `k: K`
+/// Returns none otherwise
+public fun value_id<K: copy + drop + store>(bag: &ObjectBag, k: K): Option<ID> {
+    ofield::id(&bag.id, k)
 }

--- a/crates/sui-framework/packages/sui-framework/sources/object_table.move
+++ b/crates/sui-framework/packages/sui-framework/sources/object_table.move
@@ -5,93 +5,93 @@
 /// `sui::table`, the values bound to these dynamic fields _must_ be objects themselves. This allows
 /// for the objects to still exist within in storage, which may be important for external tools.
 /// The difference is otherwise not observable from within Move.
-module sui::object_table {
-    use sui::dynamic_object_field as ofield;
+module sui::object_table;
 
-    // Attempted to destroy a non-empty table
-    const ETableNotEmpty: u64 = 0;
+use sui::dynamic_object_field as ofield;
 
-    public struct ObjectTable<phantom K: copy + drop + store, phantom V: key + store> has key, store {
-        /// the ID of this table
-        id: UID,
-        /// the number of key-value pairs in the table
-        size: u64,
+// Attempted to destroy a non-empty table
+const ETableNotEmpty: u64 = 0;
+
+public struct ObjectTable<phantom K: copy + drop + store, phantom V: key + store> has key, store {
+    /// the ID of this table
+    id: UID,
+    /// the number of key-value pairs in the table
+    size: u64,
+}
+
+/// Creates a new, empty table
+public fun new<K: copy + drop + store, V: key + store>(ctx: &mut TxContext): ObjectTable<K, V> {
+    ObjectTable {
+        id: object::new(ctx),
+        size: 0,
     }
+}
 
-    /// Creates a new, empty table
-    public fun new<K: copy + drop + store, V: key + store>(ctx: &mut TxContext): ObjectTable<K, V> {
-        ObjectTable {
-            id: object::new(ctx),
-            size: 0,
-        }
-    }
+/// Adds a key-value pair to the table `table: &mut ObjectTable<K, V>`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: key + store>(table: &mut ObjectTable<K, V>, k: K, v: V) {
+    ofield::add(&mut table.id, k, v);
+    table.size = table.size + 1;
+}
 
-    /// Adds a key-value pair to the table `table: &mut ObjectTable<K, V>`
-    /// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
-    /// that key `k: K`.
-    public fun add<K: copy + drop + store, V: key + store>(table: &mut ObjectTable<K, V>, k: K, v: V) {
-        ofield::add(&mut table.id, k, v);
-        table.size = table.size + 1;
-    }
+#[syntax(index)]
+/// Immutable borrows the value associated with the key in the table `table: &ObjectTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>, k: K): &V {
+    ofield::borrow(&table.id, k)
+}
 
-    #[syntax(index)]
-    /// Immutable borrows the value associated with the key in the table `table: &ObjectTable<K, V>`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun borrow<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>, k: K): &V {
-        ofield::borrow(&table.id, k)
-    }
+#[syntax(index)]
+/// Mutably borrows the value associated with the key in the table `table: &mut ObjectTable<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow_mut<K: copy + drop + store, V: key + store>(
+    table: &mut ObjectTable<K, V>,
+    k: K,
+): &mut V {
+    ofield::borrow_mut(&mut table.id, k)
+}
 
-    #[syntax(index)]
-    /// Mutably borrows the value associated with the key in the table `table: &mut ObjectTable<K, V>`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun borrow_mut<K: copy + drop + store, V: key + store>(
-        table: &mut ObjectTable<K, V>,
-        k: K,
-    ): &mut V {
-        ofield::borrow_mut(&mut table.id, k)
-    }
+/// Removes the key-value pair in the table `table: &mut ObjectTable<K, V>` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun remove<K: copy + drop + store, V: key + store>(table: &mut ObjectTable<K, V>, k: K): V {
+    let v = ofield::remove(&mut table.id, k);
+    table.size = table.size - 1;
+    v
+}
 
-    /// Removes the key-value pair in the table `table: &mut ObjectTable<K, V>` and returns the value.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun remove<K: copy + drop + store, V: key + store>(table: &mut ObjectTable<K, V>, k: K): V {
-        let v = ofield::remove(&mut table.id, k);
-        table.size = table.size - 1;
-        v
-    }
+/// Returns true iff there is a value associated with the key `k: K` in table
+/// `table: &ObjectTable<K, V>`
+public fun contains<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>, k: K): bool {
+    ofield::exists_<K>(&table.id, k)
+}
 
-    /// Returns true iff there is a value associated with the key `k: K` in table
-    /// `table: &ObjectTable<K, V>`
-    public fun contains<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>, k: K): bool {
-        ofield::exists_<K>(&table.id, k)
-    }
+/// Returns the size of the table, the number of key-value pairs
+public fun length<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>): u64 {
+    table.size
+}
 
-    /// Returns the size of the table, the number of key-value pairs
-    public fun length<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>): u64 {
-        table.size
-    }
+/// Returns true iff the table is empty (if `length` returns `0`)
+public fun is_empty<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>): bool {
+    table.size == 0
+}
 
-    /// Returns true iff the table is empty (if `length` returns `0`)
-    public fun is_empty<K: copy + drop + store, V: key + store>(table: &ObjectTable<K, V>): bool {
-        table.size == 0
-    }
+/// Destroys an empty table
+/// Aborts with `ETableNotEmpty` if the table still contains values
+public fun destroy_empty<K: copy + drop + store, V: key + store>(table: ObjectTable<K, V>) {
+    let ObjectTable { id, size } = table;
+    assert!(size == 0, ETableNotEmpty);
+    id.delete()
+}
 
-    /// Destroys an empty table
-    /// Aborts with `ETableNotEmpty` if the table still contains values
-    public fun destroy_empty<K: copy + drop + store, V: key + store>(table: ObjectTable<K, V>) {
-        let ObjectTable { id, size } = table;
-        assert!(size == 0, ETableNotEmpty);
-        id.delete()
-    }
-
-    /// Returns the ID of the object associated with the key if the table has an entry with key `k: K`
-    /// Returns none otherwise
-    public fun value_id<K: copy + drop + store, V: key + store>(
-        table: &ObjectTable<K, V>,
-        k: K,
-    ): Option<ID> {
-        ofield::id(&table.id, k)
-    }
+/// Returns the ID of the object associated with the key if the table has an entry with key `k: K`
+/// Returns none otherwise
+public fun value_id<K: copy + drop + store, V: key + store>(
+    table: &ObjectTable<K, V>,
+    k: K,
+): Option<ID> {
+    ofield::id(&table.id, k)
 }

--- a/crates/sui-framework/packages/sui-framework/sources/priority_queue.move
+++ b/crates/sui-framework/packages/sui-framework/sources/priority_queue.move
@@ -2,178 +2,176 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Priority queue implemented using a max heap.
-module sui::priority_queue {
+module sui::priority_queue;
 
-    /// For when heap is empty and there's no data to pop.
-    const EPopFromEmptyHeap: u64 = 0;
+/// For when heap is empty and there's no data to pop.
+const EPopFromEmptyHeap: u64 = 0;
 
-    /// Struct representing a priority queue. The `entries` vector represents a max
-    /// heap structure, where entries[0] is the root, entries[1] and entries[2] are the
-    /// left child and right child of the root, etc. More generally, the children of
-    /// entries[i] are at i * 2 + 1 and i * 2 + 2. The max heap should have the invariant
-    /// that the parent node's priority is always higher than its child nodes' priorities.
-    public struct PriorityQueue<T: drop> has store, drop {
-        entries: vector<Entry<T>>,
+/// Struct representing a priority queue. The `entries` vector represents a max
+/// heap structure, where entries[0] is the root, entries[1] and entries[2] are the
+/// left child and right child of the root, etc. More generally, the children of
+/// entries[i] are at i * 2 + 1 and i * 2 + 2. The max heap should have the invariant
+/// that the parent node's priority is always higher than its child nodes' priorities.
+public struct PriorityQueue<T: drop> has store, drop {
+    entries: vector<Entry<T>>,
+}
+
+public struct Entry<T: drop> has store, drop {
+    priority: u64, // higher value means higher priority and will be popped first
+    value: T,
+}
+
+/// Create a new priority queue from the input entry vectors.
+public fun new<T: drop>(mut entries: vector<Entry<T>>): PriorityQueue<T> {
+    let len = entries.length();
+    let mut i = len / 2;
+    // Max heapify from the first node that is a parent (node at len / 2).
+    while (i > 0) {
+        i = i - 1;
+        max_heapify_recursive(&mut entries, len, i);
+    };
+    PriorityQueue { entries }
+}
+
+/// Pop the entry with the highest priority value.
+public fun pop_max<T: drop>(pq: &mut PriorityQueue<T>): (u64, T) {
+    let len = pq.entries.length();
+    assert!(len > 0, EPopFromEmptyHeap);
+    // Swap the max element with the last element in the entries and remove the max element.
+    let Entry { priority, value } = pq.entries.swap_remove(0);
+    // Now the max heap property has been violated at the root node, but nowhere else
+    // so we call max heapify on the root node.
+    max_heapify_recursive(&mut pq.entries, len - 1, 0);
+    (priority, value)
+}
+
+/// Insert a new entry into the queue.
+public fun insert<T: drop>(pq: &mut PriorityQueue<T>, priority: u64, value: T) {
+    pq.entries.push_back(Entry { priority, value });
+    let index = pq.entries.length() - 1;
+    restore_heap_recursive(&mut pq.entries, index);
+}
+
+public fun new_entry<T: drop>(priority: u64, value: T): Entry<T> {
+    Entry { priority, value }
+}
+
+public fun create_entries<T: drop>(mut p: vector<u64>, mut v: vector<T>): vector<Entry<T>> {
+    let len = p.length();
+    assert!(v.length() == len, 0);
+    let mut res = vector[];
+    let mut i = 0;
+    while (i < len) {
+        let priority = p.remove(0);
+        let value = v.remove(0);
+        res.push_back(Entry { priority, value });
+        i = i + 1;
+    };
+    res
+}
+
+// TODO: implement iterative version too and see performance difference.
+fun restore_heap_recursive<T: drop>(v: &mut vector<Entry<T>>, i: u64) {
+    if (i == 0) {
+        return
+    };
+    let parent = (i - 1) / 2;
+
+    // If new elem is greater than its parent, swap them and recursively
+    // do the restoration upwards.
+    if (*&v[i].priority > *&v[parent].priority) {
+        v.swap(i, parent);
+        restore_heap_recursive(v, parent);
     }
+}
 
-    public struct Entry<T: drop> has store, drop {
-        priority: u64, // higher value means higher priority and will be popped first
-        value: T,
+/// Max heapify the subtree whose root is at index `i`. That means after this function
+/// finishes, the subtree should have the property that the parent node has higher priority
+/// than both child nodes.
+/// This function assumes that all the other nodes in the subtree (nodes other than the root)
+/// do satisfy the max heap property.
+fun max_heapify_recursive<T: drop>(v: &mut vector<Entry<T>>, len: u64, i: u64) {
+    if (len == 0) {
+        return
+    };
+    assert!(i < len, 1);
+    let left = i * 2 + 1;
+    let right = left + 1;
+    let mut max = i;
+    // Find the node with highest priority among node `i` and its two children.
+    if (left < len && *&v[left].priority > *&v[max].priority) {
+        max = left;
+    };
+    if (right < len && *&v[right].priority > *&v[max].priority) {
+        max = right;
+    };
+    // If the parent node (node `i`) doesn't have the highest priority, we swap the parent with the
+    // max priority node.
+    if (max != i) {
+        v.swap(max, i);
+        // After the swap, we have restored the property at node `i` but now the max heap property
+        // may be violated at node `max` since this node now has a new value. So we need to now
+        // max heapify the subtree rooted at node `max`.
+        max_heapify_recursive(v, len, max);
     }
+}
 
-    /// Create a new priority queue from the input entry vectors.
-    public fun new<T: drop>(mut entries: vector<Entry<T>>) : PriorityQueue<T> {
-        let len = entries.length();
-        let mut i = len / 2;
-        // Max heapify from the first node that is a parent (node at len / 2).
-        while (i > 0) {
-            i = i - 1;
-            max_heapify_recursive(&mut entries, len, i);
-        };
-        PriorityQueue { entries }
-    }
+public fun priorities<T: drop>(pq: &PriorityQueue<T>): vector<u64> {
+    let mut res = vector[];
+    let mut i = 0;
+    while (i < pq.entries.length()) {
+        res.push_back(pq.entries[i].priority);
+        i = i +1;
+    };
+    res
+}
 
-    /// Pop the entry with the highest priority value.
-    public fun pop_max<T: drop>(pq: &mut PriorityQueue<T>) : (u64, T) {
-        let len = pq.entries.length();
-        assert!(len > 0, EPopFromEmptyHeap);
-        // Swap the max element with the last element in the entries and remove the max element.
-        let Entry { priority, value } = pq.entries.swap_remove(0);
-        // Now the max heap property has been violated at the root node, but nowhere else
-        // so we call max heapify on the root node.
-        max_heapify_recursive(&mut pq.entries, len - 1, 0);
-        (priority, value)
-    }
+#[test]
+fun test_pq() {
+    let mut h = new(create_entries(vector[3, 1, 4, 2, 5, 2], vector[10, 20, 30, 40, 50, 60]));
+    check_pop_max(&mut h, 5, 50);
+    check_pop_max(&mut h, 4, 30);
+    check_pop_max(&mut h, 3, 10);
+    insert(&mut h, 7, 70);
+    check_pop_max(&mut h, 7, 70);
+    check_pop_max(&mut h, 2, 40);
+    insert(&mut h, 0, 80);
+    check_pop_max(&mut h, 2, 60);
+    check_pop_max(&mut h, 1, 20);
+    check_pop_max(&mut h, 0, 80);
 
-    /// Insert a new entry into the queue.
-    public fun insert<T: drop>(pq: &mut PriorityQueue<T>, priority: u64, value: T) {
-        pq.entries.push_back(Entry { priority, value});
-        let index = pq.entries.length() - 1;
-        restore_heap_recursive(&mut pq.entries, index);
-    }
+    let mut h = new(create_entries(vector[5, 3, 1, 2, 4], vector[10, 20, 30, 40, 50]));
+    check_pop_max(&mut h, 5, 10);
+    check_pop_max(&mut h, 4, 50);
+    check_pop_max(&mut h, 3, 20);
+    check_pop_max(&mut h, 2, 40);
+    check_pop_max(&mut h, 1, 30);
+}
 
-    public fun new_entry<T: drop>(priority: u64, value: T): Entry<T> {
-        Entry { priority, value }
-    }
+#[test]
+fun test_swap_remove_edge_case() {
+    // This test would fail if `remove` is used incorrectly instead of `swap_remove` in `pop_max`.
+    // It's hard to characterize exactly under what condition this bug is triggered but roughly
+    // it happens when the entire tree vector is shifted left by one because of the incorrect usage
+    // of `remove`, and the resulting new root and its two children appear to satisfy the heap invariant
+    // so we stop max-heapifying there, while the rest of the tree is all messed up because of the shift.
+    let priorities = vector[8, 7, 3, 6, 2, 1, 0, 5, 4];
+    let values = vector[0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut h = new(create_entries(priorities, values));
+    check_pop_max(&mut h, 8, 0);
+    check_pop_max(&mut h, 7, 0);
+    check_pop_max(&mut h, 6, 0);
+    check_pop_max(&mut h, 5, 0);
+    check_pop_max(&mut h, 4, 0);
+    check_pop_max(&mut h, 3, 0);
+    check_pop_max(&mut h, 2, 0);
+    check_pop_max(&mut h, 1, 0);
+    check_pop_max(&mut h, 0, 0);
+}
 
-    public fun create_entries<T: drop>(mut p: vector<u64>, mut v: vector<T>): vector<Entry<T>> {
-        let len = p.length();
-        assert!(v.length() == len, 0);
-        let mut res = vector[];
-        let mut i = 0;
-        while (i < len) {
-            let priority = p.remove(0);
-            let value = v.remove(0);
-            res.push_back(Entry { priority, value });
-            i = i + 1;
-        };
-        res
-    }
-
-    // TODO: implement iterative version too and see performance difference.
-    fun restore_heap_recursive<T: drop>(v: &mut vector<Entry<T>>, i: u64) {
-        if (i == 0) {
-            return
-        };
-        let parent = (i - 1) / 2;
-
-        // If new elem is greater than its parent, swap them and recursively
-        // do the restoration upwards.
-        if (*&v[i].priority > *&v[parent].priority) {
-            v.swap(i, parent);
-            restore_heap_recursive(v, parent);
-        }
-    }
-
-    /// Max heapify the subtree whose root is at index `i`. That means after this function
-    /// finishes, the subtree should have the property that the parent node has higher priority
-    /// than both child nodes.
-    /// This function assumes that all the other nodes in the subtree (nodes other than the root)
-    /// do satisfy the max heap property.
-    fun max_heapify_recursive<T: drop>(v: &mut vector<Entry<T>>, len: u64, i: u64) {
-        if (len == 0) {
-            return
-        };
-        assert!(i < len, 1);
-        let left = i * 2 + 1;
-        let right = left + 1;
-        let mut max = i;
-        // Find the node with highest priority among node `i` and its two children.
-        if (left < len && *&v[left].priority > *&v[max].priority) {
-            max = left;
-        };
-        if (right < len && *&v[right].priority > *&v[max].priority) {
-            max = right;
-        };
-        // If the parent node (node `i`) doesn't have the highest priority, we swap the parent with the
-        // max priority node.
-        if (max != i) {
-            v.swap(max, i);
-            // After the swap, we have restored the property at node `i` but now the max heap property
-            // may be violated at node `max` since this node now has a new value. So we need to now
-            // max heapify the subtree rooted at node `max`.
-            max_heapify_recursive(v, len, max);
-        }
-    }
-
-    public fun priorities<T: drop>(pq: &PriorityQueue<T>): vector<u64> {
-        let mut res = vector[];
-        let mut i = 0;
-        while (i < pq.entries.length()) {
-            res.push_back(pq.entries[i].priority);
-            i = i +1;
-        };
-        res
-    }
-
-    #[test]
-    fun test_pq() {
-        let mut h = new(create_entries(vector[3,1,4,2,5,2], vector[10, 20, 30, 40, 50, 60]));
-        check_pop_max(&mut h, 5, 50);
-        check_pop_max(&mut h, 4, 30);
-        check_pop_max(&mut h, 3, 10);
-        insert(&mut h, 7, 70);
-        check_pop_max(&mut h, 7, 70);
-        check_pop_max(&mut h, 2, 40);
-        insert(&mut h, 0, 80);
-        check_pop_max(&mut h, 2, 60);
-        check_pop_max(&mut h, 1, 20);
-        check_pop_max(&mut h, 0, 80);
-
-
-        let mut h = new(create_entries(vector[5,3,1,2,4], vector[10, 20, 30, 40, 50]));
-        check_pop_max(&mut h, 5, 10);
-        check_pop_max(&mut h, 4, 50);
-        check_pop_max(&mut h, 3, 20);
-        check_pop_max(&mut h, 2, 40);
-        check_pop_max(&mut h, 1, 30);
-    }
-
-    #[test]
-    fun test_swap_remove_edge_case() {
-        // This test would fail if `remove` is used incorrectly instead of `swap_remove` in `pop_max`.
-        // It's hard to characterize exactly under what condition this bug is triggered but roughly
-        // it happens when the entire tree vector is shifted left by one because of the incorrect usage
-        // of `remove`, and the resulting new root and its two children appear to satisfy the heap invariant
-        // so we stop max-heapifying there, while the rest of the tree is all messed up because of the shift.
-        let priorities = vector[8, 7, 3, 6, 2, 1, 0, 5, 4];
-        let values = vector[0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let mut h = new(create_entries(priorities, values));
-        check_pop_max(&mut h, 8, 0);
-        check_pop_max(&mut h, 7, 0);
-        check_pop_max(&mut h, 6, 0);
-        check_pop_max(&mut h, 5, 0);
-        check_pop_max(&mut h, 4, 0);
-        check_pop_max(&mut h, 3, 0);
-        check_pop_max(&mut h, 2, 0);
-        check_pop_max(&mut h, 1, 0);
-        check_pop_max(&mut h, 0, 0);
-    }
-
-    #[test_only]
-    fun check_pop_max(h: &mut PriorityQueue<u64>, expected_priority: u64, expected_value: u64) {
-        let (priority, value) = pop_max(h);
-        assert!(priority == expected_priority);
-        assert!(value == expected_value);
-    }
+#[test_only]
+fun check_pop_max(h: &mut PriorityQueue<u64>, expected_priority: u64, expected_value: u64) {
+    let (priority, value) = pop_max(h);
+    assert!(priority == expected_priority);
+    assert!(value == expected_value);
 }

--- a/crates/sui-framework/packages/sui-framework/sources/table.move
+++ b/crates/sui-framework/packages/sui-framework/sources/table.move
@@ -16,87 +16,87 @@
 /// // table1 does not equal table2, despite having the same entries
 /// assert!(&table1 != &table2);
 /// ```
-module sui::table {
-    use sui::dynamic_field as field;
+module sui::table;
 
-    // Attempted to destroy a non-empty table
-    const ETableNotEmpty: u64 = 0;
+use sui::dynamic_field as field;
 
-    public struct Table<phantom K: copy + drop + store, phantom V: store> has key, store {
-        /// the ID of this table
-        id: UID,
-        /// the number of key-value pairs in the table
-        size: u64,
+// Attempted to destroy a non-empty table
+const ETableNotEmpty: u64 = 0;
+
+public struct Table<phantom K: copy + drop + store, phantom V: store> has key, store {
+    /// the ID of this table
+    id: UID,
+    /// the number of key-value pairs in the table
+    size: u64,
+}
+
+/// Creates a new, empty table
+public fun new<K: copy + drop + store, V: store>(ctx: &mut TxContext): Table<K, V> {
+    Table {
+        id: object::new(ctx),
+        size: 0,
     }
+}
 
-    /// Creates a new, empty table
-    public fun new<K: copy + drop + store, V: store>(ctx: &mut TxContext): Table<K, V> {
-        Table {
-            id: object::new(ctx),
-            size: 0,
-        }
-    }
+/// Adds a key-value pair to the table `table: &mut Table<K, V>`
+/// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
+/// that key `k: K`.
+public fun add<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K, v: V) {
+    field::add(&mut table.id, k, v);
+    table.size = table.size + 1;
+}
 
-    /// Adds a key-value pair to the table `table: &mut Table<K, V>`
-    /// Aborts with `sui::dynamic_field::EFieldAlreadyExists` if the table already has an entry with
-    /// that key `k: K`.
-    public fun add<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K, v: V) {
-        field::add(&mut table.id, k, v);
-        table.size = table.size + 1;
-    }
+#[syntax(index)]
+/// Immutable borrows the value associated with the key in the table `table: &Table<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow<K: copy + drop + store, V: store>(table: &Table<K, V>, k: K): &V {
+    field::borrow(&table.id, k)
+}
 
-    #[syntax(index)]
-    /// Immutable borrows the value associated with the key in the table `table: &Table<K, V>`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun borrow<K: copy + drop + store, V: store>(table: &Table<K, V>, k: K): &V {
-        field::borrow(&table.id, k)
-    }
+#[syntax(index)]
+/// Mutably borrows the value associated with the key in the table `table: &mut Table<K, V>`.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun borrow_mut<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K): &mut V {
+    field::borrow_mut(&mut table.id, k)
+}
 
-    #[syntax(index)]
-    /// Mutably borrows the value associated with the key in the table `table: &mut Table<K, V>`.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun borrow_mut<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K): &mut V {
-        field::borrow_mut(&mut table.id, k)
-    }
+/// Removes the key-value pair in the table `table: &mut Table<K, V>` and returns the value.
+/// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
+/// that key `k: K`.
+public fun remove<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K): V {
+    let v = field::remove(&mut table.id, k);
+    table.size = table.size - 1;
+    v
+}
 
-    /// Removes the key-value pair in the table `table: &mut Table<K, V>` and returns the value.
-    /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the table does not have an entry with
-    /// that key `k: K`.
-    public fun remove<K: copy + drop + store, V: store>(table: &mut Table<K, V>, k: K): V {
-        let v = field::remove(&mut table.id, k);
-        table.size = table.size - 1;
-        v
-    }
+/// Returns true iff there is a value associated with the key `k: K` in table `table: &Table<K, V>`
+public fun contains<K: copy + drop + store, V: store>(table: &Table<K, V>, k: K): bool {
+    field::exists_with_type<K, V>(&table.id, k)
+}
 
-    /// Returns true iff there is a value associated with the key `k: K` in table `table: &Table<K, V>`
-    public fun contains<K: copy + drop + store, V: store>(table: &Table<K, V>, k: K): bool {
-        field::exists_with_type<K, V>(&table.id, k)
-    }
+/// Returns the size of the table, the number of key-value pairs
+public fun length<K: copy + drop + store, V: store>(table: &Table<K, V>): u64 {
+    table.size
+}
 
-    /// Returns the size of the table, the number of key-value pairs
-    public fun length<K: copy + drop + store, V: store>(table: &Table<K, V>): u64 {
-        table.size
-    }
+/// Returns true iff the table is empty (if `length` returns `0`)
+public fun is_empty<K: copy + drop + store, V: store>(table: &Table<K, V>): bool {
+    table.size == 0
+}
 
-    /// Returns true iff the table is empty (if `length` returns `0`)
-    public fun is_empty<K: copy + drop + store, V: store>(table: &Table<K, V>): bool {
-        table.size == 0
-    }
+/// Destroys an empty table
+/// Aborts with `ETableNotEmpty` if the table still contains values
+public fun destroy_empty<K: copy + drop + store, V: store>(table: Table<K, V>) {
+    let Table { id, size } = table;
+    assert!(size == 0, ETableNotEmpty);
+    id.delete()
+}
 
-    /// Destroys an empty table
-    /// Aborts with `ETableNotEmpty` if the table still contains values
-    public fun destroy_empty<K: copy + drop + store, V: store>(table: Table<K, V>) {
-        let Table { id, size } = table;
-        assert!(size == 0, ETableNotEmpty);
-        id.delete()
-    }
-
-    /// Drop a possibly non-empty table.
-    /// Usable only if the value type `V` has the `drop` ability
-    public fun drop<K: copy + drop + store, V: drop + store>(table: Table<K, V>) {
-        let Table { id, size: _ } = table;
-        id.delete()
-    }
+/// Drop a possibly non-empty table.
+/// Usable only if the value type `V` has the `drop` ability
+public fun drop<K: copy + drop + store, V: drop + store>(table: Table<K, V>) {
+    let Table { id, size: _ } = table;
+    id.delete()
 }

--- a/crates/sui-framework/packages/sui-framework/sources/table_vec.move
+++ b/crates/sui-framework/packages/sui-framework/sources/table_vec.move
@@ -2,129 +2,130 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// A basic scalable vector library implemented using `Table`.
-module sui::table_vec {
-    use sui::table::{Self, Table};
+module sui::table_vec;
 
-    public struct TableVec<phantom Element: store> has store {
-        /// The contents of the table vector.
-        contents: Table<u64, Element>,
+use sui::table::{Self, Table};
+
+public struct TableVec<phantom Element: store> has store {
+    /// The contents of the table vector.
+    contents: Table<u64, Element>,
+}
+
+const EIndexOutOfBound: u64 = 0;
+const ETableNonEmpty: u64 = 1;
+
+/// Create an empty TableVec.
+public fun empty<Element: store>(ctx: &mut TxContext): TableVec<Element> {
+    TableVec {
+        contents: table::new(ctx),
     }
+}
 
-    const EIndexOutOfBound: u64 = 0;
-    const ETableNonEmpty: u64 = 1;
+/// Return a TableVec of size one containing element `e`.
+public fun singleton<Element: store>(e: Element, ctx: &mut TxContext): TableVec<Element> {
+    let mut t = empty(ctx);
+    t.push_back(e);
+    t
+}
 
-    /// Create an empty TableVec.
-    public fun empty<Element: store>(ctx: &mut TxContext): TableVec<Element> {
-        TableVec {
-            contents: table::new(ctx)
-        }
-    }
+/// Return the length of the TableVec.
+public fun length<Element: store>(t: &TableVec<Element>): u64 {
+    t.contents.length()
+}
 
-    /// Return a TableVec of size one containing element `e`.
-    public fun singleton<Element: store>(e: Element, ctx: &mut TxContext): TableVec<Element> {
-        let mut t = empty(ctx);
-        t.push_back(e);
-        t
-    }
+/// Return if the TableVec is empty or not.
+public fun is_empty<Element: store>(t: &TableVec<Element>): bool {
+    t.length() == 0
+}
 
-    /// Return the length of the TableVec.
-    public fun length<Element: store>(t: &TableVec<Element>): u64 {
-        t.contents.length()
-    }
+#[syntax(index)]
+/// Acquire an immutable reference to the `i`th element of the TableVec `t`.
+/// Aborts if `i` is out of bounds.
+public fun borrow<Element: store>(t: &TableVec<Element>, i: u64): &Element {
+    assert!(t.length() > i, EIndexOutOfBound);
+    &t.contents[i]
+}
 
-    /// Return if the TableVec is empty or not.
-    public fun is_empty<Element: store>(t: &TableVec<Element>): bool {
-        t.length() == 0
-    }
+/// Add element `e` to the end of the TableVec `t`.
+public fun push_back<Element: store>(t: &mut TableVec<Element>, e: Element) {
+    let key = t.length();
+    t.contents.add(key, e);
+}
 
-    #[syntax(index)]
-    /// Acquire an immutable reference to the `i`th element of the TableVec `t`.
-    /// Aborts if `i` is out of bounds.
-    public fun borrow<Element: store>(t: &TableVec<Element>, i: u64): &Element {
-        assert!(t.length() > i, EIndexOutOfBound);
-        &t.contents[i]
-    }
+#[syntax(index)]
+/// Return a mutable reference to the `i`th element in the TableVec `t`.
+/// Aborts if `i` is out of bounds.
+public fun borrow_mut<Element: store>(t: &mut TableVec<Element>, i: u64): &mut Element {
+    assert!(t.length() > i, EIndexOutOfBound);
+    &mut t.contents[i]
+}
 
-    /// Add element `e` to the end of the TableVec `t`.
-    public fun push_back<Element: store>(t: &mut TableVec<Element>, e: Element) {
-        let key = t.length();
-        t.contents.add(key, e);
-    }
+/// Pop an element from the end of TableVec `t`.
+/// Aborts if `t` is empty.
+public fun pop_back<Element: store>(t: &mut TableVec<Element>): Element {
+    let length = length(t);
+    assert!(length > 0, EIndexOutOfBound);
+    t.contents.remove(length - 1)
+}
 
-    #[syntax(index)]
-    /// Return a mutable reference to the `i`th element in the TableVec `t`.
-    /// Aborts if `i` is out of bounds.
-    public fun borrow_mut<Element: store>(t: &mut TableVec<Element>, i: u64): &mut Element {
-        assert!(t.length() > i, EIndexOutOfBound);
-        &mut t.contents[i]
-    }
+/// Destroy the TableVec `t`.
+/// Aborts if `t` is not empty.
+public fun destroy_empty<Element: store>(t: TableVec<Element>) {
+    assert!(length(&t) == 0, ETableNonEmpty);
+    let TableVec { contents } = t;
+    contents.destroy_empty();
+}
 
-    /// Pop an element from the end of TableVec `t`.
-    /// Aborts if `t` is empty.
-    public fun pop_back<Element: store>(t: &mut TableVec<Element>): Element {
-        let length = length(t);
-        assert!(length > 0, EIndexOutOfBound);
-        t.contents.remove(length - 1)
-    }
+/// Drop a possibly non-empty TableVec `t`.
+/// Usable only if the value type `Element` has the `drop` ability
+public fun drop<Element: drop + store>(t: TableVec<Element>) {
+    let TableVec { contents } = t;
+    contents.drop()
+}
 
-    /// Destroy the TableVec `t`.
-    /// Aborts if `t` is not empty.
-    public fun destroy_empty<Element: store>(t: TableVec<Element>) {
-        assert!(length(&t) == 0, ETableNonEmpty);
-        let TableVec { contents } = t;
-        contents.destroy_empty();
-    }
+/// Swaps the elements at the `i`th and `j`th indices in the TableVec `t`.
+/// Aborts if `i` or `j` is out of bounds.
+public fun swap<Element: store>(t: &mut TableVec<Element>, i: u64, j: u64) {
+    assert!(t.length() > i, EIndexOutOfBound);
+    assert!(t.length() > j, EIndexOutOfBound);
+    if (i == j) {
+        return
+    };
+    let element_i = t.contents.remove(i);
+    let element_j = t.contents.remove(j);
+    t.contents.add(j, element_i);
+    t.contents.add(i, element_j);
+}
 
-    /// Drop a possibly non-empty TableVec `t`.
-    /// Usable only if the value type `Element` has the `drop` ability
-    public fun drop<Element: drop + store>(t: TableVec<Element>) {
-        let TableVec { contents } = t;
-        contents.drop()
-    }
+/// Swap the `i`th element of the TableVec `t` with the last element and then pop the TableVec.
+/// This is O(1), but does not preserve ordering of elements in the TableVec.
+/// Aborts if `i` is out of bounds.
+public fun swap_remove<Element: store>(t: &mut TableVec<Element>, i: u64): Element {
+    assert!(t.length() > i, EIndexOutOfBound);
+    let last_idx = t.length() - 1;
+    t.swap(i, last_idx);
+    t.pop_back()
+}
 
-    /// Swaps the elements at the `i`th and `j`th indices in the TableVec `t`.
-    /// Aborts if `i` or `j` is out of bounds.
-    public fun swap<Element: store>(t: &mut TableVec<Element>, i: u64, j: u64) {
-        assert!(t.length() > i, EIndexOutOfBound);
-        assert!(t.length() > j, EIndexOutOfBound);
-        if (i == j) { return };
-        let element_i = t.contents.remove(i);
-        let element_j = t.contents.remove(j);
-        t.contents.add(j, element_i);
-        t.contents.add(i, element_j);
-    }
+#[test]
+fun test_swap() {
+    let ctx = &mut sui::tx_context::dummy();
+    let mut tv = singleton(0, ctx);
+    tv.push_back(1);
+    tv.push_back(2);
+    tv.push_back(3);
+    tv.push_back(4);
+    tv.swap(4, 2);
+    tv.check_pop(2);
+    tv.check_pop(3);
+    tv.check_pop(4);
+    tv.check_pop(1);
+    tv.check_pop(0);
+    tv.drop()
+}
 
-    /// Swap the `i`th element of the TableVec `t` with the last element and then pop the TableVec.
-    /// This is O(1), but does not preserve ordering of elements in the TableVec.
-    /// Aborts if `i` is out of bounds.
-    public fun swap_remove<Element: store>(t: &mut TableVec<Element>, i: u64): Element {
-        assert!(t.length() > i, EIndexOutOfBound);
-        let last_idx = t.length() - 1;
-        t.swap(i, last_idx);
-        t.pop_back()
-    }
-
-    #[test]
-    fun test_swap() {
-        let ctx = &mut sui::tx_context::dummy();
-        let mut tv = singleton(0, ctx);
-        tv.push_back(1);
-        tv.push_back(2);
-        tv.push_back(3);
-        tv.push_back(4);
-        tv.swap(4,2);
-        tv.check_pop(2);
-        tv.check_pop(3);
-        tv.check_pop(4);
-        tv.check_pop(1);
-        tv.check_pop(0);
-        tv.drop()
-    }
-
-    #[test_only]
-    fun check_pop(tv: &mut TableVec<u64>, expected_value: u64) {
-        let value = tv.pop_back();
-        assert!(value == expected_value, value * 100 + expected_value);
-    }
-
+#[test_only]
+fun check_pop(tv: &mut TableVec<u64>, expected_value: u64) {
+    let value = tv.pop_back();
+    assert!(value == expected_value, value * 100 + expected_value);
 }

--- a/crates/sui-framework/packages/sui-framework/sources/vec_map.move
+++ b/crates/sui-framework/packages/sui-framework/sources/vec_map.move
@@ -1,217 +1,213 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module sui::vec_map {
+module sui::vec_map;
 
-    /// This key already exists in the map
-    const EKeyAlreadyExists: u64 = 0;
+/// This key already exists in the map
+const EKeyAlreadyExists: u64 = 0;
 
-    /// This key does not exist in the map
-    const EKeyDoesNotExist: u64 = 1;
+/// This key does not exist in the map
+const EKeyDoesNotExist: u64 = 1;
 
-    /// Trying to destroy a map that is not empty
-    const EMapNotEmpty: u64 = 2;
+/// Trying to destroy a map that is not empty
+const EMapNotEmpty: u64 = 2;
 
-    /// Trying to access an element of the map at an invalid index
-    const EIndexOutOfBounds: u64 = 3;
+/// Trying to access an element of the map at an invalid index
+const EIndexOutOfBounds: u64 = 3;
 
-    /// Trying to pop from a map that is empty
-    const EMapEmpty: u64 = 4;
+/// Trying to pop from a map that is empty
+const EMapEmpty: u64 = 4;
 
-    /// Trying to construct a map from keys and values of different lengths
-    const EUnequalLengths: u64 = 5;
+/// Trying to construct a map from keys and values of different lengths
+const EUnequalLengths: u64 = 5;
 
-    /// A map data structure backed by a vector. The map is guaranteed not to contain duplicate keys, but entries
-    /// are *not* sorted by key--entries are included in insertion order.
-    /// All operations are O(N) in the size of the map--the intention of this data structure is only to provide
-    /// the convenience of programming against a map API.
-    /// Large maps should use handwritten parent/child relationships instead.
-    /// Maps that need sorted iteration rather than insertion order iteration should also be handwritten.
-    public struct VecMap<K: copy, V> has copy, drop, store {
-        contents: vector<Entry<K, V>>,
-    }
+/// A map data structure backed by a vector. The map is guaranteed not to contain duplicate keys, but entries
+/// are *not* sorted by key--entries are included in insertion order.
+/// All operations are O(N) in the size of the map--the intention of this data structure is only to provide
+/// the convenience of programming against a map API.
+/// Large maps should use handwritten parent/child relationships instead.
+/// Maps that need sorted iteration rather than insertion order iteration should also be handwritten.
+public struct VecMap<K: copy, V> has copy, drop, store {
+    contents: vector<Entry<K, V>>,
+}
 
-    /// An entry in the map
-    public struct Entry<K: copy, V> has copy, drop, store {
-        key: K,
-        value: V,
-    }
+/// An entry in the map
+public struct Entry<K: copy, V> has copy, drop, store {
+    key: K,
+    value: V,
+}
 
-    /// Create an empty `VecMap`
-    public fun empty<K: copy, V>(): VecMap<K,V> {
-        VecMap { contents: vector[] }
-    }
+/// Create an empty `VecMap`
+public fun empty<K: copy, V>(): VecMap<K, V> {
+    VecMap { contents: vector[] }
+}
 
-    /// Insert the entry `key` |-> `value` into `self`.
-    /// Aborts if `key` is already bound in `self`.
-    public fun insert<K: copy, V>(self: &mut VecMap<K,V>, key: K, value: V) {
-        assert!(!self.contains(&key), EKeyAlreadyExists);
-        self.contents.push_back(Entry { key, value })
-    }
+/// Insert the entry `key` |-> `value` into `self`.
+/// Aborts if `key` is already bound in `self`.
+public fun insert<K: copy, V>(self: &mut VecMap<K, V>, key: K, value: V) {
+    assert!(!self.contains(&key), EKeyAlreadyExists);
+    self.contents.push_back(Entry { key, value })
+}
 
-    /// Remove the entry `key` |-> `value` from self. Aborts if `key` is not bound in `self`.
-    public fun remove<K: copy, V>(self: &mut VecMap<K,V>, key: &K): (K, V) {
-        let idx = self.get_idx(key);
-        let Entry { key, value } = self.contents.remove(idx);
-        (key, value)
-    }
+/// Remove the entry `key` |-> `value` from self. Aborts if `key` is not bound in `self`.
+public fun remove<K: copy, V>(self: &mut VecMap<K, V>, key: &K): (K, V) {
+    let idx = self.get_idx(key);
+    let Entry { key, value } = self.contents.remove(idx);
+    (key, value)
+}
 
-    /// Pop the most recently inserted entry from the map. Aborts if the map is empty.
-    public fun pop<K: copy, V>(self: &mut VecMap<K,V>): (K, V) {
-        assert!(!self.contents.is_empty(), EMapEmpty);
-        let Entry { key, value } = self.contents.pop_back();
-        (key, value)
-    }
+/// Pop the most recently inserted entry from the map. Aborts if the map is empty.
+public fun pop<K: copy, V>(self: &mut VecMap<K, V>): (K, V) {
+    assert!(!self.contents.is_empty(), EMapEmpty);
+    let Entry { key, value } = self.contents.pop_back();
+    (key, value)
+}
 
-    #[syntax(index)]
-    /// Get a mutable reference to the value bound to `key` in `self`.
-    /// Aborts if `key` is not bound in `self`.
-    public fun get_mut<K: copy, V>(self: &mut VecMap<K,V>, key: &K): &mut V {
-        let idx = self.get_idx(key);
-        let entry = &mut self.contents[idx];
-        &mut entry.value
-    }
+#[syntax(index)]
+/// Get a mutable reference to the value bound to `key` in `self`.
+/// Aborts if `key` is not bound in `self`.
+public fun get_mut<K: copy, V>(self: &mut VecMap<K, V>, key: &K): &mut V {
+    let idx = self.get_idx(key);
+    let entry = &mut self.contents[idx];
+    &mut entry.value
+}
 
-    #[syntax(index)]
-    /// Get a reference to the value bound to `key` in `self`.
-    /// Aborts if `key` is not bound in `self`.
-    public fun get<K: copy, V>(self: &VecMap<K,V>, key: &K): &V {
-        let idx = self.get_idx(key);
-        let entry = &self.contents[idx];
-        &entry.value
-    }
+#[syntax(index)]
+/// Get a reference to the value bound to `key` in `self`.
+/// Aborts if `key` is not bound in `self`.
+public fun get<K: copy, V>(self: &VecMap<K, V>, key: &K): &V {
+    let idx = self.get_idx(key);
+    let entry = &self.contents[idx];
+    &entry.value
+}
 
-    /// Safely try borrow a value bound to `key` in `self`.
-    /// Return Some(V) if the value exists, None otherwise.
-    /// Only works for a "copyable" value as references cannot be stored in `vector`.
-    public fun try_get<K: copy, V: copy>(self: &VecMap<K,V>, key: &K): Option<V> {
-        if (self.contains(key)) {
-            option::some(*get(self, key))
-        } else {
-            option::none()
-        }
-    }
-
-    /// Return true if `self` contains an entry for `key`, false otherwise
-    public fun contains<K: copy, V>(self: &VecMap<K, V>, key: &K): bool {
-        get_idx_opt(self, key).is_some()
-    }
-
-    /// Return the number of entries in `self`
-    public fun size<K: copy, V>(self: &VecMap<K,V>): u64 {
-        self.contents.length()
-    }
-
-    /// Return true if `self` has 0 elements, false otherwise
-    public fun is_empty<K: copy, V>(self: &VecMap<K,V>): bool {
-        self.size() == 0
-    }
-
-    /// Destroy an empty map. Aborts if `self` is not empty
-    public fun destroy_empty<K: copy, V>(self: VecMap<K, V>) {
-        let VecMap { contents } = self;
-        assert!(contents.is_empty(), EMapNotEmpty);
-        contents.destroy_empty()
-    }
-
-    /// Unpack `self` into vectors of its keys and values.
-    /// The output keys and values are stored in insertion order, *not* sorted by key.
-    public fun into_keys_values<K: copy, V>(self: VecMap<K, V>): (vector<K>, vector<V>) {
-        let VecMap { mut contents } = self;
-        // reverse the vector so the output keys and values will appear in insertion order
-        contents.reverse();
-        let mut i = 0;
-        let n = contents.length();
-        let mut keys = vector[];
-        let mut values = vector[];
-        while (i < n) {
-            let Entry { key, value } = contents.pop_back();
-            keys.push_back(key);
-            values.push_back(value);
-            i = i + 1;
-        };
-        contents.destroy_empty();
-        (keys, values)
-    }
-
-    /// Construct a new `VecMap` from two vectors, one for keys and one for values.
-    /// The key value pairs are associated via their indices in the vectors, e.g. the key at index i
-    /// in `keys` is associated with the value at index i in `values`.
-    /// The key value pairs are stored in insertion order (the original vectors ordering)
-    /// and are *not* sorted.
-    public fun from_keys_values<K: copy, V>(
-        mut keys: vector<K>,
-        mut values: vector<V>,
-    ): VecMap<K, V> {
-        assert!(keys.length() == values.length(), EUnequalLengths);
-        keys.reverse();
-        values.reverse();
-        let mut map = empty();
-        while (!keys.is_empty()) map.insert(keys.pop_back(), values.pop_back());
-        keys.destroy_empty();
-        values.destroy_empty();
-        map
-    }
-
-    /// Returns a list of keys in the map.
-    /// Do not assume any particular ordering.
-    public fun keys<K: copy, V>(self: &VecMap<K, V>): vector<K> {
-        let mut i = 0;
-        let n = self.contents.length();
-        let mut keys = vector[];
-        while (i < n) {
-            let entry = self.contents.borrow(i);
-            keys.push_back(entry.key);
-            i = i + 1;
-        };
-        keys
-    }
-
-    /// Find the index of `key` in `self`. Return `None` if `key` is not in `self`.
-    /// Note that map entries are stored in insertion order, *not* sorted by key.
-    public fun get_idx_opt<K: copy, V>(self: &VecMap<K,V>, key: &K): Option<u64> {
-        let mut i = 0;
-        let n = size(self);
-        while (i < n) {
-            if (&self.contents[i].key == key) {
-                return option::some(i)
-            };
-            i = i + 1;
-        };
+/// Safely try borrow a value bound to `key` in `self`.
+/// Return Some(V) if the value exists, None otherwise.
+/// Only works for a "copyable" value as references cannot be stored in `vector`.
+public fun try_get<K: copy, V: copy>(self: &VecMap<K, V>, key: &K): Option<V> {
+    if (self.contains(key)) {
+        option::some(*get(self, key))
+    } else {
         option::none()
     }
+}
 
-    /// Find the index of `key` in `self`. Aborts if `key` is not in `self`.
-    /// Note that map entries are stored in insertion order, *not* sorted by key.
-    public fun get_idx<K: copy, V>(self: &VecMap<K,V>, key: &K): u64 {
-        let idx_opt = self.get_idx_opt(key);
-        assert!(idx_opt.is_some(), EKeyDoesNotExist);
-        idx_opt.destroy_some()
-    }
+/// Return true if `self` contains an entry for `key`, false otherwise
+public fun contains<K: copy, V>(self: &VecMap<K, V>, key: &K): bool {
+    get_idx_opt(self, key).is_some()
+}
 
-    /// Return a reference to the `idx`th entry of `self`. This gives direct access into the backing array of the map--use with caution.
-    /// Note that map entries are stored in insertion order, *not* sorted by key.
-    /// Aborts if `idx` is greater than or equal to `size(self)`
-    public fun get_entry_by_idx<K: copy, V>(self: &VecMap<K, V>, idx: u64): (&K, &V) {
-        assert!(idx < size(self), EIndexOutOfBounds);
-        let entry = &self.contents[idx];
-        (&entry.key, &entry.value)
-    }
+/// Return the number of entries in `self`
+public fun size<K: copy, V>(self: &VecMap<K, V>): u64 {
+    self.contents.length()
+}
 
-    /// Return a mutable reference to the `idx`th entry of `self`. This gives direct access into the backing array of the map--use with caution.
-    /// Note that map entries are stored in insertion order, *not* sorted by key.
-    /// Aborts if `idx` is greater than or equal to `size(self)`
-    public fun get_entry_by_idx_mut<K: copy, V>(self: &mut VecMap<K, V>, idx: u64): (&K, &mut V) {
-        assert!(idx < size(self), EIndexOutOfBounds);
-        let entry = &mut self.contents[idx];
-        (&entry.key, &mut entry.value)
-    }
+/// Return true if `self` has 0 elements, false otherwise
+public fun is_empty<K: copy, V>(self: &VecMap<K, V>): bool {
+    self.size() == 0
+}
 
-    /// Remove the entry at index `idx` from self.
-    /// Aborts if `idx` is greater than or equal to `size(self)`
-    public fun remove_entry_by_idx<K: copy, V>(self: &mut VecMap<K, V>, idx: u64): (K, V) {
-        assert!(idx < size(self), EIndexOutOfBounds);
-        let Entry { key, value } = self.contents.remove(idx);
-        (key, value)
-    }
+/// Destroy an empty map. Aborts if `self` is not empty
+public fun destroy_empty<K: copy, V>(self: VecMap<K, V>) {
+    let VecMap { contents } = self;
+    assert!(contents.is_empty(), EMapNotEmpty);
+    contents.destroy_empty()
+}
+
+/// Unpack `self` into vectors of its keys and values.
+/// The output keys and values are stored in insertion order, *not* sorted by key.
+public fun into_keys_values<K: copy, V>(self: VecMap<K, V>): (vector<K>, vector<V>) {
+    let VecMap { mut contents } = self;
+    // reverse the vector so the output keys and values will appear in insertion order
+    contents.reverse();
+    let mut i = 0;
+    let n = contents.length();
+    let mut keys = vector[];
+    let mut values = vector[];
+    while (i < n) {
+        let Entry { key, value } = contents.pop_back();
+        keys.push_back(key);
+        values.push_back(value);
+        i = i + 1;
+    };
+    contents.destroy_empty();
+    (keys, values)
+}
+
+/// Construct a new `VecMap` from two vectors, one for keys and one for values.
+/// The key value pairs are associated via their indices in the vectors, e.g. the key at index i
+/// in `keys` is associated with the value at index i in `values`.
+/// The key value pairs are stored in insertion order (the original vectors ordering)
+/// and are *not* sorted.
+public fun from_keys_values<K: copy, V>(mut keys: vector<K>, mut values: vector<V>): VecMap<K, V> {
+    assert!(keys.length() == values.length(), EUnequalLengths);
+    keys.reverse();
+    values.reverse();
+    let mut map = empty();
+    while (!keys.is_empty()) map.insert(keys.pop_back(), values.pop_back());
+    keys.destroy_empty();
+    values.destroy_empty();
+    map
+}
+
+/// Returns a list of keys in the map.
+/// Do not assume any particular ordering.
+public fun keys<K: copy, V>(self: &VecMap<K, V>): vector<K> {
+    let mut i = 0;
+    let n = self.contents.length();
+    let mut keys = vector[];
+    while (i < n) {
+        let entry = self.contents.borrow(i);
+        keys.push_back(entry.key);
+        i = i + 1;
+    };
+    keys
+}
+
+/// Find the index of `key` in `self`. Return `None` if `key` is not in `self`.
+/// Note that map entries are stored in insertion order, *not* sorted by key.
+public fun get_idx_opt<K: copy, V>(self: &VecMap<K, V>, key: &K): Option<u64> {
+    let mut i = 0;
+    let n = size(self);
+    while (i < n) {
+        if (&self.contents[i].key == key) {
+            return option::some(i)
+        };
+        i = i + 1;
+    };
+    option::none()
+}
+
+/// Find the index of `key` in `self`. Aborts if `key` is not in `self`.
+/// Note that map entries are stored in insertion order, *not* sorted by key.
+public fun get_idx<K: copy, V>(self: &VecMap<K, V>, key: &K): u64 {
+    let idx_opt = self.get_idx_opt(key);
+    assert!(idx_opt.is_some(), EKeyDoesNotExist);
+    idx_opt.destroy_some()
+}
+
+/// Return a reference to the `idx`th entry of `self`. This gives direct access into the backing array of the map--use with caution.
+/// Note that map entries are stored in insertion order, *not* sorted by key.
+/// Aborts if `idx` is greater than or equal to `size(self)`
+public fun get_entry_by_idx<K: copy, V>(self: &VecMap<K, V>, idx: u64): (&K, &V) {
+    assert!(idx < size(self), EIndexOutOfBounds);
+    let entry = &self.contents[idx];
+    (&entry.key, &entry.value)
+}
+
+/// Return a mutable reference to the `idx`th entry of `self`. This gives direct access into the backing array of the map--use with caution.
+/// Note that map entries are stored in insertion order, *not* sorted by key.
+/// Aborts if `idx` is greater than or equal to `size(self)`
+public fun get_entry_by_idx_mut<K: copy, V>(self: &mut VecMap<K, V>, idx: u64): (&K, &mut V) {
+    assert!(idx < size(self), EIndexOutOfBounds);
+    let entry = &mut self.contents[idx];
+    (&entry.key, &mut entry.value)
+}
+
+/// Remove the entry at index `idx` from self.
+/// Aborts if `idx` is greater than or equal to `size(self)`
+public fun remove_entry_by_idx<K: copy, V>(self: &mut VecMap<K, V>, idx: u64): (K, V) {
+    assert!(idx < size(self), EIndexOutOfBounds);
+    let Entry { key, value } = self.contents.remove(idx);
+    (key, value)
 }

--- a/crates/sui-framework/packages/sui-framework/sources/vec_set.move
+++ b/crates/sui-framework/packages/sui-framework/sources/vec_set.move
@@ -1,106 +1,105 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module sui::vec_set {
+module sui::vec_set;
 
-    /// This key already exists in the map
-    const EKeyAlreadyExists: u64 = 0;
+/// This key already exists in the map
+const EKeyAlreadyExists: u64 = 0;
 
-    /// This key does not exist in the map
-    const EKeyDoesNotExist: u64 = 1;
+/// This key does not exist in the map
+const EKeyDoesNotExist: u64 = 1;
 
-    /// A set data structure backed by a vector. The set is guaranteed not to
-    /// contain duplicate keys. All operations are O(N) in the size of the set
-    /// - the intention of this data structure is only to provide the convenience
-    /// of programming against a set API. Sets that need sorted iteration rather
-    /// than insertion order iteration should be handwritten.
-    public struct VecSet<K: copy + drop> has copy, drop, store {
-        contents: vector<K>,
-    }
+/// A set data structure backed by a vector. The set is guaranteed not to
+/// contain duplicate keys. All operations are O(N) in the size of the set
+/// - the intention of this data structure is only to provide the convenience
+/// of programming against a set API. Sets that need sorted iteration rather
+/// than insertion order iteration should be handwritten.
+public struct VecSet<K: copy + drop> has copy, drop, store {
+    contents: vector<K>,
+}
 
-    /// Create an empty `VecSet`
-    public fun empty<K: copy + drop>(): VecSet<K> {
-        VecSet { contents: vector[] }
-    }
+/// Create an empty `VecSet`
+public fun empty<K: copy + drop>(): VecSet<K> {
+    VecSet { contents: vector[] }
+}
 
-    /// Create a singleton `VecSet` that only contains one element.
-    public fun singleton<K: copy + drop>(key: K): VecSet<K> {
-        VecSet { contents: vector[key] }
-    }
+/// Create a singleton `VecSet` that only contains one element.
+public fun singleton<K: copy + drop>(key: K): VecSet<K> {
+    VecSet { contents: vector[key] }
+}
 
-    /// Insert a `key` into self.
-    /// Aborts if `key` is already present in `self`.
-    public fun insert<K: copy + drop>(self: &mut VecSet<K>, key: K) {
-        assert!(!self.contains(&key), EKeyAlreadyExists);
-        self.contents.push_back(key)
-    }
+/// Insert a `key` into self.
+/// Aborts if `key` is already present in `self`.
+public fun insert<K: copy + drop>(self: &mut VecSet<K>, key: K) {
+    assert!(!self.contains(&key), EKeyAlreadyExists);
+    self.contents.push_back(key)
+}
 
-    /// Remove the entry `key` from self. Aborts if `key` is not present in `self`.
-    public fun remove<K: copy + drop>(self: &mut VecSet<K>, key: &K) {
-        let idx = get_idx(self, key);
-        self.contents.remove(idx);
-    }
+/// Remove the entry `key` from self. Aborts if `key` is not present in `self`.
+public fun remove<K: copy + drop>(self: &mut VecSet<K>, key: &K) {
+    let idx = get_idx(self, key);
+    self.contents.remove(idx);
+}
 
-    /// Return true if `self` contains an entry for `key`, false otherwise
-    public fun contains<K: copy + drop>(self: &VecSet<K>, key: &K): bool {
-        get_idx_opt(self, key).is_some()
-    }
+/// Return true if `self` contains an entry for `key`, false otherwise
+public fun contains<K: copy + drop>(self: &VecSet<K>, key: &K): bool {
+    get_idx_opt(self, key).is_some()
+}
 
-    /// Return the number of entries in `self`
-    public fun size<K: copy + drop>(self: &VecSet<K>): u64 {
-        self.contents.length()
-    }
+/// Return the number of entries in `self`
+public fun size<K: copy + drop>(self: &VecSet<K>): u64 {
+    self.contents.length()
+}
 
-    /// Return true if `self` has 0 elements, false otherwise
-    public fun is_empty<K: copy + drop>(self: &VecSet<K>): bool {
-        size(self) == 0
-    }
+/// Return true if `self` has 0 elements, false otherwise
+public fun is_empty<K: copy + drop>(self: &VecSet<K>): bool {
+    size(self) == 0
+}
 
-    /// Unpack `self` into vectors of keys.
-    /// The output keys are stored in insertion order, *not* sorted.
-    public fun into_keys<K: copy + drop>(self: VecSet<K>): vector<K> {
-        let VecSet { contents } = self;
-        contents
-    }
+/// Unpack `self` into vectors of keys.
+/// The output keys are stored in insertion order, *not* sorted.
+public fun into_keys<K: copy + drop>(self: VecSet<K>): vector<K> {
+    let VecSet { contents } = self;
+    contents
+}
 
-    /// Construct a new `VecSet` from a vector of keys.
-    /// The keys are stored in insertion order (the original `keys` ordering)
-    /// and are *not* sorted.
-    public fun from_keys<K: copy + drop>(mut keys: vector<K>): VecSet<K> {
-        keys.reverse();
-        let mut set = empty();
-        while (!keys.is_empty()) set.insert(keys.pop_back());
-        set
-    }
+/// Construct a new `VecSet` from a vector of keys.
+/// The keys are stored in insertion order (the original `keys` ordering)
+/// and are *not* sorted.
+public fun from_keys<K: copy + drop>(mut keys: vector<K>): VecSet<K> {
+    keys.reverse();
+    let mut set = empty();
+    while (!keys.is_empty()) set.insert(keys.pop_back());
+    set
+}
 
-    /// Borrow the `contents` of the `VecSet` to access content by index
-    /// without unpacking. The contents are stored in insertion order,
-    /// *not* sorted.
-    public fun keys<K: copy + drop>(self: &VecSet<K>): &vector<K> {
-        &self.contents
-    }
+/// Borrow the `contents` of the `VecSet` to access content by index
+/// without unpacking. The contents are stored in insertion order,
+/// *not* sorted.
+public fun keys<K: copy + drop>(self: &VecSet<K>): &vector<K> {
+    &self.contents
+}
 
-    // == Helper functions ==
+// == Helper functions ==
 
-    /// Find the index of `key` in `self`. Return `None` if `key` is not in `self`.
-    /// Note that keys are stored in insertion order, *not* sorted.
-    fun get_idx_opt<K: copy + drop>(self: &VecSet<K>, key: &K): Option<u64> {
-        let mut i = 0;
-        let n = size(self);
-        while (i < n) {
-            if (&self.contents[i] == key) {
-                return option::some(i)
-            };
-            i = i + 1;
+/// Find the index of `key` in `self`. Return `None` if `key` is not in `self`.
+/// Note that keys are stored in insertion order, *not* sorted.
+fun get_idx_opt<K: copy + drop>(self: &VecSet<K>, key: &K): Option<u64> {
+    let mut i = 0;
+    let n = size(self);
+    while (i < n) {
+        if (&self.contents[i] == key) {
+            return option::some(i)
         };
-        option::none()
-    }
+        i = i + 1;
+    };
+    option::none()
+}
 
-    /// Find the index of `key` in `self`. Aborts if `key` is not in `self`.
-    /// Note that map entries are stored in insertion order, *not* sorted.
-    fun get_idx<K: copy + drop>(self: &VecSet<K>, key: &K): u64 {
-        let idx_opt = get_idx_opt(self, key);
-        assert!(idx_opt.is_some(), EKeyDoesNotExist);
-        idx_opt.destroy_some()
-    }
+/// Find the index of `key` in `self`. Aborts if `key` is not in `self`.
+/// Note that map entries are stored in insertion order, *not* sorted.
+fun get_idx<K: copy + drop>(self: &VecSet<K>, key: &K): u64 {
+    let idx_opt = get_idx_opt(self, key);
+    assert!(idx_opt.is_some(), EKeyDoesNotExist);
+    idx_opt.destroy_some()
 }


### PR DESCRIPTION
## Description 

Another PR in the formatting series, covers collection modules and dynamic fields.

See also:

- #19496
- #19463  
- #19461 

## Test plan 

Tests must pass, framework must produce the same bytecode.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
