### PR TITLE
[Faucet] Add balance metric

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -631,7 +631,7 @@ impl SimpleFaucet {
                 ?balance,
                 "Balance before transfer"
             );
-            self.metrics.balance.set((balance as f64 / 9 as f64) as i64);
+            self.metrics.balance.set((balance as f64 / 9_f64) as i64);
         }
 
         Ok(client

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -618,6 +618,22 @@ impl SimpleFaucet {
 
         let tx_digest = tx.digest();
         let client = self.wallet.get_client().await?;
+        let balance = client
+            .coin_read_api()
+            .get_balance(self.active_address, None)
+            .await;
+        if let Ok(balance) = balance {
+            let balance = balance.total_balance;
+            info!(
+                ?uuid,
+                ?recipient,
+                ?coin_id,
+                ?balance,
+                "Balance before transfer"
+            );
+            self.metrics.balance.set((balance as f64 / 9 as f64) as i64);
+        }
+
         Ok(client
             .quorum_driver_api()
             .execute_transaction_block(

--- a/crates/sui-faucet/src/metrics.rs
+++ b/crates/sui-faucet/src/metrics.rs
@@ -91,7 +91,7 @@ impl FaucetMetrics {
         Self {
             balance: register_int_gauge_with_registry!(
                 "balance",
-                "Current balance of the faucet address",
+                "Current balance of the all the available coins",
                 registry,
             ).unwrap(),
             current_executions_in_flight: register_int_gauge_with_registry!(

--- a/crates/sui-faucet/src/metrics.rs
+++ b/crates/sui-faucet/src/metrics.rs
@@ -24,6 +24,7 @@ pub struct RequestMetrics {
 /// Metrics relevant to the running of the service
 #[derive(Clone, Debug)]
 pub struct FaucetMetrics {
+    pub(crate) balance: IntGauge,
     pub(crate) current_executions_in_flight: IntGauge,
     pub(crate) total_available_coins: IntGauge,
     pub(crate) total_discarded_coins: IntGauge,
@@ -88,6 +89,11 @@ impl RequestMetrics {
 impl FaucetMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
+            balance: register_int_gauge_with_registry!(
+                "balance",
+                "Current balance of the faucet address",
+                registry,
+            ).unwrap(),
             current_executions_in_flight: register_int_gauge_with_registry!(
                 "current_executions_in_flight",
                 "Current number of transactions being executed in Faucet",


### PR DESCRIPTION
## Description 

Added a balance metric for alerting when we need to top it up.

## Test plan 

Manual checks vs dashboard and `sui client balance`
<img width="1788" alt="image" src="https://github.com/user-attachments/assets/7dafd108-376f-4104-a502-c2dbadea7e64">

```
➜  ~ sui client balance
╭────────────────────────────────────────╮
│ Balance of coins owned by this address │
├────────────────────────────────────────┤
│ ╭──────────────────────────────────╮   │
│ │ coin  balance (raw)  balance     │   │
│ ├──────────────────────────────────┤   │
│ │ Sui   1959956440480  1.95K SUI   │   │
│ ╰──────────────────────────────────╯   │
╰────────────────────────────────────────╯
➜  ~ 
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
