### PR TITLE
[Cleanup] remove rolling hash from consensus handler

### DIFF
--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -3,17 +3,15 @@
 use std::fmt::Display;
 
 use consensus_core::{BlockAPI, CommitDigest};
-use fastcrypto::hash::Hash;
-use narwhal_types::{BatchAPI, CertificateAPI, ConsensusOutputDigest, HeaderAPI};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
 
 use crate::consensus_types::AuthorityIndex;
 
 /// A list of tuples of:
-/// (certificate origin authority index, all transactions corresponding to the certificate).
-/// For each transaction, returns the serialized transaction and the deserialized transaction.
-type ConsensusOutputTransactions<'a> = Vec<(AuthorityIndex, Vec<(&'a [u8], ConsensusTransaction)>)>;
+/// (block origin authority index, all transactions contained in the block).
+/// For each transaction, returns deserialized transaction and its serialized size.
+type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(ConsensusTransaction, usize)>)>;
 
 pub(crate) trait ConsensusOutputAPI: Display {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
@@ -27,81 +25,10 @@ pub(crate) trait ConsensusOutputAPI: Display {
     fn commit_sub_dag_index(&self) -> u64;
 
     /// Returns all transactions in the commit.
-    fn transactions(&self) -> ConsensusOutputTransactions<'_>;
+    fn transactions(&self) -> ConsensusOutputTransactions;
 
     /// Returns the digest of consensus output.
     fn consensus_digest(&self, protocol_config: &ProtocolConfig) -> ConsensusCommitDigest;
-}
-
-impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
-    fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
-        if !self.sub_dag.reputation_score.final_of_schedule {
-            return None;
-        }
-        Some(
-            self.sub_dag
-                .reputation_score
-                .authorities_by_score_desc()
-                .into_iter()
-                .map(|(id, score)| (id.0 as AuthorityIndex, score))
-                .collect(),
-        )
-    }
-
-    fn leader_round(&self) -> u64 {
-        self.sub_dag.leader_round()
-    }
-
-    fn leader_author_index(&self) -> AuthorityIndex {
-        self.sub_dag.leader.origin().0 as AuthorityIndex
-    }
-
-    fn commit_timestamp_ms(&self) -> u64 {
-        self.sub_dag.commit_timestamp()
-    }
-
-    fn commit_sub_dag_index(&self) -> u64 {
-        self.sub_dag.sub_dag_index
-    }
-
-    fn transactions(&self) -> ConsensusOutputTransactions {
-        assert!(self.sub_dag.certificates.len() == self.batches.len());
-        self.sub_dag
-            .certificates
-            .iter()
-            .zip(&self.batches)
-            .map(|(cert, batches)| {
-                assert_eq!(cert.header().payload().len(), batches.len());
-                let transactions: Vec<(&[u8], ConsensusTransaction)> =
-                    batches.iter().flat_map(|batch| {
-                        let digest = batch.digest();
-                        assert!(cert.header().payload().contains_key(&digest));
-                        batch.transactions().iter().map(move |serialized_transaction| {
-                            let transaction = match bcs::from_bytes::<ConsensusTransaction>(
-                                serialized_transaction,
-                            ) {
-                                Ok(transaction) => transaction,
-                                Err(err) => {
-                                    // This should have been prevented by transaction verifications in consensus.
-                                    panic!(
-                                        "Unexpected malformed transaction (failed to deserialize): {}\nCertificate={:?} BatchDigest={:?} Transaction={:?}",
-                                        err, cert, digest, serialized_transaction
-                                    );
-                                }
-                            };
-                            (serialized_transaction.as_ref(), transaction)
-                        })
-                    }).collect();
-                (cert.origin().0 as AuthorityIndex, transactions)
-            }).collect()
-    }
-
-    fn consensus_digest(&self, _protocol_config: &ProtocolConfig) -> ConsensusCommitDigest {
-        // We port ConsensusOutputDigest, a narwhal space object, into ConsensusCommitDigest, a sui-core space object.
-        // We assume they always have the same format.
-        static_assertions::assert_eq_size!(ConsensusCommitDigest, ConsensusOutputDigest);
-        ConsensusCommitDigest::new(self.digest().into_inner())
-    }
 }
 
 impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
@@ -148,8 +75,8 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
                         let transaction = bcs::from_bytes::<ConsensusTransaction>(tx.data());
                         match transaction {
                             Ok(transaction) => Some((
-                                tx.data(),
                                 transaction,
+                                tx.data().len(),
                             )),
                             Err(err) => {
                                 tracing::error!("Failed to deserialize sequenced consensus transaction(this should not happen) {} from {author} at {round}", err);


### PR DESCRIPTION
## Description 

- Each consensus commit includes its previous commit's digest. Commit digests are logged inside consensus. So I believe we have what is needed to debug forks without the rolling hash inside consensus handler now.
- Deprecate the `last_consensus_index` table. It's replacement `last_consensus_stats` has been populated for awhile.
- Remove Narwhal implementation of ConsensusOutputAPI.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
