### PR TITLE
[bridge] add sui watch dog and a few observables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12923,6 +12923,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "strum_macros 0.24.3",
  "sui-bridge",
+ "sui-bridge-watchdog",
  "sui-config",
  "sui-data-ingestion-core",
  "sui-indexer-builder",
@@ -12934,6 +12935,21 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "test-cluster",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sui-bridge-watchdog"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "ethers",
+ "futures",
+ "mysten-metrics",
+ "prometheus",
+ "sui-bridge",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
     "crates/sui-bridge",
     "crates/sui-bridge-cli",
     "crates/sui-bridge-indexer",
+    "crates/sui-bridge-watchdog",
     "crates/sui-cluster-test",
     "crates/sui-config",
     "crates/sui-core",
@@ -617,6 +618,7 @@ sui-archival = { path = "crates/sui-archival" }
 sui-authority-aggregation = { path = "crates/sui-authority-aggregation" }
 sui-benchmark = { path = "crates/sui-benchmark" }
 sui-bridge = { path = "crates/sui-bridge" }
+sui-bridge-watchdog = { path = "crates/sui-bridge-watchdog" }
 sui-cluster-test = { path = "crates/sui-cluster-test" }
 sui-config = { path = "crates/sui-config" }
 sui-core = { path = "crates/sui-core" }

--- a/crates/sui-bridge-indexer/Cargo.toml
+++ b/crates/sui-bridge-indexer/Cargo.toml
@@ -36,6 +36,7 @@ backoff.workspace = true
 sui-config.workspace = true
 tempfile.workspace = true
 sui-indexer-builder.workspace = true
