### PR TITLE
[docs] Fixed typos and formatting

### DIFF
--- a/docs/content/concepts/events.mdx
+++ b/docs/content/concepts/events.mdx
@@ -75,7 +75,7 @@ module examples::donuts_with_events {
 
         // Emit the event using future object's ID.
         event::emit(DonutBought { id: object::uid_to_inner(&id) });
-       Donut { id }
+        Donut { id }
     }
 
     /// Consume donut and get nothing...

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -11,27 +11,27 @@ Use titles in code comments to create sections for your Move code files. Structu
 
 ```move
 module conventions::comments {
-  // === Imports ===
+    // === Imports ===
 
-  // === Errors ===
+    // === Errors ===
 
-  // === Constants ===
+    // === Constants ===
 
-  // === Structs ===
+    // === Structs ===
 
-  // === Method Aliases ===
+    // === Method Aliases ===
 
-  // === Public-Mutative Functions ===
+    // === Public-Mutative Functions ===
 
-  // === Public-View Functions ===
+    // === Public-View Functions ===
 
-  // === Admin Functions ===
+    // === Admin Functions ===
 
-  // === Public-Package Functions ===
+    // === Public-Package Functions ===
 
-  // === Private Functions ===
+    // === Private Functions ===
 
-  // === Test Functions ===
+    // === Test Functions ===
 }
 ```
 
@@ -58,11 +58,11 @@ Do not use 'potato' in the name of structs. The lack of abilities define it as a
 
 ```move
 module conventions::request {
-  // ✅ Right
-  struct Request {}
+    // ✅ Right
+    struct Request {}
 
-  // ❌ Wrong
-  struct RequestPotato {}
+    // ❌ Wrong
+    struct RequestPotato {}
 }
 ```
 
@@ -73,33 +73,33 @@ Be mindful of the dot syntax when naming functions. Avoid using the object name 
 ```move
 module conventions::profile {
 
-  struct Profile {
-    age: u64
-  }
+    struct Profile {
+        age: u64
+    }
 
-  // ✅ Right
-  public fun age(self: &Profile):  u64 {
-    self.age
-  }
+    // ✅ Right
+    public fun age(self: &Profile):    u64 {
+        self.age
+    }
 
-  // ❌ Wrong
-  public fun profile_age(self: &Profile): u64 {
-    self.age
-  }
+    // ❌ Wrong
+    public fun profile_age(self: &Profile): u64 {
+        self.age
+    }
 }
 
 module conventions::defi {
 
-  use conventions::profile::{Self, Profile};
+    use conventions::profile::{Self, Profile};
 
-  public fun get_tokens(profile: &Profile) {
+    public fun get_tokens(profile: &Profile) {
 
-   // ✅ Right
-   let name = profile.age();
+     // ✅ Right
+     let name = profile.age();
 
-   // ❌ Wrong
-   let name2 = profile.profile_age();
-  }
+     // ❌ Wrong
+     let name2 = profile.profile_age();
+    }
 }
 ```
 
@@ -110,15 +110,15 @@ Name the functions that create data structures as `empty`.
 ```move
 module conventions::collection {
 
-  struct Collection has copy, drop, store {
-    bits: vector<u8>
-  }
-
-  public fun empty(): Collection {
-    Collection {
-      bits: vector[]
+    struct Collection has copy, drop, store {
+        bits: vector<u8>
     }
-  }
+
+    public fun empty(): Collection {
+        Collection {
+            bits: vector[]
+        }
+    }
 }
 ```
 
@@ -129,18 +129,18 @@ Name the functions that create objects as `new`.
 ```move
 module conventions::object {
 
-  use sui::object::{Self, UID};
-  use sui::tx_context::TxContext;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
 
-  struct Object has key, store {
-    id: UID
-  }
-
-  public fun new(ctx:&mut TxContext): Object {
-    Object {
-      id: object::new(ctx)
+    struct Object has key, store {
+        id: UID
     }
-  }
+
+    public fun new(ctx:&mut TxContext): Object {
+        Object {
+            id: object::new(ctx)
+        }
+    }
 }
 ```
 
