### PR TITLE
[sui-tool] set upper limit on num-parallel-downloads

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -262,8 +262,8 @@ pub enum ToolCommand {
         #[clap(long = "skip-indexes")]
         skip_indexes: bool,
         /// Number of parallel downloads to perform. Defaults to a reasonable
-        /// value based on number of available logical cores.
-        #[clap(long = "num-parallel-downloads")]
+        /// value based on number of available logical cores. Maximum value is 100.
+        #[clap(long = "num-parallel-downloads", value_parser = parse_parallel_downloads)]
         num_parallel_downloads: Option<usize>,
         /// Network to download snapshot for. Defaults to "mainnet".
         /// If `--snapshot-bucket` or `--archive-bucket` is not specified,
@@ -324,8 +324,8 @@ pub enum ToolCommand {
         #[clap(long = "path")]
         path: PathBuf,
         /// Number of parallel downloads to perform. Defaults to a reasonable
-        /// value based on number of available logical cores.
-        #[clap(long = "num-parallel-downloads")]
+        /// value based on number of available logical cores. Maximum value is 100.
+        #[clap(long = "num-parallel-downloads", value_parser = parse_parallel_downloads)]
         num_parallel_downloads: Option<usize>,
         /// Verification mode to employ.
         #[clap(long = "verify", default_value = "normal")]
@@ -416,6 +416,14 @@ pub enum ToolCommand {
         )]
         sender_signed_data: String,
     },
+}
+
+fn parse_parallel_downloads(s: &str) -> Result<usize, String> {
+    match s.parse::<usize>() {
+        Ok(val) if (1..=100).contains(&val) => Ok(val),
+        Ok(_) => Err(String::from("Value must be between 1 and 100")),
+        Err(_) => Err(String::from("Failed to parse value as usize")),
+    }
 }
 
 async fn check_locked_object(


### PR DESCRIPTION
## Description 

<img width="807" alt="image" src="https://github.com/user-attachments/assets/0affe5ff-7847-41b4-ae87-77c4e0fcaa54">

I've observed setting num parallel downloads to too high a value can result in sui-tool failing with cryptic errors.

## Test plan 

I checked the max value we currently set `--num-parallel-downloads` in any of our workflows is 100

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
