### PR TITLE
Delete consensus data from tables when it is no longer needed

### DIFF
--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3361,3 +3361,9 @@ impl TransactionKey {
         }
     }
 }
+
+impl From<TransactionDigest> for TransactionKey {
+    fn from(digest: TransactionDigest) -> Self {
+        TransactionKey::Digest(digest)
+    }
+}

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3361,9 +3361,3 @@ impl TransactionKey {
         }
     }
 }
-
-impl From<TransactionDigest> for TransactionKey {
-    fn from(digest: TransactionDigest) -> Self {
-        TransactionKey::Digest(digest)
-    }
-}


### PR DESCRIPTION
This PR is in preparation for data quarantining. The DQ PR will move the tables affected by this PR entirely into memory, and crash recovery will be driven by re-processing consensus commits.

However, when we deploy DQ to a validator for the first time, we will restart in a state where uncertified consensus commits have already been marked as processed, so they will not be re-processed on startup.

This means that upon starting up for the first time, some data will be on disk instead of in memory. There are two possible solutions to this:

- All reads fall back to the database. This is a lot of ugly code, and is slow.
- All data in the database is read into memory at startup. This is fast and simple.

This PR bounds the amount of data we will have to read at startup in order to make the second option feasible.
