### PR TITLE
Terminate checkpoint builder before end of epoch

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2264,7 +2264,8 @@ impl CheckpointService {
             max_checkpoint_size_bytes,
         );
 
-        spawn_monitored_task!(builder.run());
+        let epoch_store_clone = epoch_store.clone();
+        spawn_monitored_task!(epoch_store_clone.within_alive_epoch(builder.run()));
 
         let aggregator = CheckpointAggregator::new(
             checkpoint_store.clone(),


### PR DESCRIPTION
Otherwise it is possible for this panic to be hit: https://github.com/MystenLabs/sui/blob/34c9e3ef6fff67df7f6ec89b4ccee462fb111df2/crates/sui-core/src/checkpoints/mod.rs#L957