### PR TITLE
[Consensus] increase min round delay in tests

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -19,7 +19,8 @@ pub struct Parameters {
     #[serde(skip)]
     pub db_path: PathBuf,
 
-    /// Time to wait for parent round leader before sealing a block.
+    /// Time to wait for parent round leader before sealing a block, from when parent round
+    /// has a quorum.
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
 
@@ -102,6 +103,9 @@ impl Parameters {
             // leading to long reconfiguration delays. This is because simtest is single threaded,
             // and spending too much time in consensus can lead to starvation elsewhere.
             Duration::from_millis(400)
+        } else if cfg!(test) {
+            // Avoid excessive CPU, data and logs in tests.
+            Duration::from_millis(250)
         } else {
             Duration::from_millis(50)
         }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -576,7 +576,7 @@ impl Core {
                 let Some(last_decided) = decided_leaders.last().cloned() else {
                     break;
                 };
-                tracing::info!("Decided {} leaders and {commits_until_update} commits can be made before next leader schedule change", decided_leaders.len());
+                tracing::debug!("Decided {} leaders and {commits_until_update} commits can be made before next leader schedule change", decided_leaders.len());
 
                 let mut sequenced_leaders = decided_leaders
                     .into_iter()


### PR DESCRIPTION
## Description 

It seems the default delay can result in too many commits per sec.
Also turn another per-commit log into debug, since we have not seen related issues recently.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
