### PR TITLE
indexer: no need to deserialize dynamic fields

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -1,22 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use itertools::Itertools;
-use sui_types::dynamic_field::visitor as DFV;
-use tap::tap::TapFallible;
-use tokio::sync::watch;
+use sui_types::dynamic_field::DynamicFieldInfo;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::info;
 
-use move_core_types::annotated_value::MoveTypeLayout;
-use move_core_types::language_storage::TypeTag;
+use move_core_types::language_storage::{StructTag, TypeTag};
 use mysten_metrics::{get_metrics, spawn_monitored_task};
 use sui_data_ingestion_core::Worker;
-use sui_package_resolver::{PackageStore, PackageStoreWithLruCache, Resolver};
 use sui_rest_api::{CheckpointData, CheckpointTransaction};
 use sui_types::base_types::ObjectID;
 use sui_types::dynamic_field::DynamicFieldType;
@@ -32,11 +28,9 @@ use sui_types::transaction::TransactionDataAPI;
 
 use crate::errors::IndexerError;
 use crate::handlers::committer::start_tx_checkpoint_commit_task;
-use crate::handlers::tx_processor::IndexingPackageBuffer;
 use crate::metrics::IndexerMetrics;
 use crate::models::display::StoredDisplay;
 use crate::models::obj_indices::StoredObjectVersion;
-use crate::store::package_resolver::{IndexerStorePackageResolver, InterimPackageResolver};
 use crate::store::{IndexerStore, PgIndexerStore};
 use crate::types::{
     EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent,
@@ -72,12 +66,10 @@ pub async fn new_handlers(
 
     let state_clone = state.clone();
     let metrics_clone = metrics.clone();
-    let (tx, package_tx) = watch::channel(None);
     spawn_monitored_task!(start_tx_checkpoint_commit_task(
         state_clone,
         metrics_clone,
         indexed_checkpoint_receiver,
-        tx,
         next_checkpoint_sequence_number,
         cancel.clone()
     ));
@@ -85,7 +77,6 @@ pub async fn new_handlers(
         state,
         metrics,
         indexed_checkpoint_sender,
-        package_tx,
     ))
 }
 
@@ -93,10 +84,6 @@ pub struct CheckpointHandler {
     state: PgIndexerStore,
     metrics: IndexerMetrics,
     indexed_checkpoint_sender: mysten_metrics::metered_channel::Sender<CheckpointDataToCommit>,
-    // buffers for packages that are being indexed but not committed to DB,
-    // they will be periodically GCed to avoid OOM.
-    package_buffer: Arc<Mutex<IndexingPackageBuffer>>,
-    package_resolver: Arc<Resolver<PackageStoreWithLruCache<InterimPackageResolver>>>,
 }
 
 #[async_trait]
@@ -126,19 +113,9 @@ impl Worker for CheckpointHandler {
             checkpoint,
             Arc::new(self.metrics.clone()),
             Self::index_packages(std::slice::from_ref(checkpoint), &self.metrics),
-            self.package_resolver.clone(),
         )
         .await?;
         self.indexed_checkpoint_sender.send(checkpoint_data).await?;
-        Ok(())
-    }
-
-    fn preprocess_hook(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
-        let package_objects = Self::get_package_objects(std::slice::from_ref(checkpoint));
-        self.package_buffer
-            .lock()
-            .unwrap()
-            .insert_packages(package_objects);
         Ok(())
     }
 }
@@ -148,23 +125,11 @@ impl CheckpointHandler {
         state: PgIndexerStore,
         metrics: IndexerMetrics,
         indexed_checkpoint_sender: mysten_metrics::metered_channel::Sender<CheckpointDataToCommit>,
-        package_tx: watch::Receiver<Option<CheckpointSequenceNumber>>,
     ) -> Self {
-        let package_buffer = IndexingPackageBuffer::start(package_tx);
-        let package_db_resolver = IndexerStorePackageResolver::new(state.pool());
-        let in_mem_package_resolver = InterimPackageResolver::new(
-            package_db_resolver,
-            package_buffer.clone(),
-            metrics.clone(),
-        );
-        let cached_package_resolver = PackageStoreWithLruCache::new(in_mem_package_resolver);
-        let package_resolver = Arc::new(Resolver::new(cached_package_resolver));
         Self {
             state,
             metrics,
             indexed_checkpoint_sender,
-            package_buffer,
-            package_resolver,
         }
     }
 
