### PR TITLE
indexer: support TransactionFilter::AffectedObject

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.exp
+++ b/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.exp
@@ -1,0 +1,255 @@
+processed 15 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-56:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8147200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 58-60:
+//# programmable --sender A --inputs 1 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 62-64:
+//# programmable --sender A --inputs 2 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 66-68:
+//# programmable --sender A --inputs 3 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 70-71:
+//# programmable --sender A --inputs object(2,0)
+//> P::M::inc(Input(0))
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 6, lines 73-75:
+//# programmable --sender A --inputs object(2,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(6,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 7, lines 77-78:
+//# programmable --sender A --inputs object(6,0)
+//> P::M::incw(Input(0))
+mutated: object(0,0), object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 8, lines 80-82:
+//# programmable --sender A --inputs object(6,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+mutated: object(0,0)
+unwrapped: object(2,0)
+deleted: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 9, lines 84-85:
+//# programmable --sender A --inputs object(3,0) object(2,0)
+//> P::M::transfer(Input(0), Input(1))
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
+
+task 10, lines 87-88:
+//# programmable --sender A --inputs receiving(2,0)
+//> P::M::drop_receiving(Input(0))
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 11, lines 90-92:
+//# programmable --sender A --inputs object(4,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::receive_impl (function index 12) at offset 0, Abort Code: 3
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 12, instruction: 0, function_name: Some("receive_impl") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 0)] }), command: Some(0) } }
+
+task 12, lines 94-96:
+//# programmable --sender A --inputs object(3,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
+
+task 13, line 98:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 14, lines 100-115:
+//# run-graphql
+Response: {
+  "data": {
+    "all": {
+      "nodes": [
+        {
+          "digest": "EAu7t7RFbwASW5ZLxtqa33ody8xidNR3U3KFKBKAFU5q"
+        },
+        {
+          "digest": "9Gorn5uVdjc7eHBW3WafnpiqQfYg6iPSkxhZ6CbuBqwk"
+        },
+        {
+          "digest": "3qPssWeR5bvwaZiwkjbYTkR7ng9XSDp7aaky8A4DJp6S"
+        },
+        {
+          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+        },
+        {
+          "digest": "GT6fS3ko7JHfHvFmMg7AdZ2xTf1gjmckvrJSTRXSbLKt"
+        },
+        {
+          "digest": "2VpJzfhaw4oHY5LW2SLHsrYVYHHPjotB1fjwbks27VjF"
+        },
+        {
+          "digest": "3sGvS3VJnsdTVLNi14Xe7AaaaqsWwMc8ohbWEb6BNSWV"
+        },
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        },
+        {
+          "digest": "CLgQXbBzTdre9fgFkZbN9NzcQe4f3fAsg2NowXFCEpJ5"
+        },
+        {
+          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+        },
+        {
+          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+        }
+      ]
+    },
+    "affect2": {
+      "nodes": [
+        {
+          "digest": "EAu7t7RFbwASW5ZLxtqa33ody8xidNR3U3KFKBKAFU5q"
+        },
+        {
+          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+        },
+        {
+          "digest": "GT6fS3ko7JHfHvFmMg7AdZ2xTf1gjmckvrJSTRXSbLKt"
+        },
+        {
+          "digest": "3sGvS3VJnsdTVLNi14Xe7AaaaqsWwMc8ohbWEb6BNSWV"
+        },
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        },
+        {
+          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+        }
+      ]
+    },
+    "input2": {
+      "nodes": [
+        {
+          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+        },
+        {
+          "digest": "GT6fS3ko7JHfHvFmMg7AdZ2xTf1gjmckvrJSTRXSbLKt"
+        },
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        }
+      ]
+    },
+    "change2": {
+      "nodes": [
+        {
+          "digest": "EAu7t7RFbwASW5ZLxtqa33ody8xidNR3U3KFKBKAFU5q"
+        },
+        {
+          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+        },
+        {
+          "digest": "3sGvS3VJnsdTVLNi14Xe7AaaaqsWwMc8ohbWEb6BNSWV"
+        },
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        },
+        {
+          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+        }
+      ]
+    },
+    "affect3": {
+      "nodes": [
+        {
+          "digest": "9Gorn5uVdjc7eHBW3WafnpiqQfYg6iPSkxhZ6CbuBqwk"
+        },
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        },
+        {
+          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+        }
+      ]
+    },
+    "input3": {
+      "nodes": [
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        },
+        {
+          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+        }
+      ]
+    },
+    "change3": {
+      "nodes": [
+        {
+          "digest": "9Gorn5uVdjc7eHBW3WafnpiqQfYg6iPSkxhZ6CbuBqwk"
+        },
+        {
+          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+        },
+        {
+          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+        }
+      ]
+    },
+    "affect4": {
+      "nodes": [
+        {
+          "digest": "3qPssWeR5bvwaZiwkjbYTkR7ng9XSDp7aaky8A4DJp6S"
+        },
+        {
+          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+        }
+      ]
+    },
+    "input4": {
+      "nodes": [
+        {
+          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+        }
+      ]
+    },
+    "change4": {
+      "nodes": [
+        {
+          "digest": "3qPssWeR5bvwaZiwkjbYTkR7ng9XSDp7aaky8A4DJp6S"
+        },
+        {
+          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.move
+++ b/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.move
@@ -1,0 +1,115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 51 --addresses P=0x0 --accounts A --simulator
+
+//# publish
+module P::M {
+  use sui::transfer::Receiving;
+
+  public struct Object has key, store {
+    id: UID,
+    xs: u64,
+  }
+
+  public struct Wrapper has key, store {
+    id: UID,
+    obj: Object,
+  }
+
+  public fun new(xs: u64, ctx: &mut TxContext): Object {
+    Object { id: object::new(ctx), xs }
+  }
+
+  public fun inc(o: &mut Object) {
+    o.xs = o.xs + 1;
+  }
+
+  public fun destroy(o: Object) {
+    let Object { id, xs: _ } = o;
+    id.delete();
+  }
+
+  public fun wrap(o: Object, ctx: &mut TxContext): Wrapper {
+    Wrapper { id: object::new(ctx), obj: o }
+  }
+
+  public fun incw(w: &mut Wrapper) {
+    w.obj.xs = w.obj.xs + 1;
+  }
+
+  public fun unwrap(w: Wrapper): Object {
+    let Wrapper { id, obj } = w;
+    id.delete();
+    obj
+  }
+
+  public fun receive(p: &mut Object, r: Receiving<Object>): Object {
+    transfer::receive(&mut p.id, r)
+  }
+
+  public fun drop_receiving(_: Receiving<Object>) {}
+
+  public fun transfer(to: &Object, from: Object) {
+    transfer::transfer(from, to.id.to_address())
+  }
+}
+
+//# programmable --sender A --inputs 1 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 2 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 3 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(2,0)
+//> P::M::inc(Input(0))
+
+//# programmable --sender A --inputs object(2,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(6,0)
+//> P::M::incw(Input(0))
+
+//# programmable --sender A --inputs object(6,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(3,0) object(2,0)
+//> P::M::transfer(Input(0), Input(1))
+
+//# programmable --sender A --inputs receiving(2,0)
+//> P::M::drop_receiving(Input(0))
+
+//# programmable --sender A --inputs object(4,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# programmable --sender A --inputs object(3,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  all: transactionBlocks(last: 11) { nodes { digest } }
+
+  affect2: transactionBlocks(last: 11, filter: { affectedObject: "@{obj_2_0}" }) { nodes { digest } }
+  input2: transactionBlocks(last: 11, filter: { inputObject: "@{obj_2_0}" }) { nodes { digest } }
+  change2: transactionBlocks(last: 11, filter: { changedObject: "@{obj_2_0}" }) { nodes { digest } }
+
+  affect3: transactionBlocks(last: 11, filter: { affectedObject: "@{obj_3_0}" }) { nodes { digest } }
+  input3: transactionBlocks(last: 11, filter: { inputObject: "@{obj_3_0}" }) { nodes { digest } }
+  change3: transactionBlocks(last: 11, filter: { changedObject: "@{obj_3_0}" }) { nodes { digest } }
+
+  affect4: transactionBlocks(last: 11, filter: { affectedObject: "@{obj_4_0}" }) { nodes { digest } }
+  input4: transactionBlocks(last: 11, filter: { inputObject: "@{obj_4_0}" }) { nodes { digest } }
+  change4: transactionBlocks(last: 11, filter: { changedObject: "@{obj_4_0}" }) { nodes { digest } }
+}

--- a/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/filter.rs
@@ -33,8 +33,8 @@ pub(crate) struct TransactionBlockFilter {
 
     /// Limit to transactions that interacted with the given object. The object could have been
     /// created, read, modified, deleted, wrapped, or unwrapped by the transaction. Objects that
-    /// were passed as a `Receiving` input are not considered to have interacted with the object
-    /// unless they were actually received.
+    /// were passed as a `Receiving` input are not considered to have been affected by a
+    /// transaction unless they were actually received.
     #[cfg(feature = "staging")]
     pub affected_object: Option<SuiAddress>,
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -336,6 +336,14 @@ pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -
         ));
     }
 
