### PR TITLE
move: load package version when using external resolver in dependency graph

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1458,11 +1458,16 @@ impl DependencyGraph {
                         format!("Parsing response from '{resolver}' for dependency '{to_name}' of package '{from_id}'")
                     })?;
 
-                    let root_edges = sub_graph.package_graph.edges(from_id).collect::<Vec<_>>();
-                    if root_edges.len() != 1 {
-                        bail!("Expected a single root dependency but none or multiple found");
-                    }
-                    let root_sub_package_id = root_edges[0].1;
+                    let root_sub_package_id = match sub_graph
+                        .package_graph
+                        .edges(from_id)
+                        .collect::<Vec<_>>()
+                        .as_slice()
+                    {
+                        [(_, id, _)] => *id,
+                        // TODO: We can in fact allow allow multiple root packages / graphs and relax this constraint.
+                        _ => bail!("Expected a single root dependency but none or multiple found"),
+                    };
                     let root_sub_package_version = sub_graph
                         .package_table
                         .get(&root_sub_package_id)

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -510,8 +510,14 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
 
                 Ok(external_deps
                     .into_iter()
-                    .map(|(pkg_graph, _, resolved_pkg_name)| {
-                        (pkg_graph, false, true, resolved_pkg_name, None)
+                    .map(|(pkg_graph, _, resolved_pkg_id, resolved_pkg_version)| {
+                        (
+                            pkg_graph,
+                            false,
+                            true,
+                            resolved_pkg_id,
+                            resolved_pkg_version,
+                        )
                     })
                     .collect())
             }
@@ -1375,7 +1381,14 @@ impl DependencyGraph {
         resolver: Symbol,
         package_path: &Path,
         progress_output: &mut Progress,
-    ) -> Result<Vec<(DependencyGraph, PM::Dependency, PM::PackageName)>> {
+    ) -> Result<
+        Vec<(
+            DependencyGraph,
+            PM::Dependency,
+            PM::PackageName,
+            Option<Symbol>, // version
+        )>,
+    > {
         let mode_label = if mode == DependencyMode::DevOnly {
             "dev-dependencies"
         } else {
@@ -1445,22 +1458,24 @@ impl DependencyGraph {
                         format!("Parsing response from '{resolver}' for dependency '{to_name}' of package '{from_id}'")
                     })?;
 
-                    let mut root_sub_package = None;
-                    for (_from_package, to_pkg, _) in sub_graph.package_graph.edges(from_id) {
-                        if root_sub_package.is_some() {
-                            // TODO: We can in fact allow allow multiple root packages / graphs and relax this constraint.
-                            bail!("Multiple root packages in external dependencies found but expected only one");
-                        }
-                        root_sub_package = Some(to_pkg);
+                    let root_edges = sub_graph.package_graph.edges(from_id).collect::<Vec<_>>();
+                    if root_edges.len() != 1 {
+                        bail!("Expected a single root dependency but none or multiple found");
                     }
-                    let Some(root_sub_package) = root_sub_package else {
-                        bail!(
-                            "Expected a root package in external dependencies group but none found"
-                        );
-                    };
+                    let root_sub_package_id = root_edges[0].1;
+                    let root_sub_package_version = sub_graph
+                        .package_table
+                        .get(&root_sub_package_id)
+                        .unwrap()
+                        .version;
 
-                    let new_dep = PM::Dependency::External(root_sub_package);
-                    result.push((sub_graph, new_dep, root_sub_package));
+                    let new_dep = PM::Dependency::External(root_sub_package_id);
+                    result.push((
+                        sub_graph,
+                        new_dep,
+                        root_sub_package_id,
+                        root_sub_package_version,
+                    ));
                     buffer.clear();
                 }
                 Err(e) => return Err(e.into()),

--- a/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move.locked
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move.locked
@@ -12,6 +12,7 @@ dependencies = [
 [[move.package]]
 id = "bar"
 source = { local = "deps_only/bar" }
+version = "5"
 
 [[move.package]]
 id = "foo"

--- a/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move.resolved
@@ -32,7 +32,9 @@ ResolvedGraph {
                 kind: Local(
                     "deps_only/bar",
                 ),
-                version: None,
+                version: Some(
+                    "5",
+                ),
                 resolver: Some(
                     "../resolvers/successful_package_batch_response.sh",
                 ),

--- a/external-crates/move/crates/move-package/tests/test_sources/resolvers/successful_package_batch_response.sh
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolvers/successful_package_batch_response.sh
@@ -40,9 +40,10 @@ dependencies = [
 
 [[move.package]]
 id = "bar"
+version = "5"
 source = { local = "./deps_only/bar" }
 EOF
 )
 
 # Echo the two separate graph contents twice with a null separator in between
-echo "$foo\0$bar"
+printf "$foo\0$bar"


### PR DESCRIPTION
## Description 

Small fix to correctly load dependency version when using external resolver. Changed `echo` in `successful_package_batch_response.sh` to `printf` for more consistent handling of `\0` across systems (it fails on my machine).

This is part of the work to enable compiling against on-chain dependencies https://github.com/MystenLabs/sui/pull/14178.

cc @rvantonder @amnn

## Test plan 

Updated the unit test to have a dependency with `version` field.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
