### PR TITLE
[Bridge Node] Better optimize sig aggregation

### DIFF
--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -1360,6 +1360,7 @@ mod tests {
                 sui_tx_digest,
                 sui_tx_event_index,
                 Ok(signed_action.clone()),
+                None,
             );
             signed_actions.insert(secret.public().into(), signed_action.into_sig().signature);
         }
@@ -1376,6 +1377,7 @@ mod tests {
                 sui_tx_digest,
                 sui_tx_event_index,
                 Err(BridgeError::RestAPIError("small issue".into())),
+                None,
             );
         }
     }

--- a/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
+++ b/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
@@ -24,6 +24,9 @@ use sui_types::committee::StakeUnit;
 use sui_types::committee::TOTAL_VOTING_POWER;
 use tracing::{error, info, warn};
 
+const MAX_TIMEOUT_MS: u64 = 5000;
+const MIN_TIMEOUT_MS: u64 = 1500;
+
 pub struct BridgeAuthorityAggregator {
     pub committee: Arc<BridgeCommittee>,
     pub clients: Arc<BTreeMap<BridgeAuthorityPublicKeyBytes, Arc<BridgeClient>>>,
@@ -235,7 +238,8 @@ async fn request_sign_bridge_action_into_certification(
             })
         },
         // A herustic timeout, we expect the signing to finish within 5 seconds
-        Duration::from_secs(5),
+        Duration::from_secs(MAX_TIMEOUT_MS),
+        Some(Duration::from_secs(MIN_TIMEOUT_MS)),
     )
     .await
     .map_err(|state| {

--- a/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
+++ b/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
@@ -423,6 +423,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bridge_auth_agg_optimized() {
+        telemetry_subscribers::init_for_testing();
+
+        let mock0 = BridgeRequestMockHandler::new();
+        let mock1 = BridgeRequestMockHandler::new();
+        let mock2 = BridgeRequestMockHandler::new();
+        let mock3 = BridgeRequestMockHandler::new();
+        let mock4 = BridgeRequestMockHandler::new();
+        let mock5 = BridgeRequestMockHandler::new();
+        let mock6 = BridgeRequestMockHandler::new();
+        let mock7 = BridgeRequestMockHandler::new();
+        let mock8 = BridgeRequestMockHandler::new();
+
+        // start servers - there is only one permutation of size 2 (1112, 2222) that will achieve quorum
+        let (_handles, authorities, secrets) = get_test_authorities_and_run_mock_bridge_server(
+            vec![666, 1000, 1000, 1000, 1000, 1000, 1000, 1112, 2222],
+            vec![
+                mock0.clone(),
+                mock1.clone(),
+                mock2.clone(),
+                mock3.clone(),
+                mock4.clone(),
+                mock5.clone(),
+                mock6.clone(),
+                mock7.clone(),
+                mock8.clone(),
+            ],
+        );
+
+        let committee = BridgeCommittee::new(authorities).unwrap();
+
+        let agg = BridgeAuthorityAggregator::new(Arc::new(committee));
+
+        let sui_tx_digest = TransactionDigest::random();
+        let sui_tx_event_index = 0;
+        let nonce = 0;
+        let amount = 1000;
+        let action = get_test_sui_to_eth_bridge_action(
+            Some(sui_tx_digest),
+            Some(sui_tx_event_index),
+            Some(nonce),
+            Some(amount),
+            None,
+            None,
+            None,
+        );
+
+        // All authorities return signatures
+        mock0.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[0])),
+        );
+        mock1.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[1])),
+        );
+        mock2.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[2])),
+        );
+        mock3.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[3])),
+        );
+        mock4.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[4])),
+        );
+        mock5.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[5])),
+        );
+        mock6.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[6])),
+        );
+        mock7.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[7])),
+        );
+        mock8.add_sui_event_response(
+            sui_tx_digest,
+            sui_tx_event_index,
+            Ok(sign_action_with_key(&action, &secrets[8])),
+        );
+        let resp = agg
+            .request_committee_signatures(action.clone())
+            .await
+            .unwrap();
+        assert_eq!(resp.auth_sig().signatures.len(), 2);
+    }
+
+    #[tokio::test]
     async fn test_bridge_auth_agg_more_cases() {
         telemetry_subscribers::init_for_testing();
 

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -341,7 +341,7 @@ mod tests {
         );
         let sig = BridgeAuthoritySignInfo::new(&action, &secret);
         let signed_event = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig.clone());
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event.clone()));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event.clone()), None);
 
         // success
         client
@@ -362,7 +362,7 @@ mod tests {
         let wrong_sig = BridgeAuthoritySignInfo::new(&action2, &secret);
         let wrong_signed_action =
             SignedBridgeAction::new_from_data_and_sig(action2.clone(), wrong_sig.clone());
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await
@@ -372,7 +372,7 @@ mod tests {
         // The action matches but the signature is wrong, fail
         let wrong_signed_action =
             SignedBridgeAction::new_from_data_and_sig(action.clone(), wrong_sig);
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await
@@ -389,7 +389,7 @@ mod tests {
             BridgeCommittee::new(vec![authority_blocklisted.clone(), authority2.clone()]).unwrap(),
         );
         client.update_committee(committee2);
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event), None);
 
         let err = client
             .request_sign_bridge_action(action.clone())
@@ -404,7 +404,7 @@ mod tests {
         // signed by a different authority in committee would fail
         let sig2 = BridgeAuthoritySignInfo::new(&action, &secret2);
         let signed_event2 = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig2.clone());
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event2));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event2), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await
@@ -416,7 +416,7 @@ mod tests {
         let secret3 = Arc::pin(kp3);
         let sig3 = BridgeAuthoritySignInfo::new(&action, &secret3);
         let signed_event3 = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig3);
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event3));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event3), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await


### PR DESCRIPTION
## Description 

Adds path to provide min timeout for sig aggregation with preference such that, when specified, we will wait at least `min_timeout` to collect as many sigs as possible before ordering based on the provided preference.

Note that the const min timeout value provided here is for verifying functionality for now, and should ideally be replaced with something like P95 latency.

## Test plan 

Added unit test. Also ran on testnet node and observed that the client running this generated a certificate with 11 signatures, while other client generated a certificate with 28 signatures.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
