### PR TITLE
move(visitor): expose underlying byte slice

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/df_handler.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use sui_data_ingestion_core::Worker;
 use sui_indexer::errors::IndexerError;
-use sui_types::SYSTEM_PACKAGE_ADDRESSES;
+use sui_types::object::bounded_visitor::BoundedVisitor;
+use sui_types::{TypeTag, SYSTEM_PACKAGE_ADDRESSES};
 use tap::tap::TapFallible;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -17,10 +18,11 @@ use sui_json_rpc_types::SuiMoveValue;
 use sui_package_resolver::Resolver;
 use sui_rest_api::{CheckpointData, CheckpointTransaction};
 use sui_types::base_types::ObjectID;
-use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType};
+use sui_types::dynamic_field::visitor as DFV;
+use sui_types::dynamic_field::{DynamicFieldName, DynamicFieldType};
 use sui_types::object::Object;
 
-use crate::handlers::{get_move_struct, AnalyticsHandler};
+use crate::handlers::AnalyticsHandler;
 use crate::package_store::{LocalDBPackageStore, PackageCache};
 use crate::tables::DynamicFieldEntry;
 use crate::FileType;
@@ -114,28 +116,23 @@ impl DynamicFieldHandler {
         if !move_object.type_().is_dynamic_field() {
             return Ok(());
         }
-        let move_struct = if let Some((tag, contents)) = object
-            .struct_tag()
-            .and_then(|tag| object.data.try_as_move().map(|mo| (tag, mo.contents())))
-        {
-            let move_struct = get_move_struct(&tag, contents, &state.resolver).await?;
-            Some(move_struct)
-        } else {
-            None
-        };
-        let Some(move_struct) = move_struct else {
-            return Ok(());
-        };
-        let (name_value, type_, object_id) =
-            DynamicFieldInfo::parse_move_object(&move_struct).tap_err(|e| warn!("{e}"))?;
-        let name_type = move_object.type_().try_extract_field_name(&type_)?;
 
-        let bcs_name = bcs::to_bytes(&name_value.clone().undecorate()).map_err(|e| {
-            IndexerError::SerdeError(format!(
-                "Failed to serialize dynamic field name {:?}: {e}",
-                name_value
-            ))
-        })?;
+        let layout = state
+            .resolver
+            .type_layout(move_object.type_().clone().into())
+            .await?;
+        let object_id = object.id();
+
+        let field = DFV::FieldVisitor::deserialize(move_object.contents(), &layout)?;
+
+        let type_ = field.kind;
+        let name_type: TypeTag = field.name_layout.into();
+        let bcs_name = field.name_bytes.to_owned();
+
+        let name_value = BoundedVisitor::deserialize_value(field.name_bytes, field.name_layout)
+            .tap_err(|e| {
+                warn!("{e}");
+            })?;
         let name = DynamicFieldName {
             type_: name_type,
             value: SuiMoveValue::from(name_value).to_json_value(),

--- a/crates/sui-core/src/rest_index.rs
+++ b/crates/sui-core/src/rest_index.rs
@@ -20,7 +20,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
 use sui_types::digests::TransactionDigest;
-use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldType};
+use sui_types::dynamic_field::visitor as DFV;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::layout_resolver::LayoutResolver;
 use sui_types::messages_checkpoint::CheckpointContents;
@@ -671,45 +671,26 @@ fn try_create_dynamic_field_info(
         return Ok(None);
     }
 
-    let (name_value, dynamic_field_type, object_id) = {
-        let layout = sui_types::layout_resolver::into_struct_layout(
-            resolver
-                .get_annotated_layout(&move_object.type_().clone().into())
-                .map_err(StorageError::custom)?,
-        )
+    let layout = resolver
+        .get_annotated_layout(&move_object.type_().clone().into())
+        .map_err(StorageError::custom)?
+        .into_layout();
+
+    let field = DFV::FieldVisitor::deserialize(move_object.contents(), &layout)
         .map_err(StorageError::custom)?;
 
-        let move_struct = move_object
-            .to_move_struct(&layout)
-            .map_err(StorageError::serialization)?;
+    let value_metadata = field.value_metadata().map_err(StorageError::custom)?;
 
-        // SAFETY: move struct has already been validated to be of type DynamicField
-        DynamicFieldInfo::parse_move_object(&move_struct).unwrap()
-    };
-
-    let name_type = move_object
-        .type_()
-        .try_extract_field_name(&dynamic_field_type)
-        .expect("object is of type Field");
-
-    let name_value = name_value
-        .undecorate()
-        .simple_serialize()
-        .expect("serialization cannot fail");
-
-    let dynamic_object_id = match dynamic_field_type {
-        DynamicFieldType::DynamicObject => Some(object_id),
-        DynamicFieldType::DynamicField => None,
-    };
-
-    let field_info = DynamicFieldIndexInfo {
-        name_type,
-        name_value,
-        dynamic_field_type,
-        dynamic_object_id,
-    };
-
-    Ok(Some(field_info))
+    Ok(Some(DynamicFieldIndexInfo {
+        name_type: field.name_layout.into(),
+        name_value: field.name_bytes.to_owned(),
+        dynamic_field_type: field.kind,
+        dynamic_object_id: if let DFV::ValueMetadata::DynamicObjectField(id) = value_metadata {
+            Some(id)
+        } else {
+            None
+        },
+    }))
 }
 
 fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinIndexInfo)> {

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -4,17 +4,15 @@
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
 use diesel_async::scoped_futures::ScopedFutureExt;
-use move_core_types::annotated_value::{self as A, MoveStruct};
 use move_core_types::language_storage::TypeTag;
 use sui_indexer::models::objects::StoredHistoryObject;
 use sui_indexer::types::OwnerType;
-use sui_types::dynamic_field::{
-    derive_dynamic_field_id, extract_id_value, DynamicFieldInfo, DynamicFieldType,
-};
+use sui_types::dynamic_field::visitor::{Field, FieldVisitor};
+use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
 use super::available_range::AvailableRange;
 use super::cursor::{Page, Target};
-use super::object::{self, deserialize_move_struct, Object, ObjectKind};
+use super::object::{self, Object, ObjectKind};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
@@ -28,7 +26,6 @@ use crate::raw_query::RawQuery;
 
 pub(crate) struct DynamicField {
     pub super_: MoveObject,
-    pub df_kind: DynamicFieldType,
 }
 
 #[derive(Union)]
@@ -61,40 +58,28 @@ impl DynamicField {
     /// The string type, data, and serialized value of the DynamicField's 'name' field.
     /// This field is used to uniquely identify a child of the parent object.
     async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
-        let resolver: &PackageResolver = ctx
-            .data()
-            .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
-            .extend()?;
+        let resolver: &PackageResolver = ctx.data_unchecked();
 
-        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
-            .await
-            .extend()?;
+        let type_ = TypeTag::from(self.super_.native.type_().clone());
+        let layout = resolver.type_layout(type_.clone()).await.map_err(|e| {
+            Error::Internal(format!(
+                "Error fetching layout for type {}: {e}",
+                type_.to_canonical_display(/* with_prefix */ true)
+            ))
+        })?;
 
-        // Get TypeTag of the DynamicField name from StructTag of the MoveStruct
-        let type_tag = DynamicFieldInfo::try_extract_field_name(&struct_tag, &self.df_kind)
+        let Field {
+            name_layout,
+            name_bytes,
+            ..
+        } = FieldVisitor::deserialize(self.super_.native.contents(), &layout)
             .map_err(|e| Error::Internal(e.to_string()))
             .extend()?;
 
-        let name_move_value = extract_field_from_move_struct(move_struct, "name").extend()?;
-
-        let undecorated = if self.df_kind == DynamicFieldType::DynamicObject {
-            let inner_name_move_value = match name_move_value {
-                A::MoveValue::Struct(inner_struct) => {
-                    extract_field_from_move_struct(inner_struct, "name")
-                }
-                _ => Err(Error::Internal("Expected a wrapper struct".to_string())),
-            }
-            .extend()?;
-            inner_name_move_value.undecorate()
-        } else {
-            name_move_value.undecorate()
-        };
-
-        let bcs = bcs::to_bytes(&undecorated)
-            .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
-            .extend()?;
-
-        Ok(Some(MoveValue::new(type_tag, Base64::from(bcs))))
+        Ok(Some(MoveValue::new(
+            name_layout.into(),
+            Base64::from(name_bytes.to_owned()),
+        )))
     }
 
     /// The returned dynamic field is an object if its return type is `MoveObject`,
@@ -104,30 +89,31 @@ impl DynamicField {
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         let resolver: &PackageResolver = ctx.data_unchecked();
 
-        // TODO(annotated-visitor): Use custom visitors to extract just the value.
-        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
-            .await
+        let type_ = TypeTag::from(self.super_.native.type_().clone());
+        let layout = resolver.type_layout(type_.clone()).await.map_err(|e| {
+            Error::Internal(format!(
+                "Error fetching layout for type {}: {e}",
+                type_.to_canonical_display(/* with_prefix */ true)
+            ))
+        })?;
+
+        let Field {
+            kind,
+            value_layout,
+            value_bytes,
+            ..
+        } = FieldVisitor::deserialize(self.super_.native.contents(), &layout)
+            .map_err(|e| Error::Internal(e.to_string()))
             .extend()?;
 
-        let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
-
-        if self.df_kind == DynamicFieldType::DynamicObject {
-            // If `df_kind` is a DynamicObject, the object we are currently on is the field object,
-            // and we must resolve one more level down to the value object.
-            let df_object_id = extract_id_value(&value_move_value)
-                .ok_or_else(|| {
-                    Error::Internal(format!(
-                        "Couldn't find ID of dynamic object field value: {value_move_value:#?}"
-                    ))
-                })
+        if kind == DynamicFieldType::DynamicObject {
+            let df_object_id: SuiAddress = bcs::from_bytes(value_bytes)
+                .map_err(|e| Error::Internal(format!("Failed to deserialize object ID: {e}")))
                 .extend()?;
 
-            // Because we only have checkpoint-level granularity, we may end up reading a later
-            // version of the value object. Thus, we use the version of the field object to bound
-            // the value object at the correct version.
             let obj = MoveObject::query(
                 ctx,
-                df_object_id.into(),
+                df_object_id,
                 Object::under_parent(self.root_version(), self.super_.super_.checkpoint_viewed_at),
             )
             .await
@@ -135,19 +121,9 @@ impl DynamicField {
 
             Ok(obj.map(DynamicFieldValue::MoveObject))
         } else {
-            // Get TypeTag of the DynamicField value from StructTag of the MoveStruct
-            let type_tag = DynamicFieldInfo::try_extract_field_value(&struct_tag)
-                .map_err(|e| Error::Internal(e.to_string()))
-                .extend()?;
-
-            let undecorated = value_move_value.undecorate();
-            let bcs = bcs::to_bytes(&undecorated)
-                .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
-                .extend()?;
-
             Ok(Some(DynamicFieldValue::MoveValue(MoveValue::new(
-                type_tag,
-                Base64::from(bcs),
+                value_layout.into(),
+                Base64::from(value_bytes.to_owned()),
             ))))
         }
     }
@@ -297,41 +273,8 @@ impl TryFrom<MoveObject> for DynamicField {
             return Err(Error::Internal("Wrong type for DynamicField".to_string()));
         }
 
-        let Some(name) = tag.type_params.first() else {
-            return Err(Error::Internal("No type for DynamicField name".to_string()));
-        };
-
-        let df_kind = if matches!(
-            name,
-            TypeTag::Struct(s) if DynamicFieldInfo::is_dynamic_object_field_wrapper(s)
-        ) {
-            DynamicFieldType::DynamicObject
-        } else {
-            DynamicFieldType::DynamicField
-        };
-
-        Ok(DynamicField {
-            super_: stored,
-            df_kind,
-        })
+        Ok(DynamicField { super_: stored })
     }
-}
-
-pub fn extract_field_from_move_struct(
-    move_struct: MoveStruct,
-    field_name: &str,
-) -> Result<A::MoveValue, Error> {
-    move_struct
-        .fields
-        .into_iter()
-        .find_map(|(id, value)| {
-            if id.to_string() == field_name {
-                Some(value)
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| Error::Internal(format!("Field '{}' not found", field_name)))
 }
 
 /// Builds the `RawQuery` for fetching dynamic fields attached to a parent object. If

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -4,7 +4,6 @@
 use std::collections::{BTreeMap, HashMap};
 
 use tap::tap::TapFallible;
-use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use tracing::{error, info};
@@ -23,7 +22,6 @@ pub async fn start_tx_checkpoint_commit_task<S>(
     state: S,
     metrics: IndexerMetrics,
     tx_indexing_receiver: mysten_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
-    commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
     cancel: CancellationToken,
 ) -> IndexerResult<()>
@@ -60,7 +58,7 @@ where
             next_checkpoint_sequence_number += 1;
             let epoch_number_option = epoch.as_ref().map(|epoch| epoch.new_epoch.epoch);
             if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
-                commit_checkpoints(&state, batch, epoch, &metrics, &commit_notifier).await;
+                commit_checkpoints(&state, batch, epoch, &metrics).await;
                 batch = vec![];
             }
             if let Some(epoch_number) = epoch_number_option {
@@ -74,7 +72,7 @@ where
             }
         }
         if !batch.is_empty() && unprocessed.is_empty() {
-            commit_checkpoints(&state, batch, None, &metrics, &commit_notifier).await;
+            commit_checkpoints(&state, batch, None, &metrics).await;
             batch = vec![];
         }
     }
@@ -91,7 +89,6 @@ async fn commit_checkpoints<S>(
     indexed_checkpoint_batch: Vec<CheckpointDataToCommit>,
     epoch: Option<EpochToCommit>,
     metrics: &IndexerMetrics,
-    commit_notifier: &watch::Sender<Option<CheckpointSequenceNumber>>,
 ) where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
@@ -228,10 +225,6 @@ async fn commit_checkpoints<S>(
     }
 
     let elapsed = guard.stop_and_record();
