### PR TITLE
Cherry-pick: jsonrpc: populate object cache with input objects (#19589)

### DIFF
--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -182,6 +182,30 @@ impl<P> ObjectProviderCache<P> {
         }
     }
 
+    pub fn insert_objects_into_cache(&mut self, objects: Vec<Object>) {
+        let object_cache = self.object_cache.get_mut();
+        let last_version_cache = self.last_version_cache.get_mut();
+
+        for object in objects {
+            let object_id = object.id();
+            let version = object.version();
+
+            let key = (object_id, version);
+            object_cache.insert(key, object.clone());
+
+            match last_version_cache.get_mut(&key) {
+                Some(existing_seq_number) => {
+                    if version > *existing_seq_number {
+                        *existing_seq_number = version
+                    }
+                }
+                None => {
+                    last_version_cache.insert(key, version);
+                }
+            }
+        }
+    }
+
     pub fn new_with_cache(
         provider: P,
         written_objects: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
@@ -201,36 +225,6 @@ impl<P> ObjectProviderCache<P> {
                 }
                 None => {
                     last_version_cache.insert(key, object_ref.1);
-                }
-            }
-        }
-
-        Self {
-            object_cache: RwLock::new(object_cache),
-            last_version_cache: RwLock::new(last_version_cache),
-            provider,
-        }
-    }
-
-    pub fn new_with_output_objects(provider: P, output_objects: Vec<Object>) -> Self {
-        let mut object_cache = BTreeMap::new();
-        let mut last_version_cache = BTreeMap::new();
-
-        for object in output_objects {
-            let object_id = object.id();
-            let version = object.version();
-
-            let key = (object_id, version);
-            object_cache.insert(key, object.clone());
-
-            match last_version_cache.get_mut(&key) {
-                Some(existing_seq_number) => {
-                    if version > *existing_seq_number {
-                        *existing_seq_number = version
-                    }
-                }
-                None => {
-                    last_version_cache.insert(key, version);
                 }
             }
         }

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -202,9 +202,15 @@ impl TransactionExecutionApi {
             None
         };
 
-        let object_cache = response.output_objects.map(|output_objects| {
-            ObjectProviderCache::new_with_output_objects(self.state.clone(), output_objects)
-        });
+        let object_cache = match (response.input_objects, response.output_objects) {
+            (Some(input_objects), Some(output_objects)) => {
+                let mut object_cache = ObjectProviderCache::new(self.state.clone());
+                object_cache.insert_objects_into_cache(input_objects);
+                object_cache.insert_objects_into_cache(output_objects);
+                Some(object_cache)
+            }
+            _ => None,
+        };
 
         let balance_changes = match &object_cache {
             Some(object_cache) if opts.show_balance_changes => Some(


### PR DESCRIPTION
Cherrypick #19589 to 1.34

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
