### PR TITLE
indexer: affected objects include created+wrapped/unwrapped+deleted

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3923,9 +3923,7 @@ impl AuthorityState {
 
         let limit = limit + 1;
         let mut event_keys = match query {
-            EventFilter::All(fs) if fs.is_empty() => {
-                index_store.all_events(tx_num, event_num, limit, descending)?
-            }
+            EventFilter::All([]) => index_store.all_events(tx_num, event_num, limit, descending)?,
             EventFilter::Transaction(digest) => {
                 index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
             }
@@ -3957,13 +3955,6 @@ impl AuthorityState {
                     limit,
                     descending,
                 )?,
-            EventFilter::All(_) => {
-                return Err(SuiError::UserInputError {
-                    error: UserInputError::Unsupported(
-                        "This query type is not supported by the full node.".to_string(),
-                    ),
-                })
-            }
         };
 
         // skip one event if exclusive cursor is provided,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3923,17 +3923,8 @@ impl AuthorityState {
 
         let limit = limit + 1;
         let mut event_keys = match query {
-            EventFilter::All(filters) => {
-                if filters.is_empty() {
-                    index_store.all_events(tx_num, event_num, limit, descending)?
-                } else {
-                    return Err(SuiError::UserInputError {
-                        error: UserInputError::Unsupported(
-                            "This query type does not currently support filter combinations"
-                                .to_string(),
-                        ),
-                    });
-                }
+            EventFilter::All(fs) if fs.is_empty() => {
+                index_store.all_events(tx_num, event_num, limit, descending)?
             }
             EventFilter::Transaction(digest) => {
                 index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
@@ -3966,12 +3957,7 @@ impl AuthorityState {
                     limit,
                     descending,
                 )?,
-            // not using "_ =>" because we want to make sure we remember to add new variants here
-            EventFilter::Package(_)
-            | EventFilter::MoveEventField { .. }
-            | EventFilter::Any(_)
-            | EventFilter::And(_, _)
-            | EventFilter::Or(_, _) => {
+            EventFilter::All(_) => {
                 return Err(SuiError::UserInputError {
                     error: UserInputError::Unsupported(
                         "This query type is not supported by the full node.".to_string(),

--- a/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.exp
+++ b/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.exp
@@ -1,4 +1,4 @@
-processed 15 tasks
+processed 23 tasks
 
 init:
 A: object(0,0)
@@ -33,67 +33,130 @@ created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, lines 70-71:
+task 5, lines 70-73:
+//# programmable --sender A --inputs 4 @A
+//> P::M::new(Input(0));
+//> P::M::wrap(Result(0));
+//> TransferObjects([Result(1)], Input(1))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 75-76:
 //# programmable --sender A --inputs object(2,0)
 //> P::M::inc(Input(0))
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
 
-task 6, lines 73-75:
+task 7, lines 78-79:
+//# programmable --sender A --inputs object(5,0)
+//> P::M::incw(Input(0))
+mutated: object(0,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 8, lines 81-83:
 //# programmable --sender A --inputs object(2,0) @A
 //> P::M::wrap(Input(0));
 //> TransferObjects([Result(0)], Input(1))
-created: object(6,0)
+created: object(8,0)
 mutated: object(0,0)
 wrapped: object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
 
-task 7, lines 77-78:
-//# programmable --sender A --inputs object(6,0)
+task 9, lines 85-86:
+//# programmable --sender A --inputs object(8,0)
 //> P::M::incw(Input(0))
-mutated: object(0,0), object(6,0)
+mutated: object(0,0), object(8,0)
 gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
 
-task 8, lines 80-82:
-//# programmable --sender A --inputs object(6,0) @A
+task 10, lines 88-90:
+//# programmable --sender A --inputs object(8,0) @A
 //> P::M::unwrap(Input(0));
 //> TransferObjects([Result(0)], Input(1))
 mutated: object(0,0)
 unwrapped: object(2,0)
-deleted: object(6,0)
+deleted: object(8,0)
 gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
 
-task 9, lines 84-85:
+task 11, lines 92-93:
 //# programmable --sender A --inputs object(3,0) object(2,0)
 //> P::M::transfer(Input(0), Input(1))
 mutated: object(0,0), object(2,0), object(3,0)
 gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
 
-task 10, lines 87-88:
+task 12, lines 95-96:
 //# programmable --sender A --inputs receiving(2,0)
 //> P::M::drop_receiving(Input(0))
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 11, lines 90-92:
+task 13, lines 98-100:
 //# programmable --sender A --inputs object(4,0) receiving(2,0) @A
 //> P::M::receive(Input(0), Input(1));
 //> TransferObjects([Result(0)], Input(2))
 Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::receive_impl (function index 12) at offset 0, Abort Code: 3
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 12, instruction: 0, function_name: Some("receive_impl") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 0)] }), command: Some(0) } }
 
-task 12, lines 94-96:
+task 14, lines 102-104:
 //# programmable --sender A --inputs object(3,0) receiving(2,0) @A
 //> P::M::receive(Input(0), Input(1));
 //> TransferObjects([Result(0)], Input(2))
 mutated: object(0,0), object(2,0), object(3,0)
 gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
 
-task 13, line 98:
+task 15, lines 106-107:
+//# programmable --sender A --inputs object(2,0)
+//> P::M::destroy(Input(0))
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 16, lines 109-110:
+//# programmable --sender A --inputs object(3,0)
+//> P::M::destroy(Input(0))
+mutated: object(0,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 17, lines 112-113:
+//# programmable --sender A --inputs object(4,0)
+//> P::M::destroy(Input(0))
+mutated: object(0,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 18, lines 115-117:
+//# programmable --sender A --inputs object(5,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+mutated: object(0,0)
+unwrapped: object(18,0)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 19, lines 119-121:
+//# programmable --sender A --inputs object(18,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(19,0)
+mutated: object(0,0)
+wrapped: object(18,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 20, lines 123-125:
+//# programmable --sender A --inputs object(19,0)
+//> P::M::unwrap(Input(0));
+//> P::M::destroy(Result(0))
+mutated: object(0,0)
+deleted: object(19,0)
+unwrapped_then_deleted: object(18,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 21, line 127:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 14, lines 100-115:
+task 22, lines 129-150:
 //# run-graphql
 Response: {
   "data": {
@@ -109,28 +172,52 @@ Response: {
           "digest": "3qPssWeR5bvwaZiwkjbYTkR7ng9XSDp7aaky8A4DJp6S"
         },
         {
-          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+          "digest": "CU6apQSKPqGNqSxg2D5v3TVFzbDmx4gPhLEaJwiiWqXC"
         },
         {
-          "digest": "GT6fS3ko7JHfHvFmMg7AdZ2xTf1gjmckvrJSTRXSbLKt"
+          "digest": "5E5JyrSFLvhB2EcN74bUk4dEpm23jGP2GRnVK4JCBCTa"
         },
         {
-          "digest": "2VpJzfhaw4oHY5LW2SLHsrYVYHHPjotB1fjwbks27VjF"
+          "digest": "2jmmPvyktGqZcF5KFNmNvyisGwRwkvRWqGzmoY8Mucda"
         },
         {
-          "digest": "3sGvS3VJnsdTVLNi14Xe7AaaaqsWwMc8ohbWEb6BNSWV"
+          "digest": "ELRa9MREFjzU2wuUTN8hkoUQ57FhEiuPCbvWyDEAZLRr"
         },
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "2AdEFXvVLU8eXS5VamF1Dcn2VfqXdy46BFgiaawaMaTY"
         },
         {
-          "digest": "CLgQXbBzTdre9fgFkZbN9NzcQe4f3fAsg2NowXFCEpJ5"
+          "digest": "4Wx6uuwb2swwLwYghbFvGyt6ReKiKX7eUsXZY16y23to"
         },
         {
-          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
         },
         {
-          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+          "digest": "2DXNdmsHtk4YvcJKbb4hKSggWqRwxzXxDyVBzDAdotDZ"
+        },
+        {
+          "digest": "GPSMkMRGn4X9VY41STGdDR8tFC2pneWuCtXkdjqhZiZP"
+        },
+        {
+          "digest": "3bAse3nV4m79aUEq8hAVVeDuJGMs4qtyHQUJUKLoyhnQ"
+        },
+        {
+          "digest": "2uiRgJ2ddzdhy32JpxBt3gajXNz1GyRr6zQjBgnnzwDW"
+        },
+        {
+          "digest": "3vLFyUwCW4jC6kVhqcgtpVpMSVKxX63nNfKqRqQKW1Hg"
+        },
+        {
+          "digest": "92UgLjnEiiRkxWuxME8wD3Bh439gMX7RTtRoZm3G29Lx"
+        },
+        {
+          "digest": "CqYXBbBtW4nNGp66DtDuEsexmVUgasqRX1cwD2o9mojr"
+        },
+        {
+          "digest": "9A8Nc4qZkEVpRSemjZ7kVJSdTzJbPGxKijPy86ZsWSK3"
+        },
+        {
+          "digest": "Du8zQ2HM6GzfdZDpwobpntZfrQReEqkDyKCeBoXGeEEA"
         }
       ]
     },
@@ -140,32 +227,38 @@ Response: {
           "digest": "EAu7t7RFbwASW5ZLxtqa33ody8xidNR3U3KFKBKAFU5q"
         },
         {
-          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+          "digest": "5E5JyrSFLvhB2EcN74bUk4dEpm23jGP2GRnVK4JCBCTa"
         },
         {
-          "digest": "GT6fS3ko7JHfHvFmMg7AdZ2xTf1gjmckvrJSTRXSbLKt"
+          "digest": "ELRa9MREFjzU2wuUTN8hkoUQ57FhEiuPCbvWyDEAZLRr"
         },
         {
-          "digest": "3sGvS3VJnsdTVLNi14Xe7AaaaqsWwMc8ohbWEb6BNSWV"
+          "digest": "4Wx6uuwb2swwLwYghbFvGyt6ReKiKX7eUsXZY16y23to"
         },
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
         },
         {
-          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+          "digest": "3bAse3nV4m79aUEq8hAVVeDuJGMs4qtyHQUJUKLoyhnQ"
+        },
+        {
+          "digest": "2uiRgJ2ddzdhy32JpxBt3gajXNz1GyRr6zQjBgnnzwDW"
         }
       ]
     },
     "input2": {
       "nodes": [
         {
-          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+          "digest": "5E5JyrSFLvhB2EcN74bUk4dEpm23jGP2GRnVK4JCBCTa"
         },
         {
-          "digest": "GT6fS3ko7JHfHvFmMg7AdZ2xTf1gjmckvrJSTRXSbLKt"
+          "digest": "ELRa9MREFjzU2wuUTN8hkoUQ57FhEiuPCbvWyDEAZLRr"
         },
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
+        },
+        {
+          "digest": "2uiRgJ2ddzdhy32JpxBt3gajXNz1GyRr6zQjBgnnzwDW"
         }
       ]
     },
@@ -175,16 +268,16 @@ Response: {
           "digest": "EAu7t7RFbwASW5ZLxtqa33ody8xidNR3U3KFKBKAFU5q"
         },
         {
-          "digest": "9iRKWAoNUXAnBbA2sajqXN7wV4t6XvgHaqhTmMW6TcDi"
+          "digest": "5E5JyrSFLvhB2EcN74bUk4dEpm23jGP2GRnVK4JCBCTa"
         },
         {
-          "digest": "3sGvS3VJnsdTVLNi14Xe7AaaaqsWwMc8ohbWEb6BNSWV"
+          "digest": "4Wx6uuwb2swwLwYghbFvGyt6ReKiKX7eUsXZY16y23to"
         },
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
         },
         {
-          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+          "digest": "3bAse3nV4m79aUEq8hAVVeDuJGMs4qtyHQUJUKLoyhnQ"
         }
       ]
     },
