### PR TITLE
events: Remove unsupported filters

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3923,9 +3923,7 @@ impl AuthorityState {
 
         let limit = limit + 1;
         let mut event_keys = match query {
-            EventFilter::All(fs) if fs.is_empty() => {
-                index_store.all_events(tx_num, event_num, limit, descending)?
-            }
+            EventFilter::All([]) => index_store.all_events(tx_num, event_num, limit, descending)?,
             EventFilter::Transaction(digest) => {
                 index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
             }
@@ -3957,13 +3955,6 @@ impl AuthorityState {
                     limit,
                     descending,
                 )?,
-            EventFilter::All(_) => {
-                return Err(SuiError::UserInputError {
-                    error: UserInputError::Unsupported(
-                        "This query type is not supported by the full node.".to_string(),
-                    ),
-                })
-            }
         };
 
         // skip one event if exclusive cursor is provided,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3923,17 +3923,8 @@ impl AuthorityState {
 
         let limit = limit + 1;
         let mut event_keys = match query {
-            EventFilter::All(filters) => {
-                if filters.is_empty() {
-                    index_store.all_events(tx_num, event_num, limit, descending)?
-                } else {
-                    return Err(SuiError::UserInputError {
-                        error: UserInputError::Unsupported(
-                            "This query type does not currently support filter combinations"
-                                .to_string(),
-                        ),
-                    });
-                }
+            EventFilter::All(fs) if fs.is_empty() => {
+                index_store.all_events(tx_num, event_num, limit, descending)?
             }
             EventFilter::Transaction(digest) => {
                 index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
@@ -3966,12 +3957,7 @@ impl AuthorityState {
                     limit,
                     descending,
                 )?,
-            // not using "_ =>" because we want to make sure we remember to add new variants here
-            EventFilter::Package(_)
-            | EventFilter::MoveEventField { .. }
-            | EventFilter::Any(_)
-            | EventFilter::And(_, _)
-            | EventFilter::Or(_, _) => {
+            EventFilter::All(_) => {
                 return Err(SuiError::UserInputError {
                     error: UserInputError::Unsupported(
                         "This query type is not supported by the full node.".to_string(),

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1012,7 +1012,7 @@ impl IndexerReader {
                 .await;
         } else {
             let main_where_clause = match filter {
-                EventFilter::All(fs) if fs.is_empty() => {
+                EventFilter::All([]) => {
                     // No filter
                     "1 = 1".to_string()
                 }
@@ -1038,7 +1038,7 @@ impl IndexerReader {
                     // Processed above
                     unreachable!()
                 }
-                EventFilter::All(_) | EventFilter::TimeRange { .. } => {
+                EventFilter::TimeRange { .. } => {
                     return Err(IndexerError::NotSupportedError(
                         "This type of EventFilter is not supported.".to_owned(),
                     ));

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1012,8 +1012,9 @@ impl IndexerReader {
                 .await;
         } else {
             let main_where_clause = match filter {
-                EventFilter::Package(package_id) => {
-                    format!("package = '\\x{}'::bytea", package_id.to_hex())
+                EventFilter::All(fs) if fs.is_empty() => {
+                    // No filter
+                    "1 = 1".to_string()
                 }
                 EventFilter::MoveModule { package, module } => {
                     format!(
@@ -1037,14 +1038,9 @@ impl IndexerReader {
                     // Processed above
                     unreachable!()
                 }
-                EventFilter::MoveEventField { .. }
-                | EventFilter::All(_)
-                | EventFilter::Any(_)
-                | EventFilter::And(_, _)
-                | EventFilter::Or(_, _)
-                | EventFilter::TimeRange { .. } => {
+                EventFilter::All(_) | EventFilter::TimeRange { .. } => {
                     return Err(IndexerError::NotSupportedError(
-                        "This type of EventFilter is not supported.".into(),
+                        "This type of EventFilter is not supported.".to_owned(),
                     ));
                 }
             };

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -203,6 +203,9 @@ fn try_into_byte(v: &Value) -> Option<u8> {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum EventFilter {
+    /// Query by events that match all the given filters, or return all events if no filters are
+    /// supplied.
+    All(Vec<EventFilter>),
     /// Query by sender address.
     Sender(SuiAddress),
     /// Return events emitted by the given transaction.
@@ -210,8 +213,6 @@ pub enum EventFilter {
         ///digest of the transaction, as base-64 encoded string
         TransactionDigest,
     ),
-    /// Return events emitted in a specified Package.
-    Package(ObjectID),
     /// Return events emitted in a specified Move module.
     /// If the event is defined in Module A but emitted in a tx with Module B,
     /// query `MoveModule` by module B returns the event.
@@ -244,10 +245,6 @@ pub enum EventFilter {
         #[serde_as(as = "DisplayFromStr")]
         module: Identifier,
     },
-    MoveEventField {
-        path: String,
-        value: Value,
-    },
     /// Return events emitted in [start_time, end_time] interval
     #[serde(rename_all = "camelCase")]
     TimeRange {
@@ -260,32 +257,17 @@ pub enum EventFilter {
         #[serde_as(as = "BigInt<u64>")]
         end_time: u64,
     },
-
-    All(Vec<EventFilter>),
-    Any(Vec<EventFilter>),
-    And(Box<EventFilter>, Box<EventFilter>),
-    Or(Box<EventFilter>, Box<EventFilter>),
 }
 
-impl EventFilter {
-    fn try_matches(&self, item: &SuiEvent) -> SuiResult<bool> {
-        Ok(match self {
+impl Filter<SuiEvent> for EventFilter {
+    fn matches(&self, item: &SuiEvent) -> bool {
+        let _scope = monitored_scope("EventFilter::matches");
+        match self {
+            EventFilter::All(fs) => fs.iter().all(|f| f.matches(item)),
             EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
-            EventFilter::MoveEventField { path, value } => {
-                matches!(item.parsed_json.pointer(path), Some(v) if v == value)
-            }
             EventFilter::Sender(sender) => &item.sender == sender,
-            EventFilter::Package(object_id) => &item.package_id == object_id,
             EventFilter::MoveModule { package, module } => {
                 &item.transaction_module == module && &item.package_id == package
-            }
-            EventFilter::All(filters) => filters.iter().all(|f| f.matches(item)),
-            EventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
-            EventFilter::And(f1, f2) => {
-                EventFilter::All(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
-            }
-            EventFilter::Or(f1, f2) => {
-                EventFilter::Any(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
             }
             EventFilter::Transaction(digest) => digest == &item.id.tx_digest,
 
@@ -302,21 +284,7 @@ impl EventFilter {
             EventFilter::MoveEventModule { package, module } => {
                 &item.type_.module == module && &ObjectID::from(item.type_.address) == package
             }
-        })
-    }
-
-    pub fn and(self, other_filter: EventFilter) -> Self {
-        Self::All(vec![self, other_filter])
-    }
-    pub fn or(self, other_filter: EventFilter) -> Self {
-        Self::Any(vec![self, other_filter])
-    }
-}
-
-impl Filter<SuiEvent> for EventFilter {
-    fn matches(&self, item: &SuiEvent) -> bool {
-        let _scope = monitored_scope("EventFilter::matches");
-        self.try_matches(item).unwrap_or_default()
+        }
     }
 }
 

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -203,9 +203,8 @@ fn try_into_byte(v: &Value) -> Option<u8> {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum EventFilter {
-    /// Query by events that match all the given filters, or return all events if no filters are
-    /// supplied.
-    All(Vec<EventFilter>),
+    /// Return all events.
+    All([Box<EventFilter>; 0]),
     /// Query by sender address.
     Sender(SuiAddress),
     /// Return events emitted by the given transaction.
@@ -263,7 +262,7 @@ impl Filter<SuiEvent> for EventFilter {
     fn matches(&self, item: &SuiEvent) -> bool {
         let _scope = monitored_scope("EventFilter::matches");
         match self {
-            EventFilter::All(fs) => fs.iter().all(|f| f.matches(item)),
+            EventFilter::All([]) => true,
             EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
             EventFilter::Sender(sender) => &item.sender == sender,
             EventFilter::MoveModule { package, module } => {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6106,6 +6106,22 @@
       "EventFilter": {
         "oneOf": [
           {
+            "description": "Query by events that match all the given filters, or return all events if no filters are supplied.",
+            "type": "object",
+            "required": [
+              "All"
+            ],
+            "properties": {
+              "All": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EventFilter"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by sender address.",
             "type": "object",
             "required": [
@@ -6127,19 +6143,6 @@
             "properties": {
               "Transaction": {
                 "$ref": "#/components/schemas/TransactionDigest"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events emitted in a specified Package.",
-            "type": "object",
-            "required": [
-              "Package"
-            ],
-            "properties": {
-              "Package": {
-                "$ref": "#/components/schemas/ObjectID"
               }
             },
             "additionalProperties": false
@@ -6220,28 +6223,6 @@
             "additionalProperties": false
           },
           {
-            "type": "object",
-            "required": [
-              "MoveEventField"
-            ],
-            "properties": {
-              "MoveEventField": {
-                "type": "object",
-                "required": [
-                  "path",
-                  "value"
-                ],
-                "properties": {
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": true
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
             "description": "Return events emitted in [start_time, end_time] interval",
             "type": "object",
             "required": [
@@ -6272,80 +6253,6 @@
                     ]
                   }
                 }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "All"
-            ],
-            "properties": {
-              "All": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Any"
-            ],
-            "properties": {
-              "Any": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "And"
-            ],
-            "properties": {
-              "And": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Or"
-            ],
-            "properties": {
-              "Or": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6106,7 +6106,7 @@
       "EventFilter": {
         "oneOf": [
           {
-            "description": "Query by events that match all the given filters, or return all events if no filters are supplied.",
+            "description": "Return all events.",
             "type": "object",
             "required": [
               "All"
@@ -6114,9 +6114,7 @@
             "properties": {
               "All": {
                 "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
+                "maxItems": 0
               }
             },
             "additionalProperties": false

--- a/crates/sui-sdk/examples/event_api.rs
+++ b/crates/sui-sdk/examples/event_api.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let descending = true;
     let query_events = sui
         .event_api()
-        .query_events(EventFilter::All(vec![]), None, Some(5), descending) // query first 5 events in descending order
+        .query_events(EventFilter::All([]), None, Some(5), descending) // query first 5 events in descending order
         .await?;
     println!(" *** Query events *** ");
     println!("{:?}", query_events);
@@ -39,10 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
     println!("WS version {:?}", ws.api_version());
 
-    let mut subscribe = ws
-        .event_api()
-        .subscribe_event(EventFilter::All(vec![]))
-        .await?;
+    let mut subscribe = ws.event_api().subscribe_event(EventFilter::All([])).await?;
 
     loop {
         println!("{:?}", subscribe.next().await);

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -1033,7 +1033,7 @@ impl EventApi {
     ///         .await?;
     ///     let mut subscribe_all = sui
     ///         .event_api()
-    ///         .subscribe_event(EventFilter::All(vec![]))
+    ///         .subscribe_event(EventFilter::All([]))
     ///         .await?;
     ///     loop {
     ///         println!("{:?}", subscribe_all.next().await);


### PR DESCRIPTION
## Description

This PR removes EventFilters from JSON-RPC that aren't supported already by fullnode-backed JSON-RPC:

- Combination filters (`All`, `Any`, `Not`, `And`, `Or`)
- `Package`
- `EventField`

These filters were, however, supported by the now-deprecated subscription system, so a question remains whether they are safe to remove.

## Test plan

Manually tested, in particular `All: []` support, which we do still need to keep as a way to get all filters (this was also added to the `IndexerReader` implementation):

```
sui$ cargo run --bin sui -- --force-regenesis \
  --with-indexer --with-faucet
```

...run for some time, so that some system events accumulate, then test that we get them from both the fullnode-backed JSONRPC and indexer-backed:

Fullnode:
```
curl -LX POST  "http://localhost:9000" \
        --header 'Content-Type: application/json' \
        --data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_queryEvents",
  "params": [
    {
      "All": []
    },
    null,
    50,
    true
  ]
}' | jq .
```

Indexer:
```
curl -LX POST  "http://localhost:9124" \
        --header 'Content-Type: application/json' \
        --data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_queryEvents",
  "params": [
    {
      "All": []
    },
    null,
    50,
    true
  ]
}' | jq .
```

## Stack

- #19474 
- #19614 
- #19615 
- #19616 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Remove unsupported compound filters for querying events from the JSON-RPC schema to avoid confusion. Remove support for compound filters from the deprecated events subscription system.
- [x] Indexer: Remove compound filters for querying events.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
