### PR TITLE
[indexer] Simplify setting up a test indexer writer or reader

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -11,7 +11,9 @@ use sui_config::{PersistedConfig, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG};
 use sui_graphql_rpc::config::{ConnectionConfig, ServiceConfig};
 use sui_graphql_rpc::test_infra::cluster::start_graphql_server_with_fn_rpc;
 use sui_indexer::tempdb::TempDb;
-use sui_indexer::test_utils::{start_test_indexer, ReaderWriterConfig};
+use sui_indexer::test_utils::{
+    start_indexer_jsonrpc_for_testing, start_indexer_writer_for_testing,
+};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use sui_sdk::wallet_context::WalletContext;
@@ -229,22 +231,22 @@ impl Cluster for LocalNewCluster {
             let graphql_address = format!("127.0.0.1:{}", get_available_port("127.0.0.1"));
             let graphql_url = format!("http://{graphql_address}");
 
-            // Start indexer writer
-            let (_, _, writer_token) = start_test_indexer(
+            let (_, _, writer_token) = start_indexer_writer_for_testing(
                 pg_address.clone(),
-                fullnode_url.clone(),
-                ReaderWriterConfig::writer_mode(None, None),
-                data_ingestion_path.path().to_path_buf(),
+                None,
+                None,
+                Some(data_ingestion_path.path().to_path_buf()),
+                None, /* cancel */
             )
             .await;
             cancellation_tokens.push(writer_token.drop_guard());
 
             // Start indexer jsonrpc service
-            let (_, _, reader_token) = start_test_indexer(
+            let (_, reader_token) = start_indexer_jsonrpc_for_testing(
                 pg_address.clone(),
                 fullnode_url.clone(),
-                ReaderWriterConfig::reader_mode(indexer_jsonrpc_address.clone()),
-                data_ingestion_path.path().to_path_buf(),
+                indexer_jsonrpc_address.clone(),
+                None, /* cancel */
             )
             .await;
             cancellation_tokens.push(reader_token.drop_guard());

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -14,13 +14,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_graphql_rpc_client::simple_client::SimpleClient;
+use sui_indexer::config::PruningOptions;
 pub use sui_indexer::config::SnapshotLagConfig;
 use sui_indexer::errors::IndexerError;
 use sui_indexer::store::PgIndexerStore;
 use sui_indexer::tempdb::get_available_port;
 use sui_indexer::tempdb::TempDb;
-use sui_indexer::test_utils::start_test_indexer_impl;
-use sui_indexer::test_utils::ReaderWriterConfig;
+use sui_indexer::test_utils::start_indexer_writer_for_testing;
 use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_types::storage::RestStateReader;
 use tempfile::tempdir;
@@ -125,12 +125,12 @@ pub async fn start_network_cluster() -> NetworkCluster {
     let val_fn = start_validator_with_fullnode(data_ingestion_path.path().to_path_buf()).await;
 
     // Starts indexer
-    let (pg_store, pg_handle) = start_test_indexer_impl(
+    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing(
         db_url,
-        val_fn.rpc_url().to_string(),
-        ReaderWriterConfig::writer_mode(None, None),
+        None,
+        None,
         Some(data_ingestion_path.path().to_path_buf()),
-        cancellation_token.clone(),
+        Some(cancellation_token.clone()),
     )
     .await;
 
@@ -177,12 +177,14 @@ pub async fn serve_executor(
             .await;
     });
 
-    let (pg_store, pg_handle) = start_test_indexer_impl(
+    let snapshot_config = snapshot_config.unwrap_or_default();
+
+    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing(
         db_url,
-        format!("http://{}", executor_server_url),
-        ReaderWriterConfig::writer_mode(snapshot_config.clone(), epochs_to_keep),
+        Some(snapshot_config.clone()),
+        Some(PruningOptions { epochs_to_keep }),
         Some(data_ingestion_path),
-        cancellation_token.clone(),
+        Some(cancellation_token.clone()),
     )
     .await;
 
@@ -209,7 +211,7 @@ pub async fn serve_executor(
         indexer_join_handle: pg_handle,
         graphql_server_join_handle: graphql_server_handle,
         graphql_client: client,
-        snapshot_config: snapshot_config.unwrap_or_default(),
+        snapshot_config,
         graphql_connection_config,
         cancellation_token,
         database,

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -32,24 +32,6 @@ use crate::store::{IndexerStore, PgIndexerStore};
 pub struct Indexer;
 
 impl Indexer {
-    #[cfg(test)]
-    pub async fn start_writer_for_testing(
-        config: &IngestionConfig,
-        store: PgIndexerStore,
-        metrics: IndexerMetrics,
-    ) -> Result<(), IndexerError> {
-        let snapshot_config = SnapshotLagConfig::default();
-        Indexer::start_writer(
-            config,
-            store,
-            metrics,
-            snapshot_config,
-            PruningOptions::default(),
-            CancellationToken::new(),
-        )
-        .await
-    }
-
     pub async fn start_writer(
         config: &IngestionConfig,
         store: PgIndexerStore,

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn build_json_rpc_server(
     prometheus_registry: &Registry,
     reader: IndexerReader,
     config: &JsonRpcConfig,
+    cancel: CancellationToken,
 ) -> Result<ServerHandle, IndexerError> {
     let mut builder =
         JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry, None, None);
@@ -65,7 +66,6 @@ pub async fn build_json_rpc_server(
     builder.register_module(CoinReadApi::new(reader.clone()))?;
     builder.register_module(ExtendedApi::new(reader.clone()))?;
 
-    let cancel = CancellationToken::new();
     let system_package_task =
         SystemPackageTask::new(reader.clone(), cancel.clone(), Duration::from_secs(10));
 

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -60,7 +60,8 @@ async fn main() -> anyhow::Result<()> {
         Command::JsonRpcService(json_rpc_config) => {
             check_db_migration_consistency(&mut pool.get().await?).await?;
 
-            Indexer::start_reader(&json_rpc_config, &registry, pool).await?;
+            Indexer::start_reader(&json_rpc_config, &registry, pool, CancellationToken::new())
+                .await?;
         }
         Command::ResetDatabase { force } => {
             if !force {

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -23,68 +23,67 @@ use crate::tempdb::get_available_port;
 use crate::tempdb::TempDb;
 use crate::IndexerMetrics;
 
-pub enum ReaderWriterConfig {
-    Reader {
-        reader_mode_rpc_url: String,
-    },
-    Writer {
-        snapshot_config: SnapshotLagConfig,
-        pruning_options: PruningOptions,
-    },
-}
-
-impl ReaderWriterConfig {
-    pub fn reader_mode(reader_mode_rpc_url: String) -> Self {
-        Self::Reader {
-            reader_mode_rpc_url,
-        }
-    }
-
-    /// Instantiates a config for indexer in writer mode with the given snapshot config and epochs
-    /// to keep.
-    pub fn writer_mode(
-        snapshot_config: Option<SnapshotLagConfig>,
-        epochs_to_keep: Option<u64>,
-    ) -> Self {
-        Self::Writer {
-            snapshot_config: snapshot_config.unwrap_or_default(),
-            pruning_options: PruningOptions { epochs_to_keep },
-        }
-    }
-}
-
-pub async fn start_test_indexer(
+/// Wrapper over `Indexer::start_reader` to make it easier to configure an indexer jsonrpc reader
+/// for testing.
+pub async fn start_indexer_jsonrpc_for_testing(
     db_url: String,
-    rpc_url: String,
-    reader_writer_config: ReaderWriterConfig,
-    data_ingestion_path: PathBuf,
+    fullnode_url: String,
+    json_rpc_url: String,
+    cancel: Option<CancellationToken>,
+) -> (JoinHandle<Result<(), IndexerError>>, CancellationToken) {
+    let token = cancel.unwrap_or_else(CancellationToken::new);
+
+    // Reduce the connection pool size to 10 for testing
+    // to prevent maxing out
+    let pool_config = ConnectionPoolConfig {
+        pool_size: 5,
+        connection_timeout: Duration::from_secs(10),
+        statement_timeout: Duration::from_secs(30),
+    };
+
+    println!("db_url: {db_url}");
+    println!("pool_config: {pool_config:?}");
+
+    let registry = prometheus::Registry::default();
+    init_metrics(&registry);
+
+    let pool = ConnectionPool::new(db_url.parse().unwrap(), pool_config)
+        .await
+        .unwrap();
+
+    let handle = {
+        let config = crate::config::JsonRpcConfig {
+            name_service_options: crate::config::NameServiceOptions::default(),
+            rpc_address: json_rpc_url.parse().unwrap(),
+            rpc_client_url: fullnode_url,
+        };
+        let token_clone = token.clone();
+        tokio::spawn(
+            async move { Indexer::start_reader(&config, &registry, pool, token_clone).await },
+        )
+    };
+
+    (handle, token)
+}
+
+/// Wrapper over `Indexer::start_writer_with_config` to make it easier to configure an indexer
+/// writer for testing.
+pub async fn start_indexer_writer_for_testing(
+    db_url: String,
+    snapshot_config: Option<SnapshotLagConfig>,
+    pruning_options: Option<PruningOptions>,
+    data_ingestion_path: Option<PathBuf>,
+    cancel: Option<CancellationToken>,
 ) -> (
     PgIndexerStore,
     JoinHandle<Result<(), IndexerError>>,
     CancellationToken,
 ) {
-    let token = CancellationToken::new();
-    let (store, handle) = start_test_indexer_impl(
-        db_url,
-        rpc_url,
-        reader_writer_config,
-        Some(data_ingestion_path),
-        token.clone(),
-    )
-    .await;
-    (store, handle, token)
-}
+    let token = cancel.unwrap_or_else(CancellationToken::new);
+    let snapshot_config = snapshot_config.unwrap_or_default();
+    let pruning_options = pruning_options.unwrap_or_default();
 
-/// Starts an indexer reader or writer for testing depending on the `reader_writer_config`.
-pub async fn start_test_indexer_impl(
-    db_url: String,
-    rpc_url: String,
-    reader_writer_config: ReaderWriterConfig,
-    data_ingestion_path: Option<PathBuf>,
-    cancel: CancellationToken,
-) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
-    // Reduce the connection pool size to 5 for testing
-    // to prevent maxing out
+    // Reduce the connection pool size to 10 for testing to prevent maxing out
     let pool_config = ConnectionPoolConfig {
         pool_size: 5,
         connection_timeout: Duration::from_secs(10),
@@ -96,9 +95,7 @@ pub async fn start_test_indexer_impl(
     println!("{data_ingestion_path:?}");
 
     let registry = prometheus::Registry::default();
-
     init_metrics(&registry);
-
     let indexer_metrics = IndexerMetrics::new(&registry);
 
     let pool = ConnectionPool::new(db_url.parse().unwrap(), pool_config)
@@ -110,29 +107,16 @@ pub async fn start_test_indexer_impl(
         indexer_metrics.clone(),
     );
 
-    let handle = match reader_writer_config {
-        ReaderWriterConfig::Reader {
-            reader_mode_rpc_url,
-        } => {
-            let config = crate::config::JsonRpcConfig {
-                name_service_options: crate::config::NameServiceOptions::default(),
-                rpc_address: reader_mode_rpc_url.parse().unwrap(),
-                rpc_client_url: rpc_url,
-            };
-            tokio::spawn(async move { Indexer::start_reader(&config, &registry, pool).await })
-        }
-        ReaderWriterConfig::Writer {
-            snapshot_config,
-            pruning_options,
-        } => {
-            let connection = Connection::dedicated(&db_url.parse().unwrap())
-                .await
-                .unwrap();
-            crate::db::reset_database(connection).await.unwrap();
+    let handle = {
+        let connection = Connection::dedicated(&db_url.parse().unwrap())
+            .await
+            .unwrap();
+        crate::db::reset_database(connection).await.unwrap();
 
-            let store_clone = store.clone();
-            let mut ingestion_config = IngestionConfig::default();
-            ingestion_config.sources.data_ingestion_path = data_ingestion_path;
+        let store_clone = store.clone();
+        let mut ingestion_config = IngestionConfig::default();
+        ingestion_config.sources.data_ingestion_path = data_ingestion_path;
+        let token_clone = token.clone();
 
             tokio::spawn(async move {
                 Indexer::start_writer(
@@ -148,7 +132,7 @@ pub async fn start_test_indexer_impl(
         }
     };
 
-    (store, handle)
+    (store, handle, token)
 }
 
 #[derive(Clone)]

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -31,7 +31,7 @@ pub async fn start_indexer_jsonrpc_for_testing(
     json_rpc_url: String,
     cancel: Option<CancellationToken>,
 ) -> (JoinHandle<Result<(), IndexerError>>, CancellationToken) {
-    let token = cancel.unwrap_or_else(CancellationToken::new);
+    let token = cancel.unwrap_or_default();
 
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
@@ -67,7 +67,8 @@ pub async fn start_indexer_jsonrpc_for_testing(
 }
 
 /// Wrapper over `Indexer::start_writer_with_config` to make it easier to configure an indexer
-/// writer for testing.
+/// writer for testing. If the config options are null, default values that have historically worked
+/// for testing will be used.
 pub async fn start_indexer_writer_for_testing(
     db_url: String,
     snapshot_config: Option<SnapshotLagConfig>,
@@ -79,8 +80,11 @@ pub async fn start_indexer_writer_for_testing(
     JoinHandle<Result<(), IndexerError>>,
     CancellationToken,
 ) {
-    let token = cancel.unwrap_or_else(CancellationToken::new);
-    let snapshot_config = snapshot_config.unwrap_or_default();
+    let token = cancel.unwrap_or_default();
+    let snapshot_config = snapshot_config.unwrap_or(SnapshotLagConfig {
+        snapshot_min_lag: 5,
+        sleep_duration: 0,
+    });
     let pruning_options = pruning_options.unwrap_or_default();
 
     // Reduce the connection pool size to 10 for testing to prevent maxing out

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -17,6 +17,60 @@ use sui_types::effects::TransactionEffectsAPI;
 use sui_types::gas_coin::GasCoin;
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use tempfile::tempdir;
+use tokio::task::JoinHandle;
+
+/// Set up a test indexer fetching from a REST endpoint served by the given Simulacrum.
+async fn set_up(
+    sim: Arc<Simulacrum>,
+    data_ingestion_path: PathBuf,
+) -> (
+    JoinHandle<()>,
+    PgIndexerStore,
+    JoinHandle<Result<(), IndexerError>>,
+    TempDb,
+) {
+    let database = TempDb::new().unwrap();
+    let server_url: SocketAddr = format!("127.0.0.1:{}", get_available_port())
+        .parse()
+        .unwrap();
+
+    let server_handle = tokio::spawn(async move {
+        sui_rest_api::RestService::new_without_version(sim)
+            .start_service(server_url)
+            .await;
+    });
+    // Starts indexer
+    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing(
+        database.database().url().as_str().to_owned(),
+        None,
+        None,
+        Some(data_ingestion_path),
+        None, /* cancel */
+    )
+    .await;
+    (server_handle, pg_store, pg_handle, database)
+}
+
+/// Wait for the indexer to catch up to the given checkpoint sequence number.
+async fn wait_for_checkpoint(
+    pg_store: &PgIndexerStore,
+    checkpoint_sequence_number: u64,
+) -> Result<(), IndexerError> {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while {
+            let cp_opt = pg_store
+                .get_latest_checkpoint_sequence_number()
+                .await
+                .unwrap();
+            cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
+        } {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for indexer to catchup to checkpoint");
+    Ok(())
+}
 
 #[tokio::test]
 pub async fn test_transaction_table() -> Result<(), IndexerError> {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -33,7 +33,9 @@ use sui_config::{
     SUI_BENCHMARK_GENESIS_GAS_KEYSTORE_FILENAME, SUI_GENESIS_FILENAME, SUI_KEYSTORE_FILENAME,
 };
 use sui_faucet::{create_wallet_context, start_faucet, AppState, FaucetConfig, SimpleFaucet};
-use sui_indexer::test_utils::{start_test_indexer, ReaderWriterConfig};
+use sui_indexer::test_utils::{
+    start_indexer_jsonrpc_for_testing, start_indexer_writer_for_testing,
+};
 
 use sui_graphql_rpc::{
     config::{ConnectionConfig, ServiceConfig},
@@ -704,20 +706,20 @@ async fn start(
             .map_err(|_| anyhow!("Invalid indexer host and port"))?;
         info!("Starting the indexer service at {indexer_address}");
         // Start in reader mode
-        start_test_indexer(
+        start_indexer_jsonrpc_for_testing(
             pg_address.clone(),
             fullnode_url.clone(),
-            ReaderWriterConfig::reader_mode(indexer_address.to_string()),
-            data_ingestion_path.clone(),
+            indexer_address.to_string(),
+            None,
         )
         .await;
         info!("Indexer started in reader mode");
-        // Start in writer mode
-        start_test_indexer(
+        start_indexer_writer_for_testing(
             pg_address.clone(),
-            fullnode_url.clone(),
-            ReaderWriterConfig::writer_mode(None, None),
-            data_ingestion_path.clone(),
+            None,
+            None,
+            Some(data_ingestion_path.clone()),
+            None,
         )
         .await;
         info!("Indexer started in writer mode");


### PR DESCRIPTION
## Description 

Currently, tests that require spinning up an indexer do so through `start_test_indexer_impl` or `start_test_indexer`. This is further complicated by a single `start` function that accepts a `ReaderWriterConfig`. We can simplify this by exposing two functions with optional parameters that can be configured by the caller.

Part of a stack of PRs for watermarks
1. simplify setting up test indexer: https://github.com/MystenLabs/sui/pull/19663
2. update pruner config: https://github.com/MystenLabs/sui/pull/19637
3. committer writes upper bounds https://github.com/MystenLabs/sui/pull/19649
4. pruner writes lower bounds: https://github.com/MystenLabs/sui/pull/19650
5. pruner prunes (wip)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