+    #[cfg(feature = "staging")]
+    if let Some(affected) = &filter.affected_object {
+        subqueries.push((
+            "tx_affected_objects",
+            select_affected_object(affected, sender, tx_bounds),
+        ));
+    }
+
     if let Some(recv) = &filter.recv_address {
         subqueries.push(("tx_recipients", select_recipient(recv, sender, tx_bounds)));
     }
@@ -463,6 +471,18 @@ fn select_affected_address(
 ) -> RawQuery {
     filter!(
         select_tx(sender, bound, "tx_affected_addresses"),
+        format!("affected = {}", bytea_literal(affected.as_slice()))
+    )
+}
+
+#[cfg(feature = "staging")]
+fn select_affected_object(
+    affected: &SuiAddress,
+    sender: Option<SuiAddress>,
+    bound: TxBounds,
+) -> RawQuery {
+    filter!(
+        select_tx(sender, bound, "tx_affected_objects"),
         format!("affected = {}", bytea_literal(affected.as_slice()))
     )
 }

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -4338,8 +4338,8 @@ input TransactionBlockFilter {
 	"""
 	Limit to transactions that interacted with the given object. The object could have been
 	created, read, modified, deleted, wrapped, or unwrapped by the transaction. Objects that
-	were passed as a `Receiving` input are not considered to have interacted with the object
-	unless they were actually received.
+	were passed as a `Receiving` input are not considered to have been affected by a
+	transaction unless they were actually received.
 	"""
 	affectedObject: SuiAddress
 	"""

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -4336,6 +4336,13 @@ input TransactionBlockFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
+	Limit to transactions that interacted with the given object. The object could have been
+	created, read, modified, deleted, wrapped, or unwrapped by the transaction. Objects that
+	were passed as a `Receiving` input are not considered to have interacted with the object
+	unless they were actually received.
+	"""
+	affectedObject: SuiAddress
+	"""
 	Limit to transactions that were sent by the given address. NOTE: this input filter has been
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -4340,6 +4340,13 @@ input TransactionBlockFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
+	Limit to transactions that interacted with the given object. The object could have been
+	created, read, modified, deleted, wrapped, or unwrapped by the transaction. Objects that
+	were passed as a `Receiving` input are not considered to have interacted with the object
+	unless they were actually received.
+	"""
+	affectedObject: SuiAddress
+	"""
 	Limit to transactions that were sent by the given address. NOTE: this input filter has been
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -4342,8 +4342,8 @@ input TransactionBlockFilter {
 	"""
 	Limit to transactions that interacted with the given object. The object could have been
 	created, read, modified, deleted, wrapped, or unwrapped by the transaction. Objects that
-	were passed as a `Receiving` input are not considered to have interacted with the object
-	unless they were actually received.
+	were passed as a `Receiving` input are not considered to have been affected by a
+	transaction unless they were actually received.
 	"""
 	affectedObject: SuiAddress
 	"""

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -739,6 +739,13 @@ impl IndexerReader {
                     format!("object_id = '\\x{}'::bytea", object_id),
                 )
             }
