### PR TITLE
[sdk dapp] Improve generic type definitions for createNetworkConfig dAPP

### DIFF
--- a/sdk/dapp-kit/src/hooks/networkConfig.ts
+++ b/sdk/dapp-kit/src/hooks/networkConfig.ts
@@ -10,7 +10,7 @@ export type NetworkConfig<T extends object = object> = SuiClientOptions & {
 };
 
 export function createNetworkConfig<
-	const T extends Record<string, Config>,
+	T extends Record<string, Config>,
 	Config extends NetworkConfig<Variables> = T[keyof T],
 	Variables extends object = NonNullable<Config['variables']>,
 >(networkConfig: T) {


### PR DESCRIPTION
## Description 

issue: create-react-app template "typescript" has build issue with current createNetworkConfig type
solution: improve generic type definitions for createNetworkConfig

what do you think?

## Test plan 

1. run `npx create-react-app my-app --template typescript`
2. instal dependecies `npm i --save @mysten/dapp-kit @mysten/sui @tanstack/react-query`
3. add react ts component:
```
import {createNetworkConfig, SuiClientProvider, useCurrentAccount, WalletProvider} from '@mysten/dapp-kit';
import { getFullnodeUrl } from '@mysten/sui/client';
import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
import React from "react";
import {Entry} from "./components/Entry";

// Config options for the networks you want to connect to
const { networkConfig } = createNetworkConfig({
  testnet: { url: getFullnodeUrl('testnet') },
});
const queryClient = new QueryClient();

export function App() {

  return (
      <QueryClientProvider client={queryClient}>
        <SuiClientProvider networks={networkConfig} defaultNetwork="testnet">
          <WalletProvider>
            <Entry />
          </WalletProvider>
        </SuiClientProvider>
      </QueryClientProvider>
  );
}
```
4. run `npm start` 
---

## Error

![Снимок экрана 2024-10-06 в 11 38 38](https://github.com/user-attachments/assets/33c03ccb-845f-4ee8-9356-135707f775f6)

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
