### PR TITLE
Add fatal! and debug_fatal! macros

### DIFF
--- a/crates/mysten-common/src/lib.rs
+++ b/crates/mysten-common/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod logging;
 pub mod metrics;
 pub mod sync;

--- a/crates/mysten-common/src/logging.rs
+++ b/crates/mysten-common/src/logging.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_export]
+macro_rules! fatal {
+    ($($arg:tt)*) => {{
+        tracing::error!($($arg)*);
+        panic!($($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! debug_fatal {
+    ($($arg:tt)*) => {{
+        if cfg!(debug_assertions) {
+            $crate::fatal!($($arg)*);
+        } else {
+            // TODO: Export invariant metric for alerting
+            tracing::error!(debug_panic = true, $($arg)*);
+        }
+    }};
+}

--- a/crates/sui-core/src/execution_cache/object_locks.rs
+++ b/crates/sui-core/src/execution_cache/object_locks.rs
@@ -4,12 +4,13 @@
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, LockDetails};
 use dashmap::mapref::entry::Entry as DashMapEntry;
 use dashmap::DashMap;
+use mysten_common::*;
 use sui_types::base_types::{ObjectID, ObjectRef};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
 use sui_types::transaction::VerifiedSignedTransaction;
-use tracing::{debug, error, info, instrument, trace};
+use tracing::{debug, info, instrument, trace};
 
 use super::writeback_cache::WritebackCache;
 
@@ -144,11 +145,7 @@ impl ObjectLocks {
             let entry = self.locked_transactions.entry(*obj_ref);
             let mut occupied = match entry {
                 DashMapEntry::Vacant(_) => {
-                    if cfg!(debug_assertions) {
-                        panic!("lock must exist");
-                    } else {
-                        error!(?obj_ref, "lock should exist");
-                    }
+                    debug_fatal!("lock must exist for object: {:?}", obj_ref);
                     continue;
                 }
                 DashMapEntry::Occupied(occupied) => occupied,


### PR DESCRIPTION
Add two macros as superior alternatives to panic!

- `fatal!` logs its message at error level, and then panics. Logged messages are often easier to find than panic messages, both in loki and in simtest logs.
- `debug_fatal!` is a variant of `fatal!` that only logs an error in release mode.