@@ -151,23 +151,23 @@ Library modules that share objects should provide two functions: one to create t
 ```move
 module conventions::profile {
 
-  use sui::object::{Self, UID};
-  use sui::tx_context::TxContext;
-  use sui::transfer::share_object;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer::share_object;
 
-  struct Profile has key {
-    id: UID
-  }
-
-  public fun new(ctx:&mut TxContext): Profile {
-    Profile {
-      id: object::new(ctx)
+    struct Profile has key {
+        id: UID
     }
-  }
 
-  public fun share(profile: Profile) {
-    share_object(profile);
-  }
+    public fun new(ctx:&mut TxContext): Profile {
+        Profile {
+            id: object::new(ctx)
+        }
+    }
+
+    public fun share(profile: Profile) {
+        share_object(profile);
+    }
 }
 ```
 
@@ -178,25 +178,25 @@ Name the functions that return a reference as `<PROPERTY-NAME>_mut` or `<PROPERT
 ```move
 module conventions::profile {
 
-  use std::string::String;
+    use std::string::String;
 
-  use sui::object::UID;
+    use sui::object::UID;
 
-  struct Profile has key {
-    id: UID,
-    name: String,
-    age: u8
-  }
+    struct Profile has key {
+        id: UID,
+        name: String,
+        age: u8
+    }
 
-  // profile.name()
-  public fun name(self: &Profile): &String {
-    &self.name
-  }
+    // profile.name()
+    public fun name(self: &Profile): &String {
+        &self.name
+    }
 
-  // profile.age_mut()
-  public fun age_mut(self: &mut Profile): &mut u8 {
-    &mut self.age
-  }
+    // profile.age_mut()
+    public fun age_mut(self: &mut Profile): &mut u8 {
+        &mut self.age
+    }
 }
 ```
 
@@ -207,22 +207,22 @@ Design your modules around one object or data structure. A variant structure sho
 ```move
 module conventions::wallet {
 
-  use sui::object::UID;
+    use sui::object::UID;
 
-  struct Wallet has key, store {
-    id: UID,
-    amount: u64
-  }
+    struct Wallet has key, store {
+        id: UID,
+        amount: u64
+    }
 }
 
 module conventions::claw_back_wallet {
 
-  use sui::object::UID;
+    use sui::object::UID;
 
-  struct Wallet has key {
-    id: UID,
-    amount: u64
-  }
+    struct Wallet has key {
+        id: UID,
+        amount: u64
+    }
 }
 ```
 
@@ -232,11 +232,11 @@ Use PascalCase for errors, start with an E and be descriptive.
 
 ```move
 module conventions::errors {
-  // ✅ Right
-  const ENameHasMaxLengthOf64Chars: u64 = 0;
+    // ✅ Right
+    const ENameHasMaxLengthOf64Chars: u64 = 0;
 
-  // ❌ Wrong
-  const INVALID_NAME: u64 = 0;
+    // ❌ Wrong
+    const INVALID_NAME: u64 = 0;
 }
 ```
 
@@ -247,17 +247,17 @@ Describe the properties of your structs.
 ```move
 module conventions::profile {
 
-  use std::string::String;
+    use std::string::String;
 
-  use sui::object::UID;
+    use sui::object::UID;
 
-  struct Profile has key, store {
-    id: UID,
-    /// The age of the user
-    age: u8,
-    /// The first name of the user
-    name: String
-  }
+    struct Profile has key, store {
+        id: UID,
+        /// The age of the user
+        age: u8,
+        /// The first name of the user
+        name: String
+    }
 }
 ```
 
@@ -268,28 +268,28 @@ Provide functions to delete objects. Destroy empty objects with the function `de
 ```move
 module conventions::wallet {
 
-  use sui::object::{Self, UID};
-  use sui::balance::{Self, Balance};
-  use sui::sui::SUI;
+    use sui::object::{Self, UID};
+    use sui::balance::{Self, Balance};
+    use sui::sui::SUI;
 
-  struct Wallet<Value> has key, store {
-    id: UID,
-    value: Value
-  }
+    struct Wallet<Value> has key, store {
+        id: UID,
+        value: Value
+    }
 
-  // Value has drop
-  public fun drop<Value: drop>(self: Wallet<Value>) {
-    let Wallet { id, value: _ } = self;
-    object::delete(id);
-  }
+    // Value has drop
+    public fun drop<Value: drop>(self: Wallet<Value>) {
+        let Wallet { id, value: _ } = self;
+        object::delete(id);
+    }
 
-  // Value doesn't have drop
-  // Throws if the `wallet.value` is not empty.
-  public fun destroy_empty(self: Wallet<Balance<SUI>>) {
-    let Wallet { id, value } = self;
-    object::delete(id);
-    balance::destroy_zero(value);
-  }
+    // Value doesn't have drop
+    // Throws if the `wallet.value` is not empty.
+    public fun destroy_empty(self: Wallet<Balance<SUI>>) {
+        let Wallet { id, value } = self;
+        object::delete(id);
+        balance::destroy_zero(value);
+    }
 }
 ```
 
