### PR TITLE
indexer reader: use raw_checkpoints instead for JSON RPC

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -67,7 +67,7 @@ impl ExtendedApiServer for ExtendedApi {
     }
 
     async fn get_total_transactions(&self) -> RpcResult<BigInt<u64>> {
-        let latest_checkpoint = self.inner.get_latest_checkpoint().await?;
+        let latest_checkpoint = self.inner.get_latest_rpc_checkpoint().await?;
         Ok(latest_checkpoint.network_total_transactions.into())
     }
 }

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -305,7 +305,7 @@ impl IndexerApiServer for IndexerApi {
         let parent_record_id = self.name_service_config.record_field_id(&parent_domain);
 
         // get latest timestamp to check expiration.
-        let current_timestamp = self.inner.get_latest_checkpoint().await?.timestamp_ms;
+        let current_timestamp = self.inner.get_latest_rpc_checkpoint().await?.timestamp_ms;
 
         // gather the requests to fetch in the multi_get_objs.
         let mut requests = vec![record_id];

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -34,7 +34,7 @@ impl ReadApi {
     }
 
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Checkpoint, IndexerError> {
-        match self.inner.get_checkpoint(id).await {
+        match self.inner.get_rpc_checkpoint(id).await {
             Ok(Some(epoch_info)) => Ok(epoch_info),
             Ok(None) => Err(IndexerError::InvalidArgumentError(format!(
                 "Checkpoint {id:?} not found"
@@ -44,7 +44,7 @@ impl ReadApi {
     }
 
     async fn get_latest_checkpoint(&self) -> Result<Checkpoint, IndexerError> {
-        self.inner.get_latest_checkpoint().await
+        self.inner.get_latest_rpc_checkpoint().await
     }
 
     async fn get_chain_identifier(&self) -> RpcResult<ChainIdentifier> {
@@ -190,7 +190,7 @@ impl ReadApiServer for ReadApi {
 
         let mut checkpoints = self
             .inner
-            .get_checkpoints(cursor, limit + 1, descending_order)
+            .get_rpc_checkpoints(cursor, limit + 1, descending_order)
             .await?;
 
         let has_next_page = checkpoints.len() > limit;

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -311,13 +311,8 @@ impl CheckpointHandler {
                 )
                 .await?;
 
-            let successful_tx_num: u64 = db_transactions.iter().map(|t| t.successful_tx_num).sum();
             (
-                IndexedCheckpoint::from_sui_checkpoint(
-                    checkpoint_summary,
-                    checkpoint_contents,
-                    successful_tx_num as usize,
-                ),
+                IndexedCheckpoint::from_sui_checkpoint(checkpoint_summary, checkpoint_contents),
                 db_transactions,
                 db_events,
                 db_tx_indices,

--- a/crates/sui-indexer/src/models/raw_checkpoints.rs
+++ b/crates/sui-indexer/src/models/raw_checkpoints.rs
@@ -1,9 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use diesel::prelude::*;
+use tap::Pipe;
+
+use sui_json_rpc_types::Checkpoint as RpcCheckpoint;
+use sui_types::messages_checkpoint::CheckpointContents;
+
+use crate::errors::IndexerError;
 use crate::schema::raw_checkpoints;
 use crate::types::IndexedCheckpoint;
-use diesel::prelude::*;
 
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = raw_checkpoints)]
@@ -22,5 +28,49 @@ impl From<&IndexedCheckpoint> for StoredRawCheckpoint {
             certified_checkpoint: bcs::to_bytes(c.certified_checkpoint.as_ref().unwrap()).unwrap(),
             checkpoint_contents: bcs::to_bytes(c.checkpoint_contents.as_ref().unwrap()).unwrap(),
         }
+    }
+}
+
+impl TryFrom<StoredRawCheckpoint> for RpcCheckpoint {
+    type Error = IndexerError;
+
+    fn try_from(raw_cp: StoredRawCheckpoint) -> Result<RpcCheckpoint, IndexerError> {
+        let checkpoint_contents = raw_cp
+            .checkpoint_contents
+            .pipe(|contents| bcs::from_bytes::<CheckpointContents>(&contents))
+            .map_err(|e| {
+                IndexerError::PersistentStorageDataCorruptionError(format!(
+                    "Failed to decode checkpoint contents: {e}"
+                ))
+            })?;
+
+        let certified_checkpoint = raw_cp
+            .certified_checkpoint
+            .pipe(|bytes| {
+                bcs::from_bytes::<sui_types::messages_checkpoint::CertifiedCheckpointSummary>(
+                    &bytes,
+                )
+            })
+            .map_err(|e| {
+                IndexerError::PersistentStorageDataCorruptionError(format!(
+                    "Failed to decode certified checkpoint summary: {e}"
+                ))
+            })?;
+
+        Ok(RpcCheckpoint {
+            epoch: certified_checkpoint.epoch,
+            sequence_number: certified_checkpoint.sequence_number,
+            digest: *certified_checkpoint.digest(),
+            network_total_transactions: certified_checkpoint.network_total_transactions,
+            previous_digest: certified_checkpoint.previous_digest,
+            epoch_rolling_gas_cost_summary: certified_checkpoint
+                .epoch_rolling_gas_cost_summary
+                .clone(),
+            timestamp_ms: certified_checkpoint.timestamp_ms,
+            checkpoint_commitments: certified_checkpoint.checkpoint_commitments.clone(),
+            validator_signature: certified_checkpoint.auth_sig().signature.clone(),
+            end_of_epoch_data: certified_checkpoint.end_of_epoch_data.clone(),
+            transactions: checkpoint_contents.iter().map(|t| t.transaction).collect(),
+        })
     }
 }

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -44,7 +44,6 @@ pub struct IndexedCheckpoint {
     pub non_refundable_storage_fee: u64,
     pub checkpoint_commitments: Vec<CheckpointCommitment>,
     pub validator_signature: AggregateAuthoritySignature,
-    pub successful_tx_num: usize,
     pub end_of_epoch_data: Option<EndOfEpochData>,
     pub end_of_epoch: bool,
     pub min_tx_sequence_number: u64,
@@ -58,7 +57,6 @@ impl IndexedCheckpoint {
     pub fn from_sui_checkpoint(
         checkpoint: &CertifiedCheckpointSummary,
         contents: &CheckpointContents,
-        successful_tx_num: usize,
     ) -> Self {
         let total_gas_cost = checkpoint.epoch_rolling_gas_cost_summary.computation_cost as i64
             + checkpoint.epoch_rolling_gas_cost_summary.storage_cost as i64
@@ -83,7 +81,6 @@ impl IndexedCheckpoint {
             non_refundable_storage_fee: checkpoint
                 .epoch_rolling_gas_cost_summary
                 .non_refundable_storage_fee,
-            successful_tx_num,
             network_total_transactions: checkpoint.network_total_transactions,
             timestamp_ms: checkpoint.timestamp_ms,
             validator_signature: auth_sig.clone(),


### PR DESCRIPTION
## Description 

title, the related issue is https://linear.app/mysten-labs/issue/DP-45/instead-of-having-tx-digests-we-should-just-put-raw-checkpointcontents

## Test plan 

ci

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
