### PR TITLE
chore: bump up tonic version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,7 +2752,7 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tokio-stream",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tower",
  "tower-http",
@@ -7989,7 +7989,7 @@ dependencies = [
  "snap",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-health",
  "tower",
  "tower-http",
@@ -8124,7 +8124,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing",
  "typed-store",
 ]
@@ -8304,7 +8304,7 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing",
  "typed-store",
 ]
@@ -8346,7 +8346,7 @@ dependencies = [
  "sui-protocol-config",
  "thiserror",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tracing",
  "typed-store",
@@ -8387,7 +8387,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tower",
  "tracing",
  "typed-store",
@@ -14141,7 +14141,7 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tower",
  "tracing",
@@ -14548,7 +14548,7 @@ dependencies = [
  "telemetry-subscribers",
  "test-cluster",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing",
 ]
 
@@ -15167,7 +15167,7 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing",
  "typed-store-error",
  "url",
@@ -16010,9 +16010,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -16238,9 +16238,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -16268,28 +16268,29 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.78",
  "prost-build",
+ "prost-types 0.13.1",
  "quote 1.0.35",
  "syn 2.0.48",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e10e6a96ee08b6ce443487d4368442d328d0e746f3681f81127f7dc41b4955"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
  "prost 0.13.1",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -497,9 +497,9 @@ toml_edit = { version = "0.19.10" }
 # NOTE: do not enable the `tls` feature on tonic. It will break custom TLS handling
 # for self signed certificates. Unit tests under consensus/core and other integration
 # tests will fail.
-tonic = { version = "0.12", features = ["transport"] }
-tonic-build = { version = "0.12", features = ["prost", "transport"] }
-tonic-health = "0.12"
+tonic = { version = "0.12.3", features = ["transport"] }
+tonic-build = { version = "0.12.3", features = ["prost", "transport"] }
+tonic-health = "0.12.3"
 tower = { version = "0.4.12", features = [
     "full",
     "util",

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -710,6 +710,7 @@ impl<S: NetworkService> NetworkManager<S> for TonicManager {
         let service = TonicServiceProxy::new(self.context.clone(), service);
         let config = &self.context.parameters.tonic;
 
+        #[allow(deprecated)]
         let consensus_service = Server::builder()
             .layer(
                 TraceLayer::new_for_grpc()


### PR DESCRIPTION
## Description 

Bump up tonic version from 0.12.1 to 0.12.3 as it causes cargo deny to fail because of a security patch.
