### PR TITLE
[AuthorityAggregator] EpochEnded to be retryable

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1369,9 +1369,14 @@ async fn test_handle_transaction_response() {
     let agg = get_genesis_agg(authorities.clone(), clients.clone());
     assert_resp_err(
         &agg,
-        tx.clone().into(), 
-        |e| matches!(e, AggregatorProcessTransactionError::RetryableTransaction { .. }),
-        |e| matches!(e, SuiError::EpochEnded(0))
+        tx.clone().into(),
+        |e| {
+            matches!(
+                e,
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
+            )
+        },
+        |e| matches!(e, SuiError::EpochEnded(0)),
     )
     .await;
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1355,6 +1355,26 @@ async fn test_handle_transaction_response() {
     )
     .await;
 
+    println!("Case 8.3 - Retryable Transaction (EpochEnded Error)");
+
+    set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx, 0);
+
+    // 2 out 4 validators return epoch ended error
+    for (name, _) in authority_keys.iter().skip(2) {
+        clients
+            .get_mut(name)
+            .unwrap()
+            .set_tx_info_response_error(SuiError::EpochEnded(0));
+    }
+    let agg = get_genesis_agg(authorities.clone(), clients.clone());
+    assert_resp_err(
+        &agg,
+        tx.clone().into(), 
+        |e| matches!(e, AggregatorProcessTransactionError::RetryableTransaction { .. }),
+        |e| matches!(e, SuiError::EpochEnded(0))
+    )
+    .await;
+
     println!("Case 9 - Non-Retryable Transaction (>=2f+1 ObjectNotFound Error)");
     // >= 2f+1 object not found errors
     set_retryable_tx_info_response_error(&mut clients, &authority_keys);
@@ -1426,30 +1446,6 @@ async fn test_handle_transaction_response() {
             )
         },
         |e| matches!(e, SuiError::UserInputError { .. } | SuiError::RpcError(..)),
-    )
-    .await;
-
-    println!("Case 10 - Retryable Transaction (EpochEnded Error)");
-    let epoch_ended_error = SuiError::EpochEnded(0);
-
-    // 2 out 4 validators return epoch ended error
-    for (name, _) in authority_keys.iter().skip(2) {
-        clients
-            .get_mut(name)
-            .unwrap()
-            .set_tx_info_response_error(epoch_ended_error.clone());
-    }
-
-    // Some authorities return EpochEnded error while others return signed-tx
-    let committee_1 =
-        Committee::new_for_testing_with_normalized_voting_power(1, authorities.clone());
-    agg.committee_store
-        .insert_new_committee(&committee_1)
-        .unwrap();
-    assert_resp_err(
-        &agg,
-        tx.clone().into(), |e| matches!(e, AggregatorProcessTransactionError::RetryableTransaction { .. }),
-        |e| matches!(e, SuiError::WrongEpoch { expected_epoch, actual_epoch } if *expected_epoch == 0 && *actual_epoch == 1)
     )
     .await;
 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1380,6 +1380,25 @@ async fn test_handle_transaction_response() {
     )
     .await;
 
+    println!("Case 8.4 - Retryable Transaction (EpochEnded Error) eventually succeeds");
+
+    set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx, 0);
+
+    // 1 out 4 validators return epoch ended error
+    for (name, _) in authority_keys.iter().take(1) {
+        clients
+            .get_mut(name)
+            .unwrap()
+            .set_tx_info_response_error(SuiError::EpochEnded(0));
+    }
+
+    let agg = get_genesis_agg(authorities.clone(), clients.clone());
+    let cert = agg
+        .process_transaction(tx.clone().into(), Some(client_ip))
+        .await
+        .unwrap();
+    matches!(cert, ProcessTransactionResult::Certified { .. });
+
     println!("Case 9 - Non-Retryable Transaction (>=2f+1 ObjectNotFound Error)");
     // >= 2f+1 object not found errors
     set_retryable_tx_info_response_error(&mut clients, &authority_keys);

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -809,6 +809,7 @@ impl SuiError {
             SuiError::ValidatorHaltedAtEpochEnd => true,
             SuiError::MissingCommitteeAtEpoch(..) => true,
             SuiError::WrongEpoch { .. } => true,
+            SuiError::EpochEnded(..) => true,
 
             SuiError::UserInputError { error } => {
                 match error {


### PR DESCRIPTION
## Description 

E2e localnet tests appear to fail sporadically due the the `EpochEnded` error. Although it should not be the common case it's possible to happen when a transaction has reached a node's RPC endpoint, but epoch changes in the middle. In this case an `EpochEnded` can be thrown when trying to access the AuthorityEpochStore. Making the error retryable will allow the quorum driver retry the transaction and hopefully succeed.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
