### PR TITLE
[move-ide] Added support for displaying diagnostic notes

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/diagnostics.rs
+++ b/external-crates/move/crates/move-analyzer/src/diagnostics.rs
@@ -22,12 +22,12 @@ pub fn lsp_diagnostics(
     files: &MappedFiles,
 ) -> BTreeMap<PathBuf, Vec<Diagnostic>> {
     let mut lsp_diagnostics = BTreeMap::new();
-    for (s, _, (loc, msg), labels, _) in diagnostics {
+    for (s, _, (loc, msg), labels, notes) in diagnostics {
         let fpath = files.file_path(&loc.file_hash());
         if let Some(start) = loc_start_to_lsp_position_opt(files, loc) {
             if let Some(end) = loc_end_to_lsp_position_opt(files, loc) {
                 let range = Range::new(start, end);
-                let related_info_opt = if labels.is_empty() {
+                let related_info_opt = if labels.is_empty() && notes.is_empty() {
                     None
                 } else {
                     Some(
@@ -46,6 +46,16 @@ pub fn lsp_diagnostics(
                                     message: lmsg.to_string(),
                                 })
                             })
+                            .chain(notes.iter().map(|note| {
+                                // for notes use the same location as for the main message
+                                let fpath = files.file_path(&loc.file_hash());
+                                let fpos =
+                                    Location::new(Url::from_file_path(fpath).unwrap(), range);
+                                DiagnosticRelatedInformation {
+                                    location: fpos,
+                                    message: note.to_string(),
+                                }
+                            }))
                             .collect(),
                     )
                 };


### PR DESCRIPTION
## Description 

This PR adds support for displaying the "notes" part of the compiler diagnostics. The issue it was not happening before is that compiler diagnostics do not map 1:1 to LSP diagnostics - a note does not have location and the only "message" without location in the LSP diagnostic is the main one. The challenge was to display notes without cluttering the output too much and after considering multiple options (e.g., appending notes to the main message, using `source` field of the LSP diagnostic) we settled on displaying notes the same as secondary compiler diagnostic labels with the location of a note being set to that of the main message. For what it's worth, it seems like this is what `rust-analyzer` is doing as well. Here are some examples of how the notes are now displayed:

1. Main message and single note:
![image](https://github.com/user-attachments/assets/3e5eb07d-7cdd-42bf-aa95-aa1368d218ac)
2. Main message, single secondary label and single note:
![image](https://github.com/user-attachments/assets/a909c1c7-6146-4e85-990f-2b05c2892fb7)
3. Main message and two notes:
![image](https://github.com/user-attachments/assets/148bbcdb-3468-4691-bbdd-a7a6ff495f6b)

## Test plan 

All existing tests must pass



## Test plan 

All existing tests must pass
