### PR TITLE
[Indexer] Add ingestion based backfill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13599,6 +13599,7 @@ dependencies = [
  "clap",
  "criterion",
  "csv",
+ "dashmap",
  "diesel",
  "diesel-async",
  "diesel_migrations",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -67,6 +67,7 @@ move-binary-format.workspace = true
 diesel_migrations.workspace = true
 cached.workspace = true
 tokio-stream.workspace = true
+dashmap.workspace = true
 
 [dev-dependencies]
 sui-keys.workspace = true

--- a/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/ingestion_backfill_task.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/ingestion_backfill_task.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::backfill::backfill_instances::ingestion_backfills::IngestionBackfillTrait;
+use crate::backfill::backfill_task::BackfillTask;
+use crate::database::ConnectionPool;
+use dashmap::DashMap;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+use sui_data_ingestion_core::{setup_single_workflow, Worker};
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::Notify;
+
+pub struct IngestionBackfillTask<T: IngestionBackfillTrait> {
+    ready_checkpoints: Arc<DashMap<CheckpointSequenceNumber, T::ProcessedType>>,
+    notify: Arc<Notify>,
+}
+
+impl<T: IngestionBackfillTrait + 'static> IngestionBackfillTask<T> {
+    pub async fn new(remote_store_url: String, start_checkpoint: CheckpointSequenceNumber) -> Self {
+        let ready_checkpoints = Arc::new(DashMap::new());
+        let notify = Arc::new(Notify::new());
+        let adapter: Adapter<T> = Adapter {
+            ready_checkpoints: ready_checkpoints.clone(),
+            notify: notify.clone(),
+        };
+        let (executor, _exit_sender) =
+            setup_single_workflow(adapter, remote_store_url, start_checkpoint, 200, None)
+                .await
+                .unwrap();
+        tokio::task::spawn(async move {
+            executor.await.unwrap();
+        });
+        Self {
+            ready_checkpoints,
+            notify,
+        }
+    }
+}
+
+pub struct Adapter<T: IngestionBackfillTrait> {
+    ready_checkpoints: Arc<DashMap<CheckpointSequenceNumber, T::ProcessedType>>,
+    notify: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl<T: IngestionBackfillTrait> Worker for Adapter<T> {
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
+        let processed = T::process_checkpoint(checkpoint);
+        self.ready_checkpoints
+            .insert(checkpoint.checkpoint_summary.sequence_number, processed);
+        self.notify.notify_waiters();
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: IngestionBackfillTrait> BackfillTask for IngestionBackfillTask<T> {
+    async fn backfill_range(&self, pool: ConnectionPool, range: &RangeInclusive<usize>) {
+        let mut checkpoints = vec![];
+        let mut start = *range.start();
+        let end = *range.end();
+        while start <= end {
+            while start <= end {
+                if let Some(checkpoint) = self
+                    .ready_checkpoints
+                    .remove(&(start as CheckpointSequenceNumber))
+                {
+                    checkpoints.push(checkpoint.1);
+                    start += 1;
+                } else {
+                    break;
+                }
+            }
+            if start <= end {
+                self.notify.notified().await;
+            }
+        }
+        T::commit_chunk(pool.clone(), checkpoints).await;
+    }
+}

--- a/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/mod.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod ingestion_backfill_task;
+pub mod raw_checkpoints;
+
+use crate::database::ConnectionPool;
+use sui_types::full_checkpoint_content::CheckpointData;
+
+#[async_trait::async_trait]
+pub trait IngestionBackfillTrait: Send + Sync {
+    type ProcessedType: Send + Sync;
+
+    fn process_checkpoint(checkpoint: &CheckpointData) -> Self::ProcessedType;
+    async fn commit_chunk(pool: ConnectionPool, checkpoints: Vec<Self::ProcessedType>);
+}

--- a/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/mod.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/mod.rs
@@ -11,6 +11,6 @@ use sui_types::full_checkpoint_content::CheckpointData;
 pub trait IngestionBackfillTrait: Send + Sync {
     type ProcessedType: Send + Sync;
 
-    fn process_checkpoint(checkpoint: &CheckpointData) -> Self::ProcessedType;
-    async fn commit_chunk(pool: ConnectionPool, checkpoints: Vec<Self::ProcessedType>);
+    fn process_checkpoint(checkpoint: &CheckpointData) -> Vec<Self::ProcessedType>;
+    async fn commit_chunk(pool: ConnectionPool, processed_data: Vec<Self::ProcessedType>);
 }

--- a/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/raw_checkpoints.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/raw_checkpoints.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::backfill::backfill_instances::ingestion_backfills::IngestionBackfillTrait;
+use crate::database::ConnectionPool;
+use crate::models::raw_checkpoints::StoredRawCheckpoint;
+use crate::schema::raw_checkpoints::dsl::raw_checkpoints;
+use diesel_async::RunQueryDsl;
+use sui_types::full_checkpoint_content::CheckpointData;
+
+pub struct RawCheckpointsBackFill {}
+
+#[async_trait::async_trait]
+impl IngestionBackfillTrait for RawCheckpointsBackFill {
+    type ProcessedType = StoredRawCheckpoint;
+
+    fn process_checkpoint(checkpoint: &CheckpointData) -> Self::ProcessedType {
+        StoredRawCheckpoint {
+            sequence_number: checkpoint.checkpoint_summary.sequence_number as i64,
+            certified_checkpoint: bcs::to_bytes(&checkpoint.checkpoint_summary).unwrap(),
+            checkpoint_contents: bcs::to_bytes(&checkpoint.checkpoint_contents).unwrap(),
+        }
+    }
+
+    async fn commit_chunk(pool: ConnectionPool, checkpoints: Vec<Self::ProcessedType>) {
+        let mut conn = pool.get().await.unwrap();
+        diesel::insert_into(raw_checkpoints)
+            .values(checkpoints)
+            .on_conflict_do_nothing()
+            .execute(&mut conn)
+            .await
+            .unwrap();
+    }
+}

--- a/crates/sui-indexer/src/backfill/backfill_instances/mod.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/mod.rs
@@ -1,14 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::backfill::backfill_instances::ingestion_backfills::ingestion_backfill_task::IngestionBackfillTask;
+use crate::backfill::backfill_instances::ingestion_backfills::raw_checkpoints::RawCheckpointsBackFill;
 use crate::backfill::backfill_task::BackfillTask;
-use crate::backfill::BackfillTaskKind;
+use crate::backfill::{BackfillTaskKind, IngestionBackfillKind};
 use std::sync::Arc;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
+mod ingestion_backfills;
 mod sql_backfill;
-pub mod system_state_summary_json;
+mod system_state_summary_json;
 
-pub fn get_backfill_task(kind: BackfillTaskKind) -> Arc<dyn BackfillTask> {
+pub async fn get_backfill_task(
+    kind: BackfillTaskKind,
+    range_start: usize,
+) -> Arc<dyn BackfillTask> {
     match kind {
         BackfillTaskKind::SystemStateSummaryJson => {
             Arc::new(system_state_summary_json::SystemStateSummaryJsonBackfill {})
@@ -16,5 +23,17 @@ pub fn get_backfill_task(kind: BackfillTaskKind) -> Arc<dyn BackfillTask> {
         BackfillTaskKind::Sql { sql, key_column } => {
             Arc::new(sql_backfill::SqlBackFill::new(sql, key_column))
         }
+        BackfillTaskKind::Ingestion {
+            kind,
+            remote_store_url,
+        } => match kind {
+            IngestionBackfillKind::RawCheckpoints => Arc::new(
+                IngestionBackfillTask::<RawCheckpointsBackFill>::new(
+                    remote_store_url,
+                    range_start as CheckpointSequenceNumber,
+                )
+                .await,
+            ),
+        },
     }
 }

--- a/crates/sui-indexer/src/backfill/backfill_runner.rs
+++ b/crates/sui-indexer/src/backfill/backfill_runner.rs
@@ -22,7 +22,7 @@ impl BackfillRunner {
         backfill_config: BackFillConfig,
         total_range: RangeInclusive<usize>,
     ) {
-        let task = get_backfill_task(runner_kind);
+        let task = get_backfill_task(runner_kind, *total_range.start()).await;
         Self::run_impl(pool, backfill_config, total_range, task).await;
     }
 
@@ -59,10 +59,12 @@ impl BackfillRunner {
                     println!("Finished range: {:?}.", range);
                     in_progress_clone.lock().await.remove(range.start());
                     let cur_min_in_progress = in_progress_clone.lock().await.iter().next().cloned();
-                    println!(
-                        "Minimum range start number still in progress: {:?}.",
-                        cur_min_in_progress
-                    );
+                    if let Some(cur_min_in_progress) = cur_min_in_progress {
+                        println!(
+                            "Minimum range start number still in progress: {:?}.",
+                            cur_min_in_progress
+                        );
+                    }
                 }
             })
             .await;

--- a/crates/sui-indexer/src/backfill/backfill_runner.rs
+++ b/crates/sui-indexer/src/backfill/backfill_runner.rs
@@ -68,7 +68,8 @@ impl BackfillRunner {
                     let cur_min_in_progress = in_progress_clone.lock().await.iter().next().cloned();
                     if let Some(cur_min_in_progress) = cur_min_in_progress {
                         println!(
-                            "Minimum range start number still in progress: {:?}.",
+                            "Average backfill speed: {} checkpoints/s. Minimum range start number still in progress: {:?}.",
+                            cur_min_in_progress as f64 / cur_time.elapsed().as_secs_f64(),
                             cur_min_in_progress
                         );
                     }

--- a/crates/sui-indexer/src/backfill/mod.rs
+++ b/crates/sui-indexer/src/backfill/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 
 pub mod backfill_instances;
 pub mod backfill_runner;
@@ -17,4 +17,17 @@ pub enum BackfillTaskKind {
         sql: String,
         key_column: String,
     },
+    /// Starts a backfill pipeline from the ingestion engine.
+    /// \remote_store_url is the URL of the remote store to ingest from.
+    /// Any `IngestionBackfillKind` will need to map to a type that
+    /// implements `IngestionBackfillTrait`.
+    Ingestion {
+        kind: IngestionBackfillKind,
+        remote_store_url: String,
+    },
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum IngestionBackfillKind {
+    RawCheckpoints,
 }


### PR DESCRIPTION
## Description 

This PR adds a backfill pipeline based on ingestion.
It also implement backfilling the raw checkpoints table.

## Test plan 

Run backfill locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
