### PR TITLE
[Indexer] Split checkpoint fetcher logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13222,6 +13222,7 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
+ "tokio-retry",
  "tracing",
  "url",
 ]

--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -28,6 +28,7 @@ tempfile.workspace = true
 tap.workspace = true
 sui-protocol-config.workspace = true
 sui-rest-api.workspace = true
+tokio-retry.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/sui-data-ingestion-core/src/checkpoint_fetcher/archival_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/checkpoint_fetcher/archival_fetcher.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::checkpoint_fetcher::CheckpointFetcherTrait;
+use crate::create_remote_store_client;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use std::sync::Arc;
+use sui_storage::blob::Blob;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// Fetches checkpoint data from a remote archival store.
+/// The store can be either an HTTP store or a cloud store (GCS or S3).
+pub(crate) struct ArchivalFetcher {
+    object_store: Box<dyn ObjectStore>,
+}
+
+impl ArchivalFetcher {
+    pub fn new(
+        url: String,
+        remote_store_options: Vec<(String, String)>,
+        timeout_secs: u64,
+    ) -> anyhow::Result<Self> {
+        let object_store = create_remote_store_client(url, remote_store_options, timeout_secs)?;
+        Ok(Self { object_store })
+    }
+}
+
+#[async_trait::async_trait]
+impl CheckpointFetcherTrait for ArchivalFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        let path = Path::from(format!("{}.chk", sequence_number));
+        let response = self.object_store.get(&path).await?;
+        let bytes = response.bytes().await?;
+        let checkpoint_data = Blob::from_bytes::<Arc<CheckpointData>>(&bytes)?;
+        Ok((checkpoint_data, bytes.len()))
+    }
+}

--- a/crates/sui-data-ingestion-core/src/checkpoint_fetcher/file_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/checkpoint_fetcher/file_fetcher.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::checkpoint_fetcher::CheckpointFetcherTrait;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use sui_storage::blob::Blob;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+pub(crate) struct FileFetcher {
+    dir_path: PathBuf,
+}
+
+impl FileFetcher {
+    pub fn new(dir_path: PathBuf) -> Self {
+        Self { dir_path }
+    }
+}
+
+#[async_trait::async_trait]
+impl CheckpointFetcherTrait for FileFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        let file_path = self.dir_path.join(format!("{}.chk", sequence_number));
+        let bytes = fs::read(&file_path)?;
+        let checkpoint = Blob::from_bytes::<Arc<CheckpointData>>(&bytes)?;
+        let size = bytes.len();
+        Ok((checkpoint, size))
+    }
+}

