### PR TITLE
Fix sorting in peer discovery

### DIFF
--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -296,13 +296,18 @@ impl PeerBalancer {
             .unwrap()
             .peers_on_same_chain()
             // Filter out any peers who we aren't connected with.
-            .filter_map(|(peer_id, info)| network.peer(*peer_id).map(|peer| (peer, *info)))
+            .filter_map(|(peer_id, info)| {
+                network
+                    .peer(*peer_id)
+                    .map(|peer| (peer.connection_rtt(), peer, *info))
+            })
             .collect();
-        peers.sort_by(|(peer_a, _), (peer_b, _)| {
-            peer_a.connection_rtt().cmp(&peer_b.connection_rtt())
-        });
+        peers.sort_by(|(rtt_a, _, _), (rtt_b, _, _)| rtt_a.cmp(rtt_b));
         Self {
-            peers: peers.into(),
+            peers: peers
+                .into_iter()
+                .map(|(_, peer, info)| (peer, info))
+                .collect(),
             requested_checkpoint: None,
             request_type,
         }


### PR DESCRIPTION
## Description 

It seems `connection_rtt()` can get updated concurrently. This breaks total ordering, which becomes required for sorting in rust 1.81.
Other callsites of `sort_by()` are reviewed and they don't seem to have the same issue.

## Test plan 

PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
