### PR TITLE
[move-ide] Improvements to on hover for structs and enums

### DIFF
--- a/external-crates/move/crates/move-analyzer/tests/enums.exp
+++ b/external-crates/move/crates/move-analyzer/tests/enums.exp
@@ -391,15 +391,22 @@ public enum Enums::variant_match::SomeEnum has drop {
 }
 
 -- test 11 -------------------
-use line: 15, use_ndx: 3
-Use: 's', start: 45, end: 46
-Def: 'SomeStruct', line: 7, def char: 30
-TypeDef: 'SomeStruct', line: 2, char: 18
+use line: 15, use_ndx: 2
+Use: 'PositionalFields', start: 24, end: 40
+Def: 'PositionalFields', line: 7, def char: 8
+TypeDef: no info
 On Hover:
-Enums::variant_match::SomeEnum
-1: Enums::variant_match::SomeStruct
+Enums::variant_match::SomeEnum::PositionalFields(u64, Enums::variant_match::SomeStruct)
 
 -- test 12 -------------------
+use line: 15, use_ndx: 3
+Use: 's', start: 45, end: 46
+Def: 's', line: 12, def char: 29
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+s: Enums::variant_match::SomeStruct
+
+-- test 13 -------------------
 use line: 19, use_ndx: 0
 Use: 'e', start: 20, end: 21
 Def: 'e', line: 14, def char: 16
@@ -407,7 +414,7 @@ TypeDef: 'SomeEnum', line: 6, char: 16
 On Hover:
 let mut e: Enums::variant_match::SomeEnum
 
--- test 13 -------------------
+-- test 14 -------------------
 use line: 20, use_ndx: 0
 Use: 'SomeEnum', start: 12, end: 20
 Def: 'SomeEnum', line: 6, def char: 16
@@ -419,7 +426,7 @@ public enum Enums::variant_match::SomeEnum has drop {
 	PositionalFields( /* ... */ )
 }
 
--- test 14 -------------------
+-- test 15 -------------------
 use line: 20, use_ndx: 1
 Use: 'PositionalFields', start: 22, end: 38
 Def: 'PositionalFields', line: 7, def char: 8
@@ -427,7 +434,7 @@ TypeDef: no info
 On Hover:
 Enums::variant_match::SomeEnum::PositionalFields(u64, Enums::variant_match::SomeStruct)
 
--- test 15 -------------------
+-- test 16 -------------------
 use line: 20, use_ndx: 2
 Use: 'num', start: 39, end: 42
 Def: 'u64', line: 7, def char: 25
@@ -436,7 +443,7 @@ On Hover:
 Enums::variant_match::SomeEnum
 0: u64
 
--- test 16 -------------------
+-- test 17 -------------------
 use line: 20, use_ndx: 3
 Use: 's', start: 44, end: 45
 Def: 'SomeStruct', line: 7, def char: 30
@@ -445,7 +452,7 @@ On Hover:
 Enums::variant_match::SomeEnum
 1: Enums::variant_match::SomeStruct
 
--- test 17 -------------------
+-- test 18 -------------------
 use line: 21, use_ndx: 0
 Use: 'num', start: 17, end: 20
 Def: 'num', line: 19, def char: 39
@@ -453,7 +460,7 @@ TypeDef: no info
 On Hover:
 num: &mut u64
 
--- test 18 -------------------
+-- test 19 -------------------
 use line: 21, use_ndx: 1
 Use: 's', start: 23, end: 24
 Def: 's', line: 19, def char: 44
@@ -461,7 +468,7 @@ TypeDef: 'SomeStruct', line: 2, char: 18
 On Hover:
 s: &mut Enums::variant_match::SomeStruct
 
--- test 19 -------------------
+-- test 20 -------------------
 use line: 21, use_ndx: 2
 Use: 'some_field', start: 25, end: 35
 Def: 'some_field', line: 3, def char: 8
@@ -470,7 +477,7 @@ On Hover:
 Enums::variant_match::SomeStruct
 some_field: u64
 
--- test 20 -------------------
+-- test 21 -------------------
 use line: 24, use_ndx: 0
 Use: 'SE', start: 12, end: 14
 Def: 'SomeEnum', line: 6, def char: 16
@@ -482,7 +489,7 @@ public enum Enums::variant_match::SomeEnum has drop {
 	PositionalFields( /* ... */ )
 }
 
--- test 21 -------------------
+-- test 22 -------------------
 use line: 24, use_ndx: 1
 Use: 'NamedFields', start: 16, end: 27
 Def: 'NamedFields', line: 8, def char: 8
@@ -490,7 +497,7 @@ TypeDef: no info
 On Hover:
 Enums::variant_match::SomeEnum::NamedFields{num1: u64, num2: u64, s: Enums::variant_match::SomeStruct}
 
--- test 22 -------------------
+-- test 23 -------------------
 use line: 24, use_ndx: 2
 Use: 'num1', start: 30, end: 34
 Def: 'num1', line: 8, def char: 21