@@ -278,7 +243,6 @@ impl CheckpointHandler {
         data: &CheckpointData,
         metrics: Arc<IndexerMetrics>,
         packages: Vec<IndexedPackage>,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
     ) -> Result<CheckpointDataToCommit, IndexerError> {
         let checkpoint_seq = data.checkpoint_summary.sequence_number;
         info!(checkpoint_seq, "Indexing checkpoint data blob");
@@ -288,9 +252,9 @@ impl CheckpointHandler {
 
         // Index Objects
         let object_changes: TransactionObjectChangesToCommit =
-            Self::index_objects(data, &metrics, package_resolver.clone()).await?;
+            Self::index_objects(data, &metrics).await?;
         let object_history_changes: TransactionObjectChangesToCommit =
-            Self::index_objects_history(data, package_resolver.clone()).await?;
+            Self::index_objects_history(data).await?;
         let object_versions = Self::derive_object_versions(&object_history_changes);
 
         let (checkpoint, db_transactions, db_events, db_tx_indices, db_event_indices, db_displays) = {
@@ -538,7 +502,6 @@ impl CheckpointHandler {
     pub(crate) async fn index_objects(
         data: &CheckpointData,
         metrics: &IndexerMetrics,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
     ) -> Result<TransactionObjectChangesToCommit, IndexerError> {
         let _timer = metrics.indexing_objects_latency.start_timer();
         let checkpoint_seq = data.checkpoint_summary.sequence_number;
@@ -555,12 +518,10 @@ impl CheckpointHandler {
             .collect();
 
         let latest_live_output_objects = data.latest_live_output_objects();
-        let latest_live_output_object_layouts =
-            type_layout_map(&latest_live_output_objects, package_resolver).await?;
         let changed_objects = latest_live_output_objects
             .into_iter()
             .map(|o| {
-                try_extract_df_kind(o, &latest_live_output_object_layouts)
+                try_extract_df_kind(o)
                     .map(|df_kind| IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -574,7 +535,6 @@ impl CheckpointHandler {
     // similar to index_objects, but objects_history keeps all versions of objects
     async fn index_objects_history(
         data: &CheckpointData,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
     ) -> Result<TransactionObjectChangesToCommit, IndexerError> {
         let checkpoint_seq = data.checkpoint_summary.sequence_number;
         let deleted_objects = data
@@ -599,11 +559,10 @@ impl CheckpointHandler {
 
         // TODO(gegaowp): the current df_info implementation is not correct,
         // but we have decided remove all df_* except df_kind.
-        let output_layouts = type_layout_map(&output_objects, package_resolver).await?;
         let changed_objects = output_objects
             .into_iter()
             .map(|o| {
-                try_extract_df_kind(o, &output_layouts)
+                try_extract_df_kind(o)
                     .map(|df_kind| IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -641,80 +600,13 @@ impl CheckpointHandler {
             })
             .collect()
     }
-
-    pub(crate) fn get_package_objects(
-        checkpoint_data: &[CheckpointData],
-    ) -> Vec<(IndexedPackage, Object)> {
-        checkpoint_data
-            .iter()
-            .flat_map(|data| {
-                let checkpoint_sequence_number = data.checkpoint_summary.sequence_number;
-                data.transactions
-                    .iter()
-                    .flat_map(|tx| &tx.output_objects)
-                    .filter_map(|o| {
-                        if let sui_types::object::Data::Package(p) = &o.data {
-                            let indexed_pkg = IndexedPackage {
-                                package_id: o.id(),
-                                move_package: p.clone(),
-                                checkpoint_sequence_number,
-                            };
-                            Some((indexed_pkg, o.clone()))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect()
-    }
-}
-
-/// Resolve the types of all `objects` and return them in a map. This is done in one go, rather
-/// than one at a time to allow type resolution of distinct types to happen concurrently.
-async fn type_layout_map(
-    objects: &[&Object],
-    package_resolver: Arc<Resolver<impl PackageStore>>,
-) -> IndexerResult<HashMap<TypeTag, MoveTypeLayout>> {
-    let types: HashSet<TypeTag> = objects
-        .iter()
-        .filter_map(|o| Some(o.data.try_as_move()?.type_().clone().into()))
-        .collect();
-
-    info!("Resolving layouts for {} types.", types.len());
-
-    let futures: Vec<_> = types
-        .iter()
-        .map(|type_| {
-            let package_resolver = package_resolver.clone();
-            async move {
-                package_resolver
-                    .type_layout(type_.clone())
-                    .await
-                    .map_err(|e| {
-                        IndexerError::DynamicFieldError(format!(
-                            "Fail to resolve layout for {}: {e}.",
-                            type_.to_canonical_display(/* with_prefix */ true),
-                        ))
-                    })
-            }
-        })
-        .collect();
-
-    let layouts = futures::future::try_join_all(futures).await?;
-    Ok(HashMap::from_iter(
-        types.into_iter().zip(layouts.into_iter()),
-    ))
 }
 
 /// If `o` is a dynamic `Field<K, V>`, determine whether it represents a Dynamic Field or a Dynamic
-/// Object Field.
-fn try_extract_df_kind(
-    o: &Object,
-    layouts: &HashMap<TypeTag, MoveTypeLayout>,
-) -> IndexerResult<Option<DynamicFieldType>> {
+/// Object Field based on its type.
+fn try_extract_df_kind(o: &Object) -> IndexerResult<Option<DynamicFieldType>> {
     // Skip if not a move object
-    let Some(move_object) = o.data.try_as_move().cloned() else {
+    let Some(move_object) = o.data.try_as_move() else {
         return Ok(None);
     };
 
@@ -722,16 +614,17 @@ fn try_extract_df_kind(
         return Ok(None);
     }
 
-    let type_: TypeTag = move_object.type_().clone().into();
-    let layout = layouts.get(&type_).ok_or_else(|| {
-        IndexerError::DynamicFieldError(format!(
-            "Cannot find layout for {}.",
-            type_.to_canonical_display(/* with_prefix */ true)
-        ))
-    })?;
+    let type_: StructTag = move_object.type_().clone().into();
+    let [name, _] = type_.type_params.as_slice() else {
+        return Ok(None);
+    };
 
-    let field =
-        DFV::FieldVisitor::deserialize(move_object.contents(), layout).tap_err(|e| warn!("{e}"))?;
-
-    Ok(Some(field.kind))
+    Ok(Some(
+        if matches!(name, TypeTag::Struct(s) if DynamicFieldInfo::is_dynamic_object_field_wrapper(s))
+        {
+            DynamicFieldType::DynamicObject
+        } else {
+            DynamicFieldType::DynamicField
+        },
+    ))
 }

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -4,7 +4,6 @@
 use std::collections::{BTreeMap, HashMap};
 
 use tap::tap::TapFallible;
-use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use tracing::{error, info};
@@ -23,7 +22,6 @@ pub async fn start_tx_checkpoint_commit_task<S>(
     state: S,
     metrics: IndexerMetrics,
     tx_indexing_receiver: mysten_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
-    commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
     cancel: CancellationToken,
 ) -> IndexerResult<()>
@@ -60,7 +58,7 @@ where
             next_checkpoint_sequence_number += 1;
             let epoch_number_option = epoch.as_ref().map(|epoch| epoch.new_epoch.epoch);
             if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
-                commit_checkpoints(&state, batch, epoch, &metrics, &commit_notifier).await;
+                commit_checkpoints(&state, batch, epoch, &metrics).await;
                 batch = vec![];
             }
             if let Some(epoch_number) = epoch_number_option {
@@ -74,7 +72,7 @@ where
             }
         }
         if !batch.is_empty() && unprocessed.is_empty() {
-            commit_checkpoints(&state, batch, None, &metrics, &commit_notifier).await;
+            commit_checkpoints(&state, batch, None, &metrics).await;
             batch = vec![];
         }
     }
@@ -91,7 +89,6 @@ async fn commit_checkpoints<S>(
     indexed_checkpoint_batch: Vec<CheckpointDataToCommit>,
     epoch: Option<EpochToCommit>,
     metrics: &IndexerMetrics,
-    commit_notifier: &watch::Sender<Option<CheckpointSequenceNumber>>,
 ) where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
@@ -228,10 +225,6 @@ async fn commit_checkpoints<S>(
     }
 
     let elapsed = guard.stop_and_record();
-
-    commit_notifier
-        .send(Some(last_checkpoint_seq))
-        .expect("Commit watcher should not be closed");
 
     info!(
         elapsed,

--- a/crates/sui-indexer/src/handlers/tx_processor.rs
+++ b/crates/sui-indexer/src/handlers/tx_processor.rs
@@ -1,123 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO remove the dead_code attribute after integration is done
-#![allow(dead_code)]
+use std::collections::HashMap;
 
 use async_trait::async_trait;
-use mysten_metrics::monitored_scope;
-use mysten_metrics::spawn_monitored_task;
-use sui_rest_api::CheckpointData;
-use tokio::sync::watch;
-
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use sui_types::object::Object;
-use tokio::time::Duration;
-use tokio::time::Instant;
-
 use sui_json_rpc::get_balance_changes_from_effect;
 use sui_json_rpc::get_object_changes;
 use sui_json_rpc::ObjectProvider;
+use sui_rest_api::CheckpointData;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::object::Object;
 use sui_types::transaction::{TransactionData, TransactionDataAPI};
-use tracing::info;
-
-use sui_types::base_types::ObjectID;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::errors::IndexerError;
 use crate::metrics::IndexerMetrics;
-use crate::types::IndexedPackage;
 use crate::types::{IndexedObjectChange, IndexerResult};
-
-// GC the buffer every 300 checkpoints, or 5 minutes
-pub const BUFFER_GC_INTERVAL: Duration = Duration::from_secs(300);
-/// An in-mem buffer for modules during writer path indexing.
-/// It has static lifetime. Since we batch process checkpoints,
-/// it's possible that when a package is looked up (e.g. to create dynamic field),
-/// it has not been persisted in the database yet. So it works as an in-mem
-/// store for package resolution. To avoid bloating memory, we GC modules
-/// that are older than the committed checkpoints.
-pub struct IndexingPackageBuffer {
-    packages: HashMap<
-        ObjectID,
-        (
-            Arc<Object>,
-            u64, /* package version */
-            CheckpointSequenceNumber,
-        ),
-    >,
-}
-
-impl IndexingPackageBuffer {
-    pub fn start(
-        commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
-    ) -> Arc<Mutex<Self>> {
-        let cache = Arc::new(Mutex::new(Self {
-            packages: HashMap::new(),
-        }));
-        let cache_clone = cache.clone();
-        spawn_monitored_task!(Self::remove_committed(cache_clone, commit_watcher));
-        cache
-    }
-
-    pub async fn remove_committed(
-        cache: Arc<Mutex<Self>>,
-        commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
-    ) {
-        let mut interval = tokio::time::interval_at(Instant::now(), BUFFER_GC_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            interval.tick().await;
-            let _scope = monitored_scope("IndexingPackageBuffer::remove_committed");
-            let Some(committed_checkpoint) = *commit_watcher.borrow() else {
-                continue;
-            };
-            let mut cache = cache.lock().unwrap();
-            info!(
-                "About to GC packages older than: {committed_checkpoint}. Cache size is {}",
-                cache.packages.len()
-            );
-            let mut to_remove = vec![];
-            for (id, (_, _, checkpoint_seq)) in cache.packages.iter() {
-                if *checkpoint_seq <= committed_checkpoint {
-                    to_remove.push(*id);
-                }
-            }
-            for id in to_remove {
-                cache.packages.remove(&id);
-            }
-        }
-    }
-
-    pub fn insert_packages(&mut self, new_package_objects: Vec<(IndexedPackage, Object)>) {
-        let new_packages = new_package_objects
-            .into_iter()
-            .map(|(p, obj)| {
-                (
-                    p.package_id,
-                    (
-                        Arc::new(obj),
-                        p.move_package.version().value(),
-                        p.checkpoint_sequence_number,
-                    ),
-                )
-            })
-            .collect::<HashMap<_, _>>();
-        self.packages.extend(new_packages);
-    }
-
-    pub fn get_package(&self, id: &ObjectID) -> Option<Arc<Object>> {
-        self.packages.get(id).as_ref().map(|(o, _, _)| o.clone())
-    }
-
-    pub fn get_version(&self, id: &ObjectID) -> Option<u64> {
-        self.packages.get(id).as_ref().map(|(_, v, _)| *v)
-    }
-}
 
 pub struct InMemObjectCache {
     id_map: HashMap<ObjectID, Object>,


### PR DESCRIPTION
## Description

Further simplification to dynamic field indexing, where we avoid deserializing dynamic fields altogether and extract the only piece of information we need (whether the DF is a dynamic field or a dynamic object field) from its type.

DF deserialization was also the only reason to perform package resolution during indexing, so this change also means we can remove the package resolver, package buffer and logic to keep those up-to-date (pushing in new packages before indexing a checkpoint, and "evicting" packages after a checkpoint had been processed).

## Test plan

```
sui$ cargo nextest run -p sui-graphql-e2e-tests
```

## Stack

- #19517
- #19518 
- #19519 
- #19520 
- #19521 
- #19548 
- #19554
- #19565 
- #19576 
- #19621 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
