### PR TITLE
indexer restorer: simplify commands

### DIFF
--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -251,24 +251,39 @@ pub struct UploadOptions {
 
 #[derive(Args, Debug, Clone)]
 pub struct RestoreConfig {
+    #[arg(long, env = "START_EPOCH", required = true)]
+    pub start_epoch: u64,
+    #[arg(long, env = "SNAPSHOT_ENDPOINT")]
+    pub snapshot_endpoint: String,
+    #[arg(long, env = "SNAPSHOT_BUCKET")]
+    pub snapshot_bucket: String,
+    #[arg(long, env = "SNAPSHOT_DOWNLOAD_DIR", required = true)]
+    pub snapshot_download_dir: String,
+
     #[arg(long, env = "GCS_ARCHIVE_BUCKET")]
     pub gcs_archive_bucket: String,
-    #[arg(long, env = "GCS_CRED_PATH")]
-    pub gcs_cred_path: String,
     #[arg(long, env = "GCS_DISPLAY_BUCKET")]
     pub gcs_display_bucket: String,
-    #[arg(long, env = "GCS_SNAPSHOT_DIR")]
-    pub gcs_snapshot_dir: String,
-    #[arg(long, env = "GCS_SNAPSHOT_BUCKET")]
-    pub gcs_snapshot_bucket: String,
-    #[arg(long, env = "START_EPOCH")]
-    pub start_epoch: u64,
-    #[arg(long, env = "S3_ENDPOINT")]
-    pub s3_endpoint: String,
+
     #[arg(env = "OBJECT_STORE_CONCURRENT_LIMIT")]
     pub object_store_concurrent_limit: usize,
     #[arg(env = "OBJECT_STORE_MAX_TIMEOUT_SECS")]
     pub object_store_max_timeout_secs: u64,
+}
+
+impl Default for RestoreConfig {
+    fn default() -> Self {
+        Self {
+            start_epoch: 0, // not used b/c it's required
+            snapshot_endpoint: "https://formal-snapshot.mainnet.sui.io".to_string(),
+            snapshot_bucket: "mysten-mainnet-formal".to_string(),
+            snapshot_download_dir: "".to_string(), // not used b/c it's required
+            gcs_archive_bucket: "mysten-mainnet-archives".to_string(),
+            gcs_display_bucket: "mysten-mainnet-display-table".to_string(),
+            object_store_concurrent_limit: 50,
+            object_store_max_timeout_secs: 512,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -92,11 +92,8 @@ async fn main() -> anyhow::Result<()> {
             .await;
         }
         Command::Restore(restore_config) => {
-            let upload_options = UploadOptions {
-                gcs_display_bucket: Some(restore_config.gcs_display_bucket.clone()),
-                gcs_cred_path: Some(restore_config.gcs_snapshot_bucket.clone()),
-            };
-            let store = PgIndexerStore::new(pool, upload_options, indexer_metrics.clone());
+            let store =
+                PgIndexerStore::new(pool, UploadOptions::default(), indexer_metrics.clone());
             let mut formal_restorer =
                 IndexerFormalSnapshotRestorer::new(store, restore_config).await?;
             formal_restorer.restore().await?;

--- a/crates/sui-indexer/src/restorer/archives.rs
+++ b/crates/sui-indexer/src/restorer/archives.rs
@@ -21,14 +21,12 @@ pub struct RestoreCheckpointInfo {
 }
 
 pub async fn read_restore_checkpoint_info(
-    cred_path: String,
     archive_bucket: Option<String>,
     epoch: u64,
 ) -> IndexerResult<RestoreCheckpointInfo> {
     let archive_store_config = ObjectStoreConfig {
         object_store: Some(ObjectStoreType::GCS),
         bucket: archive_bucket,
-        google_service_account: Some(cred_path.clone()),
         object_store_connection_limit: 50,
         no_sign_request: false,
         ..Default::default()


### PR DESCRIPTION
## Description 

- we made `archives` and `display` buckets public, thus restorer no longer needs gcs cred
- remove un-necessary required args / env vars so that to restore from mainnet, only start-epoch & local snapshot download dir needs to be specified.

## Test plan 

local run of restorer

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