@@ -300,38 +300,38 @@ Keep your functions pure to maintain composability. Do not use `transfer::transf
 ```move
 module conventions::amm {
 
-  use sui::transfer;
-  use sui::coin::Coin;
-  use sui::object::UID;
-  use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use sui::coin::Coin;
+    use sui::object::UID;
+    use sui::tx_context::{Self, TxContext};
 
-  struct Pool has key {
-    id: UID
-  }
+    struct Pool has key {
+        id: UID
+    }
 
-  // ✅ Right
-  // Return the excess coins even if they have zero value.
-  public fun add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>): (Coin<LpCoin>, Coin<CoinX>, Coin<CoinY>) {
-    // Implementation omitted.
-    abort(0)
-  }
+    // ✅ Right
+    // Return the excess coins even if they have zero value.
+    public fun add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>): (Coin<LpCoin>, Coin<CoinX>, Coin<CoinY>) {
+        // Implementation omitted.
+        abort(0)
+    }
 
-  // ✅ Right
-  public fun add_liquidity_and_transfer<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, recipient: address) {
-    let (lp_coin, coin_x, coin_y) = add_liquidity<CoinX, CoinY, LpCoin>(pool, coin_x, coin_y);
-    transfer::public_transfer(lp_coin, recipient);
-    transfer::public_transfer(coin_x, recipient);
-    transfer::public_transfer(coin_y, recipient);
-  }
+    // ✅ Right
+    public fun add_liquidity_and_transfer<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, recipient: address) {
+        let (lp_coin, coin_x, coin_y) = add_liquidity<CoinX, CoinY, LpCoin>(pool, coin_x, coin_y);
+        transfer::public_transfer(lp_coin, recipient);
+        transfer::public_transfer(coin_x, recipient);
+        transfer::public_transfer(coin_y, recipient);
+    }
 
