### PR TITLE
fix(graphql): restore --node-rpc-url flag

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -219,6 +219,7 @@ pub struct InternalFeatureConfig {
 #[derive(clap::Args, Default)]
 pub struct TxExecFullNodeConfig {
     /// RPC URL for the fullnode to send transactions to execute and dry-run.
+    #[clap(long)]
     pub(crate) node_rpc_url: Option<String>,
 }
 


### PR DESCRIPTION
## Description

I accidentally turned it into a positional argument in a recent refactoring. This change changes it back.

## Test plan

```
sui$ cargo run --bin sui-graphql-rpc -- start-server --help
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
