### PR TITLE
[GraphQL] Rework Event type

### DIFF
--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -61,5 +61,10 @@ runs:
       shell: bash
 
     - name: Run TS SDK e2e tests
-      run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @mysten/sui --filter @mysten/graphql-transport test:e2e'
+      run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @mysten/sui'
+      shell: bash
+
+    - name: Run TS SDK GraphQL compatibility e2e tests
+      if: ${{ inputs.ref != "testnet" && inputs.ref != "devnet" }}
+      run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @mysten/graphql-transport test:e2e'
       shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,7 @@ jobs:
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @mysten/sui test:e2e'
 
       - name: Run RPC/GrpahQL comaptability e2e tests
-        if: ${{ needs.diff.outputs.isGraphQlTransport == 'true' || needs.diff.outputs.isRust == 'true'}}
+        if: ${{ needs.diff.outputs.isGraphQlTransport == 'true' || needs.diff.outputs.isRust == 'true' }}
         run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm --filter @mysten/graphql-transport test:e2e'
 
       # - name: Run Local net

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/combo_filter_error.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/combo_filter_error.exp
@@ -19,7 +19,7 @@ task 3, line 32:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 34-51:
+task 4, lines 34-53:
 //# run-graphql
 Response: {
   "data": null,

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/combo_filter_error.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/combo_filter_error.move
@@ -38,14 +38,16 @@ module Test::M2 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/event_connection.exp
@@ -49,7 +49,7 @@ task 8, line 95:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 9, lines 97-117:
+task 9, lines 97-119:
 //# run-graphql
 Response: {
   "data": {
@@ -61,16 +61,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
+              },
+              "json": {
+                "new_value": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            }
           }
         },
         {
@@ -79,16 +81,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         },
         {
@@ -97,16 +101,18 @@ Response: {
             "sendingModule": {
               "name": "M2"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventA"
+              },
+              "json": {
+                "new_value": "2"
+              },
+              "bcs": "AgAAAAAAAAA="
+            }
           }
         },
         {
@@ -115,16 +121,18 @@ Response: {
             "sendingModule": {
               "name": "M2"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::Object>"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "3"
-            },
-            "bcs": "AwAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::Object>"
+              },
+              "json": {
+                "new_value": "3"
+              },
+              "bcs": "AwAAAAAAAAA="
+            }
           }
         }
       ]
@@ -132,7 +140,7 @@ Response: {
   }
 }
 
-task 10, lines 119-139:
+task 10, lines 121-143:
 //# run-graphql
 Response: {
   "data": {
@@ -144,16 +152,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
+              },
+              "json": {
+                "new_value": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            }
           }
         },
         {
@@ -162,16 +172,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         },
         {
@@ -180,16 +192,18 @@ Response: {
             "sendingModule": {
               "name": "M2"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventA"
+              },
+              "json": {
+                "new_value": "2"
+              },
+              "bcs": "AgAAAAAAAAA="
+            }
           }
         },
         {
@@ -198,16 +212,18 @@ Response: {
             "sendingModule": {
               "name": "M2"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::Object>"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "3"
-            },
-            "bcs": "AwAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M2::Object>"
+              },
+              "json": {
+                "new_value": "3"
+              },
+              "bcs": "AwAAAAAAAAA="
+            }
           }
         }
       ]
@@ -215,7 +231,7 @@ Response: {
   }
 }
 
-task 11, lines 141-161:
+task 11, lines 145-168:
 //# run-graphql
 Response: {
   "data": {
@@ -227,16 +243,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
+              },
+              "json": {
+                "new_value": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            }
           }
         },
         {
@@ -245,16 +263,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         }
       ]
@@ -262,7 +282,7 @@ Response: {
   }
 }
 
-task 12, lines 163-183:
+task 12, lines 170-193:
 //# run-graphql
 Response: {
   "data": {
@@ -274,16 +294,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventA"
+              },
+              "json": {
+                "new_value": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            }
           }
         }
       ]
@@ -291,7 +313,7 @@ Response: {
   }
 }
 
-task 13, lines 185-205:
+task 13, lines 195-218:
 //# run-graphql
 Response: {
   "data": {
@@ -303,16 +325,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::EventB<0x08c5d7466382add5a3962c5fbe295af8fc8331bd3140f4f23b031cc1439416ab::M1::Object>"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         }
       ]
@@ -320,7 +344,7 @@ Response: {
   }
 }
 
-task 14, lines 207-227:
+task 14, lines 220-243:
 //# run-graphql
 Response: {
   "data": null,
@@ -340,7 +364,7 @@ Response: {
   ]
 }
 
-task 15, lines 229-249:
+task 15, lines 245-267:
 //# run-graphql
 Response: {
   "data": null,
@@ -360,7 +384,7 @@ Response: {
   ]
 }
 
-task 16, lines 251-271:
+task 16, lines 269-291:
 //# run-graphql
 Response: {
   "data": null,

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/event_connection.move
@@ -103,14 +103,16 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
       }
     }
   }
@@ -125,14 +127,16 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
       }
     }
   }
@@ -147,14 +151,17 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+
       }
     }
   }
@@ -169,14 +176,17 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+
       }
     }
   }
@@ -191,14 +201,17 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+
       }
     }
   }
@@ -213,14 +226,17 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+
       }
     }
   }
@@ -235,14 +251,16 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
       }
     }
   }