-
-    commit_notifier
-        .send(Some(last_checkpoint_seq))
-        .expect("Commit watcher should not be closed");
 
     info!(
         elapsed,

--- a/crates/sui-indexer/src/handlers/tx_processor.rs
+++ b/crates/sui-indexer/src/handlers/tx_processor.rs
@@ -1,123 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO remove the dead_code attribute after integration is done
-#![allow(dead_code)]
+use std::collections::HashMap;
 
 use async_trait::async_trait;
-use mysten_metrics::monitored_scope;
-use mysten_metrics::spawn_monitored_task;
-use sui_rest_api::CheckpointData;
-use tokio::sync::watch;
-
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use sui_types::object::Object;
-use tokio::time::Duration;
-use tokio::time::Instant;
-
 use sui_json_rpc::get_balance_changes_from_effect;
 use sui_json_rpc::get_object_changes;
 use sui_json_rpc::ObjectProvider;
+use sui_rest_api::CheckpointData;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::object::Object;
 use sui_types::transaction::{TransactionData, TransactionDataAPI};
-use tracing::info;
-
-use sui_types::base_types::ObjectID;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::errors::IndexerError;
 use crate::metrics::IndexerMetrics;
-use crate::types::IndexedPackage;
 use crate::types::{IndexedObjectChange, IndexerResult};
-
-// GC the buffer every 300 checkpoints, or 5 minutes
-pub const BUFFER_GC_INTERVAL: Duration = Duration::from_secs(300);
-/// An in-mem buffer for modules during writer path indexing.
-/// It has static lifetime. Since we batch process checkpoints,
-/// it's possible that when a package is looked up (e.g. to create dynamic field),
-/// it has not been persisted in the database yet. So it works as an in-mem
-/// store for package resolution. To avoid bloating memory, we GC modules
-/// that are older than the committed checkpoints.
-pub struct IndexingPackageBuffer {
-    packages: HashMap<
-        ObjectID,
-        (
-            Arc<Object>,
-            u64, /* package version */
-            CheckpointSequenceNumber,
-        ),
-    >,
-}
-
-impl IndexingPackageBuffer {
-    pub fn start(
-        commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
-    ) -> Arc<Mutex<Self>> {
-        let cache = Arc::new(Mutex::new(Self {
-            packages: HashMap::new(),
-        }));
-        let cache_clone = cache.clone();
-        spawn_monitored_task!(Self::remove_committed(cache_clone, commit_watcher));
-        cache
-    }
-
-    pub async fn remove_committed(
-        cache: Arc<Mutex<Self>>,
-        commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
-    ) {
-        let mut interval = tokio::time::interval_at(Instant::now(), BUFFER_GC_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            interval.tick().await;
-            let _scope = monitored_scope("IndexingPackageBuffer::remove_committed");
-            let Some(committed_checkpoint) = *commit_watcher.borrow() else {
-                continue;
-            };
-            let mut cache = cache.lock().unwrap();
-            info!(
-                "About to GC packages older than: {committed_checkpoint}. Cache size is {}",
-                cache.packages.len()
-            );
-            let mut to_remove = vec![];
-            for (id, (_, _, checkpoint_seq)) in cache.packages.iter() {
-                if *checkpoint_seq <= committed_checkpoint {
-                    to_remove.push(*id);
-                }
-            }
-            for id in to_remove {
-                cache.packages.remove(&id);
-            }
-        }
-    }
-
-    pub fn insert_packages(&mut self, new_package_objects: Vec<(IndexedPackage, Object)>) {
-        let new_packages = new_package_objects
-            .into_iter()
-            .map(|(p, obj)| {
-                (
-                    p.package_id,
-                    (
-                        Arc::new(obj),
-                        p.move_package.version().value(),
-                        p.checkpoint_sequence_number,
-                    ),
-                )
-            })
-            .collect::<HashMap<_, _>>();
-        self.packages.extend(new_packages);
-    }
-
-    pub fn get_package(&self, id: &ObjectID) -> Option<Arc<Object>> {
-        self.packages.get(id).as_ref().map(|(o, _, _)| o.clone())
-    }
-
-    pub fn get_version(&self, id: &ObjectID) -> Option<u64> {
-        self.packages.get(id).as_ref().map(|(_, v, _)| *v)
-    }
-}
 
 pub struct InMemObjectCache {
     id_map: HashMap<ObjectID, Object>,

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -68,7 +68,7 @@ impl From<IndexedObject> for StoredObject {
         let IndexedObject {
             checkpoint_sequence_number: _,
             object,
-            df_info,
+            df_kind,
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
@@ -94,7 +94,7 @@ impl From<IndexedObject> for StoredObject {
             serialized_object: bcs::to_bytes(&object).unwrap(),
             coin_type,
             coin_balance: coin_balance.map(|b| b as i64),
-            df_kind: df_info.as_ref().map(|k| match k.type_ {
+            df_kind: df_kind.map(|k| match k {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
@@ -143,7 +143,7 @@ impl From<IndexedObject> for StoredObjectSnapshot {
         let IndexedObject {
             checkpoint_sequence_number,
             object,
-            df_info,
+            df_kind,
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
@@ -172,7 +172,7 @@ impl From<IndexedObject> for StoredObjectSnapshot {
             serialized_object: Some(bcs::to_bytes(&object).unwrap()),
             coin_type,
             coin_balance: coin_balance.map(|b| b as i64),
-            df_kind: df_info.as_ref().map(|k| match k.type_ {
+            df_kind: df_kind.map(|k| match k {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
@@ -227,7 +227,7 @@ impl From<IndexedObject> for StoredHistoryObject {
         let IndexedObject {
             checkpoint_sequence_number,
             object,
-            df_info,
+            df_kind,
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
@@ -256,7 +256,7 @@ impl From<IndexedObject> for StoredHistoryObject {
             serialized_object: Some(bcs::to_bytes(&object).unwrap()),
             coin_type,
             coin_balance: coin_balance.map(|b| b as i64),
-            df_kind: df_info.as_ref().map(|k| match k.type_ {
+            df_kind: df_kind.map(|k| match k {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::{ObjectDigest, SequenceNumber};
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::TransactionDigest;
-use sui_types::dynamic_field::DynamicFieldInfo;
+use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::effects::TransactionEffects;
 use sui_types::event::SystemEpochInfoEvent;
 use sui_types::messages_checkpoint::{
@@ -347,19 +347,19 @@ pub enum DynamicFieldKind {
 pub struct IndexedObject {
     pub checkpoint_sequence_number: CheckpointSequenceNumber,
     pub object: Object,
-    pub df_info: Option<DynamicFieldInfo>,
+    pub df_kind: Option<DynamicFieldType>,
 }
 
 impl IndexedObject {
     pub fn from_object(
         checkpoint_sequence_number: CheckpointSequenceNumber,
         object: Object,
-        df_info: Option<DynamicFieldInfo>,
+        df_kind: Option<DynamicFieldType>,
     ) -> Self {
         Self {
             checkpoint_sequence_number,
             object,
-            df_info,
+            df_kind,
         }
     }
 }

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -27,6 +27,8 @@ use shared_crypto::intent::HashingIntentScope;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+pub mod visitor;
+
 const DYNAMIC_FIELD_MODULE_NAME: &IdentStr = ident_str!("dynamic_field");
 const DYNAMIC_FIELD_FIELD_STRUCT_NAME: &IdentStr = ident_str!("Field");
 

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -95,7 +95,9 @@ impl Display for DynamicFieldName {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(
+    Copy, Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug,
+)]
 pub enum DynamicFieldType {
     #[serde(rename_all = "camelCase")]
     DynamicField,

--- a/crates/sui-types/src/dynamic_field/visitor.rs
+++ b/crates/sui-types/src/dynamic_field/visitor.rs
@@ -1,0 +1,503 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{
+    account_address::AccountAddress,
+    annotated_value as A,
+    annotated_visitor::{self, StructDriver, ValueDriver, VariantDriver, VecDriver, Visitor},
+    u256::U256,
+};
+
+use crate::{base_types::ObjectID, id::UID};
+
+use super::{DynamicFieldInfo, DynamicFieldType};
+
+/// Visitor to deserialize the outer structure of a `0x2::dynamic_field::Field` while leaving its
+/// name and value untouched.
+pub struct FieldVisitor;
+
+#[derive(Debug, Clone)]
+pub struct Field<'b, 'l> {
+    pub id: ObjectID,
+    pub kind: DynamicFieldType,
+    pub name_layout: &'l A::MoveTypeLayout,
+    pub name_bytes: &'b [u8],
+    pub value_layout: &'l A::MoveTypeLayout,
+    pub value_bytes: &'b [u8],
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Not a dynamic field")]
+    NotADynamicField,
+
+    #[error("{0}")]
+    Visitor(#[from] annotated_visitor::Error),
+}
+
+impl FieldVisitor {
+    /// Deserialize the top-level structure from a dynamic field's `0x2::dynamic_field::Field`
+    /// without having to fully deserialize its name or value.
+    pub fn deserialize<'b, 'l>(
+        bytes: &'b [u8],
+        layout: &'l A::MoveTypeLayout,
+    ) -> anyhow::Result<Field<'b, 'l>> {
+        A::MoveValue::visit_deserialize(bytes, layout, &mut FieldVisitor)
+    }
+}
+
+impl<'b, 'l> Visitor<'b, 'l> for FieldVisitor {
+    type Value = Field<'b, 'l>;
+    type Error = Error;
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Error> {
+        if !DynamicFieldInfo::is_dynamic_field(&driver.struct_layout().type_) {
+            return Err(Error::NotADynamicField);
+        }
+
+        // Set-up optionals to fill while visiting fields -- all of them must be filled by the end
+        // to successfully return a `Field`.
+        let mut id = None;
+        let mut name_parts = None;
+        let mut value_parts = None;
+
+        while let Some(A::MoveFieldLayout { name, layout }) = driver.peek_field() {
+            match name.as_str() {
+                "id" => {
+                    let lo = driver.position();
+                    driver.skip_field()?;
+                    let hi = driver.position();
+
+                    if !matches!(layout, A::MoveTypeLayout::Struct(s) if s.as_ref() == &UID::layout())
+                    {
+                        return Err(Error::NotADynamicField);
+                    }
+
+                    // HACK: Bypassing `id`'s layout to deserialize its bytes as a Rust type.
+                    let bytes = &driver.bytes()[lo..hi];
+                    id = Some(ObjectID::from_bytes(bytes).map_err(|_| Error::NotADynamicField)?);
+                }
+
+                "name" => {
+                    let lo = driver.position();
+                    driver.skip_field()?;
+                    let hi = driver.position();
+
+                    let (kind, layout) = extract_name_layout(layout)?;
+                    name_parts = Some((&driver.bytes()[lo..hi], layout, kind));
+                }
+
+                "value" => {
+                    let lo = driver.position();
+                    driver.skip_field()?;
+                    let hi = driver.position();
+                    value_parts = Some((&driver.bytes()[lo..hi], layout));
+                }
+
+                _ => {
+                    return Err(Error::NotADynamicField);
+                }
+            }
+        }
+
+        let (Some(id), Some((name_bytes, name_layout, kind)), Some((value_bytes, value_layout))) =
+            (id, name_parts, value_parts)
+        else {
+            return Err(Error::NotADynamicField);
+        };
+
+        Ok(Field {
+            id,
+            kind,
+            name_layout,
+            name_bytes,
+            value_layout,
+            value_bytes,
+        })
+    }
+
+    // === Empty/default casees ===
+    //
+    // A dynamic field must be a struct, so if the visitor is fed anything else, it complains.
+
+    fn visit_u8(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: u8) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_u16(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: u16) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_u32(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: u32) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_u64(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: u64) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_u128(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: u128) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_u256(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: U256) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_bool(&mut self, _: &ValueDriver<'_, 'b, 'l>, _: bool) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_address(
+        &mut self,
+        _: &ValueDriver<'_, 'b, 'l>,
+        _: AccountAddress,
+    ) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_signer(
+        &mut self,
+        _: &ValueDriver<'_, 'b, 'l>,
+        _: AccountAddress,
+    ) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_vector(&mut self, _: &mut VecDriver<'_, 'b, 'l>) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+
+    fn visit_variant(&mut self, _: &mut VariantDriver<'_, 'b, 'l>) -> Result<Self::Value, Error> {
+        Err(Error::NotADynamicField)
+    }
+}
+
+/// Extract the type and layout of a dynamic field name, from the layout of its `Field.name`.
+fn extract_name_layout(
+    layout: &A::MoveTypeLayout,
+) -> Result<(DynamicFieldType, &A::MoveTypeLayout), Error> {
+    let A::MoveTypeLayout::Struct(struct_) = layout else {
+        return Ok((DynamicFieldType::DynamicField, layout));
+    };
+
+    if !DynamicFieldInfo::is_dynamic_object_field_wrapper(&struct_.type_) {
+        return Ok((DynamicFieldType::DynamicField, layout));
+    }
+
+    // Wrapper contains just one field
+    let [A::MoveFieldLayout { name, layout }] = &struct_.fields[..] else {
+        return Err(Error::NotADynamicField);
+    };
+
+    // ...called `name`
+    if name.as_str() != "name" {
+        return Err(Error::NotADynamicField);
+    }
+
+    Ok((DynamicFieldType::DynamicObject, layout))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use move_core_types::{
+        account_address::AccountAddress, annotated_value as A, language_storage::TypeTag,
+    };
+
+    use crate::{
+        base_types::ObjectID,
+        dynamic_field,
+        id::UID,
+        object::bounded_visitor::tests::{enum_, layout_, value_, variant_},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_dynamic_field_name() {
+        for (name, name_layout, name_bcs) in fixtures() {
+            for (value, value_layout, value_bcs) in fixtures() {
+                let df = serialized_df("0x264", name.clone(), value.clone());
+                let df_layout = df_layout(name_layout.clone(), value_layout.clone());
+                let field = FieldVisitor::deserialize(&df, &df_layout)
+                    .unwrap_or_else(|e| panic!("Failed to deserialize {name} => {value}: {e}"));
+
+                assert_eq!(field.id, oid_("0x264"), "{name} => {value}");
+                assert_eq!(field.name_bytes, &name_bcs, "{name} => {value}");
+                assert_eq!(field.value_bytes, &value_bcs, "{name} => {value}");
+
+                assert_eq!(
+                    field.kind,
+                    DynamicFieldType::DynamicField,
+                    "{name} => {value}",
+                );
+
+                assert_eq!(
+                    TypeTag::from(field.name_layout),
+                    TypeTag::from(&name_layout),
+                    "{name} => {value}",
+                );
+
+                assert_eq!(
+                    TypeTag::from(field.value_layout),
+                    TypeTag::from(&value_layout),
+                    "{name} => {value}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_dynamic_object_field_name() {
+        let addr = A::MoveValue::Address(AccountAddress::ONE);
+        let id = value_("0x2::object::ID", vec![("bytes", addr)]);
+        let id_bcs = id.clone().undecorate().simple_serialize().unwrap();
+
+        for (name, name_layout, name_bcs) in fixtures() {
+            let df = serialized_df("0x264", name.clone(), id.clone());
+            let df_layout = dof_layout(name_layout.clone());
+            let field = FieldVisitor::deserialize(&df, &df_layout)
+                .unwrap_or_else(|e| panic!("Failed to deserialize {name}: {e}"));
+
+            assert_eq!(field.id, oid_("0x264"), "{name}");
+            assert_eq!(field.name_bytes, &name_bcs, "{name}");
+            assert_eq!(field.value_bytes, &id_bcs, "{name}");
+
+            assert_eq!(field.kind, DynamicFieldType::DynamicObject, "{name}",);
+
+            assert_eq!(
+                TypeTag::from(field.name_layout),
+                TypeTag::from(&name_layout),
+                "{name}",
+            );
+
+            assert_eq!(
+                TypeTag::from(field.value_layout),
+                TypeTag::from(&id_layout()),
+                "{name}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_name_from_not_dynamic_field() {
+        for (value, layout, bytes) in fixtures() {
+            let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+                panic!("Expected NotADynamicField error for {value}");
+            };
+
+            assert_eq!(
+                e.to_string(),
+                "Not a dynamic field",
+                "Unexpected error for {value}"
+            );
+        }
+    }
+
+    /// If the visitor is run over a type that isn't actually a `0x2::dynamic_field::Field`, it
+    /// will complain.
+    #[test]
+    fn test_from_bad_type() {
+        for (value, layout, bytes) in fixtures() {
+            let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+                panic!("Expected NotADynamicField error for {value}");
+            };
+
+            assert_eq!(
+                e.to_string(),
+                "Not a dynamic field",
+                "Unexpected error for {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_dynamic_field_missing_id() {
+        let bytes = bcs::to_bytes(&(42u8, 43u8)).unwrap();
+        let layout = layout_(
+            "0x2::dynamic_field::Field<u8, u8>",
+            vec![
+                ("name", A::MoveTypeLayout::U8),
+                ("value", A::MoveTypeLayout::U8),
+            ],
+        );
+
+        let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+            panic!("Expected NotADynamicField error");
+        };
+
+        assert_eq!(e.to_string(), "Not a dynamic field");
+    }
+
+    #[test]
+    fn test_from_dynamic_field_missing_name() {
+        let bytes = bcs::to_bytes(&(oid_("0x264"), 43u8)).unwrap();
+        let layout = layout_(
+            "0x2::dynamic_field::Field<u8, u8>",
+            vec![("id", id_layout()), ("value", A::MoveTypeLayout::U8)],
+        );
+
+        let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+            panic!("Expected NotADynamicField error");
+        };
+
+        assert_eq!(e.to_string(), "Not a dynamic field");
+    }
+
+    #[test]
+    fn test_from_dynamic_field_missing_value() {
+        let bytes = bcs::to_bytes(&(oid_("0x264"), 42u8)).unwrap();
+        let layout = layout_(
+            "0x2::dynamic_field::Field<u8, u8>",
+            vec![("id", id_layout()), ("name", A::MoveTypeLayout::U8)],
+        );
+
+        let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+            panic!("Expected NotADynamicField error");
+        };
+
+        assert_eq!(e.to_string(), "Not a dynamic field");
+    }
+
+    #[test]
+    fn test_from_dynamic_field_weird_id() {
+        let bytes = bcs::to_bytes(&(42u8, 43u8, 44u8)).unwrap();
+        let layout = layout_(
+            "0x2::dynamic_field::Field<u8, u8>",
+            vec![
+                ("id", A::MoveTypeLayout::U8),
+                ("name", A::MoveTypeLayout::U8),
+                ("value", A::MoveTypeLayout::U8),
+            ],
+        );
+
+        let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+            panic!("Expected NotADynamicField error");
+        };
+
+        assert_eq!(e.to_string(), "Not a dynamic field");
+    }
+
+    /// If the name is wrapped in `0x2::dynamic_object_field::Wrapper`, but the wrapper's structure
+    /// is somehow incorrect, that will result in an error.
+    #[test]
+    fn test_from_dynamic_object_field_bad_wrapper() {
+        let bytes = bcs::to_bytes(&(oid_("0x264"), 42u8)).unwrap();
+        let layout = layout_(
+            "0x2::dynamic_field::Field<0x2::dynamic_object_field::Wrapper<u8>, u8>",
+            vec![
+                ("id", id_layout()),
+                (
+                    "name",
+                    layout_(
+                        "0x2::dynamic_object_field::Wrapper<u8>",
+                        // In the real type, the field is called "name"
+                        vec![("wrapped", A::MoveTypeLayout::U8)],
+                    ),
+                ),
+                ("value", A::MoveTypeLayout::U8),
+            ],
+        );
+
+        let Err(e) = FieldVisitor::deserialize(&bytes, &layout) else {
+            panic!("Expected NotADynamicField error");
+        };
+
+        assert_eq!(e.to_string(), "Not a dynamic field");
+    }
+
+    /// Various Move values to use as dynamic field names and values.
+    fn fixtures() -> Vec<(A::MoveValue, A::MoveTypeLayout, Vec<u8>)> {
+        use A::MoveTypeLayout as T;
+        use A::MoveValue as V;
+
+        vec![
+            fixture(V::U8(42), T::U8),
+            fixture(V::Address(AccountAddress::ONE), T::Address),
+            fixture(
+                V::Vector(vec![V::U32(43), V::U32(44), V::U32(45)]),
+                T::Vector(Box::new(T::U32)),
+            ),
+            fixture(
+                value_(
+                    "0x2::object::ID",
+                    vec![("bytes", V::Address(AccountAddress::TWO))],
+                ),
+                layout_("0x2::object::ID", vec![("bytes", T::Address)]),
+            ),
+            fixture(
+                variant_(
+                    "0x1::option::Option<u64>",
+                    "Some",
+                    1,
+                    vec![("value", V::U64(46))],
+                ),
+                enum_(
+                    "0x1::option::Option<u64>",
+                    vec![
+                        (("None", 0), vec![]),
+                        (("Some", 1), vec![("value", T::U64)]),
+                    ],
+                ),
+            ),
+        ]
+    }
+
+    fn fixture(
+        value: A::MoveValue,
+        layout: A::MoveTypeLayout,
+    ) -> (A::MoveValue, A::MoveTypeLayout, Vec<u8>) {
+        let bytes = value
+            .clone()
+            .undecorate()
+            .simple_serialize()
+            .unwrap_or_else(|| panic!("Failed to serialize {}", value.clone()));
+
+        (value, layout, bytes)
+    }
+
+    fn oid_(rep: &str) -> ObjectID {
+        ObjectID::from_str(rep).unwrap()
+    }
+
+    fn serialized_df(id: &str, name: A::MoveValue, value: A::MoveValue) -> Vec<u8> {
+        bcs::to_bytes(&dynamic_field::Field {
+            id: UID::new(oid_(id)),
+            name: name.undecorate(),
+            value: value.undecorate(),
+        })
+        .unwrap()
+    }
+
+    fn id_layout() -> A::MoveTypeLayout {
+        let addr = A::MoveTypeLayout::Address;
+        layout_("0x2::object::ID", vec![("bytes", addr)])
+    }
+
+    fn df_layout(name: A::MoveTypeLayout, value: A::MoveTypeLayout) -> A::MoveTypeLayout {
+        let uid = layout_("0x2::object::UID", vec![("id", id_layout())]);
+        let field = format!(
+            "0x2::dynamic_field::Field<{}, {}>",
+            TypeTag::from(&name).to_canonical_display(/* with_prefix */ true),
+            TypeTag::from(&value).to_canonical_display(/* with_prefix */ true)
+        );
+
+        layout_(&field, vec![("id", uid), ("name", name), ("value", value)])
+    }
+
+    fn dof_layout(name: A::MoveTypeLayout) -> A::MoveTypeLayout {
+        let tag = TypeTag::from(&name);
+        let wrapper = format!(
+            "0x2::dynamic_object_field::Wrapper<{}>",
+            tag.to_canonical_display(/* with_prefix */ true)
+        );
+
+        let name = layout_(&wrapper, vec![("name", name)]);
+        df_layout(name, id_layout())
+    }
+}

--- a/crates/sui-types/src/object/balance_traversal.rs
+++ b/crates/sui-types/src/object/balance_traversal.rs
@@ -54,7 +54,7 @@ impl<'b, 'l> Traversal<'b, 'l> for Accumulator {
     type Error = annotated_visitor::Error;
     fn traverse_u64(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: u64,
     ) -> Result<(), Self::Error> {
         self.total += value;

--- a/crates/sui-types/src/object/balance_traversal.rs
+++ b/crates/sui-types/src/object/balance_traversal.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 
 use move_core_types::{
-    annotated_visitor::{self, StructDriver, Traversal},
+    annotated_visitor::{self, StructDriver, Traversal, ValueDriver},
     language_storage::{StructTag, TypeTag},
 };
 
@@ -52,7 +52,11 @@ impl Traversal for BalanceTraversal {
 
 impl Traversal for Accumulator {
     type Error = annotated_visitor::Error;
-    fn traverse_u64(&mut self, value: u64) -> Result<(), Self::Error> {
+    fn traverse_u64(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: u64,
+    ) -> Result<(), Self::Error> {
         self.total += value;
         Ok(())
     }

--- a/crates/sui-types/src/object/balance_traversal.rs
+++ b/crates/sui-types/src/object/balance_traversal.rs
@@ -30,12 +30,12 @@ impl BalanceTraversal {
     }
 }
 
-impl Traversal for BalanceTraversal {
+impl<'b, 'l> Traversal<'b, 'l> for BalanceTraversal {
     type Error = annotated_visitor::Error;
 
     fn traverse_struct(
         &mut self,
-        driver: &mut StructDriver<'_, '_, '_>,
+        driver: &mut StructDriver<'_, 'b, 'l>,
     ) -> Result<(), Self::Error> {
         let Some(coin_type) = is_balance(&driver.struct_layout().type_) else {
             // Not a balance, search recursively for balances among fields.
@@ -50,11 +50,11 @@ impl Traversal for BalanceTraversal {
     }
 }
 
-impl Traversal for Accumulator {
+impl<'b, 'l> Traversal<'b, 'l> for Accumulator {
     type Error = annotated_visitor::Error;
     fn traverse_u64(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: u64,
     ) -> Result<(), Self::Error> {
         self.total += value;

--- a/crates/sui-types/src/object/bounded_visitor.rs
+++ b/crates/sui-types/src/object/bounded_visitor.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use move_core_types::{
     account_address::AccountAddress,
     annotated_value as A,
-    annotated_visitor::{self, StructDriver, VecDriver, Visitor},
+    annotated_visitor::{self, StructDriver, ValueDriver, VecDriver, Visitor},
     language_storage::TypeTag,
     u256::U256,
 };
@@ -150,39 +150,75 @@ impl Visitor for BoundedVisitor {
     type Value = A::MoveValue;
     type Error = Error;
 
-    fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error> {
+    fn visit_u8(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: u8,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U8(value))
     }
 
-    fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error> {
+    fn visit_u16(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: u16,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U16(value))
     }
 
-    fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
+    fn visit_u32(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: u32,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U32(value))
     }
 
-    fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+    fn visit_u64(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: u64,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U64(value))
     }
 
-    fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error> {
+    fn visit_u128(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: u128,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U128(value))
     }
 
-    fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error> {
+    fn visit_u256(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: U256,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U256(value))
     }
 
-    fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
+    fn visit_bool(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: bool,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Bool(value))
     }
 
-    fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+    fn visit_address(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Address(value))
     }
 
-    fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+    fn visit_signer(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Signer(value))
     }
 

--- a/crates/sui-types/src/object/bounded_visitor.rs
+++ b/crates/sui-types/src/object/bounded_visitor.rs
@@ -146,13 +146,13 @@ impl BoundedVisitor {
     }
 }
 
-impl Visitor for BoundedVisitor {
+impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
     type Value = A::MoveValue;
     type Error = Error;
 
     fn visit_u8(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: u8,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U8(value))
@@ -160,7 +160,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_u16(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: u16,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U16(value))
@@ -168,7 +168,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_u32(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: u32,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U32(value))
@@ -176,7 +176,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_u64(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: u64,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U64(value))
@@ -184,7 +184,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_u128(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: u128,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U128(value))
@@ -192,7 +192,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_u256(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: U256,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U256(value))
@@ -200,7 +200,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_bool(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: bool,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Bool(value))
@@ -208,7 +208,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_address(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Address(value))
@@ -216,7 +216,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_signer(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Signer(value))
@@ -224,7 +224,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_vector(
         &mut self,
-        driver: &mut VecDriver<'_, '_, '_>,
+        driver: &mut VecDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         let mut elems = vec![];
         while let Some(elem) = driver.next_element(self)? {
@@ -236,7 +236,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_struct(
         &mut self,
-        driver: &mut StructDriver<'_, '_, '_>,
+        driver: &mut StructDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         let tag = driver.struct_layout().type_.clone().into();
 
@@ -262,7 +262,7 @@ impl Visitor for BoundedVisitor {
 
     fn visit_variant(
         &mut self,
-        driver: &mut annotated_visitor::VariantDriver<'_, '_, '_>,
+        driver: &mut annotated_visitor::VariantDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         let type_ = driver.enum_layout().type_.clone().into();
 

--- a/crates/sui-types/src/object/bounded_visitor.rs
+++ b/crates/sui-types/src/object/bounded_visitor.rs
@@ -152,7 +152,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_u8(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: u8,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U8(value))
@@ -160,7 +160,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_u16(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: u16,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U16(value))
@@ -168,7 +168,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_u32(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: u32,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U32(value))
@@ -176,7 +176,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_u64(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: u64,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U64(value))
@@ -184,7 +184,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_u128(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: u128,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U128(value))
@@ -192,7 +192,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_u256(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: U256,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::U256(value))
@@ -200,7 +200,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_bool(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: bool,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Bool(value))
@@ -208,7 +208,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_address(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Address(value))
@@ -216,7 +216,7 @@ impl<'b, 'l> Visitor<'b, 'l> for BoundedVisitor {
 
     fn visit_signer(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         Ok(A::MoveValue::Signer(value))

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -243,7 +243,7 @@ impl MoveStruct {
         V::Error: std::error::Error + Send + Sync + 'static,
     {
         let mut bytes = Cursor::new(blob);
-        let driver = ValueDriver::new(&mut bytes);
+        let driver = ValueDriver::new(&mut bytes, None);
         let res = visit_struct(driver, ty, visitor)?;
         if bytes.position() as usize == blob.len() {
             Ok(res)

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     account_address::AccountAddress,
-    annotated_visitor::{visit_struct, visit_value, Error as VError, Visitor},
+    annotated_visitor::{visit_struct, visit_value, Error as VError, ValueDriver, Visitor},
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
     runtime_value::{self as R, MOVE_STRUCT_FIELDS, MOVE_STRUCT_TYPE},
@@ -243,7 +243,8 @@ impl MoveStruct {
         V::Error: std::error::Error + Send + Sync + 'static,
     {
         let mut bytes = Cursor::new(blob);
-        let res = visit_struct(&mut bytes, ty, visitor)?;
+        let driver = ValueDriver::new(&mut bytes);
+        let res = visit_struct(driver, ty, visitor)?;
         if bytes.position() as usize == blob.len() {
             Ok(res)
         } else {

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -167,9 +167,9 @@ impl MoveValue {
     ///
     /// Deserialization can fail because of an issue in the serialized format (data doesn't match
     /// layout, unexpected bytes or trailing bytes), or a custom error expressed by the visitor.
-    pub fn visit_deserialize<V: Visitor>(
-        blob: &[u8],
-        ty: &MoveTypeLayout,
+    pub fn visit_deserialize<'b, 'l, V: Visitor<'b, 'l>>(
+        blob: &'b [u8],
+        ty: &'l MoveTypeLayout,
         visitor: &mut V,
     ) -> AResult<V::Value>
     where
@@ -234,9 +234,9 @@ impl MoveStruct {
     /// Like `MoveValue::visit_deserialize` (see for details), but specialized to visiting a struct
     /// (the `blob` is known to be a serialized Move struct, and the layout is a
     /// `MoveStructLayout`).
-    pub fn visit_deserialize<V: Visitor>(
-        blob: &[u8],
-        ty: &MoveStructLayout,
+    pub fn visit_deserialize<'b, 'l, V: Visitor<'b, 'l>>(
+        blob: &'b [u8],
+        ty: &'l MoveStructLayout,
         visitor: &mut V,
     ) -> AResult<V::Value>
     where

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -72,7 +72,7 @@ pub enum MoveValue {
     Variant(MoveVariant),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MoveFieldLayout {
     pub name: Identifier,
     pub layout: MoveTypeLayout,
@@ -84,14 +84,14 @@ impl MoveFieldLayout {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MoveStructLayout {
     /// An decorated representation with both types and human-readable field names
     pub type_: StructTag,
     pub fields: Box<Vec<MoveFieldLayout>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MoveEnumLayout {
     pub type_: StructTag,
     pub variants: BTreeMap<(Identifier, u16), Vec<MoveFieldLayout>>,
@@ -112,7 +112,7 @@ impl MoveDatatypeLayout {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum MoveTypeLayout {
     #[serde(rename(serialize = "bool", deserialize = "bool"))]
     Bool,

--- a/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
@@ -29,15 +29,59 @@ pub trait Visitor {
     /// ```
     type Error: From<Error>;
 
-    fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error>;
-    fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error>;
-    fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error>;
-    fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error>;
-    fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error>;
-    fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error>;
-    fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error>;
-    fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error>;
-    fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error>;
+    fn visit_u8(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u8,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u16(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u16,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u32(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u32,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u64(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u64,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u128(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u128,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u256(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: U256,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_bool(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: bool,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_address(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_signer(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error>;
 
     fn visit_vector(
         &mut self,
@@ -71,39 +115,75 @@ pub trait Visitor {
 pub trait Traversal {
     type Error: From<Error>;
 
-    fn traverse_u8(&mut self, _value: u8) -> Result<(), Self::Error> {
+    fn traverse_u8(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: u8,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_u16(&mut self, _value: u16) -> Result<(), Self::Error> {
+    fn traverse_u16(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: u16,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_u32(&mut self, _value: u32) -> Result<(), Self::Error> {
+    fn traverse_u32(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: u32,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_u64(&mut self, _value: u64) -> Result<(), Self::Error> {
+    fn traverse_u64(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: u64,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_u128(&mut self, _value: u128) -> Result<(), Self::Error> {
+    fn traverse_u128(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: u128,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_u256(&mut self, _value: U256) -> Result<(), Self::Error> {
+    fn traverse_u256(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: U256,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_bool(&mut self, _value: bool) -> Result<(), Self::Error> {
+    fn traverse_bool(
+        &mut self,
+        _driver: &ValueDriver<'_, '_>,
+        _value: bool,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_address(&mut self, _value: AccountAddress) -> Result<(), Self::Error> {
+    fn traverse_address(
+        &mut self,
+        _: &ValueDriver<'_, '_>,
+        _: AccountAddress,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_signer(&mut self, _value: AccountAddress) -> Result<(), Self::Error> {
+    fn traverse_signer(
+        &mut self,
+        _: &ValueDriver<'_, '_>,
+        _: AccountAddress,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -134,40 +214,76 @@ impl<T: Traversal + ?Sized> Visitor for T {
     type Value = ();
     type Error = T::Error;
 
-    fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error> {
-        self.traverse_u8(value)
+    fn visit_u8(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u8,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u8(driver, value)
     }
 
-    fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error> {
-        self.traverse_u16(value)
+    fn visit_u16(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u16,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u16(driver, value)
     }
 
-    fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
-        self.traverse_u32(value)
+    fn visit_u32(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u32,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u32(driver, value)
     }
 
-    fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
-        self.traverse_u64(value)
+    fn visit_u64(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u64,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u64(driver, value)
     }
 
-    fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error> {
-        self.traverse_u128(value)
+    fn visit_u128(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: u128,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u128(driver, value)
     }
 
-    fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error> {
-        self.traverse_u256(value)
+    fn visit_u256(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: U256,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u256(driver, value)
     }
 
-    fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
-        self.traverse_bool(value)
+    fn visit_bool(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: bool,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_bool(driver, value)
     }
 
-    fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
-        self.traverse_address(value)
+    fn visit_address(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_address(driver, value)
     }
 
-    fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
-        self.traverse_signer(value)
+    fn visit_signer(
+        &mut self,
+        driver: &ValueDriver<'_, '_>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_signer(driver, value)
     }
 
     fn visit_vector(
@@ -260,6 +376,26 @@ impl<'c, 'b> ValueDriver<'c, 'b> {
         Self { bytes, start }
     }
 
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.bytes.position() as usize
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.bytes.get_ref()
+    }
+    ///
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        &self.bytes.get_ref()[self.position()..]
+    }
+
     fn read_exact<const N: usize>(&mut self) -> Result<[u8; N], Error> {
         let mut buf = [0u8; N];
         self.bytes
@@ -282,6 +418,26 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
             len,
             off: 0,
         }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.inner.start()
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.inner.bytes()
+    }
+
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        self.inner.remaining_bytes()
     }
 
     /// Type layout for the vector's inner type.
@@ -333,6 +489,26 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
             layout,
             off: 0,
         }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.inner.start()
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.inner.bytes()
+    }
+
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        self.inner.remaining_bytes()
     }
 
     /// The layout of the struct being visited.
@@ -390,6 +566,26 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
             variant_layout,
             off: 0,
         }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.inner.start()
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.inner.bytes()
+    }
+
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        self.inner.remaining_bytes()
     }
 
     /// The layout of the enum being visited.
@@ -458,20 +654,51 @@ pub(crate) fn visit_value<V: Visitor + ?Sized>(
 
     let mut driver = ValueDriver::new(bytes);
     match layout {
-        L::Bool => match read_exact::<1>(bytes)? {
-            [0] => visitor.visit_bool(false),
-            [1] => visitor.visit_bool(true),
+        L::Bool => match driver.read_exact()? {
+            [0] => visitor.visit_bool(&driver, false),
+            [1] => visitor.visit_bool(&driver, true),
             [b] => Err(Error::UnexpectedByte(b).into()),
         },
 
-        L::U8 => visitor.visit_u8(u8::from_le_bytes(driver.read_exact()?)),
-        L::U16 => visitor.visit_u16(u16::from_le_bytes(driver.read_exact()?)),
-        L::U32 => visitor.visit_u32(u32::from_le_bytes(driver.read_exact()?)),
-        L::U64 => visitor.visit_u64(u64::from_le_bytes(driver.read_exact()?)),
-        L::U128 => visitor.visit_u128(u128::from_le_bytes(driver.read_exact()?)),
-        L::U256 => visitor.visit_u256(U256::from_le_bytes(&driver.read_exact()?)),
-        L::Address => visitor.visit_address(AccountAddress::new(driver.read_exact()?)),
-        L::Signer => visitor.visit_signer(AccountAddress::new(driver.read_exact()?)),
+        L::U8 => {
+            let v = u8::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u8(&driver, v)
+        }
+
+        L::U16 => {
+            let v = u16::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u16(&driver, v)
+        }
+
+        L::U32 => {
+            let v = u32::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u32(&driver, v)
+        }
+
+        L::U64 => {
+            let v = u64::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u64(&driver, v)
+        }
+
+        L::U128 => {
+            let v = u128::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u128(&driver, v)
+        }
+
+        L::U256 => {
+            let v = U256::from_le_bytes(&driver.read_exact()?);
+            visitor.visit_u256(&driver, v)
+        }
+
+        L::Address => {
+            let v = AccountAddress::new(driver.read_exact()?);
+            visitor.visit_address(&driver, v)
+        }
+
+        L::Signer => {
+            let v = AccountAddress::new(driver.read_exact()?);
+            visitor.visit_signer(&driver, v)
+        }
 
         L::Vector(l) => visit_vector(driver, l.as_ref(), visitor),
         L::Struct(l) => visit_struct(driver, l, visitor),
@@ -536,12 +763,4 @@ fn visit_variant<V: Visitor + ?Sized>(
     let res = visitor.visit_variant(&mut driver)?;
     while driver.skip_field()?.is_some() {}
     Ok(res)
-}
-
-fn read_exact<const N: usize>(bytes: &mut Cursor<&[u8]>) -> Result<[u8; N], Error> {
-    let mut buf = [0u8; N];
-    bytes
-        .read_exact(&mut buf)
-        .map_err(|_| Error::UnexpectedEof)?;
-    Ok(buf)
 }

--- a/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Visitors can be used for building values out of a serialized Move struct or value.
-pub trait Visitor {
+pub trait Visitor<'b, 'l> {
     type Value;
 
     /// Visitors can return any error as long as it can represent an error from the visitor itself.
@@ -31,71 +31,71 @@ pub trait Visitor {
 
     fn visit_u8(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u8,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u16(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u16,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u32(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u32,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u64(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u64,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u128(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u128,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u256(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: U256,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_bool(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: bool,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_address(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_signer(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_vector(
         &mut self,
-        driver: &mut VecDriver<'_, '_, '_>,
+        driver: &mut VecDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_struct(
         &mut self,
-        driver: &mut StructDriver<'_, '_, '_>,
+        driver: &mut StructDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_variant(
         &mut self,
-        driver: &mut VariantDriver<'_, '_, '_>,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error>;
 }
 
@@ -112,12 +112,12 @@ pub trait Visitor {
 ///     Ok(())
 /// }
 /// ```
-pub trait Traversal {
+pub trait Traversal<'b, 'l> {
     type Error: From<Error>;
 
     fn traverse_u8(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: u8,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -125,7 +125,7 @@ pub trait Traversal {
 
     fn traverse_u16(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: u16,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -133,7 +133,7 @@ pub trait Traversal {
 
     fn traverse_u32(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: u32,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -141,7 +141,7 @@ pub trait Traversal {
 
     fn traverse_u64(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: u64,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -149,7 +149,7 @@ pub trait Traversal {
 
     fn traverse_u128(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: u128,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -157,7 +157,7 @@ pub trait Traversal {
 
     fn traverse_u256(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: U256,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -165,7 +165,7 @@ pub trait Traversal {
 
     fn traverse_bool(
         &mut self,
-        _driver: &ValueDriver<'_, '_>,
+        _driver: &ValueDriver<'_, 'b>,
         _value: bool,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -173,7 +173,7 @@ pub trait Traversal {
 
     fn traverse_address(
         &mut self,
-        _: &ValueDriver<'_, '_>,
+        _: &ValueDriver<'_, 'b>,
         _: AccountAddress,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -181,20 +181,20 @@ pub trait Traversal {
 
     fn traverse_signer(
         &mut self,
-        _: &ValueDriver<'_, '_>,
+        _: &ValueDriver<'_, 'b>,
         _: AccountAddress,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn traverse_vector(&mut self, driver: &mut VecDriver<'_, '_, '_>) -> Result<(), Self::Error> {
+    fn traverse_vector(&mut self, driver: &mut VecDriver<'_, 'b, 'l>) -> Result<(), Self::Error> {
         while driver.next_element(self)?.is_some() {}
         Ok(())
     }
 
     fn traverse_struct(
         &mut self,
-        driver: &mut StructDriver<'_, '_, '_>,
+        driver: &mut StructDriver<'_, 'b, 'l>,
     ) -> Result<(), Self::Error> {
         while driver.next_field(self)?.is_some() {}
         Ok(())
@@ -202,7 +202,7 @@ pub trait Traversal {
 
     fn traverse_variant(
         &mut self,
-        driver: &mut VariantDriver<'_, '_, '_>,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
     ) -> Result<(), Self::Error> {
         while driver.next_field(self)?.is_some() {}
         Ok(())
@@ -210,13 +210,13 @@ pub trait Traversal {
 }
 
 /// Default implementation converting any traversal into a visitor.
-impl<T: Traversal + ?Sized> Visitor for T {
+impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
     type Value = ();
     type Error = T::Error;
 
     fn visit_u8(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u8,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u8(driver, value)
@@ -224,7 +224,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_u16(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u16,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u16(driver, value)
@@ -232,7 +232,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_u32(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u32,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u32(driver, value)
@@ -240,7 +240,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_u64(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u64,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u64(driver, value)
@@ -248,7 +248,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_u128(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: u128,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u128(driver, value)
@@ -256,7 +256,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_u256(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: U256,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u256(driver, value)
@@ -264,7 +264,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_bool(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: bool,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_bool(driver, value)
@@ -272,7 +272,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_address(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_address(driver, value)
@@ -280,7 +280,7 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_signer(
         &mut self,
-        driver: &ValueDriver<'_, '_>,
+        driver: &ValueDriver<'_, 'b>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_signer(driver, value)
@@ -288,21 +288,21 @@ impl<T: Traversal + ?Sized> Visitor for T {
 
     fn visit_vector(
         &mut self,
-        driver: &mut VecDriver<'_, '_, '_>,
+        driver: &mut VecDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_vector(driver)
     }
 
     fn visit_struct(
         &mut self,
-        driver: &mut StructDriver<'_, '_, '_>,
+        driver: &mut StructDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_struct(driver)
     }
 
     fn visit_variant(
         &mut self,
-        driver: &mut VariantDriver<'_, '_, '_>,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_variant(driver)
     }
@@ -366,7 +366,7 @@ pub enum Error {
 /// value structure.
 pub struct NullTraversal;
 
-impl Traversal for NullTraversal {
+impl<'b, 'l> Traversal<'b, 'l> for NullTraversal {
     type Error = Error;
 }
 
@@ -462,7 +462,7 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
     /// Returns `Ok(None)` if there are no more elements in the vector, `Ok(v)` if there was an
     /// element and it was successfully visited (where `v` is the value returned by the visitor) or
     /// an error if there was an underlying deserialization error, or an error during visitation.
-    pub fn next_element<V: Visitor + ?Sized>(
+    pub fn next_element<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
     ) -> Result<Option<V::Value>, V::Error> {
@@ -529,7 +529,7 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
     /// field and it was successfully visited (where `v` is the value returned by the visitor, and
     /// `f` is the layout of the field that was visited) or an error if there was an underlying
     /// deserialization error, or an error during visitation.
-    pub fn next_field<V: Visitor + ?Sized>(
+    pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
     ) -> Result<Option<(&'l MoveFieldLayout, V::Value)>, V::Error> {
@@ -621,7 +621,7 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
     /// field and it was successfully visited (where `v` is the value returned by the visitor, and
     /// `f` is the layout of the field that was visited) or an error if there was an underlying
     /// deserialization error, or an error during visitation.
-    pub fn next_field<V: Visitor + ?Sized>(
+    pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
     ) -> Result<Option<(&'l MoveFieldLayout, V::Value)>, V::Error> {
@@ -645,9 +645,9 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
 /// Visit a serialized Move value with the provided `layout`, held in `bytes`, using the provided
 /// visitor to build a value out of it. See `annoted_value::MoveValue::visit_deserialize` for
 /// details.
-pub(crate) fn visit_value<V: Visitor + ?Sized>(
-    bytes: &mut Cursor<&[u8]>,
-    layout: &MoveTypeLayout,
+pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    bytes: &'c mut Cursor<&'b [u8]>,
+    layout: &'l MoveTypeLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     use MoveTypeLayout as L;
@@ -708,9 +708,9 @@ pub(crate) fn visit_value<V: Visitor + ?Sized>(
 
 /// Like `visit_value` but specialized to visiting a vector (where the `bytes` is known to be a
 /// serialized move vector), and the layout is the vector's element's layout.
-fn visit_vector<V: Visitor + ?Sized>(
-    mut inner: ValueDriver,
-    layout: &MoveTypeLayout,
+fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    mut inner: ValueDriver<'c, 'b>,
+    layout: &'l MoveTypeLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     let len = inner.read_leb128()?;
@@ -722,9 +722,9 @@ fn visit_vector<V: Visitor + ?Sized>(
 
 /// Like `visit_value` but specialized to visiting a struct (where the `bytes` is known to be a
 /// serialized move struct), and the layout is a struct layout.
-pub(crate) fn visit_struct<V: Visitor + ?Sized>(
-    inner: ValueDriver,
-    layout: &MoveStructLayout,
+pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    inner: ValueDriver<'c, 'b>,
+    layout: &'l MoveStructLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     let mut driver = StructDriver::new(inner, layout);
@@ -735,9 +735,9 @@ pub(crate) fn visit_struct<V: Visitor + ?Sized>(
 
 /// Like `visit_struct` but specialized to visiting a variant (where the `bytes` is known to be a
 /// serialized move variant), and the layout is an enum layout.
-fn visit_variant<V: Visitor + ?Sized>(
-    mut inner: ValueDriver,
-    layout: &MoveEnumLayout,
+fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    mut inner: ValueDriver<'c, 'b>,
+    layout: &'l MoveEnumLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     // Since variants are bounded at 127, we can read the tag as a single byte.

--- a/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
@@ -31,55 +31,55 @@ pub trait Visitor<'b, 'l> {
 
     fn visit_u8(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u8,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u16(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u16,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u32(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u32,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u64(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u64,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u128(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u128,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_u256(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: U256,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_bool(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: bool,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_address(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_signer(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error>;
 
@@ -117,7 +117,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_u8(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: u8,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -125,7 +125,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_u16(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: u16,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -133,7 +133,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_u32(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: u32,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -141,7 +141,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_u64(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: u64,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -149,7 +149,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_u128(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: u128,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -157,7 +157,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_u256(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: U256,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -165,7 +165,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_bool(
         &mut self,
-        _driver: &ValueDriver<'_, 'b>,
+        _driver: &ValueDriver<'_, 'b, 'l>,
         _value: bool,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -173,7 +173,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_address(
         &mut self,
-        _: &ValueDriver<'_, 'b>,
+        _: &ValueDriver<'_, 'b, 'l>,
         _: AccountAddress,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -181,7 +181,7 @@ pub trait Traversal<'b, 'l> {
 
     fn traverse_signer(
         &mut self,
-        _: &ValueDriver<'_, 'b>,
+        _: &ValueDriver<'_, 'b, 'l>,
         _: AccountAddress,
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -216,7 +216,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_u8(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u8,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u8(driver, value)
@@ -224,7 +224,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_u16(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u16,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u16(driver, value)
@@ -232,7 +232,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_u32(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u32,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u32(driver, value)
@@ -240,7 +240,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_u64(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u64,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u64(driver, value)
@@ -248,7 +248,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_u128(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: u128,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u128(driver, value)
@@ -256,7 +256,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_u256(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: U256,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_u256(driver, value)
@@ -264,7 +264,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_bool(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: bool,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_bool(driver, value)
@@ -272,7 +272,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_address(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_address(driver, value)
@@ -280,7 +280,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 
     fn visit_signer(
         &mut self,
-        driver: &ValueDriver<'_, 'b>,
+        driver: &ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         self.traverse_signer(driver, value)
@@ -309,9 +309,11 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 }
 
 /// Exposes information about the byte stream that the value being visited came from, namely the
-/// bytes themselves, and the offset at which the value starts.
-pub struct ValueDriver<'c, 'b> {
+/// bytes themselves, and the offset at which the value starts. Also exposes the layout of the
+/// value being visited.
+pub struct ValueDriver<'c, 'b, 'l> {
     bytes: &'c mut Cursor<&'b [u8]>,
+    layout: Option<&'l MoveTypeLayout>,
     start: usize,
 }
 
@@ -319,7 +321,7 @@ pub struct ValueDriver<'c, 'b> {
 /// implementation, and allows that visitor to progress the traversal (by visiting or skipping
 /// elements).
 pub struct VecDriver<'c, 'b, 'l> {
-    inner: ValueDriver<'c, 'b>,
+    inner: ValueDriver<'c, 'b, 'l>,
     layout: &'l MoveTypeLayout,
     len: u64,
     off: u64,
@@ -329,7 +331,7 @@ pub struct VecDriver<'c, 'b, 'l> {
 /// visited) to a visitor implementation, and allows that visitor to progress the traversal (by
 /// visiting or skipping fields).
 pub struct StructDriver<'c, 'b, 'l> {
-    inner: ValueDriver<'c, 'b>,
+    inner: ValueDriver<'c, 'b, 'l>,
     layout: &'l MoveStructLayout,
     off: usize,
 }
@@ -338,7 +340,7 @@ pub struct StructDriver<'c, 'b, 'l> {
 /// be visited, the variant's tag, and name) to a visitor implementation, and allows that visitor
 /// to progress the traversal (by visiting or skipping fields).
 pub struct VariantDriver<'c, 'b, 'l> {
-    inner: ValueDriver<'c, 'b>,
+    inner: ValueDriver<'c, 'b, 'l>,
     layout: &'l MoveEnumLayout,
     tag: u16,
     variant_name: &'l IdentStr,
@@ -359,6 +361,9 @@ pub enum Error {
 
     #[error("invalid variant tag: {0}")]
     UnexpectedVariantTag(usize),
+
+    #[error("no layout available for value")]
+    NoValueLayout,
 }
 
 /// The null traversal implements `Traversal` and `Visitor` but without doing anything (does not
@@ -370,10 +375,14 @@ impl<'b, 'l> Traversal<'b, 'l> for NullTraversal {
     type Error = Error;
 }
 
-impl<'c, 'b> ValueDriver<'c, 'b> {
-    pub(crate) fn new(bytes: &'c mut Cursor<&'b [u8]>) -> Self {
+impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
+    pub(crate) fn new(bytes: &'c mut Cursor<&'b [u8]>, layout: Option<&'l MoveTypeLayout>) -> Self {
         let start = bytes.position() as usize;
-        Self { bytes, start }
+        Self {
+            bytes,
+            layout,
+            start,
+        }
     }
 
     /// The offset at which the value being visited starts in the byte stream.
@@ -396,6 +405,13 @@ impl<'c, 'b> ValueDriver<'c, 'b> {
         &self.bytes.get_ref()[self.position()..]
     }
 
+    /// Type layout for the value being visited. May produce an error if a layout was not supplied
+    /// when the driver was created (which should only happen if the driver was created for
+    /// visiting a struct specifically).
+    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+        self.layout.ok_or(Error::NoValueLayout)
+    }
+
     fn read_exact<const N: usize>(&mut self) -> Result<[u8; N], Error> {
         let mut buf = [0u8; N];
         self.bytes
@@ -411,7 +427,7 @@ impl<'c, 'b> ValueDriver<'c, 'b> {
 
 #[allow(clippy::len_without_is_empty)]
 impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
-    fn new(inner: ValueDriver<'c, 'b>, layout: &'l MoveTypeLayout, len: u64) -> Self {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveTypeLayout, len: u64) -> Self {
         Self {
             inner,
             layout,
@@ -483,7 +499,7 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
 }
 
 impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
-    fn new(inner: ValueDriver<'c, 'b>, layout: &'l MoveStructLayout) -> Self {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveStructLayout) -> Self {
         Self {
             inner,
             layout,
@@ -552,7 +568,7 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
 
 impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
     fn new(
-        inner: ValueDriver<'c, 'b>,
+        inner: ValueDriver<'c, 'b, 'l>,
         layout: &'l MoveEnumLayout,
         variant_layout: &'l [MoveFieldLayout],
         variant_name: &'l IdentStr,
@@ -652,7 +668,7 @@ pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 ) -> Result<V::Value, V::Error> {
     use MoveTypeLayout as L;
 
-    let mut driver = ValueDriver::new(bytes);
+    let mut driver = ValueDriver::new(bytes, Some(layout));
     match layout {
         L::Bool => match driver.read_exact()? {
             [0] => visitor.visit_bool(&driver, false),
@@ -709,7 +725,7 @@ pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// Like `visit_value` but specialized to visiting a vector (where the `bytes` is known to be a
 /// serialized move vector), and the layout is the vector's element's layout.
 fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
-    mut inner: ValueDriver<'c, 'b>,
+    mut inner: ValueDriver<'c, 'b, 'l>,
     layout: &'l MoveTypeLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
@@ -723,7 +739,7 @@ fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// Like `visit_value` but specialized to visiting a struct (where the `bytes` is known to be a
 /// serialized move struct), and the layout is a struct layout.
 pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
-    inner: ValueDriver<'c, 'b>,
+    inner: ValueDriver<'c, 'b, 'l>,
     layout: &'l MoveStructLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
@@ -736,7 +752,7 @@ pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// Like `visit_struct` but specialized to visiting a variant (where the `bytes` is known to be a
 /// serialized move variant), and the layout is an enum layout.
 fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
-    mut inner: ValueDriver<'c, 'b>,
+    mut inner: ValueDriver<'c, 'b, 'l>,
     layout: &'l MoveEnumLayout,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -32,7 +32,7 @@ fn traversal() {
 
         fn traverse_u8(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: u8,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -41,7 +41,7 @@ fn traversal() {
 
         fn traverse_u16(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: u16,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -50,7 +50,7 @@ fn traversal() {
 
         fn traverse_u32(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: u32,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -59,7 +59,7 @@ fn traversal() {
 
         fn traverse_u64(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: u64,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -68,7 +68,7 @@ fn traversal() {
 
         fn traverse_u128(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: u128,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -77,7 +77,7 @@ fn traversal() {
 
         fn traverse_u256(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: U256,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -86,7 +86,7 @@ fn traversal() {
 
         fn traverse_bool(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: bool,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -95,7 +95,7 @@ fn traversal() {
 
         fn traverse_address(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: AccountAddress,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -104,7 +104,7 @@ fn traversal() {
 
         fn traverse_signer(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             _value: AccountAddress,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -346,7 +346,7 @@ fn nested_datatype_visit() {
 
         fn visit_u8(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: u8,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u8", self.depth).unwrap();
@@ -355,7 +355,7 @@ fn nested_datatype_visit() {
 
         fn visit_u16(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: u16,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u16", self.depth).unwrap();
@@ -364,7 +364,7 @@ fn nested_datatype_visit() {
 
         fn visit_u32(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: u32,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u32", self.depth).unwrap();
@@ -373,7 +373,7 @@ fn nested_datatype_visit() {
 
         fn visit_u64(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: u64,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u64", self.depth).unwrap();
@@ -382,7 +382,7 @@ fn nested_datatype_visit() {
 
         fn visit_u128(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: u128,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u128", self.depth).unwrap();
@@ -391,7 +391,7 @@ fn nested_datatype_visit() {
 
         fn visit_u256(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: U256,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u256", self.depth).unwrap();
@@ -400,7 +400,7 @@ fn nested_datatype_visit() {
 
         fn visit_bool(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: bool,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: bool", self.depth).unwrap();
@@ -409,7 +409,7 @@ fn nested_datatype_visit() {
 
         fn visit_address(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: address", self.depth).unwrap();
@@ -418,7 +418,7 @@ fn nested_datatype_visit() {
 
         fn visit_signer(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: signer", self.depth).unwrap();
@@ -599,7 +599,7 @@ fn peek_field_test() {
 
         fn visit_u64(
             &mut self,
-            _driver: &ValueDriver<'_, 'b>,
+            _driver: &ValueDriver<'_, 'b, 'l>,
             value: u64,
         ) -> Result<Self::Value, Self::Error> {
             Ok(self.fields.is_empty().then_some(value))
@@ -649,13 +649,17 @@ fn peek_field_test() {
 
         // === Empty/default cases ===
 
-        fn visit_u8(&mut self, _: &ValueDriver<'_, 'b>, _: u8) -> Result<Self::Value, Self::Error> {
+        fn visit_u8(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: u8,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
         fn visit_u16(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: u16,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -663,7 +667,7 @@ fn peek_field_test() {
 
         fn visit_u32(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: u32,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -671,7 +675,7 @@ fn peek_field_test() {
 
         fn visit_u128(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: u128,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -679,7 +683,7 @@ fn peek_field_test() {
 
         fn visit_u256(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: U256,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -687,7 +691,7 @@ fn peek_field_test() {
 
         fn visit_bool(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: bool,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -695,7 +699,7 @@ fn peek_field_test() {
 
         fn visit_address(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -703,7 +707,7 @@ fn peek_field_test() {
 
         fn visit_signer(
             &mut self,
-            _: &ValueDriver<'_, 'b>,
+            _: &ValueDriver<'_, 'b, 'l>,
             _: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -788,7 +792,7 @@ fn byte_offset_test() {
 
         fn traverse_u8(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: u8,
         ) -> Result<(), Self::Error> {
             write!(
@@ -803,7 +807,7 @@ fn byte_offset_test() {
 
         fn traverse_u16(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: u16,
         ) -> Result<(), Self::Error> {
             write!(
@@ -818,7 +822,7 @@ fn byte_offset_test() {
 
         fn traverse_u32(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: u32,
         ) -> Result<(), Self::Error> {
             write!(
@@ -833,7 +837,7 @@ fn byte_offset_test() {
 
         fn traverse_u64(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: u64,
         ) -> Result<(), Self::Error> {
             write!(
@@ -848,7 +852,7 @@ fn byte_offset_test() {
 
         fn traverse_u128(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: u128,
         ) -> Result<(), Self::Error> {
             write!(
@@ -863,7 +867,7 @@ fn byte_offset_test() {
 
         fn traverse_u256(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: U256,
         ) -> Result<(), Self::Error> {
             write!(
@@ -878,7 +882,7 @@ fn byte_offset_test() {
 
         fn traverse_bool(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: bool,
         ) -> Result<(), Self::Error> {
             write!(
@@ -893,7 +897,7 @@ fn byte_offset_test() {
 
         fn traverse_address(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: AccountAddress,
         ) -> Result<(), Self::Error> {
             write!(
@@ -909,7 +913,7 @@ fn byte_offset_test() {
 
         fn traverse_signer(
             &mut self,
-            driver: &ValueDriver<'_, 'b>,
+            driver: &ValueDriver<'_, 'b, 'l>,
             value: AccountAddress,
         ) -> Result<(), Self::Error> {
             write!(

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -10,7 +10,8 @@ use crate::{
         MoveVariant,
     },
     annotated_visitor::{
-        self, NullTraversal, StructDriver, Traversal, VariantDriver, VecDriver, Visitor,
+        self, NullTraversal, StructDriver, Traversal, ValueDriver, VariantDriver, VecDriver,
+        Visitor,
     },
     identifier::Identifier,
     language_storage::StructTag,
@@ -29,47 +30,83 @@ fn traversal() {
     impl Traversal for CountingTraversal {
         type Error = annotated_visitor::Error;
 
-        fn traverse_u8(&mut self, _: u8) -> Result<(), Self::Error> {
+        fn traverse_u8(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: u8,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_u16(&mut self, _: u16) -> Result<(), Self::Error> {
+        fn traverse_u16(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: u16,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_u32(&mut self, _: u32) -> Result<(), Self::Error> {
+        fn traverse_u32(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: u32,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_u64(&mut self, _: u64) -> Result<(), Self::Error> {
+        fn traverse_u64(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: u64,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_u128(&mut self, _: u128) -> Result<(), Self::Error> {
+        fn traverse_u128(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: u128,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_u256(&mut self, _: U256) -> Result<(), Self::Error> {
+        fn traverse_u256(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: U256,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_bool(&mut self, _: bool) -> Result<(), Self::Error> {
+        fn traverse_bool(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: bool,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_address(&mut self, _: AccountAddress) -> Result<(), Self::Error> {
+        fn traverse_address(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: AccountAddress,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
 
-        fn traverse_signer(&mut self, _: AccountAddress) -> Result<(), Self::Error> {
+        fn traverse_signer(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            _value: AccountAddress,
+        ) -> Result<(), Self::Error> {
             self.0 += 1;
             Ok(())
         }
@@ -307,47 +344,83 @@ fn nested_datatype_visit() {
         type Value = MoveValue;
         type Error = annotated_visitor::Error;
 
-        fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error> {
+        fn visit_u8(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: u8,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u8", self.depth).unwrap();
             Ok(V::U8(value))
         }
 
-        fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error> {
+        fn visit_u16(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: u16,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u16", self.depth).unwrap();
             Ok(V::U16(value))
         }
 
-        fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
+        fn visit_u32(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: u32,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u32", self.depth).unwrap();
             Ok(V::U32(value))
         }
 
-        fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+        fn visit_u64(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: u64,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u64", self.depth).unwrap();
             Ok(V::U64(value))
         }
 
-        fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error> {
+        fn visit_u128(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: u128,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u128", self.depth).unwrap();
             Ok(V::U128(value))
         }
 
-        fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error> {
+        fn visit_u256(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: U256,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u256", self.depth).unwrap();
             Ok(V::U256(value))
         }
 
-        fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
+        fn visit_bool(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: bool,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: bool", self.depth).unwrap();
             Ok(V::Bool(value))
         }
 
-        fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+        fn visit_address(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: AccountAddress,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: address", self.depth).unwrap();
             Ok(V::Address(value))
         }
 
-        fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+        fn visit_signer(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: AccountAddress,
+        ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: signer", self.depth).unwrap();
             Ok(V::Signer(value))
         }
@@ -524,7 +597,11 @@ fn peek_field_test() {
         type Value = Option<u64>;
         type Error = annotated_visitor::Error;
 
-        fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+        fn visit_u64(
+            &mut self,
+            _driver: &ValueDriver<'_, '_>,
+            value: u64,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(self.fields.is_empty().then_some(value))
         }
 
@@ -572,35 +649,63 @@ fn peek_field_test() {
 
         // === Empty/default cases ===
 
-        fn visit_u8(&mut self, _: u8) -> Result<Self::Value, Self::Error> {
+        fn visit_u8(&mut self, _: &ValueDriver<'_, '_>, _: u8) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_u16(&mut self, _: u16) -> Result<Self::Value, Self::Error> {
+        fn visit_u16(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: u16,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_u32(&mut self, _: u32) -> Result<Self::Value, Self::Error> {
+        fn visit_u32(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: u32,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_u128(&mut self, _: u128) -> Result<Self::Value, Self::Error> {
+        fn visit_u128(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: u128,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_u256(&mut self, _: U256) -> Result<Self::Value, Self::Error> {
+        fn visit_u256(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: U256,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_bool(&mut self, _: bool) -> Result<Self::Value, Self::Error> {
+        fn visit_bool(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: bool,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_address(&mut self, _: AccountAddress) -> Result<Self::Value, Self::Error> {
+        fn visit_address(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: AccountAddress,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
-        fn visit_signer(&mut self, _: AccountAddress) -> Result<Self::Value, Self::Error> {
+        fn visit_signer(
+            &mut self,
+            _: &ValueDriver<'_, '_>,
+            _: AccountAddress,
+        ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
@@ -668,6 +773,284 @@ fn peek_field_test() {
     assert_eq!(visit_struct(&["c"]), None);
     assert_eq!(visit_struct(&["d", "e"]), Some(45));
     assert_eq!(visit_struct(&["f", "h"]), Some(46));
+}
+
+#[test]
+fn byte_offset_test() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    #[derive(Default)]
+    struct ByteOffsetVisitor(String);
+
+    impl Traversal for ByteOffsetVisitor {
+        type Error = annotated_visitor::Error;
+
+        fn traverse_u8(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: u8,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u8",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u16(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: u16,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u16",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u32(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: u32,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u32",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u64(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: u64,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u64",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u128(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: u128,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u128",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u256(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: U256,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u256",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_bool(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: bool,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: bool",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_address(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {}: address",
+                driver.start(),
+                driver.position(),
+                value.to_canonical_display(/* with_prefix */ true),
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_signer(
+            &mut self,
+            driver: &ValueDriver<'_, '_>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {}: address",
+                driver.start(),
+                driver.position(),
+                value.to_canonical_display(/* with_prefix */ true),
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_vector(
+            &mut self,
+            driver: &mut VecDriver<'_, '_, '_>,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] vector<{:#}>",
+                driver.start(),
+                driver.position(),
+                driver.element_layout(),
+            )
+            .unwrap();
+            while driver.next_element(self)?.is_some() {}
+            Ok(())
+        }
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut StructDriver<'_, '_, '_>,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {:#}",
+                driver.start(),
+                driver.position(),
+                driver.struct_layout(),
+            )
+            .unwrap();
+
+            while let Some((_, ())) = driver.next_field(self)? {}
+            Ok(())
+        }
+
+        fn traverse_variant(
+            &mut self,
+            driver: &mut VariantDriver<'_, '_, '_>,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {:#}",
+                driver.start(),
+                driver.position(),
+                driver.enum_layout(),
+            )
+            .unwrap();
+
+            while let Some((_, ())) = driver.next_field(self)? {}
+            Ok(())
+        }
+    }
+
+    let type_layout = struct_layout_(
+        "0x0::foo::Bar",
+        vec![
+            (
+                "inner",
+                struct_layout_(
+                    "0x0::baz::Qux",
+                    vec![("f", T::U64), ("g", T::Vector(Box::new(T::U32)))],
+                ),
+            ),
+            (
+                "last",
+                enum_layout_("0x0::foo::Baz", vec![("e", vec![("h", T::U64)])]),
+            ),
+        ],
+    );
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let bytes = serialize(struct_value_(
+        "0x0::foo::Bar",
+        vec![
+            (
+                "inner",
+                struct_value_(
+                    "0x0::baz::Qux",
+                    vec![
+                        ("f", V::U64(7)),
+                        ("g", V::Vector(vec![V::U32(1), V::U32(2), V::U32(3)])),
+                    ],
+                ),
+            ),
+            (
+                "last",
+                variant_value_("0x0::foo::Baz", "e", 0, vec![("h", V::U64(4))]),
+            ),
+        ],
+    ));
+
+    let mut value_visitor = ByteOffsetVisitor::default();
+    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+
+    let mut struct_visitor = ByteOffsetVisitor::default();
+    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+
+    let expected_output = r#"
+[  0 ..   0] struct 0x0::foo::Bar {
+    inner: struct 0x0::baz::Qux {
+        f: u64,
+        g: vector<u32>,
+    },
+    last: enum 0x0::foo::Baz {
+        e {
+            h: u64,
+        },
+    },
+}
+[  0 ..   0] struct 0x0::baz::Qux {
+    f: u64,
+    g: vector<u32>,
+}
+[  0 ..   8] 7: u64
+[  8 ..   9] vector<u32>
+[  9 ..  13] 1: u32
+[ 13 ..  17] 2: u32
+[ 17 ..  21] 3: u32
+[ 21 ..  22] enum 0x0::foo::Baz {
+    e {
+        h: u64,
+    },
+}
+[ 22 ..  30] 4: u64"#;
+
+    assert_eq!(value_visitor.0, expected_output);
+    assert_eq!(struct_visitor.0, expected_output);
 }
 
 /// Create a struct value for test purposes.

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -27,12 +27,12 @@ fn traversal() {
     #[derive(Default)]
     struct CountingTraversal(usize);
 
-    impl Traversal for CountingTraversal {
+    impl<'b, 'l> Traversal<'b, 'l> for CountingTraversal {
         type Error = annotated_visitor::Error;
 
         fn traverse_u8(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: u8,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -41,7 +41,7 @@ fn traversal() {
 
         fn traverse_u16(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: u16,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -50,7 +50,7 @@ fn traversal() {
 
         fn traverse_u32(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: u32,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -59,7 +59,7 @@ fn traversal() {
 
         fn traverse_u64(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: u64,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -68,7 +68,7 @@ fn traversal() {
 
         fn traverse_u128(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: u128,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -77,7 +77,7 @@ fn traversal() {
 
         fn traverse_u256(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: U256,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -86,7 +86,7 @@ fn traversal() {
 
         fn traverse_bool(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: bool,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -95,7 +95,7 @@ fn traversal() {
 
         fn traverse_address(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: AccountAddress,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -104,7 +104,7 @@ fn traversal() {
 
         fn traverse_signer(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             _value: AccountAddress,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
@@ -113,7 +113,7 @@ fn traversal() {
 
         fn traverse_vector(
             &mut self,
-            driver: &mut VecDriver<'_, '_, '_>,
+            driver: &mut VecDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
             while driver.next_element(self)?.is_some() {}
@@ -122,7 +122,7 @@ fn traversal() {
 
         fn traverse_struct(
             &mut self,
-            driver: &mut StructDriver<'_, '_, '_>,
+            driver: &mut StructDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
             while driver.next_field(self)?.is_some() {}
@@ -131,7 +131,7 @@ fn traversal() {
 
         fn traverse_variant(
             &mut self,
-            driver: &mut VariantDriver<'_, '_, '_>,
+            driver: &mut VariantDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             self.0 += 1;
             while driver.next_field(self)?.is_some() {}
@@ -340,13 +340,13 @@ fn nested_datatype_visit() {
         output: String,
     }
 
-    impl Visitor for PrintVisitor {
+    impl<'b, 'l> Visitor<'b, 'l> for PrintVisitor {
         type Value = MoveValue;
         type Error = annotated_visitor::Error;
 
         fn visit_u8(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: u8,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u8", self.depth).unwrap();
@@ -355,7 +355,7 @@ fn nested_datatype_visit() {
 
         fn visit_u16(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: u16,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u16", self.depth).unwrap();
@@ -364,7 +364,7 @@ fn nested_datatype_visit() {
 
         fn visit_u32(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: u32,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u32", self.depth).unwrap();
@@ -373,7 +373,7 @@ fn nested_datatype_visit() {
 
         fn visit_u64(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: u64,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u64", self.depth).unwrap();
@@ -382,7 +382,7 @@ fn nested_datatype_visit() {
 
         fn visit_u128(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: u128,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u128", self.depth).unwrap();
@@ -391,7 +391,7 @@ fn nested_datatype_visit() {
 
         fn visit_u256(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: U256,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: u256", self.depth).unwrap();
@@ -400,7 +400,7 @@ fn nested_datatype_visit() {
 
         fn visit_bool(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: bool,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: bool", self.depth).unwrap();
@@ -409,7 +409,7 @@ fn nested_datatype_visit() {
 
         fn visit_address(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: address", self.depth).unwrap();
@@ -418,7 +418,7 @@ fn nested_datatype_visit() {
 
         fn visit_signer(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             write!(self.output, "\n[{}] {value}: signer", self.depth).unwrap();
@@ -427,7 +427,7 @@ fn nested_datatype_visit() {
 
         fn visit_vector(
             &mut self,
-            driver: &mut VecDriver<'_, '_, '_>,
+            driver: &mut VecDriver<'_, 'b, 'l>,
         ) -> Result<Self::Value, Self::Error> {
             let layout = driver.element_layout();
             write!(self.output, "\n[{}] vector<{layout:#}>", self.depth).unwrap();
@@ -448,7 +448,7 @@ fn nested_datatype_visit() {
 
         fn visit_struct(
             &mut self,
-            driver: &mut StructDriver<'_, '_, '_>,
+            driver: &mut StructDriver<'_, 'b, 'l>,
         ) -> Result<Self::Value, Self::Error> {
             let layout = driver.struct_layout();
             write!(self.output, "\n[{}] {layout:#}", self.depth).unwrap();
@@ -470,7 +470,7 @@ fn nested_datatype_visit() {
 
         fn visit_variant(
             &mut self,
-            driver: &mut VariantDriver<'_, '_, '_>,
+            driver: &mut VariantDriver<'_, 'b, 'l>,
         ) -> Result<Self::Value, Self::Error> {
             let layout = driver.enum_layout();
             write!(self.output, "\n[{}] {layout:#}", self.depth).unwrap();
@@ -593,13 +593,13 @@ fn peek_field_test() {
         fields: &'f [&'f str],
     }
 
-    impl<'f> Visitor for PeekU64Visitor<'f> {
+    impl<'b, 'l, 'f> Visitor<'b, 'l> for PeekU64Visitor<'f> {
         type Value = Option<u64>;
         type Error = annotated_visitor::Error;
 
         fn visit_u64(
             &mut self,
-            _driver: &ValueDriver<'_, '_>,
+            _driver: &ValueDriver<'_, 'b>,
             value: u64,
         ) -> Result<Self::Value, Self::Error> {
             Ok(self.fields.is_empty().then_some(value))
@@ -607,7 +607,7 @@ fn peek_field_test() {
 
         fn visit_struct(
             &mut self,
-            driver: &mut StructDriver<'_, '_, '_>,
+            driver: &mut StructDriver<'_, 'b, 'l>,
         ) -> Result<Self::Value, Self::Error> {
             let [field, fields @ ..] = self.fields else {
                 return Ok(None);
@@ -628,7 +628,7 @@ fn peek_field_test() {
 
         fn visit_variant(
             &mut self,
-            driver: &mut VariantDriver<'_, '_, '_>,
+            driver: &mut VariantDriver<'_, 'b, 'l>,
         ) -> Result<Self::Value, Self::Error> {
             let [field, fields @ ..] = self.fields else {
                 return Ok(None);
@@ -649,13 +649,13 @@ fn peek_field_test() {
 
         // === Empty/default cases ===
 
-        fn visit_u8(&mut self, _: &ValueDriver<'_, '_>, _: u8) -> Result<Self::Value, Self::Error> {
+        fn visit_u8(&mut self, _: &ValueDriver<'_, 'b>, _: u8) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
 
         fn visit_u16(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: u16,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -663,7 +663,7 @@ fn peek_field_test() {
 
         fn visit_u32(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: u32,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -671,7 +671,7 @@ fn peek_field_test() {
 
         fn visit_u128(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: u128,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -679,7 +679,7 @@ fn peek_field_test() {
 
         fn visit_u256(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: U256,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -687,7 +687,7 @@ fn peek_field_test() {
 
         fn visit_bool(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: bool,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -695,7 +695,7 @@ fn peek_field_test() {
 
         fn visit_address(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -703,7 +703,7 @@ fn peek_field_test() {
 
         fn visit_signer(
             &mut self,
-            _: &ValueDriver<'_, '_>,
+            _: &ValueDriver<'_, 'b>,
             _: AccountAddress,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
@@ -713,7 +713,7 @@ fn peek_field_test() {
         /// under here.
         fn visit_vector(
             &mut self,
-            _: &mut VecDriver<'_, '_, '_>,
+            _: &mut VecDriver<'_, 'b, 'l>,
         ) -> Result<Self::Value, Self::Error> {
             Ok(None)
         }
@@ -783,12 +783,12 @@ fn byte_offset_test() {
     #[derive(Default)]
     struct ByteOffsetVisitor(String);
 
-    impl Traversal for ByteOffsetVisitor {
+    impl<'b, 'l> Traversal<'b, 'l> for ByteOffsetVisitor {
         type Error = annotated_visitor::Error;
 
         fn traverse_u8(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: u8,
         ) -> Result<(), Self::Error> {
             write!(
@@ -803,7 +803,7 @@ fn byte_offset_test() {
 
         fn traverse_u16(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: u16,
         ) -> Result<(), Self::Error> {
             write!(
@@ -818,7 +818,7 @@ fn byte_offset_test() {
 
         fn traverse_u32(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: u32,
         ) -> Result<(), Self::Error> {
             write!(
@@ -833,7 +833,7 @@ fn byte_offset_test() {
 
         fn traverse_u64(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: u64,
         ) -> Result<(), Self::Error> {
             write!(
@@ -848,7 +848,7 @@ fn byte_offset_test() {
 
         fn traverse_u128(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: u128,
         ) -> Result<(), Self::Error> {
             write!(
@@ -863,7 +863,7 @@ fn byte_offset_test() {
 
         fn traverse_u256(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: U256,
         ) -> Result<(), Self::Error> {
             write!(
@@ -878,7 +878,7 @@ fn byte_offset_test() {
 
         fn traverse_bool(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: bool,
         ) -> Result<(), Self::Error> {
             write!(
@@ -893,7 +893,7 @@ fn byte_offset_test() {
 
         fn traverse_address(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: AccountAddress,
         ) -> Result<(), Self::Error> {
             write!(
@@ -909,7 +909,7 @@ fn byte_offset_test() {
 
         fn traverse_signer(
             &mut self,
-            driver: &ValueDriver<'_, '_>,
+            driver: &ValueDriver<'_, 'b>,
             value: AccountAddress,
         ) -> Result<(), Self::Error> {
             write!(
@@ -925,7 +925,7 @@ fn byte_offset_test() {
 
         fn traverse_vector(
             &mut self,
-            driver: &mut VecDriver<'_, '_, '_>,
+            driver: &mut VecDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             write!(
                 &mut self.0,
@@ -941,7 +941,7 @@ fn byte_offset_test() {
 
         fn traverse_struct(
             &mut self,
-            driver: &mut StructDriver<'_, '_, '_>,
+            driver: &mut StructDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             write!(
                 &mut self.0,
@@ -958,7 +958,7 @@ fn byte_offset_test() {
 
         fn traverse_variant(
             &mut self,
-            driver: &mut VariantDriver<'_, '_, '_>,
+            driver: &mut VariantDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             write!(
                 &mut self.0,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -693,10 +693,13 @@ pub fn get_all_uids(
     struct UIDTraversalV2<'i>(&'i mut BTreeSet<ObjectID>);
     struct UIDCollectorV2<'i>(&'i mut BTreeSet<ObjectID>);
 
-    impl<'i> AV::Traversal for UIDTraversalV2<'i> {
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversalV2<'i> {
         type Error = AV::Error;
 
-        fn traverse_struct(&mut self, driver: &mut AV::StructDriver) -> Result<(), Self::Error> {
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
             if driver.struct_layout().type_ == UID::type_() {
                 while driver.next_field(&mut UIDCollectorV2(self.0))?.is_some() {}
             } else {
@@ -706,9 +709,13 @@ pub fn get_all_uids(
         }
     }
 
-    impl<'i> AV::Traversal for UIDCollectorV2<'i> {
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollectorV2<'i> {
         type Error = AV::Error;
-        fn traverse_address(&mut self, value: AccountAddress) -> Result<(), Self::Error> {
+        fn traverse_address(
+            &mut self,
+            _driver: &AV::ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
             self.0.insert(value.into());
             Ok(())
         }

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -690,10 +690,10 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    struct UIDTraversalV2<'i>(&'i mut BTreeSet<ObjectID>);
-    struct UIDCollectorV2<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDTraversal<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollector<'i>(&'i mut BTreeSet<ObjectID>);
 
-    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversalV2<'i> {
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversal<'i> {
         type Error = AV::Error;
 
         fn traverse_struct(
@@ -701,7 +701,7 @@ pub fn get_all_uids(
             driver: &mut AV::StructDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             if driver.struct_layout().type_ == UID::type_() {
-                while driver.next_field(&mut UIDCollectorV2(self.0))?.is_some() {}
+                while driver.next_field(&mut UIDCollector(self.0))?.is_some() {}
             } else {
                 while driver.next_field(self)?.is_some() {}
             }
@@ -709,7 +709,7 @@ pub fn get_all_uids(
         }
     }
 
-    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollectorV2<'i> {
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollector<'i> {
         type Error = AV::Error;
         fn traverse_address(
             &mut self,
@@ -724,7 +724,7 @@ pub fn get_all_uids(
     MoveValue::visit_deserialize(
         bcs_bytes,
         fully_annotated_layout,
-        &mut UIDTraversalV2(&mut ids),
+        &mut UIDTraversal(&mut ids),
     )
     .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
     Ok(ids)

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -10,8 +10,8 @@ use indexmap::{IndexMap, IndexSet};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveValue, MoveVariant},
-    identifier::Identifier,
+    annotated_value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     language_storage::StructTag,
     vm_status::StatusCode,
 };
@@ -864,113 +864,105 @@ fn pack_option(opt: Option<Value>) -> Value {
     )]))
 }
 
-fn find_all_wrapped_objects<'a>(
+fn find_all_wrapped_objects<'a, 'i>(
     context: &NativeContext,
-    ids: &mut BTreeSet<ObjectID>,
+    ids: &'i mut BTreeSet<ObjectID>,
     new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a Type, impl Borrow<Value>)>,
 ) {
-    for (_id, ty, value) in new_object_values {
-        let layout = match context.type_to_type_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let annotated_layout = match context.type_to_fully_annotated_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let blob = value.borrow().simple_serialize(&layout).unwrap();
-        // TODO (annotated-visitor): Replace with a custom visitor.
-        let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
-        let uid = UID::type_();
-        visit_structs(&move_value, |depth, tag, fields| {
-            if tag != &uid {
-                return if depth == 0 {
-                    debug_assert!(!fields.is_empty());
-                    // all object values so the first field is a UID that should be skipped
-                    &fields[1..]
-                } else {
-                    fields
-                };
-            }
-            debug_assert!(fields.len() == 1);
-            let id = &fields[0].1;
-            let addr_field = match &id {
-                MoveValue::Struct(MoveStruct { fields, .. }) => {
-                    debug_assert!(fields.len() == 1);
-                    &fields[0].1
-                }
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            let addr = match addr_field {
-                MoveValue::Address(a) => *a,
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            ids.insert(addr.into());
-            fields
-        })
+    #[derive(Copy, Clone)]
+    enum LookingFor {
+        Wrapped,
+        Uid,
+        Address,
     }
-}
 
-fn visit_structs<FVisitTypes>(move_value: &MoveValue, mut visit_with_types: FVisitTypes)
-where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    visit_structs_impl(move_value, &mut visit_with_types, 0)
-}
+    struct Traversal<'i, 'u> {
+        state: LookingFor,
+        ids: &'i mut BTreeSet<ObjectID>,
+        uid: &'u MoveStructLayout,
+    }
 
-fn visit_structs_impl<FVisitTypes>(
-    move_value: &MoveValue,
-    visit_with_types: &mut FVisitTypes,
-    depth: usize,
-) where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    let next_depth = depth + 1;
-    match move_value {
-        MoveValue::U8(_)
-        | MoveValue::U16(_)
-        | MoveValue::U32(_)
-        | MoveValue::U64(_)
-        | MoveValue::U128(_)
-        | MoveValue::U256(_)
-        | MoveValue::Bool(_)
-        | MoveValue::Address(_)
-        | MoveValue::Signer(_) => (),
-        MoveValue::Vector(vs) => {
-            for v in vs {
-                visit_structs_impl(v, visit_with_types, next_depth)
+    impl<'i, 'u, 'b, 'l> AV::Traversal<'b, 'l> for Traversal<'i, 'u> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            match self.state {
+                // We're at the top-level of the traversal, looking for an object to recurse into.
+                // We can unconditionally switch to looking for UID fields at the level below,
+                // because we know that all the top-level values are objects.
+                LookingFor::Wrapped => {
+                    while driver
+                        .next_field(&mut Traversal {
+                            state: LookingFor::Uid,
+                            ids: self.ids,
+                            uid: self.uid,
+                        })?
+                        .is_some()
+                    {}
+                }
+
+                // We are looking for UID fields. If we find one (which we confirm by checking its
+                // layout), switch to looking for addresses in its sub-structure.
+                LookingFor::Uid => {
+                    while let Some(MoveFieldLayout { name: _, layout }) = driver.peek_field() {
+                        if matches!(layout, MoveTypeLayout::Struct(s) if s.as_ref() == self.uid) {
+                            driver.next_field(&mut Traversal {
+                                state: LookingFor::Address,
+                                ids: self.ids,
+                                uid: self.uid,
+                            })?;
+                        } else {
+                            driver.next_field(self)?;
+                        }
+                    }
+                }
+
+                // When looking for addresses, recurse through structs, as the address is nested
+                // within the UID.
+                LookingFor::Address => while driver.next_field(self)?.is_some() {},
             }
+
+            Ok(())
         }
-        MoveValue::Struct(MoveStruct { type_, fields }) => {
-            let fields = visit_with_types(depth, type_, fields);
-            for (_, v) in fields {
-                visit_structs_impl(v, visit_with_types, next_depth)
+
+        fn traverse_address(
+            &mut self,
+            _: &AV::ValueDriver<'_, 'b, 'l>,
+            address: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            // If we're looking for addresses, and we found one, then save it.
+            if matches!(self.state, LookingFor::Address) {
+                self.ids.insert(address.into());
             }
+            Ok(())
         }
-        MoveValue::Variant(MoveVariant {
-            type_,
-            variant_name: _,
-            tag: _,
-            fields,
-        }) => {
-            let fields = visit_with_types(depth, type_, fields);
-            for (_, v) in fields {
-                visit_structs_impl(v, visit_with_types, next_depth)
-            }
-        }
+    }
+
+    let uid = UID::layout();
+    for (_id, ty, value) in new_object_values {
+        let Ok(Some(layout)) = context.type_to_type_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let Ok(Some(annotated_layout)) = context.type_to_fully_annotated_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let blob = value.borrow().simple_serialize(&layout).unwrap();
+        MoveValue::visit_deserialize(
+            &blob,
+            &annotated_layout,
+            &mut Traversal {
+                state: LookingFor::Wrapped,
+                ids,
+                uid: &uid,
+            },
+        )
+        .unwrap();
     }
 }

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -5,7 +5,7 @@ use better_any::{Tid, TidAble};
 use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress, annotated_value as A, effects::Op,
+    account_address::AccountAddress, annotated_value as A, annotated_visitor as AV, effects::Op,
     language_storage::StructTag, runtime_value as R, vm_status::StatusCode,
 };
 use move_vm_types::{
@@ -608,7 +608,6 @@ fn update_owner_map(
     Ok(())
 }
 
-// TODO use a custom DeserializerSeed and improve this performance
 /// WARNING! This function assumes that the bcs bytes have already been validated,
 /// and it will give an invariant violation otherwise.
 /// In short, we are relying on the invariant that the bytes are valid for objects
@@ -619,40 +618,42 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    // TODO (annotated-visitor): Replace with a custom visitor
-    let v = A::MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
-        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
-    get_all_uids_in_value(&mut ids, &v)?;
-    Ok(ids)
-}
+    struct UIDTraversal<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollector<'i>(&'i mut BTreeSet<ObjectID>);
 
-fn get_all_uids_in_value(
-    acc: &mut BTreeSet<ObjectID>,
-    v: &A::MoveValue,
-) -> Result<(), /* invariant violation */ String> {
-    let mut stack = vec![v];
-    while let Some(cur) = stack.pop() {
-        let s = match cur {
-            A::MoveValue::Struct(s) => s,
-            A::MoveValue::Vector(vec) => {
-                stack.extend(vec);
-                continue;
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversal<'i> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            if driver.struct_layout().type_ == UID::type_() {
+                while driver.next_field(&mut UIDCollector(self.0))?.is_some() {}
+            } else {
+                while driver.next_field(self)?.is_some() {}
             }
-            _ => continue,
-        };
-        let A::MoveStruct { type_, fields } = s;
-        if type_ == &UID::type_() {
-            let inner = match &fields[0].1 {
-                A::MoveValue::Struct(A::MoveStruct { fields, .. }) => fields,
-                v => return Err(format!("Unexpected UID layout. {v:?}")),
-            };
-            match &inner[0].1 {
-                A::MoveValue::Address(id) => acc.insert((*id).into()),
-                v => return Err(format!("Unexpected ID layout. {v:?}")),
-            };
-        } else {
-            stack.extend(fields.iter().map(|(_, v)| v));
+            Ok(())
         }
     }
-    Ok(())
+
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollector<'i> {
+        type Error = AV::Error;
+        fn traverse_address(
+            &mut self,
+            _driver: &AV::ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            self.0.insert(value.into());
+            Ok(())
+        }
+    }
+
+    A::MoveValue::visit_deserialize(
+        bcs_bytes,
+        fully_annotated_layout,
+        &mut UIDTraversal(&mut ids),
+    )
+    .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    Ok(ids)
 }

--- a/sui-execution/v0/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v0/sui-move-natives/src/test_scenario.rs
@@ -9,9 +9,8 @@ use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveValue},
-    identifier::Identifier,
-    language_storage::StructTag,
+    annotated_value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     vm_status::StatusCode,
 };
 use move_vm_runtime::native_functions::NativeContext;
@@ -635,103 +634,105 @@ fn pack_option(opt: Option<Value>) -> Value {
     )]))
 }
 
-fn find_all_wrapped_objects<'a>(
+fn find_all_wrapped_objects<'a, 'i>(
     context: &NativeContext,
-    ids: &mut BTreeSet<ObjectID>,
+    ids: &'i mut BTreeSet<ObjectID>,
     new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a Type, impl Borrow<Value>)>,
 ) {
-    for (_id, ty, value) in new_object_values {
-        let layout = match context.type_to_type_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let annotated_layout = match context.type_to_fully_annotated_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let blob = value.borrow().simple_serialize(&layout).unwrap();
-        // TODO (annotated-visitor): Replace with a custom visitor.
-        let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
-        let uid = UID::type_();
-        visit_structs(&move_value, |depth, tag, fields| {
-            if tag != &uid {
-                return if depth == 0 {
-                    debug_assert!(!fields.is_empty());
-                    // all object values so the first field is a UID that should be skipped
-                    &fields[1..]
-                } else {
-                    fields
-                };
-            }
-            debug_assert!(fields.len() == 1);
-            let id = &fields[0].1;
-            let addr_field = match &id {
-                MoveValue::Struct(MoveStruct { fields, .. }) => {
-                    debug_assert!(fields.len() == 1);
-                    &fields[0].1
-                }
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            let addr = match addr_field {
-                MoveValue::Address(a) => *a,
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            ids.insert(addr.into());
-            fields
-        })
+    #[derive(Copy, Clone)]
+    enum LookingFor {
+        Wrapped,
+        Uid,
+        Address,
     }
-}
 
-fn visit_structs<FVisitTypes>(move_value: &MoveValue, mut visit_with_types: FVisitTypes)
-where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    visit_structs_impl(move_value, &mut visit_with_types, 0)
-}
+    struct Traversal<'i, 'u> {
+        state: LookingFor,
+        ids: &'i mut BTreeSet<ObjectID>,
+        uid: &'u MoveStructLayout,
+    }
 
-fn visit_structs_impl<FVisitTypes>(
-    move_value: &MoveValue,
-    visit_with_types: &mut FVisitTypes,
-    depth: usize,
-) where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    let next_depth = depth + 1;
-    match move_value {
-        MoveValue::U8(_)
-        | MoveValue::U16(_)
-        | MoveValue::U32(_)
-        | MoveValue::U64(_)
-        | MoveValue::U128(_)
-        | MoveValue::U256(_)
-        | MoveValue::Bool(_)
-        | MoveValue::Address(_)
-        | MoveValue::Signer(_) => (),
-        MoveValue::Vector(vs) => {
-            for v in vs {
-                visit_structs_impl(v, visit_with_types, next_depth)
+    impl<'i, 'u, 'b, 'l> AV::Traversal<'b, 'l> for Traversal<'i, 'u> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            match self.state {
+                // We're at the top-level of the traversal, looking for an object to recurse into.
+                // We can unconditionally switch to looking for UID fields at the level below,
+                // because we know that all the top-level values are objects.
+                LookingFor::Wrapped => {
+                    while driver
+                        .next_field(&mut Traversal {
+                            state: LookingFor::Uid,
+                            ids: self.ids,
+                            uid: self.uid,
+                        })?
+                        .is_some()
+                    {}
+                }
+
+                // We are looking for UID fields. If we find one (which we confirm by checking its
+                // layout), switch to looking for addresses in its sub-structure.
+                LookingFor::Uid => {
+                    while let Some(MoveFieldLayout { name: _, layout }) = driver.peek_field() {
+                        if matches!(layout, MoveTypeLayout::Struct(s) if s.as_ref() == self.uid) {
+                            driver.next_field(&mut Traversal {
+                                state: LookingFor::Address,
+                                ids: self.ids,
+                                uid: self.uid,
+                            })?;
+                        } else {
+                            driver.next_field(self)?;
+                        }
+                    }
+                }
+
+                // When looking for addresses, recurse through structs, as the address is nested
+                // within the UID.
+                LookingFor::Address => while driver.next_field(self)?.is_some() {},
             }
+
+            Ok(())
         }
-        MoveValue::Struct(MoveStruct { type_, fields }) => {
-            let fields = visit_with_types(depth, type_, fields);
-            for (_, v) in fields {
-                visit_structs_impl(v, visit_with_types, next_depth)
+
+        fn traverse_address(
+            &mut self,
+            _: &AV::ValueDriver<'_, 'b, 'l>,
+            address: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            // If we're looking for addresses, and we found one, then save it.
+            if matches!(self.state, LookingFor::Address) {
+                self.ids.insert(address.into());
             }
+            Ok(())
         }
-        MoveValue::Variant(_) => unreachable!("Enums not supported in v0"),
+    }
+
+    let uid = UID::layout();
+    for (_id, ty, value) in new_object_values {
+        let Ok(Some(layout)) = context.type_to_type_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let Ok(Some(annotated_layout)) = context.type_to_fully_annotated_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let blob = value.borrow().simple_serialize(&layout).unwrap();
+        MoveValue::visit_deserialize(
+            &blob,
+            &annotated_layout,
+            &mut Traversal {
+                state: LookingFor::Wrapped,
+                ids,
+                uid: &uid,
+            },
+        )
+        .unwrap();
     }
 }

--- a/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
@@ -6,7 +6,8 @@ use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveTypeLayout, MoveValue},
+    annotated_value::{MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     effects::Op,
     language_storage::StructTag,
     runtime_value as R,
@@ -660,7 +661,6 @@ fn check_circular_ownership(
     Ok(())
 }
 
-// TODO use a custom DeserializerSeed and improve this performance
 /// WARNING! This function assumes that the bcs bytes have already been validated,
 /// and it will give an invariant violation otherwise.
 /// In short, we are relying on the invariant that the bytes are valid for objects
@@ -671,41 +671,42 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    // TODO (annotated-visitor): Replace with a custom visitor
-    let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
-        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
-    get_all_uids_in_value(&mut ids, &v)?;
-    Ok(ids)
-}
+    struct UIDTraversal<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollector<'i>(&'i mut BTreeSet<ObjectID>);
 
-fn get_all_uids_in_value(
-    acc: &mut BTreeSet<ObjectID>,
-    v: &MoveValue,
-) -> Result<(), /* invariant violation */ String> {
-    let mut stack = vec![v];
-    while let Some(cur) = stack.pop() {
-        let s = match cur {
-            MoveValue::Struct(s) => s,
-            MoveValue::Vector(vec) => {
-                stack.extend(vec);
-                continue;
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversal<'i> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            if driver.struct_layout().type_ == UID::type_() {
+                while driver.next_field(&mut UIDCollector(self.0))?.is_some() {}
+            } else {
+                while driver.next_field(self)?.is_some() {}
             }
-            _ => continue,
-        };
-
-        let MoveStruct { type_, fields } = s;
-        if type_ == &UID::type_() {
-            let inner = match &fields[0].1 {
-                MoveValue::Struct(MoveStruct { fields, .. }) => fields,
-                v => return Err(format!("Unexpected UID layout. {v:?}")),
-            };
-            match &inner[0].1 {
-                MoveValue::Address(id) => acc.insert((*id).into()),
-                v => return Err(format!("Unexpected ID layout. {v:?}")),
-            };
-        } else {
-            stack.extend(fields.iter().map(|(_, v)| v));
+            Ok(())
         }
     }
-    Ok(())
+
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollector<'i> {
+        type Error = AV::Error;
+        fn traverse_address(
+            &mut self,
+            _driver: &AV::ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            self.0.insert(value.into());
+            Ok(())
+        }
+    }
+
+    MoveValue::visit_deserialize(
+        bcs_bytes,
+        fully_annotated_layout,
+        &mut UIDTraversal(&mut ids),
+    )
+    .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    Ok(ids)
 }

--- a/sui-execution/v1/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v1/sui-move-natives/src/test_scenario.rs
@@ -9,9 +9,8 @@ use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveValue},
-    identifier::Identifier,
-    language_storage::StructTag,
+    annotated_value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     vm_status::StatusCode,
 };
 use move_vm_runtime::native_functions::NativeContext;
@@ -630,103 +629,105 @@ fn pack_option(opt: Option<Value>) -> Value {
     )]))
 }
 
-fn find_all_wrapped_objects<'a>(
+fn find_all_wrapped_objects<'a, 'i>(
     context: &NativeContext,
-    ids: &mut BTreeSet<ObjectID>,
+    ids: &'i mut BTreeSet<ObjectID>,
     new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a Type, impl Borrow<Value>)>,
 ) {
-    for (_id, ty, value) in new_object_values {
-        let layout = match context.type_to_type_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let annotated_layout = match context.type_to_fully_annotated_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let blob = value.borrow().simple_serialize(&layout).unwrap();
-        // TODO (annotated-visitor): Replace with a custom visitor.
-        let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
-        let uid = UID::type_();
-        visit_structs(&move_value, |depth, tag, fields| {
-            if tag != &uid {
-                return if depth == 0 {
-                    debug_assert!(!fields.is_empty());
-                    // all object values so the first field is a UID that should be skipped
-                    &fields[1..]
-                } else {
-                    fields
-                };
-            }
-            debug_assert!(fields.len() == 1);
-            let id = &fields[0].1;
-            let addr_field = match &id {
-                MoveValue::Struct(MoveStruct { fields, .. }) => {
-                    debug_assert!(fields.len() == 1);
-                    &fields[0].1
-                }
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            let addr = match addr_field {
-                MoveValue::Address(a) => *a,
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            ids.insert(addr.into());
-            fields
-        })
+    #[derive(Copy, Clone)]
+    enum LookingFor {
+        Wrapped,
+        Uid,
+        Address,
     }
-}
 
-fn visit_structs<FVisitTypes>(move_value: &MoveValue, mut visit_with_types: FVisitTypes)
-where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    visit_structs_impl(move_value, &mut visit_with_types, 0)
-}
+    struct Traversal<'i, 'u> {
+        state: LookingFor,
+        ids: &'i mut BTreeSet<ObjectID>,
+        uid: &'u MoveStructLayout,
+    }
 
-fn visit_structs_impl<FVisitTypes>(
-    move_value: &MoveValue,
-    visit_with_types: &mut FVisitTypes,
-    depth: usize,
-) where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    let next_depth = depth + 1;
-    match move_value {
-        MoveValue::U8(_)
-        | MoveValue::U16(_)
-        | MoveValue::U32(_)
-        | MoveValue::U64(_)
-        | MoveValue::U128(_)
-        | MoveValue::U256(_)
-        | MoveValue::Bool(_)
-        | MoveValue::Address(_)
-        | MoveValue::Signer(_) => (),
-        MoveValue::Vector(vs) => {
-            for v in vs {
-                visit_structs_impl(v, visit_with_types, next_depth)
+    impl<'i, 'u, 'b, 'l> AV::Traversal<'b, 'l> for Traversal<'i, 'u> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            match self.state {
+                // We're at the top-level of the traversal, looking for an object to recurse into.
+                // We can unconditionally switch to looking for UID fields at the level below,
+                // because we know that all the top-level values are objects.
+                LookingFor::Wrapped => {
+                    while driver
+                        .next_field(&mut Traversal {
+                            state: LookingFor::Uid,
+                            ids: self.ids,
+                            uid: self.uid,
+                        })?
+                        .is_some()
+                    {}
+                }
+
+                // We are looking for UID fields. If we find one (which we confirm by checking its
+                // layout), switch to looking for addresses in its sub-structure.
+                LookingFor::Uid => {
+                    while let Some(MoveFieldLayout { name: _, layout }) = driver.peek_field() {
+                        if matches!(layout, MoveTypeLayout::Struct(s) if s.as_ref() == self.uid) {
+                            driver.next_field(&mut Traversal {
+                                state: LookingFor::Address,
+                                ids: self.ids,
+                                uid: self.uid,
+                            })?;
+                        } else {
+                            driver.next_field(self)?;
+                        }
+                    }
+                }
+
+                // When looking for addresses, recurse through structs, as the address is nested
+                // within the UID.
+                LookingFor::Address => while driver.next_field(self)?.is_some() {},
             }
+
+            Ok(())
         }
-        MoveValue::Struct(MoveStruct { type_, fields }) => {
-            let fields = visit_with_types(depth, type_, fields);
-            for (_, v) in fields {
-                visit_structs_impl(v, visit_with_types, next_depth)
+
+        fn traverse_address(
+            &mut self,
+            _: &AV::ValueDriver<'_, 'b, 'l>,
+            address: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            // If we're looking for addresses, and we found one, then save it.
+            if matches!(self.state, LookingFor::Address) {
+                self.ids.insert(address.into());
             }
+            Ok(())
         }
-        MoveValue::Variant(_) => unreachable!("Enums not supported in v1"),
+    }
+
+    let uid = UID::layout();
+    for (_id, ty, value) in new_object_values {
+        let Ok(Some(layout)) = context.type_to_type_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let Ok(Some(annotated_layout)) = context.type_to_fully_annotated_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let blob = value.borrow().simple_serialize(&layout).unwrap();
+        MoveValue::visit_deserialize(
+            &blob,
+            &annotated_layout,
+            &mut Traversal {
+                state: LookingFor::Wrapped,
+                ids,
+                uid: &uid,
+            },
+        )
+        .unwrap();
     }
 }

--- a/sui-execution/v2/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v2/sui-move-natives/src/test_scenario.rs
@@ -9,9 +9,8 @@ use indexmap::{IndexMap, IndexSet};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveValue, MoveVariant},
-    identifier::Identifier,
-    language_storage::StructTag,
+    annotated_value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     vm_status::StatusCode,
 };
 use move_vm_runtime::native_functions::NativeContext;
@@ -632,108 +631,105 @@ fn pack_option(opt: Option<Value>) -> Value {
     )]))
 }
 
-fn find_all_wrapped_objects<'a>(
+fn find_all_wrapped_objects<'a, 'i>(
     context: &NativeContext,
-    ids: &mut BTreeSet<ObjectID>,
+    ids: &'i mut BTreeSet<ObjectID>,
     new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a Type, impl Borrow<Value>)>,
 ) {
-    for (_id, ty, value) in new_object_values {
-        let layout = match context.type_to_type_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let annotated_layout = match context.type_to_fully_annotated_layout(ty) {
-            Ok(Some(layout)) => layout,
-            _ => {
-                debug_assert!(false);
-                continue;
-            }
-        };
-        let blob = value.borrow().simple_serialize(&layout).unwrap();
-        // TODO (annotated-visitor): Replace with a custom visitor.
-        let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
-        let uid = UID::type_();
-        visit_structs(&move_value, |depth, tag, fields| {
-            if tag != &uid {
-                return if depth == 0 {
-                    debug_assert!(!fields.is_empty());
-                    // all object values so the first field is a UID that should be skipped
-                    &fields[1..]
-                } else {
-                    fields
-                };
-            }
-            debug_assert!(fields.len() == 1);
-            let id = &fields[0].1;
-            let addr_field = match &id {
-                MoveValue::Struct(MoveStruct { fields, .. }) => {
-                    debug_assert!(fields.len() == 1);
-                    &fields[0].1
-                }
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            let addr = match addr_field {
-                MoveValue::Address(a) => *a,
-                v => unreachable!("Not reachable via Move type system: {:?}", v),
-            };
-            ids.insert(addr.into());
-            fields
-        })
+    #[derive(Copy, Clone)]
+    enum LookingFor {
+        Wrapped,
+        Uid,
+        Address,
     }
-}
 
-fn visit_structs<FVisitTypes>(move_value: &MoveValue, mut visit_with_types: FVisitTypes)
-where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    visit_structs_impl(move_value, &mut visit_with_types, 0)
-}
+    struct Traversal<'i, 'u> {
+        state: LookingFor,
+        ids: &'i mut BTreeSet<ObjectID>,
+        uid: &'u MoveStructLayout,
+    }
 
-fn visit_structs_impl<FVisitTypes>(
-    move_value: &MoveValue,
-    visit_with_types: &mut FVisitTypes,
-    depth: usize,
-) where
-    for<'a> FVisitTypes: FnMut(
-        /* value depth */ usize,
-        &StructTag,
-        &'a Vec<(Identifier, MoveValue)>,
-    ) -> &'a [(Identifier, MoveValue)],
-{
-    let next_depth = depth + 1;
-    match move_value {
-        MoveValue::U8(_)
-        | MoveValue::U16(_)
-        | MoveValue::U32(_)
-        | MoveValue::U64(_)
-        | MoveValue::U128(_)
-        | MoveValue::U256(_)
-        | MoveValue::Bool(_)
-        | MoveValue::Address(_)
-        | MoveValue::Signer(_) => (),
-        MoveValue::Vector(vs) => {
-            for v in vs {
-                visit_structs_impl(v, visit_with_types, next_depth)
+    impl<'i, 'u, 'b, 'l> AV::Traversal<'b, 'l> for Traversal<'i, 'u> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            match self.state {
+                // We're at the top-level of the traversal, looking for an object to recurse into.
+                // We can unconditionally switch to looking for UID fields at the level below,
+                // because we know that all the top-level values are objects.
+                LookingFor::Wrapped => {
+                    while driver
+                        .next_field(&mut Traversal {
+                            state: LookingFor::Uid,
+                            ids: self.ids,
+                            uid: self.uid,
+                        })?
+                        .is_some()
+                    {}
+                }
+
+                // We are looking for UID fields. If we find one (which we confirm by checking its
+                // layout), switch to looking for addresses in its sub-structure.
+                LookingFor::Uid => {
+                    while let Some(MoveFieldLayout { name: _, layout }) = driver.peek_field() {
+                        if matches!(layout, MoveTypeLayout::Struct(s) if s.as_ref() == self.uid) {
+                            driver.next_field(&mut Traversal {
+                                state: LookingFor::Address,
+                                ids: self.ids,
+                                uid: self.uid,
+                            })?;
+                        } else {
+                            driver.next_field(self)?;
+                        }
+                    }
+                }
+
+                // When looking for addresses, recurse through structs, as the address is nested
+                // within the UID.
+                LookingFor::Address => while driver.next_field(self)?.is_some() {},
             }
+
+            Ok(())
         }
-        MoveValue::Struct(MoveStruct { type_, fields }) => {
-            let fields = visit_with_types(depth, type_, fields);
-            for (_, v) in fields {
-                visit_structs_impl(v, visit_with_types, next_depth)
+
+        fn traverse_address(
+            &mut self,
+            _: &AV::ValueDriver<'_, 'b, 'l>,
+            address: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            // If we're looking for addresses, and we found one, then save it.
+            if matches!(self.state, LookingFor::Address) {
+                self.ids.insert(address.into());
             }
+            Ok(())
         }
-        MoveValue::Variant(MoveVariant { type_, fields, .. }) => {
-            let fields = visit_with_types(depth, type_, fields);
-            for (_, v) in fields {
-                visit_structs_impl(v, visit_with_types, next_depth)
-            }
-        }
+    }
+
+    let uid = UID::layout();
+    for (_id, ty, value) in new_object_values {
+        let Ok(Some(layout)) = context.type_to_type_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let Ok(Some(annotated_layout)) = context.type_to_fully_annotated_layout(ty) else {
+            debug_assert!(false);
+            continue;
+        };
+
+        let blob = value.borrow().simple_serialize(&layout).unwrap();
+        MoveValue::visit_deserialize(
+            &blob,
+            &annotated_layout,
+            &mut Traversal {
+                state: LookingFor::Wrapped,
+                ids,
+                uid: &uid,
+            },
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
## Description 

Various refactors to expose the underlying byte stream, and the driver's progress through it to the visitor. This is done by:

- Introducing a `Cursor` to track the progress of the visitor, instead of using a `&mut &[u8]` (which "forgets" the bytes it has already produced).
- Introducing a `ValueDriver` to act as a driver for all other types that don't currently have a driver.
- Parametrizing the trait and drivers with lifetimes, so that it's possible for implementations to return values that reference those lifetimes.

## Test plan 

New unit test for byte offset tracking:

```
move-core-types$ cargo nextest run -- byte_offset_test
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