--- a/crates/sui-data-ingestion-core/src/checkpoint_fetcher/hybrid_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/checkpoint_fetcher/hybrid_fetcher.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::checkpoint_fetcher::archival_fetcher::ArchivalFetcher;
+use crate::checkpoint_fetcher::rest_fetcher::RestFetcher;
+use crate::checkpoint_fetcher::CheckpointFetcherTrait;
+use std::sync::Arc;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// The HybridFetcher first tries to fetch the checkpoint from the REST API.
+/// If that fails, it falls back to fetching the checkpoint from the archival store.
+pub(crate) struct HybridFetcher {
+    archival_fetcher: ArchivalFetcher,
+    rest_fetcher: RestFetcher,
+}
+
+impl HybridFetcher {
+    pub fn new(archival_fetcher: ArchivalFetcher, rest_fetcher: RestFetcher) -> Self {
+        Self {
+            archival_fetcher,
+            rest_fetcher,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CheckpointFetcherTrait for HybridFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        match self.rest_fetcher.fetch_checkpoint(sequence_number).await {
+            Ok(result) => Ok(result),
+            Err(_) => {
+                self.archival_fetcher
+                    .fetch_checkpoint(sequence_number)
+                    .await
+            }
+        }
+    }
+}

--- a/crates/sui-data-ingestion-core/src/checkpoint_fetcher/mod.rs
+++ b/crates/sui-data-ingestion-core/src/checkpoint_fetcher/mod.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::checkpoint_fetcher::archival_fetcher::ArchivalFetcher;
+use crate::checkpoint_fetcher::file_fetcher::FileFetcher;
+use crate::checkpoint_fetcher::hybrid_fetcher::HybridFetcher;
+use crate::checkpoint_fetcher::rest_fetcher::RestFetcher;
+use futures::StreamExt;
+use mysten_metrics::spawn_monitored_task;
+use std::path::PathBuf;
+use std::sync::Arc;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tap::Pipe;
+use tokio::sync::mpsc;
+use tokio_retry::strategy::{jitter, FixedInterval};
+use tokio_retry::Retry;
+
+mod archival_fetcher;
+mod file_fetcher;
+mod hybrid_fetcher;
+mod rest_fetcher;
+
+#[async_trait::async_trait]
+trait CheckpointFetcherTrait: Sync + Send {
+    /// Given a sequence number, fetches the corresponding checkpoint data.
+    /// Returns the checkpoint data and the size of the response in bytes.
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)>;
+}
+
+#[derive(Clone)]
+pub struct CheckpointFetcher {
+    file_fetcher: Arc<FileFetcher>,
+    remote_fetcher: Option<Arc<dyn CheckpointFetcherTrait>>,
+}
+
+impl CheckpointFetcher {
+    pub fn new(
+        path: PathBuf,
+        url: Option<String>,
+        remote_store_options: Vec<(String, String)>,
+        timeout_secs: u64,
+    ) -> Self {
+        let file_fetcher = Arc::new(FileFetcher::new(path));
+        let remote_fetcher = if let Some(url) = url {
+            let remote_fetcher: Arc<dyn CheckpointFetcherTrait> =
+                if let Some((fn_url, remote_url)) = url.split_once('|') {
+                    let archival_fetcher = ArchivalFetcher::new(
+                        remote_url.to_string(),
+                        remote_store_options,
+                        timeout_secs,
+                    )
+                    .expect("failed to create remote store client");
+                    let rest_fetcher = RestFetcher::new(fn_url.to_string());
+                    Arc::new(HybridFetcher::new(archival_fetcher, rest_fetcher))
+                } else if url.ends_with("/rest") {
+                    Arc::new(RestFetcher::new(url))
+                } else {
+                    Arc::new(
+                        ArchivalFetcher::new(url, remote_store_options, timeout_secs)
+                            .expect("failed to create remote store client"),
+                    )
+                };
+            Some(remote_fetcher)
+        } else {
+            None
+        };
+        Self {
+            file_fetcher,
+            remote_fetcher,
+        }
+    }
+
+    pub async fn start_fetching_checkpoints(
+        self,
+        batch_size: usize,
+        start_checkpoint: CheckpointSequenceNumber,
+    ) -> mpsc::Receiver<(Arc<CheckpointData>, usize)> {
+        let (sender, receiver) = mpsc::channel(batch_size);
+        spawn_monitored_task!(async move {
+            let mut checkpoint_stream = (start_checkpoint..u64::MAX)
+                .map(|checkpoint_number| self.fetch_one_checkpoint(checkpoint_number))
+                .pipe(futures::stream::iter)
+                .buffered(batch_size);
+
+            while let Some(checkpoint) = checkpoint_stream.next().await {
+                if sender.send(checkpoint).await.is_err() {
+                    tracing::error!("Remote reader dropped");
+                    break;
+                }
+            }
+        });
+        receiver
+    }
+
+    async fn fetch_one_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> (Arc<CheckpointData>, usize) {
+        // Retry indefinitely with constant 100ms intervals plus some jitter.
+        let retry_strategy = FixedInterval::from_millis(100).map(jitter);
+
+        Retry::spawn(retry_strategy, || async {
+            // Attempt to fetch from local files
+            let local_err = match self.file_fetcher.fetch_checkpoint(sequence_number).await {
+                Ok(data) => return Ok(data),
+                Err(err) => {
+                    tracing::trace!("Failed to fetch checkpoint from local files: {}", err);
+                    // Fall through to remote fetcher
+                    err
+                }
+            };
+            let Some(remote_fetcher) = &self.remote_fetcher else {
+                return Err(local_err);
+            };
+
+            // Attempt to fetch from remote store
+            match remote_fetcher.fetch_checkpoint(sequence_number).await {
+                Ok(data) => Ok(data),
+                Err(err) => {
+                    if !err.to_string().contains("404") {
+                        tracing::debug!(
+                            "Failed to fetch checkpoint from remote store: {}. Retrying...",
+                            err
+                        );
+                    }
+                    Err(err)
+                }
+            }
+        })
+        .await
+        .expect("Expected to retry indefinitely")
+    }
+}

