### PR TITLE
Remove use of assigned_shared_object_versions

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -413,9 +413,12 @@ pub struct AuthorityEpochTables {
     ///     versions from the transaction effect. Next object versions are not updated.
     ///
     /// REQUIRED: all authorities must assign the same shared object versions for each transaction.
-    assigned_shared_object_versions: DBMap<TransactionDigest, Vec<(ObjectID, SequenceNumber)>>,
     assigned_shared_object_versions_v2: DBMap<TransactionKey, Vec<(ObjectID, SequenceNumber)>>,
     next_shared_object_versions: DBMap<ObjectID, SequenceNumber>,
+
+    /// Deprecated table for pre-random-beacon shared object versions.
+    #[allow(dead_code)]
+    assigned_shared_object_versions: DBMap<TransactionDigest, Vec<(ObjectID, SequenceNumber)>>,
 
     /// Certificates that have been received from clients or received from consensus, but not yet
     /// executed. Entries are cleared after execution.

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -11,7 +11,6 @@ use rand::{
     Rng,
 };
 use std::collections::{HashMap, HashSet};
-use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::make_transfer_sui_transaction;
 use tokio::time::{sleep, Duration, Instant};
 use tracing::{debug, trace};

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -126,15 +126,6 @@ async fn test_hash_collections() {
 // repeatable and deterministic.
 #[sim_test(check_determinism)]
 async fn test_net_determinism() {
-    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        // TODO: this test fails due to some non-determinism caused by submitting messages to
-        // consensus. It does not appear to be caused by this feature itself, so I'm disabling this
-        // until I have time to debug further.
-        config.set_enable_jwk_consensus_updates_for_testing(false);
-        config.set_random_beacon_for_testing(false);
-        config
-    });
-
     let mut test_cluster = TestClusterBuilder::new().build().await;
 
     let txn = make_transfer_sui_transaction(&test_cluster.wallet, None, None).await;


### PR DESCRIPTION
The new table can be used with or without the random beacon. The only requirement is that we don't deploy this commit to a validator that is currently using the old table. An assert is added which will stop us from doing this accidentally.
