### PR TITLE
[sdk docs] Remove import duplication for dapp-kit sui client provider

### DIFF
--- a/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
+++ b/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
@@ -163,8 +163,6 @@ to get the variables defined in your configuration.
 - `useNetworkVariable` returns a specific variable from the network configuration
 
 ```tsx
-import { createNetworkConfig, SuiClientProvider } from '@mysten/dapp-kit';
-
 import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { getFullnodeUrl } from '@mysten/sui/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
+++ b/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
@@ -173,13 +173,13 @@ const { networkConfig, useNetworkVariable } = createNetworkConfig({
 		url: getFullnodeUrl('localnet'),
 		variables: {
 			myMovePackageId: '0x123',
-		}
+		},
 	},
 	mainnet: {
 		url: getFullnodeUrl('mainnet'),
 		variables: {
 			myMovePackageId: '0x456',
-		}
+		},
 	},
 });
 
@@ -196,7 +196,6 @@ function App() {
 		</QueryClientProvider>
 	);
 }
-
 
 function YourApp() {
 	const id = useNetworkVariable('myMovePackageId');


### PR DESCRIPTION
## Description 

Remove import duplication `from '@mysten/dapp-kit'` for Sui Client Provider "Using network specific configuration" code example (dapp-kit doc)

## Test plan 

Sui Client Provider "Using network specific configuration" code example, link (https://sdk.mystenlabs.com/dapp-kit/sui-client-provider#using-network-specific-configuration)
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