@@ -194,20 +287,26 @@ Response: {
           "digest": "9Gorn5uVdjc7eHBW3WafnpiqQfYg6iPSkxhZ6CbuBqwk"
         },
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
         },
         {
-          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+          "digest": "3bAse3nV4m79aUEq8hAVVeDuJGMs4qtyHQUJUKLoyhnQ"
+        },
+        {
+          "digest": "3vLFyUwCW4jC6kVhqcgtpVpMSVKxX63nNfKqRqQKW1Hg"
         }
       ]
     },
     "input3": {
       "nodes": [
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
         },
         {
-          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+          "digest": "3bAse3nV4m79aUEq8hAVVeDuJGMs4qtyHQUJUKLoyhnQ"
+        },
+        {
+          "digest": "3vLFyUwCW4jC6kVhqcgtpVpMSVKxX63nNfKqRqQKW1Hg"
         }
       ]
     },
@@ -217,10 +316,10 @@ Response: {
           "digest": "9Gorn5uVdjc7eHBW3WafnpiqQfYg6iPSkxhZ6CbuBqwk"
         },
         {
-          "digest": "4yvTSsQXNH9nJeU1yXG66bFBkq9DFdYMNYyanvp8qqLi"
+          "digest": "D6NJc8Mg1cqXPXTdVCtVmHbxzyepNBh26K6mfUmW7pxU"
         },
         {
-          "digest": "HHKfCgrv9gBQ6j3sGK7qDNDahmYzK8Rf3on6JGA4DanS"
+          "digest": "3bAse3nV4m79aUEq8hAVVeDuJGMs4qtyHQUJUKLoyhnQ"
         }
       ]
     },