+sui-bridge-watchdog.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-bridge-watchdog/Cargo.toml
+++ b/crates/sui-bridge-watchdog/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sui-bridge-watchdog"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+sui-bridge.workspace = true
+mysten-metrics.workspace = true
+prometheus.workspace = true
+anyhow.workspace = true
+futures.workspace = true
+async-trait.workspace = true
+ethers = { version = "2.0" }
+tracing.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-bridge-watchdog/src/eth_bridge_status.rs
+++ b/crates/sui-bridge-watchdog/src/eth_bridge_status.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The EthBridgeStatus observable monitors whether the Eth Bridge is paused.
+
+use crate::Observable;
+use async_trait::async_trait;
+use ethers::providers::Provider;
+use ethers::types::Address as EthAddress;
+use prometheus::IntGauge;
+use std::sync::Arc;
+use sui_bridge::abi::EthSuiBridge;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
+use tokio::time::Duration;
+use tracing::{error, info};
+
+pub struct EthBridgeStatus {
+    bridge_contract: EthSuiBridge<Provider<MeteredEthHttpProvier>>,
+    metric: IntGauge,
+}
+
+impl EthBridgeStatus {
+    pub fn new(
+        provider: Arc<Provider<MeteredEthHttpProvier>>,
+        bridge_address: EthAddress,
+        metric: IntGauge,
+    ) -> Self {
+        let bridge_contract = EthSuiBridge::new(bridge_address, provider.clone());
+        Self {
+            bridge_contract,
+            metric,
+        }
+    }
+}
+
+#[async_trait]
+impl Observable for EthBridgeStatus {
+    fn name(&self) -> &str {
+        "EthBridgeStatus"
+    }
+
+    async fn observe_and_report(&self) {
+        let status = self.bridge_contract.paused().call().await;
+        match status {
+            Ok(status) => {
+                self.metric.set(status as i64);
+                info!("Eth Bridge Status: {:?}", status);
+            }
+            Err(e) => {
+                error!("Error getting eth bridge status: {:?}", e);
+            }
+        }
+    }
+
+    fn interval(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}

--- a/crates/sui-bridge-watchdog/src/eth_vault_balance.rs
+++ b/crates/sui-bridge-watchdog/src/eth_vault_balance.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Observable;
+use async_trait::async_trait;
+use ethers::providers::Provider;
+use ethers::types::{Address as EthAddress, U256};
+use prometheus::IntGauge;
+use std::sync::Arc;
+use sui_bridge::abi::EthERC20;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
+use tokio::time::Duration;
+use tracing::{error, info};
+
+pub struct EthVaultBalance {
+    coin_contract: EthERC20<Provider<MeteredEthHttpProvier>>,
+    vault_address: EthAddress,
+    ten_zeros: U256,
+    metric: IntGauge,
+}
+
+impl EthVaultBalance {
+    pub fn new(
+        provider: Arc<Provider<MeteredEthHttpProvier>>,
+        vault_address: EthAddress,
+        coin_address: EthAddress, // for now this only support one coin which is WETH
+        metric: IntGauge,
+    ) -> Self {
+        let ten_zeros = U256::from(10_u64.pow(10));
+        let coin_contract = EthERC20::new(coin_address, provider);
+        Self {
+            coin_contract,
+            vault_address,
+            ten_zeros,
+            metric,
+        }
+    }
+}
+
+#[async_trait]
+impl Observable for EthVaultBalance {
+    fn name(&self) -> &str {
+        "EthVaultBalance"
+    }
+
+    async fn observe_and_report(&self) {
+        match self
+            .coin_contract
+            .balance_of(self.vault_address)
+            .call()
+            .await
+        {
+            Ok(balance) => {
+                // Why downcasting is safe:
+                // 1. On Ethereum we only take the first 8 decimals into account,
+                // meaning the trailing 10 digits can be ignored
+                // 2. i64::MAX is 9_223_372_036_854_775_807, with 8 decimal places is
+                // 92_233_720_368. We likely won't see any balance higher than this
+                // in the next 12 months.
+                let balance = (balance / self.ten_zeros).as_u64() as i64;
+                self.metric.set(balance);
+                info!("Eth Vault Balance: {:?}", balance);
+            }
+            Err(e) => {
+                error!("Error getting balance from vault: {:?}", e);
+            }
+        }
+    }
+
+    fn interval(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+}

--- a/crates/sui-bridge-watchdog/src/lib.rs
+++ b/crates/sui-bridge-watchdog/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The BridgeWatchDog module is responsible for monitoring the health
+//! of the bridge by periodically running various observables and
+//! reporting the results.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use mysten_metrics::spawn_logged_monitored_task;
+use std::sync::Arc;
+use tokio::time::Duration;
+use tokio::time::MissedTickBehavior;
+use tracing::{error_span, info, Instrument};
+
+pub mod eth_bridge_status;
+pub mod eth_vault_balance;
+pub mod metrics;
+pub mod sui_bridge_status;
+
+pub struct BridgeWatchDog {
+    observables: Vec<Arc<dyn Observable + Send + Sync>>,
+}
+
+impl BridgeWatchDog {
+    pub fn new(observables: Vec<Arc<dyn Observable + Send + Sync>>) -> Self {
+        Self { observables }
+    }
+
+    pub async fn run(self) {
+        let mut handles = vec![];
+        for observable in self.observables.into_iter() {
+            let handle = spawn_logged_monitored_task!(Self::run_observable(observable));
+            handles.push(handle);
+        }
+        // Return when any task returns an error or all tasks exit.
+        futures::future::try_join_all(handles).await.unwrap();
+        unreachable!("watch dog tasks should not exit");
+    }
+
+    async fn run_observable(observable: Arc<dyn Observable + Send + Sync>) -> Result<()> {
+        let mut interval = tokio::time::interval(observable.interval());
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let name = observable.name();
+        let span = error_span!("observable", name);
+        loop {
+            info!("Running observable {}", name);
+            observable
+                .observe_and_report()
+                .instrument(span.clone())
+                .await;
+            interval.tick().await;
+        }
+    }
+}
+
+#[async_trait]
+pub trait Observable {
+    fn name(&self) -> &str;
+    async fn observe_and_report(&self);
+    fn interval(&self) -> Duration;
+}

--- a/crates/sui-bridge-watchdog/src/metrics.rs
+++ b/crates/sui-bridge-watchdog/src/metrics.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
+
+#[derive(Clone, Debug)]
+pub struct WatchdogMetrics {
+    pub eth_vault_balance: IntGauge,
+    pub eth_bridge_paused: IntGauge,
+    pub sui_bridge_paused: IntGauge,
+}
+
+impl WatchdogMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            eth_vault_balance: register_int_gauge_with_registry!(
+                "bridge_eth_vault_balance",
+                "Current balance of eth vault",
+                registry,
+            )
+            .unwrap(),
+            eth_bridge_paused: register_int_gauge_with_registry!(
+                "bridge_eth_bridge_paused",
+                "Whether the eth bridge is paused",
+                registry,
+            )
+            .unwrap(),
+            sui_bridge_paused: register_int_gauge_with_registry!(
+                "bridge_sui_bridge_paused",
+                "Whether the sui bridge is paused",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+
+    pub fn new_for_testing() -> Self {
+        let registry = Registry::new();
+        Self::new(&registry)
+    }
+}

--- a/crates/sui-bridge-watchdog/src/sui_bridge_status.rs
+++ b/crates/sui-bridge-watchdog/src/sui_bridge_status.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The SuiBridgeStatus observable monitors whether the Sui Bridge is paused.
+
+use crate::Observable;
+use async_trait::async_trait;
+use prometheus::IntGauge;
+use std::sync::Arc;
+use sui_bridge::sui_client::SuiBridgeClient;
+
+use tokio::time::Duration;
+use tracing::{error, info};
+
+pub struct SuiBridgeStatus {
+    sui_client: Arc<SuiBridgeClient>,
+    metric: IntGauge,
+}
+
+impl SuiBridgeStatus {
+    pub fn new(sui_client: Arc<SuiBridgeClient>, metric: IntGauge) -> Self {
+        Self { sui_client, metric }
+    }
+}
+
+#[async_trait]
+impl Observable for SuiBridgeStatus {
+    fn name(&self) -> &str {
+        "SuiBridgeStatus"
+    }
+
+    async fn observe_and_report(&self) {
+        let status = self.sui_client.is_bridge_paused().await;
+        match status {
+            Ok(status) => {
+                self.metric.set(status as i64);
+                info!("Sui Bridge Status: {:?}", status);
+            }
+            Err(e) => {
+                error!("Error getting sui bridge status: {:?}", e);
+            }
+        }
+    }
+
+    fn interval(&self) -> Duration {
+        Duration::from_secs(2)
+    }
+}

--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -249,7 +249,7 @@ impl BridgeNodeConfig {
                 .interval(std::time::Duration::from_millis(2000)),
         );
         let chain_id = provider.get_chainid().await?;
-        let (committee_address, limiter_address, vault_address, config_address) =
+        let (committee_address, limiter_address, vault_address, config_address, _weth_address) =
             get_eth_contract_addresses(bridge_proxy_address, &provider).await?;
         let config = EthBridgeConfig::new(config_address, provider.clone());
 

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -103,11 +103,13 @@ pub fn generate_bridge_client_key_and_write_to_file(
 pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 'static>(
     bridge_proxy_address: EthAddress,
     provider: &Arc<Provider<P>>,
-) -> anyhow::Result<(EthAddress, EthAddress, EthAddress, EthAddress)> {
+) -> anyhow::Result<(EthAddress, EthAddress, EthAddress, EthAddress, EthAddress)> {
     let sui_bridge = EthSuiBridge::new(bridge_proxy_address, provider.clone());
     let committee_address: EthAddress = sui_bridge.committee().call().await?;
     let limiter_address: EthAddress = sui_bridge.limiter().call().await?;
     let vault_address: EthAddress = sui_bridge.vault().call().await?;
+    let vault = EthBridgeVault::new(vault_address, provider.clone());
+    let weth_address: EthAddress = vault.w_eth().call().await?;
     let committee = EthBridgeCommittee::new(committee_address, provider.clone());
     let config_address: EthAddress = committee.config().call().await?;
 
@@ -116,6 +118,7 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
         limiter_address,
         vault_address,
         config_address,
+        weth_address,
     ))
 }
 


### PR DESCRIPTION
## Description 

This PR adds
1. `Observable` traits that each perform an observation task to monitor bridge status.
1. `SuiWatchDog` that facilitates running `Observable` tasks
2. `EthVaultBalance` `SuiBridgeStatus`, and `EthBridgeStatus` that monitors vault balances on eth vault, whether sui bridge is paused and whether eth bridge is paused respectively.

## Test plan 

running locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
