### PR TITLE
indexer: add indices to aid pruning

### DIFF
--- a/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2023-10-06-204335_tx_indices/up.sql
@@ -18,7 +18,6 @@ CREATE TABLE tx_input_objects (
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number)
 );
-CREATE INDEX tx_input_objects_tx_sequence_number_index ON tx_input_objects (tx_sequence_number);
 CREATE INDEX tx_input_objects_sender ON tx_input_objects (sender, object_id, tx_sequence_number);
 
 CREATE TABLE tx_changed_objects (
@@ -27,7 +26,6 @@ CREATE TABLE tx_changed_objects (
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number)
 );
-CREATE INDEX tx_changed_objects_tx_sequence_number_index ON tx_changed_objects (tx_sequence_number);
 CREATE INDEX tx_changed_objects_sender ON tx_changed_objects (sender, object_id, tx_sequence_number);
 
 CREATE TABLE tx_calls_pkg (
@@ -61,7 +59,6 @@ CREATE TABLE tx_digests (
     tx_digest                   BYTEA        PRIMARY KEY,
     tx_sequence_number          BIGINT       NOT NULL
 );
-CREATE INDEX tx_digests_tx_sequence_number ON tx_digests (tx_sequence_number);
 
 CREATE TABLE tx_kinds (
     tx_sequence_number          BIGINT       NOT NULL,

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135801_event_emit_module_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135801_event_emit_module_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_emit_module_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135801_event_emit_module_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135801_event_emit_module_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135801_event_emit_module_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135801_event_emit_module_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_emit_module_tx_sequence_number
+ON  event_emit_module (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135802_event_emit_package_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135802_event_emit_package_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_emit_package_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135802_event_emit_package_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135802_event_emit_package_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135802_event_emit_package_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135802_event_emit_package_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_emit_package_tx_sequence_number
+ON  event_emit_package (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135803_event_senders_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135803_event_senders_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_senders_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135803_event_senders_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135803_event_senders_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135803_event_senders_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135803_event_senders_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_senders_tx_sequence_number
+ON  event_senders (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135804_event_struct_instantiation_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135804_event_struct_instantiation_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_instantiation_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135804_event_struct_instantiation_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135804_event_struct_instantiation_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135804_event_struct_instantiation_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135804_event_struct_instantiation_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_instantiation_tx_sequence_number
+ON  event_struct_instantiation (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135805_event_struct_module_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135805_event_struct_module_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_module_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135805_event_struct_module_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135805_event_struct_module_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135805_event_struct_module_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135805_event_struct_module_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_module_tx_sequence_number
+ON  event_struct_module (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135806_event_struct_name_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135806_event_struct_name_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_name_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135806_event_struct_name_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135806_event_struct_name_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135806_event_struct_name_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135806_event_struct_name_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_name_tx_sequence_number
+ON  event_struct_name (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135807_event_struct_package_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135807_event_struct_package_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_package_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135807_event_struct_package_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135807_event_struct_package_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135807_event_struct_package_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135807_event_struct_package_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_package_tx_sequence_number
+ON  event_struct_package (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135808_tx_calls_fun_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135808_tx_calls_fun_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_calls_fun_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135808_tx_calls_fun_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135808_tx_calls_fun_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135808_tx_calls_fun_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135808_tx_calls_fun_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_calls_fun_tx_sequence_number
+ON  tx_calls_fun (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135809_tx_calls_mod_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135809_tx_calls_mod_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_calls_mod_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135809_tx_calls_mod_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135809_tx_calls_mod_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135809_tx_calls_mod_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135809_tx_calls_mod_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_calls_mod_tx_sequence_number
+ON  tx_calls_mod (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135810_tx_calls_pkg_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135810_tx_calls_pkg_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_calls_pkg_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135810_tx_calls_pkg_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135810_tx_calls_pkg_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135810_tx_calls_pkg_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135810_tx_calls_pkg_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_calls_pkg_tx_sequence_number
+ON  tx_calls_pkg (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135811_tx_changed_objects_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135811_tx_changed_objects_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_changed_objects_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135811_tx_changed_objects_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135811_tx_changed_objects_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135811_tx_changed_objects_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135811_tx_changed_objects_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_changed_objects_tx_sequence_number
+ON  tx_changed_objects (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135812_tx_digests_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135812_tx_digests_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_digests_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135812_tx_digests_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135812_tx_digests_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135812_tx_digests_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135812_tx_digests_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_digests_tx_sequence_number
+ON  tx_digests (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135813_tx_input_objects_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135813_tx_input_objects_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_input_objects_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135813_tx_input_objects_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135813_tx_input_objects_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135813_tx_input_objects_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135813_tx_input_objects_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_input_objects_tx_sequence_number
+ON  tx_input_objects (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135814_tx_kinds_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135814_tx_kinds_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_kinds_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135814_tx_kinds_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135814_tx_kinds_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135814_tx_kinds_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135814_tx_kinds_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_kinds_tx_sequence_number
+ON  tx_kinds (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135815_tx_recipients_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135815_tx_recipients_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_recipients_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135815_tx_recipients_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135815_tx_recipients_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135815_tx_recipients_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135815_tx_recipients_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_recipients_tx_sequence_number
+ON  tx_recipients (tx_sequence_number);

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135816_tx_senders_pruning_index/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135816_tx_senders_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_senders_tx_sequence_number;

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135816_tx_senders_pruning_index/metadata.toml
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135816_tx_senders_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/sui-indexer/migrations/pg/2024-09-25-135816_tx_senders_pruning_index/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-25-135816_tx_senders_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_senders_tx_sequence_number
+ON  tx_senders (tx_sequence_number);


### PR DESCRIPTION
## Description

All the transaction and events lookup tables are missing indices that allow the pruner to efficiently pick out the ranges of rows to remove.

Note that because these indices are being added to existing tables, they are being added using `CONCURRENTLY IF NOT EXISTS`, and because of that, they need to each be in their own migration file (concurrent index creation cannot go in a DB transaction).

## Test plan

```
sui$ ./scripts/generate_indexer_schema.sh
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Add indices to support efficient pruning by tx sequence number.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