@@ -230,14 +329,20 @@ Response: {
           "digest": "3qPssWeR5bvwaZiwkjbYTkR7ng9XSDp7aaky8A4DJp6S"
         },
         {
-          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+          "digest": "GPSMkMRGn4X9VY41STGdDR8tFC2pneWuCtXkdjqhZiZP"
+        },
+        {
+          "digest": "92UgLjnEiiRkxWuxME8wD3Bh439gMX7RTtRoZm3G29Lx"
         }
       ]
     },
     "input4": {
       "nodes": [
         {
-          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+          "digest": "GPSMkMRGn4X9VY41STGdDR8tFC2pneWuCtXkdjqhZiZP"
+        },
+        {
+          "digest": "92UgLjnEiiRkxWuxME8wD3Bh439gMX7RTtRoZm3G29Lx"
         }
       ]
     },
@@ -247,7 +352,37 @@ Response: {
           "digest": "3qPssWeR5bvwaZiwkjbYTkR7ng9XSDp7aaky8A4DJp6S"
         },
         {
-          "digest": "B6avepddy14XNQf7Bwv1YL5Kt6JKj4wuFgkwNrGTDa3Y"
+          "digest": "GPSMkMRGn4X9VY41STGdDR8tFC2pneWuCtXkdjqhZiZP"
+        }
+      ]
+    },
+    "affect5": {
+      "nodes": [
+        {
+          "digest": "CU6apQSKPqGNqSxg2D5v3TVFzbDmx4gPhLEaJwiiWqXC"
+        },
+        {
+          "digest": "CqYXBbBtW4nNGp66DtDuEsexmVUgasqRX1cwD2o9mojr"
+        },
+        {
+          "digest": "9A8Nc4qZkEVpRSemjZ7kVJSdTzJbPGxKijPy86ZsWSK3"
+        },
+        {
+          "digest": "Du8zQ2HM6GzfdZDpwobpntZfrQReEqkDyKCeBoXGeEEA"
+        }
+      ]
+    },
+    "input5": {
+      "nodes": [
+        {
+          "digest": "9A8Nc4qZkEVpRSemjZ7kVJSdTzJbPGxKijPy86ZsWSK3"
+        }
+      ]
+    },
+    "change5": {
+      "nodes": [
+        {
+          "digest": "CqYXBbBtW4nNGp66DtDuEsexmVUgasqRX1cwD2o9mojr"
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.move
+++ b/crates/sui-graphql-e2e-tests/tests/staging/transactions/filters/affected_object.move
@@ -67,17 +67,25 @@ module P::M {
 //> P::M::new(Input(0));
 //> TransferObjects([Result(0)], Input(1))
 
+//# programmable --sender A --inputs 4 @A
+//> P::M::new(Input(0));
+//> P::M::wrap(Result(0));
+//> TransferObjects([Result(1)], Input(1))
+
 //# programmable --sender A --inputs object(2,0)
 //> P::M::inc(Input(0))
+
+//# programmable --sender A --inputs object(5,0)
+//> P::M::incw(Input(0))
 
 //# programmable --sender A --inputs object(2,0) @A
 //> P::M::wrap(Input(0));
 //> TransferObjects([Result(0)], Input(1))
 
-//# programmable --sender A --inputs object(6,0)
+//# programmable --sender A --inputs object(8,0)
 //> P::M::incw(Input(0))
 
-//# programmable --sender A --inputs object(6,0) @A
+//# programmable --sender A --inputs object(8,0) @A
 //> P::M::unwrap(Input(0));
 //> TransferObjects([Result(0)], Input(1))
 
@@ -95,21 +103,48 @@ module P::M {
 //> P::M::receive(Input(0), Input(1));
 //> TransferObjects([Result(0)], Input(2))
 
+//# programmable --sender A --inputs object(2,0)
+//> P::M::destroy(Input(0))
+
+//# programmable --sender A --inputs object(3,0)
+//> P::M::destroy(Input(0))
+
+//# programmable --sender A --inputs object(4,0)
+//> P::M::destroy(Input(0))
+
+//# programmable --sender A --inputs object(5,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(18,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(19,0)
+//> P::M::unwrap(Input(0));
+//> P::M::destroy(Result(0))
+
 //# create-checkpoint
 
 //# run-graphql
 {
-  all: transactionBlocks(last: 11) { nodes { digest } }
+  all: transactionBlocks(last: 19) { nodes { digest } }
 
-  affect2: transactionBlocks(last: 11, filter: { affectedObject: "@{obj_2_0}" }) { nodes { digest } }
-  input2: transactionBlocks(last: 11, filter: { inputObject: "@{obj_2_0}" }) { nodes { digest } }
-  change2: transactionBlocks(last: 11, filter: { changedObject: "@{obj_2_0}" }) { nodes { digest } }
+  affect2: transactionBlocks(last: 19, filter: { affectedObject: "@{obj_2_0}" }) { nodes { digest } }
+  input2: transactionBlocks(last: 19, filter: { inputObject: "@{obj_2_0}" }) { nodes { digest } }
+  change2: transactionBlocks(last: 19, filter: { changedObject: "@{obj_2_0}" }) { nodes { digest } }
 
-  affect3: transactionBlocks(last: 11, filter: { affectedObject: "@{obj_3_0}" }) { nodes { digest } }
-  input3: transactionBlocks(last: 11, filter: { inputObject: "@{obj_3_0}" }) { nodes { digest } }
-  change3: transactionBlocks(last: 11, filter: { changedObject: "@{obj_3_0}" }) { nodes { digest } }
+  affect3: transactionBlocks(last: 19, filter: { affectedObject: "@{obj_3_0}" }) { nodes { digest } }
+  input3: transactionBlocks(last: 19, filter: { inputObject: "@{obj_3_0}" }) { nodes { digest } }
+  change3: transactionBlocks(last: 19, filter: { changedObject: "@{obj_3_0}" }) { nodes { digest } }
 
-  affect4: transactionBlocks(last: 11, filter: { affectedObject: "@{obj_4_0}" }) { nodes { digest } }
-  input4: transactionBlocks(last: 11, filter: { inputObject: "@{obj_4_0}" }) { nodes { digest } }
-  change4: transactionBlocks(last: 11, filter: { changedObject: "@{obj_4_0}" }) { nodes { digest } }
+  affect4: transactionBlocks(last: 19, filter: { affectedObject: "@{obj_4_0}" }) { nodes { digest } }
+  input4: transactionBlocks(last: 19, filter: { inputObject: "@{obj_4_0}" }) { nodes { digest } }
+  change4: transactionBlocks(last: 19, filter: { changedObject: "@{obj_4_0}" }) { nodes { digest } }
+
+  # The object that was first created at transaction 5 was unwrapped at transaction 18, so that's
+  # the variable we refer to it at.
+  affect5: transactionBlocks(last: 19, filter: { affectedObject: "@{obj_18_0}" }) { nodes { digest } }
+  input5: transactionBlocks(last: 19, filter: { inputObject: "@{obj_18_0}" }) { nodes { digest } }
+  change5: transactionBlocks(last: 19, filter: { changedObject: "@{obj_18_0}" }) { nodes { digest } }
 }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -511,7 +511,7 @@ impl CheckpointHandler {
             let move_calls = tx
                 .move_calls()
                 .into_iter()
-                .map(|(p, m, f)| (p.clone(), m.to_string(), f.to_string()))
+                .map(|(p, m, f)| (*p, m.to_string(), f.to_string()))
                 .collect();
 
             db_tx_indices.push(TxIndex {

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1012,7 +1012,7 @@ impl IndexerReader {
                 .await;
         } else {
             let main_where_clause = match filter {
-                EventFilter::All(fs) if fs.is_empty() => {
+                EventFilter::All([]) => {
                     // No filter
                     "1 = 1".to_string()
                 }
@@ -1038,7 +1038,7 @@ impl IndexerReader {
                     // Processed above
                     unreachable!()
                 }
-                EventFilter::All(_) | EventFilter::TimeRange { .. } => {
+                EventFilter::TimeRange { .. } => {
                     return Err(IndexerError::NotSupportedError(
                         "This type of EventFilter is not supported.".to_owned(),
                     ));

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1012,8 +1012,9 @@ impl IndexerReader {
                 .await;
         } else {
             let main_where_clause = match filter {
-                EventFilter::Package(package_id) => {
-                    format!("package = '\\x{}'::bytea", package_id.to_hex())
+                EventFilter::All(fs) if fs.is_empty() => {
+                    // No filter
+                    "1 = 1".to_string()
                 }
                 EventFilter::MoveModule { package, module } => {
                     format!(
@@ -1037,14 +1038,9 @@ impl IndexerReader {
                     // Processed above
                     unreachable!()
                 }
-                EventFilter::MoveEventField { .. }
-                | EventFilter::All(_)
-                | EventFilter::Any(_)
-                | EventFilter::And(_, _)
-                | EventFilter::Or(_, _)
-                | EventFilter::TimeRange { .. } => {
+                EventFilter::All(_) | EventFilter::TimeRange { .. } => {
                     return Err(IndexerError::NotSupportedError(
-                        "This type of EventFilter is not supported.".into(),
+                        "This type of EventFilter is not supported.".to_owned(),
                     ));
                 }
             };

--- a/crates/sui-indexer/src/models/tx_indices.rs
+++ b/crates/sui-indexer/src/models/tx_indices.rs
@@ -144,10 +144,8 @@ impl TxIndex {
             .collect();
 
         let tx_affected_objects = self
-            .input_objects
+            .affected_objects
             .iter()
-            .chain(self.changed_objects.iter())
-            .unique()
             .map(|o| StoredTxAffectedObjects {
                 tx_sequence_number,
                 affected: o.to_vec(),

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -407,6 +407,7 @@ pub struct TxIndex {
     pub checkpoint_sequence_number: u64,
     pub input_objects: Vec<ObjectID>,
     pub changed_objects: Vec<ObjectID>,
+    pub affected_objects: Vec<ObjectID>,
     pub payers: Vec<SuiAddress>,
     pub sender: SuiAddress,
     pub recipients: Vec<SuiAddress>,

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -203,6 +203,9 @@ fn try_into_byte(v: &Value) -> Option<u8> {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum EventFilter {
+    /// Query by events that match all the given filters, or return all events if no filters are
+    /// supplied.
+    All(Vec<EventFilter>),
     /// Query by sender address.
     Sender(SuiAddress),
     /// Return events emitted by the given transaction.
@@ -210,8 +213,6 @@ pub enum EventFilter {
         ///digest of the transaction, as base-64 encoded string
         TransactionDigest,
     ),
-    /// Return events emitted in a specified Package.
-    Package(ObjectID),
     /// Return events emitted in a specified Move module.
     /// If the event is defined in Module A but emitted in a tx with Module B,
     /// query `MoveModule` by module B returns the event.
@@ -244,10 +245,6 @@ pub enum EventFilter {
         #[serde_as(as = "DisplayFromStr")]
         module: Identifier,
     },
-    MoveEventField {
-        path: String,
-        value: Value,
-    },
     /// Return events emitted in [start_time, end_time] interval
     #[serde(rename_all = "camelCase")]
     TimeRange {
@@ -260,32 +257,17 @@ pub enum EventFilter {
         #[serde_as(as = "BigInt<u64>")]
         end_time: u64,
     },
-
-    All(Vec<EventFilter>),
-    Any(Vec<EventFilter>),
-    And(Box<EventFilter>, Box<EventFilter>),
-    Or(Box<EventFilter>, Box<EventFilter>),
 }
 
-impl EventFilter {
-    fn try_matches(&self, item: &SuiEvent) -> SuiResult<bool> {
-        Ok(match self {
+impl Filter<SuiEvent> for EventFilter {
+    fn matches(&self, item: &SuiEvent) -> bool {
+        let _scope = monitored_scope("EventFilter::matches");
+        match self {
+            EventFilter::All(fs) => fs.iter().all(|f| f.matches(item)),
             EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
-            EventFilter::MoveEventField { path, value } => {
-                matches!(item.parsed_json.pointer(path), Some(v) if v == value)
-            }
             EventFilter::Sender(sender) => &item.sender == sender,
-            EventFilter::Package(object_id) => &item.package_id == object_id,
             EventFilter::MoveModule { package, module } => {
                 &item.transaction_module == module && &item.package_id == package
-            }
-            EventFilter::All(filters) => filters.iter().all(|f| f.matches(item)),
-            EventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
-            EventFilter::And(f1, f2) => {
-                EventFilter::All(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
-            }
-            EventFilter::Or(f1, f2) => {
-                EventFilter::Any(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
             }
             EventFilter::Transaction(digest) => digest == &item.id.tx_digest,
 
@@ -302,21 +284,7 @@ impl EventFilter {
             EventFilter::MoveEventModule { package, module } => {
                 &item.type_.module == module && &ObjectID::from(item.type_.address) == package
             }
-        })
-    }
-
-    pub fn and(self, other_filter: EventFilter) -> Self {
-        Self::All(vec![self, other_filter])
-    }
-    pub fn or(self, other_filter: EventFilter) -> Self {
-        Self::Any(vec![self, other_filter])
-    }
-}
-
-impl Filter<SuiEvent> for EventFilter {
-    fn matches(&self, item: &SuiEvent) -> bool {
-        let _scope = monitored_scope("EventFilter::matches");
-        self.try_matches(item).unwrap_or_default()
+        }
     }
 }
 

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -203,9 +203,8 @@ fn try_into_byte(v: &Value) -> Option<u8> {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum EventFilter {
-    /// Query by events that match all the given filters, or return all events if no filters are
-    /// supplied.
-    All(Vec<EventFilter>),
+    /// Return all events.
+    All([Box<EventFilter>; 0]),
     /// Query by sender address.
     Sender(SuiAddress),
     /// Return events emitted by the given transaction.
@@ -263,7 +262,7 @@ impl Filter<SuiEvent> for EventFilter {
     fn matches(&self, item: &SuiEvent) -> bool {
         let _scope = monitored_scope("EventFilter::matches");
         match self {
-            EventFilter::All(fs) => fs.iter().all(|f| f.matches(item)),
+            EventFilter::All([]) => true,
             EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
             EventFilter::Sender(sender) => &item.sender == sender,
             EventFilter::MoveModule { package, module } => {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6106,6 +6106,22 @@
       "EventFilter": {
         "oneOf": [
           {
+            "description": "Query by events that match all the given filters, or return all events if no filters are supplied.",
+            "type": "object",
+            "required": [
+              "All"
+            ],
+            "properties": {
+              "All": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EventFilter"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by sender address.",
             "type": "object",
             "required": [
@@ -6127,19 +6143,6 @@
             "properties": {
               "Transaction": {
                 "$ref": "#/components/schemas/TransactionDigest"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events emitted in a specified Package.",
-            "type": "object",
-            "required": [
-              "Package"
-            ],
-            "properties": {
-              "Package": {
-                "$ref": "#/components/schemas/ObjectID"
               }
             },
             "additionalProperties": false
@@ -6220,28 +6223,6 @@
             "additionalProperties": false
           },
           {
-            "type": "object",
-            "required": [
-              "MoveEventField"
-            ],
-            "properties": {
-              "MoveEventField": {
-                "type": "object",
-                "required": [
-                  "path",
-                  "value"
-                ],
-                "properties": {
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": true
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
             "description": "Return events emitted in [start_time, end_time] interval",
             "type": "object",
             "required": [
@@ -6272,80 +6253,6 @@
                     ]
                   }
                 }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "All"
-            ],
-            "properties": {
-              "All": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Any"
-            ],
-            "properties": {
-              "Any": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "And"
-            ],
-            "properties": {
-              "And": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Or"
-            ],
-            "properties": {
-              "Or": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6106,7 +6106,7 @@
       "EventFilter": {
         "oneOf": [
           {
-            "description": "Query by events that match all the given filters, or return all events if no filters are supplied.",
+            "description": "Return all events.",
             "type": "object",
             "required": [
               "All"
@@ -6114,9 +6114,7 @@
             "properties": {
               "All": {
                 "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
+                "maxItems": 0
               }
             },
             "additionalProperties": false

--- a/crates/sui-sdk/examples/event_api.rs
+++ b/crates/sui-sdk/examples/event_api.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let descending = true;
     let query_events = sui
         .event_api()
-        .query_events(EventFilter::All(vec![]), None, Some(5), descending) // query first 5 events in descending order
+        .query_events(EventFilter::All([]), None, Some(5), descending) // query first 5 events in descending order
         .await?;
     println!(" *** Query events *** ");
     println!("{:?}", query_events);
@@ -39,10 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
     println!("WS version {:?}", ws.api_version());
 
-    let mut subscribe = ws
-        .event_api()
-        .subscribe_event(EventFilter::All(vec![]))
-        .await?;
+    let mut subscribe = ws.event_api().subscribe_event(EventFilter::All([])).await?;
 
     loop {
         println!("{:?}", subscribe.next().await);

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -1033,7 +1033,7 @@ impl EventApi {
     ///         .await?;
     ///     let mut subscribe_all = sui
     ///         .event_api()
-    ///         .subscribe_event(EventFilter::All(vec![]))
+    ///         .subscribe_event(EventFilter::All([]))
     ///         .await?;
     ///     loop {
     ///         println!("{:?}", subscribe_all.next().await);


### PR DESCRIPTION
## Description

Broaden the definition of "affected object" to include objects that a transaction creates and then immediately wraps, or objects that it unwraps and then immediately deletes. This ensures that a transaction will show up in the response to an `affectedObject` query if and only if the Object's ID shows up in its `objectChanges` response.

## Test plan

Updated GraphQL E2E test:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests \
  --features staging -- affected_object
```

## Stack

- #19474 
- #19614 
- #19615 
- #19616 
- #19617

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: A transaction's "affected objects" include objects that it created and wrapped, or unwrapped.
- [x] JSON-RPC: A transaction's "affected objects" include objects that it created and wrapped, or unwrapped.
- [x] GraphQL: A transaction's "affected objects" include objects that it created and wrapped, or unwrapped.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
