### PR TITLE
[Swarm] Set default committee size to 4

### DIFF
--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -84,7 +84,7 @@ impl ConfigBuilder {
             rng: Some(OsRng),
             config_directory: config_directory.as_ref().into(),
             supported_protocol_versions_config: None,
-            committee: CommitteeConfig::Size(NonZeroUsize::new(1).unwrap()),
+            committee: CommitteeConfig::Size(NonZeroUsize::new(4).unwrap()),
             genesis_config: None,
             reference_gas_price: None,
             additional_objects: vec![],


### PR DESCRIPTION
## Description 

With committee size of 1, the network cannot remain live.
Set it to 4 to avoid mistakes in tests.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