--- a/crates/sui-data-ingestion-core/src/checkpoint_fetcher/rest_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/checkpoint_fetcher/rest_fetcher.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::checkpoint_fetcher::CheckpointFetcherTrait;
+use std::sync::Arc;
+use sui_rest_api::Client;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// Fetches checkpoint data from the REST API.
+pub(crate) struct RestFetcher {
+    client: Client,
+}
+
+impl RestFetcher {
+    pub fn new(url: String) -> Self {
+        let client = Client::new(url);
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl CheckpointFetcherTrait for RestFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        let checkpoint = self.client.get_full_checkpoint(sequence_number).await?;
+        let size = bcs::serialized_size(&checkpoint)?;
+        Ok((Arc::new(checkpoint), size))
+    }
+}

--- a/crates/sui-data-ingestion-core/src/executor.rs
+++ b/crates/sui-data-ingestion-core/src/executor.rs
@@ -76,7 +76,8 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                 remote_store_url,
                 remote_store_options,
                 reader_options,
-            );
+            )
+            .await;
         spawn_monitored_task!(checkpoint_reader.run());
 
         for pool in std::mem::take(&mut self.pools) {

--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod checkpoint_fetcher;
 mod executor;
 mod metrics;
 mod progress_store;

--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -1,44 +1,33 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::create_remote_store_client;
+use crate::checkpoint_fetcher::CheckpointFetcher;
 use crate::executor::MAX_CHECKPOINTS_IN_PROGRESS;
 use anyhow::Result;
-use backoff::backoff::Backoff;
-use futures::StreamExt;
-use mysten_metrics::spawn_monitored_task;
 #[cfg(not(target_os = "macos"))]
 use notify::{RecommendedWatcher, RecursiveMode};
-use object_store::path::Path;
-use object_store::ObjectStore;
 use std::ffi::OsString;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
-use sui_rest_api::Client;
-use sui_storage::blob::Blob;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use tap::pipe::Pipe;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 pub struct CheckpointReader {
     /// Used to read from a local directory when running with a colocated FN.
     /// When fetching from a remote store, a temp dir can be passed in and it will be an no-op
     path: PathBuf,
-    remote_store_url: Option<String>,
-    remote_store_options: Vec<(String, String)>,
     current_checkpoint_number: CheckpointSequenceNumber,
     last_pruned_watermark: CheckpointSequenceNumber,
     checkpoint_sender: mpsc::Sender<Arc<CheckpointData>>,
     processed_receiver: mpsc::Receiver<CheckpointSequenceNumber>,
-    #[allow(clippy::type_complexity)]
-    remote_fetcher_receiver: Option<mpsc::Receiver<Result<(Arc<CheckpointData>, usize)>>>,
+    fetcher_receiver: mpsc::Receiver<(Arc<CheckpointData>, usize)>,
     exit_receiver: oneshot::Receiver<()>,
     options: ReaderOptions,
     data_limiter: DataLimiter,
@@ -46,7 +35,7 @@ pub struct CheckpointReader {
 
 #[derive(Clone)]
 pub struct ReaderOptions {
-    pub tick_interal_ms: u64,
+    pub tick_interval_ms: u64,
     pub timeout_secs: u64,
     /// number of maximum concurrent requests to the remote store. Increase it for backfills
     pub batch_size: usize,
@@ -57,7 +46,7 @@ pub struct ReaderOptions {
 impl Default for ReaderOptions {
     fn default() -> Self {
         Self {
-            tick_interal_ms: 100,
+            tick_interval_ms: 100,
             timeout_secs: 5,
             batch_size: 10,
             data_limit: 0,
@@ -66,178 +55,22 @@ impl Default for ReaderOptions {
     }
 }
 
-enum RemoteStore {
-    ObjectStore(Box<dyn ObjectStore>),
-    Rest(sui_rest_api::Client),
-    Hybrid(Box<dyn ObjectStore>, sui_rest_api::Client),
-}
-
 impl CheckpointReader {
-    /// Represents a single iteration of the reader.
-    /// Reads files in a local directory, validates them, and forwards `CheckpointData` to the executor.
-    async fn read_local_files(&self) -> Result<Vec<Arc<CheckpointData>>> {
-        let mut files = vec![];
-        for entry in fs::read_dir(self.path.clone())? {
-            let entry = entry?;
-            let filename = entry.file_name();
-            if let Some(sequence_number) = Self::checkpoint_number_from_file_path(&filename) {
-                if sequence_number >= self.current_checkpoint_number {
-                    files.push((sequence_number, entry.path()));
-                }
-            }
-        }
-        files.sort();
-        debug!("unprocessed local files {:?}", files);
-        let mut checkpoints = vec![];
-        for (_, filename) in files.iter().take(MAX_CHECKPOINTS_IN_PROGRESS) {
-            let checkpoint = Blob::from_bytes::<Arc<CheckpointData>>(&fs::read(filename)?)?;
-            if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number) {
-                break;
-            }
-            checkpoints.push(checkpoint);
-        }
-        Ok(checkpoints)
-    }
-
     fn exceeds_capacity(&self, checkpoint_number: CheckpointSequenceNumber) -> bool {
         ((MAX_CHECKPOINTS_IN_PROGRESS as u64 + self.last_pruned_watermark) <= checkpoint_number)
             || self.data_limiter.exceeds()
     }
 
-    async fn fetch_from_object_store(
-        store: &dyn ObjectStore,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        let path = Path::from(format!("{}.chk", checkpoint_number));
-        let response = store.get(&path).await?;
-        let bytes = response.bytes().await?;
-        Ok((
-            Blob::from_bytes::<Arc<CheckpointData>>(&bytes)?,
-            bytes.len(),
-        ))
-    }
-
-    async fn fetch_from_full_node(
-        client: &Client,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        let checkpoint = client.get_full_checkpoint(checkpoint_number).await?;
-        let size = bcs::serialized_size(&checkpoint)?;
-        Ok((Arc::new(checkpoint), size))
-    }
-
-    async fn remote_fetch_checkpoint_internal(
-        store: &RemoteStore,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        match store {
-            RemoteStore::ObjectStore(store) => {
-                Self::fetch_from_object_store(store, checkpoint_number).await
-            }
-            RemoteStore::Rest(client) => {
-                Self::fetch_from_full_node(client, checkpoint_number).await
-            }
-            RemoteStore::Hybrid(store, client) => {
-                match Self::fetch_from_full_node(client, checkpoint_number).await {
-                    Ok(result) => Ok(result),
-                    Err(_) => Self::fetch_from_object_store(store, checkpoint_number).await,
-                }
-            }
-        }
-    }
-
-    async fn remote_fetch_checkpoint(
-        store: &RemoteStore,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        let mut backoff = backoff::ExponentialBackoff::default();
-        backoff.max_elapsed_time = Some(Duration::from_secs(60));
-        backoff.initial_interval = Duration::from_millis(100);
-        backoff.current_interval = backoff.initial_interval;
-        backoff.multiplier = 1.0;
-        loop {
-            match Self::remote_fetch_checkpoint_internal(store, checkpoint_number).await {
-                Ok(data) => return Ok(data),
-                Err(err) => match backoff.next_backoff() {
-                    Some(duration) => {
-                        if !err.to_string().contains("404") {
-                            debug!(
-                                "remote reader retry in {} ms. Error is {:?}",
-                                duration.as_millis(),
-                                err
-                            );
-                        }
-                        tokio::time::sleep(duration).await
-                    }
-                    None => return Err(err),
-                },
-            }
-        }
-    }
-
-    fn start_remote_fetcher(&mut self) -> mpsc::Receiver<Result<(Arc<CheckpointData>, usize)>> {
-        let batch_size = self.options.batch_size;
-        let start_checkpoint = self.current_checkpoint_number;
-        let (sender, receiver) = mpsc::channel(batch_size);
-        let url = self
-            .remote_store_url
-            .clone()
-            .expect("remote store url must be set");
-        let store = if let Some((fn_url, remote_url)) = url.split_once('|') {
-            let object_store = create_remote_store_client(
-                remote_url.to_string(),
-                self.remote_store_options.clone(),
-                self.options.timeout_secs,
-            )
-            .expect("failed to create remote store client");
-            RemoteStore::Hybrid(object_store, sui_rest_api::Client::new(fn_url))
-        } else if url.ends_with("/rest") {
-            RemoteStore::Rest(sui_rest_api::Client::new(url))
-        } else {
-            let object_store = create_remote_store_client(
-                url,
-                self.remote_store_options.clone(),
-                self.options.timeout_secs,
-            )
-            .expect("failed to create remote store client");
-            RemoteStore::ObjectStore(object_store)
-        };
-
-        spawn_monitored_task!(async move {
-            let mut checkpoint_stream = (start_checkpoint..u64::MAX)
-                .map(|checkpoint_number| Self::remote_fetch_checkpoint(&store, checkpoint_number))
-                .pipe(futures::stream::iter)
-                .buffered(batch_size);
-
-            while let Some(checkpoint) = checkpoint_stream.next().await {
-                if sender.send(checkpoint).await.is_err() {
-                    info!("remote reader dropped");
-                    break;
-                }
-            }
-        });
-        receiver
-    }
-
-    fn remote_fetch(&mut self) -> Vec<Arc<CheckpointData>> {
+    fn receive_checkpoints(&mut self) -> Vec<Arc<CheckpointData>> {
         let mut checkpoints = vec![];
-        if self.remote_fetcher_receiver.is_none() {
-            self.remote_fetcher_receiver = Some(self.start_remote_fetcher());
-        }
         while !self.exceeds_capacity(self.current_checkpoint_number + checkpoints.len() as u64) {
-            match self.remote_fetcher_receiver.as_mut().unwrap().try_recv() {
-                Ok(Ok((checkpoint, size))) => {
+            match self.fetcher_receiver.try_recv() {
+                Ok((checkpoint, size)) => {
                     self.data_limiter.add(&checkpoint, size);
                     checkpoints.push(checkpoint);
                 }
-                Ok(Err(err)) => {
-                    error!("remote reader transient error {:?}", err);
-                    self.remote_fetcher_receiver = None;
-                    break;
-                }
                 Err(TryRecvError::Disconnected) => {
                     error!("remote reader channel disconnect error");
-                    self.remote_fetcher_receiver = None;
                     break;
                 }
                 Err(TryRecvError::Empty) => break,
@@ -247,41 +80,15 @@ impl CheckpointReader {
     }
 
     async fn sync(&mut self) -> Result<()> {
-        let backoff = backoff::ExponentialBackoff::default();
-        let mut checkpoints = backoff::future::retry(backoff, || async {
-            self.read_local_files().await.map_err(|err| {
-                info!("transient local read error {:?}", err);
-                backoff::Error::transient(err)
-            })
-        })
-        .await?;
-
-        let mut read_source: &str = "local";
-        if self.remote_store_url.is_some()
-            && (checkpoints.is_empty()
-                || checkpoints[0].checkpoint_summary.sequence_number
-                    > self.current_checkpoint_number)
-        {
-            checkpoints = self.remote_fetch();
-            read_source = "remote";
-        } else {
-            // cancel remote fetcher execution because local reader has made progress
-            self.remote_fetcher_receiver = None;
-        }
+        let checkpoints = self.receive_checkpoints();
 
         info!(
-            "Read from {}. Current checkpoint number: {}, pruning watermark: {}, new updates: {:?}",
-            read_source,
+            "Current checkpoint number: {}, pruning watermark: {}, new updates: {:?}",
             self.current_checkpoint_number,
             self.last_pruned_watermark,
             checkpoints.len(),
         );
         for checkpoint in checkpoints {
-            if read_source == "local"
-                && checkpoint.checkpoint_summary.sequence_number > self.current_checkpoint_number
-            {
-                break;
-            }
             assert_eq!(
                 checkpoint.checkpoint_summary.sequence_number,
                 self.current_checkpoint_number
@@ -316,7 +123,7 @@ impl CheckpointReader {
             .and_then(|s| s.parse().ok())
     }
 
-    pub fn initialize(
+    pub async fn initialize(
         path: PathBuf,
         starting_checkpoint_number: CheckpointSequenceNumber,
         remote_store_url: Option<String>,
@@ -331,15 +138,22 @@ impl CheckpointReader {
         let (checkpoint_sender, checkpoint_recv) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (processed_sender, processed_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (exit_sender, exit_receiver) = oneshot::channel();
-        let reader = Self {
-            path,
+        let checkpoint_fetcher = CheckpointFetcher::new(
+            path.clone(),
             remote_store_url,
             remote_store_options,
+            options.timeout_secs,
+        );
+        let fetcher_receiver = checkpoint_fetcher
+            .start_fetching_checkpoints(options.batch_size, starting_checkpoint_number)
+            .await;
+        let reader = Self {
+            path,
             current_checkpoint_number: starting_checkpoint_number,
             last_pruned_watermark: starting_checkpoint_number,
             checkpoint_sender,
             processed_receiver,
-            remote_fetcher_receiver: None,
+            fetcher_receiver,
             exit_receiver,
             data_limiter: DataLimiter::new(options.data_limit),
             options,
@@ -384,7 +198,7 @@ impl CheckpointReader {
                 Some(gc_checkpoint_number) = self.processed_receiver.recv() => {
                     self.gc_processed_files(gc_checkpoint_number).expect("Failed to clean the directory");
                 }
-                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(self.options.tick_interal_ms), inotify_recv.recv())  => {
+                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(self.options.tick_interval_ms), inotify_recv.recv())  => {
                     self.sync().await.expect("Failed to read checkpoint files");
                 }
             }

--- a/crates/sui-data-ingestion-core/src/tests.rs
+++ b/crates/sui-data-ingestion-core/src/tests.rs
@@ -40,7 +40,7 @@ async fn run(
     duration: Option<Duration>,
 ) -> Result<ExecutorProgress> {
     let options = ReaderOptions {
-        tick_interal_ms: 10,
+        tick_interval_ms: 10,
         batch_size: 1,
         ..Default::default()
     };


### PR DESCRIPTION
## Description 

This PR does two things primarily:
It splits all the logic that fetches checkpoints from different sources into a subdir and put each fetching logic in its own file/struct, sharing the same trait. This allows us to clearly see how each fetcher logic works.

It simplifies the fetching process. Previously, after the reader wakes up, it first loads checkpoints from the file system, then check whether it contains the next checkpoint. If not, it then creates a remote fetcher (if not yet created) and start fetch checkpoints continuously until a limit is reached or no more checkpoint is received; it there are checkpoints from the file system, it then shut down the remote fetcher and use the checkpoints from the files. This process repeats.
This PR simplifies it by having a fetcher running continuously without ever stopping, but for each checkpoint, it first checks the local file before using the remote fetcher, and the fetching of each checkpoint is retried indefinitely to ensure liveness. This makes the fetching logic cleaner and easier to reason about.
Most of the above logic is in checkpoint_fetcher/mod.rs, so please review that file in depth.

Let me know if this is in the right direction of changes or if it makes things worse.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
