### PR TITLE
[indexer][watermarks][2/n] committer writes upper bounds to watermarks table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13638,6 +13638,8 @@ dependencies = [
  "serde_json",
  "serde_with 3.9.0",
  "simulacrum",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "sui-archival",
  "sui-config",
  "sui-core",
@@ -13666,6 +13668,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.10",
+ "toml 0.7.4",
  "tracing",
  "url",
 ]

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_graphql_rpc_client::simple_client::SimpleClient;
-use sui_indexer::config::PruningOptions;
+pub use sui_indexer::config::RetentionConfig;
 pub use sui_indexer::config::SnapshotLagConfig;
 use sui_indexer::errors::IndexerError;
 use sui_indexer::store::PgIndexerStore;
@@ -151,7 +151,7 @@ pub async fn start_network_cluster() -> NetworkCluster {
 pub async fn serve_executor(
     executor: Arc<dyn RestStateReader + Send + Sync>,
     snapshot_config: Option<SnapshotLagConfig>,
-    epochs_to_keep: Option<u64>,
+    retention_config: Option<RetentionConfig>,
     data_ingestion_path: PathBuf,
 ) -> ExecutorCluster {
     let database = TempDb::new().unwrap();
@@ -184,7 +184,7 @@ pub async fn serve_executor(
     let (pg_store, pg_handle, _) = start_indexer_writer_for_testing(
         db_url,
         Some(snapshot_config.clone()),
-        Some(PruningOptions { epochs_to_keep }),
+        retention_config,
         Some(data_ingestion_path),
         Some(cancellation_token.clone()),
     )

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -31,11 +31,14 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["rt"] }
+toml.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -32,7 +32,7 @@ See the [docs](https://docs.sui.io/guides/developer/getting-started/local-networ
 
 Start a local network using the `sui` binary:
 ```sh
-cargo run --bin sui -- start --with-faucet --force-regenesis 
+cargo run --bin sui -- start --with-faucet --force-regenesis
 ```
 
 If you want to run a local network with the indexer enabled (note that `libpq` is required), you can run the following command after following the steps in the next section to set up an indexer DB:
@@ -65,11 +65,12 @@ cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https
 ```
 cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --rpc-server-worker
 ```
-More flags info can be found in this [file](https://github.com/MystenLabs/sui/blob/main/crates/sui-indexer/src/lib.rs#L83-L123).
+More flags info can be found in this [file](src/main.rs#L41).
+
 ### DB reset
-Run this command under `sui/crates/sui-indexer`, which will wipe DB; In case of schema changes in `.sql` files, this will also update corresponding `schema.rs` file.
+When making db-related changes, you may find yourself having to run migrations and reset dbs often. The commands below are how you can invoke these actions.
 ```sh
-diesel database reset --database-url="<DATABASE_URL>"
+cargo run --bin sui-indexer -- --database-url "<DATABASE_URL>" reset-database --force
 ```
 
 ## Steps to run locally (TiDB)

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -125,3 +125,9 @@ Note that you need an existing database for this to work. Using the DATABASE_URL
 # Change the RPC_CLIENT_URL to http://0.0.0.0:9000 to run indexer against local validator & fullnode
 cargo run --bin sui-indexer --features mysql-feature --no-default-features -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker --reset-db
 ```
+
+### Extending the indexer
+
+To add a new table, run `diesel migration generate your_table_name`, and modify the newly created `up.sql` and `down.sql` files.
+
+You would apply the migration with `diesel migration run`, and run the script in `./scripts/generate_indexer_schema.sh` to update the `schema.rs` file.

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS watermarks;

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
@@ -1,0 +1,32 @@
+CREATE TABLE watermarks
+(
+    -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    entity                      TEXT          NOT NULL,
+    -- Inclusive upper bound epoch this entity has data for. Committer updates this field. Pruner
+    -- uses this field for per-entity epoch-level retention, and is mostly useful for pruning
+    -- unpartitioned tables.
+    epoch_hi                    BIGINT        NOT NULL,
+    -- Inclusive lower bound epoch this entity has data for. Pruner updates this field, and uses
+    -- this field in tandem with `epoch_hi` for per-entity epoch-level retention. This is mostly
+    -- useful for pruning unpartitioned tables.
+    epoch_lo                    BIGINT        NOT NULL,
+    -- Inclusive upper bound checkpoint this entity has data for. Committer updates this field. All
+    -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
+    -- committer or ingestion task refers to this on disaster recovery.
+    checkpoint_hi               BIGINT        NOT NULL,
+    -- Inclusive high watermark that the committer advances. For `checkpoints`, this represents the
+    -- checkpoint sequence number, for `transactions`, the transaction sequence number, etc.
+    reader_hi                   BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Data before this watermark is considered
+    -- pruned by a reader. The underlying data may still exist in the db instance.
+    reader_lo                   BIGINT        NOT NULL,
+    -- Updated using the database's current timestamp when the pruner sees that some data needs to
+    -- be dropped. The pruner uses this column to determine whether to prune or wait long enough
+    -- that all in-flight reads complete or timeout before it acts on an updated watermark.
+    timestamp_ms                BIGINT        NOT NULL,
+    -- Column used by the pruner to track its true progress. Data at and below this watermark has
+    -- been truly pruned from the db, and should no longer exist. When recovering from a crash, the
+    -- pruner will consult this column to determine where to continue.
+    pruned_lo                   BIGINT,
+    PRIMARY KEY (entity)
+);

--- a/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-09-12-213234_watermarks/up.sql
@@ -2,23 +2,21 @@ CREATE TABLE watermarks
 (
     -- The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
     entity                      TEXT          NOT NULL,
-    -- Inclusive upper bound epoch this entity has data for. Committer updates this field. Pruner
-    -- uses this field for per-entity epoch-level retention, and is mostly useful for pruning
-    -- unpartitioned tables.
+    -- Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
+    -- this to determine if pruning is necessary based on the retention policy.
     epoch_hi                    BIGINT        NOT NULL,
-    -- Inclusive lower bound epoch this entity has data for. Pruner updates this field, and uses
-    -- this field in tandem with `epoch_hi` for per-entity epoch-level retention. This is mostly
-    -- useful for pruning unpartitioned tables.
+    -- Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
     epoch_lo                    BIGINT        NOT NULL,
-    -- Inclusive upper bound checkpoint this entity has data for. Committer updates this field. All
+    -- Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
     -- data of this entity in the checkpoint must be persisted before advancing this watermark. The
-    -- committer or ingestion task refers to this on disaster recovery.
+    -- committer refers to this on disaster recovery to resume writing.
     checkpoint_hi               BIGINT        NOT NULL,
-    -- Inclusive high watermark that the committer advances. For `checkpoints`, this represents the
-    -- checkpoint sequence number, for `transactions`, the transaction sequence number, etc.
-    reader_hi                   BIGINT        NOT NULL,
-    -- Inclusive low watermark that the pruner advances. Data before this watermark is considered
-    -- pruned by a reader. The underlying data may still exist in the db instance.
+    -- Inclusive upper transaction sequence number bound for this entity's data. Committer updates
+    -- this field.
+    tx_hi                       BIGINT        NOT NULL,
+    -- Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
+    -- sequence number, or tx sequence number depending on the entity. Data before this watermark is
+    -- considered pruned by a reader. The underlying data may still exist in the db instance.
     reader_lo                   BIGINT        NOT NULL,
     -- Updated using the database's current timestamp when the pruner sees that some data needs to
     -- be dropped. The pruner uses this column to determine whether to prune or wait long enough

--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -1,13 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::backfill::BackfillTaskKind;
 use crate::db::ConnectionPoolConfig;
+use crate::{backfill::BackfillTaskKind, handlers::pruner::PrunableTable};
 use clap::{Args, Parser, Subcommand};
-use std::{net::SocketAddr, path::PathBuf};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use strum::IntoEnumIterator;
 use sui_json_rpc::name_service::NameServiceConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use url::Url;
+
+/// The primary purpose of objects_history is to serve consistency query.
+/// A short retention is sufficient.
+const OBJECTS_HISTORY_EPOCHS_TO_KEEP: u64 = 2;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(
@@ -208,8 +214,93 @@ pub enum Command {
 
 #[derive(Args, Default, Debug, Clone)]
 pub struct PruningOptions {
-    #[arg(long, env = "EPOCHS_TO_KEEP")]
-    pub epochs_to_keep: Option<u64>,
+    /// Path to TOML file containing configuration for retention policies.
+    #[arg(long)]
+    pub pruning_config_path: Option<PathBuf>,
+}
+
+/// Represents the default retention policy and overrides for prunable tables. Instantiated only if
+/// `PruningOptions` is provided on indexer start.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    /// Default retention policy for all tables.
+    pub epochs_to_keep: u64,
+    /// A map of tables to their respective retention policies that will override the default.
+    /// Prunable tables not named here will use the default retention policy.
+    #[serde(default)]
+    pub overrides: HashMap<PrunableTable, u64>,
+}
+
+impl PruningOptions {
+    /// Load default retention policy and overrides from file.
+    pub fn load_from_file(&self) -> Option<RetentionConfig> {
+        let config_path = self.pruning_config_path.as_ref()?;
+
+        let contents = std::fs::read_to_string(config_path)
+            .expect("Failed to read default retention policy and overrides from file");
+        let retention_with_overrides = toml::de::from_str::<RetentionConfig>(&contents)
+            .expect("Failed to parse into RetentionConfig struct");
+
+        let default_retention = retention_with_overrides.epochs_to_keep;
+
+        assert!(
+            default_retention > 0,
+            "Default retention must be greater than 0"
+        );
+        assert!(
+            retention_with_overrides
+                .overrides
+                .values()
+                .all(|&policy| policy > 0),
+            "All retention overrides must be greater than 0"
+        );
+
+        Some(retention_with_overrides)
+    }
+}
+
+impl RetentionConfig {
+    /// Create a new `RetentionConfig` with the specified default retention and overrides. Call
+    /// `finalize()` on the instance to update the `policies` field with the default retention
+    /// policy for all tables that do not have an override specified.
+    pub fn new(epochs_to_keep: u64, overrides: HashMap<PrunableTable, u64>) -> Self {
+        Self {
+            epochs_to_keep,
+            overrides,
+        }
+    }
+
+    pub fn new_with_default_retention_only_for_testing(epochs_to_keep: u64) -> Self {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            PrunableTable::ObjectsHistory,
+            OBJECTS_HISTORY_EPOCHS_TO_KEEP,
+        );
+
+        Self::new(epochs_to_keep, HashMap::new())
+    }
+
+    /// Consumes this struct to produce a full mapping of every prunable table and its retention
+    /// policy. By default, every prunable table will have the default retention policy from
+    /// `epochs_to_keep`. Some tables like `objects_history` will observe a different default
+    /// retention policy. These default values are overridden by any entries in `overrides`.
+    pub fn retention_policies(self) -> HashMap<PrunableTable, u64> {
+        let RetentionConfig {
+            epochs_to_keep,
+            mut overrides,
+        } = self;
+
+        for table in PrunableTable::iter() {
+            let default_retention = match table {
+                PrunableTable::ObjectsHistory => OBJECTS_HISTORY_EPOCHS_TO_KEEP,
+                _ => epochs_to_keep,
+            };
+
+            overrides.entry(table).or_insert(default_retention);
+        }
+
+        overrides
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -290,7 +381,9 @@ impl Default for RestoreConfig {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::io::Write;
     use tap::Pipe;
+    use tempfile::NamedTempFile;
 
     fn parse_args<'a, T>(args: impl IntoIterator<Item = &'a str>) -> Result<T, clap::error::Error>
     where
@@ -353,5 +446,130 @@ mod test {
 
         // fullnode rpc url must be present
         parse_args::<JsonRpcConfig>([]).unwrap_err();
+    }
+
+    #[test]
+    fn pruning_options_with_objects_history_override() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let toml_content = r#"
+        epochs_to_keep = 5
+
+        [overrides]
+        objects_history = 10
+        transactions = 20
+        "#;
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+        let temp_path: PathBuf = temp_file.path().to_path_buf();
+        let pruning_options = PruningOptions {
+            pruning_config_path: Some(temp_path.clone()),
+        };
+        let retention_config = pruning_options.load_from_file().unwrap();
+
+        // Assert the parsed values
+        assert_eq!(retention_config.epochs_to_keep, 5);
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::ObjectsHistory)
+                .copied(),
+            Some(10)
+        );
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::Transactions)
+                .copied(),
+            Some(20)
+        );
+        assert_eq!(retention_config.overrides.len(), 2);
+
+        let retention_policies = retention_config.retention_policies();
+
+        for table in PrunableTable::iter() {
+            let Some(retention) = retention_policies.get(&table).copied() else {
+                panic!("Expected a retention policy for table {:?}", table);
+            };
+
+            match table {
+                PrunableTable::ObjectsHistory => assert_eq!(retention, 10),
+                PrunableTable::Transactions => assert_eq!(retention, 20),
+                _ => assert_eq!(retention, 5),
+            };
+        }
+    }
+
+    #[test]
+    fn pruning_options_no_objects_history_override() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let toml_content = r#"
+        epochs_to_keep = 5
+
+        [overrides]
+        tx_affected_addresses = 10
+        transactions = 20
+        "#;
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+        let temp_path: PathBuf = temp_file.path().to_path_buf();
+        let pruning_options = PruningOptions {
+            pruning_config_path: Some(temp_path.clone()),
+        };
+        let retention_config = pruning_options.load_from_file().unwrap();
+
+        // Assert the parsed values
+        assert_eq!(retention_config.epochs_to_keep, 5);
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::TxAffectedAddresses)
+                .copied(),
+            Some(10)
+        );
+        assert_eq!(
+            retention_config
+                .overrides
+                .get(&PrunableTable::Transactions)
+                .copied(),
+            Some(20)
+        );
+        assert_eq!(retention_config.overrides.len(), 2);
+
+        let retention_policies = retention_config.retention_policies();
+
+        for table in PrunableTable::iter() {
+            let Some(retention) = retention_policies.get(&table).copied() else {
+                panic!("Expected a retention policy for table {:?}", table);
+            };
+
+            match table {
+                PrunableTable::ObjectsHistory => {
+                    assert_eq!(retention, OBJECTS_HISTORY_EPOCHS_TO_KEEP)
+                }
+                PrunableTable::TxAffectedAddresses => assert_eq!(retention, 10),
+                PrunableTable::Transactions => assert_eq!(retention, 20),
+                _ => assert_eq!(retention, 5),
+            };
+        }
+    }
+
+    #[test]
+    fn test_invalid_pruning_config_file() {
+        let toml_str = r#"
+        epochs_to_keep = 5
+
+        [overrides]
+        objects_history = 10
+        transactions = 20
+        invalid_table = 30
+        "#;
+
+        let result = toml::from_str::<RetentionConfig>(toml_str);
+        assert!(result.is_err(), "Expected an error, but parsing succeeded");
+
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("unknown variant `invalid_table`"),
+                "Error message doesn't mention the invalid table"
+            );
+        }
     }
 }

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -10,13 +10,11 @@ use tracing::{error, info};
 
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
-use crate::handlers::pruner::PrunableTable;
 use crate::metrics::IndexerMetrics;
 use crate::store::IndexerStore;
 use crate::types::IndexerResult;
-use strum::IntoEnumIterator;
 
-use super::{CheckpointDataToCommit, CommitterWatermark, EpochToCommit};
+use super::{CheckpointDataToCommit, CommitterTables, CommitterWatermark, EpochToCommit};
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
 
@@ -221,10 +219,8 @@ async fn commit_checkpoints<S>(
         })
         .expect("Persisting data into DB should not fail.");
 
-    let table_names: Vec<String> = PrunableTable::iter().map(|v| v.to_string()).collect();
-
     state
-        .update_watermarks_upper_bound(table_names, committer_watermark)
+        .update_watermarks_upper_bound::<CommitterTables>(committer_watermark)
         .await
         .tap_err(|e| {
             error!(

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 
+use sui_rest_api::CheckpointData;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -64,7 +65,7 @@ impl<T> CommonHandler<T> {
 
     async fn start_transform_and_load(
         &self,
-        cp_receiver: mysten_metrics::metered_channel::Receiver<(u64, T)>,
+        cp_receiver: mysten_metrics::metered_channel::Receiver<(CommitterWatermark, T)>,
         cancel: CancellationToken,
     ) -> IndexerResult<()> {
         let checkpoint_commit_batch_size = std::env::var("CHECKPOINT_COMMIT_BATCH_SIZE")
@@ -74,7 +75,9 @@ impl<T> CommonHandler<T> {
         let mut stream = mysten_metrics::metered_channel::ReceiverStream::new(cp_receiver)
             .ready_chunks(checkpoint_commit_batch_size);
 
-        let mut unprocessed = BTreeMap::new();
+        // Mapping of ordered checkpoint data to ensure that we process them in order. The key is
+        // just the checkpoint sequence number, and the tuple is (CommitterWatermark, T).
+        let mut unprocessed: BTreeMap<u64, (CommitterWatermark, _)> = BTreeMap::new();
         let mut tuple_batch = vec![];
         let mut next_cp_to_process = self
             .handler
@@ -95,7 +98,7 @@ impl<T> CommonHandler<T> {
                         return Ok(());
                     }
                     for tuple in tuple_chunk {
-                        unprocessed.insert(tuple.0, tuple);
+                        unprocessed.insert(tuple.0.cp, tuple);
                     }
                 }
                 Some(None) => break, // Stream has ended
@@ -114,7 +117,7 @@ impl<T> CommonHandler<T> {
             }
 
             if !tuple_batch.is_empty() {
-                let last_checkpoint_seq = tuple_batch.last().unwrap().0;
+                let committer_watermark = tuple_batch.last().unwrap().0;
                 let batch = tuple_batch.into_iter().map(|t| t.1).collect();
                 self.handler.load(batch).await.map_err(|e| {
                     IndexerError::PostgresWriteError(format!(
@@ -123,7 +126,7 @@ impl<T> CommonHandler<T> {
                         e
                     ))
                 })?;
-                self.handler.set_watermark_hi(last_checkpoint_seq).await?;
+                self.handler.set_watermark_hi(committer_watermark).await?;
                 tuple_batch = vec![];
             }
         }
@@ -145,8 +148,9 @@ pub trait Handler<T>: Send + Sync {
     /// read high watermark of the table DB
     async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>>;
 
-    /// set high watermark of the table DB, also update metrics.
-    async fn set_watermark_hi(&self, watermark_hi: u64) -> IndexerResult<()>;
+    /// Updates the relevant entries on the `watermarks` table with the full `CommitterWatermark`,
+    /// which tracks the latest epoch, cp, and tx sequence number of the committed batch.
+    async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()>;
 
     /// By default, return u64::MAX, which means no extra waiting is needed before commiting;
     /// get max committable checkpoint, for handlers that want to wait for some condition before commiting,
@@ -154,5 +158,36 @@ pub trait Handler<T>: Send + Sync {
     /// which waits for the lag between snapshot and latest checkpoint to reach a certain threshold.
     async fn get_max_committable_checkpoint(&self) -> IndexerResult<u64> {
         Ok(u64::MAX)
+    }
+}
+
+/// Represents the latest epoch, checkpoint, and transaction of the batch that was just committed.
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CommitterWatermark {
+    pub epoch: u64,
+    pub cp: u64,
+    pub tx: u64,
+}
+
+impl From<&IndexedCheckpoint> for CommitterWatermark {
+    fn from(checkpoint: &IndexedCheckpoint) -> Self {
+        Self {
+            epoch: checkpoint.epoch,
+            cp: checkpoint.sequence_number,
+            tx: checkpoint.network_total_transactions.saturating_sub(1),
+        }
+    }
+}
+
+impl From<&CheckpointData> for CommitterWatermark {
+    fn from(checkpoint: &CheckpointData) -> Self {
+        Self {
+            epoch: checkpoint.checkpoint_summary.epoch,
+            cp: checkpoint.checkpoint_summary.sequence_number,
+            tx: checkpoint
+                .checkpoint_summary
+                .network_total_transactions
+                .saturating_sub(1),
+        }
     }
 }

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 
+use serde::{Deserialize, Serialize};
 use sui_rest_api::CheckpointData;
 use tokio_util::sync::CancellationToken;
 
@@ -161,7 +162,9 @@ pub trait Handler<T>: Send + Sync {
     }
 }
 
-/// Represents the latest epoch, checkpoint, and transaction of the batch that was just committed.
+/// The indexer writer operates on checkpoint data, which contains information on the current epoch,
+/// checkpoint, and transaction. These three numbers form the watermark upper bound for each
+/// committed table.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CommitterWatermark {
     pub epoch: u64,
@@ -190,4 +193,82 @@ impl From<&CheckpointData> for CommitterWatermark {
                 .saturating_sub(1),
         }
     }
+}
+
+/// Enum representing tables that a committer updates.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CommitterTables {
+    // Unpruned tables
+    ChainIdentifier,
+    Display,
+    Epochs,
+    FeatureFlags,
+    FullObjectsHistory,
+    Objects,
+    ObjectsVersion,
+    Packages,
+    ProtocolConfigs,
+    RawCheckpoints,
+
+    // Prunable tables
+    ObjectsHistory,
+    Transactions,
+    Events,
+
+    EventEmitPackage,
+    EventEmitModule,
+    EventSenders,
+    EventStructInstantiation,
+    EventStructModule,
+    EventStructName,
+    EventStructPackage,
+
+    TxAffectedAddresses,
+    TxAffectedObjects,
+    TxCallsPkg,
+    TxCallsMod,
+    TxCallsFun,
+    TxChangedObjects,
+    TxDigests,
+    TxInputObjects,
+    TxKinds,
+    TxRecipients,
+    TxSenders,
+
+    Checkpoints,
+    PrunerCpWatermark,
+}
+
+/// Enum representing tables that the objects snapshot processor updates.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectsSnapshotHandlerTables {
+    ObjectsSnapshot,
 }

--- a/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use mysten_metrics::get_metrics;
 use mysten_metrics::metered_channel::Sender;
 use mysten_metrics::spawn_monitored_task;
-use strum::IntoEnumIterator;
 use sui_data_ingestion_core::Worker;
 use sui_rest_api::CheckpointData;
 use tokio_util::sync::CancellationToken;

--- a/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use mysten_metrics::get_metrics;
 use mysten_metrics::metered_channel::Sender;
 use mysten_metrics::spawn_monitored_task;
+use strum::IntoEnumIterator;
 use sui_data_ingestion_core::Worker;
 use sui_rest_api::CheckpointData;
 use tokio_util::sync::CancellationToken;
@@ -16,7 +17,7 @@ use crate::types::IndexerResult;
 use crate::{metrics::IndexerMetrics, store::IndexerStore};
 
 use super::checkpoint_handler::CheckpointHandler;
-use super::{CommitterWatermark, TransactionObjectChangesToCommit};
+use super::{CommitterWatermark, ObjectsSnapshotHandlerTables, TransactionObjectChangesToCommit};
 use super::{CommonHandler, Handler};
 
 #[derive(Clone)]
@@ -67,7 +68,7 @@ impl Handler<TransactionObjectChangesToCommit> for ObjectsSnapshotHandler {
 
     async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {
         self.store
-            .update_watermarks_upper_bound(vec!["objects_snapshot".to_string()], watermark)
+            .update_watermarks_upper_bound::<ObjectsSnapshotHandlerTables>(watermark)
             .await?;
 
         self.metrics

--- a/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
@@ -16,13 +16,13 @@ use crate::types::IndexerResult;
 use crate::{metrics::IndexerMetrics, store::IndexerStore};
 
 use super::checkpoint_handler::CheckpointHandler;
-use super::TransactionObjectChangesToCommit;
+use super::{CommitterWatermark, TransactionObjectChangesToCommit};
 use super::{CommonHandler, Handler};
 
 #[derive(Clone)]
 pub struct ObjectsSnapshotHandler {
     pub store: PgIndexerStore,
-    pub sender: Sender<(u64, TransactionObjectChangesToCommit)>,
+    pub sender: Sender<(CommitterWatermark, TransactionObjectChangesToCommit)>,
     snapshot_config: SnapshotLagConfig,
     metrics: IndexerMetrics,
 }
@@ -37,10 +37,7 @@ impl Worker for ObjectsSnapshotHandler {
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
         let transformed_data = CheckpointHandler::index_objects(checkpoint, &self.metrics).await?;
         self.sender
-            .send((
-                checkpoint.checkpoint_summary.sequence_number,
-                transformed_data,
-            ))
+            .send((CommitterWatermark::from(checkpoint), transformed_data))
             .await?;
         Ok(())
     }
@@ -62,18 +59,20 @@ impl Handler<TransactionObjectChangesToCommit> for ObjectsSnapshotHandler {
         Ok(())
     }
 
-    // TODO: read watermark table when it's ready.
     async fn get_watermark_hi(&self) -> IndexerResult<Option<u64>> {
         self.store
             .get_latest_object_snapshot_checkpoint_sequence_number()
             .await
     }
 
-    // TODO: update watermark table when it's ready.
-    async fn set_watermark_hi(&self, watermark_hi: u64) -> IndexerResult<()> {
+    async fn set_watermark_hi(&self, watermark: CommitterWatermark) -> IndexerResult<()> {
+        self.store
+            .update_watermarks_upper_bound(vec!["objects_snapshot".to_string()], watermark)
+            .await?;
+
         self.metrics
             .latest_object_snapshot_sequence_number
-            .set(watermark_hi as i64);
+            .set(watermark.cp as i64);
         Ok(())
     }
 
@@ -113,7 +112,7 @@ pub async fn start_objects_snapshot_handler(
 impl ObjectsSnapshotHandler {
     pub fn new(
         store: PgIndexerStore,
-        sender: Sender<(u64, TransactionObjectChangesToCommit)>,
+        sender: Sender<(CommitterWatermark, TransactionObjectChangesToCommit)>,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
     ) -> ObjectsSnapshotHandler {

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -1,40 +1,103 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
+use strum_macros;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
+use crate::config::RetentionConfig;
 use crate::errors::IndexerError;
 use crate::store::pg_partition_manager::PgPartitionManager;
 use crate::store::PgIndexerStore;
 use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
 
-/// The primary purpose of objects_history is to serve consistency query.
-/// A short retention is sufficient.
-const OBJECTS_HISTORY_EPOCHS_TO_KEEP: u64 = 2;
-
 pub struct Pruner {
     pub store: PgIndexerStore,
     pub partition_manager: PgPartitionManager,
+    // TODO: (wlmyng) - we can remove this when pruner logic is updated to use `retention_policies`.
     pub epochs_to_keep: u64,
+    pub retention_policies: HashMap<PrunableTable, u64>,
     pub metrics: IndexerMetrics,
 }
 
+/// Enum representing tables that the pruner is allowed to prune. The pruner will ignore any table
+/// that is not listed here.
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+    strum_macros::AsRefStr,
+    Hash,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum PrunableTable {
+    ObjectsHistory,
+    Transactions,
+    Events,
+
+    EventEmitPackage,
+    EventEmitModule,
+    EventSenders,
+    EventStructInstantiation,
+    EventStructModule,
+    EventStructName,
+    EventStructPackage,
+
+    TxAffectedAddresses,
+    TxAffectedObjects,
+    TxCallsPkg,
+    TxCallsMod,
+    TxCallsFun,
+    TxChangedObjects,
+    TxDigests,
+    TxInputObjects,
+    TxKinds,
+    TxRecipients,
+    TxSenders,
+
+    Checkpoints,
+    PrunerCpWatermark,
+}
+
 impl Pruner {
+    /// Instantiates a pruner with default retention and overrides. Pruner will finalize the
+    /// retention policies so there is a value for every prunable table.
     pub fn new(
         store: PgIndexerStore,
-        epochs_to_keep: u64,
+        retention_config: RetentionConfig,
         metrics: IndexerMetrics,
     ) -> Result<Self, IndexerError> {
         let partition_manager = PgPartitionManager::new(store.pool())?;
+        let epochs_to_keep = retention_config.epochs_to_keep;
+        let retention_policies = retention_config.retention_policies();
+
         Ok(Self {
             store,
-            partition_manager,
             epochs_to_keep,
+            partition_manager,
+            retention_policies,
             metrics,
         })
+    }
+
+    /// Given a table name, return the number of epochs to keep for that table. Return `None` if the
+    /// table is not prunable.
+    fn table_retention(&self, table_name: &str) -> Option<u64> {
+        if let Ok(variant) = table_name.parse::<PrunableTable>() {
+            self.retention_policies.get(&variant).copied()
+        } else {
+            None
+        }
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
@@ -63,34 +126,36 @@ impl Pruner {
                 .collect();
 
             for (table_name, (min_partition, max_partition)) in &table_partitions {
-                if last_seen_max_epoch != *max_partition {
-                    error!(
-                        "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
-                        table_name, last_seen_max_epoch, max_partition
-                    );
-                }
-
-                let epochs_to_keep = if table_name == "objects_history" {
-                    OBJECTS_HISTORY_EPOCHS_TO_KEEP
-                } else {
-                    self.epochs_to_keep
-                };
-                for epoch in *min_partition..last_seen_max_epoch.saturating_sub(epochs_to_keep - 1)
-                {
-                    if cancel.is_cancelled() {
-                        info!("Pruner task cancelled.");
-                        return Ok(());
+                if let Some(epochs_to_keep) = self.table_retention(table_name) {
+                    if last_seen_max_epoch != *max_partition {
+                        error!(
+                            "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
+                            table_name, last_seen_max_epoch, max_partition
+                        );
                     }
-                    self.partition_manager
-                        .drop_table_partition(table_name.clone(), epoch)
-                        .await?;
-                    info!(
-                        "Batch dropped table partition {} epoch {}",
-                        table_name, epoch
-                    );
+
+                    for epoch in
+                        *min_partition..last_seen_max_epoch.saturating_sub(epochs_to_keep - 1)
+                    {
+                        if cancel.is_cancelled() {
+                            info!("Pruner task cancelled.");
+                            return Ok(());
+                        }
+                        self.partition_manager
+                            .drop_table_partition(table_name.clone(), epoch)
+                            .await?;
+                        info!(
+                            "Batch dropped table partition {} epoch {}",
+                            table_name, epoch
+                        );
+                    }
                 }
             }
 
+            // TODO: (wlmyng) Once we have the watermarks table, we can iterate through each row
+            // returned from `watermarks`, look it up against `retention_policies`, and process them
+            // independently. This also means that pruning overrides will only apply for
+            // epoch-partitioned tables right now.
             let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
             let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
             for epoch in prune_start_epoch..prune_to_epoch {

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -69,6 +69,19 @@ pub enum PrunableTable {
     PrunerCpWatermark,
 }
 
+impl PrunableTable {
+    /// Given a committer's report of the latest written checkpoint and tx, return the value that
+    /// corresponds to the variant's unit to be used by readers.
+    pub fn map_to_reader_unit(&self, cp: u64, tx: u64) -> u64 {
+        match self {
+            PrunableTable::ObjectsHistory
+            | PrunableTable::Checkpoints
+            | PrunableTable::PrunerCpWatermark => cp,
+            _ => tx,
+        }
+    }
+}
+
 impl Pruner {
     /// Instantiates a pruner with default retention and overrides. Pruner will finalize the
     /// retention policies so there is a value for every prunable table.

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -69,19 +69,6 @@ pub enum PrunableTable {
     PrunerCpWatermark,
 }
 
-impl PrunableTable {
-    /// Given a committer's report of the latest written checkpoint and tx, return the value that
-    /// corresponds to the variant's unit to be used by readers.
-    pub fn map_to_reader_unit(&self, cp: u64, tx: u64) -> u64 {
-        match self {
-            PrunableTable::ObjectsHistory
-            | PrunableTable::Checkpoints
-            | PrunableTable::PrunerCpWatermark => cp,
-            _ => tx,
-        }
-    }
-}
-
 impl Pruner {
     /// Instantiates a pruner with default retention and overrides. Pruner will finalize the
     /// retention policies so there is a value for every prunable table.

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -87,6 +87,8 @@ impl Indexer {
 
         let mut exit_senders = vec![];
         let mut executors = vec![];
+        // Ingestion task watermarks are snapshotted once on indexer startup based on the
+        // corresponding watermark table before being handed off to the ingestion task.
         let progress_store = ShimIndexerProgressStore::new(vec![
             ("primary".to_string(), primary_watermark),
             ("object_snapshot".to_string(), object_snapshot_watermark),

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -5,7 +5,9 @@ use clap::Parser;
 use sui_indexer::backfill::backfill_runner::BackfillRunner;
 use sui_indexer::config::{Command, UploadOptions};
 use sui_indexer::database::ConnectionPool;
-use sui_indexer::db::{check_db_migration_consistency, reset_database, run_migrations};
+use sui_indexer::db::{
+    check_db_migration_consistency, check_prunable_tables_valid, reset_database, run_migrations,
+};
 use sui_indexer::indexer::Indexer;
 use sui_indexer::metrics::{
     spawn_connection_pool_metric_collector, start_prometheus_server, IndexerMetrics,
@@ -45,6 +47,11 @@ async fn main() -> anyhow::Result<()> {
         } => {
             // Make sure to run all migrations on startup, and also serve as a compatibility check.
             run_migrations(pool.dedicated_connection().await?).await?;
+            let retention_config = pruning_options.load_from_file();
+            if retention_config.is_some() {
+                check_prunable_tables_valid(&mut pool.get().await?).await?;
+            }
+
             let store = PgIndexerStore::new(pool, upload_options, indexer_metrics.clone());
 
             Indexer::start_writer(
@@ -52,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
                 store,
                 indexer_metrics,
                 snapshot_config,
-                pruning_options,
+                retention_config,
                 CancellationToken::new(),
             )
             .await?;

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -125,6 +125,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_tx_indices_chunks: Histogram,
     pub checkpoint_db_commit_latency_checkpoints: Histogram,
     pub checkpoint_db_commit_latency_epoch: Histogram,
+    pub checkpoint_db_commit_latency_watermarks: Histogram,
     pub thousand_transaction_avg_db_commit_latency: Histogram,
     pub object_db_commit_latency: Histogram,
     pub object_mutation_db_commit_latency: Histogram,
@@ -532,6 +533,13 @@ impl IndexerMetrics {
             checkpoint_db_commit_latency_epoch: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_epochs",
                 "Time spent committing epochs",
+                DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            checkpoint_db_commit_latency_watermarks: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_watermarks",
+                "Time spent committing watermarks",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -12,3 +12,4 @@ pub mod packages;
 pub mod raw_checkpoints;
 pub mod transactions;
 pub mod tx_indices;
+pub mod watermarks;

--- a/crates/sui-indexer/src/models/watermarks.rs
+++ b/crates/sui-indexer/src/models/watermarks.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::watermarks::{self};
+use diesel::prelude::*;
+
+/// Represents a row in the `watermarks` table.
+#[derive(Queryable, Insertable, Default, QueryableByName)]
+#[diesel(table_name = watermarks, primary_key(entity))]
+pub struct StoredWatermark {
+    /// The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
+    pub entity: String,
+    /// Inclusive upper bound epoch this entity has data for. Committer updates this field. Pruner
+    /// uses this field for per-entity epoch-level retention, and is mostly useful for pruning
+    /// unpartitioned tables.
+    pub epoch_hi: i64,
+    /// Inclusive lower bound epoch this entity has data for. Pruner updates this field, and uses
+    /// this field in tandem with `epoch_hi` for per-entity epoch-level retention. This is mostly
+    /// useful for pruning unpartitioned tables.
+    pub epoch_lo: i64,
+    /// Inclusive upper bound checkpoint this entity has data for. Committer updates this field. All
+    /// data of this entity in the checkpoint must be persisted before advancing this watermark. The
+    /// committer or ingestion task refers to this on disaster recovery.
+    pub checkpoint_hi: i64,
+    /// Inclusive high watermark that the committer advances. For `checkpoints`, this represents the
+    /// checkpoint sequence number, for `transactions`, the transaction sequence number, etc.
+    pub reader_hi: i64,
+    /// Inclusive low watermark that the pruner advances. Data before this watermark is considered
+    /// pruned by a reader. The underlying data may still exist in the db instance.
+    pub reader_lo: i64,
+    /// Updated using the database's current timestamp when the pruner sees that some data needs to
+    /// be dropped. The pruner uses this column to determine whether to prune or wait long enough
+    /// that all in-flight reads complete or timeout before it acts on an updated watermark.
+    pub timestamp_ms: i64,
+    /// Column used by the pruner to track its true progress. Data at and below this watermark has
+    /// been truly pruned from the db, and should no longer exist. When recovering from a crash, the
+    /// pruner will consult this column to determine where to continue.
+    pub pruned_lo: Option<i64>,
+}
+
+impl StoredWatermark {
+    pub fn from_upper_bound_update(
+        entity: &str,
+        epoch_hi: u64,
+        checkpoint_hi: u64,
+        reader_hi: u64,
+    ) -> Self {
+        StoredWatermark {
+            entity: entity.to_string(),
+            epoch_hi: epoch_hi as i64,
+            checkpoint_hi: checkpoint_hi as i64,
+            reader_hi: reader_hi as i64,
+            ..StoredWatermark::default()
+        }
+    }
+}

--- a/crates/sui-indexer/src/models/watermarks.rs
+++ b/crates/sui-indexer/src/models/watermarks.rs
@@ -13,23 +13,21 @@ use diesel::prelude::*;
 pub struct StoredWatermark {
     /// The table governed by this watermark, i.e `epochs`, `checkpoints`, `transactions`.
     pub entity: String,
-    /// Inclusive upper bound epoch this entity has data for. Committer updates this field. Pruner
-    /// uses this field for per-entity epoch-level retention, and is mostly useful for pruning
-    /// unpartitioned tables.
+    /// Inclusive upper epoch bound for this entity's data. Committer updates this field. Pruner uses
+    /// this to determine if pruning is necessary based on the retention policy.
     pub epoch_hi: i64,
-    /// Inclusive lower bound epoch this entity has data for. Pruner updates this field, and uses
-    /// this field in tandem with `epoch_hi` for per-entity epoch-level retention. This is mostly
-    /// useful for pruning unpartitioned tables.
+    /// Inclusive lower epoch bound for this entity's data. Pruner updates this field when the epoch range exceeds the retention policy.
     pub epoch_lo: i64,
-    /// Inclusive upper bound checkpoint this entity has data for. Committer updates this field. All
+    /// Inclusive upper checkpoint bound for this entity's data. Committer updates this field. All
     /// data of this entity in the checkpoint must be persisted before advancing this watermark. The
-    /// committer or ingestion task refers to this on disaster recovery.
+    /// committer refers to this on disaster recovery to resume writing.
     pub checkpoint_hi: i64,
-    /// Inclusive high watermark that the committer advances. For `checkpoints`, this represents the
-    /// checkpoint sequence number, for `transactions`, the transaction sequence number, etc.
-    pub reader_hi: i64,
-    /// Inclusive low watermark that the pruner advances. Data before this watermark is considered
-    /// pruned by a reader. The underlying data may still exist in the db instance.
+    /// Inclusive upper transaction sequence number bound for this entity's data. Committer updates
+    /// this field.
+    pub tx_hi: i64,
+    /// Inclusive low watermark that the pruner advances. Corresponds to the epoch id, checkpoint
+    /// sequence number, or tx sequence number depending on the entity. Data before this watermark is
+    /// considered pruned by a reader. The underlying data may still exist in the db instance.
     pub reader_lo: i64,
     /// Updated using the database's current timestamp when the pruner sees that some data needs to
     /// be dropped. The pruner uses this column to determine whether to prune or wait long enough
@@ -47,7 +45,7 @@ impl StoredWatermark {
             entity: entity.to_string(),
             epoch_hi: watermark.epoch as i64,
             checkpoint_hi: watermark.cp as i64,
-            reader_hi: watermark.tx as i64,
+            tx_hi: watermark.tx as i64,
             ..StoredWatermark::default()
         }
     }

--- a/crates/sui-indexer/src/models/watermarks.rs
+++ b/crates/sui-indexer/src/models/watermarks.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::schema::watermarks::{self};
+use crate::{
+    handlers::CommitterWatermark,
+    schema::watermarks::{self},
+};
 use diesel::prelude::*;
 
 /// Represents a row in the `watermarks` table.
@@ -39,17 +42,12 @@ pub struct StoredWatermark {
 }
 
 impl StoredWatermark {
-    pub fn from_upper_bound_update(
-        entity: &str,
-        epoch_hi: u64,
-        checkpoint_hi: u64,
-        reader_hi: u64,
-    ) -> Self {
+    pub fn from_upper_bound_update(entity: &str, watermark: CommitterWatermark) -> Self {
         StoredWatermark {
             entity: entity.to_string(),
-            epoch_hi: epoch_hi as i64,
-            checkpoint_hi: checkpoint_hi as i64,
-            reader_hi: reader_hi as i64,
+            epoch_hi: watermark.epoch as i64,
+            checkpoint_hi: watermark.cp as i64,
+            reader_hi: watermark.tx as i64,
             ..StoredWatermark::default()
         }
     }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -368,6 +368,19 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    watermarks (entity) {
+        entity -> Text,
+        epoch_hi -> Int8,
+        epoch_lo -> Int8,
+        checkpoint_hi -> Int8,
+        reader_hi -> Int8,
+        reader_lo -> Int8,
+        timestamp_ms -> Int8,
+        pruned_lo -> Nullable<Int8>,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     chain_identifier,
     checkpoints,
@@ -403,4 +416,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     tx_kinds,
     tx_recipients,
     tx_senders,
+    watermarks,
 );

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -374,7 +374,7 @@ diesel::table! {
         epoch_hi -> Int8,
         epoch_lo -> Int8,
         checkpoint_hi -> Int8,
-        reader_hi -> Int8,
+        tx_hi -> Int8,
         reader_lo -> Int8,
         timestamp_ms -> Int8,
         pruned_lo -> Nullable<Int8>,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 
 use crate::errors::IndexerError;
+use crate::handlers::pruner::PrunableTable;
 use crate::handlers::{EpochToCommit, TransactionObjectChangesToCommit};
 use crate::models::display::StoredDisplay;
 use crate::models::obj_indices::StoredObjectVersion;
@@ -113,5 +114,13 @@ pub trait IndexerStore: Clone + Sync + Send + 'static {
     async fn persist_raw_checkpoints(
         &self,
         checkpoints: Vec<StoredRawCheckpoint>,
+    ) -> Result<(), IndexerError>;
+
+    async fn update_watermarks_upper_bound(
+        &self,
+        tables: Vec<PrunableTable>,
+        epoch: u64,
+        cp: u64,
+        tx: u64,
     ) -> Result<(), IndexerError>;
 }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -6,8 +6,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 
 use crate::errors::IndexerError;
-use crate::handlers::pruner::PrunableTable;
-use crate::handlers::{EpochToCommit, TransactionObjectChangesToCommit};
+use crate::handlers::{CommitterWatermark, EpochToCommit, TransactionObjectChangesToCommit};
 use crate::models::display::StoredDisplay;
 use crate::models::obj_indices::StoredObjectVersion;
 use crate::models::objects::{StoredDeletedObject, StoredObject};
@@ -116,11 +115,10 @@ pub trait IndexerStore: Clone + Sync + Send + 'static {
         checkpoints: Vec<StoredRawCheckpoint>,
     ) -> Result<(), IndexerError>;
 
+    /// Update the upper bound of the watermarks for the given tables.
     async fn update_watermarks_upper_bound(
         &self,
-        tables: Vec<PrunableTable>,
-        epoch: u64,
-        cp: u64,
-        tx: u64,
+        table_names: Vec<String>,
+        watermark: CommitterWatermark,
     ) -> Result<(), IndexerError>;
 }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
+use strum::IntoEnumIterator;
 
 use crate::errors::IndexerError;
 use crate::handlers::{CommitterWatermark, EpochToCommit, TransactionObjectChangesToCommit};
@@ -116,9 +117,10 @@ pub trait IndexerStore: Clone + Sync + Send + 'static {
     ) -> Result<(), IndexerError>;
 
     /// Update the upper bound of the watermarks for the given tables.
-    async fn update_watermarks_upper_bound(
+    async fn update_watermarks_upper_bound<E: IntoEnumIterator>(
         &self,
-        table_names: Vec<String>,
         watermark: CommitterWatermark,
-    ) -> Result<(), IndexerError>;
+    ) -> Result<(), IndexerError>
+    where
+        E::Iterator: Iterator<Item: AsRef<str>>;
 }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1484,7 +1484,7 @@ impl PgIndexerStore {
                     .set((
                         watermarks::epoch_hi.eq(excluded(watermarks::epoch_hi)),
                         watermarks::checkpoint_hi.eq(excluded(watermarks::checkpoint_hi)),
-                        watermarks::reader_hi.eq(excluded(watermarks::reader_hi)),
+                        watermarks::tx_hi.eq(excluded(watermarks::tx_hi)),
                     ))
                     .execute(conn)
                     .await

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 
-use crate::config::{IngestionConfig, PruningOptions, SnapshotLagConfig, UploadOptions};
+use crate::config::{IngestionConfig, RetentionConfig, SnapshotLagConfig, UploadOptions};
 use crate::database::Connection;
 use crate::database::ConnectionPool;
 use crate::db::ConnectionPoolConfig;
@@ -72,7 +72,7 @@ pub async fn start_indexer_jsonrpc_for_testing(
 pub async fn start_indexer_writer_for_testing(
     db_url: String,
     snapshot_config: Option<SnapshotLagConfig>,
-    pruning_options: Option<PruningOptions>,
+    retention_config: Option<RetentionConfig>,
     data_ingestion_path: Option<PathBuf>,
     cancel: Option<CancellationToken>,
 ) -> (
@@ -85,7 +85,6 @@ pub async fn start_indexer_writer_for_testing(
         snapshot_min_lag: 5,
         sleep_duration: 0,
     });
-    let pruning_options = pruning_options.unwrap_or_default();
 
     // Reduce the connection pool size to 10 for testing to prevent maxing out
     let pool_config = ConnectionPoolConfig {
@@ -128,7 +127,7 @@ pub async fn start_indexer_writer_for_testing(
                 store_clone,
                 indexer_metrics,
                 snapshot_config,
-                pruning_options,
+                retention_config,
                 token_clone,
             )
             .await


### PR DESCRIPTION
## Description 

Adds `watermarks` table, and has committer writing upper bounds to it.

The committer works on the checkpoints level, so to simplify what it needs to do, we can have the committer call `store.update_watermarks_upper_bound()` once when it completes its batch of work. The upper bound update function relies on `PrunableTable` to tell it which of epoch, cp, or tx should be used to update the upper bound.

Part of a stack of PRs for watermarks
1. simplify setting up test indexer: https://github.com/MystenLabs/sui/pull/19663
2. update pruner config: https://github.com/MystenLabs/sui/pull/19637
3. committer writes upper bounds https://github.com/MystenLabs/sui/pull/19649
4. pruner writes lower bounds: https://github.com/MystenLabs/sui/pull/19650
5. pruner prunes (wip)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