@@ -499,7 +506,7 @@ On Hover:
 Enums::variant_match::SomeEnum
 num1: u64
 
--- test 23 -------------------
+-- test 24 -------------------
 use line: 24, use_ndx: 3
 Use: 'num2', start: 36, end: 40
 Def: 'num2', line: 8, def char: 32
@@ -508,7 +515,7 @@ On Hover:
 Enums::variant_match::SomeEnum
 num2: u64
 
--- test 24 -------------------
+-- test 25 -------------------
 use line: 24, use_ndx: 4
 Use: 's', start: 46, end: 47
 Def: 's', line: 8, def char: 43
@@ -517,7 +524,7 @@ On Hover:
 Enums::variant_match::SomeEnum
 s: Enums::variant_match::SomeStruct
 
--- test 25 -------------------
+-- test 26 -------------------
 use line: 24, use_ndx: 5
 Use: 'num1', start: 55, end: 59
 Def: 'num1', line: 23, def char: 30
@@ -525,7 +532,7 @@ TypeDef: no info
 On Hover:
 num1: &u64
 
--- test 26 -------------------
+-- test 27 -------------------
 use line: 24, use_ndx: 6
 Use: 's', start: 62, end: 63
 Def: 's', line: 23, def char: 46
@@ -533,7 +540,7 @@ TypeDef: 'SomeStruct', line: 2, char: 18
 On Hover:
 s: &Enums::variant_match::SomeStruct
 
--- test 27 -------------------
+-- test 28 -------------------
 use line: 24, use_ndx: 8
 Use: 'num1', start: 79, end: 83
 Def: 'num1', line: 23, def char: 30
@@ -541,7 +548,7 @@ TypeDef: no info
 On Hover:
 num1: &u64
 
--- test 28 -------------------
+-- test 29 -------------------
 use line: 24, use_ndx: 9
 Use: 'local', start: 86, end: 91
 Def: 'local', line: 16, def char: 12
@@ -549,7 +556,7 @@ TypeDef: no info
 On Hover:
 let local: u64
 
--- test 29 -------------------
+-- test 30 -------------------
 use line: 25, use_ndx: 0
 Use: 's', start: 16, end: 17
 Def: 's', line: 23, def char: 46
@@ -557,7 +564,7 @@ TypeDef: 'SomeStruct', line: 2, char: 18
 On Hover:
 s: &mut Enums::variant_match::SomeStruct
 
--- test 30 -------------------
+-- test 31 -------------------
 use line: 25, use_ndx: 2
 Use: 'num1', start: 32, end: 36
 Def: 'num1', line: 23, def char: 30
@@ -565,7 +572,7 @@ TypeDef: no info
 On Hover:
 num1: &mut u64
 
--- test 31 -------------------
+-- test 32 -------------------
 use line: 25, use_ndx: 3
 Use: 'num2', start: 40, end: 44
 Def: 'num2', line: 23, def char: 36

--- a/external-crates/move/crates/move-analyzer/tests/enums.ide
+++ b/external-crates/move/crates/move-analyzer/tests/enums.ide
@@ -51,6 +51,10 @@
         },
         {
           "use_line": 15,
+          "use_ndx": 2
+        },
+        {
+          "use_line": 15,
           "use_ndx": 3
         },
         {

--- a/external-crates/move/crates/move-analyzer/tests/move-2024/sources/structs.move
+++ b/external-crates/move/crates/move-analyzer/tests/move-2024/sources/structs.move
@@ -8,4 +8,41 @@ module Move2024::structs {
         (positional.0, positional.1)
     }
 
+    public struct Named has drop, copy {
+        some_field: u64,
+        another_field: SomeStruct,
+    }
+
+    public fun pack_named(val1: u64, another_field: SomeStruct): Named {
+        Named {
+            some_field: val1,
+            another_field,
+        }
+    }
+
+    public fun pack_positional(val1: u64, val2: SomeStruct): Positional {
+        Positional(val1, val2)
+    }
+
+    public fun unpack_named(named: Named): (u64, SomeStruct) {
+        let Named {
+            some_field: val1,
+            another_field,
+        } = named;
+        (val1, another_field)
+    }
+
+    public fun unpack_positional(positional: Positional): (u64, SomeStruct) {
+        let Positional(val1, val2) = positional;
+        (val1, val2)
+    }
+
+    public fun borrow_named(named: Named): u64 {
+        named.some_field
+    }
+
+    public fun borrow_positional(positional: Positional): u64 {
+        positional.0
+    }
+
 }

--- a/external-crates/move/crates/move-analyzer/tests/structs.exp
+++ b/external-crates/move/crates/move-analyzer/tests/structs.exp
@@ -63,3 +63,125 @@ On Hover:
 Move2024::structs::Positional
 1: Move2024::structs::SomeStruct
 
