### PR TITLE
adapter(visitor): Use UIDTraversal across all execution layers

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/df_handler.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use sui_data_ingestion_core::Worker;
 use sui_indexer::errors::IndexerError;
-use sui_types::SYSTEM_PACKAGE_ADDRESSES;
+use sui_types::object::bounded_visitor::BoundedVisitor;
+use sui_types::{TypeTag, SYSTEM_PACKAGE_ADDRESSES};
 use tap::tap::TapFallible;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -17,10 +18,11 @@ use sui_json_rpc_types::SuiMoveValue;
 use sui_package_resolver::Resolver;
 use sui_rest_api::{CheckpointData, CheckpointTransaction};
 use sui_types::base_types::ObjectID;
-use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType};
+use sui_types::dynamic_field::visitor as DFV;
+use sui_types::dynamic_field::{DynamicFieldName, DynamicFieldType};
 use sui_types::object::Object;
 
-use crate::handlers::{get_move_struct, AnalyticsHandler};
+use crate::handlers::AnalyticsHandler;
 use crate::package_store::{LocalDBPackageStore, PackageCache};
 use crate::tables::DynamicFieldEntry;
 use crate::FileType;
@@ -114,28 +116,23 @@ impl DynamicFieldHandler {
         if !move_object.type_().is_dynamic_field() {
             return Ok(());
         }
-        let move_struct = if let Some((tag, contents)) = object
-            .struct_tag()
-            .and_then(|tag| object.data.try_as_move().map(|mo| (tag, mo.contents())))
-        {
-            let move_struct = get_move_struct(&tag, contents, &state.resolver).await?;
-            Some(move_struct)
-        } else {
-            None
-        };
-        let Some(move_struct) = move_struct else {
-            return Ok(());
-        };
-        let (name_value, type_, object_id) =
-            DynamicFieldInfo::parse_move_object(&move_struct).tap_err(|e| warn!("{e}"))?;
-        let name_type = move_object.type_().try_extract_field_name(&type_)?;
 
-        let bcs_name = bcs::to_bytes(&name_value.clone().undecorate()).map_err(|e| {
-            IndexerError::SerdeError(format!(
-                "Failed to serialize dynamic field name {:?}: {e}",
-                name_value
-            ))
-        })?;
+        let layout = state
+            .resolver
+            .type_layout(move_object.type_().clone().into())
+            .await?;
+        let object_id = object.id();
+
+        let field = DFV::FieldVisitor::deserialize(move_object.contents(), &layout)?;
+
+        let type_ = field.kind;
+        let name_type: TypeTag = field.name_layout.into();
+        let bcs_name = field.name_bytes.to_owned();
+
+        let name_value = BoundedVisitor::deserialize_value(field.name_bytes, field.name_layout)
+            .tap_err(|e| {
+                warn!("{e}");
+            })?;
         let name = DynamicFieldName {
             type_: name_type,
             value: SuiMoveValue::from(name_value).to_json_value(),

--- a/crates/sui-core/src/rest_index.rs
+++ b/crates/sui-core/src/rest_index.rs
@@ -20,7 +20,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
 use sui_types::digests::TransactionDigest;
-use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldType};
+use sui_types::dynamic_field::visitor as DFV;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::layout_resolver::LayoutResolver;
 use sui_types::messages_checkpoint::CheckpointContents;
@@ -671,45 +671,26 @@ fn try_create_dynamic_field_info(
         return Ok(None);
     }
 
-    let (name_value, dynamic_field_type, object_id) = {
-        let layout = sui_types::layout_resolver::into_struct_layout(
-            resolver
-                .get_annotated_layout(&move_object.type_().clone().into())
-                .map_err(StorageError::custom)?,
-        )
+    let layout = resolver
+        .get_annotated_layout(&move_object.type_().clone().into())
+        .map_err(StorageError::custom)?
+        .into_layout();
+
+    let field = DFV::FieldVisitor::deserialize(move_object.contents(), &layout)
         .map_err(StorageError::custom)?;
 
-        let move_struct = move_object
-            .to_move_struct(&layout)
-            .map_err(StorageError::serialization)?;
+    let value_metadata = field.value_metadata().map_err(StorageError::custom)?;
 
-        // SAFETY: move struct has already been validated to be of type DynamicField
-        DynamicFieldInfo::parse_move_object(&move_struct).unwrap()
-    };
-
-    let name_type = move_object
-        .type_()
-        .try_extract_field_name(&dynamic_field_type)
-        .expect("object is of type Field");
-
-    let name_value = name_value
-        .undecorate()
-        .simple_serialize()
-        .expect("serialization cannot fail");
-
-    let dynamic_object_id = match dynamic_field_type {
-        DynamicFieldType::DynamicObject => Some(object_id),
-        DynamicFieldType::DynamicField => None,
-    };
-
-    let field_info = DynamicFieldIndexInfo {
-        name_type,
-        name_value,
-        dynamic_field_type,
-        dynamic_object_id,
-    };
-
-    Ok(Some(field_info))
+    Ok(Some(DynamicFieldIndexInfo {
+        name_type: field.name_layout.into(),
+        name_value: field.name_bytes.to_owned(),
+        dynamic_field_type: field.kind,
+        dynamic_object_id: if let DFV::ValueMetadata::DynamicObjectField(id) = value_metadata {
+            Some(id)
+        } else {
+            None
+        },
+    }))
 }
 
 fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinIndexInfo)> {

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -1,26 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use itertools::Itertools;
+use sui_types::dynamic_field::visitor as DFV;
 use tap::tap::TapFallible;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use move_core_types::annotated_value::{MoveStructLayout, MoveTypeLayout};
-use move_core_types::language_storage::{StructTag, TypeTag};
+use move_core_types::annotated_value::MoveTypeLayout;
+use move_core_types::language_storage::TypeTag;
 use mysten_metrics::{get_metrics, spawn_monitored_task};
 use sui_data_ingestion_core::Worker;
-use sui_json_rpc_types::SuiMoveValue;
 use sui_package_resolver::{PackageStore, PackageStoreWithLruCache, Resolver};
 use sui_rest_api::{CheckpointData, CheckpointTransaction};
 use sui_types::base_types::ObjectID;
-use sui_types::dynamic_field::DynamicFieldInfo;
-use sui_types::dynamic_field::DynamicFieldName;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::effects::{ObjectChange, TransactionEffectsAPI};
 use sui_types::event::SystemEpochInfoEvent;
@@ -557,25 +555,16 @@ impl CheckpointHandler {
             .collect();
 
         let latest_live_output_objects = data.latest_live_output_objects();
-        let latest_live_output_object_map = latest_live_output_objects
-            .clone()
-            .into_iter()
-            .map(|o| (o.id(), o.clone()))
-            .collect::<HashMap<_, _>>();
-        let move_struct_layout_map =
-            get_move_struct_layout_map(latest_live_output_objects.clone(), package_resolver)
-                .await?;
+        let latest_live_output_object_layouts =
+            type_layout_map(&latest_live_output_objects, package_resolver).await?;
         let changed_objects = latest_live_output_objects
             .into_iter()
             .map(|o| {
-                let df_info = try_create_dynamic_field_info(
-                    o,
-                    &move_struct_layout_map,
-                    &latest_live_output_object_map,
-                );
-                df_info.map(|info| IndexedObject::from_object(checkpoint_seq, o.clone(), info))
+                try_extract_df_kind(o, &latest_live_output_object_layouts)
+                    .map(|df_kind| IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
         Ok(TransactionObjectChangesToCommit {
             changed_objects,
             deleted_objects: indexed_eventually_removed_objects,
@@ -602,31 +591,20 @@ impl CheckpointHandler {
             })
             .collect();
 
-        let latest_live_output_objects = data.latest_live_output_objects();
-        let latest_live_output_object_map = latest_live_output_objects
-            .clone()
-            .into_iter()
-            .map(|o| (o.id(), o.clone()))
-            .collect::<HashMap<_, _>>();
-
-        let output_objects = data
+        let output_objects: Vec<_> = data
             .transactions
             .iter()
             .flat_map(|tx| &tx.output_objects)
-            .collect::<Vec<_>>();
+            .collect();
+
         // TODO(gegaowp): the current df_info implementation is not correct,
         // but we have decided remove all df_* except df_kind.
-        let move_struct_layout_map =
-            get_move_struct_layout_map(output_objects.clone(), package_resolver).await?;
+        let output_layouts = type_layout_map(&output_objects, package_resolver).await?;
         let changed_objects = output_objects
             .into_iter()
             .map(|o| {
-                let df_info = try_create_dynamic_field_info(
-                    o,
-                    &move_struct_layout_map,
-                    &latest_live_output_object_map,
-                );
-                df_info.map(|info| IndexedObject::from_object(checkpoint_seq, o.clone(), info))
+                try_extract_df_kind(o, &output_layouts)
+                    .map(|df_kind| IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind))
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -692,67 +670,49 @@ impl CheckpointHandler {
     }
 }
 
-async fn get_move_struct_layout_map(
-    objects: Vec<&Object>,
+/// Resolve the types of all `objects` and return them in a map. This is done in one go, rather
+/// than one at a time to allow type resolution of distinct types to happen concurrently.
+async fn type_layout_map(
+    objects: &[&Object],
     package_resolver: Arc<Resolver<impl PackageStore>>,
-) -> Result<HashMap<StructTag, MoveStructLayout>, IndexerError> {
-    let struct_tags = objects
-        .into_iter()
-        .filter_map(|o| {
-            let move_object = o.data.try_as_move().cloned();
-            move_object.map(|move_object| {
-                let struct_tag: StructTag = move_object.type_().clone().into();
-                struct_tag
-            })
-        })
-        .collect::<Vec<_>>();
-    let struct_tags = struct_tags.into_iter().unique().collect::<Vec<_>>();
-    info!(
-        "Resolving Move struct layouts for struct tags of size {}.",
-        struct_tags.len()
-    );
-    let move_struct_layout_futures = struct_tags
-        .into_iter()
-        .map(|struct_tag| {
-            let package_resolver_clone = package_resolver.clone();
+) -> IndexerResult<HashMap<TypeTag, MoveTypeLayout>> {
+    let types: HashSet<TypeTag> = objects
+        .iter()
+        .filter_map(|o| Some(o.data.try_as_move()?.type_().clone().into()))
+        .collect();
+
+    info!("Resolving layouts for {} types.", types.len());
+
+    let futures: Vec<_> = types
+        .iter()
+        .map(|type_| {
+            let package_resolver = package_resolver.clone();
             async move {
-                let move_type_layout = package_resolver_clone
-                    .type_layout(TypeTag::Struct(Box::new(struct_tag.clone())))
+                package_resolver
+                    .type_layout(type_.clone())
                     .await
                     .map_err(|e| {
                         IndexerError::DynamicFieldError(format!(
-                            "Fail to resolve struct layout for {:?} with {:?}.",
-                            struct_tag, e
+                            "Fail to resolve layout for {}: {e}.",
+                            type_.to_canonical_display(/* with_prefix */ true),
                         ))
-                    })?;
-                let move_struct_layout = match move_type_layout {
-                    MoveTypeLayout::Struct(s) => Ok(s),
-                    _ => Err(IndexerError::ResolveMoveStructError(
-                        "MoveTypeLayout is not Struct".to_string(),
-                    )),
-                }?;
-                Ok::<
-                    (
-                        move_core_types::language_storage::StructTag,
-                        move_core_types::annotated_value::MoveStructLayout,
-                    ),
-                    IndexerError,
-                >((struct_tag, *move_struct_layout))
+                    })
             }
         })
-        .collect::<Vec<_>>();
-    let move_struct_layout_map = futures::future::try_join_all(move_struct_layout_futures)
-        .await?
-        .into_iter()
-        .collect::<HashMap<_, _>>();
-    Ok(move_struct_layout_map)
+        .collect();
+
+    let layouts = futures::future::try_join_all(futures).await?;
+    Ok(HashMap::from_iter(
+        types.into_iter().zip(layouts.into_iter()),
+    ))
 }
 
-fn try_create_dynamic_field_info(
+/// If `o` is a dynamic `Field<K, V>`, determine whether it represents a Dynamic Field or a Dynamic
+/// Object Field.
+fn try_extract_df_kind(
     o: &Object,
-    struct_tag_to_move_struct_layout: &HashMap<StructTag, MoveStructLayout>,
-    latest_objects: &HashMap<ObjectID, Object>,
-) -> IndexerResult<Option<DynamicFieldInfo>> {
+    layouts: &HashMap<TypeTag, MoveTypeLayout>,
+) -> IndexerResult<Option<DynamicFieldType>> {
     // Skip if not a move object
     let Some(move_object) = o.data.try_as_move().cloned() else {
         return Ok(None);
@@ -762,60 +722,16 @@ fn try_create_dynamic_field_info(
         return Ok(None);
     }
 
-    let struct_tag: StructTag = move_object.type_().clone().into();
-    let move_struct_layout = struct_tag_to_move_struct_layout
-        .get(&struct_tag)
-        .cloned()
-        .ok_or_else(|| {
-            IndexerError::DynamicFieldError(format!(
-                "Cannot find struct layout in mapfor {:?}.",
-                struct_tag
-            ))
-        })?;
-    let move_struct = move_object.to_move_struct(&move_struct_layout)?;
-    let (move_value, type_, object_id) =
-        DynamicFieldInfo::parse_move_object(&move_struct).tap_err(|e| warn!("{e}"))?;
-    let name_type = move_object.type_().try_extract_field_name(&type_)?;
-    let bcs_name = bcs::to_bytes(&move_value.clone().undecorate()).map_err(|e| {
-        IndexerError::SerdeError(format!(
-            "Failed to serialize dynamic field name {:?}: {e}",
-            move_value
+    let type_: TypeTag = move_object.type_().clone().into();
+    let layout = layouts.get(&type_).ok_or_else(|| {
+        IndexerError::DynamicFieldError(format!(
+            "Cannot find layout for {}.",
+            type_.to_canonical_display(/* with_prefix */ true)
         ))
     })?;
-    let name = DynamicFieldName {
-        type_: name_type,
-        value: SuiMoveValue::from(move_value).to_json_value(),
-    };
-    Ok(Some(match type_ {
-        DynamicFieldType::DynamicObject => {
-            let object = latest_objects
-                .get(&object_id)
-                .ok_or(IndexerError::UncategorizedError(anyhow::anyhow!(
-                    "Failed to find object_id {:?} when trying to create dynamic field info",
-                    object_id
-                )))?;
-            let version = object.version();
-            let digest = object.digest();
-            let object_type = object.data.type_().unwrap().clone();
-            DynamicFieldInfo {
-                name,
-                bcs_name,
-                type_,
-                object_type: object_type.to_canonical_string(/* with_prefix */ true),
-                object_id,
-                version,
-                digest,
-            }
-        }
-        DynamicFieldType::DynamicField => DynamicFieldInfo {
-            name,
-            bcs_name,
-            type_,
-            object_type: move_object.into_type().into_type_params()[1]
-                .to_canonical_string(/* with_prefix */ true),
-            object_id: o.id(),
-            version: o.version(),
-            digest: o.digest(),
-        },
-    }))
+
+    let field =
+        DFV::FieldVisitor::deserialize(move_object.contents(), layout).tap_err(|e| warn!("{e}"))?;
+
+    Ok(Some(field.kind))
 }

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -68,7 +68,7 @@ impl From<IndexedObject> for StoredObject {
         let IndexedObject {
             checkpoint_sequence_number: _,
             object,
-            df_info,
+            df_kind,
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
@@ -94,7 +94,7 @@ impl From<IndexedObject> for StoredObject {
             serialized_object: bcs::to_bytes(&object).unwrap(),
             coin_type,
             coin_balance: coin_balance.map(|b| b as i64),
-            df_kind: df_info.as_ref().map(|k| match k.type_ {
+            df_kind: df_kind.map(|k| match k {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
@@ -143,7 +143,7 @@ impl From<IndexedObject> for StoredObjectSnapshot {
         let IndexedObject {
             checkpoint_sequence_number,
             object,
-            df_info,
+            df_kind,
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
@@ -172,7 +172,7 @@ impl From<IndexedObject> for StoredObjectSnapshot {
             serialized_object: Some(bcs::to_bytes(&object).unwrap()),
             coin_type,
             coin_balance: coin_balance.map(|b| b as i64),
-            df_kind: df_info.as_ref().map(|k| match k.type_ {
+            df_kind: df_kind.map(|k| match k {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
@@ -227,7 +227,7 @@ impl From<IndexedObject> for StoredHistoryObject {
         let IndexedObject {
             checkpoint_sequence_number,
             object,
-            df_info,
+            df_kind,
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
@@ -256,7 +256,7 @@ impl From<IndexedObject> for StoredHistoryObject {
             serialized_object: Some(bcs::to_bytes(&object).unwrap()),
             coin_type,
             coin_balance: coin_balance.map(|b| b as i64),
-            df_kind: df_info.as_ref().map(|k| match k.type_ {
+            df_kind: df_kind.map(|k| match k {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::{ObjectDigest, SequenceNumber};
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::TransactionDigest;
-use sui_types::dynamic_field::DynamicFieldInfo;
+use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::effects::TransactionEffects;
 use sui_types::event::SystemEpochInfoEvent;
 use sui_types::messages_checkpoint::{
@@ -347,19 +347,19 @@ pub enum DynamicFieldKind {
 pub struct IndexedObject {
     pub checkpoint_sequence_number: CheckpointSequenceNumber,
     pub object: Object,
-    pub df_info: Option<DynamicFieldInfo>,
+    pub df_kind: Option<DynamicFieldType>,
 }
 
 impl IndexedObject {
     pub fn from_object(
         checkpoint_sequence_number: CheckpointSequenceNumber,
         object: Object,
-        df_info: Option<DynamicFieldInfo>,
+        df_kind: Option<DynamicFieldType>,
     ) -> Self {
         Self {
             checkpoint_sequence_number,
             object,
-            df_info,
+            df_kind,
         }
     }
 }

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -95,7 +95,9 @@ impl Display for DynamicFieldName {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(
+    Copy, Clone, Serialize, Deserialize, JsonSchema, Ord, PartialOrd, Eq, PartialEq, Debug,
+)]
 pub enum DynamicFieldType {
     #[serde(rename_all = "camelCase")]
     DynamicField,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -690,10 +690,10 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    struct UIDTraversalV2<'i>(&'i mut BTreeSet<ObjectID>);
-    struct UIDCollectorV2<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDTraversal<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollector<'i>(&'i mut BTreeSet<ObjectID>);
 
-    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversalV2<'i> {
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversal<'i> {
         type Error = AV::Error;
 
         fn traverse_struct(
@@ -701,7 +701,7 @@ pub fn get_all_uids(
             driver: &mut AV::StructDriver<'_, 'b, 'l>,
         ) -> Result<(), Self::Error> {
             if driver.struct_layout().type_ == UID::type_() {
-                while driver.next_field(&mut UIDCollectorV2(self.0))?.is_some() {}
+                while driver.next_field(&mut UIDCollector(self.0))?.is_some() {}
             } else {
                 while driver.next_field(self)?.is_some() {}
             }
@@ -709,7 +709,7 @@ pub fn get_all_uids(
         }
     }
 
-    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollectorV2<'i> {
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollector<'i> {
         type Error = AV::Error;
         fn traverse_address(
             &mut self,
@@ -724,7 +724,7 @@ pub fn get_all_uids(
     MoveValue::visit_deserialize(
         bcs_bytes,
         fully_annotated_layout,
-        &mut UIDTraversalV2(&mut ids),
+        &mut UIDTraversal(&mut ids),
     )
     .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
     Ok(ids)

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -5,7 +5,7 @@ use better_any::{Tid, TidAble};
 use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress, annotated_value as A, effects::Op,
+    account_address::AccountAddress, annotated_value as A, annotated_visitor as AV, effects::Op,
     language_storage::StructTag, runtime_value as R, vm_status::StatusCode,
 };
 use move_vm_types::{
@@ -608,7 +608,6 @@ fn update_owner_map(
     Ok(())
 }
 
-// TODO use a custom DeserializerSeed and improve this performance
 /// WARNING! This function assumes that the bcs bytes have already been validated,
 /// and it will give an invariant violation otherwise.
 /// In short, we are relying on the invariant that the bytes are valid for objects
@@ -619,40 +618,42 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    // TODO (annotated-visitor): Replace with a custom visitor
-    let v = A::MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
-        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
-    get_all_uids_in_value(&mut ids, &v)?;
-    Ok(ids)
-}
+    struct UIDTraversal<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollector<'i>(&'i mut BTreeSet<ObjectID>);
 
-fn get_all_uids_in_value(
-    acc: &mut BTreeSet<ObjectID>,
-    v: &A::MoveValue,
-) -> Result<(), /* invariant violation */ String> {
-    let mut stack = vec![v];
-    while let Some(cur) = stack.pop() {
-        let s = match cur {
-            A::MoveValue::Struct(s) => s,
-            A::MoveValue::Vector(vec) => {
-                stack.extend(vec);
-                continue;
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversal<'i> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            if driver.struct_layout().type_ == UID::type_() {
+                while driver.next_field(&mut UIDCollector(self.0))?.is_some() {}
+            } else {
+                while driver.next_field(self)?.is_some() {}
             }
-            _ => continue,
-        };
-        let A::MoveStruct { type_, fields } = s;
-        if type_ == &UID::type_() {
-            let inner = match &fields[0].1 {
-                A::MoveValue::Struct(A::MoveStruct { fields, .. }) => fields,
-                v => return Err(format!("Unexpected UID layout. {v:?}")),
-            };
-            match &inner[0].1 {
-                A::MoveValue::Address(id) => acc.insert((*id).into()),
-                v => return Err(format!("Unexpected ID layout. {v:?}")),
-            };
-        } else {
-            stack.extend(fields.iter().map(|(_, v)| v));
+            Ok(())
         }
     }
-    Ok(())
+
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollector<'i> {
+        type Error = AV::Error;
+        fn traverse_address(
+            &mut self,
+            _driver: &AV::ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            self.0.insert(value.into());
+            Ok(())
+        }
+    }
+
+    A::MoveValue::visit_deserialize(
+        bcs_bytes,
+        fully_annotated_layout,
+        &mut UIDTraversal(&mut ids),
+    )
+    .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    Ok(ids)
 }

--- a/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
@@ -6,7 +6,8 @@ use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveTypeLayout, MoveValue},
+    annotated_value::{MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     effects::Op,
     language_storage::StructTag,
     runtime_value as R,
@@ -660,7 +661,6 @@ fn check_circular_ownership(
     Ok(())
 }
 
-// TODO use a custom DeserializerSeed and improve this performance
 /// WARNING! This function assumes that the bcs bytes have already been validated,
 /// and it will give an invariant violation otherwise.
 /// In short, we are relying on the invariant that the bytes are valid for objects
@@ -671,41 +671,42 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    // TODO (annotated-visitor): Replace with a custom visitor
-    let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
-        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
-    get_all_uids_in_value(&mut ids, &v)?;
-    Ok(ids)
-}
+    struct UIDTraversal<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollector<'i>(&'i mut BTreeSet<ObjectID>);
 
-fn get_all_uids_in_value(
-    acc: &mut BTreeSet<ObjectID>,
-    v: &MoveValue,
-) -> Result<(), /* invariant violation */ String> {
-    let mut stack = vec![v];
-    while let Some(cur) = stack.pop() {
-        let s = match cur {
-            MoveValue::Struct(s) => s,
-            MoveValue::Vector(vec) => {
-                stack.extend(vec);
-                continue;
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDTraversal<'i> {
+        type Error = AV::Error;
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut AV::StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            if driver.struct_layout().type_ == UID::type_() {
+                while driver.next_field(&mut UIDCollector(self.0))?.is_some() {}
+            } else {
+                while driver.next_field(self)?.is_some() {}
             }
-            _ => continue,
-        };
-
-        let MoveStruct { type_, fields } = s;
-        if type_ == &UID::type_() {
-            let inner = match &fields[0].1 {
-                MoveValue::Struct(MoveStruct { fields, .. }) => fields,
-                v => return Err(format!("Unexpected UID layout. {v:?}")),
-            };
-            match &inner[0].1 {
-                MoveValue::Address(id) => acc.insert((*id).into()),
-                v => return Err(format!("Unexpected ID layout. {v:?}")),
-            };
-        } else {
-            stack.extend(fields.iter().map(|(_, v)| v));
+            Ok(())
         }
     }
-    Ok(())
+
+    impl<'i, 'b, 'l> AV::Traversal<'b, 'l> for UIDCollector<'i> {
+        type Error = AV::Error;
+        fn traverse_address(
+            &mut self,
+            _driver: &AV::ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            self.0.insert(value.into());
+            Ok(())
+        }
+    }
+
+    MoveValue::visit_deserialize(
+        bcs_bytes,
+        fully_annotated_layout,
+        &mut UIDTraversal(&mut ids),
+    )
+    .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    Ok(ids)
 }


### PR DESCRIPTION
## Description

Replace the legacy implementations of `get_all_uids` with the one that has been used in `latest` for some time now. This version avoids inflating the whole struct just to read its UIDs.

The main motivation in making the switch is to reduce the number of call-sites that use `simple_deserialize`, so that we can eventually get rid of it entirely, and replace it with a visitor based ipmplementation that includes the appropriate caveats around inflating a whole struct in memory.

## Test plan

```
sui$ cargo simtest
```

## Stack

- #19517
- #19518 
- #19519 
- #19520 
- #19521 
- #19548 
- #19554
- #19565

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
