### PR TITLE
graphql: add flag to skip db compatibility

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -251,14 +251,12 @@ impl Cluster for LocalNewCluster {
 
             // Start the graphql service
             let graphql_address = graphql_address.parse::<SocketAddr>()?;
-            let graphql_connection_config = ConnectionConfig::new(
-                Some(graphql_address.port()),
-                Some(graphql_address.ip().to_string()),
-                Some(pg_address),
-                None,
-                None,
-                None,
-            );
+            let graphql_connection_config = ConnectionConfig {
+                port: graphql_address.port(),
+                host: graphql_address.ip().to_string(),
+                db_url: pg_address,
+                ..Default::default()
+            };
 
             start_graphql_server_with_fn_rpc(
                 graphql_connection_config.clone(),

--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -4,6 +4,8 @@
 use clap::*;
 use std::path::PathBuf;
 
+use crate::config::{ConnectionConfig, Ide, TxExecFullNodeConfig};
+
 #[derive(Parser)]
 #[clap(
     name = "sui-graphql-rpc",
@@ -21,34 +23,17 @@ pub enum Command {
     },
 
     StartServer {
-        /// The title to display at the top of the page
-        #[clap(short, long)]
-        ide_title: Option<String>,
-        /// DB URL for data fetching
-        #[clap(short, long)]
-        db_url: Option<String>,
-        /// Pool size for DB connections
-        #[clap(long)]
-        db_pool_size: Option<u32>,
-        /// Port to bind the server to
-        #[clap(short, long)]
-        port: Option<u16>,
-        /// Host to bind the server to
-        #[clap(long)]
-        host: Option<String>,
-        /// Port to bind the prom server to
-        #[clap(long)]
-        prom_port: Option<u16>,
-        /// Host to bind the prom server to
-        #[clap(long)]
-        prom_host: Option<String>,
+        #[clap(flatten)]
+        ide: Ide,
+
+        #[clap(flatten)]
+        connection: ConnectionConfig,
 
         /// Path to TOML file containing configuration for service.
         #[clap(short, long)]
         config: Option<PathBuf>,
 
-        /// RPC url to the Node for tx execution
-        #[clap(long)]
-        node_rpc_url: Option<String>,
+        #[clap(flatten)]
+        tx_exec_full_node: TxExecFullNodeConfig,
     },
 }

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -42,15 +42,25 @@ pub struct ServerConfig {
 /// specific connections between this service and other services, and might differ from instance to
 /// instance of the GraphQL service.
 #[GraphQLConfig]
-#[derive(Clone, Eq, PartialEq)]
+#[derive(clap::Args, Clone, Eq, PartialEq)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
+    #[clap(short, long, default_value_t = ConnectionConfig::default().port)]
     pub port: u16,
     /// Host to bind the server to
+    #[clap(long, default_value_t = ConnectionConfig::default().host)]
     pub host: String,
+    /// DB URL for data fetching
+    #[clap(short, long, default_value_t = ConnectionConfig::default().db_url)]
     pub db_url: String,
+    /// Pool size for DB connections
+    #[clap(long, default_value_t = ConnectionConfig::default().db_pool_size)]
     pub db_pool_size: u32,
-    pub prom_url: String,
+    /// Host to bind the prom server to
+    #[clap(long, default_value_t = ConnectionConfig::default().prom_host)]
+    pub prom_host: String,
+    /// Port to bind the prom server to
+    #[clap(long, default_value_t = ConnectionConfig::default().prom_port)]
     pub prom_port: u16,
 }
 
@@ -172,8 +182,11 @@ impl Version {
 }
 
 #[GraphQLConfig]
+#[derive(clap::Args)]
 pub struct Ide {
-    pub(crate) ide_title: String,
+    /// The title to display at the top of the web-based GraphiQL IDE.
+    #[clap(short, long, default_value_t = Ide::default().ide_title)]
+    pub ide_title: String,
 }
 
 #[GraphQLConfig]
@@ -199,8 +212,9 @@ pub struct InternalFeatureConfig {
 }
 
 #[GraphQLConfig]
-#[derive(Default)]
+#[derive(clap::Args, Default)]
 pub struct TxExecFullNodeConfig {
+    /// RPC URL for the fullnode to send transactions to execute and dry-run.
     pub(crate) node_rpc_url: Option<String>,
 }
 
@@ -337,25 +351,6 @@ impl TxExecFullNodeConfig {
 }
 
 impl ConnectionConfig {
-    pub fn new(
-        port: Option<u16>,
-        host: Option<String>,
-        db_url: Option<String>,
-        db_pool_size: Option<u32>,
-        prom_url: Option<String>,
-        prom_port: Option<u16>,
-    ) -> Self {
-        let default = Self::default();
-        Self {
-            port: port.unwrap_or(default.port),
-            host: host.unwrap_or(default.host),
-            db_url: db_url.unwrap_or(default.db_url),
-            db_pool_size: db_pool_size.unwrap_or(default.db_pool_size),
-            prom_url: prom_url.unwrap_or(default.prom_url),
-            prom_port: prom_port.unwrap_or(default.prom_port),
-        }
-    }
-
     pub fn db_name(&self) -> String {
         self.db_url.split('/').last().unwrap().to_string()
     }
@@ -432,14 +427,6 @@ impl Limits {
     }
 }
 
-impl Ide {
-    pub fn new(ide_title: Option<String>) -> Self {
-        ide_title
-            .map(|ide_title| Ide { ide_title })
-            .unwrap_or_default()
-    }
-}
-
 impl BackgroundTasksConfig {
     pub fn test_defaults() -> Self {
         Self {
@@ -481,7 +468,7 @@ impl Default for ConnectionConfig {
             host: "127.0.0.1".to_string(),
             db_url: "postgres://postgres:postgrespw@localhost:5432/sui_indexer".to_string(),
             db_pool_size: 10,
-            prom_url: "0.0.0.0".to_string(),
+            prom_host: "0.0.0.0".to_string(),
             prom_port: 9184,
         }
     }

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -62,6 +62,10 @@ pub struct ConnectionConfig {
     /// Port to bind the prom server to
     #[clap(long, default_value_t = ConnectionConfig::default().prom_port)]
     pub prom_port: u16,
+    /// Skip checking whether the service is compatible with the DB it is about to connect to, on
+    /// start-up.
+    #[clap(long, default_value_t = ConnectionConfig::default().skip_migration_consistency_check)]
+    pub skip_migration_consistency_check: bool,
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a TOML-based file. These
@@ -470,6 +474,7 @@ impl Default for ConnectionConfig {
             db_pool_size: 10,
             prom_host: "0.0.0.0".to_string(),
             prom_port: 9184,
+            skip_migration_consistency_check: false,
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -6,9 +6,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use sui_graphql_rpc::commands::Command;
-use sui_graphql_rpc::config::{
-    ConnectionConfig, Ide, ServerConfig, ServiceConfig, TxExecFullNodeConfig, Version,
-};
+use sui_graphql_rpc::config::{ServerConfig, ServiceConfig, Version};
 use sui_graphql_rpc::server::graphiql_server::start_graphiql_server;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -51,18 +49,11 @@ async fn main() {
         }
 
         Command::StartServer {
-            ide_title,
-            db_url,
-            db_pool_size,
-            port,
-            host,
+            ide,
+            connection,
             config,
-            node_rpc_url,
-            prom_host,
-            prom_port,
+            tx_exec_full_node,
         } => {
-            let connection =
-                ConnectionConfig::new(port, host, db_url, db_pool_size, prom_host, prom_port);
             let service_config = service_config(config);
             let _guard = telemetry_subscribers::TelemetryConfig::new()
                 .with_env()
@@ -74,8 +65,8 @@ async fn main() {
             let server_config = ServerConfig {
                 connection,
                 service: service_config,
-                ide: Ide::new(ide_title),
-                tx_exec_full_node: TxExecFullNodeConfig::new(node_rpc_url),
+                ide,
+                tx_exec_full_node,
                 ..ServerConfig::default()
             };
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -378,13 +378,13 @@ impl ServerBuilder {
         // PROMETHEUS
         let prom_addr: SocketAddr = format!(
             "{}:{}",
-            config.connection.prom_url, config.connection.prom_port
+            config.connection.prom_host, config.connection.prom_port
         )
         .parse()
         .map_err(|_| {
             Error::Internal(format!(
                 "Failed to parse url {}, port {} into socket address",
-                config.connection.prom_url, config.connection.prom_port
+                config.connection.prom_host, config.connection.prom_port
             ))
         })?;
 
@@ -706,7 +706,7 @@ pub mod tests {
             host: "127.0.0.1".to_owned(),
             db_url,
             db_pool_size: 5,
-            prom_url: "127.0.0.1".to_owned(),
+            prom_host: "127.0.0.1".to_owned(),
             prom_port: get_available_port(),
         };
         let service_config = service_config.unwrap_or_default();

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -79,7 +79,6 @@ pub(crate) struct Server {
     system_package_task: SystemPackageTask,
     trigger_exchange_rates_task: TriggerExchangeRatesTask,
     state: AppState,
-    db_reader: Db,
 }
 
 impl Server {
@@ -87,15 +86,6 @@ impl Server {
     /// signal is received, the method waits for all tasks to complete before returning.
     pub async fn run(mut self) -> Result<(), Error> {
         get_or_init_server_start_time().await;
-
-        let mut connection = self
-            .db_reader
-            .inner
-            .pool()
-            .get()
-            .await
-            .map_err(|e| Error::Internal(e.to_string()))?;
-        check_db_migration_consistency(&mut connection).await?;
 
         // A handle that spawns a background task to periodically update the `Watermark`, which
         // consists of the checkpoint upper bound and current epoch.
@@ -342,7 +332,7 @@ impl ServerBuilder {
         );
 
         let trigger_exchange_rates_task = TriggerExchangeRatesTask::new(
-            db_reader.clone(),
+            db_reader,
             watermark_task.epoch_receiver(),
             state.cancellation_token.clone(),
         );
@@ -364,7 +354,6 @@ impl ServerBuilder {
             system_package_task,
             trigger_exchange_rates_task,
             state,
-            db_reader,
         })
     }
 
@@ -423,6 +412,17 @@ impl ServerBuilder {
         )
         .await
         .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
+
+        if !config.connection.skip_migration_consistency_check {
+            check_db_migration_consistency(
+                &mut reader
+                    .pool()
+                    .get()
+                    .await
+                    .map_err(|e| Error::Internal(e.to_string()))?,
+            )
+            .await?;
+        }
 
         // DB
         let db = Db::new(

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -708,6 +708,7 @@ pub mod tests {
             db_pool_size: 5,
             prom_host: "127.0.0.1".to_owned(),
             prom_port: get_available_port(),
+            skip_migration_consistency_check: false,
         };
         let service_config = service_config.unwrap_or_default();
 

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -117,6 +117,7 @@ pub async fn start_network_cluster() -> NetworkCluster {
         db_pool_size: 5,
         prom_host: "127.0.0.1".to_owned(),
         prom_port: get_available_port(),
+        skip_migration_consistency_check: false,
     };
     let data_ingestion_path = tempfile::tempdir().unwrap();
     let db_url = graphql_connection_config.db_url.clone();
@@ -162,6 +163,7 @@ pub async fn serve_executor(
         db_pool_size: 5,
         prom_host: "127.0.0.1".to_owned(),
         prom_port: get_available_port(),
+        skip_migration_consistency_check: false,
     };
     let db_url = graphql_connection_config.db_url.clone();
     // Creates a cancellation token and adds this to the ExecutorCluster, so that we can send a

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -115,7 +115,7 @@ pub async fn start_network_cluster() -> NetworkCluster {
         host: "127.0.0.1".to_owned(),
         db_url: database.database().url().as_str().to_owned(),
         db_pool_size: 5,
-        prom_url: "127.0.0.1".to_owned(),
+        prom_host: "127.0.0.1".to_owned(),
         prom_port: get_available_port(),
     };
     let data_ingestion_path = tempfile::tempdir().unwrap();
@@ -160,7 +160,7 @@ pub async fn serve_executor(
         host: "127.0.0.1".to_owned(),
         db_url: database.database().url().as_str().to_owned(),
         db_pool_size: 5,
-        prom_url: "127.0.0.1".to_owned(),
+        prom_host: "127.0.0.1".to_owned(),
         prom_port: get_available_port(),
     };
     let db_url = graphql_connection_config.db_url.clone();

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -727,14 +727,13 @@ async fn start(
         let graphql_address = parse_host_port(input, DEFAULT_GRAPHQL_PORT)
             .map_err(|_| anyhow!("Invalid graphql host and port"))?;
         tracing::info!("Starting the GraphQL service at {graphql_address}");
-        let graphql_connection_config = ConnectionConfig::new(
-            Some(graphql_address.port()),
-            Some(graphql_address.ip().to_string()),
-            Some(pg_address),
-            None,
-            None,
-            None,
-        );
+        let graphql_connection_config = ConnectionConfig {
+            port: graphql_address.port(),
+            host: graphql_address.ip().to_string(),
+            db_url: pg_address,
+            ..Default::default()
+        };
+
         start_graphql_server_with_fn_rpc(
             graphql_connection_config,
             Some(fullnode_url.clone()),


### PR DESCRIPTION
## Description

Add a flag to optionally skip database migration compatibility checks. This is helpful when trying to connect a local build up to a production database to test a specific change, even if you are aware that other queries may not be compatible.

To accommodate this change, the compatibility check was also moved into `ServerBuilder` where the config is readily available. This also slightly simplifies the `Server` itself, which no longer needs to hold onto its own instance of the `Db`.

## Test plan

Connected a local build of GraphQL to the production DB, which it is not compatible with.

## Stack

- #19670

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Add `--skip-migration-consistency-check` to allow bypassing the database compatibility checks.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
