### PR TITLE
indexer(visitor): avoid fully deserializing dynamic field

### DIFF
--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -95,7 +95,9 @@ impl Display for DynamicFieldName {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(
+    Copy, Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug,
+)]
 pub enum DynamicFieldType {
     #[serde(rename_all = "camelCase")]
     DynamicField,


### PR DESCRIPTION
## Description

Use `FieldVisitor` to extract necessary information from a dynamic field object, rather than fully expanding it, which can fail if the overall size is too large.

Unfortunately, because `DynamicFieldInfo` includes a structured representation of the field name, this operation can still fail if the name alone is too large to deserialize using `BoundedVisitor`, but we can at least avoid deserializing the value.

## Test plan

Build and run the indexer reader against a mainnet DB, and check for `0x5`:

```
sui$ cargo run --bin sui-indexer -- --database-url "$DB" --pool-size 10 \
  json-rpc-service --rpc-client-url "https://fullnode.mainnet.sui.io:443"
```

Make the request:
```
$ curl -LX POST  "https:/fullnode.mainnet.sui.io:443" \
        --header 'Content-Type: application/json' \
        --data-raw '{
            "jsonrpc": "2.0",
            "method": "suix_getDynamicFields",
            "id": 1,
            "params": ["0x5"]
        }' | jq  -C . | less -r
```

Expects a response like:
```
{
  "jsonrpc": "2.0",
  "result": {
    "data": [
      {
        "name": {
          "type": "u64",
          "value": "2"
        },
        "bcsName": "LQM2cdzDY3",
        "type": "DynamicField",
        "objectType": "0x3::sui_system_state_inner::SuiSystemStateInnerV2",
        "objectId": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
        "version": 339253281,
        "digest": "89nPMzp31fiSy39a7fg6TBzALdm3xA4Byd4hWr2QLahg"
      }
    ],
    "nextCursor": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
    "hasNextPage": false
  },
  "id": 1
}
```

## Stack

- #19517 
- #19518 
- #19519 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
