### PR TITLE
pick(19618), indexer: affected objects include created+wrapped/unwrapped+deleted

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -511,7 +511,7 @@ impl CheckpointHandler {
             let move_calls = tx
                 .move_calls()
                 .into_iter()
-                .map(|(p, m, f)| (p.clone(), m.to_string(), f.to_string()))
+                .map(|(p, m, f)| (*p, m.to_string(), f.to_string()))
                 .collect();
 
             db_tx_indices.push(TxIndex {

--- a/crates/sui-indexer/src/models/tx_indices.rs
+++ b/crates/sui-indexer/src/models/tx_indices.rs
@@ -144,10 +144,8 @@ impl TxIndex {
             .collect();
 
         let tx_affected_objects = self
-            .input_objects
+            .affected_objects
             .iter()
-            .chain(self.changed_objects.iter())
-            .unique()
             .map(|o| StoredTxAffectedObjects {
                 tx_sequence_number,
                 affected: o.to_vec(),

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -401,6 +401,7 @@ pub struct TxIndex {
     pub checkpoint_sequence_number: u64,
     pub input_objects: Vec<ObjectID>,
     pub changed_objects: Vec<ObjectID>,
+    pub affected_objects: Vec<ObjectID>,
     pub payers: Vec<SuiAddress>,
     pub sender: SuiAddress,
     pub recipients: Vec<SuiAddress>,


### PR DESCRIPTION
## Description

Broaden the definition of "affected object" to include objects that a transaction creates and then immediately wraps, or objects that it unwraps and then immediately deletes. This ensures that a transaction will show up in the response to an `affectedObject` query if and only if the Object's ID shows up in its `objectChanges` response.

## Test plan

Updated GraphQL E2E test:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests \
  --features staging -- affected_object
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
