### PR TITLE
[cli] Make prerender clever errors to use context instead of client

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1645,8 +1645,7 @@ impl SuiClientCommands {
                 SuiClientCommandResult::NoOutput
             }
         };
-        let client = context.get_client().await?;
-        Ok(ret.prerender_clever_errors(client.read_api()).await)
+        Ok(ret.prerender_clever_errors(context).await)
     }
 
     pub fn switch_env(config: &mut SuiClientConfig, env: &str) -> Result<(), anyhow::Error> {
@@ -2297,13 +2296,16 @@ impl SuiClientCommandResult {
         }
     }
 
-    pub async fn prerender_clever_errors(mut self, read_api: &ReadApi) -> Self {
+    pub async fn prerender_clever_errors(mut self, context: &mut WalletContext) -> Self {
         match &mut self {
             SuiClientCommandResult::DryRun(DryRunTransactionBlockResponse { effects, .. })
             | SuiClientCommandResult::TransactionBlock(SuiTransactionBlockResponse {
                 effects: Some(effects),
                 ..
-            }) => prerender_clever_errors(effects, read_api).await,
+            }) => {
+                let client = context.get_client().await.expect("Cannot connect to RPC");
+                prerender_clever_errors(effects, client.read_api()).await
+            }
 
             SuiClientCommandResult::TransactionBlock(SuiTransactionBlockResponse {
                 effects: None,
@@ -2686,7 +2688,7 @@ fn format_balance(
 
 /// Helper function to reduce code duplication for executing dry run
 pub async fn execute_dry_run(
-    client: &SuiClient,
+    context: &mut WalletContext,
     signer: SuiAddress,
     kind: TransactionKind,
     gas_budget: Option<u64>,
@@ -2694,9 +2696,10 @@ pub async fn execute_dry_run(
     gas_payment: Option<Vec<ObjectID>>,
     sponsor: Option<SuiAddress>,
 ) -> Result<SuiClientCommandResult, anyhow::Error> {
+    let client = context.get_client().await?;
     let gas_budget = match gas_budget {
         Some(gas_budget) => gas_budget,
-        None => max_gas_budget(client).await?,
+        None => max_gas_budget(&client).await?,
     };
     let dry_run_tx_data = client
         .transaction_builder()
@@ -2710,7 +2713,7 @@ pub async fn execute_dry_run(
         .map_err(|e| anyhow!("Dry run failed: {e}"))?;
     debug!("Finished executing dry run");
     let resp = SuiClientCommandResult::DryRun(response)
-        .prerender_clever_errors(client.read_api())
+        .prerender_clever_errors(context)
         .await;
     Ok(resp)
 }
@@ -2726,15 +2729,16 @@ pub async fn execute_dry_run(
 /// This gas estimate is computed exactly as in the TypeScript SDK
 /// <https://github.com/MystenLabs/sui/blob/3c4369270605f78a243842098b7029daf8d883d9/sdk/typescript/src/transactions/TransactionBlock.ts#L845-L858>
 pub async fn estimate_gas_budget(
-    client: &SuiClient,
+    context: &mut WalletContext,
     signer: SuiAddress,
     kind: TransactionKind,
     gas_price: u64,
     gas_payment: Option<Vec<ObjectID>>,
     sponsor: Option<SuiAddress>,
 ) -> Result<u64, anyhow::Error> {
+    let client = context.get_client().await?;
     let Ok(SuiClientCommandResult::DryRun(dry_run)) =
-        execute_dry_run(client, signer, kind, None, gas_price, gas_payment, sponsor).await
+        execute_dry_run(context, signer, kind, None, gas_price, gas_payment, sponsor).await
     else {
         bail!("Could not automatically determine the gas budget. Please supply one using the --gas-budget flag.")
     };
@@ -2808,7 +2812,7 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
     let client = context.get_client().await?;
     if dry_run {
         return execute_dry_run(
-            &client,
+            context,
             signer,
             tx_kind,
             gas_budget,
@@ -2824,7 +2828,7 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         None => {
             debug!("Estimating gas budget");
             let budget = estimate_gas_budget(
-                &client,
+                context,
                 signer,
                 tx_kind.clone(),
                 gas_price,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -427,8 +427,8 @@ impl SuiCommand {
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
-                let mut context = WalletContext::new(&config_path, None, None)?;
                 if let Some(cmd) = cmd {
+                    let mut context = WalletContext::new(&config_path, None, None)?;
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
                     // Print help

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3762,7 +3762,7 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
     let sender = context.active_address().unwrap();
     let tx_builder = client.transaction_builder();
     let tx_kind = tx_builder.transfer_sui_tx_kind(address2, Some(amount));
-    let gas_estimate = estimate_gas_budget(&client, sender, tx_kind, rgp, None, None).await;
+    let gas_estimate = estimate_gas_budget(context, sender, tx_kind, rgp, None, None).await;
     assert!(gas_estimate.is_ok());
 
     let transfer_sui_cmd = SuiClientCommands::TransferSui {


### PR DESCRIPTION
## Description 

Fixes the issue that if the active env cannot be connected to, `active-env` and `envs` do not display the output but instead a low level network error appears.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixes an issue with `active-env` and `envs` commands that were not showing an output if the active RPC url was not correct.
- [ ] Rust SDK:
- [ ] REST API:
