### PR TITLE
[on-chain-deps][manifest] change `Custom` dependency to `OnChain`

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -37,7 +37,7 @@ use move_package::{
     BuildConfig as MoveBuildConfig,
 };
 use move_package::{
-    resolution::resolution_graph::Package, source_package::parsed_manifest::CustomDepInfo,
+    resolution::resolution_graph::Package, source_package::parsed_manifest::OnChainInfo,
     source_package::parsed_manifest::SourceManifest,
 };
 use move_symbol_pool::Symbol;
@@ -631,14 +631,10 @@ impl PackageHooks for SuiPackageHooks {
         ]
     }
 
-    fn custom_dependency_key(&self) -> Option<String> {
-        None
-    }
-
-    fn resolve_custom_dependency(
+    fn resolve_on_chain_dependency(
         &self,
         _dep_name: move_symbol_pool::Symbol,
-        _info: &CustomDepInfo,
+        _info: &OnChainInfo,
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/external-crates/move/crates/move-package/src/package_hooks.rs
+++ b/external-crates/move/crates/move-package/src/package_hooks.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::source_package::parsed_manifest::{CustomDepInfo, SourceManifest};
+use crate::source_package::parsed_manifest::{OnChainInfo, SourceManifest};
 use anyhow::bail;
 use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
@@ -17,17 +17,13 @@ pub trait PackageHooks {
     /// Returns custom fields allowed in `PackageInfo`.
     fn custom_package_info_fields(&self) -> Vec<String>;
 
-    /// Returns a custom key for dependencies, if available. This is the string used
-    /// in dependencies `{ <key> = value, address = addr }.
-    fn custom_dependency_key(&self) -> Option<String>;
-
-    /// A resolver for custom dependencies in the manifest. This is called to download the
+    /// A resolver for on-chain dependencies in the manifest. This is called to download the
     /// dependency from the dependency into the `info.local_path` location, similar as with git
     /// dependencies.
-    fn resolve_custom_dependency(
+    fn resolve_on_chain_dependency(
         &self,
         dep_name: Symbol,
-        info: &CustomDepInfo,
+        info: &OnChainInfo,
     ) -> anyhow::Result<()>;
 
     fn custom_resolve_pkg_id(&self, manifest: &SourceManifest)
@@ -44,22 +40,14 @@ pub fn register_package_hooks(hooks: Box<dyn PackageHooks + Send + Sync>) {
 }
 
 /// Calls any registered hook to resolve a node dependency. Bails if none is registered.
-pub(crate) fn resolve_custom_dependency(
+pub(crate) fn resolve_on_chain_dependency(
     dep_name: Symbol,
-    info: &CustomDepInfo,
+    info: &OnChainInfo,
 ) -> anyhow::Result<()> {
     if let Some(hooks) = &*HOOKS.lock().unwrap() {
-        hooks.resolve_custom_dependency(dep_name, info)
+        hooks.resolve_on_chain_dependency(dep_name, info)
     } else {
-        bail!("use of unsupported custom dependency in package manifest")
-    }
-}
-
-pub(crate) fn custom_dependency_key() -> Option<String> {
-    if let Some(hooks) = &*HOOKS.lock().unwrap() {
-        hooks.custom_dependency_key()
-    } else {
-        None
+        bail!("use of unsupported on-chain dependency in package manifest")
     }
 }
 

--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -48,12 +48,12 @@ impl DependencyCache {
         match kind {
             DependencyKind::Local(_) => Ok(()),
 
-            DependencyKind::Custom(node_info) => {
+            DependencyKind::OnChain(info) => {
                 // check if a give dependency type has already been fetched
                 if !self.fetched_deps.insert(repository_path(kind)) {
                     return Ok(());
                 }
-                package_hooks::resolve_custom_dependency(dep_name, node_info)
+                package_hooks::resolve_on_chain_dependency(dep_name, info)
             }
 
             DependencyKind::Git(GitInfo {

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     lock_file::{schema, LockFile},
-    package_hooks::{self, custom_resolve_pkg_id, resolve_version, PackageIdentifier},
+    package_hooks::{custom_resolve_pkg_id, resolve_version, PackageIdentifier},
     source_package::{
         layout::SourcePackageLayout,
         manifest_parser::{
@@ -1117,7 +1117,7 @@ impl DependencyGraph {
         } in packages.packages.into_iter().flatten()
         {
             let pkg_id = PackageIdentifier::from(pkg_id.as_str());
-            let source = parse_dependency(pkg_id.as_str(), source)
+            let source = parse_dependency(source)
                 .with_context(|| format!("Deserializing dependency '{pkg_id}'"))?;
 
             let source = match source {
@@ -1523,23 +1523,9 @@ impl fmt::Display for Package {
                 f.write_str(&path_escape(subdir)?)?;
             }
 
-            PM::DependencyKind::Custom(PM::CustomDepInfo {
-                node_url,
-                package_address,
-                subdir,
-                package_name: _,
-            }) => {
-                let custom_key = package_hooks::custom_dependency_key().ok_or(fmt::Error)?;
-
-                f.write_str(&custom_key)?;
-                write!(f, " = ")?;
-                f.write_str(&str_escape(node_url.as_str())?)?;
-
-                write!(f, ", address = ")?;
-                f.write_str(&str_escape(package_address.as_str())?)?;
-
-                write!(f, ", subdir = ")?;
-                f.write_str(&path_escape(subdir)?)?;
+            PM::DependencyKind::OnChain(PM::OnChainInfo { id }) => {
+                write!(f, "id = ")?;
+                f.write_str(&str_escape(id.as_str())?)?;
             }
         }
 

--- a/external-crates/move/crates/move-package/src/resolution/mod.rs
+++ b/external-crates/move/crates/move-package/src/resolution/mod.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::{
-    source_package::parsed_manifest::{CustomDepInfo, DependencyKind, GitInfo},
+    source_package::parsed_manifest::{DependencyKind, GitInfo, OnChainInfo},
     BuildConfig,
 };
 
@@ -93,23 +93,12 @@ fn repository_path(kind: &DependencyKind) -> PathBuf {
         .iter()
         .collect(),
 
-        // Downloaded packages are of the form <sanitized_node_url>_<address>_<package>
-        DependencyKind::Custom(CustomDepInfo {
-            node_url,
-            package_address,
-            package_name,
-            subdir: _,
-        }) => [
-            &*MOVE_HOME,
-            &format!(
-                "{}_{}_{}",
-                url_to_file_name(node_url.as_str()),
-                package_address.as_str(),
-                package_name.as_str(),
-            ),
-        ]
-        .iter()
-        .collect(),
+        // Downloaded packages are of the form <id>
+        DependencyKind::OnChain(OnChainInfo { id }) => {
+            [&*MOVE_HOME, &url_to_file_name(id.as_str()).to_string()]
+                .iter()
+                .collect()
+        }
     }
 }
 
@@ -117,9 +106,7 @@ fn repository_path(kind: &DependencyKind) -> PathBuf {
 fn local_path(kind: &DependencyKind) -> PathBuf {
     let mut repo_path = repository_path(kind);
 
-    if let DependencyKind::Git(GitInfo { subdir, .. })
-    | DependencyKind::Custom(CustomDepInfo { subdir, .. }) = kind
-    {
+    if let DependencyKind::Git(GitInfo { subdir, .. }) = kind {
         repo_path.push(subdir);
     }
 

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -125,7 +125,7 @@ impl ResolvedGraph {
                 match dep {
                     PM::Dependency::External(_) => continue,
                     PM::Dependency::Internal(internal) => {
-                        if let PM::DependencyKind::Custom(_) = internal.kind {
+                        if let PM::DependencyKind::OnChain(_) = internal.kind {
                             continue;
                         }
                         let dep_path = &resolved_pkg.package_path.join(local_path(&internal.kind));

--- a/external-crates/move/crates/move-package/src/source_package/manifest_parser.rs
+++ b/external-crates/move/crates/move-package/src/source_package/manifest_parser.rs
@@ -206,7 +206,7 @@ pub fn parse_dependencies(tval: TV) -> Result<PM::Dependencies> {
             let mut deps = BTreeMap::new();
             for (dep_name, dep) in table.into_iter() {
                 let dep_name_ident = PM::PackageName::from(dep_name.clone());
-                let dep = parse_dependency(&dep_name, dep)?;
+                let dep = parse_dependency(dep)?;
                 deps.insert(dep_name_ident, dep);
             }
             Ok(deps)
@@ -329,7 +329,7 @@ fn parse_address_literal(address_str: &str) -> Result<AccountAddress, AccountAdd
     AccountAddress::from_hex_literal(address_str)
 }
 
-pub fn parse_dependency(dep_id: &str, mut tval: TV) -> Result<PM::Dependency> {
+pub fn parse_dependency(mut tval: TV) -> Result<PM::Dependency> {
     let Some(table) = tval.as_table_mut() else {
         bail!("Malformed dependency {}", tval);
     };
@@ -349,8 +349,6 @@ pub fn parse_dependency(dep_id: &str, mut tval: TV) -> Result<PM::Dependency> {
         return Ok(PM::Dependency::External(resolver));
     }
 
-    let custom_key_opt = &package_hooks::custom_dependency_key();
-
     let subst = table
         .remove("addr_subst")
         .map(parse_substitution)
@@ -366,7 +364,7 @@ pub fn parse_dependency(dep_id: &str, mut tval: TV) -> Result<PM::Dependency> {
         table.remove("local"),
         table.remove("subdir"),
         table.remove("git"),
-        custom_key_opt.as_ref().and_then(|k| table.remove(k)),
+        table.remove("id"),
     ) {
         (Some(local), subdir, None, None) => {
             if subdir.is_some() {
@@ -411,43 +409,16 @@ pub fn parse_dependency(dep_id: &str, mut tval: TV) -> Result<PM::Dependency> {
             })
         }
 
-        (None, subdir, None, Some(custom_key)) => {
-            let Some(package_address) = table.remove("address") else {
-                bail!("Address not supplied for 'node' dependency");
+        (None, None, None, Some(id)) => {
+            let Some(id) = id.as_str().map(Symbol::from) else {
+                bail!("ID not a string")
             };
 
-            let Some(package_address) = package_address.as_str().map(Symbol::from) else {
-                bail!("Node address not a string")
-            };
-
-            let Some(node_url) = custom_key.as_str().map(Symbol::from) else {
-                bail!("Git URL not a string")
-            };
-
-            let subdir = match subdir {
-                None => PathBuf::new(),
-                Some(path) => path
-                    .as_str()
-                    .map(PathBuf::from)
-                    .ok_or_else(|| anyhow!("'subdir' not a string"))?,
-            };
-
-            let package_name = Symbol::from(dep_id);
-
-            PM::DependencyKind::Custom(PM::CustomDepInfo {
-                node_url,
-                package_address,
-                package_name,
-                subdir,
-            })
+            PM::DependencyKind::OnChain(PM::OnChainInfo { id })
         }
 
         _ => {
-            let mut keys = vec!["'local'", "'git'", "'resolver'"];
-            let quoted_custom_key = custom_key_opt.as_ref().map(|k| format!("'{}'", k));
-            if let Some(k) = &quoted_custom_key {
-                keys.push(k.as_str())
-            }
+            let keys = ["'local'", "'git'", "'resolver'", "'id'"];
             bail!(
                 "must provide exactly one of {} for dependency.",
                 keys.join(" or ")

--- a/external-crates/move/crates/move-package/tests/test_runner.rs
+++ b/external-crates/move/crates/move-package/tests/test_runner.rs
@@ -14,7 +14,7 @@ use move_package::{
     package_hooks::PackageHooks,
     package_hooks::PackageIdentifier,
     resolution::resolution_graph::Package,
-    source_package::parsed_manifest::{CustomDepInfo, PackageDigest, SourceManifest},
+    source_package::parsed_manifest::{OnChainInfo, PackageDigest, SourceManifest},
     BuildConfig, ModelConfig,
 };
 use move_symbol_pool::Symbol;
@@ -203,23 +203,12 @@ impl PackageHooks for TestHooks {
         vec!["test_hooks_field".to_owned(), "version".to_owned()]
     }
 
-    fn custom_dependency_key(&self) -> Option<String> {
-        Some("custom".to_owned())
-    }
-
-    fn resolve_custom_dependency(
+    fn resolve_on_chain_dependency(
         &self,
         dep_name: Symbol,
-        info: &CustomDepInfo,
+        info: &OnChainInfo,
     ) -> anyhow::Result<()> {
-        bail!(
-            "TestHooks resolve dep {:?} = {:?} {:?} {:?} {:?}",
-            dep_name,
-            info.node_url,
-            info.package_name,
-            info.package_address,
-            info.subdir.to_string_lossy(),
-        )
+        bail!("TestHooks resolve dep {:?} = {:?}", dep_name, info.id,)
     }
 
     fn custom_resolve_pkg_id(

--- a/external-crates/move/crates/move-package/tests/test_sources/package_hooks/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/package_hooks/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'test': Fetching 'Pkg': TestHooks resolve dep "Pkg" = "localhost:8080" "Pkg" "0x1" ""
+Failed to resolve dependencies for package 'test': Fetching 'Pkg': TestHooks resolve dep "Pkg" = "0x1"

--- a/external-crates/move/crates/move-package/tests/test_sources/package_hooks/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/package_hooks/Move.toml
@@ -2,4 +2,4 @@
 name = "test"
 
 [dependencies]
-Pkg = { custom = "localhost:8080", address = "0x1" }
+Pkg = { id = "0x1" }

--- a/external-crates/move/crates/move-package/tests/test_sources/package_hooks_subdir/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/package_hooks_subdir/Move.resolved
@@ -1,1 +1,0 @@
-Failed to resolve dependencies for package 'test': Fetching 'Pkg': TestHooks resolve dep "Pkg" = "localhost:8080" "Pkg" "0x1" "foo/bar"

--- a/external-crates/move/crates/move-package/tests/test_sources/package_hooks_subdir/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/package_hooks_subdir/Move.toml
@@ -1,5 +1,0 @@
-[package]
-name = "test"
-
-[dependencies]
-Pkg = { custom = "localhost:8080", address = "0x1", subdir = "foo/bar" }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_no_path_set_for_dependency/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_no_path_set_for_dependency/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[dependencies]' section of manifest: must provide exactly one of 'local' or 'git' or 'resolver' or 'custom' for dependency.
+Error parsing '[dependencies]' section of manifest: must provide exactly one of 'local' or 'git' or 'resolver' or 'id' for dependency.


### PR DESCRIPTION
## Description 

Refactor `Custom` dependency to `OnChain` (in the manifest) and streamline it. It now requires only the `id` field which specifies dependency's on-chain id (e.g. `Foo = { id = "0x123" }`. `Custom` dependencies aren't supported on Sui so this should be a fairly safe change.

This is part of the work to enable compiling against on-chain dependencies https://github.com/MystenLabs/sui/pull/14178.

cc @rvantonder @amnn

## Test plan 

Updated existing unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Remove legacy support for custom package hooks, replacing it with initial logic for on-chain dependencies.
- [ ] Rust SDK:
- [ ] REST API:
