### PR TITLE
move: ignore dependency entries in manifest with resolver

### DIFF
--- a/external-crates/move/crates/move-package/src/source_package/manifest_parser.rs
+++ b/external-crates/move/crates/move-package/src/source_package/manifest_parser.rs
@@ -338,14 +338,6 @@ pub fn parse_dependency(dep_id: &str, mut tval: TV) -> Result<PM::Dependency> {
         let Some(resolver) = resolver.as_str().map(Symbol::from) else {
             bail!("Resolver name is not a string")
         };
-
-        // Not relevant except for the external resolver, but remove it to mark it as a
-        // recognised part of the manifest.
-        let _ = table.remove("packages");
-
-        // Any fields that are left are unknown
-        warn_if_unknown_field_names(table, &[]);
-
         return Ok(PM::Dependency::External(resolver));
     }
 


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/19057.

Previously when parsing the `Move.toml` we expect that if a dependency entry contains a `resolver`, then it ought to contain a `packages` entry, and any `other` entries would generate a warning:

```
[dependencies]
stuff = { resolver = "foo", packages = <anything>, other = <more stuff> }
```

As of #19057 it's more appropriate to instead require no strict validation here, such that any dependency with `resolver` is free to choose other entries in it's table:

```
[dependencies]
stuff = { resolver = "foo", <whatever-you-want> }
```

## Test plan 

Tested manually that no warning is generated for packages other than `packages`. Since there aren't existing tests and this change makes the requirement less strict, and no functional uses, it's unclear if we need a rigorous test here.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