-  // ❌ Wrong
-  public fun impure_add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, ctx: &mut TxContext): Coin<LpCoin> {
-    let (lp_coin, coin_x, coin_y) = add_liquidity<CoinX, CoinY, LpCoin>(pool, coin_x, coin_y);
-    transfer::public_transfer(coin_x, tx_context::sender(ctx));
-    transfer::public_transfer(coin_y, tx_context::sender(ctx));
+    // ❌ Wrong
+    public fun impure_add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, ctx: &mut TxContext): Coin<LpCoin> {
+        let (lp_coin, coin_x, coin_y) = add_liquidity<CoinX, CoinY, LpCoin>(pool, coin_x, coin_y);
+        transfer::public_transfer(coin_x, tx_context::sender(ctx));
+        transfer::public_transfer(coin_y, tx_context::sender(ctx));
 
-    lp_coin
-  }
+        lp_coin
+    }
 }
 ```
 
@@ -342,24 +342,24 @@ Pass the `Coin` object by value with the right amount directly because it's bett
 ```move
 module conventions::amm {
 
-  use sui::coin::Coin;
-  use sui::object::UID;
+    use sui::coin::Coin;
+    use sui::object::UID;
 
-  struct Pool has key {
-    id: UID
-  }
+    struct Pool has key {
+        id: UID
+    }
 
-  // ✅ Right
-  public fun swap<CoinX, CoinY>(coin_in: Coin<CoinX>): Coin<CoinY> {
-    // Implementation omitted.
-    abort(0)
-  }
+    // ✅ Right
+    public fun swap<CoinX, CoinY>(coin_in: Coin<CoinX>): Coin<CoinY> {
+        // Implementation omitted.
+        abort(0)
+    }
 
-  // ❌ Wrong
-  public fun exchange<CoinX, CoinY>(coin_in: &mut Coin<CoinX>, value: u64): Coin<CoinY> {
-    // Implementation omitted.
-    abort(0)
-  }
+    // ❌ Wrong
+    public fun exchange<CoinX, CoinY>(coin_in: &mut Coin<CoinX>, value: u64): Coin<CoinY> {
+        // Implementation omitted.
+        abort(0)
+    }
 }
 ```
 
@@ -370,44 +370,44 @@ To maintain composability, use capabilities instead of addresses for access cont
 ```move
 module conventions::access_control {
 
-  use sui::sui::SUI;
-  use sui::object::UID;
-  use sui::balance::Balance;
-  use sui::coin::{Self, Coin};
-  use sui::table::{Self, Table};
-  use sui::tx_context::{Self, TxContext};
+    use sui::sui::SUI;
+    use sui::object::UID;
+    use sui::balance::Balance;
+    use sui::coin::{Self, Coin};
+    use sui::table::{Self, Table};
+    use sui::tx_context::{Self, TxContext};
 
-  struct Account has key, store {
-    id: UID,
-    balance: u64
-  }
+    struct Account has key, store {
+        id: UID,
+        balance: u64
+    }
 
-  struct State has key {
-    id: UID,
-    accounts: Table<address, u64>,
-    balance: Balance<SUI>
-  }
+    struct State has key {
+        id: UID,
+        accounts: Table<address, u64>,
+        balance: Balance<SUI>
+    }
 
-  // ✅ Right
-  // With this function, another protocol can hold the `Account` on behalf of a user.
-  public fun withdraw(state: &mut State, account: &mut Account, ctx: &mut TxContext): Coin<SUI> {
-    let authorized_balance = account.balance;
+    // ✅ Right
+    // With this function, another protocol can hold the `Account` on behalf of a user.
+    public fun withdraw(state: &mut State, account: &mut Account, ctx: &mut TxContext): Coin<SUI> {
+        let authorized_balance = account.balance;
 
-    account.balance = 0;
+        account.balance = 0;
 
-    coin::take(&mut state.balance, authorized_balance, ctx)
-  }
+        coin::take(&mut state.balance, authorized_balance, ctx)
+    }
 
-  // ❌ Wrong
-  // This is less composable.
-  public fun wrong_withdraw(state: &mut State, ctx: &mut TxContext): Coin<SUI> {
-    let sender = tx_context::sender(ctx);
+    // ❌ Wrong
+    // This is less composable.
+    public fun wrong_withdraw(state: &mut State, ctx: &mut TxContext): Coin<SUI> {
+        let sender = tx_context::sender(ctx);
 
-    let authorized_balance = table::borrow_mut(&mut state.accounts, sender);
-    let value = *authorized_balance;
-    *authorized_balance = 0;
-    coin::take(&mut state.balance, value, ctx)
-  }
+        let authorized_balance = table::borrow_mut(&mut state.accounts, sender);
+        let value = *authorized_balance;
+        *authorized_balance = 0;
+        coin::take(&mut state.balance, value, ctx)
+    }
 }
 ```
 
@@ -418,42 +418,42 @@ If your dApp data has a one to one relationship, it's best to use owned objects.
 ```move
 module conventions::vesting_wallet {
 
-  use sui::sui::SUI;
-  use sui::coin::Coin;
-  use sui::object::UID;
-  use sui::table::Table;
-  use sui::balance::Balance;
-  use sui::tx_context::TxContext;
+    use sui::sui::SUI;
+    use sui::coin::Coin;
+    use sui::object::UID;
+    use sui::table::Table;
+    use sui::balance::Balance;
+    use sui::tx_context::TxContext;
 
-  struct OwnedWallet has key {
-    id: UID,
-    balance: Balance<SUI>
-  }
+    struct OwnedWallet has key {
+        id: UID,
+        balance: Balance<SUI>
+    }
 
-  struct SharedWallet has key {
-    id: UID,
-    balance: Balance<SUI>,
-    accounts: Table<address, u64>
-  }
+    struct SharedWallet has key {
+        id: UID,
+        balance: Balance<SUI>,
+        accounts: Table<address, u64>
+    }
 
-  /*
-  * A vesting wallet releases a certain amount of coin over a period of time.
-  * If the entire balance belongs to one user and the wallet has no additional functionalities, it is best to store it in an owned object.
-  */
-  public fun new(deposit: Coin<SUI>, ctx: &mut TxContext): OwnedWallet {
-    // Implementation omitted.
-    abort(0)
-  }
+    /*
+    * A vesting wallet releases a certain amount of coin over a period of time.
+    * If the entire balance belongs to one user and the wallet has no additional functionalities, it is best to store it in an owned object.
+    */
+    public fun new(deposit: Coin<SUI>, ctx: &mut TxContext): OwnedWallet {
+        // Implementation omitted.
+        abort(0)
+    }
 
-  /*
-  * If you wish to add extra functionality to a vesting wallet, it is best to share the object.
-  * For example, if you wish the issuer of the wallet to be able to cancel the contract in the future.
-  */
-  public fun new_shared(deposit: Coin<SUI>, ctx: &mut TxContext) {
-    // Implementation omitted.
-    // It shares the `SharedWallet`.
-    abort(0)
-  }
+    /*
+    * If you wish to add extra functionality to a vesting wallet, it is best to share the object.
+    * For example, if you wish the issuer of the wallet to be able to cancel the contract in the future.
+    */
+    public fun new_shared(deposit: Coin<SUI>, ctx: &mut TxContext) {
+        // Implementation omitted.
+        // It shares the `SharedWallet`.
+        abort(0)
+    }
 }
 ```
 
@@ -464,31 +464,31 @@ In admin-gated functions, the first parameter should be the capability. It helps
 ```move
 module conventions::social_network {
 
-  use std::string::String;
+    use std::string::String;
 
-  use sui::object::UID;
+    use sui::object::UID;
 
-  struct Account has key {
-    id: UID,
-    name: String
-  }
+    struct Account has key {
+        id: UID,
+        name: String
+    }
 
-  struct Admin has key {
-    id: UID,
-  }
+    struct Admin has key {
+        id: UID,
+    }
 
-  // ✅ Right
-  // cap.update(&mut account, b"jose");
-  public fun update(_: &Admin, account: &mut Account, new_name: String) {
-    // Implementation omitted.
-    abort(0)
-  }
+    // ✅ Right
+    // cap.update(&mut account, b"jose");
+    public fun update(_: &Admin, account: &mut Account, new_name: String) {
+        // Implementation omitted.
+        abort(0)
+    }
 
-  // ❌ Wrong
-  // account.update(&cap, b"jose");
-  public fun set(account: &mut Account, _: &Admin, new_name: String) {
-    // Implementation omitted.
-    abort(0)
-  }
+    // ❌ Wrong
+    // account.update(&cap, b"jose");
+    public fun set(account: &mut Account, _: &Admin, new_name: String) {
+        // Implementation omitted.
+        abort(0)
+    }
 }
 ```

--- a/docs/content/concepts/sui-move-concepts/packages/custom-policies.mdx
+++ b/docs/content/concepts/sui-move-concepts/packages/custom-policies.mdx
@@ -523,9 +523,8 @@ The instruction that follows publishes this example package and then upgrades it
 
 Create a new directory to store a Node.js project. You can use the `npm init` function to create the `package.json`, or manually create the file. Depending on your approach to creating `package.json`, populate or add the following JSON to it:
 
-```JSON
+```json
 { "type": "module" }
-
 ```
 
 Open a terminal or console to the root of your Node.js project. Run the following command to add the Sui TypeScript SDK as a dependency:
