### PR TITLE
Add missed react import for dapp-kit doc

### DIFF
--- a/sdk/docs/pages/dapp-kit/wallet-components/ConnectModal.mdx
+++ b/sdk/docs/pages/dapp-kit/wallet-components/ConnectModal.mdx
@@ -12,6 +12,7 @@ the dApp.
 
 ```tsx
 import { ConnectModal, useCurrentAccount } from '@mysten/dapp-kit';
+import { useState } from 'react';
 
 export function YourApp() {
 	const currentAccount = useCurrentAccount();


### PR DESCRIPTION
## Description 

Add missed import useState from react lib for Connect Modal " Controlled example"  code example (dapp-kit doc)

## Test plan 

Review Connect Modal "Controlled example", link (https://sdk.mystenlabs.com/dapp-kit/wallet-components/ConnectModal)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
