### PR TITLE
[data ingestion] introduce reducer functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13203,6 +13203,7 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]

--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -53,6 +53,7 @@ const CHECK_FILE_SIZE_ITERATION_CYCLE: u64 = 50;
 
 #[async_trait::async_trait]
 impl<S: Serialize + ParquetSchema + 'static> Worker for AnalyticsProcessor<S> {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         // get epoch id, checkpoint sequence number and timestamp, those are important
         // indexes when operating on data

--- a/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
@@ -25,6 +25,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for CheckpointHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/df_handler.rs
@@ -39,6 +39,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for DynamicFieldHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/event_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/event_handler.rs
@@ -33,6 +33,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for EventHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/mod.rs
+++ b/crates/sui-analytics-indexer/src/handlers/mod.rs
@@ -38,7 +38,7 @@ const WRAPPED_INDEXING_DISALLOW_LIST: [&str; 4] = [
 ];
 
 #[async_trait::async_trait]
-pub trait AnalyticsHandler<S>: Worker {
+pub trait AnalyticsHandler<S>: Worker<Result = ()> {
     /// Read back rows which are ready to be persisted. This function
     /// will be invoked by the analytics processor after every call to
     /// process_checkpoint

--- a/crates/sui-analytics-indexer/src/handlers/move_call_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/move_call_handler.rs
@@ -23,6 +23,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for MoveCallHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -35,6 +35,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for ObjectHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/package_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/package_handler.rs
@@ -23,6 +23,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for PackageHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -28,6 +28,8 @@ pub(crate) struct State {
 
 #[async_trait::async_trait]
 impl Worker for TransactionHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -24,6 +24,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for TransactionObjectsHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
@@ -30,6 +30,8 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for WrappedObjectHandler {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         let CheckpointData {
             checkpoint_summary,

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -487,12 +487,14 @@ impl FileMetadata {
 }
 
 pub struct Processor {
-    pub processor: Box<dyn Worker>,
+    pub processor: Box<dyn Worker<Result = ()>>,
     pub starting_checkpoint_seq_num: CheckpointSequenceNumber,
 }
 
 #[async_trait::async_trait]
 impl Worker for Processor {
+    type Result = ();
+
     #[inline]
     async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
         self.processor.process_checkpoint(checkpoint_data).await

--- a/crates/sui-bridge-indexer/src/sui_datasource.rs
+++ b/crates/sui-bridge-indexer/src/sui_datasource.rs
@@ -196,6 +196,8 @@ pub type CheckpointTxnData = (CheckpointTransaction, u64, u64);
 
 #[async_trait]
 impl Worker for IndexerWorker<CheckpointTxnData> {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint: &SuiCheckpointData) -> anyhow::Result<()> {
         tracing::trace!(
             "Received checkpoint [{}] {}: {}",

--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -20,6 +20,7 @@ object_store.workspace = true
 prometheus.workspace = true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-stream.workspace = true
 tracing.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true

--- a/crates/sui-data-ingestion-core/src/executor.rs
+++ b/crates/sui-data-ingestion-core/src/executor.rs
@@ -108,6 +108,14 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         }
         Ok(self.progress_store.stats())
     }
+
+    pub async fn update_watermark(
+        &mut self,
+        task_name: String,
+        watermark: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        self.progress_store.save(task_name, watermark).await
+    }
 }
 
 pub async fn setup_single_workflow<W: Worker + 'static>(

--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -5,6 +5,7 @@ mod executor;
 mod metrics;
 mod progress_store;
 mod reader;
+mod reducer;
 #[cfg(test)]
 mod tests;
 mod util;
@@ -17,25 +18,24 @@ pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
 pub use reader::ReaderOptions;
 use sui_types::full_checkpoint_content::CheckpointData;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 pub use util::create_remote_store_client;
 pub use worker_pool::WorkerPool;
 
 #[async_trait]
 pub trait Worker: Send + Sync {
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()>;
-    /// Optional method. Allows controlling when workflow progress is updated in the progress store.
-    /// For instance, some pipelines may benefit from aggregating checkpoints, thus skipping
-    /// the saving of updates for intermediate checkpoints.
-    /// The default implementation is to update the progress store for every processed checkpoint.
-    async fn save_progress(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<CheckpointSequenceNumber> {
-        Some(sequence_number)
-    }
+    type Result: Send + Sync;
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Result>;
 
     fn preprocess_hook(&self, _: &CheckpointData) -> Result<()> {
         Ok(())
+    }
+}
+
+#[async_trait]
+pub trait Reducer<R: Send + Sync>: Send + Sync {
+    async fn commit(&self, batch: Vec<R>) -> Result<()>;
+
+    fn should_close_batch(&self, _batch: &[R], next_item: Option<&R>) -> bool {
+        next_item.is_none()
     }
 }

--- a/crates/sui-data-ingestion-core/src/reducer.rs
+++ b/crates/sui-data-ingestion-core/src/reducer.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Reducer, Worker, MAX_CHECKPOINTS_IN_PROGRESS};
+use anyhow::Result;
+use futures::StreamExt;
+use std::collections::HashMap;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+pub(crate) async fn reduce<W: Worker>(
+    task_name: String,
+    mut current_checkpoint_number: CheckpointSequenceNumber,
+    progress_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Result)>,
+    executor_progress_sender: mpsc::Sender<(String, CheckpointSequenceNumber)>,
+    reducer: Option<Box<dyn Reducer<W::Result>>>,
+) -> Result<()> {
+    // convert to a stream of MAX size. This way, each iteration of the loop will process all ready messages
+    let mut stream =
+        ReceiverStream::new(progress_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
+    let mut unprocessed = HashMap::new();
+    let mut batch = vec![];
+    let mut progress_update = None;
+
+    while let Some(update_batch) = stream.next().await {
+        for (checkpoint_number, message) in update_batch {
+            unprocessed.insert(checkpoint_number, message);
+        }
+        while let Some(message) = unprocessed.remove(&current_checkpoint_number) {
+            if let Some(ref reducer) = reducer {
+                if reducer.should_close_batch(&batch, Some(&message)) {
+                    reducer.commit(std::mem::take(&mut batch)).await?;
+                    batch = vec![message];
+                    progress_update = Some(current_checkpoint_number);
+                } else {
+                    batch.push(message);
+                }
+            }
+            current_checkpoint_number += 1;
+        }
+        match reducer {
+            Some(ref reducer) => {
+                if reducer.should_close_batch(&batch, None) {
+                    reducer.commit(std::mem::take(&mut batch)).await?;
+                    progress_update = Some(current_checkpoint_number);
+                }
+            }
+            None => progress_update = Some(current_checkpoint_number),
+        }
+        if let Some(watermark) = progress_update {
+            executor_progress_sender
+                .send((task_name.clone(), watermark))
+                .await?;
+            progress_update = None;
+        }
+    }
+    Ok(())
+}

--- a/crates/sui-data-ingestion-core/src/tests.rs
+++ b/crates/sui-data-ingestion-core/src/tests.rs
@@ -74,6 +74,7 @@ struct TestWorker;
 
 #[async_trait]
 impl Worker for TestWorker {
+    type Result = ();
     async fn process_checkpoint(&self, _checkpoint: &CheckpointData) -> Result<()> {
         Ok(())
     }

--- a/crates/sui-data-ingestion/Cargo.toml
+++ b/crates/sui-data-ingestion/Cargo.toml
@@ -32,6 +32,7 @@ sui-archival.workspace = true
 sui-storage.workspace = true
 sui-data-ingestion-core.workspace = true
 sui-types.workspace = true
+tempfile.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-data-ingestion/src/lib.rs
+++ b/crates/sui-data-ingestion/src/lib.rs
@@ -6,5 +6,6 @@ mod workers;
 
 pub use progress_store::DynamoDBProgressStore;
 pub use workers::{
-    ArchivalConfig, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig, KVStoreWorker,
+    ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig,
+    KVStoreWorker,
 };

--- a/crates/sui-data-ingestion/src/workers/archival.rs
+++ b/crates/sui-data-ingestion/src/workers/archival.rs
@@ -10,18 +10,16 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
-use std::ops::Range;
 use sui_archival::{
     create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes, FileType,
     Manifest, CHECKPOINT_FILE_MAGIC, SUMMARY_FILE_MAGIC,
 };
-use sui_data_ingestion_core::{create_remote_store_client, Worker};
+use sui_data_ingestion_core::{create_remote_store_client, Reducer, Worker};
 use sui_storage::blob::{Blob, BlobEncoding};
 use sui_storage::{compress, FileCompression, StorageFormat};
 use sui_types::base_types::{EpochId, ExecutionData};
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, FullCheckpointContents};
-use tokio::sync::Mutex;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ArchivalConfig {
@@ -31,90 +29,67 @@ pub struct ArchivalConfig {
     pub commit_duration_seconds: u64,
 }
 
-struct AccumulatedState {
-    epoch: EpochId,
-    checkpoint_range: Range<u64>,
-    buffer: Vec<u8>,
-    summary_buffer: Vec<u8>,
-    last_commit_ms: u64,
-    should_update_progress: bool,
+pub struct ArchivalWorker;
+#[async_trait]
+impl Worker for ArchivalWorker {
+    type Result = CheckpointData;
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<CheckpointData> {
+        Ok(checkpoint.clone())
+    }
 }
 
-pub struct ArchivalWorker {
+pub struct ArchivalReducer {
     remote_store: Box<dyn ObjectStore>,
-    state: Mutex<AccumulatedState>,
-    commit_file_size: usize,
     commit_duration_ms: u64,
 }
 
-impl ArchivalWorker {
+impl ArchivalReducer {
     pub async fn new(config: ArchivalConfig) -> Result<Self> {
         let remote_store =
             create_remote_store_client(config.remote_url, config.remote_store_options, 10)?;
-        let manifest = Self::read_manifest(&remote_store).await?;
-        let state = AccumulatedState {
-            epoch: manifest.epoch_num(),
-            checkpoint_range: manifest.next_checkpoint_seq_num()
-                ..manifest.next_checkpoint_seq_num(),
-            buffer: vec![],
-            summary_buffer: vec![],
-            last_commit_ms: 0,
-            should_update_progress: false,
-        };
         Ok(Self {
             remote_store,
-            state: Mutex::new(state),
-            commit_file_size: config.commit_file_size,
             commit_duration_ms: config.commit_duration_seconds * 1000,
         })
     }
-
-    async fn read_manifest(remote_store: &dyn ObjectStore) -> Result<Manifest> {
-        Ok(match remote_store.get(&Path::from("MANIFEST")).await {
-            Ok(resp) => read_manifest_from_bytes(resp.bytes().await?.to_vec())?,
-            Err(err) if err.to_string().contains("404") => Manifest::new(0, 0),
-            Err(err) => Err(err)?,
-        })
-    }
-
-    async fn upload(&self, state: &AccumulatedState) -> Result<()> {
-        let checkpoint_file_path =
-            format!("epoch_{}/{}.chk", state.epoch, state.checkpoint_range.start);
+    async fn upload(
+        &self,
+        epoch: EpochId,
+        start: CheckpointSequenceNumber,
+        end: CheckpointSequenceNumber,
+        summary_buffer: Vec<u8>,
+        buffer: Vec<u8>,
+    ) -> Result<()> {
+        let checkpoint_file_path = format!("epoch_{}/{}.chk", epoch, start);
         let chk_bytes = self
             .upload_file(
                 Path::from(checkpoint_file_path.clone()),
                 CHECKPOINT_FILE_MAGIC,
-                &state.buffer,
+                &buffer,
             )
             .await?;
-        let summary_file_path =
-            format!("epoch_{}/{}.sum", state.epoch, state.checkpoint_range.start);
+        let summary_file_path = format!("epoch_{}/{}.sum", epoch, start);
         let sum_bytes = self
             .upload_file(
                 Path::from(summary_file_path.clone()),
                 SUMMARY_FILE_MAGIC,
-                &state.summary_buffer,
+                &summary_buffer,
             )
             .await?;
         let mut manifest = Self::read_manifest(&self.remote_store).await?;
         let checkpoint_file_metadata = create_file_metadata_from_bytes(
             chk_bytes,
             FileType::CheckpointContent,
-            state.epoch,
-            state.checkpoint_range.clone(),
+            epoch,
+            start..end,
         )?;
         let summary_file_metadata = create_file_metadata_from_bytes(
             sum_bytes,
             FileType::CheckpointSummary,
-            state.epoch,
-            state.checkpoint_range.clone(),
+            epoch,
+            start..end,
         )?;
-        manifest.update(
-            state.epoch,
-            state.checkpoint_range.end,
-            checkpoint_file_metadata,
-            summary_file_metadata,
-        );
+        manifest.update(epoch, end, checkpoint_file_metadata, summary_file_metadata);
 
         let bytes = finalize_manifest(manifest)?;
         self.remote_store
@@ -122,7 +97,6 @@ impl ArchivalWorker {
             .await?;
         Ok(())
     }
-
     async fn upload_file(&self, location: Path, magic: u32, content: &[u8]) -> Result<Bytes> {
         let mut buffer = vec![0; 4];
         BigEndian::write_u32(&mut buffer, magic);
@@ -138,67 +112,69 @@ impl ArchivalWorker {
         Ok(Bytes::from(compressed_buffer))
     }
 
-    pub async fn initial_checkpoint_number(&self) -> CheckpointSequenceNumber {
-        self.state.lock().await.checkpoint_range.start
+    pub async fn get_watermark(&self) -> Result<CheckpointSequenceNumber> {
+        let manifest = Self::read_manifest(&self.remote_store).await?;
+        Ok(manifest.next_checkpoint_seq_num())
+    }
+    async fn read_manifest(remote_store: &dyn ObjectStore) -> Result<Manifest> {
+        Ok(match remote_store.get(&Path::from("MANIFEST")).await {
+            Ok(resp) => read_manifest_from_bytes(resp.bytes().await?.to_vec())?,
+            Err(err) if err.to_string().contains("404") => Manifest::new(0, 0),
+            Err(err) => Err(err)?,
+        })
     }
 }
 
 #[async_trait]
-impl Worker for ArchivalWorker {
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
-        let mut state = self.state.lock().await;
-        let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        if sequence_number < state.checkpoint_range.start {
-            return Ok(());
+impl Reducer<CheckpointData> for ArchivalReducer {
+    async fn commit(&self, batch: Vec<CheckpointData>) -> Result<()> {
+        if batch.is_empty() {
+            return Err(anyhow::anyhow!("commit batch can't be empty"));
         }
-        let epoch = checkpoint.checkpoint_summary.epoch;
-        if state.buffer.is_empty() {
-            assert!(epoch == state.epoch || epoch == state.epoch + 1);
-            state.epoch = epoch;
-            state.last_commit_ms = checkpoint.checkpoint_summary.timestamp_ms;
+        let mut summary_buffer = vec![];
+        let mut buffer = vec![];
+        let first_checkpoint = &batch[0];
+        let epoch = first_checkpoint.checkpoint_summary.epoch;
+        let start_checkpoint = first_checkpoint.checkpoint_summary.sequence_number;
+        let mut last_checkpoint = start_checkpoint;
+        for checkpoint in batch {
+            let full_checkpoint_contents = FullCheckpointContents::from_contents_and_execution_data(
+                checkpoint.checkpoint_contents.clone(),
+                checkpoint
+                    .transactions
+                    .iter()
+                    .map(|t| ExecutionData::new(t.transaction.clone(), t.effects.clone())),
+            );
+            let contents_blob = Blob::encode(&full_checkpoint_contents, BlobEncoding::Bcs)?;
+            let summary_blob = Blob::encode(&checkpoint.checkpoint_summary, BlobEncoding::Bcs)?;
+            contents_blob.write(&mut buffer)?;
+            summary_blob.write(&mut summary_buffer)?;
+            last_checkpoint += 1;
         }
-        let full_checkpoint_contents = FullCheckpointContents::from_contents_and_execution_data(
-            checkpoint.checkpoint_contents.clone(),
-            checkpoint
-                .transactions
-                .iter()
-                .map(|t| ExecutionData::new(t.transaction.clone(), t.effects.clone())),
-        );
-        let contents_blob = Blob::encode(&full_checkpoint_contents, BlobEncoding::Bcs)?;
-        let blob_size = contents_blob.size();
-        let summary_blob = Blob::encode(&checkpoint.checkpoint_summary, BlobEncoding::Bcs)?;
-
-        if !state.buffer.is_empty()
-            && (((state.buffer.len() + blob_size) > self.commit_file_size)
-                || state.epoch != epoch
-                || checkpoint.checkpoint_summary.timestamp_ms
-                    > (self.commit_duration_ms + state.last_commit_ms))
-        {
-            self.upload(&state).await?;
-            state.epoch = epoch;
-            state.checkpoint_range = sequence_number..sequence_number;
-            state.buffer = vec![];
-            state.summary_buffer = vec![];
-            state.last_commit_ms = checkpoint.checkpoint_summary.timestamp_ms;
-            state.should_update_progress = true;
-        }
-        contents_blob.write(&mut state.buffer)?;
-        summary_blob.write(&mut state.summary_buffer)?;
-        state.checkpoint_range.end += 1;
+        self.upload(
+            epoch,
+            start_checkpoint,
+            last_checkpoint,
+            summary_buffer,
+            buffer,
+        )
+        .await?;
         Ok(())
     }
 
-    async fn save_progress(
+    fn should_close_batch(
         &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<CheckpointSequenceNumber> {
-        let mut state = self.state.lock().await;
-        let should_update_progress = state.should_update_progress;
-        state.should_update_progress = false;
-        if should_update_progress && sequence_number > 0 {
-            Some(sequence_number - 1)
-        } else {
-            None
+        batch: &[CheckpointData],
+        next_item: Option<&CheckpointData>,
+    ) -> bool {
+        // never close a batch without a trigger condition
+        if batch.is_empty() || next_item.is_none() {
+            return false;
         }
+        let first_checkpoint = &batch[0].checkpoint_summary;
+        let next_checkpoint = next_item.expect("invariant's checked");
+        next_checkpoint.checkpoint_summary.epoch != first_checkpoint.epoch
+            || next_checkpoint.checkpoint_summary.timestamp_ms
+                > (self.commit_duration_ms + first_checkpoint.timestamp_ms)
     }
 }

--- a/crates/sui-data-ingestion/src/workers/blob.rs
+++ b/crates/sui-data-ingestion/src/workers/blob.rs
@@ -32,6 +32,7 @@ impl BlobWorker {
 
 #[async_trait]
 impl Worker for BlobWorker {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
         let bytes = Blob::encode(checkpoint, BlobEncoding::Bcs)?.to_bytes();
         let location = Path::from(format!(

--- a/crates/sui-data-ingestion/src/workers/kv_store.rs
+++ b/crates/sui-data-ingestion/src/workers/kv_store.rs
@@ -172,6 +172,8 @@ impl KVStoreWorker {
 
 #[async_trait]
 impl Worker for KVStoreWorker {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
         let mut transactions = vec![];
         let mut effects = vec![];

--- a/crates/sui-data-ingestion/src/workers/mod.rs
+++ b/crates/sui-data-ingestion/src/workers/mod.rs
@@ -4,6 +4,6 @@
 mod archival;
 mod blob;
 mod kv_store;
-pub use archival::{ArchivalConfig, ArchivalWorker};
+pub use archival::{ArchivalConfig, ArchivalReducer, ArchivalWorker};
 pub use blob::{BlobTaskConfig, BlobWorker};
 pub use kv_store::{KVStoreTaskConfig, KVStoreWorker};

--- a/crates/sui-deepbook-indexer/src/sui_datasource.rs
+++ b/crates/sui-deepbook-indexer/src/sui_datasource.rs
@@ -161,6 +161,8 @@ pub type CheckpointTxnData = (CheckpointTransaction, u64, u64);
 
 #[async_trait]
 impl Worker for IndexerWorker<CheckpointTxnData> {
+    type Result = ();
+
     async fn process_checkpoint(&self, checkpoint: &SuiCheckpointData) -> anyhow::Result<()> {
         tracing::trace!(
             "Received checkpoint [{}] {}: {}",

--- a/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/ingestion_backfill_task.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/ingestion_backfill_task.rs
@@ -57,6 +57,7 @@ pub struct Adapter<T: IngestionBackfillTrait> {
 
 #[async_trait::async_trait]
 impl<T: IngestionBackfillTrait> Worker for Adapter<T> {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
         let processed = T::process_checkpoint(checkpoint);
         self.ready_checkpoints

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -87,6 +87,7 @@ pub struct CheckpointHandler {
 
 #[async_trait]
 impl Worker for CheckpointHandler {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
         let time_now_ms = chrono::Utc::now().timestamp_millis();
         let cp_download_lag = time_now_ms - checkpoint.checkpoint_summary.timestamp_ms as i64;

--- a/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
@@ -34,6 +34,7 @@ pub struct CheckpointObjectChanges {
 
 #[async_trait]
 impl Worker for ObjectsSnapshotHandler {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
         let transformed_data = CheckpointHandler::index_objects(checkpoint, &self.metrics).await?;
         self.sender

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -107,6 +107,7 @@ impl SuinsIndexerWorker {
 
 #[async_trait]
 impl Worker for SuinsIndexerWorker {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
         let checkpoint_seq_number = checkpoint.checkpoint_summary.sequence_number;
         let (updates, removals) = self.indexer.process_checkpoint(checkpoint);

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -16,6 +16,7 @@ struct CustomWorker;
 
 #[async_trait]
 impl Worker for CustomWorker {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
         // custom processing logic
         println!("Processing Local checkpoint: {}", checkpoint.checkpoint_summary.to_string());

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -10,6 +10,7 @@ struct CustomWorker;
 
 #[async_trait]
 impl Worker for CustomWorker {
+    type Result = ();
     async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
         // custom processing logic
         // print out the checkpoint number


### PR DESCRIPTION
## Description 

The PR introduces a new `reduce` functionality to the data ingestion framework. 
The functionality is optional and will not impact existing workflows. 
When enabled, it allows for the accumulation of a batch of checkpoints for post-processing. 
The watermark in the progress store is now updated after the reducer has completed its job. 
The old method, `Worker::save_progress`, is deprecated in favor of this approach.

As a proof of concept and to demonstrate the functionality, the archival workflow has been migrated to utilize a reducer. Note that the previous implementation would still work, but using a reducer for batch aggregation is more intuitive compared to accumulating state within a worker

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