@@ -1126,8 +1125,8 @@ If you attempt the first upgrade before Tuesday or you change the constant again
 ```bash
 ...
 status: {
-        status: 'failure',
-        error: 'MoveAbort(MoveLocation { module: ModuleId { address: <POLICY-PACKAGE>, name: Identifier("day_of_week") }, function: 1, instruction: 11, function_name: Some("authorize_upgrade") }, 2) in command 0'
-      },
+  status: 'failure',
+  error: 'MoveAbort(MoveLocation { module: ModuleId { address: <POLICY-PACKAGE>, name: Identifier("day_of_week") }, function: 1, instruction: 11, function_name: Some("authorize_upgrade") }, 2) in command 0'
+},
 ...
 ```

--- a/docs/content/concepts/transactions/prog-txn-blocks.mdx
+++ b/docs/content/concepts/transactions/prog-txn-blocks.mdx
@@ -320,7 +320,7 @@ Results: [
 
 Now the command, `MoveCall("some_package", "some_marketplace", "buy_two", [], [Input(1), NestedResult(0, 0)])`. Call the function `some_package::some_marketplace::buy_two` with the arguments `Input(1)` and `NestedResult(0, 0)`. To determine how they are used, you need to look at the function's signature. For this example, assume the signature is
 
-```rust
+```move
 entry fun buy_two(
     marketplace: &mut Marketplace,
     coin: Coin<Sui>,
@@ -372,7 +372,7 @@ Results: [
 
 Make another Move call, this one to `sui::tx_context::sender` with the signature
 
-```rust
+```move
 public fun sender(ctx: &TxContext): address
 ```
 


### PR DESCRIPTION
## Description 

- Use `move` instead of `rust` for some code blocks
- Fix alignment in `conventions.md` with standard 4 spaces
- Fix minor formatting issues elsewhere

