### PR TITLE
[Indexer] Stop reading old system_state in epochs

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/system_state.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/system_state.exp
@@ -99,8 +99,8 @@ Response: {
       "epochId": 4,
       "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "15762400",
-        "nonRefundableBalance": "180424"
+        "totalObjectStorageRebates": "16066400",
+        "nonRefundableBalance": "29640"
       }
     }
   }
@@ -114,8 +114,8 @@ Response: {
       "epochId": 3,
       "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "16066400",
-        "nonRefundableBalance": "29640"
+        "totalObjectStorageRebates": "15078400",
+        "nonRefundableBalance": "19760"
       }
     }
   }
@@ -144,8 +144,8 @@ Response: {
       "epochId": 1,
       "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "15078400",
-        "nonRefundableBalance": "19760"
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
       }
     }
   }
@@ -159,8 +159,8 @@ Response: {
       "epochId": 4,
       "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "15762400",
-        "nonRefundableBalance": "180424"
+        "totalObjectStorageRebates": "16066400",
+        "nonRefundableBalance": "29640"
       }
     }
   }

--- a/crates/sui-indexer/migrations/pg/2024-09-24-213054_epochs_system_state_nullable/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-24-213054_epochs_system_state_nullable/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE epochs ALTER COLUMN system_state SET NOT NULL;

--- a/crates/sui-indexer/migrations/pg/2024-09-24-213054_epochs_system_state_nullable/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-24-213054_epochs_system_state_nullable/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE epochs ALTER COLUMN system_state DROP NOT NULL;

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -324,27 +324,7 @@ impl IndexerReader {
             Some(stored_epoch) => stored_epoch,
             None => return Err(IndexerError::InvalidArgumentError("Invalid epoch".into())),
         };
-
-        let system_state_summary: SuiSystemStateSummary =
-            bcs::from_bytes(&stored_epoch.system_state).map_err(|_| {
-                IndexerError::PersistentStorageDataCorruptionError(format!(
-                    "Failed to deserialize `system_state` for epoch {:?}",
-                    epoch,
-                ))
-            })?;
-        #[cfg(debug_assertions)]
-        {
-            let correct_system_state_summary: SuiSystemStateSummary =
-                serde_json::from_value(stored_epoch.system_state_summary_json.clone().unwrap())
-                    .unwrap();
-            // The old system state summary is incorrect and its epoch will be offset by 1.
-            // This is fixed in the new system state summary. Assert it here to double check.
-            assert_eq!(
-                correct_system_state_summary.epoch,
-                stored_epoch.epoch as u64
-            );
-        }
-        Ok(system_state_summary)
+        stored_epoch.get_json_system_state_summary()
     }
 
     async fn get_checkpoint_from_db(

--- a/crates/sui-indexer/src/models/epoch.rs
+++ b/crates/sui-indexer/src/models/epoch.rs
@@ -18,7 +18,7 @@ pub struct StoredEpochInfo {
     pub protocol_version: i64,
     pub total_stake: i64,
     pub storage_fund_balance: i64,
-    pub system_state: Vec<u8>,
+    pub system_state: Option<Vec<u8>>,
     pub epoch_total_transactions: Option<i64>,
     pub last_checkpoint_id: Option<i64>,
     pub epoch_end_timestamp: Option<i64>,
@@ -95,11 +95,13 @@ impl StoredEpochInfo {
         }
     }
 
+    // TODO: It's a bit fragile to construct the full data structure but only
+    // commit partial data. We should refactor this.
     pub fn from_epoch_end_info(e: &IndexedEpochInfo) -> Self {
         Self {
             epoch: e.epoch as i64,
             // TODO: Deprecate this.
-            system_state: bcs::to_bytes(&e.system_state_summary.clone()).unwrap(),
+            system_state: None,
             // At epoch end the system state would be the state of the next epoch, so we ignore it.
             system_state_summary_json: None,
             epoch_total_transactions: e.epoch_total_transactions.map(|v| v as i64),
@@ -129,6 +131,23 @@ impl StoredEpochInfo {
             storage_fund_balance: 0,
         }
     }
+
+    pub fn get_json_system_state_summary(&self) -> Result<SuiSystemStateSummary, IndexerError> {
+        let Some(system_state_summary_json) = self.system_state_summary_json.clone() else {
+            return Err(IndexerError::PersistentStorageDataCorruptionError(
+                "System state summary is null for the given epoch".into(),
+            ));
+        };
+        let system_state_summary: SuiSystemStateSummary =
+            serde_json::from_value(system_state_summary_json).map_err(|_| {
+                IndexerError::PersistentStorageDataCorruptionError(format!(
+                    "Failed to deserialize `system_state` for epoch {:?}",
+                    self.epoch,
+                ))
+            })?;
+        debug_assert_eq!(system_state_summary.epoch, self.epoch as u64);
+        Ok(system_state_summary)
+    }
 }
 
 impl From<&StoredEpochInfo> for Option<EndOfEpochInfo> {
@@ -157,25 +176,11 @@ impl TryFrom<StoredEpochInfo> for EpochInfo {
     type Error = IndexerError;
 
     fn try_from(value: StoredEpochInfo) -> Result<Self, Self::Error> {
-        let epoch = value.epoch as u64;
         let end_of_epoch_info = (&value).into();
-        // FIXME: We should not swallow the error here.
-        // However currently there is a bug in the system_state column where it's always
-        // off-by-one, and hence there will be a period of time when
-        // this conversion will fail.
-        // We should fix this once we replace it with the new json column.
-        let system_state: Option<SuiSystemStateSummary> = bcs::from_bytes(&value.system_state)
-            .map_err(|_| {
-                IndexerError::PersistentStorageDataCorruptionError(format!(
-                    "Failed to deserialize `system_state` for epoch {epoch}",
-                ))
-            })
-            .ok();
+        let system_state_summary = value.get_json_system_state_summary()?;
         Ok(EpochInfo {
             epoch: value.epoch as u64,
-            validators: system_state
-                .map(|s| s.active_validators)
-                .unwrap_or_default(),
+            validators: system_state_summary.active_validators,
             epoch_total_transactions: value.epoch_total_transactions.unwrap_or(0) as u64,
             first_checkpoint_id: value.first_checkpoint_id as u64,
             epoch_start_timestamp: value.epoch_start_timestamp as u64,

--- a/crates/sui-indexer/src/models/epoch.rs
+++ b/crates/sui-indexer/src/models/epoch.rs
@@ -30,6 +30,7 @@ pub struct StoredEpochInfo {
     pub total_stake_rewards_distributed: Option<i64>,
     pub leftover_storage_fund_inflow: Option<i64>,
     pub epoch_commitments: Option<Vec<u8>>,
+    /// This is the system state summary at the beginning of the epoch, serialized as JSON.
     pub system_state_summary_json: Option<serde_json::Value>,
 }
 

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -49,7 +49,7 @@ diesel::table! {
         protocol_version -> Int8,
         total_stake -> Int8,
         storage_fund_balance -> Int8,
-        system_state -> Bytea,
+        system_state -> Nullable<Bytea>,
         epoch_total_transactions -> Nullable<Int8>,
         last_checkpoint_id -> Nullable<Int8>,
         epoch_end_timestamp -> Nullable<Int8>,


### PR DESCRIPTION
## Description 

This PR makes the old system_state column nullable, and stop reading from it.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
