### PR TITLE
docs: examples of things only GraphQL can do

### DIFF
--- a/docs/content/guides/developer/advanced/graphql-migration.mdx
+++ b/docs/content/guides/developer/advanced/graphql-migration.mdx
@@ -142,6 +142,47 @@ The cursor is now passed in the `after` (or `before`) fields on the connection, 
 </TabItem>
 </Tabs>
 
+## New features
+
+There are also things that GraphQL can do, which JSON-RPC cannot:
+
+### Example 4: Getting objects by type
+
+This query fetches the latest versions of objects of type `0x2::package::Publisher` that are currently live on-chain.
+
+```graphql
+query {
+  objects(filter: { type: "0x2::package::Publisher" }) {
+    nodes {
+      address
+      digest
+      asMoveObject {
+        contents { json }
+      }
+    }
+  }
+}
+```
+
+### Example 5: Paging through package versions
+
+The goal is to find all versions of the Sui framework, and list their modules:
+
+```graphql
+query {
+  packageVersions(address: "0x2") {
+    nodes {
+      version
+      modules {
+        nodes {
+          name
+        }
+      }
+    }
+  } 
+}
+```
+
 ## Related links
   
 - [GraphQL reference](../../../references/sui-graphql.mdx): Auto-generated GraphQL reference for Sui RPC.


### PR DESCRIPTION
## Description

Adding some examples of things that we can do with GraphQL that can't be done with JSON-RPC.

## Test plan

:eyes: (and trying out the queries)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
