### PR TITLE
[Fastpath] execute transactions certified via fastpath

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -426,7 +426,7 @@ mod tests {
     use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
     use consensus_config::{local_committee_and_keys, Parameters};
-    use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver};
+    use mysten_metrics::monitored_mpsc::UnboundedReceiver;
     use prometheus::Registry;
     use rstest::rstest;
     use sui_protocol_config::ProtocolConfig;
@@ -457,8 +457,7 @@ mod tests {
         let protocol_keypair = keypairs[own_index].1.clone();
         let network_keypair = keypairs[own_index].0.clone();
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
-        let commit_consumer = CommitConsumer::new(sender, 0);
+        let (commit_consumer, _, _) = CommitConsumer::new(0);
 
         let authority = ConsensusAuthority::start(
             network_type,
@@ -721,8 +720,7 @@ mod tests {
         let protocol_keypair = keypairs[index].1.clone();
         let network_keypair = keypairs[index].0.clone();
 
-        let (sender, receiver) = unbounded_channel("consensus_output");
-        let commit_consumer = CommitConsumer::new(sender, 0);
+        let (commit_consumer, commit_receiver, _) = CommitConsumer::new(0);
 
         let authority = ConsensusAuthority::start(
             network_type,
@@ -739,6 +737,6 @@ mod tests {
         )
         .await;
 
-        (authority, receiver)
+        (authority, commit_receiver)
     }
 }

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -19,6 +19,7 @@ use crate::{
     block::{BlockAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock},
     leader_scoring::ReputationScores,
     storage::Store,
+    TransactionIndex,
 };
 
 /// Index of a commit among all consensus commits.
@@ -109,6 +110,7 @@ pub(crate) struct CommitV1 {
     leader: BlockRef,
     /// Refs to committed blocks, in the commit order.
     blocks: Vec<BlockRef>,
+    // TODO(fastpath): record rejected transactions.
 }
 
 impl CommitAPI for CommitV1 {
@@ -293,6 +295,8 @@ pub struct CommittedSubDag {
     pub leader: BlockRef,
     /// All the committed blocks that are part of this sub-dag
     pub blocks: Vec<VerifiedBlock>,
+    /// Indices of rejected transactions in each block.
+    pub rejected_transactions: Vec<Vec<TransactionIndex>>,
     /// The timestamp of the commit, obtained from the timestamp of the leader block.
     pub timestamp_ms: BlockTimestampMs,
     /// The reference of the commit.
@@ -309,13 +313,16 @@ impl CommittedSubDag {
     pub fn new(
         leader: BlockRef,
         blocks: Vec<VerifiedBlock>,
+        rejected_transactions: Vec<Vec<TransactionIndex>>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> Self {
+        assert_eq!(blocks.len(), rejected_transactions.len());
         Self {
             leader,
             blocks,
+            rejected_transactions,
             timestamp_ms,
             commit_ref,
             reputation_scores_desc,
@@ -386,11 +393,14 @@ pub fn load_committed_subdag_from_store(
             commit_block
         })
         .collect::<Vec<_>>();
+    // TODO(fastpath): recover rejected transaction indices from commit.
+    let rejected_transactions = vec![vec![]; blocks.len()];
     let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
     let leader_block_ref = blocks[leader_block_idx].reference();
     CommittedSubDag::new(
         leader_block_ref,
         blocks,
+        rejected_transactions,
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -296,7 +296,7 @@ pub struct CommittedSubDag {
     /// All the committed blocks that are part of this sub-dag
     pub blocks: Vec<VerifiedBlock>,
     /// Indices of rejected transactions in each block.
-    pub rejected_transactions: Vec<Vec<TransactionIndex>>,
+    pub rejected_transactions_by_block: Vec<Vec<TransactionIndex>>,
     /// The timestamp of the commit, obtained from the timestamp of the leader block.
     pub timestamp_ms: BlockTimestampMs,
     /// The reference of the commit.
@@ -313,16 +313,16 @@ impl CommittedSubDag {
     pub fn new(
         leader: BlockRef,
         blocks: Vec<VerifiedBlock>,
-        rejected_transactions: Vec<Vec<TransactionIndex>>,
+        rejected_transactions_by_block: Vec<Vec<TransactionIndex>>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> Self {
-        assert_eq!(blocks.len(), rejected_transactions.len());
+        assert_eq!(blocks.len(), rejected_transactions_by_block.len());
         Self {
             leader,
             blocks,
-            rejected_transactions,
+            rejected_transactions_by_block,
             timestamp_ms,
             commit_ref,
             reputation_scores_desc,

--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -4,13 +4,20 @@
 use std::sync::{Arc, RwLock};
 use tokio::sync::watch;
 
-use mysten_metrics::monitored_mpsc::UnboundedSender;
+use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
-use crate::{CommitIndex, CommittedSubDag};
+use crate::{CommitIndex, CommittedSubDag, TransactionIndex, VerifiedBlock};
 
+#[derive(Clone)]
 pub struct CommitConsumer {
-    // A channel to send the committed sub dags through
-    pub(crate) sender: UnboundedSender<CommittedSubDag>,
+    // A channel to output the committed sub dags.
+    pub(crate) commit_sender: UnboundedSender<CommittedSubDag>,
+    // A channel to output certified and rejected transactions by batches of blocks.
+    // Each tuple contains the block containing transactions, and indices of rejected transactions.
+    // In each block, transactions that are not rejected are considered certified.
+    // Batches of blocks are sent together, to improve efficiency.
+    #[allow(unused)]
+    pub(crate) transaction_sender: UnboundedSender<Vec<(VerifiedBlock, Vec<TransactionIndex>)>>,
     // Index of the last commit that the consumer has processed. This is useful for
     // crash/recovery so mysticeti can replay the commits from the next index.
     // First commit in the replayed sequence will have index last_processed_commit_index + 1.
@@ -22,15 +29,26 @@ pub struct CommitConsumer {
 
 impl CommitConsumer {
     pub fn new(
-        sender: UnboundedSender<CommittedSubDag>,
         last_processed_commit_index: CommitIndex,
-    ) -> Self {
+    ) -> (
+        Self,
+        UnboundedReceiver<CommittedSubDag>,
+        UnboundedReceiver<Vec<(VerifiedBlock, Vec<TransactionIndex>)>>,
+    ) {
+        let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
+        let (transaction_sender, transaction_receiver) = unbounded_channel("consensus_certified");
+
         let monitor = Arc::new(CommitConsumerMonitor::new(last_processed_commit_index));
-        Self {
-            sender,
-            last_processed_commit_index,
-            monitor,
-        }
+        (
+            Self {
+                commit_sender,
+                transaction_sender,
+                last_processed_commit_index,
+                monitor,
+            },
+            commit_receiver,
+            transaction_receiver,
+        )
     }
 
     pub fn monitor(&self) -> Arc<CommitConsumerMonitor> {

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -8,7 +8,7 @@ use consensus_config::{local_committee_and_keys, Stake};
 use consensus_config::{AuthorityIndex, ProtocolKeyPair};
 use itertools::Itertools as _;
 #[cfg(test)]
-use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver};
+use mysten_metrics::monitored_mpsc::UnboundedReceiver;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use sui_macros::fail_point;
@@ -940,10 +940,10 @@ impl CoreTextFixture {
         // Need at least one subscriber to the block broadcast channel.
         let block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(commit_sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -979,7 +979,6 @@ mod test {
     use std::{collections::BTreeSet, time::Duration};
 
     use consensus_config::{AuthorityIndex, Parameters};
-    use mysten_metrics::monitored_mpsc::unbounded_channel;
     use sui_protocol_config::ProtocolConfig;
     use tokio::time::sleep;
 
@@ -1039,10 +1038,10 @@ mod test {
             dag_state.clone(),
         ));
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1157,10 +1156,10 @@ mod test {
             dag_state.clone(),
         ));
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1254,10 +1253,10 @@ mod test {
             dag_state.clone(),
         ));
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1359,10 +1358,10 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1448,10 +1447,10 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1636,10 +1635,10 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
@@ -1701,10 +1700,10 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -390,7 +390,6 @@ impl CoreThreadDispatcher for MockCoreThreadDispatcher {
 
 #[cfg(test)]
 mod test {
-    use mysten_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::RwLock;
 
     use super::*;
@@ -423,14 +422,14 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let _block_receiver = signal_receivers.block_broadcast_receiver();
-        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
         let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
             dag_state.clone(),
         ));
         let commit_observer = CommitObserver::new(
             context.clone(),
-            CommitConsumer::new(sender.clone(), 0),
+            commit_consumer,
             dag_state.clone(),
             store,
             leader_schedule.clone(),

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -888,6 +888,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
             vec![],
+            vec![],
             context.clock.timestamp_utc_ms(),
             CommitRef::new(1, CommitDigest::MIN),
             vec![],
@@ -969,6 +970,7 @@ mod tests {
         let leader_block = leader.unwrap();
         let leader_ref = leader_block.reference();
         let commit_index = 1;
+        let rejected_transactions = vec![vec![]; blocks.len()];
 
         let last_commit = TrustedCommit::new_for_test(
             commit_index,
@@ -984,6 +986,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             leader_ref,
             blocks,
+            rejected_transactions,
             context.clock.timestamp_utc_ms(),
             last_commit.reference(),
             vec![],
@@ -1535,6 +1538,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
             vec![],
+            vec![],
             context.clock.timestamp_utc_ms(),
             CommitRef::new(1, CommitDigest::MIN),
             vec![],
@@ -1622,6 +1626,7 @@ mod tests {
         let leader_block = leader.unwrap();
         let leader_ref = leader_block.reference();
         let commit_index = 1;
+        let rejected_transactions = vec![vec![]; blocks.len()];
 
         let last_commit = TrustedCommit::new_for_test(
             commit_index,
@@ -1637,6 +1642,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             leader_ref,
             blocks,
+            rejected_transactions,
             context.clock.timestamp_utc_ms(),
             last_commit.reference(),
             vec![],

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -692,6 +692,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
             blocks,
+            vec![],
             context.clock.timestamp_utc_ms(),
             CommitRef::new(1, CommitDigest::MIN),
             vec![],

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -107,6 +107,10 @@ impl Linearizer {
         // Sort the blocks of the sub-dag blocks
         sort_sub_dag_blocks(&mut to_commit);
 
+        // TODO(fastpath): determine rejected transactions from voting.
+        // Get rejected transactions.
+        let rejected_transactions = vec![vec![]; to_commit.len()];
+
         // Create the Commit.
         let commit = Commit::new(
             last_commit_index + 1,
@@ -127,6 +131,7 @@ impl Linearizer {
         let sub_dag = CommittedSubDag::new(
             leader_block_ref,
             to_commit,
+            rejected_transactions,
             timestamp_ms,
             commit.reference(),
             reputation_scores_desc,

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -161,6 +161,8 @@ impl DagBuilder {
 
         sort_sub_dag_blocks(&mut to_commit);
 
+        let rejected_transactions = vec![vec![]; to_commit.len()];
+
         let commit = TrustedCommit::new_for_test(
             commit_index,
             CommitDigest::MIN,
@@ -175,6 +177,7 @@ impl DagBuilder {
         let sub_dag = CommittedSubDag::new(
             leader_block_ref,
             to_commit,
+            rejected_transactions,
             timestamp_ms,
             commit.reference(),
             vec![],

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -278,7 +278,7 @@ pub struct AuthorityMetrics {
     post_processing_total_tx_had_event_processed: IntCounter,
     post_processing_total_failures: IntCounter,
 
-    /// Consensus handler metrics
+    /// Consensus commit and transaction handler metrics
     pub consensus_handler_processed: IntCounterVec,
     pub consensus_handler_transaction_sizes: HistogramVec,
     pub consensus_handler_num_low_scoring_authorities: IntGauge,
@@ -292,6 +292,8 @@ pub struct AuthorityMetrics {
     pub consensus_committed_user_transactions: IntGaugeVec,
     pub consensus_calculated_throughput: IntGauge,
     pub consensus_calculated_throughput_profile: IntGauge,
+    pub consensus_transaction_handler_processed: IntCounterVec,
+    pub consensus_transaction_handler_fastpath_executions: IntCounter,
 
     pub limits_metrics: Arc<LimitsMetrics>,
 
@@ -759,6 +761,17 @@ impl AuthorityMetrics {
                 "The current active calculated throughput profile",
                 registry
             ).unwrap(),
+            consensus_transaction_handler_processed: register_int_counter_vec_with_registry!(
+                "consensus_transaction_handler_processed",
+                "Number of transactions processed by consensus transaction handler, by whether they are certified or rejected.",
+                &["outcome"],
+                registry
+            ).unwrap(),
+            consensus_transaction_handler_fastpath_executions: register_int_counter_with_registry!(
+                "consensus_transaction_handler_fastpath_executions",
+                "Number of fastpath transactions sent for execution by consensus transaction handler",
+                registry,
+            ).unwrap(),
             execution_queueing_latency: LatencyObserver::new(),
             txn_ready_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
             execution_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
@@ -1196,6 +1209,7 @@ impl AuthorityState {
 
         self.metrics.total_cert_attempts.inc();
 
+        // TODO(fastpath): use a separate function to check if a transaction should be executed in fastpath.
         if !certificate.contains_shared_object() {
             // Shared object transactions need to be sequenced by the consensus before enqueueing
             // for execution, done in AuthorityPerEpochStore::handle_consensus_transaction().

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3685,7 +3685,7 @@ impl AuthorityPerEpochStore {
                 kind: ConsensusTransactionKind::UserTransaction(_tx),
                 ..
             }) => {
-                // TODO(fastpath): implement handling of consensus finalized user transactions.
+                // TODO(fastpath): implement handling of user transactions from consensus commits.
                 Ok(ConsensusCertificateResult::Ignored)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1878,20 +1878,26 @@ impl AuthorityPerEpochStore {
             .pending_consensus_transactions
             .multi_insert(key_value_pairs)?;
 
-        // TODO: lock once for all insert() calls.
-        for transaction in transactions {
-            if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
-                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
-                // Caller is responsible for performing graceful check
-                assert!(
-                    state.should_accept_user_certs(),
-                    "Reconfiguration state should allow accepting user transactions"
-                );
-                self.pending_consensus_certificates
-                    .write()
-                    .insert(*cert.digest());
-            }
+        // UserTransaction exists only when mysticeti_fastpath is enabled in protocol config.
+        let digests: Vec<_> = transactions
+            .iter()
+            .filter_map(|tx| match &tx.kind {
+                ConsensusTransactionKind::CertifiedTransaction(cert) => Some(cert.digest()),
+                ConsensusTransactionKind::UserTransaction(txn) => Some(txn.digest()),
+                _ => None,
+            })
+            .collect();
+        if !digests.is_empty() {
+            let state = lock.expect("Must pass reconfiguration lock when storing certificate");
+            // Caller is responsible for performing graceful check
+            assert!(
+                state.should_accept_user_certs(),
+                "Reconfiguration state should allow accepting user transactions"
+            );
+            let mut pending_consensus_certificates = self.pending_consensus_certificates.write();
+            pending_consensus_certificates.extend(digests);
         }
+
         Ok(())
     }
 
@@ -2768,7 +2774,7 @@ impl AuthorityPerEpochStore {
             .collect();
 
         let (
-            transactions_to_schedule,
+            verified_transactions,
             notifications,
             lock,
             final_round,
@@ -2790,10 +2796,7 @@ impl AuthorityPerEpochStore {
                 authority_metrics,
             )
             .await?;
-        self.finish_consensus_certificate_process_with_batch(
-            &mut output,
-            &transactions_to_schedule,
-        )?;
+        self.finish_consensus_certificate_process_with_batch(&mut output, &verified_transactions)?;
         output.record_consensus_commit_stats(consensus_stats.clone());
 
         // Create pending checkpoints if we are still accepting tx.
@@ -2901,7 +2904,7 @@ impl AuthorityPerEpochStore {
             self.record_end_of_message_quorum_time_metric();
         }
 
-        Ok(transactions_to_schedule)
+        Ok(verified_transactions)
     }
 
     // Adds the consensus commit prologue transaction to the beginning of input `transactions` to update
@@ -3682,7 +3685,7 @@ impl AuthorityPerEpochStore {
                 kind: ConsensusTransactionKind::UserTransaction(_tx),
                 ..
             }) => {
-                // TODO: implement handling of unsigned user transactions.
+                // TODO(fastpath): implement handling of consensus finalized user transactions.
                 Ok(ConsensusCertificateResult::Ignored)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -10,9 +10,13 @@ use std::{
 
 use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
-use consensus_core::CommitConsumerMonitor;
+use consensus_core::{CommitConsumerMonitor, TransactionIndex, VerifiedBlock};
 use lru::LruCache;
-use mysten_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
+use mysten_metrics::{
+    monitored_future,
+    monitored_mpsc::{self, UnboundedReceiver},
+    monitored_scope, spawn_monitored_task,
+};
 use serde::{Deserialize, Serialize};
 use sui_macros::{fail_point_async, fail_point_if};
 use sui_protocol_config::ProtocolConfig;
@@ -21,10 +25,13 @@ use sui_types::{
     base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest},
     digests::ConsensusCommitDigest,
     executable_transaction::{TrustedExecutableTransaction, VerifiedExecutableTransaction},
-    messages_consensus::{ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind},
+    messages_consensus::{
+        AuthorityIndex, ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
+    },
     sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
     transaction::{SenderSignedData, VerifiedTransaction},
 };
+use tokio::task::JoinSet;
 use tracing::{debug, error, info, instrument, trace_span, warn};
 
 use crate::{
@@ -38,7 +45,9 @@ use crate::{
     },
     checkpoints::{CheckpointService, CheckpointServiceNotify},
     consensus_throughput_calculator::ConsensusThroughputCalculator,
-    consensus_types::{consensus_output_api::ConsensusOutputAPI, AuthorityIndex},
+    consensus_types::consensus_output_api::{
+        parse_block_transactions, ConsensusCommitAPI, ParsedTransaction,
+    },
     execution_cache::ObjectCacheRead,
     scoring_decision::update_low_scoring_authorities,
     transaction_manager::TransactionManager,
@@ -69,7 +78,8 @@ impl ConsensusHandlerInitializer {
         }
     }
 
-    pub fn new_for_testing(
+    #[cfg(test)]
+    pub(crate) fn new_for_testing(
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
     ) -> Self {
@@ -85,7 +95,7 @@ impl ConsensusHandlerInitializer {
         }
     }
 
-    pub fn new_consensus_handler(&self) -> ConsensusHandler<CheckpointService> {
+    pub(crate) fn new_consensus_handler(&self) -> ConsensusHandler<CheckpointService> {
         let new_epoch_start_state = self.epoch_store.epoch_start_state();
         let consensus_committee = new_epoch_start_state.get_consensus_committee();
 
@@ -99,6 +109,10 @@ impl ConsensusHandlerInitializer {
             self.state.metrics.clone(),
             self.throughput_calculator.clone(),
         )
+    }
+
+    pub(crate) fn metrics(&self) -> &Arc<AuthorityMetrics> {
+        &self.state.metrics
     }
 }
 
@@ -122,7 +136,8 @@ pub struct ConsensusHandler<C> {
     metrics: Arc<AuthorityMetrics>,
     /// Lru cache to quickly discard transactions processed by consensus
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
-    transaction_scheduler: AsyncTransactionScheduler,
+    /// Enqueues transactions to the transaction manager via a separate task.
+    transaction_manager_sender: TransactionManagerSender,
     /// Using the throughput calculator to record the current consensus throughput
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
 }
@@ -148,8 +163,8 @@ impl<C> ConsensusHandler<C> {
         if !last_consensus_stats.stats.is_initialized() {
             last_consensus_stats.stats = ConsensusStats::new(committee.size());
         }
-        let transaction_scheduler =
-            AsyncTransactionScheduler::start(transaction_manager, epoch_store.clone());
+        let transaction_manager_sender =
+            TransactionManagerSender::start(transaction_manager, epoch_store.clone());
         Self {
             epoch_store,
             last_consensus_stats,
@@ -159,31 +174,29 @@ impl<C> ConsensusHandler<C> {
             committee,
             metrics,
             processed_cache: LruCache::new(NonZeroUsize::new(PROCESSED_CACHE_CAP).unwrap()),
-            transaction_scheduler,
+            transaction_manager_sender,
             throughput_calculator,
         }
     }
 
     /// Returns the last subdag index processed by the handler.
-    pub fn last_processed_subdag_index(&self) -> u64 {
+    pub(crate) fn last_processed_subdag_index(&self) -> u64 {
         self.last_consensus_stats.index.sub_dag_index
+    }
+
+    pub(crate) fn transaction_manager_sender(&self) -> &TransactionManagerSender {
+        &self.transaction_manager_sender
     }
 }
 
 impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     #[instrument(level = "debug", skip_all)]
-    async fn handle_consensus_output(&mut self, consensus_output: impl ConsensusOutputAPI) {
+    async fn handle_consensus_commit(&mut self, consensus_commit: impl ConsensusCommitAPI) {
         let _scope = monitored_scope("HandleConsensusOutput");
-
-        // This code no longer supports old protocol versions.
-        assert!(self
-            .epoch_store
-            .protocol_config()
-            .consensus_order_end_of_epoch_last());
 
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
 
-        let round = consensus_output.leader_round();
+        let round = consensus_commit.leader_round();
 
         // TODO: Remove this once narwhal is deprecated. For now mysticeti will not return
         // more than one leader per round so we are not in danger of ignoring any commits.
@@ -199,11 +212,11 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             return;
         }
 
-        /* (serialized, transaction, output_cert) */
+        /* (transaction, serialized length) */
         let mut transactions = vec![];
-        let timestamp = consensus_output.commit_timestamp_ms();
-        let leader_author = consensus_output.leader_author_index();
-        let commit_sub_dag_index = consensus_output.commit_sub_dag_index();
+        let timestamp = consensus_commit.commit_timestamp_ms();
+        let leader_author = consensus_commit.leader_author_index();
+        let commit_sub_dag_index = consensus_commit.commit_sub_dag_index();
 
         let epoch_start = self
             .epoch_store
@@ -219,7 +232,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         };
 
         info!(
-            %consensus_output,
+            %consensus_commit,
             epoch = ?self.epoch_store.epoch(),
             "Received consensus output"
         );
@@ -269,7 +282,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             self.low_scoring_authorities.clone(),
             self.epoch_store.committee(),
             &self.committee,
-            consensus_output.reputation_score_sorted_desc(),
+            consensus_commit.reputation_score_sorted_desc(),
             &self.metrics,
             self.epoch_store
                 .protocol_config()
@@ -284,13 +297,18 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         {
             let span = trace_span!("process_consensus_certs");
             let _guard = span.enter();
-            for (authority_index, authority_transactions) in consensus_output.transactions() {
+            for (authority_index, parsed_transactions) in consensus_commit.transactions() {
                 // TODO: consider only messages within 1~3 rounds of the leader?
                 self.last_consensus_stats
                     .stats
                     .inc_num_messages(authority_index as usize);
-                for (transaction, serialized_len) in authority_transactions {
-                    let kind = classify(&transaction);
+                for parsed in parsed_transactions {
+                    // Skip executing rejected transactions. Unlocking is the responsibility of the
+                    // consensus transaction handler.
+                    if parsed.rejected {
+                        continue;
+                    }
+                    let kind = classify(&parsed.transaction);
                     self.metrics
                         .consensus_handler_processed
                         .with_label_values(&[kind])
@@ -298,22 +316,25 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     self.metrics
                         .consensus_handler_transaction_sizes
                         .with_label_values(&[kind])
-                        .observe(serialized_len as f64);
+                        .observe(parsed.serialized_len as f64);
+                    // UserTransaction exists only when mysticeti_fastpath is enabled in protocol config.
                     if matches!(
-                        &transaction.kind,
+                        &parsed.transaction.kind,
                         ConsensusTransactionKind::CertifiedTransaction(_)
+                            | ConsensusTransactionKind::UserTransaction(_)
                     ) {
                         self.last_consensus_stats
                             .stats
                             .inc_num_user_transactions(authority_index as usize);
                     }
                     if let ConsensusTransactionKind::RandomnessStateUpdate(randomness_round, _) =
-                        &transaction.kind
+                        &parsed.transaction.kind
                     {
                         // These are deprecated and we should never see them. Log an error and eat the tx if one appears.
                         error!("BUG: saw deprecated RandomnessStateUpdate tx for commit round {round:?}, randomness round {randomness_round:?}")
                     } else {
-                        let transaction = SequencedConsensusTransactionKind::External(transaction);
+                        let transaction =
+                            SequencedConsensusTransactionKind::External(parsed.transaction);
                         transactions.push((transaction, authority_index));
                     }
                 }
@@ -383,14 +404,14 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             }
         }
 
-        let transactions_to_schedule = self
+        let executable_transactions = self
             .epoch_store
             .process_consensus_transactions_and_commit_boundary(
                 all_transactions,
                 &self.last_consensus_stats,
                 &self.checkpoint_service,
                 self.cache_reader.as_ref(),
-                &ConsensusCommitInfo::new(self.epoch_store.protocol_config(), &consensus_output),
+                &ConsensusCommitInfo::new(self.epoch_store.protocol_config(), &consensus_commit),
                 &self.metrics,
             )
             .await
@@ -398,7 +419,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         // update the calculated throughput
         self.throughput_calculator
-            .add_transactions(timestamp, transactions_to_schedule.len() as u64);
+            .add_transactions(timestamp, executable_transactions.len() as u64);
 
         fail_point_if!("correlated-crash-after-consensus-commit-boundary", || {
             let key = [commit_sub_dag_index, self.epoch_store.epoch()];
@@ -409,32 +430,35 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         fail_point_async!("crash"); // for tests that produce random crashes
 
-        self.transaction_scheduler
-            .schedule(transactions_to_schedule)
-            .await;
+        self.transaction_manager_sender
+            .send(executable_transactions);
     }
 }
 
-struct AsyncTransactionScheduler {
-    sender: tokio::sync::mpsc::Sender<Vec<VerifiedExecutableTransaction>>,
+/// Sends transactions to the transaction manager in a separate task,
+/// to avoid blocking consensus handler.
+#[derive(Clone)]
+pub(crate) struct TransactionManagerSender {
+    // Using unbounded channel to avoid blocking consensus commit and transaction handler.
+    sender: monitored_mpsc::UnboundedSender<Vec<VerifiedExecutableTransaction>>,
 }
 
-impl AsyncTransactionScheduler {
-    pub fn start(
+impl TransactionManagerSender {
+    fn start(
         transaction_manager: Arc<TransactionManager>,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) -> Self {
-        let (sender, recv) = tokio::sync::mpsc::channel(16);
+        let (sender, recv) = monitored_mpsc::unbounded_channel("transaction_manager_sender");
         spawn_monitored_task!(Self::run(recv, transaction_manager, epoch_store));
         Self { sender }
     }
 
-    pub async fn schedule(&self, transactions: Vec<VerifiedExecutableTransaction>) {
-        self.sender.send(transactions).await.ok();
+    fn send(&self, transactions: Vec<VerifiedExecutableTransaction>) {
+        let _ = self.sender.send(transactions);
     }
 
-    pub async fn run(
-        mut recv: tokio::sync::mpsc::Receiver<Vec<VerifiedExecutableTransaction>>,
+    async fn run(
+        mut recv: monitored_mpsc::UnboundedReceiver<Vec<VerifiedExecutableTransaction>>,
         transaction_manager: Arc<TransactionManager>,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) {
@@ -445,48 +469,51 @@ impl AsyncTransactionScheduler {
     }
 }
 
-/// Consensus handler used by Mysticeti. Since Mysticeti repo is not yet integrated, we use a
-/// channel to receive the consensus output from Mysticeti.
-/// During initialization, the sender is passed into Mysticeti which can send consensus output
-/// to the channel.
-pub struct MysticetiConsensusHandler {
-    handle: Option<tokio::task::JoinHandle<()>>,
+/// Manages the lifetime of tasks handling the commits and transactions output by consensus.
+pub(crate) struct MysticetiConsensusHandler {
+    tasks: JoinSet<()>,
 }
 
 impl MysticetiConsensusHandler {
-    pub fn new(
+    pub(crate) fn new(
         mut consensus_handler: ConsensusHandler<CheckpointService>,
-        mut receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
+        consensus_transaction_handler: ConsensusTransactionHandler,
+        mut commit_receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
+        mut transaction_receiver: UnboundedReceiver<Vec<(VerifiedBlock, Vec<TransactionIndex>)>>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     ) -> Self {
-        let handle = spawn_monitored_task!(async move {
+        let mut tasks = JoinSet::new();
+        tasks.spawn(monitored_future!(async move {
             // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
-            while let Some(consensus_output) = receiver.recv().await {
-                let commit_index = consensus_output.commit_ref.index;
+            while let Some(consensus_commit) = commit_receiver.recv().await {
+                let commit_index = consensus_commit.commit_ref.index;
                 consensus_handler
-                    .handle_consensus_output(consensus_output)
+                    .handle_consensus_commit(consensus_commit)
                     .await;
                 commit_consumer_monitor.set_highest_handled_commit(commit_index);
             }
-        });
-        Self {
-            handle: Some(handle),
+        }));
+        if consensus_transaction_handler.enabled() {
+            tasks.spawn(monitored_future!(async move {
+                while let Some(blocks_and_rejected_transactions) = transaction_receiver.recv().await
+                {
+                    let parsed_transactions = blocks_and_rejected_transactions
+                        .into_iter()
+                        .flat_map(|(block, rejected_transactions)| {
+                            parse_block_transactions(&block, &rejected_transactions)
+                        })
+                        .collect::<Vec<_>>();
+                    consensus_transaction_handler
+                        .handle_consensus_transactions(parsed_transactions)
+                        .await;
+                }
+            }));
         }
+        Self { tasks }
     }
 
-    pub async fn abort(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-            let _ = handle.await;
-        }
-    }
-}
-
-impl Drop for MysticetiConsensusHandler {
-    fn drop(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-        }
+    pub(crate) async fn abort(&mut self) {
+        self.tasks.shutdown().await;
     }
 }
 
@@ -749,11 +776,11 @@ pub struct ConsensusCommitInfo {
 }
 
 impl ConsensusCommitInfo {
-    fn new(protocol_config: &ProtocolConfig, consensus_output: &impl ConsensusOutputAPI) -> Self {
+    fn new(protocol_config: &ProtocolConfig, consensus_commit: &impl ConsensusCommitAPI) -> Self {
         Self {
-            round: consensus_output.leader_round(),
-            timestamp: consensus_output.commit_timestamp_ms(),
-            consensus_commit_digest: consensus_output.consensus_digest(protocol_config),
+            round: consensus_commit.leader_round(),
+            timestamp: consensus_commit.commit_timestamp_ms(),
+            consensus_commit_digest: consensus_commit.consensus_digest(protocol_config),
 
             #[cfg(any(test, feature = "test-utils"))]
             skip_consensus_commit_prologue_in_test: false,
@@ -829,6 +856,105 @@ impl ConsensusCommitInfo {
     }
 }
 
+/// Handles certified and rejected transactions output by consensus.
+pub(crate) struct ConsensusTransactionHandler {
+    /// Whether to enable handling certified transactions.
+    enabled: bool,
+    /// Per-epoch store.
+    epoch_store: Arc<AuthorityPerEpochStore>,
+    /// Enqueues transactions to the transaction manager via a separate task.
+    transaction_manager_sender: TransactionManagerSender,
+    /// Metrics for consensus transaction handling.
+    metrics: Arc<AuthorityMetrics>,
+}
+
+impl ConsensusTransactionHandler {
+    pub fn new(
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        transaction_manager_sender: TransactionManagerSender,
+        metrics: Arc<AuthorityMetrics>,
+    ) -> Self {
+        Self {
+            enabled: epoch_store.protocol_config().mysticeti_fastpath(),
+            epoch_store,
+            transaction_manager_sender,
+            metrics,
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub async fn handle_consensus_transactions(&self, parsed_transactions: Vec<ParsedTransaction>) {
+        let mut pending_consensus_transactions = vec![];
+        let executable_transactions: Vec<_> = parsed_transactions
+            .into_iter()
+            .filter_map(|parsed| {
+                // TODO(fastpath): unlock rejected transactions.
+                // TODO(fastpath): maybe avoid parsing blocks twice between commit and transaction handling?
+                if parsed.rejected {
+                    self.metrics
+                        .consensus_transaction_handler_processed
+                        .with_label_values(&["rejected"])
+                        .inc();
+                    return None;
+                }
+                self.metrics
+                    .consensus_transaction_handler_processed
+                    .with_label_values(&["certified"])
+                    .inc();
+                match &parsed.transaction.kind {
+                    ConsensusTransactionKind::UserTransaction(tx) => {
+                        // TODO(fastpath): use a separate function to check if a transaction should be executed in fastpath.
+                        if tx.contains_shared_object() {
+                            return None;
+                        }
+                        pending_consensus_transactions.push(parsed.transaction.clone());
+                        let tx = VerifiedTransaction::new_from_verified(*tx.clone());
+                        Some(VerifiedExecutableTransaction::new_from_consensus(
+                            tx,
+                            self.epoch_store.epoch(),
+                            parsed.round,
+                            parsed.authority,
+                            parsed.transaction_index,
+                        ))
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        if pending_consensus_transactions.is_empty() {
+            return;
+        }
+        {
+            let reconfig_state = self.epoch_store.get_reconfig_state_read_lock_guard();
+            // Stop executing fastpath transactions when epoch change starts.
+            if !reconfig_state.should_accept_user_certs() {
+                return;
+            }
+            // Otherwise, try to ensure the certified transactions get into consensus before epoch change.
+            // TODO(fastpath): avoid race with removals in consensus adapter, by waiting to handle commit after
+            // all blocks in the commit are processed via the transaction handler. Other kinds of races need to be
+            // avoided as well. Or we can track pending consensus transactions inside consensus instead.
+            self.epoch_store
+                .insert_pending_consensus_transactions(
+                    &pending_consensus_transactions,
+                    Some(&reconfig_state),
+                )
+                .unwrap_or_else(|e| {
+                    panic!("Failed to insert pending consensus transactions: {}", e)
+                });
+        }
+        self.metrics
+            .consensus_transaction_handler_fastpath_executions
+            .inc_by(executable_transactions.len() as u64);
+        self.transaction_manager_sender
+            .send(executable_transactions);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use consensus_core::{
@@ -839,6 +965,7 @@ mod tests {
     use sui_types::{
         base_types::{random_object_ref, AuthorityName, SuiAddress},
         committee::Committee,
+        crypto::deterministic_random_account_key,
         messages_consensus::{
             AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind,
         },
@@ -856,12 +983,14 @@ mod tests {
             test_authority_builder::TestAuthorityBuilder,
         },
         checkpoints::CheckpointServiceNoop,
-        consensus_adapter::consensus_tests::{test_certificates, test_gas_objects},
+        consensus_adapter::consensus_tests::{
+            test_certificates, test_gas_objects, test_user_transaction,
+        },
         post_consensus_tx_reorder::PostConsensusTxReorder,
     };
 
     #[tokio::test]
-    pub async fn test_consensus_handler() {
+    pub async fn test_consensus_commit_handler() {
         // GIVEN
         let mut objects = test_gas_objects();
         let shared_object = Object::shared_for_testing();
@@ -922,6 +1051,7 @@ mod tests {
         let committed_sub_dag = CommittedSubDag::new(
             leader_block.reference(),
             blocks.clone(),
+            vec![vec![]; blocks.len()],
             leader_block.timestamp_ms(),
             CommitRef::new(10, CommitDigest::MIN),
             vec![],
@@ -929,7 +1059,7 @@ mod tests {
 
         // AND processing the consensus output once
         consensus_handler
-            .handle_consensus_output(committed_sub_dag.clone())
+            .handle_consensus_commit(committed_sub_dag.clone())
             .await;
 
         // AND capturing the consensus stats
@@ -956,10 +1086,136 @@ mod tests {
         // THEN the consensus stats do not update
         for _ in 0..2 {
             consensus_handler
-                .handle_consensus_output(committed_sub_dag.clone())
+                .handle_consensus_commit(committed_sub_dag.clone())
                 .await;
             let last_consensus_stats_2 = consensus_handler.last_consensus_stats.clone();
             assert_eq!(last_consensus_stats_1, last_consensus_stats_2);
+        }
+    }
+
+    #[tokio::test]
+    pub async fn test_consensus_transaction_handler() {
+        // GIVEN
+        // 1 account keypair
+        let (sender, keypair) = deterministic_random_account_key();
+        // 8 gas objects.
+        let gas_objects: Vec<Object> = (0..8)
+            .map(|_| Object::with_id_owner_for_testing(ObjectID::random(), sender))
+            .collect();
+        // 4 owned objects.
+        let owned_objects: Vec<Object> = (0..4)
+            .map(|_| Object::with_id_owner_for_testing(ObjectID::random(), sender))
+            .collect();
+        // 4 shared objects.
+        let shared_objects: Vec<Object> = (0..4)
+            .map(|_| Object::shared_for_testing())
+            .collect::<Vec<_>>();
+        let mut all_objects = gas_objects.clone();
+        all_objects.extend(owned_objects.clone());
+        all_objects.extend(shared_objects.clone());
+
+        let network_config =
+            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .with_objects(all_objects.clone())
+                .build();
+
+        let state = TestAuthorityBuilder::new()
+            .with_network_config(&network_config, 0)
+            .build()
+            .await;
+        let epoch_store = state.epoch_store_for_testing().clone();
+        let transaction_manager_sender = TransactionManagerSender::start(
+            state.transaction_manager().clone(),
+            epoch_store.clone(),
+        );
+        let transaction_handler = ConsensusTransactionHandler::new(
+            epoch_store,
+            transaction_manager_sender,
+            state.metrics.clone(),
+        );
+
+        // AND create test transactions alternating between owned and shared input.
+        let mut transactions = vec![];
+        for (i, gas_object) in gas_objects.iter().enumerate() {
+            let input_object = if i % 2 == 0 {
+                owned_objects.get(i / 2).unwrap().clone()
+            } else {
+                shared_objects.get(i / 2).unwrap().clone()
+            };
+            let transaction = test_user_transaction(
+                &state,
+                sender,
+                &keypair,
+                gas_object.clone(),
+                vec![input_object],
+            )
+            .await;
+            transactions.push(transaction);
+        }
+
+        let serialized_transactions: Vec<_> = transactions
+            .iter()
+            .map(|t| {
+                Transaction::new(
+                    bcs::to_bytes(&ConsensusTransaction::new_user_transaction_message(
+                        &state.name,
+                        t.inner().clone(),
+                    ))
+                    .unwrap(),
+                )
+            })
+            .collect();
+
+        // AND create block for all transactions
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(100, 1)
+                .set_transactions(serialized_transactions.clone())
+                .build(),
+        );
+
+        // AND set rejected transactions.
+        let rejected_transactions = vec![0, 3, 4];
+
+        // AND process the transactions from consensus output.
+        transaction_handler
+            .handle_consensus_transactions(parse_block_transactions(&block, &rejected_transactions))
+            .await;
+
+        // THEN check for execution status of transactions.
+        for (i, t) in transactions.iter().enumerate() {
+            // Do not expect shared transactions or rejected transactions to be executed.
+            if i % 2 == 1 || rejected_transactions.contains(&(i as TransactionIndex)) {
+                continue;
+            }
+            let digest = t.digest();
+            if let Ok(Ok(_)) = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                state.notify_read_effects(*digest),
+            )
+            .await
+            {
+                // Effects exist as expected.
+            } else {
+                panic!("Transaction {} {} did not execute", i, digest);
+            }
+        }
+
+        // THEN check for no inflight or suspended transactions.
+        state.transaction_manager().check_empty_for_testing();
+
+        // THEN check that rejected transactions are not executed.
+        for (i, t) in transactions.iter().enumerate() {
+            // Expect shared transactions or rejected transactions to not have executed.
+            if i % 2 == 0 && !rejected_transactions.contains(&(i as TransactionIndex)) {
+                continue;
+            }
+            let digest = t.digest();
+            assert!(
+                !state.is_tx_already_executed(digest).unwrap(),
+                "Rejected transaction {} {} should not have been executed",
+                i,
+                digest
+            );
         }
     }
 

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -1,19 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::fmt::Display;
+use std::{cmp::Ordering, fmt::Display};
 
-use consensus_core::{BlockAPI, CommitDigest};
+use consensus_core::{BlockAPI, CommitDigest, TransactionIndex, VerifiedBlock};
 use sui_protocol_config::ProtocolConfig;
-use sui_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
+use sui_types::{
+    digests::ConsensusCommitDigest,
+    messages_consensus::{AuthorityIndex, ConsensusTransaction, Round},
+};
 
-use crate::consensus_types::AuthorityIndex;
+pub(crate) struct ParsedTransaction {
+    // Transaction from consensus output.
+    pub(crate) transaction: ConsensusTransaction,
+    // Whether the transaction was rejected in voting.
+    pub(crate) rejected: bool,
+    // Bytes length of the serialized transaction
+    pub(crate) serialized_len: usize,
+    // Consensus round of the block containing the transaction.
+    pub(crate) round: Round,
+    // Authority index of the block containing the transaction.
+    pub(crate) authority: AuthorityIndex,
+    // Transaction index in the block.
+    pub(crate) transaction_index: TransactionIndex,
+}
 
-/// A list of tuples of:
-/// (block origin authority index, all transactions contained in the block).
-/// For each transaction, returns deserialized transaction and its serialized size.
-type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(ConsensusTransaction, usize)>)>;
-
-pub(crate) trait ConsensusOutputAPI: Display {
+pub(crate) trait ConsensusCommitAPI: Display {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
     fn leader_round(&self) -> u64;
     fn leader_author_index(&self) -> AuthorityIndex;
@@ -24,14 +35,14 @@ pub(crate) trait ConsensusOutputAPI: Display {
     /// Returns a unique global index for each committed sub-dag.
     fn commit_sub_dag_index(&self) -> u64;
 
-    /// Returns all transactions in the commit.
-    fn transactions(&self) -> ConsensusOutputTransactions;
+    /// Returns all accepted and rejected transactions per block in the commit in deterministic order.
+    fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)>;
 
     /// Returns the digest of consensus output.
     fn consensus_digest(&self, protocol_config: &ProtocolConfig) -> ConsensusCommitDigest;
 }
 
-impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
+impl ConsensusCommitAPI for consensus_core::CommittedSubDag {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
         if !self.reputation_scores_desc.is_empty() {
             Some(
@@ -62,30 +73,15 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
         self.commit_ref.index.into()
     }
 
-    fn transactions(&self) -> ConsensusOutputTransactions {
+    fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)> {
         self.blocks
             .iter()
-            .map(|block| {
-                let round = block.round();
-                let author = block.author().value() as AuthorityIndex;
-                let transactions: Vec<_> = block
-                    .transactions()
-                    .iter()
-                    .flat_map(|tx| {
-                        let transaction = bcs::from_bytes::<ConsensusTransaction>(tx.data());
-                        match transaction {
-                            Ok(transaction) => Some((
-                                transaction,
-                                tx.data().len(),
-                            )),
-                            Err(err) => {
-                                tracing::error!("Failed to deserialize sequenced consensus transaction(this should not happen) {} from {author} at {round}", err);
-                                None
-                            },
-                        }
-                    })
-                    .collect();
-                (author, transactions)
+            .zip(self.rejected_transactions.iter())
+            .map(|(block, rejected_transactions)| {
+                (
+                    block.author().value() as AuthorityIndex,
+                    parse_block_transactions(block, rejected_transactions),
+                )
             })
             .collect()
     }
@@ -100,4 +96,50 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
             ConsensusCommitDigest::default()
         }
     }
+}
+
+pub(crate) fn parse_block_transactions(
+    block: &VerifiedBlock,
+    rejected_transactions: &[TransactionIndex],
+) -> Vec<ParsedTransaction> {
+    let round = block.round();
+    let authority = block.author().value() as AuthorityIndex;
+
+    let mut rejected_i = 0;
+    block
+        .transactions()
+        .iter().enumerate()
+        .map(|(index, tx)| {
+            let transaction = match bcs::from_bytes::<ConsensusTransaction>(tx.data()) {
+                Ok(transaction) => transaction,
+                Err(err) => {
+                    panic!("Failed to deserialize sequenced consensus transaction(this should not happen) {err} from {authority} at {round}");
+                },
+            };
+            let rejected = if rejected_i < rejected_transactions.len() {
+                match rejected_transactions[rejected_i].cmp(&(index as TransactionIndex)) {
+                    Ordering::Less => {
+                        panic!("Rejected transaction indices are not in order. Block {block:?}, rejected transactions: {rejected_transactions:?}");
+                    },
+                    Ordering::Equal => {
+                        rejected_i += 1;
+                        true
+                    },
+                    Ordering::Greater => {
+                        false
+                    },
+                }
+            } else {
+                false
+            };
+            ParsedTransaction {
+                transaction,
+                rejected,
+                serialized_len: tx.data().len(),
+                round,
+                authority,
+                transaction_index: index as TransactionIndex,
+            }
+        })
+        .collect()
 }

--- a/crates/sui-core/src/consensus_types/mod.rs
+++ b/crates/sui-core/src/consensus_types/mod.rs
@@ -2,7 +2,3 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod consensus_output_api;
-
-/// An unique integer ID for a validator used by consensus.
-/// In Mysticeti, this is used the same way as the AuthorityIndex type there.
-pub type AuthorityIndex = u32;

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -91,7 +91,13 @@ impl SuiTxValidator {
                 | ConsensusTransactionKind::RandomnessStateUpdate(_, _) => {}
 
                 ConsensusTransactionKind::UserTransaction(_tx) => {
-                    // TODO: implement verification for uncertified user transactions if needed
+                    if !self.epoch_store.protocol_config().mysticeti_fastpath() {
+                        return Err(SuiError::UnexpectedMessage(
+                            "ConsensusTransactionKind::UserTransaction is unsupported".to_string(),
+                        )
+                        .into());
+                    }
+                    // TODO(fastpath): implement verification for uncertified user transactions.
                 }
             }
         }

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -4,10 +4,12 @@ use std::{collections::HashMap, sync::Arc};
 
 use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
-use sui_types::{base_types::AuthorityName, committee::Committee};
+use sui_types::{
+    base_types::AuthorityName, committee::Committee, messages_consensus::AuthorityIndex,
+};
 use tracing::debug;
 
-use crate::{authority::AuthorityMetrics, consensus_types::AuthorityIndex};
+use crate::authority::AuthorityMetrics;
 
 /// Updates list of authorities that are deemed to have low reputation scores by consensus
 /// these may be lagging behind the network, byzantine, or not reliably participating for any reason.

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -863,7 +863,7 @@ impl TransactionManager {
 
     // Verify TM has no pending item for tests.
     #[cfg(test)]
-    fn check_empty_for_testing(&self) {
+    pub(crate) fn check_empty_for_testing(&self) {
         let reconfig_lock = self.inner.read();
         let inner = reconfig_lock.read();
         assert!(

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -554,8 +554,9 @@ mod tests {
 
         #[test]
         fn test_quorum_driver_internal_error() {
-            let quorum_driver_error =
-                QuorumDriverError::QuorumDriverInternalError(SuiError::UnexpectedMessage);
+            let quorum_driver_error = QuorumDriverError::QuorumDriverInternalError(
+                SuiError::UnexpectedMessage("test".to_string()),
+            );
 
             let rpc_error: RpcError = Error::QuorumDriverError(quorum_driver_error).into();
 
@@ -570,7 +571,7 @@ mod tests {
         fn test_system_overload() {
             let quorum_driver_error = QuorumDriverError::SystemOverload {
                 overloaded_stake: 10,
-                errors: vec![(SuiError::UnexpectedMessage, 0, vec![])],
+                errors: vec![(SuiError::UnexpectedMessage("test".to_string()), 0, vec![])],
             };
 
             let rpc_error: RpcError = Error::QuorumDriverError(quorum_driver_error).into();

--- a/crates/sui-transaction-checks/src/deny.rs
+++ b/crates/sui-transaction-checks/src/deny.rs
@@ -81,7 +81,7 @@ fn check_disabled_features(
             deny_if_true!(
                 filter_config.zklogin_disabled_providers().contains(
                     &OIDCProvider::from_iss(z.get_iss())
-                        .map_err(|_| SuiError::UnexpectedMessage)?
+                        .map_err(|_| SuiError::UnexpectedMessage(z.get_iss().to_string()))?
                         .to_string()
                 ),
                 "zkLogin OAuth provider is temporarily disabled"

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -443,8 +443,8 @@ pub enum SuiError {
     #[error("Invalid DKG message size")]
     InvalidDkgMessageSize,
 
-    #[error("Unexpected message.")]
-    UnexpectedMessage,
+    #[error("Unexpected message: {0}")]
+    UnexpectedMessage(String),
 
     // Move module publishing related errors
     #[error("Failed to verify the Move module, reason: {error:?}.")]


### PR DESCRIPTION
## Description 

- Add support to execute certified transactions from consensus output.
- Refactor how consensus commit handler processes blocks from consensus commits, so the logic can be reused for consensus transaction handler.
- Small refactors in CommitConsumer and DagState.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
