### PR TITLE
indexer: backfill tx_affected_objects 

### DIFF
--- a/crates/sui-indexer/src/backfill/backfill_instances/mod.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/mod.rs
@@ -11,6 +11,7 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 mod ingestion_backfills;
 mod sql_backfill;
 mod system_state_summary_json;
+mod tx_affected_objects;
 
 pub async fn get_backfill_task(
     kind: BackfillTaskKind,
@@ -18,7 +19,10 @@ pub async fn get_backfill_task(
 ) -> Arc<dyn BackfillTask> {
     match kind {
         BackfillTaskKind::SystemStateSummaryJson => {
-            Arc::new(system_state_summary_json::SystemStateSummaryJsonBackfill {})
+            Arc::new(system_state_summary_json::SystemStateSummaryJsonBackfill)
+        }
+        BackfillTaskKind::TxAffectedObjects => {
+            Arc::new(tx_affected_objects::TxAffectedObjectsBackfill)
         }
         BackfillTaskKind::Sql { sql, key_column } => {
             Arc::new(sql_backfill::SqlBackFill::new(sql, key_column))

--- a/crates/sui-indexer/src/backfill/backfill_instances/sql_backfills/event_sender.sh
+++ b/crates/sui-indexer/src/backfill/backfill_instances/sql_backfills/event_sender.sh
@@ -1,4 +1,6 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-sui-indexer --database-url postgres://postgres@localhost:5432/postgres run-back-fill "$1" "$2" sql "UPDATE events SET sender = CASE WHEN cardinality(senders) > 0 THEN senders[1] ELSE NULL END" checkpoint_sequence_number
+INDEXER=${INDEXER:-"sui-indexer"}
+DB=${DB:-"postgres://postgres@localhost:5432/postgres"}
+"$INDEXER" --database-url "$DB" run-back-fill "$1" "$2" sql "UPDATE events SET sender = CASE WHEN cardinality(senders) > 0 THEN senders[1] ELSE NULL END" checkpoint_sequence_number

--- a/crates/sui-indexer/src/backfill/backfill_instances/sql_backfills/full_objects_history.sh
+++ b/crates/sui-indexer/src/backfill/backfill_instances/sql_backfills/full_objects_history.sh
@@ -1,4 +1,6 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-sui-indexer --database-url postgres://postgres@localhost:5432/postgres run-back-fill "$1" "$2" sql "INSERT INTO full_objects_history (object_id, object_version, serialized_object) SELECT object_id, object_version, serialized_object FROM objects_history" checkpoint_sequence_number
+INDEXER=${INDEXER:-"sui-indexer"}
+DB=${DB:-"postgres://postgres@localhost:5432/postgres"}
+"$INDEXER" --database-url "$DB" run-back-fill "$1" "$2" sql "INSERT INTO full_objects_history (object_id, object_version, serialized_object) SELECT object_id, object_version, serialized_object FROM objects_history" checkpoint_sequence_number

--- a/crates/sui-indexer/src/backfill/backfill_instances/system_state_summary_json.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/system_state_summary_json.rs
@@ -10,7 +10,7 @@ use diesel_async::{AsyncConnection, RunQueryDsl};
 use std::ops::RangeInclusive;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
-pub struct SystemStateSummaryJsonBackfill {}
+pub struct SystemStateSummaryJsonBackfill;
 
 #[async_trait]
 impl BackfillTask for SystemStateSummaryJsonBackfill {

--- a/crates/sui-indexer/src/backfill/backfill_instances/tx_affected_objects.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/tx_affected_objects.rs
@@ -6,10 +6,7 @@ use std::ops::RangeInclusive;
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::RunQueryDsl;
-use sui_types::{
-    base_types::ObjectID,
-    effects::{TransactionEffects, TransactionEffectsAPI},
-};
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 
 use crate::{
     backfill::backfill_task::BackfillTask,

--- a/crates/sui-indexer/src/backfill/backfill_instances/tx_affected_objects.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/tx_affected_objects.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::RangeInclusive;
+
+use async_trait::async_trait;
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::RunQueryDsl;
+use sui_types::{
+    base_types::ObjectID,
+    effects::{TransactionEffects, TransactionEffectsAPI},
+};
+
+use crate::{
+    backfill::backfill_task::BackfillTask,
+    database::ConnectionPool,
+    models::tx_indices::StoredTxAffectedObjects,
+    schema::{transactions, tx_affected_objects, tx_senders},
+};
+
+pub struct TxAffectedObjectsBackfill;
+
+#[async_trait]
+impl BackfillTask for TxAffectedObjectsBackfill {
+    async fn backfill_range(&self, pool: ConnectionPool, range: &RangeInclusive<usize>) {
+        use transactions::dsl as tx;
+        use tx_senders::dsl as ts;
+
+        let mut conn = pool.get().await.unwrap();
+
+        let join = tx_senders::table.on(tx::tx_sequence_number.eq(ts::tx_sequence_number));
+
+        let results: Vec<(i64, Vec<u8>, Vec<u8>)> = transactions::table
+            .inner_join(join)
+            .select((tx::tx_sequence_number, ts::sender, tx::raw_effects))
+            .filter(tx::tx_sequence_number.between(*range.start() as i64, *range.end() as i64))
+            .load(&mut conn)
+            .await
+            .unwrap();
+
+        let effects: Vec<(i64, Vec<u8>, TransactionEffects)> = results
+            .into_iter()
+            .map(|(tx_sequence_number, sender, bytes)| {
+                (tx_sequence_number, sender, bcs::from_bytes(&bytes).unwrap())
+            })
+            .collect();
+
+        let affected_objects: Vec<StoredTxAffectedObjects> = effects
+            .into_iter()
+            .flat_map(|(tx_sequence_number, sender, effects)| {
+                effects
+                    .object_changes()
+                    .into_iter()
+                    .map(move |change| StoredTxAffectedObjects {
+                        tx_sequence_number,
+                        affected: change.id.to_vec(),
+                        sender: sender.clone(),
+                    })
+            })
+            .collect();
+
+        diesel::insert_into(tx_affected_objects::table)
+            .values(&affected_objects)
+            .on_conflict_do_nothing()
+            .execute(&mut conn)
+            .await
+            .unwrap();
+    }
+}

--- a/crates/sui-indexer/src/backfill/mod.rs
+++ b/crates/sui-indexer/src/backfill/mod.rs
@@ -10,6 +10,7 @@ pub mod backfill_task;
 #[derive(Subcommand, Clone, Debug)]
 pub enum BackfillTaskKind {
     SystemStateSummaryJson,
+    TxAffectedObjects,
     /// \sql is the SQL string to run, appended with the range between the start and end,
     /// as well as conflict resolution (see sql_backfill.rs).
     /// \key_column is the primary key column to use for the range.


### PR DESCRIPTION
## Description

Custom backfill script for populating `tx_affected_objects` by loading the raw effects from the database and pulling the `object_changes` from it.

Includes a small clean-up parameterising the script-based SQL backfills.

## Test plan

Ran an updated version of this script locally, just printing the values to be added and ran that locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
