### PR TITLE
[bridge-indexer] move current checkpoint metric to retrieval stage

### DIFF
--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -85,14 +85,12 @@ async fn main() -> Result<()> {
         ProgressSavingPolicy::SaveAfterDuration(SaveAfterDurationPolicy::new(
             tokio::time::Duration::from_secs(30),
         )),
-        indexer_meterics.clone(),
     );
     let datastore_with_out_of_order_source = PgBridgePersistent::new(
         get_connection_pool(db_url.clone()).await,
         ProgressSavingPolicy::OutOfOrderSaveAfterDuration(OutOfOrderSaveAfterDurationPolicy::new(
             tokio::time::Duration::from_secs(30),
         )),
-        indexer_meterics.clone(),
     );
 
     let eth_client: Arc<EthClient<MeteredEthHttpProvier>> = Arc::new(

--- a/crates/sui-bridge-indexer/src/metrics.rs
+++ b/crates/sui-bridge-indexer/src/metrics.rs
@@ -20,7 +20,7 @@ pub struct BridgeIndexerMetrics {
     pub(crate) last_committed_sui_checkpoint: IntGauge,
     pub(crate) backfill_tasks_remaining_checkpoints: IntGaugeVec,
     pub(crate) tasks_processed_checkpoints: IntCounterVec,
-    pub(crate) tasks_current_checkpoints: IntGaugeVec,
+    pub(crate) tasks_latest_retrieved_checkpoints: IntGaugeVec,
     pub(crate) inflight_live_tasks: IntGaugeVec,
 }
 
@@ -95,9 +95,9 @@ impl BridgeIndexerMetrics {
                 registry,
             )
             .unwrap(),
-            tasks_current_checkpoints: register_int_gauge_vec_with_registry!(
-                "bridge_indexer_tasks_current_checkpoints",
-                "Current checkpoint for each task",
+            tasks_latest_retrieved_checkpoints: register_int_gauge_vec_with_registry!(
+                "bridge_indexer_tasks_latest_retrieved_checkpoints",
+                "latest retrieved checkpoint for each task",
                 &["task_name", "task_type"],
                 registry,
             )

--- a/crates/sui-bridge-indexer/src/storage.rs
+++ b/crates/sui-bridge-indexer/src/storage.rs
@@ -12,7 +12,6 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
 
-use crate::metrics::BridgeIndexerMetrics;
 use crate::postgres_manager::PgPool;
 use crate::schema::progress_store::{columns, dsl};
 use crate::schema::{sui_error_transactions, token_transfer, token_transfer_data};
@@ -27,19 +26,13 @@ use sui_indexer_builder::{
 pub struct PgBridgePersistent {
     pool: PgPool,
     save_progress_policy: ProgressSavingPolicy,
-    indexer_metrics: BridgeIndexerMetrics,
 }
 
 impl PgBridgePersistent {
-    pub fn new(
-        pool: PgPool,
-        save_progress_policy: ProgressSavingPolicy,
-        indexer_metrics: BridgeIndexerMetrics,
-    ) -> Self {
+    pub fn new(pool: PgPool, save_progress_policy: ProgressSavingPolicy) -> Self {
         Self {
             pool,
             save_progress_policy,
-            indexer_metrics,
         }
     }
 }
@@ -176,8 +169,6 @@ impl IndexerProgressStore for PgBridgePersistent {
             return Ok(None);
         }
         let task_name = task.task_name.clone();
-        let task_name_prefix = task.name_prefix();
-        let task_type_label = task.type_str();
         if let Some(checkpoint_to_save) = self
             .save_progress_policy
             .cache_progress(task, checkpoint_numbers)
@@ -200,10 +191,6 @@ impl IndexerProgressStore for PgBridgePersistent {
                 ))
                 .execute(&mut conn)
                 .await?;
-            self.indexer_metrics
-                .tasks_current_checkpoints
-                .with_label_values(&[task_name_prefix, task_type_label])
-                .set(checkpoint_to_save as i64);
             return Ok(Some(checkpoint_to_save));
         }
         Ok(None)


### PR DESCRIPTION
## Description 

Currently indexer reports `current_checkpoint` when saving progress to DB. This makes the metrics a bit out of state when we cache the metrics in memory. This PR:
1. moves the metrics to data retrieval stage,
2. rename it to `latest_retrieved_checkpoints`
3. in EthSubscription task, periodically fetch the latest block height and update this metric

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