+            Some(TransactionFilter::AffectedObject(object_id)) => {
+                let object_id = Hex::encode(object_id.to_vec());
+                (
+                    "tx_affected_objects".into(),
+                    format!("affected = '\\x{}'::bytea", object_id),
+                )
+            }
             Some(TransactionFilter::FromAddress(from_address)) => {
                 let from_address = Hex::encode(from_address.to_vec());
                 (

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -10863,6 +10863,19 @@
             "additionalProperties": false
           },
           {
+            "description": "Query for transactions that touch this object.",
+            "type": "object",
+            "required": [
+              "AffectedObject"
+            ],
+            "properties": {
+              "AffectedObject": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by sender address.",
             "type": "object",
             "required": [


### PR DESCRIPTION
## Description

Add an `AffectedObject` filter on `TransactionFilter` and implement it in `IndexerReader` and in the subscription system.

This filter is not implemented on fullnode indices, and in a follow-up PR, support for `InputObject` and `ChangedObject` will be removed from the PG-backed implementation of JSON-RPC.

It was difficult to replace `InputObject`/`ChangedObject` support on fullnode with `AffectedObject` because we don't have (and don't want to add) the necessary indices, and the current filters are referred to in certain tests.

## Test plan

Manually tested with a local network:

```
sui$ cargo run --bin sui -- start --with-indexer --force-regenesis
```

```
sui$ curl -LX POST  "http://localhost:9124" \
        --header 'Content-Type: application/json' \
        --data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_queryTransactionBlocks",
  "params": [
    { "filter": { "AffectedObject":"0x2" } },
    null,
    50,
    true
  ]
}' | jq '.result.data.[].digest'
```

## Stack

- #19474 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Adds support for filtering transactions by their affected object
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
