### PR TITLE
[RFC] experimenting with dynamic coin types

### DIFF
--- a/crates/sui-framework/packages/sui-framework/Move.lock
+++ b/crates/sui-framework/packages/sui-framework/Move.lock
@@ -14,6 +14,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.30.0"
+compiler-version = "1.33.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/crates/sui-framework/packages/sui-framework/sources/balances.move
+++ b/crates/sui-framework/packages/sui-framework/sources/balances.move
@@ -1,0 +1,79 @@
+module sui::balances;
+
+use std::type_name::{Self, TypeName};
+
+use sui::balance::Balance;
+use sui::dynamic_field;
+use sui::coin::Coin;
+use sui::vec_set::{Self, VecSet};
+
+#[error]
+const EInvalidDestroy: vector<u8> = b"Cannot destroy non-empty Balances";
+#[error]
+const EBalanceTypeNotFound: vector<u8> = b"This Balances object does not have a balance of the given type";
+#[error]
+const EInsufficientBalance: vector<u8> = b"This Balances object does not have a sufficient balance in the given type";
+
+/// Heterogenous collection of `Balance`s stored via dynamic fields.
+/// Supports splitting, joining, and other iteration operations that would not be possible in pure Move.
+public struct Balances has key, store {
+    id: UID,
+    // TODO: need sorted collection here
+    types: VecSet<TypeName>,
+}
+
+public struct Amount has copy, drop {
+    typ: TypeName,
+    amount: u64
+}
+
+public fun new(ctx: &mut TxContext): Balances {
+    Balances { id: object::new(ctx), types: vec_set::empty() }
+}
+
+/// Merge the balances in `other` into `bals`
+public fun join(bals: &mut Balances, other: Balances) {
+    let Balances { id, types } = other;
+    types.into_keys().do!(|t| bals.types.insert(t));
+    id.delete()
+}
+
+/// Join Balance dynamic fields of `from` into `to`
+native fun join_balances(to: UID, from: &mut UID);
+
+/// Create a new `Balances` object by splitting out the amount specified in `amounts
+public fun split(bals: &mut Balances, amounts: vector<Amount>): Balances {
+    let types = &bals.types;
+    amounts.do_ref!(|amount| assert!(types.contains(&amount.typ), EBalanceTypeNotFound));
+    split_balances(&mut bals.id, amounts)
+}
+
+native fun split_balances(bals: &mut UID, amounts: vector<Amount>): Balances;
+
+public fun insert_coin<T>(bals: &mut Balances, c: Coin<T>) {
+    bals.insert_balance(c.into_balance())
+}
+
+public fun insert_balance<T>(bals: &mut Balances, b: Balance<T>) {
+    let t = type_name::get<T>();
+    // TODO: use insertion sort here
+    bals.types.insert(t);
+    dynamic_field::add(&mut bals.id, t, b)
+}
+
+public fun split_balance<T>(bals: &mut Balances, amount: u64): Balance<T> {
+    let t = type_name::get<T>();
+    assert!(dynamic_field::exists_(&bals.id, t), EBalanceTypeNotFound);
+    let mut bal = dynamic_field::borrow_mut<TypeName, Balance<T>>(&mut bals.id, t);
+    assert!(bal.value() >= amount, EInsufficientBalance);
+    bal.split(amount)
+}
+
+// TODO: could provide native function that tolerated non-emptiness if balances are all zero
+/// Destroy an empty collection of Balances
+public fun destroy_empty(bals: Balances) {
+    let Balances { id, types } = bals;
+    assert!(types.is_empty(), EInvalidDestroy);
+    id.delete()
+}
+

--- a/crates/sui-framework/packages/sui-framework/sources/dcoin.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dcoin.move
@@ -1,0 +1,46 @@
+module sui::dcoin;
+
+use std::type_name::{Self, TypeName};
+
+use sui::dynamic_field;
+use sui::balance::Balance;
+
+/// A balance whose type is carried in a field rather than a phantom type parameter
+public struct DCoin has key, store {
+    id: UID,
+    // TODO: could also issue unique int at registration time and use that instead
+    typ: TypeName,
+    value: u64
+    // TODO: decimals also?
+}
+
+public struct Registry has key {
+    id: UID,
+    // carries dynamic fields mapping TypeName -> Balance<TypeName>
+    // note: might want a single global Registry, but separate exchange pool for each coin type to avoid contention
+
+}
+
+fun init(ctx: &mut TxContext) {
+    transfer::share_object(Registry { id: object::new(ctx)} )
+}
+
+public fun new<T>(registry: &mut Registry, b: Balance<T>, ctx: &mut TxContext): DCoin {
+    let typ = type_name::get<T>();
+    let value = b.value();
+    if (!dynamic_field::exists_(&registry.id, typ)) {
+        dynamic_field::add(&mut registry.id, typ, b)
+    } else {
+        dynamic_field::borrow_mut<TypeName, Balance<T>>(&mut registry.id, typ).join(b);
+    };
+    DCoin { id: object::new(ctx), typ, value }
+}
+
+public fun delete<T>(registry: &mut Registry, c: DCoin): Balance<T> {
+    let DCoin { id, typ, value } = c;
+    id.delete();
+    dynamic_field::borrow_mut<TypeName, Balance<T>>(&mut registry.id, typ).split(value)
+}
+
+// ... split, join, other coin ops on DCoin, similar DBalance type
+


### PR DESCRIPTION
Playing with two different ideas for more dynamic coin types (and soliciting ideas for others)--feedback welcome!

- Goal: Trying to solve specific problems for DeFi builders that need to work with heterogenous collections of coins and find the strong types of `Coin` painful
- Non-goal: introduce a new coin standard understood by the wallet/explorer, or that is broadly used outside of the (I think relatively narrow) needs of these DeFi builders. A new coin standard could happen in the long term and would likely be dynamic, but would likely want a lot more features that aren't ready yet (coin metadata v2, private balances, traits or similar to allow custom data inside coins, restricted transfers, dynamic loading of per epoch-immutable or immutable objects like coin metadata, possible consolidation with closed loop tokens, ...)
- Two approaches: `Coins` container w/ magic native functions, for `split`, `join`, etc. designated DCoin type + conversion functions from strongly typed coins. I think the second one is more appealing/more flexible, and can already be implemented with no Sui Framework changes. However, a framework version of `DCoin` would surely help with interoperability/evolution toward wallet and explorer support if that make sense