+-- test 7 -------------------
+use line: 12, use_ndx: 0
+Use: 'some_field', start: 8, end: 18
+Def: 'some_field', line: 11, def char: 8
+TypeDef: no info
+On Hover:
+Move2024::structs::Named
+some_field: u64
+
+-- test 8 -------------------
+use line: 13, use_ndx: 0
+Use: 'another_field', start: 8, end: 21
+Def: 'another_field', line: 12, def char: 8
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Move2024::structs::Named
+another_field: Move2024::structs::SomeStruct
+
+-- test 9 -------------------
+use line: 18, use_ndx: 0
+Use: 'some_field', start: 12, end: 22
+Def: 'some_field', line: 11, def char: 8
+TypeDef: no info
+On Hover:
+Move2024::structs::Named
+some_field: u64
+
+-- test 10 -------------------
+use line: 18, use_ndx: 1
+Use: 'val1', start: 24, end: 28
+Def: 'val1', line: 15, def char: 26
+TypeDef: no info
+On Hover:
+val1: u64
+
+-- test 11 -------------------
+use line: 19, use_ndx: 0
+Use: 'another_field', start: 12, end: 25
+Def: 'another_field', line: 12, def char: 8
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Move2024::structs::Named
+another_field: Move2024::structs::SomeStruct
+
+-- test 12 -------------------
+use line: 24, use_ndx: 1
+Use: 'val1', start: 19, end: 23
+Def: 'val1', line: 22, def char: 31
+TypeDef: no info
+On Hover:
+val1: u64
+
+-- test 13 -------------------
+use line: 24, use_ndx: 2
+Use: 'val2', start: 25, end: 29
+Def: 'val2', line: 22, def char: 42
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+val2: Move2024::structs::SomeStruct
+
+-- test 14 -------------------
+use line: 29, use_ndx: 0
+Use: 'some_field', start: 12, end: 22
+Def: 'some_field', line: 11, def char: 8
+TypeDef: no info
+On Hover:
+Move2024::structs::Named
+some_field: u64
+
+-- test 15 -------------------
+use line: 29, use_ndx: 1
+Use: 'val1', start: 24, end: 28
+Def: 'val1', line: 28, def char: 24
+TypeDef: no info
+On Hover:
+val1: u64
+
+-- test 16 -------------------
+use line: 30, use_ndx: 0
+Use: 'another_field', start: 12, end: 25
+Def: 'another_field', line: 12, def char: 8
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Move2024::structs::Named
+another_field: Move2024::structs::SomeStruct
+
+-- test 17 -------------------
+use line: 36, use_ndx: 1
+Use: 'v', start: 23, end: 24
+Def: 'u64', line: 4, def char: 29
+TypeDef: no info
+On Hover:
+Move2024::structs::Positional
+0: u64
+
+-- test 18 -------------------
+use line: 36, use_ndx: 2
+Use: 'v', start: 29, end: 30
+Def: 'SomeStruct', line: 4, def char: 34
+TypeDef: 'SomeStruct', line: 2, char: 18
+On Hover:
+Move2024::structs::Positional
+1: Move2024::structs::SomeStruct
+
+-- test 19 -------------------
+use line: 41, use_ndx: 1
+Use: 'INVALID USE IDENT', start: 14, end: 24
+Def: 'some_field', line: 11, def char: 8
+TypeDef: no info
+On Hover:
+Move2024::structs::Named
+some_field: u64
+
+-- test 20 -------------------
+use line: 45, use_ndx: 1
+Use: 'INVALID USE IDENT', start: 19, end: 20
+Def: 'u64', line: 4, def char: 29
+TypeDef: no info
+On Hover:
+Move2024::structs::Positional
+0: u64
+

--- a/external-crates/move/crates/move-analyzer/tests/structs.ide
+++ b/external-crates/move/crates/move-analyzer/tests/structs.ide
@@ -32,6 +32,62 @@
         {
           "use_line": 8,
           "use_ndx": 3
+        },
+        {
+          "use_line": 12,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 13,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 18,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 18,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 19,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 24,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 24,
+          "use_ndx": 2
+        },
+        {
+          "use_line": 29,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 29,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 30,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 36,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 36,
+          "use_ndx": 2
+        },
+        {
+          "use_line": 41,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 45,
+          "use_ndx": 1
         }
       ]
     }


### PR DESCRIPTION
## Description 

This PR improves on certain aspects of on hover for structs and enums. Mainly, it shows more meaningful information for struct/variant field values when packing structs/variants. Before, it would show information about the field itself, which was not very useful when inspecting the pack operation:

![image](https://github.com/user-attachments/assets/77753a0b-c0de-4230-9ce5-1e9d95192f49)

In the case above, it makes a lot more sense to show information about constant `TMP` which is what is implemented in this PR:

![image](https://github.com/user-attachments/assets/e7c2563d-7dae-4001-9529-4a568067c69b)

This PR also includes a fix to displaying on-hover information for variants when inspecting the pack operation

## Test plan 

Old and newly added tests must pass
