### PR TITLE
indexer ingestion: more eager commit

### DIFF
--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -73,7 +73,7 @@ where
                 })?;
             }
         }
-        if !batch.is_empty() && unprocessed.is_empty() {
+        if !batch.is_empty() {
             commit_checkpoints(&state, batch, None, &metrics).await;
             batch = vec![];
         }

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -8,9 +8,10 @@ use diesel_async::RunQueryDsl;
 use simulacrum::Simulacrum;
 use sui_indexer::errors::IndexerError;
 use sui_indexer::models::{
-    objects::StoredObject, objects::StoredObjectSnapshot, transactions::StoredTransaction,
+    checkpoints::StoredCheckpoint, objects::StoredObject, objects::StoredObjectSnapshot,
+    transactions::StoredTransaction,
 };
-use sui_indexer::schema::{objects, objects_snapshot, transactions};
+use sui_indexer::schema::{checkpoints, objects, objects_snapshot, transactions};
 use sui_indexer::store::indexer_store::IndexerStore;
 use sui_indexer::test_utils::{set_up, wait_for_checkpoint, wait_for_objects_snapshot};
 use sui_indexer::types::EventIndex;
@@ -211,5 +212,39 @@ pub async fn test_insert_large_batch_event_indices() -> Result<(), IndexerError>
         v.push(EventIndex::random());
     }
     pg_store.persist_event_indices(v).await?;
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
+    println!("test_epoch_boundary");
+    let tempdir = tempdir().unwrap();
+    let mut sim = Simulacrum::new();
+    let data_ingestion_path = tempdir.path().to_path_buf();
+    sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+    let transfer_recipient = SuiAddress::random_for_testing_only();
+    let (transaction, _) = sim.transfer_txn(transfer_recipient);
+    let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();
+    assert!(err.is_none());
+
+    sim.create_checkpoint(); // checkpoint 1
+    sim.advance_epoch(true); // checkpoint 2 and epoch 1
+
+    let (transaction, _) = sim.transfer_txn(transfer_recipient);
+    let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();
+    sim.create_checkpoint(); // checkpoint 3
+    assert!(err.is_none());
+
+    let (_, pg_store, _, _database) = set_up(Arc::new(sim), data_ingestion_path).await;
+    wait_for_checkpoint(&pg_store, 3).await?;
+    let mut connection = pg_store.pool().dedicated_connection().await.unwrap();
+    let db_checkpoint: StoredCheckpoint = checkpoints::table
+        .order(checkpoints::sequence_number.desc())
+        .first::<StoredCheckpoint>(&mut connection)
+        .await
+        .expect("Failed reading checkpoint from PostgresDB");
+    assert_eq!(db_checkpoint.sequence_number, 3);
+    assert_eq!(db_checkpoint.epoch, 1);
     Ok(())
 }


### PR DESCRIPTION
## Description 

commit more eagerly, prev we only commit either filling the whole batch, or drained the un-processed, or at end of epoch, this pr changes it to commit more eagerly.

I was looking at average indexer extra data lag: it's about 2s from download to commit 
https://metrics.sui.io/goto/mj7m62zHg?orgId=1
however commit latency itself is about 1.7s and index is all in mem and very fast
https://metrics.sui.io/goto/W2FGehkHg?orgId=1

## Test plan 

indexer ingestion test, also added one for end of epoch ingestion.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
