### PR TITLE
Add new router utilities to dapp-kit

### DIFF
--- a/.changeset/warm-parrots-flow.md
+++ b/.changeset/warm-parrots-flow.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': patch
+---
+
+Add `getSuiClientQuery` to get the `queryOptions` config for usage with the `QueryClient` outside of React hooks. Added `useSuiClientSuspenseQuery` to support suspense-based data fetching.


### PR DESCRIPTION
## Description 

This adds two new features two dapp kit:

- `getSuiClientQuery`, which returns a `queryOptions` config that can be used with the query client directly. This is important for data prefetching where we need to load data in the route loader, not in the react render.
- `useSuiClientSuspenseQuery`, which works well with new routers like tanstack router.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
