### PR TITLE
refactor(enoki): enoki custom nonce

### DIFF
--- a/sdk/enoki/src/EnokiFlow.ts
+++ b/sdk/enoki/src/EnokiFlow.ts
@@ -110,9 +110,18 @@ export class EnokiFlow {
 		redirectUrl: string;
 		network?: 'mainnet' | 'testnet' | 'devnet';
 		extraParams?: Record<string, unknown>;
+		nonceData?: {
+			nonce: string;
+			randomness: string;
+			epoch: number;
+			maxEpoch: number;
+			estimatedExpiration: number;
+		}
+		ephemeralKeyPair?: Ed25519Keypair
 	}) {
-		const ephemeralKeyPair = new Ed25519Keypair();
-		const { nonce, randomness, maxEpoch, estimatedExpiration } =
+		const ephemeralKeyPair = input.ephemeralKeyPair || new Ed25519Keypair();
+
+		const { nonce, randomness, maxEpoch, estimatedExpiration } = input.nonceData ||
 			await this.#enokiClient.createZkLoginNonce({
 				network: input.network,
 				ephemeralPublicKey: ephemeralKeyPair.getPublicKey(),


### PR DESCRIPTION
I don't know if this is a good solution, 

but it would be cool to generate nonce on the backend (CSRF).

and send it to the frontend for operations and check it on the backend afterwards. 

and maybe it would be better to add two arguments (publicKey, secretKey) instead of Ed25519Keypair.