@@ -257,14 +275,16 @@ module Test::M2 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
       }
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/nested_emit_event.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/nested_emit_event.exp
@@ -19,7 +19,7 @@ task 3, line 41:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 43-60:
+task 4, lines 43-62:
 //# run-graphql
 Response: {
   "data": {
@@ -29,23 +29,25 @@ Response: {
           "sendingModule": {
             "name": "M3"
           },
-          "type": {
-            "repr": "0x0d72d40a7520bc67f48a16f325a5f189cb79788025784c7f41bf02598d02d2d0::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x0d72d40a7520bc67f48a16f325a5f189cb79788025784c7f41bf02598d02d2d0::M1::EventA"
+            },
+            "bcs": "AgAAAAAAAAA=",
+            "json": {
+              "new_value": "2"
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 5, lines 62-79:
+task 5, lines 64-83:
 //# run-graphql
 Response: {
   "data": {
@@ -55,23 +57,25 @@ Response: {
           "sendingModule": {
             "name": "M3"
           },
-          "type": {
-            "repr": "0x0d72d40a7520bc67f48a16f325a5f189cb79788025784c7f41bf02598d02d2d0::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x0d72d40a7520bc67f48a16f325a5f189cb79788025784c7f41bf02598d02d2d0::M1::EventA"
+            },
+            "bcs": "AgAAAAAAAAA=",
+            "json": {
+              "new_value": "2"
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 6, lines 81-98:
+task 6, lines 85-104:
 //# run-graphql
 Response: {
   "data": {
@@ -81,7 +85,7 @@ Response: {
   }
 }
 
-task 7, lines 100-117:
+task 7, lines 106-125:
 //# run-graphql
 Response: {
   "data": {
@@ -91,7 +95,7 @@ Response: {
   }
 }
 
-task 8, lines 119-136:
+task 8, lines 127-146:
 //# run-graphql
 Response: {
   "data": {
@@ -101,16 +105,18 @@ Response: {
           "sendingModule": {
             "name": "M3"
           },
-          "type": {
-            "repr": "0x0d72d40a7520bc67f48a16f325a5f189cb79788025784c7f41bf02598d02d2d0::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x0d72d40a7520bc67f48a16f325a5f189cb79788025784c7f41bf02598d02d2d0::M1::EventA"
+            },
+            "bcs": "AgAAAAAAAAA=",
+            "json": {
+              "new_value": "2"
+            }
+          }
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/nested_emit_event.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/nested_emit_event.move
@@ -47,14 +47,16 @@ module Test::M3 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -66,14 +68,16 @@ module Test::M3 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -85,14 +89,16 @@ module Test::M3 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -104,14 +110,16 @@ module Test::M3 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -123,14 +131,16 @@ module Test::M3 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/no_filter.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/no_filter.exp
@@ -19,7 +19,7 @@ task 3, line 29:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 31-44:
+task 4, lines 31-46:
 //# run-graphql
 Response: {
   "data": {
@@ -32,103 +32,143 @@ Response: {
       },
       "nodes": [
         {
-          "json": {
-            "new_value": "0"
+          "contents": {
+            "json": {
+              "new_value": "0"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "1"
+          "contents": {
+            "json": {
+              "new_value": "1"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "2"
+          "contents": {
+            "json": {
+              "new_value": "2"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "3"
+          "contents": {
+            "json": {
+              "new_value": "3"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "4"
+          "contents": {
+            "json": {
+              "new_value": "4"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "5"
+          "contents": {
+            "json": {
+              "new_value": "5"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "6"
+          "contents": {
+            "json": {
+              "new_value": "6"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "7"
+          "contents": {
+            "json": {
+              "new_value": "7"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "8"
+          "contents": {
+            "json": {
+              "new_value": "8"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "9"
+          "contents": {
+            "json": {
+              "new_value": "9"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "10"
+          "contents": {
+            "json": {
+              "new_value": "10"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "11"
+          "contents": {
+            "json": {
+              "new_value": "11"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "12"
+          "contents": {
+            "json": {
+              "new_value": "12"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "13"
+          "contents": {
+            "json": {
+              "new_value": "13"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "14"
+          "contents": {
+            "json": {
+              "new_value": "14"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "15"
+          "contents": {
+            "json": {
+              "new_value": "15"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "16"
+          "contents": {
+            "json": {
+              "new_value": "16"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "17"
+          "contents": {
+            "json": {
+              "new_value": "17"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "18"
+          "contents": {
+            "json": {
+              "new_value": "18"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "19"
+          "contents": {
+            "json": {
+              "new_value": "19"
+            }
           }
         }
       ]
@@ -136,7 +176,7 @@ Response: {
   }
 }
 
-task 5, lines 46-59:
+task 5, lines 48-63:
 //# run-graphql --cursors {"tx":2,"e":19,"c":1}
 Response: {
   "data": {
@@ -149,103 +189,143 @@ Response: {
       },
       "nodes": [
         {
-          "json": {
-            "new_value": "20"
+          "contents": {
+            "json": {
+              "new_value": "20"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "21"
+          "contents": {
+            "json": {
+              "new_value": "21"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "22"
+          "contents": {
+            "json": {
+              "new_value": "22"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "23"
+          "contents": {
+            "json": {
+              "new_value": "23"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "24"
+          "contents": {
+            "json": {
+              "new_value": "24"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "25"
+          "contents": {
+            "json": {
+              "new_value": "25"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "26"
+          "contents": {
+            "json": {
+              "new_value": "26"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "27"
+          "contents": {
+            "json": {
+              "new_value": "27"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "28"
+          "contents": {
+            "json": {
+              "new_value": "28"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "29"
+          "contents": {
+            "json": {
+              "new_value": "29"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "30"
+          "contents": {
+            "json": {
+              "new_value": "30"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "31"
+          "contents": {
+            "json": {
+              "new_value": "31"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "32"
+          "contents": {
+            "json": {
+              "new_value": "32"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "33"
+          "contents": {
+            "json": {
+              "new_value": "33"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "34"
+          "contents": {
+            "json": {
+              "new_value": "34"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "35"
+          "contents": {
+            "json": {
+              "new_value": "35"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "36"
+          "contents": {
+            "json": {
+              "new_value": "36"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "37"
+          "contents": {
+            "json": {
+              "new_value": "37"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "38"
+          "contents": {
+            "json": {
+              "new_value": "38"
+            }
           }
         },
         {
-          "json": {
-            "new_value": "39"
+          "contents": {
+            "json": {
+              "new_value": "39"
+            }
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/no_filter.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/no_filter.move
@@ -38,7 +38,9 @@ module Test::M1 {
             endCursor
         }
         nodes {
+          contents {
             json
+          }
         }
     }
 }
@@ -53,7 +55,9 @@ module Test::M1 {
             endCursor
         }
         nodes {
-            json
+            contents {
+                json
+            }
         }
     }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/pagination.exp
@@ -25,7 +25,7 @@ task 4, line 28:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 30-54:
+task 5, lines 30-56:
 //# run-graphql
 Response: {
   "data": {
@@ -41,16 +41,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            }
           }
         },
         {
@@ -59,16 +61,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         },
         {
@@ -77,16 +81,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "2"
+              },
+              "bcs": "AgAAAAAAAAA="
+            }
           }
         }
       ]
@@ -94,7 +100,7 @@ Response: {
   }
 }
 
-task 6, lines 56-80:
+task 6, lines 58-84:
 //# run-graphql --cursors {"tx":2,"e":0,"c":1}
 Response: {
   "data": {
@@ -110,16 +116,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         },
         {
@@ -128,16 +136,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "2"
+              },
+              "bcs": "AgAAAAAAAAA="
+            }
           }
         }
       ]
@@ -145,7 +155,7 @@ Response: {
   }
 }
 
-task 7, lines 82-106:
+task 7, lines 86-113:
 //# run-graphql --cursors {"tx":3,"e":1,"c":1}
 Response: {
   "data": {
@@ -161,16 +171,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            }
           }
         },
         {
@@ -179,16 +191,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         }
       ]
@@ -196,7 +210,7 @@ Response: {
   }
 }
 
-task 8, lines 108-132:
+task 8, lines 115-141:
 //# run-graphql
 Response: {
   "data": {
@@ -212,16 +226,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
           }
         },
         {
@@ -230,16 +246,18 @@ Response: {
             "sendingModule": {
               "name": "M1"
             },
-            "type": {
-              "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
-            },
             "sender": {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
+            "contents": {
+              "type": {
+                "repr": "0x5ba7fdbca31dfa8d9642b26cd297043adba83d87276b248ef9feecd2fe80f9ec::M1::EventA"
+              },
+              "json": {
+                "new_value": "2"
+              },
+              "bcs": "AgAAAAAAAAA="
+            }
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/pagination.move
@@ -40,14 +40,16 @@ module Test::M1 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
       }
     }
   }
@@ -66,14 +68,16 @@ module Test::M1 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
       }
     }
   }
@@ -92,14 +96,17 @@ module Test::M1 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
         }
-        json
-        bcs
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+
       }
     }
   }
@@ -118,14 +125,16 @@ module Test::M1 {
         sendingModule {
           name
         }
-        type {
-          repr
-        }
         sender {
           address
+        }        
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
         }
-        json
-        bcs
       }
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.exp
@@ -56,7 +56,7 @@ Response: {
   }
 }
 
-task 7, lines 45-55:
+task 7, lines 45-57:
 //# run-graphql
 Response: {
   "data": {
@@ -65,16 +65,20 @@ Response: {
         {
           "cursor": "eyJ0eCI6MywiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "2"
+            "contents": {
+              "json": {
+                "new_value": "2"
+              }
             }
           }
         },
         {
           "cursor": "eyJ0eCI6MywiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "3"
+            "contents": {
+              "json": {
+                "new_value": "3"
+              }
             }
           }
         }
@@ -83,7 +87,7 @@ Response: {
   }
 }
 
-task 8, lines 57-68:
+task 8, lines 59-72:
 //# run-graphql --cursors {"tx":3,"e":1,"c":1}
 Response: {
   "data": {
@@ -93,7 +97,7 @@ Response: {
   }
 }
 
-task 9, lines 70-83:
+task 9, lines 74-89:
 //# run-graphql --cursors {"tx":1,"e":1,"c":1}
 Response: {
   "data": {
@@ -103,7 +107,7 @@ Response: {
   }
 }
 
-task 10, lines 86-96:
+task 10, lines 92-104:
 //# run-graphql
 Response: {
   "data": {
@@ -112,16 +116,20 @@ Response: {
         {
           "cursor": "eyJ0eCI6NCwiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "4"
+            "contents": {
+              "json": {
+                "new_value": "4"
+              }
             }
           }
         },
         {
           "cursor": "eyJ0eCI6NCwiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "5"
+            "contents": {
+              "json": {
+                "new_value": "5"
+              }
             }
           }
         }
@@ -130,7 +138,7 @@ Response: {
   }
 }
 
-task 11, lines 98-108:
+task 11, lines 106-118:
 //# run-graphql --cursors {"tx":4,"e":0,"c":1}
 Response: {
   "data": {
@@ -139,8 +147,10 @@ Response: {
         {
           "cursor": "eyJ0eCI6NCwiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "5"
+            "contents": {
+              "json": {
+                "new_value": "5"
+              }
             }
           }
         }
@@ -149,7 +159,7 @@ Response: {
   }
 }
 
-task 12, lines 111-121:
+task 12, lines 121-133:
 //# run-graphql
 Response: {
   "data": {
@@ -158,16 +168,20 @@ Response: {
         {
           "cursor": "eyJ0eCI6MywiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "2"
+            "contents": {
+              "json": {
+                "new_value": "2"
+              }
             }
           }
         },
         {
           "cursor": "eyJ0eCI6MywiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "3"
+            "contents": {
+              "json": {
+                "new_value": "3"
+              }
             }
           }
         }
@@ -176,7 +190,7 @@ Response: {
   }
 }
 
-task 13, lines 123-134:
+task 13, lines 135-148:
 //# run-graphql --cursors {"tx":3,"e":1,"c":1}
 Response: {
   "data": {
@@ -185,8 +199,10 @@ Response: {
         {
           "cursor": "eyJ0eCI6MywiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "2"
+            "contents": {
+              "json": {
+                "new_value": "2"
+              }
             }
           }
         }
@@ -195,7 +211,7 @@ Response: {
   }
 }
 
-task 14, lines 136-149:
+task 14, lines 150-165:
 //# run-graphql --cursors {"tx":4,"e":1,"c":1}
 Response: {
   "data": {
@@ -205,7 +221,7 @@ Response: {
   }
 }
 
-task 15, lines 152-162:
+task 15, lines 168-180:
 //# run-graphql
 Response: {
   "data": {
@@ -214,16 +230,20 @@ Response: {
         {
           "cursor": "eyJ0eCI6NCwiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "4"
+            "contents": {
+              "json": {
+                "new_value": "4"
+              }
             }
           }
         },
         {
           "cursor": "eyJ0eCI6NCwiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "5"
+            "contents": {
+              "json": {
+                "new_value": "5"
+              }
             }
           }
         }
@@ -232,26 +252,24 @@ Response: {
   }
 }
 
-task 16, lines 164-174:
+task 16, lines 182-195:
 //# run-graphql --cursors {"tx":4,"e":1,"c":1}
 Response: {
-  "data": {
-    "events": {
-      "edges": [
+  "data": null,
+  "errors": [
+    {
+      "message": "Unknown field \"json\" on type \"Event\".",
+      "locations": [
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MCwiYyI6MX0",
-          "node": {
-            "json": {
-              "new_value": "4"
-            }
-          }
+          "line": 9,
+          "column": 17
         }
       ]
     }
-  }
+  ]
 }
 
-task 17, lines 176-187:
+task 17, lines 197-210:
 //# run-graphql
 Response: {
   "data": {
@@ -260,16 +278,20 @@ Response: {
         {
           "cursor": "eyJ0eCI6MywiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "2"
+            "contents": {
+              "json": {
+                "new_value": "2"
+              }
             }
           }
         },
         {
           "cursor": "eyJ0eCI6MywiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "3"
+            "contents": {
+              "json": {
+                "new_value": "3"
+              }
             }
           }
         }
@@ -278,7 +300,7 @@ Response: {
   }
 }
 
-task 18, lines 189-200:
+task 18, lines 212-225:
 //# run-graphql
 Response: {
   "data": {
@@ -287,16 +309,20 @@ Response: {
         {
           "cursor": "eyJ0eCI6NCwiZSI6MCwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "4"
+            "contents": {
+              "json": {
+                "new_value": "4"
+              }
             }
           }
         },
         {
           "cursor": "eyJ0eCI6NCwiZSI6MSwiYyI6MX0",
           "node": {
-            "json": {
-              "new_value": "5"
+            "contents": {
+              "json": {
+                "new_value": "5"
+              }
             }
           }
         }
@@ -305,7 +331,7 @@ Response: {
   }
 }
 
-task 19, lines 202-213:
+task 19, lines 227-240:
 //# run-graphql
 Response: {
   "data": {
@@ -315,7 +341,7 @@ Response: {
   }
 }
 
-task 20, lines 215-226:
+task 20, lines 242-255:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/tx_digest.move
@@ -48,7 +48,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -61,7 +63,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -76,7 +80,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -89,7 +95,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -101,7 +109,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -114,7 +124,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -127,7 +139,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -142,7 +156,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -155,7 +171,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -167,6 +185,9 @@ module Test::M1 {
         edges {
             cursor
             node {
+                contents {
+                    json
+                }
                 json
             }
         }
@@ -180,7 +201,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -193,7 +216,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -206,7 +231,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }
@@ -219,7 +246,9 @@ module Test::M1 {
         edges {
             cursor
             node {
-                json
+                contents {
+                    json
+                }
             }
         }
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_filter.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_filter.exp
@@ -19,7 +19,7 @@ task 3, line 38:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 40-57:
+task 4, lines 40-59:
 //# run-graphql
 Response: {
   "data": {
@@ -29,39 +29,41 @@ Response: {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "20"
-          },
-          "bcs": "FAAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
+            },
+            "bcs": "FAAAAAAAAAA=",
+            "json": {
+              "new_value": "20"
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 5, line 59:
+task 5, line 61:
 //# run Test::M2::emit_b --sender A --args 42
 events: Event { package_id: Test, transaction_module: Identifier("M2"), sender: A, type_: StructTag { address: Test, module: Identifier("M2"), name: Identifier("EventB"), type_params: [] }, contents: [42, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 6, line 61:
+task 6, line 63:
 //# run Test::M2::emit_b --sender B --args 43
 events: Event { package_id: Test, transaction_module: Identifier("M2"), sender: B, type_: StructTag { address: Test, module: Identifier("M2"), name: Identifier("EventB"), type_params: [] }, contents: [43, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 7, line 63:
+task 7, line 65:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 8, lines 65-82:
+task 8, lines 67-86:
 //# run-graphql
 Response: {
   "data": {
@@ -71,23 +73,25 @@ Response: {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "20"
-          },
-          "bcs": "FAAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
+            },
+            "bcs": "FAAAAAAAAAA=",
+            "json": {
+              "new_value": "20"
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 9, lines 84-101:
+task 9, lines 88-107:
 //# run-graphql
 Response: {
   "data": {
@@ -97,23 +101,25 @@ Response: {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "42"
-          },
-          "bcs": "KgAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
+            },
+            "bcs": "KgAAAAAAAAA=",
+            "json": {
+              "new_value": "42"
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 10, lines 103-120:
+task 10, lines 109-128:
 //# run-graphql
 Response: {
   "data": {
@@ -123,38 +129,42 @@ Response: {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "20"
-          },
-          "bcs": "FAAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
+            },
+            "bcs": "FAAAAAAAAAA=",
+            "json": {
+              "new_value": "20"
+            }
+          }
         },
         {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "42"
-          },
-          "bcs": "KgAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
+            },
+            "bcs": "KgAAAAAAAAA=",
+            "json": {
+              "new_value": "42"
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 11, lines 122-139:
+task 11, lines 130-149:
 //# run-graphql
 Response: {
   "data": {
@@ -164,46 +174,52 @@ Response: {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "20"
-          },
-          "bcs": "FAAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M1::EventA"
+            },
+            "bcs": "FAAAAAAAAAA=",
+            "json": {
+              "new_value": "20"
+            }
+          }
         },
         {
           "sendingModule": {
             "name": "M2"
           },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "new_value": "42"
-          },
-          "bcs": "KgAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
+            },
+            "bcs": "KgAAAAAAAAA=",
+            "json": {
+              "new_value": "42"
+            }
+          }
         },
         {
           "sendingModule": {
             "name": "M2"
-          },
-          "type": {
-            "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
           },
           "sender": {
             "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
           },
-          "json": {
-            "new_value": "43"
-          },
-          "bcs": "KwAAAAAAAAA="
+          "contents": {
+            "type": {
+              "repr": "0x6edb181eb03cea19a3c4b09d2d6b5de8d0a741df186d072d18b2030eb36faee1::M2::EventB"
+            },
+            "bcs": "KwAAAAAAAAA=",
+            "json": {
+              "new_value": "43"
+            }
+          }
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_filter.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_filter.move
@@ -44,14 +44,16 @@ module Test::M2 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -69,14 +71,16 @@ module Test::M2 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -88,14 +92,16 @@ module Test::M2 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -107,14 +113,16 @@ module Test::M2 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }
@@ -126,14 +134,16 @@ module Test::M2 {
       sendingModule {
         name
       }
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
-      bcs
+      contents {
+        type {
+          repr
+        }
+        bcs
+        json
+      }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_param_filter.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_param_filter.exp
@@ -57,61 +57,69 @@ Response: {
   }
 }
 
-task 7, lines 49-62:
+task 7, lines 49-64:
 //# run-graphql
 Response: {
   "data": {
     "events": {
       "nodes": [
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         },
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T2>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T2>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         },
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         },
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T2>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T2>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         }
@@ -120,35 +128,39 @@ Response: {
   }
 }
 
-task 8, lines 64-77:
+task 8, lines 66-81:
 //# run-graphql
 Response: {
   "data": {
     "events": {
       "nodes": [
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         },
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T1>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         }
@@ -157,22 +169,24 @@ Response: {
   }
 }
 
-task 9, lines 79-92:
+task 9, lines 83-98:
 //# run-graphql
 Response: {
   "data": {
     "events": {
       "nodes": [
         {
-          "type": {
-            "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T2>"
-          },
           "sender": {
             "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
           },
-          "json": {
-            "value": {
-              "dummy_field": false
+          "contents": {
+            "type": {
+              "repr": "0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::EventA<0xe722de9e58a9bab3a202b769b7518f91f852460d3d2c6d6743c301d08b9e614a::M1::T2>"
+            },
+            "json": {
+              "value": {
+                "dummy_field": false
+              }
             }
           }
         }

--- a/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_param_filter.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/event_connection/type_param_filter.move
@@ -50,13 +50,15 @@ module Test::M1 {
 {
   events(filter: {eventType: "@{Test}::M1::EventA"}) {
     nodes {
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
+      contents {
+        type {
+          repr
+        }
+        json
+      }
     }
   }
 }
@@ -65,13 +67,15 @@ module Test::M1 {
 {
   events(filter: {eventType: "@{Test}::M1::EventA<@{Test}::M1::T1>"}) {
     nodes {
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
+      contents {
+        type {
+          repr
+        }
+        json
+      }
     }
   }
 }
@@ -80,13 +84,15 @@ module Test::M1 {
 {
   events(filter: {eventType: "@{Test}::M1::EventA<@{Test}::M1::T2>", transactionDigest: "9nu1ivpL9hHcbJ9GwGfmD3Kuet5w74t2GBp8f1Ggy3UD"}) {
     nodes {
-      type {
-        repr
-      }
       sender {
         address
       }
-      json
+      contents {
+        type {
+          repr
+        }
+        json
+      }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.exp
@@ -31,7 +31,7 @@ task 5, line 36:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, lines 38-57:
+task 6, lines 38-59:
 //# run-graphql
 Response: {
   "data": {
@@ -46,10 +46,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "1"
-                    },
-                    "bcs": "AQAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "1"
+                      },
+                      "bcs": "AQAAAAAAAAA="
+                    }
                   }
                 }
               ]
@@ -65,10 +67,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "10"
-                    },
-                    "bcs": "CgAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "10"
+                      },
+                      "bcs": "CgAAAAAAAAA="
+                    }
                   }
                 },
                 {
@@ -76,10 +80,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "11"
-                    },
-                    "bcs": "CwAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "11"
+                      },
+                      "bcs": "CwAAAAAAAAA="
+                    }
                   }
                 }
               ]
@@ -95,10 +101,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "100"
-                    },
-                    "bcs": "ZAAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "100"
+                      },
+                      "bcs": "ZAAAAAAAAAA="
+                    }
                   }
                 },
                 {
@@ -106,10 +114,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "101"
-                    },
-                    "bcs": "ZQAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "101"
+                      },
+                      "bcs": "ZQAAAAAAAAA="
+                    }
                   }
                 },
                 {
@@ -117,10 +127,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "102"
-                    },
-                    "bcs": "ZgAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "102"
+                      },
+                      "bcs": "ZgAAAAAAAAA="
+                    }
                   }
                 }
               ]
@@ -132,7 +144,7 @@ Response: {
   }
 }
 
-task 7, lines 59-70:
+task 7, lines 61-74:
 //# run-graphql
 Response: {
   "data": {
@@ -142,62 +154,74 @@ Response: {
           "sendingModule": {
             "name": "M1"
           },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "contents": {
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         },
         {
           "sendingModule": {
             "name": "M1"
           },
-          "json": {
-            "new_value": "10"
-          },
-          "bcs": "CgAAAAAAAAA="
+          "contents": {
+            "json": {
+              "new_value": "10"
+            },
+            "bcs": "CgAAAAAAAAA="
+          }
         },
         {
           "sendingModule": {
             "name": "M1"
           },
-          "json": {
-            "new_value": "11"
-          },
-          "bcs": "CwAAAAAAAAA="
+          "contents": {
+            "json": {
+              "new_value": "11"
+            },
+            "bcs": "CwAAAAAAAAA="
+          }
         },
         {
           "sendingModule": {
             "name": "M1"
           },
-          "json": {
-            "new_value": "100"
-          },
-          "bcs": "ZAAAAAAAAAA="
+          "contents": {
+            "json": {
+              "new_value": "100"
+            },
+            "bcs": "ZAAAAAAAAAA="
+          }
         },
         {
           "sendingModule": {
             "name": "M1"
           },
-          "json": {
-            "new_value": "101"
-          },
-          "bcs": "ZQAAAAAAAAA="
+          "contents": {
+            "json": {
+              "new_value": "101"
+            },
+            "bcs": "ZQAAAAAAAAA="
+          }
         },
         {
           "sendingModule": {
             "name": "M1"
           },
-          "json": {
-            "new_value": "102"
-          },
-          "bcs": "ZgAAAAAAAAA="
+          "contents": {
+            "json": {
+              "new_value": "102"
+            },
+            "bcs": "ZgAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 8, lines 72-91:
+task 8, lines 76-97:
 //# run-graphql
 Response: {
   "data": {
@@ -212,10 +236,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "1"
-                    },
-                    "bcs": "AQAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "1"
+                      },
+                      "bcs": "AQAAAAAAAAA="
+                    }
                   }
                 }
               ]
@@ -227,7 +253,7 @@ Response: {
   }
 }
 
-task 9, lines 93-112:
+task 9, lines 99-120:
 //# run-graphql --cursors {"i":0,"c":1}
 Response: {
   "data": {
@@ -242,10 +268,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "101"
-                    },
-                    "bcs": "ZQAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "101"
+                      },
+                      "bcs": "ZQAAAAAAAAA="
+                    }
                   }
                 },
                 {
@@ -253,10 +281,12 @@ Response: {
                     "sendingModule": {
                       "name": "M1"
                     },
-                    "json": {
-                      "new_value": "102"
-                    },
-                    "bcs": "ZgAAAAAAAAA="
+                    "contents": {
+                      "json": {
+                        "new_value": "102"
+                      },
+                      "bcs": "ZgAAAAAAAAA="
+                    }
                   }
                 }
               ]

--- a/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.move
@@ -46,8 +46,10 @@ module Test::M1 {
               sendingModule {
                 name
               }
-              json
-              bcs
+              contents {
+                json
+                bcs
+              }
             }
           }
         }
@@ -63,8 +65,10 @@ module Test::M1 {
       sendingModule {
         name
       }
-      json
-      bcs
+      contents {
+        json
+        bcs
+      }
     }
   }
 }
@@ -80,8 +84,10 @@ module Test::M1 {
               sendingModule {
                 name
               }
-              json
-              bcs
+              contents {
+                json
+                bcs
+              }
             }
           }
         }
@@ -101,8 +107,10 @@ module Test::M1 {
               sendingModule {
                 name
               }
-              json
-              bcs
+              contents {
+                json
+                bcs
+              }
             }
           }
         }

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -1218,32 +1218,13 @@ type Event {
 	"""
 	timestamp: DateTime
 	"""
-	The value's Move type.
+	The event's contents as a Move value.
 	"""
-	type: MoveType!
+	contents: MoveValue!
 	"""
-	The BCS representation of this value, Base64 encoded.
+	The Base64 encoded BCS serialized bytes of the event.
 	"""
 	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type EventConnection {

--- a/crates/sui-graphql-rpc/src/types/event/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/event/mod.rs
@@ -87,11 +87,18 @@ impl Event {
         }
     }
 
-    #[graphql(flatten)]
-    async fn move_value(&self) -> Result<MoveValue> {
+    /// The event's contents as a Move value.
+    async fn contents(&self) -> Result<MoveValue> {
         Ok(MoveValue::new(
             self.native.type_.clone().into(),
             Base64::from(self.native.contents.clone()),
+        ))
+    }
+
+    /// The Base64 encoded BCS serialized bytes of the event.
+    async fn bcs(&self) -> Result<Base64> {
+        Ok(Base64::from(
+            bcs::to_bytes(&self.native).map_err(|e| Error::Internal(e.to_string()))?,
         ))
     }
 }

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -1223,32 +1223,13 @@ type Event {
 	"""
 	timestamp: DateTime
 	"""
-	The value's Move type.
+	The event's contents as a Move value.
 	"""
-	type: MoveType!
+	contents: MoveValue!
 	"""
-	The BCS representation of this value, Base64 encoded.
+	The Base64 encoded BCS serialized bytes of the event.
 	"""
 	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type EventConnection {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -1222,32 +1222,13 @@ type Event {
 	"""
 	timestamp: DateTime
 	"""
-	The value's Move type.
+	The event's contents as a Move value.
 	"""
-	type: MoveType!
+	contents: MoveValue!
 	"""
-	The BCS representation of this value, Base64 encoded.
+	The Base64 encoded BCS serialized bytes of the event.
 	"""
 	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type EventConnection {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -1227,32 +1227,13 @@ type Event {
 	"""
 	timestamp: DateTime
 	"""
-	The value's Move type.
+	The event's contents as a Move value.
 	"""
-	type: MoveType!
+	contents: MoveValue!
 	"""
-	The BCS representation of this value, Base64 encoded.
+	The Base64 encoded BCS serialized bytes of the event.
 	"""
 	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type EventConnection {

--- a/sdk/graphql-transport/codegen.ts
+++ b/sdk/graphql-transport/codegen.ts
@@ -11,7 +11,7 @@ const header = `
 
 const config: CodegenConfig = {
 	overwrite: true,
-	schema: '../typescript/src/graphql/generated/2024.4/schema.graphql',
+	schema: '../../crates/sui-graphql-rpc/schema.graphql',
 	documents: ['src/queries/*.graphql'],
 	ignoreNoDocuments: true,
 	generates: {

--- a/sdk/graphql-transport/src/generated/queries.ts
+++ b/sdk/graphql-transport/src/generated/queries.ts
@@ -37,7 +37,11 @@ export type Scalars = {
    *   | { String:  string }
    *   | { Vector:  [MoveData] }
    *   | { Option:   MoveData? }
-   *   | { Struct:  [{ name: string, value: MoveData }] }
+   *   | { Struct:  [{ name: string , value: MoveData }] }
+   *   | { Variant: {
+   *       name: string,
+   *       fields: [{ name: string, value: MoveData }],
+   *   }
    */
   MoveData: { input: any; output: any; }
   /**
@@ -54,6 +58,14 @@ export type Scalars = {
    *         fields: [{ name: string, layout: MoveTypeLayout }],
    *       }
    *     }
+   *   | { enum: [{
+   *           type: string,
+   *           variants: [{
+   *               name: string,
+   *               fields: [{ name: string, layout: MoveTypeLayout }],
+   *           }]
+   *       }]
+   *   }
    */
   MoveTypeLayout: { input: any; output: any; }
   /**
@@ -100,6 +112,11 @@ export type Scalars = {
   OpenMoveTypeSignature: { input: any; output: any; }
   /** String containing 32B hex-encoded address, with a leading "0x". Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long). */
   SuiAddress: { input: any; output: any; }
+  /**
+   * An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`,
+   * but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
+   */
+  UInt53: { input: any; output: any; }
 };
 
 export type ActiveJwk = {
@@ -169,7 +186,26 @@ export type Address = IOwner & {
   suinsRegistrations: SuinsRegistrationConnection;
   /**
    * Similar behavior to the `transactionBlocks` in Query but supporting the additional
-   * `AddressTransactionBlockRelationship` filter, which defaults to `SIGN`.
+   * `AddressTransactionBlockRelationship` filter, which defaults to `SENT`.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
    */
   transactionBlocks: TransactionBlockConnection;
 };
@@ -242,6 +278,7 @@ export type AddressTransactionBlocksArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   relation?: InputMaybe<AddressTransactionBlockRelationship>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type AddressConnection = {
@@ -273,11 +310,25 @@ export type AddressOwner = {
   owner?: Maybe<Owner>;
 };
 
-/** The possible relationship types for a transaction block: sign, sent, received, or paid. */
+/** The possible relationship types for a transaction block: sent, or received. */
 export enum AddressTransactionBlockRelationship {
-  /** Transactions that sent objects to this address. */
+  /**
+   * Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+   * in favor of `AFFECTED`, which offers an easier to understand behavior.
+   *
+   * This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+   * `AFFECTED` is introduced, whichever is later.
+   */
   Recv = 'RECV',
-  /** Transactions this address has signed either as a sender or as a sponsor. */
+  /** Transactions this address has sent. */
+  Sent = 'SENT',
+  /**
+   * Transactions this address has sent. NOTE: this input filter has been deprecated in favor of
+   * `SENT` which behaves identically but is named more clearly. Both filters restrict
+   * transactions by their sender, only, not signers in general.
+   *
+   * This filter will be removed with 1.36.0 (2024-10-14).
+   */
   Sign = 'SIGN'
 }
 
@@ -291,7 +342,7 @@ export type AuthenticatorStateCreateTransaction = {
 export type AuthenticatorStateExpireTransaction = {
   __typename?: 'AuthenticatorStateExpireTransaction';
   /** The initial version that the AuthenticatorStateUpdate was shared at. */
-  authenticatorObjInitialSharedVersion: Scalars['Int']['output'];
+  authenticatorObjInitialSharedVersion: Scalars['UInt53']['output'];
   /** Expire JWKs that have a lower epoch than this. */
   minEpoch?: Maybe<Epoch>;
 };
@@ -300,13 +351,13 @@ export type AuthenticatorStateExpireTransaction = {
 export type AuthenticatorStateUpdateTransaction = {
   __typename?: 'AuthenticatorStateUpdateTransaction';
   /** The initial version of the authenticator object that it was shared at. */
-  authenticatorObjInitialSharedVersion: Scalars['Int']['output'];
+  authenticatorObjInitialSharedVersion: Scalars['UInt53']['output'];
   /** Epoch of the authenticator state update transaction. */
   epoch?: Maybe<Epoch>;
   /** Newly active JWKs (JSON Web Keys). */
   newActiveJwks: ActiveJwkConnection;
   /** Consensus round of the authenticator state update. */
-  round: Scalars['Int']['output'];
+  round: Scalars['UInt53']['output'];
 };
 
 
@@ -329,7 +380,7 @@ export type AvailableRange = {
 export type Balance = {
   __typename?: 'Balance';
   /** How many coins of this type constitute the balance */
-  coinObjectCount?: Maybe<Scalars['Int']['output']>;
+  coinObjectCount?: Maybe<Scalars['UInt53']['output']>;
   /** Coin type for the balance, such as 0x2::sui::SUI */
   coinType: MoveType;
   /** Total balance across all coin objects of the coin type */
@@ -385,6 +436,16 @@ export type BalanceEdge = {
   node: Balance;
 };
 
+export type BridgeCommitteeInitTransaction = {
+  __typename?: 'BridgeCommitteeInitTransaction';
+  bridgeObjInitialSharedVersion: Scalars['UInt53']['output'];
+};
+
+export type BridgeStateCreateTransaction = {
+  __typename?: 'BridgeStateCreateTransaction';
+  chainId: Scalars['String']['output'];
+};
+
 /**
  * A system transaction that updates epoch information on-chain (increments the current epoch).
  * Executed by the system once per epoch, without using gas. Epoch change transactions cannot be
@@ -404,7 +465,7 @@ export type ChangeEpochTransaction = {
    */
   nonRefundableStorageFee: Scalars['BigInt']['output'];
   /** The protocol version in effect in the new epoch. */
-  protocolVersion: Scalars['Int']['output'];
+  protocolVersion: Scalars['UInt53']['output'];
   /** Time at which the next epoch will start. */
   startTimestamp: Scalars['DateTime']['output'];
   /** The total amount of gas charged for storage during the previous epoch (in MIST). */
@@ -449,7 +510,7 @@ export type Checkpoint = {
   /** The epoch this checkpoint is part of. */
   epoch?: Maybe<Epoch>;
   /** The total number of transaction blocks in the network by the end of this checkpoint. */
-  networkTotalTransactions?: Maybe<Scalars['Int']['output']>;
+  networkTotalTransactions?: Maybe<Scalars['UInt53']['output']>;
   /** The digest of the checkpoint at the previous sequence number. */
   previousCheckpointDigest?: Maybe<Scalars['String']['output']>;
   /**
@@ -462,13 +523,32 @@ export type Checkpoint = {
    * This checkpoint's position in the total order of finalized checkpoints, agreed upon by
    * consensus.
    */
-  sequenceNumber: Scalars['Int']['output'];
+  sequenceNumber: Scalars['UInt53']['output'];
   /**
    * The timestamp at which the checkpoint is agreed to have happened according to consensus.
    * Transactions that access time in this checkpoint will observe this timestamp.
    */
   timestamp: Scalars['DateTime']['output'];
-  /** Transactions in this checkpoint. */
+  /**
+   * Transactions in this checkpoint.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range consists of all transactions in this checkpoint.
+   */
   transactionBlocks: TransactionBlockConnection;
   /**
    * This is an aggregation of signatures from a quorum of validators for the checkpoint
@@ -488,6 +568,7 @@ export type CheckpointTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type CheckpointConnection = {
@@ -512,7 +593,7 @@ export type CheckpointEdge = {
 /** Filter either by the digest, or the sequence number, or neither, to get the latest checkpoint. */
 export type CheckpointId = {
   digest?: InputMaybe<Scalars['String']['input']>;
-  sequenceNumber?: InputMaybe<Scalars['Int']['input']>;
+  sequenceNumber?: InputMaybe<Scalars['UInt53']['input']>;
 };
 
 /** Some 0x2::coin::Coin Move object. */
@@ -590,7 +671,28 @@ export type Coin = IMoveObject & IObject & IOwner & {
   owner?: Maybe<ObjectOwner>;
   /** The transaction block that created this version of the object. */
   previousTransactionBlock?: Maybe<TransactionBlock>;
-  /** The transaction blocks that sent objects to this object. */
+  /**
+   * The transaction blocks that sent objects to this object.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   receivedTransactionBlocks: TransactionBlockConnection;
   /** The `0x3::staking_pool::StakedSui` objects owned by this object. */
   stakedSuis: StakedSuiConnection;
@@ -614,7 +716,7 @@ export type Coin = IMoveObject & IObject & IOwner & {
    * manage the associated domain.
    */
   suinsRegistrations: SuinsRegistrationConnection;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -687,6 +789,7 @@ export type CoinReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -812,7 +915,28 @@ export type CoinMetadata = IMoveObject & IObject & IOwner & {
   owner?: Maybe<ObjectOwner>;
   /** The transaction block that created this version of the object. */
   previousTransactionBlock?: Maybe<TransactionBlock>;
-  /** The transaction blocks that sent objects to this object. */
+  /**
+   * The transaction blocks that sent objects to this object.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   receivedTransactionBlocks: TransactionBlockConnection;
   /** The `0x3::staking_pool::StakedSui` objects owned by this object. */
   stakedSuis: StakedSuiConnection;
@@ -840,7 +964,7 @@ export type CoinMetadata = IMoveObject & IObject & IOwner & {
   supply?: Maybe<Scalars['BigInt']['output']>;
   /** The token's identifying abbreviation. */
   symbol?: Maybe<Scalars['String']['output']>;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -913,6 +1037,7 @@ export type CoinMetadataReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -949,7 +1074,7 @@ export type ConsensusCommitPrologueTransaction = {
   /** Epoch of the commit prologue transaction. */
   epoch?: Maybe<Epoch>;
   /** Consensus round of the commit. */
-  round: Scalars['Int']['output'];
+  round: Scalars['UInt53']['output'];
 };
 
 export type DependencyConnection = {
@@ -1045,9 +1170,10 @@ export type DynamicField = {
    */
   name?: Maybe<MoveValue>;
   /**
-   * The actual data stored in the dynamic field.
-   * The returned dynamic field is an object if its return type is MoveObject,
-   * in which case it is also accessible off-chain via its address.
+   * The returned dynamic field is an object if its return type is `MoveObject`,
+   * in which case it is also accessible off-chain via its address. Its contents
+   * will be from the latest version that is at most equal to its parent object's
+   * version
    */
   value?: Maybe<DynamicFieldValue>;
 };
@@ -1107,7 +1233,7 @@ export type EndOfEpochTransactionTransactionsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-export type EndOfEpochTransactionKind = AuthenticatorStateCreateTransaction | AuthenticatorStateExpireTransaction | ChangeEpochTransaction | CoinDenyListStateCreateTransaction | RandomnessStateCreateTransaction;
+export type EndOfEpochTransactionKind = AuthenticatorStateCreateTransaction | AuthenticatorStateExpireTransaction | BridgeCommitteeInitTransaction | BridgeStateCreateTransaction | ChangeEpochTransaction | CoinDenyListStateCreateTransaction | RandomnessStateCreateTransaction;
 
 export type EndOfEpochTransactionKindConnection = {
   __typename?: 'EndOfEpochTransactionKindConnection';
@@ -1144,7 +1270,7 @@ export type Epoch = {
   /** The epoch's ending timestamp. */
   endTimestamp?: Maybe<Scalars['DateTime']['output']>;
   /** The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change. */
-  epochId: Scalars['Int']['output'];
+  epochId: Scalars['UInt53']['output'];
   /** The storage fees paid for transactions executed during the epoch. */
   fundInflow?: Maybe<Scalars['BigInt']['output']>;
   /**
@@ -1196,9 +1322,9 @@ export type Epoch = {
    * version changes whenever the fields contained in the system state object (held in a dynamic
    * field attached to `0x5`) change.
    */
-  systemStateVersion?: Maybe<Scalars['Int']['output']>;
+  systemStateVersion?: Maybe<Scalars['UInt53']['output']>;
   /** The total number of checkpoints in this epoch. */
-  totalCheckpoints?: Maybe<Scalars['BigInt']['output']>;
+  totalCheckpoints?: Maybe<Scalars['UInt53']['output']>;
   /** The total amount of gas fees (in MIST) that were paid in this epoch. */
   totalGasFees?: Maybe<Scalars['BigInt']['output']>;
   /** The total MIST rewarded as stake. */
@@ -1206,8 +1332,27 @@ export type Epoch = {
   /** The amount added to total gas fees to make up the total stake rewards. */
   totalStakeSubsidies?: Maybe<Scalars['BigInt']['output']>;
   /** The total number of transaction blocks in this epoch. */
-  totalTransactions?: Maybe<Scalars['Int']['output']>;
-  /** The epoch's corresponding transaction blocks. */
+  totalTransactions?: Maybe<Scalars['UInt53']['output']>;
+  /**
+   * The epoch's corresponding transaction blocks.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range consists of all transactions in this epoch.
+   */
   transactionBlocks: TransactionBlockConnection;
   /** Validator related properties, including the active validators. */
   validatorSet?: Maybe<ValidatorSet>;
@@ -1246,29 +1391,15 @@ export type EpochTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type Event = {
   __typename?: 'Event';
-  /** The BCS representation of this value, Base64 encoded. */
+  /** The Base64 encoded BCS serialized bytes of the event. */
   bcs: Scalars['Base64']['output'];
-  /** Structured contents of a Move value. */
-  data: Scalars['MoveData']['output'];
-  /**
-   * Representation of a Move value in JSON, where:
-   *
-   * - Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
-   * - Bools are represented by JSON boolean literals.
-   * - u8, u16, and u32 are represented as JSON numbers.
-   * - u64, u128, and u256 are represented as JSON strings.
-   * - Vectors are represented by JSON arrays.
-   * - Structs are represented by JSON objects.
-   * - Empty optional values are represented by `null`.
-   *
-   * This form is offered as a less verbose convenience in cases where the layout of the type is
-   * known by the client.
-   */
-  json: Scalars['JSON']['output'];
+  /** The event's contents as a Move value. */
+  contents: MoveValue;
   /** Address of the sender of the event */
   sender?: Maybe<Address>;
   /**
@@ -1281,8 +1412,6 @@ export type Event = {
   sendingModule?: Maybe<MoveModule>;
   /** UTC timestamp in milliseconds since epoch (1/1/1970) */
   timestamp?: Maybe<Scalars['DateTime']['output']>;
-  /** The value's Move type. */
-  type: MoveType;
 };
 
 export type EventConnection = {
@@ -1311,6 +1440,8 @@ export type EventFilter = {
    * PTB and emits an event.
    *
    * Modules can be filtered by their package, or package::module.
+   * We currently do not support filtering by emitting module and event type
+   * at the same time so if both are provided in one filter, the query will error.
    */
   emittingModule?: InputMaybe<Scalars['String']['input']>;
   /**
@@ -1324,7 +1455,9 @@ export type EventFilter = {
    * `0x2::coin::Coin<0x2::sui::SUI>`.
    */
   eventType?: InputMaybe<Scalars['String']['input']>;
+  /** Filter down to events from transactions sent by this address. */
   sender?: InputMaybe<Scalars['SuiAddress']['input']>;
+  /** Filter down to the events from this transaction (given by its transaction digest). */
   transactionDigest?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1360,6 +1493,8 @@ export enum Feature {
   Coins = 'COINS',
   /** Querying an object's dynamic fields. */
   DynamicFields = 'DYNAMIC_FIELDS',
+  /** Named packages service (utilizing dotmove package registry). */
+  MoveRegistry = 'MOVE_REGISTRY',
   /** SuiNS name and reverse name look-up. */
   NameService = 'NAME_SERVICE',
   /** Transaction and Event subscriptions. */
@@ -1450,6 +1585,23 @@ export type GenesisTransactionObjectsArgs = {
 };
 
 /**
+ * Interface implemented by all GraphQL types that represent a Move datatype (either structs or
+ * enums). This interface is used to provide a way to access fields that are shared by both
+ * structs and enums, e.g., the module that the datatype belongs to, the name of the datatype,
+ * type parameters etc.
+ */
+export type IMoveDatatype = {
+  /** The abilities of the datatype. */
+  abilities?: Maybe<Array<MoveAbility>>;
+  /** The module that the datatype belongs to. */
+  module: MoveModule;
+  /** The name of the datatype. */
+  name: Scalars['String']['output'];
+  /** The type parameters of the datatype. */
+  typeParameters?: Maybe<Array<MoveStructTypeParameter>>;
+};
+
+/**
  * This interface is implemented by types that represent a Move object on-chain (A Move value whose
  * type has `key`).
  */
@@ -1531,7 +1683,7 @@ export type IObject = {
   /** The current status of the object as read from the off-chain store. The possible states are: NOT_INDEXED, the object is loaded from serialized data, such as the contents of a genesis or system package upgrade transaction. LIVE, the version returned is the most recent for the object, and it is not deleted or wrapped at that version. HISTORICAL, the object was referenced at a specific version or checkpoint, so is fetched from historical tables and may not be the latest version of the object. WRAPPED_OR_DELETED, the object is deleted or wrapped and only partial information can be loaded. */
   status: ObjectKind;
   storageRebate?: Maybe<Scalars['BigInt']['output']>;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -1545,6 +1697,7 @@ export type IObjectReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /**
@@ -1693,7 +1846,7 @@ export type Linkage = {
   /** The ID on-chain of the version of the dependency that this package depends on. */
   upgradedId: Scalars['SuiAddress']['output'];
   /** The version of the dependency that this package depends on. */
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 /** Create a vector (possibly empty). */
@@ -1741,6 +1894,92 @@ export type MoveCallTransaction = {
   package: Scalars['SuiAddress']['output'];
   /** The actual type parameters passed in for this move call. */
   typeArguments: Array<MoveType>;
+};
+
+/**
+ * The generic representation of a Move datatype (either a struct or an enum) which exposes common
+ * fields and information (module, name, abilities, type parameters etc.) that is shared across
+ * them.
+ */
+export type MoveDatatype = IMoveDatatype & {
+  __typename?: 'MoveDatatype';
+  abilities?: Maybe<Array<MoveAbility>>;
+  asMoveEnum?: Maybe<MoveEnum>;
+  asMoveStruct?: Maybe<MoveStruct>;
+  module: MoveModule;
+  name: Scalars['String']['output'];
+  typeParameters?: Maybe<Array<MoveStructTypeParameter>>;
+};
+
+export type MoveDatatypeConnection = {
+  __typename?: 'MoveDatatypeConnection';
+  /** A list of edges. */
+  edges: Array<MoveDatatypeEdge>;
+  /** A list of nodes. */
+  nodes: Array<MoveDatatype>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type MoveDatatypeEdge = {
+  __typename?: 'MoveDatatypeEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: MoveDatatype;
+};
+
+/** Description of an enum type, defined in a Move module. */
+export type MoveEnum = IMoveDatatype & {
+  __typename?: 'MoveEnum';
+  /** The enum's abilities. */
+  abilities?: Maybe<Array<MoveAbility>>;
+  /** The module this enum was originally defined in. */
+  module: MoveModule;
+  /** The enum's (unqualified) type name. */
+  name: Scalars['String']['output'];
+  /**
+   * Constraints on the enum's formal type parameters.  Move bytecode does not name type
+   * parameters, so when they are referenced (e.g. in field types) they are identified by their
+   * index in this list.
+   */
+  typeParameters?: Maybe<Array<MoveStructTypeParameter>>;
+  /**
+   * The names and types of the enum's fields.  Field types reference type parameters, by their
+   * index in the defining enum's `typeParameters` list.
+   */
+  variants?: Maybe<Array<MoveEnumVariant>>;
+};
+
+export type MoveEnumConnection = {
+  __typename?: 'MoveEnumConnection';
+  /** A list of edges. */
+  edges: Array<MoveEnumEdge>;
+  /** A list of nodes. */
+  nodes: Array<MoveEnum>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type MoveEnumEdge = {
+  __typename?: 'MoveEnumEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: MoveEnum;
+};
+
+export type MoveEnumVariant = {
+  __typename?: 'MoveEnumVariant';
+  /**
+   * The names and types of the variant's fields.  Field types reference type parameters, by their
+   * index in the defining enum's `typeParameters` list.
+   */
+  fields?: Maybe<Array<MoveField>>;
+  /** The name of the variant */
+  name: Scalars['String']['output'];
 };
 
 /** Information for a particular field on a Move struct. */
@@ -1812,8 +2051,16 @@ export type MoveModule = {
   __typename?: 'MoveModule';
   /** The Base64 encoded bcs serialization of the module. */
   bytes?: Maybe<Scalars['Base64']['output']>;
+  /** Look-up the definition of a datatype (struct or enum) defined in this module, by its name. */
+  datatype?: Maybe<MoveDatatype>;
+  /** Iterate through the datatypes (enmums and structs) defined in this module. */
+  datatypes?: Maybe<MoveDatatypeConnection>;
   /** Textual representation of the module's bytecode. */
   disassembly?: Maybe<Scalars['String']['output']>;
+  /** Look-up the definition of a enum defined in this module, by its name. */
+  enum?: Maybe<MoveEnum>;
+  /** Iterate through the enums defined in this module. */
+  enums?: Maybe<MoveEnumConnection>;
   /** Format version of this module's bytecode. */
   fileFormatVersion: Scalars['Int']['output'];
   /**
@@ -1833,6 +2080,48 @@ export type MoveModule = {
   struct?: Maybe<MoveStruct>;
   /** Iterate through the structs defined in this module. */
   structs?: Maybe<MoveStructConnection>;
+};
+
+
+/**
+ * Represents a module in Move, a library that defines struct types
+ * and functions that operate on these types.
+ */
+export type MoveModuleDatatypeArgs = {
+  name: Scalars['String']['input'];
+};
+
+
+/**
+ * Represents a module in Move, a library that defines struct types
+ * and functions that operate on these types.
+ */
+export type MoveModuleDatatypesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/**
+ * Represents a module in Move, a library that defines struct types
+ * and functions that operate on these types.
+ */
+export type MoveModuleEnumArgs = {
+  name: Scalars['String']['input'];
+};
+
+
+/**
+ * Represents a module in Move, a library that defines struct types
+ * and functions that operate on these types.
+ */
+export type MoveModuleEnumsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -1992,7 +2281,28 @@ export type MoveObject = IMoveObject & IObject & IOwner & {
   owner?: Maybe<ObjectOwner>;
   /** The transaction block that created this version of the object. */
   previousTransactionBlock?: Maybe<TransactionBlock>;
-  /** The transaction blocks that sent objects to this object. */
+  /**
+   * The transaction blocks that sent objects to this object.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   receivedTransactionBlocks: TransactionBlockConnection;
   /** The `0x3::staking_pool::StakedSui` objects owned by this object. */
   stakedSuis: StakedSuiConnection;
@@ -2016,7 +2326,7 @@ export type MoveObject = IMoveObject & IObject & IOwner & {
    * manage the associated domain.
    */
   suinsRegistrations: SuinsRegistrationConnection;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -2116,6 +2426,7 @@ export type MoveObjectReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2198,6 +2509,11 @@ export type MovePackage = IObject & IOwner & {
   defaultSuinsName?: Maybe<Scalars['String']['output']>;
   /** 32-byte hash that identifies the package's contents, encoded as a Base58 string. */
   digest?: Maybe<Scalars['String']['output']>;
+  /**
+   * Fetch the latest version of this package (the package with the highest `version` that shares
+   * this packages's original ID)
+   */
+  latestPackage: MovePackage;
   /** The transitive dependencies of this package. */
   linkage?: Maybe<Array<Linkage>>;
   /**
@@ -2224,12 +2540,42 @@ export type MovePackage = IObject & IOwner & {
    * Packages are always Immutable.
    */
   owner?: Maybe<ObjectOwner>;
+  /**
+   * Fetch another version of this package (the package that shares this package's original ID,
+   * but has the specified `version`).
+   */
+  packageAtVersion?: Maybe<MovePackage>;
+  /**
+   * Fetch all versions of this package (packages that share this package's original ID),
+   * optionally bounding the versions exclusively from below with `afterVersion`, or from above
+   * with `beforeVersion`.
+   */
+  packageVersions: MovePackageConnection;
   /** The transaction block that published or upgraded this package. */
   previousTransactionBlock?: Maybe<TransactionBlock>;
   /**
    * The transaction blocks that sent objects to this package.
    *
    * Note that objects that have been sent to a package become inaccessible.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
    */
   receivedTransactionBlocks: TransactionBlockConnection;
   /**
@@ -2267,7 +2613,7 @@ export type MovePackage = IObject & IOwner & {
   suinsRegistrations: SuinsRegistrationConnection;
   /** The (previous) versions of this package that introduced its types. */
   typeOrigins?: Maybe<Array<TypeOrigin>>;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -2352,12 +2698,35 @@ export type MovePackageObjectsArgs = {
  * A MovePackage is a kind of Move object that represents code that has been published on chain.
  * It exposes information about its modules, type definitions, functions, and dependencies.
  */
+export type MovePackagePackageAtVersionArgs = {
+  version: Scalars['Int']['input'];
+};
+
+
+/**
+ * A MovePackage is a kind of Move object that represents code that has been published on chain.
+ * It exposes information about its modules, type definitions, functions, and dependencies.
+ */
+export type MovePackagePackageVersionsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<MovePackageVersionFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/**
+ * A MovePackage is a kind of Move object that represents code that has been published on chain.
+ * It exposes information about its modules, type definitions, functions, and dependencies.
+ */
 export type MovePackageReceivedTransactionBlocksArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2384,6 +2753,20 @@ export type MovePackageSuinsRegistrationsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/** Filter for paginating `MovePackage`s that were created within a range of checkpoints. */
+export type MovePackageCheckpointFilter = {
+  /**
+   * Fetch packages that were published strictly after this checkpoint. Omitting this fetches
+   * packages published since genesis.
+   */
+  afterCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /**
+   * Fetch packages that were published strictly before this checkpoint. Omitting this fetches
+   * packages published up to the latest checkpoint (inclusive).
+   */
+  beforeCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+};
+
 export type MovePackageConnection = {
   __typename?: 'MovePackageConnection';
   /** A list of edges. */
@@ -2403,8 +2786,22 @@ export type MovePackageEdge = {
   node: MovePackage;
 };
 
-/** Description of a type, defined in a Move module. */
-export type MoveStruct = {
+/** Filter for paginating versions of a given `MovePackage`. */
+export type MovePackageVersionFilter = {
+  /**
+   * Fetch versions of this package that are strictly newer than this version. Omitting this
+   * fetches versions since the original version.
+   */
+  afterVersion?: InputMaybe<Scalars['UInt53']['input']>;
+  /**
+   * Fetch versions of this package that are strictly older than this version. Omitting this
+   * fetches versions up to the latest version (inclusive).
+   */
+  beforeVersion?: InputMaybe<Scalars['UInt53']['input']>;
+};
+
+/** Description of a struct type, defined in a Move module. */
+export type MoveStruct = IMoveDatatype & {
   __typename?: 'MoveStruct';
   /** Abilities this struct has. */
   abilities?: Maybe<Array<MoveAbility>>;
@@ -2453,10 +2850,13 @@ export type MoveStructTypeParameter = {
 /** Represents concrete types (no type parameters, no references). */
 export type MoveType = {
   __typename?: 'MoveType';
-  /** The abilities this concrete type has. */
-  abilities: Array<MoveAbility>;
-  /** Structured representation of the "shape" of values that match this type. */
-  layout: Scalars['MoveTypeLayout']['output'];
+  /** The abilities this concrete type has. Returns no abilities if the type is invalid. */
+  abilities?: Maybe<Array<MoveAbility>>;
+  /**
+   * Structured representation of the "shape" of values that match this type. May return no
+   * layout if the type is invalid.
+   */
+  layout?: Maybe<Scalars['MoveTypeLayout']['output']>;
   /** Flat representation of the type signature, as a displayable string. */
   repr: Scalars['String']['output'];
   /** Structured representation of the type signature. */
@@ -2605,7 +3005,28 @@ export type Object = IObject & IOwner & {
   owner?: Maybe<ObjectOwner>;
   /** The transaction block that created this version of the object. */
   previousTransactionBlock?: Maybe<TransactionBlock>;
-  /** The transaction blocks that sent objects to this object. */
+  /**
+   * The transaction blocks that sent objects to this object.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   receivedTransactionBlocks: TransactionBlockConnection;
   /** The `0x3::staking_pool::StakedSui` objects owned by this object. */
   stakedSuis: StakedSuiConnection;
@@ -2629,7 +3050,7 @@ export type Object = IObject & IOwner & {
    * manage the associated domain.
    */
   suinsRegistrations: SuinsRegistrationConnection;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -2738,6 +3159,7 @@ export type ObjectReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2835,11 +3257,8 @@ export type ObjectFilter = {
   /** Filter for live objects by their current owners. */
   owner?: InputMaybe<Scalars['SuiAddress']['input']>;
   /**
-   * This field is used to specify the type of objects that should be included in the query
-   * results.
-   *
-   * Objects can be filtered by their type's package, package::module, or their fully qualified
-   * type name.
+   * Filter objects by their type's `package`, `package::module`, or their fully qualified type
+   * name.
    *
    * Generic types can be queried by either the generic type name, e.g. `0x2::coin::Coin`, or by
    * the full type name, such as `0x2::coin::Coin<0x2::sui::SUI>`.
@@ -2849,7 +3268,7 @@ export type ObjectFilter = {
 
 export type ObjectKey = {
   objectId: Scalars['SuiAddress']['input'];
-  version: Scalars['Int']['input'];
+  version: Scalars['UInt53']['input'];
 };
 
 export enum ObjectKind {
@@ -2876,7 +3295,7 @@ export type ObjectRef = {
   /** Digest of the object. */
   digest: Scalars['String']['input'];
   /** Version or sequence number of the object. */
-  version: Scalars['Int']['input'];
+  version: Scalars['UInt53']['input'];
 };
 
 /**
@@ -2904,7 +3323,7 @@ export type OwnedOrImmutable = {
   /** The object at this version.  May not be available due to pruning. */
   object?: Maybe<Object>;
   /** Version of the object being read. */
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 /**
@@ -3207,7 +3626,7 @@ export type ProtocolConfigs = {
    * The protocol is not required to change on every epoch boundary, so the protocol version
    * tracks which change to the protocol these configs are from.
    */
-  protocolVersion: Scalars['Int']['output'];
+  protocolVersion: Scalars['UInt53']['output'];
 };
 
 
@@ -3298,8 +3717,19 @@ export type Query = {
   dryRunTransactionBlock: DryRunResult;
   /** Fetch epoch information by ID (defaults to the latest epoch). */
   epoch?: Maybe<Epoch>;
-  /** The events that exist in the network. */
+  /**
+   * Query events that are emitted in the network.
+   * We currently do not support filtering by emitting module and event type
+   * at the same time so if both are provided in one filter, the query will error.
+   */
   events: EventConnection;
+  /**
+   * The latest version of the package at `address`.
+   *
+   * This corresponds to the package with the highest `version` that shares its original ID with
+   * the package at `address`.
+   */
+  latestPackage?: Maybe<MovePackage>;
   /**
    * The object corresponding to the given address at the (optionally) given version.
    * When no version is given, the latest version is returned.
@@ -3307,7 +3737,53 @@ export type Query = {
   object?: Maybe<Object>;
   /** The objects that exist in the network. */
   objects: ObjectConnection;
+  /**
+   * Look up an Owner by its SuiAddress.
+   *
+   * `rootVersion` represents the version of the root object in some nested chain of dynamic
+   * fields. It allows consistent historical queries for the case of wrapped objects, which don't
+   * have a version. For example, if querying the dynamic field of a table wrapped in a parent
+   * object, passing the parent object's version here will ensure we get the dynamic field's
+   * state at the moment that parent's version was created.
+   *
+   * Also, if this Owner is an object itself, `rootVersion` will be used to bound its version
+   * from above when querying `Owner.asObject`. This can be used, for example, to get the
+   * contents of a dynamic object field when its parent was at `rootVersion`.
+   *
+   * If `rootVersion` is omitted, dynamic fields will be from a consistent snapshot of the Sui
+   * state at the latest checkpoint known to the GraphQL RPC. Similarly, `Owner.asObject` will
+   * return the object's version at the latest checkpoint.
+   */
   owner?: Maybe<Owner>;
+  /**
+   * The package corresponding to the given address (at the optionally given version).
+   *
+   * When no version is given, the package is loaded directly from the address given. Otherwise,
+   * the address is translated before loading to point to the package whose original ID matches
+   * the package at `address`, but whose version is `version`. For non-system packages, this
+   * might result in a different address than `address` because different versions of a package,
+   * introduced by upgrades, exist at distinct addresses.
+   *
+   * Note that this interpretation of `version` is different from a historical object read (the
+   * interpretation of `version` for the `object` query).
+   */
+  package?: Maybe<MovePackage>;
+  /** Fetch a package by its name (using dot move service) */
+  packageByName?: Maybe<MovePackage>;
+  /**
+   * Fetch all versions of package at `address` (packages that share this package's original ID),
+   * optionally bounding the versions exclusively from below with `afterVersion`, or from above
+   * with `beforeVersion`.
+   */
+  packageVersions: MovePackageConnection;
+  /**
+   * The Move packages that exist in the network, optionally filtered to be strictly before
+   * `beforeCheckpoint` and/or strictly after `afterCheckpoint`.
+   *
+   * This query returns all versions of a given user package that appear between the specified
+   * checkpoints, but only records the latest versions of system packages.
+   */
+  packages: MovePackageConnection;
   /**
    * Fetch the protocol config by protocol version (defaults to the latest protocol
    * version known to the GraphQL service).
@@ -3319,13 +3795,36 @@ export type Query = {
   serviceConfig: ServiceConfig;
   /** Fetch a transaction block by its transaction digest. */
   transactionBlock?: Maybe<TransactionBlock>;
-  /** The transaction blocks that exist in the network. */
+  /**
+   * The transaction blocks that exist in the network.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   transactionBlocks: TransactionBlockConnection;
   /**
    * Fetch a structured representation of a concrete type, including its layout information.
    * Fails if the type is malformed.
    */
   type: MoveType;
+  /** Fetch a type that includes dot move service names in it. */
+  typeByName: MoveType;
   /**
    * Verify a zkLogin signature based on the provided transaction or personal message
    * based on current epoch, chain id, and latest JWKs fetched on-chain. If the
@@ -3383,7 +3882,7 @@ export type QueryDryRunTransactionBlockArgs = {
 
 
 export type QueryEpochArgs = {
-  id?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['UInt53']['input']>;
 };
 
 
@@ -3396,9 +3895,14 @@ export type QueryEventsArgs = {
 };
 
 
+export type QueryLatestPackageArgs = {
+  address: Scalars['SuiAddress']['input'];
+};
+
+
 export type QueryObjectArgs = {
   address: Scalars['SuiAddress']['input'];
-  version?: InputMaybe<Scalars['Int']['input']>;
+  version?: InputMaybe<Scalars['UInt53']['input']>;
 };
 
 
@@ -3413,11 +3917,42 @@ export type QueryObjectsArgs = {
 
 export type QueryOwnerArgs = {
   address: Scalars['SuiAddress']['input'];
+  rootVersion?: InputMaybe<Scalars['UInt53']['input']>;
+};
+
+
+export type QueryPackageArgs = {
+  address: Scalars['SuiAddress']['input'];
+  version?: InputMaybe<Scalars['UInt53']['input']>;
+};
+
+
+export type QueryPackageByNameArgs = {
+  name: Scalars['String']['input'];
+};
+
+
+export type QueryPackageVersionsArgs = {
+  address: Scalars['SuiAddress']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<MovePackageVersionFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryPackagesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<MovePackageCheckpointFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
 export type QueryProtocolConfigArgs = {
-  protocolVersion?: InputMaybe<Scalars['Int']['input']>;
+  protocolVersion?: InputMaybe<Scalars['UInt53']['input']>;
 };
 
 
@@ -3437,11 +3972,17 @@ export type QueryTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
 export type QueryTypeArgs = {
   type: Scalars['String']['input'];
+};
+
+
+export type QueryTypeByNameArgs = {
+  name: Scalars['String']['input'];
 };
 
 
@@ -3466,9 +4007,9 @@ export type RandomnessStateUpdateTransaction = {
   /** Updated random bytes, encoded as Base64. */
   randomBytes: Scalars['Base64']['output'];
   /** The initial version the randomness object was shared at. */
-  randomnessObjInitialSharedVersion: Scalars['Int']['output'];
+  randomnessObjInitialSharedVersion: Scalars['UInt53']['output'];
   /** Randomness round of the update. */
-  randomnessRound: Scalars['Int']['output'];
+  randomnessRound: Scalars['UInt53']['output'];
 };
 
 /** A Move object that can be received in this transaction. */
@@ -3484,7 +4025,7 @@ export type Receiving = {
   /** The object at this version.  May not be available due to pruning. */
   object?: Maybe<Object>;
   /** Version of the object being read. */
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 /** The result of another transaction command. */
@@ -3527,7 +4068,7 @@ export type ServiceConfig = {
    * Maximum estimated cost of a database query used to serve a GraphQL request.  This is
    * measured in the same units that the database uses in EXPLAIN queries.
    */
-  maxDbQueryCost: Scalars['BigInt']['output'];
+  maxDbQueryCost: Scalars['Int']['output'];
   /** Maximum nesting allowed in struct fields when calculating the layout of a single Move Type. */
   maxMoveValueDepth: Scalars['Int']['output'];
   /**
@@ -3549,8 +4090,25 @@ export type ServiceConfig = {
   maxQueryDepth: Scalars['Int']['output'];
   /** The maximum number of nodes (field names) the service will accept in a single query. */
   maxQueryNodes: Scalars['Int']['output'];
-  /** Maximum length of a query payload string. */
+  /**
+   * The maximum bytes allowed for the JSON object in the request body of a GraphQL query, for
+   * the read part of the query.
+   * In case of mutations or dryRunTransactionBlocks the txBytes and signatures are not
+   * included in this limit.
+   */
   maxQueryPayloadSize: Scalars['Int']['output'];
+  /** Maximum number of candidates to scan when gathering a page of results. */
+  maxScanLimit: Scalars['Int']['output'];
+  /** Maximum number of transaction ids that can be passed to a `TransactionBlockFilter`. */
+  maxTransactionIds: Scalars['Int']['output'];
+  /**
+   * The maximum bytes allowed for the `txBytes` and `signatures` fields of the GraphQL mutation
+   * `executeTransactionBlock` node, or for the `txBytes` of a `dryRunTransactionBlock`.
+   *
+   * It is the value of the maximum transaction bytes (including the signatures) allowed by the
+   * protocol, plus the Base64 overhead (roughly 1/3 of the original string).
+   */
+  maxTransactionPayloadSize: Scalars['Int']['output'];
   /** Maximum nesting allowed in type arguments in Move Types resolved by this service. */
   maxTypeArgumentDepth: Scalars['Int']['output'];
   /**
@@ -3563,7 +4121,14 @@ export type ServiceConfig = {
    * Move Type.
    */
   maxTypeNodes: Scalars['Int']['output'];
-  /** Maximum time in milliseconds that will be spent to serve one request. */
+  /**
+   * Maximum time in milliseconds spent waiting for a response from fullnode after issuing a
+   * a transaction to execute. Note that the transaction may still succeed even in the case of a
+   * timeout. Transactions are idempotent, so a transaction that times out should be resubmitted
+   * until the network returns a definite response (success or failure, not timeout).
+   */
+  mutationTimeoutMs: Scalars['Int']['output'];
+  /** Maximum time in milliseconds that will be spent to serve one query request. */
   requestTimeoutMs: Scalars['Int']['output'];
 };
 
@@ -3579,7 +4144,7 @@ export type ServiceConfigIsEnabledArgs = {
  */
 export type Shared = {
   __typename?: 'Shared';
-  initialSharedVersion: Scalars['Int']['output'];
+  initialSharedVersion: Scalars['UInt53']['output'];
 };
 
 /** A Move object that's shared. */
@@ -3587,7 +4152,7 @@ export type SharedInput = {
   __typename?: 'SharedInput';
   address: Scalars['SuiAddress']['output'];
   /** The version that this this object was shared at. */
-  initialSharedVersion: Scalars['Int']['output'];
+  initialSharedVersion: Scalars['UInt53']['output'];
   /**
    * Controls whether the transaction block can reference the shared object as a mutable
    * reference or by value. This has implications for scheduling: Transactions that just read
@@ -3596,6 +4161,15 @@ export type SharedInput = {
    * respect to each other.
    */
   mutable: Scalars['Boolean']['output'];
+};
+
+/** The transaction accpeted a shared object as input, but its execution was cancelled. */
+export type SharedObjectCancelled = {
+  __typename?: 'SharedObjectCancelled';
+  /** ID of the shared object. */
+  address: Scalars['SuiAddress']['output'];
+  /** The assigned shared object version. It is a special version indicating transaction cancellation reason. */
+  version: Scalars['UInt53']['output'];
 };
 
 /**
@@ -3615,7 +4189,7 @@ export type SharedObjectDelete = {
    * The version of the shared object that was assigned to this transaction during by consensus,
    * during sequencing.
    */
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 /** The transaction accepted a shared object as input, but only to read it. */
@@ -3631,7 +4205,7 @@ export type SharedObjectRead = {
   /** The object at this version.  May not be available due to pruning. */
   object?: Maybe<Object>;
   /** Version of the object being read. */
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 /**
@@ -3775,7 +4349,28 @@ export type StakedSui = IMoveObject & IObject & IOwner & {
   previousTransactionBlock?: Maybe<TransactionBlock>;
   /** The SUI that was initially staked. */
   principal?: Maybe<Scalars['BigInt']['output']>;
-  /** The transaction blocks that sent objects to this object. */
+  /**
+   * The transaction blocks that sent objects to this object.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   receivedTransactionBlocks: TransactionBlockConnection;
   /** The epoch at which this object was requested to join a stake pool. */
   requestedEpoch?: Maybe<Epoch>;
@@ -3803,7 +4398,7 @@ export type StakedSui = IMoveObject & IObject & IOwner & {
    * manage the associated domain.
    */
   suinsRegistrations: SuinsRegistrationConnection;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -3876,6 +4471,7 @@ export type StakedSuiReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -4004,7 +4600,28 @@ export type SuinsRegistration = IMoveObject & IObject & IOwner & {
   owner?: Maybe<ObjectOwner>;
   /** The transaction block that created this version of the object. */
   previousTransactionBlock?: Maybe<TransactionBlock>;
-  /** The transaction blocks that sent objects to this object. */
+  /**
+   * The transaction blocks that sent objects to this object.
+   *
+   * `scanLimit` restricts the number of candidate transactions scanned when gathering a page of
+   * results. It is required for queries that apply more than two complex filters (on function,
+   * kind, sender, recipient, input object, changed object, or ids), and can be at most
+   * `serviceConfig.maxScanLimit`.
+   *
+   * When the scan limit is reached the page will be returned even if it has fewer than `first`
+   * results when paginating forward (`last` when paginating backwards). If there are more
+   * transactions to scan, `pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+   * `true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set to the last
+   * transaction that was scanned as opposed to the last (or first) transaction in the page.
+   *
+   * Requesting the next (or previous) page after this cursor will resume the search, scanning
+   * the next `scanLimit` many transactions in the direction of pagination, and so on until all
+   * transactions in the scanning range have been visited.
+   *
+   * By default, the scanning range includes all transactions known to GraphQL, but it can be
+   * restricted by the `after` and `before` cursors, and the `beforeCheckpoint`,
+   * `afterCheckpoint` and `atCheckpoint` filters.
+   */
   receivedTransactionBlocks: TransactionBlockConnection;
   /** The `0x3::staking_pool::StakedSui` objects owned by this object. */
   stakedSuis: StakedSuiConnection;
@@ -4028,7 +4645,7 @@ export type SuinsRegistration = IMoveObject & IObject & IOwner & {
    * manage the associated domain.
    */
   suinsRegistrations: SuinsRegistrationConnection;
-  version: Scalars['Int']['output'];
+  version: Scalars['UInt53']['output'];
 };
 
 
@@ -4092,6 +4709,7 @@ export type SuinsRegistrationReceivedTransactionBlocksArgs = {
   filter?: InputMaybe<TransactionBlockFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -4141,7 +4759,7 @@ export type SystemParameters = {
   /** Minimum stake needed to become a new validator. */
   minValidatorJoiningStake?: Maybe<Scalars['BigInt']['output']>;
   /** The epoch at which stake subsidies start being paid out. */
-  stakeSubsidyStartEpoch?: Maybe<Scalars['Int']['output']>;
+  stakeSubsidyStartEpoch?: Maybe<Scalars['UInt53']['output']>;
   /**
    * The number of epochs that a validator has to recover from having less than
    * `validatorLowStakeThreshold` stake.
@@ -4239,7 +4857,11 @@ export type TransactionBlockEffects = {
   dependencies: DependencyConnection;
   /** The epoch this transaction was finalized in. */
   epoch?: Maybe<Epoch>;
-  /** The reason for a transaction failure, if it did fail. */
+  /**
+   * The reason for a transaction failure, if it did fail.
+   * If the error is a Move abort, the error message will be resolved to a human-readable form if
+   * possible, otherwise it will fall back to displaying the abort code and location.
+   */
   errors?: Maybe<Scalars['String']['output']>;
   /** Events emitted by this transaction block. */
   events: EventConnection;
@@ -4249,7 +4871,7 @@ export type TransactionBlockEffects = {
    * The latest version of all objects (apart from packages) that have been created or modified
    * by this transaction, immediately following this transaction.
    */
-  lamportVersion: Scalars['Int']['output'];
+  lamportVersion: Scalars['UInt53']['output'];
   /** The effect this transaction had on objects on-chain. */
   objectChanges: ObjectChangeConnection;
   /** Whether the transaction executed successfully or not. */
@@ -4308,16 +4930,55 @@ export type TransactionBlockEffectsUnchangedSharedObjectsArgs = {
 };
 
 export type TransactionBlockFilter = {
-  afterCheckpoint?: InputMaybe<Scalars['Int']['input']>;
-  atCheckpoint?: InputMaybe<Scalars['Int']['input']>;
-  beforeCheckpoint?: InputMaybe<Scalars['Int']['input']>;
+  /** Limit to transactions that occured strictly after the given checkpoint. */
+  afterCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transactions in the given checkpoint. */
+  atCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /** Limit to transaction that occured strictly before the given checkpoint. */
+  beforeCheckpoint?: InputMaybe<Scalars['UInt53']['input']>;
+  /**
+   * Limit to transactions that output a versioon of this object. NOTE: this input filter has
+   * been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+   *
+   * This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+   * `affectedObject` is introduced, whichever is later.
+   */
   changedObject?: InputMaybe<Scalars['SuiAddress']['input']>;
+  /**
+   * Filter transactions by move function called. Calls can be filtered by the `package`,
+   * `package::module`, or the `package::module::name` of their function.
+   */
   function?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Limit to transactions that accepted the given object as an input. NOTE: this input filter
+   * has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+   *
+   * This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+   * `affectedObject` is introduced, whichever is later.
+   */
   inputObject?: InputMaybe<Scalars['SuiAddress']['input']>;
   /** An input filter selecting for either system or programmable transactions. */
   kind?: InputMaybe<TransactionBlockKindInput>;
+  /**
+   * Limit to transactions that sent an object to the given address. NOTE: this input filter has
+   * been deprecated in favor of `affectedAddress` which offers an easier to understand
+   * behavior.
+   *
+   * This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+   * `affectedAddress` is introduced, whichever is later.
+   */
   recvAddress?: InputMaybe<Scalars['SuiAddress']['input']>;
+  /** Limit to transactions that were sent by the given address. */
+  sentAddress?: InputMaybe<Scalars['SuiAddress']['input']>;
+  /**
+   * Limit to transactions that were sent by the given address. NOTE: this input filter has been
+   * deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
+   * Both filters restrict transactions by their sender, only, not signers in general.
+   *
+   * This filter will be removed with 1.36.0 (2024-10-14).
+   */
   signAddress?: InputMaybe<Scalars['SuiAddress']['input']>;
+  /** Select transactions by their digest. */
   transactionIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -4364,9 +5025,9 @@ export type TransactionInputEdge = {
  * to the sender.
  */
 export type TransactionMetadata = {
-  gasBudget?: InputMaybe<Scalars['Int']['input']>;
+  gasBudget?: InputMaybe<Scalars['UInt53']['input']>;
   gasObjects?: InputMaybe<Array<ObjectRef>>;
-  gasPrice?: InputMaybe<Scalars['Int']['input']>;
+  gasPrice?: InputMaybe<Scalars['UInt53']['input']>;
   gasSponsor?: InputMaybe<Scalars['SuiAddress']['input']>;
   sender?: InputMaybe<Scalars['SuiAddress']['input']>;
 };
@@ -4400,7 +5061,7 @@ export type TypeOrigin = {
  * the shared object as input, consensus must schedule it and pick the version that is actually
  * used.
  */
-export type UnchangedSharedObject = SharedObjectDelete | SharedObjectRead;
+export type UnchangedSharedObject = SharedObjectCancelled | SharedObjectDelete | SharedObjectRead;
 
 export type UnchangedSharedObjectConnection = {
   __typename?: 'UnchangedSharedObjectConnection';
@@ -4447,7 +5108,7 @@ export type Validator = {
    * The number of epochs for which this validator has been below the
    * low stake threshold.
    */
-  atRisk?: Maybe<Scalars['Int']['output']>;
+  atRisk?: Maybe<Scalars['UInt53']['output']>;
   /** The fee charged by the validator for staking services. */
   commissionRate?: Maybe<Scalars['Int']['output']>;
   /** Validator's set of credentials such as public keys, network addresses and others. */
@@ -4461,7 +5122,7 @@ export type Validator = {
    */
   exchangeRates?: Maybe<MoveObject>;
   /** Number of exchange rates in the table. */
-  exchangeRatesSize?: Maybe<Scalars['Int']['output']>;
+  exchangeRatesSize?: Maybe<Scalars['UInt53']['output']>;
   /**
    * A wrapped object containing the validator's exchange rates. This is a table from epoch
    * number to `PoolTokenExchangeRate` value. The exchange rate is used to determine the amount
@@ -4512,7 +5173,7 @@ export type Validator = {
    */
   stakingPool?: Maybe<MoveObject>;
   /** The epoch at which this pool became active. */
-  stakingPoolActivationEpoch?: Maybe<Scalars['Int']['output']>;
+  stakingPoolActivationEpoch?: Maybe<Scalars['UInt53']['output']>;
   /** The ID of this validator's `0x3::staking_pool::StakingPool`. */
   stakingPoolId: Scalars['SuiAddress']['output'];
   /** The total number of SUI tokens in this pool. */
@@ -4629,7 +5290,7 @@ export type GetCheckpointQueryVariables = Exact<{
 }>;
 
 
-export type GetCheckpointQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', digest: string, networkTotalTransactions?: number | null, previousCheckpointDigest?: string | null, sequenceNumber: number, timestamp: any, validatorSignatures: any, epoch?: { __typename?: 'Epoch', epochId: number } | null, rollingGasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, storageCost?: any | null, storageRebate?: any | null, nonRefundableStorageFee?: any | null } | null, transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> }, endOfEpoch: { __typename?: 'TransactionBlockConnection', nodes: Array<{ __typename?: 'TransactionBlock', kind?: { __typename: 'AuthenticatorStateUpdateTransaction' } | { __typename: 'ChangeEpochTransaction' } | { __typename: 'ConsensusCommitPrologueTransaction' } | { __typename: 'EndOfEpochTransaction', transactions: { __typename?: 'EndOfEpochTransactionKindConnection', nodes: Array<{ __typename: 'AuthenticatorStateCreateTransaction' } | { __typename: 'AuthenticatorStateExpireTransaction' } | { __typename: 'ChangeEpochTransaction', epoch?: { __typename?: 'Epoch', epochId: number, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: number } } | null } | { __typename: 'CoinDenyListStateCreateTransaction' } | { __typename: 'RandomnessStateCreateTransaction' }> } } | { __typename: 'GenesisTransaction' } | { __typename: 'ProgrammableTransactionBlock' } | { __typename: 'RandomnessStateUpdateTransaction' } | null }> } } | null };
+export type GetCheckpointQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', digest: string, networkTotalTransactions?: any | null, previousCheckpointDigest?: string | null, sequenceNumber: any, timestamp: any, validatorSignatures: any, epoch?: { __typename?: 'Epoch', epochId: any } | null, rollingGasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, storageCost?: any | null, storageRebate?: any | null, nonRefundableStorageFee?: any | null } | null, transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> }, endOfEpoch: { __typename?: 'TransactionBlockConnection', nodes: Array<{ __typename?: 'TransactionBlock', kind?: { __typename: 'AuthenticatorStateUpdateTransaction' } | { __typename: 'ChangeEpochTransaction' } | { __typename: 'ConsensusCommitPrologueTransaction' } | { __typename: 'EndOfEpochTransaction', transactions: { __typename?: 'EndOfEpochTransactionKindConnection', nodes: Array<{ __typename: 'AuthenticatorStateCreateTransaction' } | { __typename: 'AuthenticatorStateExpireTransaction' } | { __typename: 'BridgeCommitteeInitTransaction' } | { __typename: 'BridgeStateCreateTransaction' } | { __typename: 'ChangeEpochTransaction', epoch?: { __typename?: 'Epoch', epochId: any, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: any } } | null } | { __typename: 'CoinDenyListStateCreateTransaction' } | { __typename: 'RandomnessStateCreateTransaction' }> } } | { __typename: 'GenesisTransaction' } | { __typename: 'ProgrammableTransactionBlock' } | { __typename: 'RandomnessStateUpdateTransaction' } | null }> } } | null };
 
 export type GetCheckpointsQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -4639,7 +5300,7 @@ export type GetCheckpointsQueryVariables = Exact<{
 }>;
 
 
-export type GetCheckpointsQuery = { __typename?: 'Query', checkpoints: { __typename?: 'CheckpointConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Checkpoint', digest: string, networkTotalTransactions?: number | null, previousCheckpointDigest?: string | null, sequenceNumber: number, timestamp: any, validatorSignatures: any, epoch?: { __typename?: 'Epoch', epochId: number } | null, rollingGasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, storageCost?: any | null, storageRebate?: any | null, nonRefundableStorageFee?: any | null } | null, transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> }, endOfEpoch: { __typename?: 'TransactionBlockConnection', nodes: Array<{ __typename?: 'TransactionBlock', kind?: { __typename: 'AuthenticatorStateUpdateTransaction' } | { __typename: 'ChangeEpochTransaction' } | { __typename: 'ConsensusCommitPrologueTransaction' } | { __typename: 'EndOfEpochTransaction', transactions: { __typename?: 'EndOfEpochTransactionKindConnection', nodes: Array<{ __typename: 'AuthenticatorStateCreateTransaction' } | { __typename: 'AuthenticatorStateExpireTransaction' } | { __typename: 'ChangeEpochTransaction', epoch?: { __typename?: 'Epoch', epochId: number, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: number } } | null } | { __typename: 'CoinDenyListStateCreateTransaction' } | { __typename: 'RandomnessStateCreateTransaction' }> } } | { __typename: 'GenesisTransaction' } | { __typename: 'ProgrammableTransactionBlock' } | { __typename: 'RandomnessStateUpdateTransaction' } | null }> } }> } };
+export type GetCheckpointsQuery = { __typename?: 'Query', checkpoints: { __typename?: 'CheckpointConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, nodes: Array<{ __typename?: 'Checkpoint', digest: string, networkTotalTransactions?: any | null, previousCheckpointDigest?: string | null, sequenceNumber: any, timestamp: any, validatorSignatures: any, epoch?: { __typename?: 'Epoch', epochId: any } | null, rollingGasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, storageCost?: any | null, storageRebate?: any | null, nonRefundableStorageFee?: any | null } | null, transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> }, endOfEpoch: { __typename?: 'TransactionBlockConnection', nodes: Array<{ __typename?: 'TransactionBlock', kind?: { __typename: 'AuthenticatorStateUpdateTransaction' } | { __typename: 'ChangeEpochTransaction' } | { __typename: 'ConsensusCommitPrologueTransaction' } | { __typename: 'EndOfEpochTransaction', transactions: { __typename?: 'EndOfEpochTransactionKindConnection', nodes: Array<{ __typename: 'AuthenticatorStateCreateTransaction' } | { __typename: 'AuthenticatorStateExpireTransaction' } | { __typename: 'BridgeCommitteeInitTransaction' } | { __typename: 'BridgeStateCreateTransaction' } | { __typename: 'ChangeEpochTransaction', epoch?: { __typename?: 'Epoch', epochId: any, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: any } } | null } | { __typename: 'CoinDenyListStateCreateTransaction' } | { __typename: 'RandomnessStateCreateTransaction' }> } } | { __typename: 'GenesisTransaction' } | { __typename: 'ProgrammableTransactionBlock' } | { __typename: 'RandomnessStateUpdateTransaction' } | null }> } }> } };
 
 export type PaginateCheckpointTransactionBlocksQueryVariables = Exact<{
   id?: InputMaybe<CheckpointId>;
@@ -4649,7 +5310,7 @@ export type PaginateCheckpointTransactionBlocksQueryVariables = Exact<{
 
 export type PaginateCheckpointTransactionBlocksQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> } } | null };
 
-export type Rpc_Checkpoint_FieldsFragment = { __typename?: 'Checkpoint', digest: string, networkTotalTransactions?: number | null, previousCheckpointDigest?: string | null, sequenceNumber: number, timestamp: any, validatorSignatures: any, epoch?: { __typename?: 'Epoch', epochId: number } | null, rollingGasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, storageCost?: any | null, storageRebate?: any | null, nonRefundableStorageFee?: any | null } | null, transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> }, endOfEpoch: { __typename?: 'TransactionBlockConnection', nodes: Array<{ __typename?: 'TransactionBlock', kind?: { __typename: 'AuthenticatorStateUpdateTransaction' } | { __typename: 'ChangeEpochTransaction' } | { __typename: 'ConsensusCommitPrologueTransaction' } | { __typename: 'EndOfEpochTransaction', transactions: { __typename?: 'EndOfEpochTransactionKindConnection', nodes: Array<{ __typename: 'AuthenticatorStateCreateTransaction' } | { __typename: 'AuthenticatorStateExpireTransaction' } | { __typename: 'ChangeEpochTransaction', epoch?: { __typename?: 'Epoch', epochId: number, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: number } } | null } | { __typename: 'CoinDenyListStateCreateTransaction' } | { __typename: 'RandomnessStateCreateTransaction' }> } } | { __typename: 'GenesisTransaction' } | { __typename: 'ProgrammableTransactionBlock' } | { __typename: 'RandomnessStateUpdateTransaction' } | null }> } };
+export type Rpc_Checkpoint_FieldsFragment = { __typename?: 'Checkpoint', digest: string, networkTotalTransactions?: any | null, previousCheckpointDigest?: string | null, sequenceNumber: any, timestamp: any, validatorSignatures: any, epoch?: { __typename?: 'Epoch', epochId: any } | null, rollingGasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, storageCost?: any | null, storageRebate?: any | null, nonRefundableStorageFee?: any | null } | null, transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null }> }, endOfEpoch: { __typename?: 'TransactionBlockConnection', nodes: Array<{ __typename?: 'TransactionBlock', kind?: { __typename: 'AuthenticatorStateUpdateTransaction' } | { __typename: 'ChangeEpochTransaction' } | { __typename: 'ConsensusCommitPrologueTransaction' } | { __typename: 'EndOfEpochTransaction', transactions: { __typename?: 'EndOfEpochTransactionKindConnection', nodes: Array<{ __typename: 'AuthenticatorStateCreateTransaction' } | { __typename: 'AuthenticatorStateExpireTransaction' } | { __typename: 'BridgeCommitteeInitTransaction' } | { __typename: 'BridgeStateCreateTransaction' } | { __typename: 'ChangeEpochTransaction', epoch?: { __typename?: 'Epoch', epochId: any, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: any } } | null } | { __typename: 'CoinDenyListStateCreateTransaction' } | { __typename: 'RandomnessStateCreateTransaction' }> } } | { __typename: 'GenesisTransaction' } | { __typename: 'ProgrammableTransactionBlock' } | { __typename: 'RandomnessStateUpdateTransaction' } | null }> } };
 
 export type DevInspectTransactionBlockQueryVariables = Exact<{
   txBytes: Scalars['String']['input'];
@@ -4664,7 +5325,7 @@ export type DevInspectTransactionBlockQueryVariables = Exact<{
 }>;
 
 
-export type DevInspectTransactionBlockQuery = { __typename?: 'Query', dryRunTransactionBlock: { __typename?: 'DryRunResult', error?: string | null, results?: Array<{ __typename?: 'DryRunEffect', mutatedReferences?: Array<{ __typename?: 'DryRunMutation', bcs: any, input: { __typename: 'GasCoin' } | { __typename: 'Input', inputIndex: number } | { __typename: 'Result', cmd: number, resultIndex?: number | null }, type: { __typename?: 'MoveType', repr: string } }> | null, returnValues?: Array<{ __typename?: 'DryRunReturn', bcs: any, type: { __typename?: 'MoveType', repr: string } }> | null }> | null, transaction?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null } };
+export type DevInspectTransactionBlockQuery = { __typename?: 'Query', dryRunTransactionBlock: { __typename?: 'DryRunResult', error?: string | null, results?: Array<{ __typename?: 'DryRunEffect', mutatedReferences?: Array<{ __typename?: 'DryRunMutation', bcs: any, input: { __typename: 'GasCoin' } | { __typename: 'Input', inputIndex: number } | { __typename: 'Result', cmd: number, resultIndex?: number | null }, type: { __typename?: 'MoveType', repr: string } }> | null, returnValues?: Array<{ __typename?: 'DryRunReturn', bcs: any, type: { __typename?: 'MoveType', repr: string } }> | null }> | null, transaction?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null } };
 
 export type DryRunTransactionBlockQueryVariables = Exact<{
   txBytes: Scalars['String']['input'];
@@ -4678,7 +5339,7 @@ export type DryRunTransactionBlockQueryVariables = Exact<{
 }>;
 
 
-export type DryRunTransactionBlockQuery = { __typename?: 'Query', dryRunTransactionBlock: { __typename?: 'DryRunResult', error?: string | null, transaction?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null } };
+export type DryRunTransactionBlockQuery = { __typename?: 'Query', dryRunTransactionBlock: { __typename?: 'DryRunResult', error?: string | null, transaction?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null } };
 
 export type ExecuteTransactionBlockMutationVariables = Exact<{
   txBytes: Scalars['String']['input'];
@@ -4693,7 +5354,7 @@ export type ExecuteTransactionBlockMutationVariables = Exact<{
 }>;
 
 
-export type ExecuteTransactionBlockMutation = { __typename?: 'Mutation', executeTransactionBlock: { __typename?: 'ExecutionResult', errors?: Array<string> | null, effects: { __typename?: 'TransactionBlockEffects', transactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null } } };
+export type ExecuteTransactionBlockMutation = { __typename?: 'Mutation', executeTransactionBlock: { __typename?: 'ExecutionResult', errors?: Array<string> | null, effects: { __typename?: 'TransactionBlockEffects', transactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null } } };
 
 export type GetAllBalancesQueryVariables = Exact<{
   owner: Scalars['SuiAddress']['input'];
@@ -4702,7 +5363,7 @@ export type GetAllBalancesQueryVariables = Exact<{
 }>;
 
 
-export type GetAllBalancesQuery = { __typename?: 'Query', address?: { __typename?: 'Address', balances: { __typename?: 'BalanceConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Balance', coinObjectCount?: number | null, totalBalance?: any | null, coinType: { __typename?: 'MoveType', repr: string } }> } } | null };
+export type GetAllBalancesQuery = { __typename?: 'Query', address?: { __typename?: 'Address', balances: { __typename?: 'BalanceConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Balance', coinObjectCount?: any | null, totalBalance?: any | null, coinType: { __typename?: 'MoveType', repr: string } }> } } | null };
 
 export type GetBalanceQueryVariables = Exact<{
   owner: Scalars['SuiAddress']['input'];
@@ -4710,7 +5371,7 @@ export type GetBalanceQueryVariables = Exact<{
 }>;
 
 
-export type GetBalanceQuery = { __typename?: 'Query', address?: { __typename?: 'Address', balance?: { __typename?: 'Balance', coinObjectCount?: number | null, totalBalance?: any | null, coinType: { __typename?: 'MoveType', repr: string } } | null } | null };
+export type GetBalanceQuery = { __typename?: 'Query', address?: { __typename?: 'Address', balance?: { __typename?: 'Balance', coinObjectCount?: any | null, totalBalance?: any | null, coinType: { __typename?: 'MoveType', repr: string } } | null } | null };
 
 export type GetChainIdentifierQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4732,30 +5393,30 @@ export type GetCoinsQueryVariables = Exact<{
 }>;
 
 
-export type GetCoinsQuery = { __typename?: 'Query', address?: { __typename?: 'Address', address: any, coins: { __typename?: 'CoinConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Coin', coinBalance?: any | null, address: any, version: number, digest?: string | null, contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null }> } } | null };
+export type GetCoinsQuery = { __typename?: 'Query', address?: { __typename?: 'Address', address: any, coins: { __typename?: 'CoinConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Coin', coinBalance?: any | null, address: any, version: any, digest?: string | null, contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null }> } } | null };
 
 export type GetCommitteeInfoQueryVariables = Exact<{
-  epochId?: InputMaybe<Scalars['Int']['input']>;
+  epochId?: InputMaybe<Scalars['UInt53']['input']>;
   after?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type GetCommitteeInfoQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: number, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null } | null };
+export type GetCommitteeInfoQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: any, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', votingPower?: number | null, credentials?: { __typename?: 'ValidatorCredentials', protocolPubKey?: any | null } | null }> } } | null } | null };
 
 export type GetCurrentEpochQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCurrentEpochQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: number, totalTransactions?: number | null, startTimestamp: any, endTimestamp?: any | null, referenceGasPrice?: any | null, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', atRisk?: number | null, commissionRate?: number | null, exchangeRatesSize?: number | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: number | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } }> } } | null, firstCheckpoint: { __typename?: 'CheckpointConnection', nodes: Array<{ __typename?: 'Checkpoint', sequenceNumber: number }> } } | null };
+export type GetCurrentEpochQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: any, totalTransactions?: any | null, startTimestamp: any, endTimestamp?: any | null, referenceGasPrice?: any | null, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', atRisk?: any | null, commissionRate?: number | null, exchangeRatesSize?: any | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: any | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } }> } } | null, firstCheckpoint: { __typename?: 'CheckpointConnection', nodes: Array<{ __typename?: 'Checkpoint', sequenceNumber: any }> } } | null };
 
 export type PaginateEpochValidatorsQueryVariables = Exact<{
-  id: Scalars['Int']['input'];
+  id: Scalars['UInt53']['input'];
   after?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type PaginateEpochValidatorsQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', atRisk?: number | null, commissionRate?: number | null, exchangeRatesSize?: number | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: number | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } }> } } | null } | null };
+export type PaginateEpochValidatorsQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', atRisk?: any | null, commissionRate?: number | null, exchangeRatesSize?: any | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: any | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } }> } } | null } | null };
 
-export type Rpc_Validator_FieldsFragment = { __typename?: 'Validator', atRisk?: number | null, commissionRate?: number | null, exchangeRatesSize?: number | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: number | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } };
+export type Rpc_Validator_FieldsFragment = { __typename?: 'Validator', atRisk?: any | null, commissionRate?: number | null, exchangeRatesSize?: any | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: any | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } };
 
 export type Rpc_Credential_FieldsFragment = { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null };
 
@@ -4764,7 +5425,7 @@ export type GetTypeLayoutQueryVariables = Exact<{
 }>;
 
 
-export type GetTypeLayoutQuery = { __typename?: 'Query', type: { __typename?: 'MoveType', layout: any } };
+export type GetTypeLayoutQuery = { __typename?: 'Query', type: { __typename?: 'MoveType', layout?: any | null } };
 
 export type GetDynamicFieldObjectQueryVariables = Exact<{
   parentId: Scalars['SuiAddress']['input'];
@@ -4772,7 +5433,7 @@ export type GetDynamicFieldObjectQueryVariables = Exact<{
 }>;
 
 
-export type GetDynamicFieldObjectQuery = { __typename?: 'Query', owner?: { __typename?: 'Owner', dynamicObjectField?: { __typename?: 'DynamicField', value?: { __typename: 'MoveObject', owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any, digest?: string | null, version: number, storageRebate?: any | null, owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared' } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, type: { __typename?: 'MoveType', repr: string, layout: any } } | null } | null } | null } | { __typename: 'Shared' } | null } | { __typename: 'MoveValue' } | null } | null } | null };
+export type GetDynamicFieldObjectQuery = { __typename?: 'Query', owner?: { __typename?: 'Owner', dynamicObjectField?: { __typename?: 'DynamicField', value?: { __typename: 'MoveObject', owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any, digest?: string | null, version: any, storageRebate?: any | null, owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared' } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null } } | null } | null } | null } | { __typename: 'Shared' } | null } | { __typename: 'MoveValue' } | null } | null } | null };
 
 export type GetDynamicFieldsQueryVariables = Exact<{
   parentId: Scalars['SuiAddress']['input'];
@@ -4781,17 +5442,17 @@ export type GetDynamicFieldsQueryVariables = Exact<{
 }>;
 
 
-export type GetDynamicFieldsQuery = { __typename?: 'Query', owner?: { __typename?: 'Owner', dynamicFields: { __typename?: 'DynamicFieldConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'DynamicField', name?: { __typename?: 'MoveValue', bcs: any, json: any, type: { __typename?: 'MoveType', layout: any, repr: string } } | null, value?: { __typename: 'MoveObject', address: any, digest?: string | null, version: number, contents?: { __typename?: 'MoveValue', json: any, type: { __typename?: 'MoveType', repr: string } } | null } | { __typename: 'MoveValue', json: any, type: { __typename?: 'MoveType', repr: string } } | null }> } } | null };
+export type GetDynamicFieldsQuery = { __typename?: 'Query', owner?: { __typename?: 'Owner', dynamicFields: { __typename?: 'DynamicFieldConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'DynamicField', name?: { __typename?: 'MoveValue', bcs: any, json: any, type: { __typename?: 'MoveType', layout?: any | null, repr: string } } | null, value?: { __typename: 'MoveObject', address: any, digest?: string | null, version: any, contents?: { __typename?: 'MoveValue', json: any, type: { __typename?: 'MoveType', repr: string } } | null } | { __typename: 'MoveValue', json: any, type: { __typename?: 'MoveType', repr: string } } | null }> } } | null };
 
 export type GetLatestCheckpointSequenceNumberQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetLatestCheckpointSequenceNumberQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null };
+export type GetLatestCheckpointSequenceNumberQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null };
 
 export type GetLatestSuiSystemStateQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetLatestSuiSystemStateQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: number, startTimestamp: any, endTimestamp?: any | null, referenceGasPrice?: any | null, systemStateVersion?: number | null, safeMode?: { __typename?: 'SafeMode', enabled?: boolean | null, gasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, nonRefundableStorageFee?: any | null, storageCost?: any | null, storageRebate?: any | null } | null } | null, systemStakeSubsidy?: { __typename?: 'StakeSubsidy', balance?: any | null, currentDistributionAmount?: any | null, decreaseRate?: number | null, distributionCounter?: number | null, periodLength?: number | null } | null, storageFund?: { __typename?: 'StorageFund', nonRefundableBalance?: any | null, totalObjectStorageRebates?: any | null } | null, systemParameters?: { __typename?: 'SystemParameters', minValidatorCount?: number | null, maxValidatorCount?: number | null, minValidatorJoiningStake?: any | null, durationMs?: any | null, validatorLowStakeThreshold?: any | null, validatorLowStakeGracePeriod?: any | null, validatorVeryLowStakeThreshold?: any | null, stakeSubsidyStartEpoch?: number | null } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: number }, validatorSet?: { __typename?: 'ValidatorSet', inactivePoolsSize?: number | null, pendingActiveValidatorsSize?: number | null, stakingPoolMappingsSize?: number | null, validatorCandidatesSize?: number | null, pendingRemovals?: Array<number> | null, totalStake?: any | null, stakingPoolMappingsId?: any | null, pendingActiveValidatorsId?: any | null, validatorCandidatesId?: any | null, inactivePoolsId?: any | null, activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', atRisk?: number | null, commissionRate?: number | null, exchangeRatesSize?: number | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: number | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } }> } } | null } | null };
+export type GetLatestSuiSystemStateQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: any, startTimestamp: any, endTimestamp?: any | null, referenceGasPrice?: any | null, systemStateVersion?: any | null, safeMode?: { __typename?: 'SafeMode', enabled?: boolean | null, gasSummary?: { __typename?: 'GasCostSummary', computationCost?: any | null, nonRefundableStorageFee?: any | null, storageCost?: any | null, storageRebate?: any | null } | null } | null, systemStakeSubsidy?: { __typename?: 'StakeSubsidy', balance?: any | null, currentDistributionAmount?: any | null, decreaseRate?: number | null, distributionCounter?: number | null, periodLength?: number | null } | null, storageFund?: { __typename?: 'StorageFund', nonRefundableBalance?: any | null, totalObjectStorageRebates?: any | null } | null, systemParameters?: { __typename?: 'SystemParameters', minValidatorCount?: number | null, maxValidatorCount?: number | null, minValidatorJoiningStake?: any | null, durationMs?: any | null, validatorLowStakeThreshold?: any | null, validatorLowStakeGracePeriod?: any | null, validatorVeryLowStakeThreshold?: any | null, stakeSubsidyStartEpoch?: any | null } | null, protocolConfigs: { __typename?: 'ProtocolConfigs', protocolVersion: any }, validatorSet?: { __typename?: 'ValidatorSet', inactivePoolsSize?: number | null, pendingActiveValidatorsSize?: number | null, stakingPoolMappingsSize?: number | null, validatorCandidatesSize?: number | null, pendingRemovals?: Array<number> | null, totalStake?: any | null, stakingPoolMappingsId?: any | null, pendingActiveValidatorsId?: any | null, validatorCandidatesId?: any | null, inactivePoolsId?: any | null, activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', atRisk?: any | null, commissionRate?: number | null, exchangeRatesSize?: any | null, description?: string | null, gasPrice?: any | null, imageUrl?: string | null, name?: string | null, nextEpochCommissionRate?: number | null, nextEpochGasPrice?: any | null, nextEpochStake?: any | null, pendingPoolTokenWithdraw?: any | null, pendingStake?: any | null, pendingTotalSuiWithdraw?: any | null, poolTokenBalance?: any | null, projectUrl?: string | null, rewardsPool?: any | null, stakingPoolActivationEpoch?: any | null, stakingPoolSuiBalance?: any | null, votingPower?: number | null, exchangeRates?: { __typename?: 'MoveObject', address: any, contents?: { __typename?: 'MoveValue', json: any } | null } | null, credentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, nextEpochCredentials?: { __typename?: 'ValidatorCredentials', netAddress?: string | null, networkPubKey?: any | null, p2PAddress?: string | null, primaryAddress?: string | null, workerPubKey?: any | null, workerAddress?: string | null, proofOfPossession?: any | null, protocolPubKey?: any | null } | null, operationCap?: { __typename?: 'MoveObject', address: any } | null, stakingPool?: { __typename?: 'MoveObject', address: any } | null, address: { __typename?: 'Address', address: any } }> } } | null } | null };
 
 export type GetMoveFunctionArgTypesQueryVariables = Exact<{
   packageId: Scalars['SuiAddress']['input'];
@@ -4857,11 +5518,11 @@ export type GetNormalizedMoveStructQuery = { __typename?: 'Query', object?: { __
 export type Rpc_Move_Struct_FieldsFragment = { __typename?: 'MoveStruct', name: string, abilities?: Array<MoveAbility> | null, fields?: Array<{ __typename?: 'MoveField', name: string, type?: { __typename?: 'OpenMoveType', signature: any } | null }> | null, typeParameters?: Array<{ __typename?: 'MoveStructTypeParameter', isPhantom: boolean, constraints: Array<MoveAbility> }> | null };
 
 export type GetProtocolConfigQueryVariables = Exact<{
-  protocolVersion?: InputMaybe<Scalars['Int']['input']>;
+  protocolVersion?: InputMaybe<Scalars['UInt53']['input']>;
 }>;
 
 
-export type GetProtocolConfigQuery = { __typename?: 'Query', protocolConfig: { __typename?: 'ProtocolConfigs', protocolVersion: number, configs: Array<{ __typename?: 'ProtocolConfigAttr', key: string, value?: string | null }>, featureFlags: Array<{ __typename?: 'ProtocolConfigFeatureFlag', key: string, value: boolean }> } };
+export type GetProtocolConfigQuery = { __typename?: 'Query', protocolConfig: { __typename?: 'ProtocolConfigs', protocolVersion: any, configs: Array<{ __typename?: 'ProtocolConfigAttr', key: string, value?: string | null }>, featureFlags: Array<{ __typename?: 'ProtocolConfigFeatureFlag', key: string, value: boolean }> } };
 
 export type GetReferenceGasPriceQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4878,12 +5539,12 @@ export type GetTotalSupplyQuery = { __typename?: 'Query', coinMetadata?: { __typ
 export type GetTotalTransactionBlocksQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetTotalTransactionBlocksQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', networkTotalTransactions?: number | null } | null };
+export type GetTotalTransactionBlocksQuery = { __typename?: 'Query', checkpoint?: { __typename?: 'Checkpoint', networkTotalTransactions?: any | null } | null };
 
 export type GetValidatorsApyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetValidatorsApyQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: number, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', apy?: number | null, address: { __typename?: 'Address', address: any } }> } } | null } | null };
+export type GetValidatorsApyQuery = { __typename?: 'Query', epoch?: { __typename?: 'Epoch', epochId: any, validatorSet?: { __typename?: 'ValidatorSet', activeValidators: { __typename?: 'ValidatorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Validator', apy?: number | null, address: { __typename?: 'Address', address: any } }> } } | null } | null };
 
 export type ResolveNameServiceAddressQueryVariables = Exact<{
   domain: Scalars['String']['input'];
@@ -4916,7 +5577,7 @@ export type GetOwnedObjectsQueryVariables = Exact<{
 }>;
 
 
-export type GetOwnedObjectsQuery = { __typename?: 'Query', address?: { __typename?: 'Address', objects: { __typename?: 'MoveObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: number, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout: any, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: number } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } } | null };
+export type GetOwnedObjectsQuery = { __typename?: 'Query', address?: { __typename?: 'Address', objects: { __typename?: 'MoveObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: any, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } } | null };
 
 export type GetObjectQueryVariables = Exact<{
   id: Scalars['SuiAddress']['input'];
@@ -4930,11 +5591,11 @@ export type GetObjectQueryVariables = Exact<{
 }>;
 
 
-export type GetObjectQuery = { __typename?: 'Query', object?: { __typename?: 'Object', version: number, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout: any, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: number } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
+export type GetObjectQuery = { __typename?: 'Query', object?: { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
 
 export type TryGetPastObjectQueryVariables = Exact<{
   id: Scalars['SuiAddress']['input'];
-  version?: InputMaybe<Scalars['Int']['input']>;
+  version?: InputMaybe<Scalars['UInt53']['input']>;
   showBcs?: InputMaybe<Scalars['Boolean']['input']>;
   showOwner?: InputMaybe<Scalars['Boolean']['input']>;
   showPreviousTransaction?: InputMaybe<Scalars['Boolean']['input']>;
@@ -4945,7 +5606,7 @@ export type TryGetPastObjectQueryVariables = Exact<{
 }>;
 
 
-export type TryGetPastObjectQuery = { __typename?: 'Query', current?: { __typename?: 'Object', address: any, version: number } | null, object?: { __typename?: 'Object', version: number, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout: any, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: number } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
+export type TryGetPastObjectQuery = { __typename?: 'Query', current?: { __typename?: 'Object', address: any, version: any } | null, object?: { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
 
 export type MultiGetObjectsQueryVariables = Exact<{
   ids: Array<Scalars['SuiAddress']['input']> | Scalars['SuiAddress']['input'];
@@ -4961,11 +5622,11 @@ export type MultiGetObjectsQueryVariables = Exact<{
 }>;
 
 
-export type MultiGetObjectsQuery = { __typename?: 'Query', objects: { __typename?: 'ObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Object', version: number, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout: any, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: number } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } };
+export type MultiGetObjectsQuery = { __typename?: 'Query', objects: { __typename?: 'ObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } };
 
-export type Rpc_Object_FieldsFragment = { __typename?: 'Object', version: number, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout: any, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: number } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
+export type Rpc_Object_FieldsFragment = { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
 
-export type Rpc_Move_Object_FieldsFragment = { __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: number, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout: any, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: number } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
+export type Rpc_Move_Object_FieldsFragment = { __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: any, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
 
 type Rpc_Object_Owner_Fields_AddressOwner_Fragment = { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null };
 
@@ -4973,7 +5634,7 @@ type Rpc_Object_Owner_Fields_Immutable_Fragment = { __typename: 'Immutable' };
 
 type Rpc_Object_Owner_Fields_Parent_Fragment = { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null };
 
-type Rpc_Object_Owner_Fields_Shared_Fragment = { __typename: 'Shared', initialSharedVersion: number };
+type Rpc_Object_Owner_Fields_Shared_Fragment = { __typename: 'Shared', initialSharedVersion: any };
 
 export type Rpc_Object_Owner_FieldsFragment = Rpc_Object_Owner_Fields_AddressOwner_Fragment | Rpc_Object_Owner_Fields_Immutable_Fragment | Rpc_Object_Owner_Fields_Parent_Fragment | Rpc_Object_Owner_Fields_Shared_Fragment;
 
@@ -4986,9 +5647,9 @@ export type QueryEventsQueryVariables = Exact<{
 }>;
 
 
-export type QueryEventsQuery = { __typename?: 'Query', events: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> } };
+export type QueryEventsQuery = { __typename?: 'Query', events: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> } };
 
-export type Rpc_Events_FieldsFragment = { __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } };
+export type Rpc_Events_FieldsFragment = { __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } };
 
 export type GetStakesQueryVariables = Exact<{
   owner: Scalars['SuiAddress']['input'];
@@ -4997,7 +5658,7 @@ export type GetStakesQueryVariables = Exact<{
 }>;
 
 
-export type GetStakesQuery = { __typename?: 'Query', address?: { __typename?: 'Address', stakedSuis: { __typename?: 'StakedSuiConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'StakedSui', principal?: any | null, stakeStatus: StakeStatus, address: any, estimatedReward?: any | null, activatedEpoch?: { __typename?: 'Epoch', epochId: number, referenceGasPrice?: any | null } | null, requestedEpoch?: { __typename?: 'Epoch', epochId: number } | null, contents?: { __typename?: 'MoveValue', json: any } | null }> } } | null };
+export type GetStakesQuery = { __typename?: 'Query', address?: { __typename?: 'Address', stakedSuis: { __typename?: 'StakedSuiConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'StakedSui', principal?: any | null, stakeStatus: StakeStatus, address: any, estimatedReward?: any | null, activatedEpoch?: { __typename?: 'Epoch', epochId: any, referenceGasPrice?: any | null } | null, requestedEpoch?: { __typename?: 'Epoch', epochId: any } | null, contents?: { __typename?: 'MoveValue', json: any } | null }> } } | null };
 
 export type GetStakesByIdsQueryVariables = Exact<{
   ids: Array<Scalars['SuiAddress']['input']> | Scalars['SuiAddress']['input'];
@@ -5006,9 +5667,9 @@ export type GetStakesByIdsQueryVariables = Exact<{
 }>;
 
 
-export type GetStakesByIdsQuery = { __typename?: 'Query', objects: { __typename?: 'ObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', asStakedSui?: { __typename?: 'StakedSui', principal?: any | null, stakeStatus: StakeStatus, address: any, estimatedReward?: any | null, activatedEpoch?: { __typename?: 'Epoch', epochId: number, referenceGasPrice?: any | null } | null, requestedEpoch?: { __typename?: 'Epoch', epochId: number } | null, contents?: { __typename?: 'MoveValue', json: any } | null } | null } | null }> } };
+export type GetStakesByIdsQuery = { __typename?: 'Query', objects: { __typename?: 'ObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', asStakedSui?: { __typename?: 'StakedSui', principal?: any | null, stakeStatus: StakeStatus, address: any, estimatedReward?: any | null, activatedEpoch?: { __typename?: 'Epoch', epochId: any, referenceGasPrice?: any | null } | null, requestedEpoch?: { __typename?: 'Epoch', epochId: any } | null, contents?: { __typename?: 'MoveValue', json: any } | null } | null } | null }> } };
 
-export type Rpc_Stake_FieldsFragment = { __typename?: 'StakedSui', principal?: any | null, stakeStatus: StakeStatus, address: any, estimatedReward?: any | null, activatedEpoch?: { __typename?: 'Epoch', epochId: number, referenceGasPrice?: any | null } | null, requestedEpoch?: { __typename?: 'Epoch', epochId: number } | null, contents?: { __typename?: 'MoveValue', json: any } | null };
+export type Rpc_Stake_FieldsFragment = { __typename?: 'StakedSui', principal?: any | null, stakeStatus: StakeStatus, address: any, estimatedReward?: any | null, activatedEpoch?: { __typename?: 'Epoch', epochId: any, referenceGasPrice?: any | null } | null, requestedEpoch?: { __typename?: 'Epoch', epochId: any } | null, contents?: { __typename?: 'MoveValue', json: any } | null };
 
 export type QueryTransactionBlocksQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -5026,7 +5687,7 @@ export type QueryTransactionBlocksQueryVariables = Exact<{
 }>;
 
 
-export type QueryTransactionBlocksQuery = { __typename?: 'Query', transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null }> } };
+export type QueryTransactionBlocksQuery = { __typename?: 'Query', transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null }> } };
 
 export type GetTransactionBlockQueryVariables = Exact<{
   digest: Scalars['String']['input'];
@@ -5040,7 +5701,7 @@ export type GetTransactionBlockQueryVariables = Exact<{
 }>;
 
 
-export type GetTransactionBlockQuery = { __typename?: 'Query', transactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null };
+export type GetTransactionBlockQuery = { __typename?: 'Query', transactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null };
 
 export type MultiGetTransactionBlocksQueryVariables = Exact<{
   digests: Array<Scalars['String']['input']> | Scalars['String']['input'];
@@ -5056,7 +5717,7 @@ export type MultiGetTransactionBlocksQueryVariables = Exact<{
 }>;
 
 
-export type MultiGetTransactionBlocksQuery = { __typename?: 'Query', transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null }> } };
+export type MultiGetTransactionBlocksQuery = { __typename?: 'Query', transactionBlocks: { __typename?: 'TransactionBlockConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, nodes: Array<{ __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null }> } };
 
 export type PaginateTransactionBlockListsQueryVariables = Exact<{
   digest: Scalars['String']['input'];
@@ -5069,11 +5730,11 @@ export type PaginateTransactionBlockListsQueryVariables = Exact<{
 }>;
 
 
-export type PaginateTransactionBlockListsQuery = { __typename?: 'Query', transactionBlock?: { __typename?: 'TransactionBlock', effects?: { __typename?: 'TransactionBlockEffects', events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null };
+export type PaginateTransactionBlockListsQuery = { __typename?: 'Query', transactionBlock?: { __typename?: 'TransactionBlock', effects?: { __typename?: 'TransactionBlockEffects', events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null } | null };
 
-export type Paginate_Transaction_ListsFragment = { __typename?: 'TransactionBlock', effects?: { __typename?: 'TransactionBlockEffects', events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null };
+export type Paginate_Transaction_ListsFragment = { __typename?: 'TransactionBlock', effects?: { __typename?: 'TransactionBlockEffects', events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null };
 
-export type Rpc_Transaction_FieldsFragment = { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', json: any, bcs: any, timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, type: { __typename?: 'MoveType', repr: string } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: number } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: number, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null };
+export type Rpc_Transaction_FieldsFragment = { __typename?: 'TransactionBlock', digest?: string | null, signatures?: Array<any> | null, rawTransaction?: any | null, sender?: { __typename?: 'Address', address: any } | null, effects?: { __typename?: 'TransactionBlockEffects', bcs?: any, timestamp?: any | null, events?: { __typename?: 'EventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Event', timestamp?: any | null, sendingModule?: { __typename?: 'MoveModule', name: string, package: { __typename?: 'MovePackage', address: any } } | null, sender?: { __typename?: 'Address', address: any } | null, contents: { __typename?: 'MoveValue', json: any, bcs: any, type: { __typename?: 'MoveType', repr: string } } }> }, checkpoint?: { __typename?: 'Checkpoint', sequenceNumber: any } | null, balanceChanges?: { __typename?: 'BalanceChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'BalanceChange', amount?: any | null, coinType?: { __typename?: 'MoveType', repr: string } | null, owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null }> }, objectChanges?: { __typename?: 'ObjectChangeConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'ObjectChange', address: any, inputState?: { __typename?: 'Object', version: any, asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null } | null, outputState?: { __typename?: 'Object', asMoveObject?: { __typename?: 'MoveObject', contents?: { __typename?: 'MoveValue', type: { __typename?: 'MoveType', repr: string } } | null } | null, asMovePackage?: { __typename?: 'MovePackage', modules?: { __typename?: 'MoveModuleConnection', nodes: Array<{ __typename?: 'MoveModule', name: string }> } | null } | null } | null }> } } | null };
 
 export class TypedDocumentString<TResult, TVariables>
   extends String
@@ -5499,11 +6160,13 @@ export const Rpc_Events_FieldsFragmentDoc = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
     `, {"fragmentName":"RPC_EVENTS_FIELDS"}) as unknown as TypedDocumentString<Rpc_Events_FieldsFragment, unknown>;
@@ -5586,11 +6249,13 @@ export const Paginate_Transaction_ListsFragmentDoc = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }`, {"fragmentName":"PAGINATE_TRANSACTION_LISTS"}) as unknown as TypedDocumentString<Paginate_Transaction_ListsFragment, unknown>;
 export const Rpc_Transaction_FieldsFragmentDoc = new TypedDocumentString(`
@@ -5686,11 +6351,13 @@ export const Rpc_Transaction_FieldsFragmentDoc = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }`, {"fragmentName":"RPC_TRANSACTION_FIELDS"}) as unknown as TypedDocumentString<Rpc_Transaction_FieldsFragment, unknown>;
 export const GetCheckpointDocument = new TypedDocumentString(`
@@ -5895,11 +6562,13 @@ export const DevInspectTransactionBlockDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
@@ -6003,11 +6672,13 @@ export const DryRunTransactionBlockDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
@@ -6113,11 +6784,13 @@ export const ExecuteTransactionBlockDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
@@ -6279,7 +6952,7 @@ export const GetCoinsDocument = new TypedDocumentString(`
 }
     `) as unknown as TypedDocumentString<GetCoinsQuery, GetCoinsQueryVariables>;
 export const GetCommitteeInfoDocument = new TypedDocumentString(`
-    query getCommitteeInfo($epochId: Int, $after: String) {
+    query getCommitteeInfo($epochId: UInt53, $after: String) {
   epoch(id: $epochId) {
     epochId
     validatorSet {
@@ -6379,7 +7052,7 @@ fragment RPC_CREDENTIAL_FIELDS on ValidatorCredentials {
   protocolPubKey
 }`) as unknown as TypedDocumentString<GetCurrentEpochQuery, GetCurrentEpochQueryVariables>;
 export const PaginateEpochValidatorsDocument = new TypedDocumentString(`
-    query paginateEpochValidators($id: Int!, $after: String) {
+    query paginateEpochValidators($id: UInt53!, $after: String) {
   epoch(id: $id) {
     validatorSet {
       activeValidators(after: $after) {
@@ -6960,7 +7633,7 @@ export const GetNormalizedMoveStructDocument = new TypedDocumentString(`
   }
 }`) as unknown as TypedDocumentString<GetNormalizedMoveStructQuery, GetNormalizedMoveStructQueryVariables>;
 export const GetProtocolConfigDocument = new TypedDocumentString(`
-    query getProtocolConfig($protocolVersion: Int) {
+    query getProtocolConfig($protocolVersion: UInt53) {
   protocolConfig(protocolVersion: $protocolVersion) {
     protocolVersion
     configs {
@@ -7186,7 +7859,7 @@ fragment RPC_OBJECT_OWNER_FIELDS on ObjectOwner {
   }
 }`) as unknown as TypedDocumentString<GetObjectQuery, GetObjectQueryVariables>;
 export const TryGetPastObjectDocument = new TypedDocumentString(`
-    query tryGetPastObject($id: SuiAddress!, $version: Int, $showBcs: Boolean = false, $showOwner: Boolean = false, $showPreviousTransaction: Boolean = false, $showContent: Boolean = false, $showDisplay: Boolean = false, $showType: Boolean = false, $showStorageRebate: Boolean = false) {
+    query tryGetPastObject($id: SuiAddress!, $version: UInt53, $showBcs: Boolean = false, $showOwner: Boolean = false, $showPreviousTransaction: Boolean = false, $showContent: Boolean = false, $showDisplay: Boolean = false, $showType: Boolean = false, $showStorageRebate: Boolean = false) {
   current: object(address: $id) {
     address
     version
@@ -7369,11 +8042,13 @@ export const QueryEventsDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }`) as unknown as TypedDocumentString<QueryEventsQuery, QueryEventsQueryVariables>;
 export const GetStakesDocument = new TypedDocumentString(`
@@ -7474,11 +8149,13 @@ export const QueryTransactionBlocksDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
@@ -7579,11 +8256,13 @@ export const GetTransactionBlockDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
@@ -7696,11 +8375,13 @@ export const MultiGetTransactionBlocksDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
@@ -7801,11 +8482,13 @@ export const PaginateTransactionBlockListsDocument = new TypedDocumentString(`
   sender {
     address
   }
-  type {
-    repr
+  contents {
+    type {
+      repr
+    }
+    json
+    bcs
   }
-  json
-  bcs
   timestamp
 }
 fragment PAGINATE_TRANSACTION_LISTS on TransactionBlock {

--- a/sdk/graphql-transport/src/mappers/transaction-block.ts
+++ b/sdk/graphql-transport/src/mappers/transaction-block.ts
@@ -55,17 +55,17 @@ export function mapGraphQLTransactionBlockToRpcTransactionBlock(
 		...(errors ? { errors: errors } : {}),
 		events:
 			transactionBlock.effects?.events?.nodes.map((event) => ({
-				bcs: event.bcs,
+				bcs: event.contents.bcs,
 				id: {
 					eventSeq: '', // TODO
 					txDigest: '', // TODO
 				},
 				packageId: event.sendingModule?.package.address!,
-				parsedJson: event.json ? JSON.parse(event.json) : undefined,
+				parsedJson: event.contents.json ? JSON.parse(event.contents.json) : undefined,
 				sender: event.sender?.address,
 				timestampMs: new Date(event.timestamp).getTime().toString(),
 				transactionModule: `${event.sendingModule?.package.address}::${event.sendingModule?.name}`,
-				type: toShortTypeString(event.type?.repr)!,
+				type: toShortTypeString(event.contents.type?.repr)!,
 			})) ?? [],
 		rawTransaction: options?.showRawInput ? transactionBlock.rawTransaction : undefined,
 		...(options?.showInput

--- a/sdk/graphql-transport/src/methods.ts
+++ b/sdk/graphql-transport/src/methods.ts
@@ -888,17 +888,17 @@ export const RPC_METHODS: {
 			hasNextPage: pagination.last ? pageInfo.hasPreviousPage : pageInfo.hasNextPage,
 			nextCursor: (pagination.last ? pageInfo.startCursor : pageInfo.endCursor) as never,
 			data: events.map((event) => ({
-				bcs: event.bcs,
+				bcs: event.contents.bcs,
 				id: {
 					eventSeq: '', // TODO
 					txDigest: '', // TODO
 				},
 				packageId: event.sendingModule?.package.address!,
-				parsedJson: event.json ? JSON.parse(event.json) : undefined,
+				parsedJson: event.contents.json ? JSON.parse(event.contents.json) : undefined,
 				sender: event.sender?.address,
 				timestampMs: new Date(event.timestamp).getTime().toString(),
 				transactionModule: `${event.sendingModule?.package.address}::${event.sendingModule?.name}`,
-				type: toShortTypeString(event.type?.repr)!,
+				type: toShortTypeString(event.contents.type?.repr)!,
 			})),
 		};
 	},

--- a/sdk/graphql-transport/src/queries/getCommitteeInfo.graphql
+++ b/sdk/graphql-transport/src/queries/getCommitteeInfo.graphql
@@ -1,7 +1,7 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-query getCommitteeInfo($epochId: Int, $after: String) {
+query getCommitteeInfo($epochId: UInt53, $after: String) {
 	epoch(id: $epochId) {
 		epochId
 		validatorSet {

--- a/sdk/graphql-transport/src/queries/getCurrentEpoch.graphql
+++ b/sdk/graphql-transport/src/queries/getCurrentEpoch.graphql
@@ -27,7 +27,7 @@ query getCurrentEpoch {
 	}
 }
 
-query paginateEpochValidators($id: Int!, $after: String) {
+query paginateEpochValidators($id: UInt53!, $after: String) {
 	epoch(id: $id) {
 		validatorSet {
 			activeValidators(after: $after) {

--- a/sdk/graphql-transport/src/queries/getProtocolConfig.graphql
+++ b/sdk/graphql-transport/src/queries/getProtocolConfig.graphql
@@ -1,7 +1,7 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-query getProtocolConfig($protocolVersion: Int) {
+query getProtocolConfig($protocolVersion: UInt53) {
 	protocolConfig(protocolVersion: $protocolVersion) {
 		protocolVersion
 		configs {

--- a/sdk/graphql-transport/src/queries/objects.graphql
+++ b/sdk/graphql-transport/src/queries/objects.graphql
@@ -44,7 +44,7 @@ query getObject(
 
 query tryGetPastObject(
 	$id: SuiAddress!
-	$version: Int
+	$version: UInt53
 	$showBcs: Boolean = false
 	$showOwner: Boolean = false
 	$showPreviousTransaction: Boolean = false

--- a/sdk/graphql-transport/src/queries/queryEvents.graphql
+++ b/sdk/graphql-transport/src/queries/queryEvents.graphql
@@ -36,10 +36,13 @@ fragment RPC_EVENTS_FIELDS on Event {
 	sender {
 		address
 	}
-	type {
-		repr
+	contents {
+		type {
+			repr
+		}
+
+		json
+		bcs
 	}
-	json
-	bcs
 	timestamp
 }


### PR DESCRIPTION
## Description 

Accessing the `bcs` field of an `Event` is rather confusing, as it is not the whole event BCS encoded, but just the contents of it, more specifically, the BCS bytes of a `MoveValue`.

This PR removes the #flatten in `Event`, adds a `contents` field to the type, and adds the `bcs` field to the `Event` type which encodes the whole `Event`.

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: The `Event` type has a new field called `contents`, which is the event's content value as a `MoveValue`. This replaces the previous scheme that flattened the `MoveValue` type in the `Event` type. A `bcs` field was also added, which represents the Base64 encoded BCS serialized event.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
