### PR TITLE
graphql: Event.transactionBlock

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.exp
@@ -298,7 +298,7 @@ Response: {
   }
 }
 
-task 10, lines 114-130:
+task 10, lines 122-138:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.exp
@@ -1,4 +1,4 @@
-processed 10 tasks
+processed 11 tasks
 
 init:
 A: object(0,0)
@@ -287,6 +287,90 @@ Response: {
                       },
                       "bcs": "ZgAAAAAAAAA="
                     }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 10, lines 114-130:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "FPhSSzT7tHmrPhs3H9GT1n4Dqj3eyCgaFLkQSc9FEDVV",
+          "effects": {
+            "events": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "digest": "GJMTYHH46d31ohELwH3ZfvGvbiDZ7GCqNcyg4fGGFJJQ",
+          "effects": {
+            "events": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "digest": "48LNnMV9MFXiXfXwDRWzu6SndwxY3ZfKUNEKJiDqJqM7",
+          "effects": {
+            "events": {
+              "nodes": [
+                {
+                  "transactionBlock": {
+                    "digest": "48LNnMV9MFXiXfXwDRWzu6SndwxY3ZfKUNEKJiDqJqM7"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "digest": "FhpR5hSSP2wf8ABXKcDVVTzo7H1DZYUUgABWPtADHcQA",
+          "effects": {
+            "events": {
+              "nodes": [
+                {
+                  "transactionBlock": {
+                    "digest": "FhpR5hSSP2wf8ABXKcDVVTzo7H1DZYUUgABWPtADHcQA"
+                  }
+                },
+                {
+                  "transactionBlock": {
+                    "digest": "FhpR5hSSP2wf8ABXKcDVVTzo7H1DZYUUgABWPtADHcQA"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "digest": "2CdTttmE8ciZggrK8qnyjgLaDoDNzT6UCzFsn4834UWX",
+          "effects": {
+            "events": {
+              "nodes": [
+                {
+                  "transactionBlock": {
+                    "digest": "2CdTttmE8ciZggrK8qnyjgLaDoDNzT6UCzFsn4834UWX"
+                  }
+                },
+                {
+                  "transactionBlock": {
+                    "digest": "2CdTttmE8ciZggrK8qnyjgLaDoDNzT6UCzFsn4834UWX"
+                  }
+                },
+                {
+                  "transactionBlock": {
+                    "digest": "2CdTttmE8ciZggrK8qnyjgLaDoDNzT6UCzFsn4834UWX"
                   }
                 }
               ]

--- a/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/events.move
@@ -118,3 +118,21 @@ module Test::M1 {
     }
   }
 }
+
+//# run-graphql
+{
+  transactionBlocks {
+    nodes {
+      digest
+      effects {
+        events {
+          nodes {
+            transactionBlock {
+              digest
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -1231,6 +1231,12 @@ type EpochEdge {
 
 type Event {
 	"""
+	The transaction block that emitted this event. This information is only available for
+	events from indexed transactions, and not from transactions that have just been executed or
+	dry-run.
+	"""
+	transactionBlock: TransactionBlock
+	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
 	For example, if a PTB invokes A::m1::foo, which internally

--- a/crates/sui-graphql-rpc/src/types/event/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/event/mod.rs
@@ -58,12 +58,12 @@ impl Event {
             return Ok(None);
         };
 
-        Ok(TransactionBlock::query(
+        TransactionBlock::query(
             ctx,
             TransactionBlock::by_seq(stored.tx_sequence_number as u64, self.checkpoint_viewed_at),
         )
         .await
-        .extend()?)
+        .extend()
     }
 
     /// The Move module containing some function that when called by

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -51,6 +51,7 @@ use sui_types::object::{
     MoveObject as NativeMoveObject, Object as NativeObject, Owner as NativeOwner,
 };
 use sui_types::TypeTag;
+
 #[derive(Clone, Debug)]
 pub(crate) struct Object {
     pub address: SuiAddress,
@@ -632,9 +633,12 @@ impl ObjectImpl<'_> {
         };
         let digest = native.previous_transaction;
 
-        TransactionBlock::query(ctx, digest.into(), self.0.checkpoint_viewed_at)
-            .await
-            .extend()
+        TransactionBlock::query(
+            ctx,
+            TransactionBlock::by_digest(digest.into(), self.0.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn storage_rebate(&self) -> Option<BigInt> {

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -323,9 +323,8 @@ impl Query {
         digest: Digest,
     ) -> Result<Option<TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
-        TransactionBlock::query(ctx, digest, checkpoint)
-            .await
-            .extend()
+        let lookup = TransactionBlock::by_digest(digest, checkpoint);
+        TransactionBlock::query(ctx, lookup).await.extend()
     }
 
     /// The coin objects that exist in the network.

--- a/crates/sui-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/mod.rs
@@ -93,6 +93,18 @@ pub(crate) enum TransactionBlockKindInput {
     ProgrammableTx = 1,
 }
 
+/// Filter for a point query of a TransactionBlock.
+pub(crate) enum TransactionBlockLookup {
+    ByDigest {
+        digest: Digest,
+        checkpoint_viewed_at: u64,
+    },
+    BySeq {
+        tx_sequence_number: u64,
+        checkpoint_viewed_at: u64,
+    },
+}
+
 type Query<ST, GB> = data::Query<ST, transactions::table, GB>;
 
 /// The cursor returned for each `TransactionBlock` in a connection's page of results. The
@@ -110,11 +122,19 @@ pub(crate) struct TransactionBlockCursor {
     pub tx_checkpoint_number: u64,
 }
 
-/// `DataLoader` key for fetching a `TransactionBlock` by its digest, optionally constrained by a
-/// consistency cursor.
+/// `DataLoader` key for fetching a `TransactionBlock` by its digest, constrained by a consistency
+/// cursor.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 struct DigestKey {
     pub digest: Digest,
+    pub checkpoint_viewed_at: u64,
+}
+
+/// `DataLoader` key for fetching a `TransactionBlock` by its sequence number, constrained by a
+/// consistency cursor.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+struct SeqKey {
+    pub tx_sequence_number: u64,
     pub checkpoint_viewed_at: u64,
 }
 
@@ -230,21 +250,60 @@ impl TransactionBlock {
         }
     }
 
+    /// Look-up the transaction block by its transaction digest.
+    pub(crate) fn by_digest(digest: Digest, checkpoint_viewed_at: u64) -> TransactionBlockLookup {
+        TransactionBlockLookup::ByDigest {
+            digest,
+            checkpoint_viewed_at,
+        }
+    }
+
+    /// Look-up the transaction block by its sequence number (this is not usually exposed through
+    /// the GraphQL schema, but internally, othe entities in the DB will refer to transactions at
+    /// their sequence number).
+    pub(crate) fn by_seq(
+        tx_sequence_number: u64,
+        checkpoint_viewed_at: u64,
+    ) -> TransactionBlockLookup {
+        TransactionBlockLookup::BySeq {
+            tx_sequence_number,
+            checkpoint_viewed_at,
+        }
+    }
+
     /// Look up a `TransactionBlock` in the database, by its transaction digest. Treats it as if it
     /// is being viewed at the `checkpoint_viewed_at` (e.g. the state of all relevant addresses will
     /// be at that checkpoint).
     pub(crate) async fn query(
         ctx: &Context<'_>,
-        digest: Digest,
-        checkpoint_viewed_at: u64,
+        lookup: TransactionBlockLookup,
     ) -> Result<Option<Self>, Error> {
         let DataLoader(loader) = ctx.data_unchecked();
-        loader
-            .load_one(DigestKey {
+
+        match lookup {
+            TransactionBlockLookup::ByDigest {
                 digest,
                 checkpoint_viewed_at,
-            })
-            .await
+            } => {
+                loader
+                    .load_one(DigestKey {
+                        digest,
+                        checkpoint_viewed_at,
+                    })
+                    .await
+            }
+            TransactionBlockLookup::BySeq {
+                tx_sequence_number,
+                checkpoint_viewed_at,
+            } => {
+                loader
+                    .load_one(SeqKey {
+                        tx_sequence_number,
+                        checkpoint_viewed_at,
+                    })
+                    .await
+            }
+        }
     }
 
     /// Look up multiple `TransactionBlock`s by their digests. Returns a map from those digests to
@@ -473,6 +532,63 @@ impl Loader<DigestKey> for Db {
                 .get(key.digest.as_slice())
                 .cloned()
             else {
+                continue;
+            };
+
+            // Filter by key's checkpoint viewed at here. Doing this in memory because it should be
+            // quite rare that this query actually filters something, but encoding it in SQL is
+            // complicated.
+            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                continue;
+            }
+
+            let inner = TransactionBlockInner::try_from(stored)?;
+            results.insert(
+                *key,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at: key.checkpoint_viewed_at,
+                },
+            );
+        }
+
+        Ok(results)
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<SeqKey> for Db {
+    type Value = TransactionBlock;
+    type Error = Error;
+
+    async fn load(&self, keys: &[SeqKey]) -> Result<HashMap<SeqKey, TransactionBlock>, Error> {
+        use transactions::dsl as tx;
+
+        let seqs: Vec<_> = keys.iter().map(|k| k.tx_sequence_number as i64).collect();
+
+        let transactions: Vec<StoredTransaction> = self
+            .execute(move |conn| {
+                async move {
+                    conn.results(move || {
+                        tx::transactions
+                            .select(StoredTransaction::as_select())
+                            .filter(tx::tx_sequence_number.eq_any(seqs.clone()))
+                    })
+                    .await
+                }
+                .scope_boxed()
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
+
+        let seq_to_stored: BTreeMap<_, _> = transactions
+            .into_iter()
+            .map(|tx| (tx.tx_sequence_number as u64, tx))
+            .collect();
+
+        let mut results = HashMap::new();
+        for key in keys {
+            let Some(stored) = seq_to_stored.get(&key.tx_sequence_number).cloned() else {
                 continue;
             };
 

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -1236,6 +1236,12 @@ type EpochEdge {
 
 type Event {
 	"""
+	The transaction block that emitted this event. This information is only available for
+	events from indexed transactions, and not from transactions that have just been executed or
+	dry-run.
+	"""
+	transactionBlock: TransactionBlock
+	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
 	For example, if a PTB invokes A::m1::foo, which internally

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -1235,6 +1235,12 @@ type EpochEdge {
 
 type Event {
 	"""
+	The transaction block that emitted this event. This information is only available for
+	events from indexed transactions, and not from transactions that have just been executed or
+	dry-run.
+	"""
+	transactionBlock: TransactionBlock
+	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
 	For example, if a PTB invokes A::m1::foo, which internally

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -1240,6 +1240,12 @@ type EpochEdge {
 
 type Event {
 	"""
+	The transaction block that emitted this event. This information is only available for
+	events from indexed transactions, and not from transactions that have just been executed or
+	dry-run.
+	"""
+	transactionBlock: TransactionBlock
+	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
 	For example, if a PTB invokes A::m1::foo, which internally


### PR DESCRIPTION
## Description

Add the ability to fetch the transaction block that emitted the event.

## Test plan

New E2E tests:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests
sui$ cargo nextest run -p sui-graphql-rpc -- test_schema_sdl_export
sui$ cargo nextest run -p sui-graphql-rpc --features staging -- test_schema_sdl_export
```

## Stack

- #19670 
- #19671 
- #19672 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Add `Event.transactionBlock` for fetching the transaction that emitted the event, as long as the event is indexed (not just executed).
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
