### PR TITLE
[Indexer] Split remote fetcher in reader

### DIFF
--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -5,6 +5,7 @@ mod executor;
 mod metrics;
 mod progress_store;
 mod reader;
+mod remote_fetcher;
 #[cfg(test)]
 mod tests;
 mod util;

--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -1,44 +1,33 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::create_remote_store_client;
 use crate::executor::MAX_CHECKPOINTS_IN_PROGRESS;
+use crate::remote_fetcher::RemoteFetcher;
 use anyhow::Result;
-use backoff::backoff::Backoff;
-use futures::StreamExt;
-use mysten_metrics::spawn_monitored_task;
 #[cfg(not(target_os = "macos"))]
 use notify::{RecommendedWatcher, RecursiveMode};
-use object_store::path::Path;
-use object_store::ObjectStore;
 use std::ffi::OsString;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
-use sui_rest_api::Client;
 use sui_storage::blob::Blob;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use tap::pipe::Pipe;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 pub struct CheckpointReader {
     /// Used to read from a local directory when running with a colocated FN.
     /// When fetching from a remote store, a temp dir can be passed in and it will be an no-op
     path: PathBuf,
-    remote_store_url: Option<String>,
-    remote_store_options: Vec<(String, String)>,
+    remote_fetcher: Option<RemoteFetcher>,
     current_checkpoint_number: CheckpointSequenceNumber,
     last_pruned_watermark: CheckpointSequenceNumber,
     checkpoint_sender: mpsc::Sender<Arc<CheckpointData>>,
     processed_receiver: mpsc::Receiver<CheckpointSequenceNumber>,
-    #[allow(clippy::type_complexity)]
-    remote_fetcher_receiver: Option<mpsc::Receiver<Result<(Arc<CheckpointData>, usize)>>>,
     exit_receiver: oneshot::Receiver<()>,
     options: ReaderOptions,
     data_limiter: DataLimiter,
@@ -46,7 +35,7 @@ pub struct CheckpointReader {
 
 #[derive(Clone)]
 pub struct ReaderOptions {
-    pub tick_interal_ms: u64,
+    pub tick_interval_ms: u64,
     pub timeout_secs: u64,
     /// number of maximum concurrent requests to the remote store. Increase it for backfills
     pub batch_size: usize,
@@ -57,7 +46,8 @@ pub struct ReaderOptions {
 impl Default for ReaderOptions {
     fn default() -> Self {
         Self {
-            tick_interal_ms: 100,
+            // FIXME: This needs to be much larger.
+            tick_interval_ms: 100,
             timeout_secs: 5,
             batch_size: 10,
             data_limit: 0,
@@ -66,16 +56,12 @@ impl Default for ReaderOptions {
     }
 }
 
-enum RemoteStore {
-    ObjectStore(Box<dyn ObjectStore>),
-    Rest(sui_rest_api::Client),
-    Hybrid(Box<dyn ObjectStore>, sui_rest_api::Client),
-}
-
 impl CheckpointReader {
     /// Represents a single iteration of the reader.
     /// Reads files in a local directory, validates them, and forwards `CheckpointData` to the executor.
     async fn read_local_files(&self) -> Result<Vec<Arc<CheckpointData>>> {
+        // FIXME: The following implementation is inefficient.
+        // We should directly read the files starting from the right checkpoint number.
         let mut files = vec![];
         for entry in fs::read_dir(self.path.clone())? {
             let entry = entry?;
@@ -104,143 +90,24 @@ impl CheckpointReader {
             || self.data_limiter.exceeds()
     }
 
-    async fn fetch_from_object_store(
-        store: &dyn ObjectStore,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        let path = Path::from(format!("{}.chk", checkpoint_number));
-        let response = store.get(&path).await?;
-        let bytes = response.bytes().await?;
-        Ok((
-            Blob::from_bytes::<Arc<CheckpointData>>(&bytes)?,
-            bytes.len(),
-        ))
-    }
-
-    async fn fetch_from_full_node(
-        client: &Client,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        let checkpoint = client.get_full_checkpoint(checkpoint_number).await?;
-        let size = bcs::serialized_size(&checkpoint)?;
-        Ok((Arc::new(checkpoint), size))
-    }
-
-    async fn remote_fetch_checkpoint_internal(
-        store: &RemoteStore,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        match store {
-            RemoteStore::ObjectStore(store) => {
-                Self::fetch_from_object_store(store, checkpoint_number).await
-            }
-            RemoteStore::Rest(client) => {
-                Self::fetch_from_full_node(client, checkpoint_number).await
-            }
-            RemoteStore::Hybrid(store, client) => {
-                match Self::fetch_from_full_node(client, checkpoint_number).await {
-                    Ok(result) => Ok(result),
-                    Err(_) => Self::fetch_from_object_store(store, checkpoint_number).await,
-                }
-            }
-        }
-    }
-
-    async fn remote_fetch_checkpoint(
-        store: &RemoteStore,
-        checkpoint_number: CheckpointSequenceNumber,
-    ) -> Result<(Arc<CheckpointData>, usize)> {
-        let mut backoff = backoff::ExponentialBackoff::default();
-        backoff.max_elapsed_time = Some(Duration::from_secs(60));
-        backoff.initial_interval = Duration::from_millis(100);
-        backoff.current_interval = backoff.initial_interval;
-        backoff.multiplier = 1.0;
-        loop {
-            match Self::remote_fetch_checkpoint_internal(store, checkpoint_number).await {
-                Ok(data) => return Ok(data),
-                Err(err) => match backoff.next_backoff() {
-                    Some(duration) => {
-                        if !err.to_string().contains("404") {
-                            debug!(
-                                "remote reader retry in {} ms. Error is {:?}",
-                                duration.as_millis(),
-                                err
-                            );
-                        }
-                        tokio::time::sleep(duration).await
-                    }
-                    None => return Err(err),
-                },
-            }
-        }
-    }
-
-    fn start_remote_fetcher(&mut self) -> mpsc::Receiver<Result<(Arc<CheckpointData>, usize)>> {
-        let batch_size = self.options.batch_size;
-        let start_checkpoint = self.current_checkpoint_number;
-        let (sender, receiver) = mpsc::channel(batch_size);
-        let url = self
-            .remote_store_url
-            .clone()
-            .expect("remote store url must be set");
-        let store = if let Some((fn_url, remote_url)) = url.split_once('|') {
-            let object_store = create_remote_store_client(
-                remote_url.to_string(),
-                self.remote_store_options.clone(),
-                self.options.timeout_secs,
-            )
-            .expect("failed to create remote store client");
-            RemoteStore::Hybrid(object_store, sui_rest_api::Client::new(fn_url))
-        } else if url.ends_with("/rest") {
-            RemoteStore::Rest(sui_rest_api::Client::new(url))
-        } else {
-            let object_store = create_remote_store_client(
-                url,
-                self.remote_store_options.clone(),
-                self.options.timeout_secs,
-            )
-            .expect("failed to create remote store client");
-            RemoteStore::ObjectStore(object_store)
-        };
-
-        spawn_monitored_task!(async move {
-            let mut checkpoint_stream = (start_checkpoint..u64::MAX)
-                .map(|checkpoint_number| Self::remote_fetch_checkpoint(&store, checkpoint_number))
-                .pipe(futures::stream::iter)
-                .buffered(batch_size);
-
-            while let Some(checkpoint) = checkpoint_stream.next().await {
-                if sender.send(checkpoint).await.is_err() {
-                    info!("remote reader dropped");
-                    break;
-                }
-            }
-        });
-        receiver
+    fn remote_fetcher_must_exists(&mut self) -> &mut RemoteFetcher {
+        self.remote_fetcher
+            .as_mut()
+            .expect("Remote fetcher is not initialized")
     }
 
     fn remote_fetch(&mut self) -> Vec<Arc<CheckpointData>> {
         let mut checkpoints = vec![];
-        if self.remote_fetcher_receiver.is_none() {
-            self.remote_fetcher_receiver = Some(self.start_remote_fetcher());
-        }
-        while !self.exceeds_capacity(self.current_checkpoint_number + checkpoints.len() as u64) {
-            match self.remote_fetcher_receiver.as_mut().unwrap().try_recv() {
-                Ok(Ok((checkpoint, size))) => {
+        let current_checkpoint_number = self.current_checkpoint_number;
+        self.remote_fetcher_must_exists()
+            .start_receiving(current_checkpoint_number);
+        while !self.exceeds_capacity(current_checkpoint_number + checkpoints.len() as u64) {
+            match self.remote_fetcher_must_exists().try_recv() {
+                Some((checkpoint, size)) => {
                     self.data_limiter.add(&checkpoint, size);
                     checkpoints.push(checkpoint);
                 }
-                Ok(Err(err)) => {
-                    error!("remote reader transient error {:?}", err);
-                    self.remote_fetcher_receiver = None;
-                    break;
-                }
-                Err(TryRecvError::Disconnected) => {
-                    error!("remote reader channel disconnect error");
-                    self.remote_fetcher_receiver = None;
-                    break;
-                }
-                Err(TryRecvError::Empty) => break,
+                None => break,
             }
         }
         checkpoints
@@ -257,16 +124,17 @@ impl CheckpointReader {
         .await?;
 
         let mut read_source: &str = "local";
-        if self.remote_store_url.is_some()
-            && (checkpoints.is_empty()
+        if let Some(remote_fetcher) = &mut self.remote_fetcher {
+            if checkpoints.is_empty()
                 || checkpoints[0].checkpoint_summary.sequence_number
-                    > self.current_checkpoint_number)
-        {
-            checkpoints = self.remote_fetch();
-            read_source = "remote";
-        } else {
-            // cancel remote fetcher execution because local reader has made progress
-            self.remote_fetcher_receiver = None;
+                    > self.current_checkpoint_number
+            {
+                checkpoints = self.remote_fetch();
+                read_source = "remote";
+            } else {
+                // cancel remote fetcher execution because local reader has made progress
+                remote_fetcher.stop_receiving();
+            }
         }
 
         info!(
@@ -331,15 +199,21 @@ impl CheckpointReader {
         let (checkpoint_sender, checkpoint_recv) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (processed_sender, processed_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (exit_sender, exit_receiver) = oneshot::channel();
+        let remote_fetcher = remote_store_url.map(|url| {
+            RemoteFetcher::new(
+                url,
+                remote_store_options,
+                options.timeout_secs,
+                options.batch_size,
+            )
+        });
         let reader = Self {
             path,
-            remote_store_url,
-            remote_store_options,
+            remote_fetcher,
             current_checkpoint_number: starting_checkpoint_number,
             last_pruned_watermark: starting_checkpoint_number,
             checkpoint_sender,
             processed_receiver,
-            remote_fetcher_receiver: None,
             exit_receiver,
             data_limiter: DataLimiter::new(options.data_limit),
             options,
@@ -384,7 +258,7 @@ impl CheckpointReader {
                 Some(gc_checkpoint_number) = self.processed_receiver.recv() => {
                     self.gc_processed_files(gc_checkpoint_number).expect("Failed to clean the directory");
                 }
-                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(self.options.tick_interal_ms), inotify_recv.recv())  => {
+                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(self.options.tick_interval_ms), inotify_recv.recv())  => {
                     self.sync().await.expect("Failed to read checkpoint files");
                 }
             }

--- a/crates/sui-data-ingestion-core/src/remote_fetcher/hybrid_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/remote_fetcher/hybrid_fetcher.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::remote_fetcher::object_store_fetcher::ObjectStoreFetcher;
+use crate::remote_fetcher::rest_fetcher::RestFetcher;
+use crate::remote_fetcher::RemoteFetcherTrait;
+use std::sync::Arc;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// The HybridFetcher first tries to fetch the checkpoint from the REST API.
+/// If that fails, it falls back to fetching the checkpoint from the archival store.
+pub(crate) struct HybridFetcher {
+    archival_fetcher: ObjectStoreFetcher,
+    rest_fetcher: RestFetcher,
+}
+
+impl HybridFetcher {
+    pub fn new(archival_fetcher: ObjectStoreFetcher, rest_fetcher: RestFetcher) -> Self {
+        Self {
+            archival_fetcher,
+            rest_fetcher,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RemoteFetcherTrait for HybridFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        match self.rest_fetcher.fetch_checkpoint(sequence_number).await {
+            Ok(result) => Ok(result),
+            Err(_) => {
+                self.archival_fetcher
+                    .fetch_checkpoint(sequence_number)
+                    .await
+            }
+        }
+    }
+}

--- a/crates/sui-data-ingestion-core/src/remote_fetcher/mod.rs
+++ b/crates/sui-data-ingestion-core/src/remote_fetcher/mod.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::remote_fetcher::hybrid_fetcher::HybridFetcher;
+use crate::remote_fetcher::object_store_fetcher::ObjectStoreFetcher;
+use crate::remote_fetcher::rest_fetcher::RestFetcher;
+use backoff::backoff::Backoff;
+use futures::StreamExt;
+use mysten_metrics::spawn_monitored_task;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tap::Pipe;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
+use tracing::{debug, error, info};
+
+mod hybrid_fetcher;
+mod object_store_fetcher;
+mod rest_fetcher;
+
+#[async_trait::async_trait]
+pub trait RemoteFetcherTrait: Sync + Send {
+    /// Given a sequence number, fetches the corresponding checkpoint data.
+    /// Returns the checkpoint data and the size of the response in bytes.
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)>;
+}
+
+pub struct RemoteFetcher {
+    #[allow(clippy::type_complexity)]
+    fetcher_receiver: Option<mpsc::Receiver<anyhow::Result<(Arc<CheckpointData>, usize)>>>,
+    fetcher: Arc<dyn RemoteFetcherTrait>,
+    batch_size: usize,
+}
+
+impl RemoteFetcher {
+    pub fn new(
+        url: String,
+        remote_store_options: Vec<(String, String)>,
+        timeout_secs: u64,
+        batch_size: usize,
+    ) -> Self {
+        let fetcher: Arc<dyn RemoteFetcherTrait> = if let Some((fn_url, remote_url)) =
+            url.split_once('|')
+        {
+            let archival_fetcher =
+                ObjectStoreFetcher::new(remote_url.to_string(), remote_store_options, timeout_secs)
+                    .expect("failed to create remote store client");
+            let rest_fetcher = RestFetcher::new(fn_url.to_string());
+            Arc::new(HybridFetcher::new(archival_fetcher, rest_fetcher))
+        } else if url.ends_with("/rest") {
+            Arc::new(RestFetcher::new(url))
+        } else {
+            Arc::new(
+                ObjectStoreFetcher::new(url, remote_store_options, timeout_secs)
+                    .expect("failed to create remote store client"),
+            )
+        };
+        Self {
+            fetcher_receiver: None,
+            fetcher,
+            batch_size,
+        }
+    }
+
+    pub fn start_receiving(&mut self, start_checkpoint: CheckpointSequenceNumber) {
+        if self.fetcher_receiver.is_some() {
+            return;
+        }
+        let batch_size = self.batch_size;
+        let (sender, receiver) = mpsc::channel(batch_size);
+        self.fetcher_receiver = Some(receiver);
+        let fetcher = self.fetcher.clone();
+        spawn_monitored_task!(async move {
+            let mut checkpoint_stream = (start_checkpoint..u64::MAX)
+                .map(|checkpoint_number| Self::remote_fetch_checkpoint(&fetcher, checkpoint_number))
+                .pipe(futures::stream::iter)
+                .buffered(batch_size);
+
+            while let Some(checkpoint) = checkpoint_stream.next().await {
+                if sender.send(checkpoint).await.is_err() {
+                    info!("remote reader dropped");
+                    break;
+                }
+            }
+        });
+    }
+
+    async fn remote_fetch_checkpoint(
+        fetcher: &Arc<dyn RemoteFetcherTrait>,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        // TODO: Should just use a fixed interval backoff.
+        let mut backoff = backoff::ExponentialBackoff::default();
+        backoff.max_elapsed_time = Some(Duration::from_secs(60));
+        backoff.initial_interval = Duration::from_millis(100);
+        backoff.current_interval = backoff.initial_interval;
+        backoff.multiplier = 1.0;
+        loop {
+            match fetcher.fetch_checkpoint(checkpoint_number).await {
+                Ok(data) => return Ok(data),
+                Err(err) => match backoff.next_backoff() {
+                    Some(duration) => {
+                        if !err.to_string().contains("404") {
+                            debug!(
+                                "remote reader retry in {} ms. Error is {:?}",
+                                duration.as_millis(),
+                                err
+                            );
+                        }
+                        tokio::time::sleep(duration).await
+                    }
+                    None => return Err(err),
+                },
+            }
+        }
+    }
+
+    pub fn try_recv(&mut self) -> Option<(Arc<CheckpointData>, usize)> {
+        match self.fetcher_receiver.as_mut().unwrap().try_recv() {
+            Ok(Ok(data)) => Some(data),
+            Ok(Err(err)) => {
+                error!("remote reader transient error {:?}", err);
+                self.stop_receiving();
+                None
+            }
+            Err(TryRecvError::Disconnected) => {
+                error!("remote reader channel disconnect error");
+                self.stop_receiving();
+                None
+            }
+            Err(TryRecvError::Empty) => None,
+        }
+    }
+
+    pub fn stop_receiving(&mut self) {
+        self.fetcher_receiver = None;
+    }
+}

--- a/crates/sui-data-ingestion-core/src/remote_fetcher/object_store_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/remote_fetcher/object_store_fetcher.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::create_remote_store_client;
+use crate::remote_fetcher::RemoteFetcherTrait;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use std::sync::Arc;
+use sui_storage::blob::Blob;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// Fetches checkpoint data from a remote object store.
+/// The store can be either an HTTP store or a cloud store (GCS or S3).
+pub(crate) struct ObjectStoreFetcher {
+    object_store: Box<dyn ObjectStore>,
+}
+
+impl ObjectStoreFetcher {
+    pub fn new(
+        url: String,
+        remote_store_options: Vec<(String, String)>,
+        timeout_secs: u64,
+    ) -> anyhow::Result<Self> {
+        let object_store = create_remote_store_client(url, remote_store_options, timeout_secs)?;
+        Ok(Self { object_store })
+    }
+}
+
+#[async_trait::async_trait]
+impl RemoteFetcherTrait for ObjectStoreFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        let path = Path::from(format!("{}.chk", sequence_number));
+        let response = self.object_store.get(&path).await?;
+        let bytes = response.bytes().await?;
+        let checkpoint_data = Blob::from_bytes::<Arc<CheckpointData>>(&bytes)?;
+        Ok((checkpoint_data, bytes.len()))
+    }
+}

--- a/crates/sui-data-ingestion-core/src/remote_fetcher/rest_fetcher.rs
+++ b/crates/sui-data-ingestion-core/src/remote_fetcher/rest_fetcher.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::remote_fetcher::RemoteFetcherTrait;
+use std::sync::Arc;
+use sui_rest_api::Client;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// Fetches checkpoint data from the REST API.
+pub(crate) struct RestFetcher {
+    client: Client,
+}
+
+impl RestFetcher {
+    pub fn new(url: String) -> Self {
+        let client = Client::new(url);
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl RemoteFetcherTrait for RestFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<(Arc<CheckpointData>, usize)> {
+        let checkpoint = self.client.get_full_checkpoint(sequence_number).await?;
+        let size = bcs::serialized_size(&checkpoint)?;
+        Ok((Arc::new(checkpoint), size))
+    }
+}

--- a/crates/sui-data-ingestion-core/src/tests.rs
+++ b/crates/sui-data-ingestion-core/src/tests.rs
@@ -40,7 +40,7 @@ async fn run(
     duration: Option<Duration>,
 ) -> Result<ExecutorProgress> {
     let options = ReaderOptions {
-        tick_interal_ms: 10,
+        tick_interval_ms: 10,
         batch_size: 1,
         ..Default::default()
     };


### PR DESCRIPTION
## Description 

This PR moves all the remote fetch logic to individual files for clarify.
No functional change in this PR.
It does apply one optimization: we no longer re-create the remote object store every time we need to receive.
The remote fetcher is created during reader initialization.
The fetch behavior is already controlled via the sender/receiver channel, which does not change in this PR.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
