### PR TITLE
graphql: return live objects from consistent object query

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/call/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/call/dynamic_fields.exp
@@ -115,68 +115,7 @@ task 9, lines 91-114:
 //# run-graphql
 Response: {
   "data": {
-    "object": {
-      "dynamicFields": {
-        "nodes": [
-          {
-            "name": {
-              "type": {
-                "repr": "vector<u8>"
-              },
-              "data": {
-                "Vector": []
-              },
-              "bcs": "AA=="
-            },
-            "value": {
-              "__typename": "MoveValue"
-            }
-          },
-          {
-            "name": {
-              "type": {
-                "repr": "u64"
-              },
-              "data": {
-                "Number": "0"
-              },
-              "bcs": "AAAAAAAAAAA="
-            },
-            "value": {
-              "__typename": "MoveObject"
-            }
-          },
-          {
-            "name": {
-              "type": {
-                "repr": "bool"
-              },
-              "data": {
-                "Bool": false
-              },
-              "bcs": "AA=="
-            },
-            "value": {
-              "__typename": "MoveValue"
-            }
-          },
-          {
-            "name": {
-              "type": {
-                "repr": "u64"
-              },
-              "data": {
-                "Number": "0"
-              },
-              "bcs": "AAAAAAAAAAA="
-            },
-            "value": {
-              "__typename": "MoveValue"
-            }
-          }
-        ]
-      }
-    }
+    "object": null
   }
 }
 

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.exp
@@ -144,9 +144,7 @@ Response: {
   "data": {
     "object": {
       "owner": {
-        "parent": {
-          "address": "0x9958869e2da5c5af828a334520a81de2bec0861e171b575db12fb4987cb27a78"
-        }
+        "parent": null
       },
       "dynamicFields": {
         "nodes": []

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/object_at_version.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/object_at_version.exp
@@ -93,11 +93,7 @@ task 10, lines 111-137:
 //# run-graphql
 Response: {
   "data": {
-    "latest_wrapped": {
-      "status": "WRAPPED_OR_DELETED",
-      "version": 5,
-      "asMoveObject": null
-    },
+    "latest_wrapped": null,
     "previous_version": {
       "status": "INDEXED",
       "version": 4,
@@ -140,11 +136,7 @@ Response: {
         }
       }
     },
-    "previous_version": {
-      "status": "WRAPPED_OR_DELETED",
-      "version": 5,
-      "asMoveObject": null
-    },
+    "previous_version": null,
     "first_version": {
       "status": "INDEXED",
       "version": 3,
@@ -174,16 +166,8 @@ task 16, lines 187-213:
 //# run-graphql
 Response: {
   "data": {
-    "latest_deleted": {
-      "status": "WRAPPED_OR_DELETED",
-      "version": 7,
-      "asMoveObject": null
-    },
-    "version_specified": {
-      "status": "WRAPPED_OR_DELETED",
-      "version": 7,
-      "asMoveObject": null
-    }
+    "latest_deleted": null,
+    "version_specified": null
   }
 }
 
@@ -275,11 +259,7 @@ Response: {
         }
       }
     },
-    "wrapped_or_deleted_object": {
-      "status": "WRAPPED_OR_DELETED",
-      "version": 5,
-      "asMoveObject": null
-    },
+    "wrapped_or_deleted_object": null,
     "object_not_in_snapshot": {
       "status": "INDEXED",
       "version": 3,

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/wrap_unwrap.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/wrap_unwrap.exp
@@ -46,9 +46,7 @@ Response: {
     "object1": {
       "digest": "4ZQVjpKKr9Et5qZNWvYQvpmydf2j7ohU1wB8bZ9LFKrG"
     },
-    "object2": {
-      "digest": null
-    }
+    "object2": null
   }
 }
 
@@ -77,9 +75,7 @@ task 10, lines 66-74:
 //# run-graphql
 Response: {
   "data": {
-    "object1": {
-      "digest": null
-    },
+    "object1": null,
     "object2": {
       "digest": "jVRpzwEAGgYKYJ5rQfpW2zjMajazCAF9VVGUXEACpN1"
     }
@@ -106,8 +102,6 @@ Response: {
     "object1": {
       "digest": "8B8PFHkbEB8w99ZevdLkb6CBuR2gZyPsE7zUWyXJZwDw"
     },
-    "object2": {
-      "digest": null
-    }
+    "object2": null
   }
 }

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -2901,11 +2901,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be loaded from the
-	indexer.
-	"""
-	WRAPPED_OR_DELETED
 }
 
 """

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -68,10 +68,11 @@ impl ScanLimited for JsonCursor<ConsistentNamedCursor> {}
 /// The `objects_snapshot` table contains the latest versions of objects up to a checkpoint sequence
 /// number, and `objects_history` captures changes after that, so a query to both tables is
 /// necessary to handle these object states:
-/// 1) In snapshot, not in history - occurs when an object gets snapshotted and then has not been
+/// 1) In snapshot, not in history - occurs when a live object gets snapshotted and then has not been
 ///    modified since
-/// 2) In history, not in snapshot - occurs when a new object is created
-/// 3) In snapshot and in history - occurs when an object is snapshotted and further modified
+/// 2) Not in snapshot, in history - occurs when a new object is created or a wrapped object is unwrapped
+/// 3) In snapshot and in history - occurs when an object is snapshotted and further modified, the modification
+///    can be wrapping or deleting.
 ///
 /// Additionally, even among objects that satisfy the filtering criteria, it is possible that there
 /// is a yet more recent version of the object within the checkpoint range, such as when the owner
@@ -166,6 +167,7 @@ pub(crate) fn build_objects_query(
                 newer
             );
             history_objs = filter!(history_objs, "newer.object_version IS NULL");
+            history_objs = filter!(history_objs, "object_status = 0");
             history_objs
         }
         View::Historical => {

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -172,10 +172,11 @@ pub(crate) fn build_objects_query(
         }
         View::Historical => {
             // The cursor pagination logic refers to the table with the `candidates` alias
-            query!(
+            let query = query!(
                 "SELECT candidates.* FROM ({}) candidates",
                 history_objs_inner
-            )
+            );
+            filter!(query, "object_status = 0")
         }
     };
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -253,12 +253,6 @@ impl TryFrom<MoveObject> for DynamicField {
             ObjectKind::NotIndexed(native) | ObjectKind::Indexed(native, _) => native.clone(),
             ObjectKind::Serialized(bytes) => bcs::from_bytes(bytes)
                 .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?,
-
-            ObjectKind::WrappedOrDeleted => {
-                return Err(Error::Internal(
-                    "DynamicField is wrapped or deleted.".to_string(),
-                ));
-            }
         };
 
         let Some(object) = native.data.try_as_move() else {

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -2906,11 +2906,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be loaded from the
-	indexer.
-	"""
-	WRAPPED_OR_DELETED
 }
 
 """

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -2905,11 +2905,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be loaded from the
-	indexer.
-	"""
-	WRAPPED_OR_DELETED
 }
 
 """

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -2910,11 +2910,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be loaded from the
-	indexer.
-	"""
-	WRAPPED_OR_DELETED
 }
 
 """

--- a/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/down.sql
@@ -1,0 +1,23 @@
+-- Drop the new partial indices
+DROP INDEX IF EXISTS objects_history_owner;
+DROP INDEX IF EXISTS objects_history_coin_owner;
+DROP INDEX IF EXISTS objects_history_coin_only;
+DROP INDEX IF EXISTS objects_history_type;
+DROP INDEX IF EXISTS objects_history_package_module_name_full_type;
+DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type;
+
+-- Recreate the original indices without the object_status condition
+CREATE INDEX IF NOT EXISTS objects_history_owner ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 
+WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS objects_history_coin_owner ON objects_history (checkpoint_sequence_number, owner_id, coin_type, object_id) 
+WHERE coin_type IS NOT NULL AND owner_type = 1;
+
+CREATE INDEX IF NOT EXISTS objects_history_coin_only ON objects_history (checkpoint_sequence_number, coin_type, object_id) 
+WHERE coin_type IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS objects_history_type ON objects_history (checkpoint_sequence_number, object_type);
+
+CREATE INDEX IF NOT EXISTS objects_history_package_module_name_full_type ON objects_history (checkpoint_sequence_number, object_type_package, object_type_module, object_type_name, object_type);
+
+CREATE INDEX IF NOT EXISTS objects_history_owner_package_module_name_full_type ON objects_history (checkpoint_sequence_number, owner_id, object_type_package, object_type_module, object_type_name, object_type);

--- a/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/down.sql
@@ -1,10 +1,10 @@
 -- Drop the new partial indices
-DROP INDEX IF EXISTS objects_history_owner;
-DROP INDEX IF EXISTS objects_history_coin_owner;
-DROP INDEX IF EXISTS objects_history_coin_only;
-DROP INDEX IF EXISTS objects_history_type;
-DROP INDEX IF EXISTS objects_history_package_module_name_full_type;
-DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type;
+DROP INDEX IF EXISTS objects_history_owner_partial;
+DROP INDEX IF EXISTS objects_history_coin_owner_partial;
+DROP INDEX IF EXISTS objects_history_coin_only_partial;
+DROP INDEX IF EXISTS objects_history_type_partial;
+DROP INDEX IF EXISTS objects_history_package_module_name_full_type_partial;
+DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type_partial;
 
 -- Recreate the original indices without the object_status condition
 CREATE INDEX IF NOT EXISTS objects_history_owner ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 

--- a/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/down.sql
@@ -5,19 +5,3 @@ DROP INDEX IF EXISTS objects_history_coin_only_partial;
 DROP INDEX IF EXISTS objects_history_type_partial;
 DROP INDEX IF EXISTS objects_history_package_module_name_full_type_partial;
 DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type_partial;
-
--- Recreate the original indices without the object_status condition
-CREATE INDEX IF NOT EXISTS objects_history_owner ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 
-WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
-
-CREATE INDEX IF NOT EXISTS objects_history_coin_owner ON objects_history (checkpoint_sequence_number, owner_id, coin_type, object_id) 
-WHERE coin_type IS NOT NULL AND owner_type = 1;
-
-CREATE INDEX IF NOT EXISTS objects_history_coin_only ON objects_history (checkpoint_sequence_number, coin_type, object_id) 
-WHERE coin_type IS NOT NULL;
-
-CREATE INDEX IF NOT EXISTS objects_history_type ON objects_history (checkpoint_sequence_number, object_type);
-
-CREATE INDEX IF NOT EXISTS objects_history_package_module_name_full_type ON objects_history (checkpoint_sequence_number, object_type_package, object_type_module, object_type_name, object_type);
-
-CREATE INDEX IF NOT EXISTS objects_history_owner_package_module_name_full_type ON objects_history (checkpoint_sequence_number, owner_id, object_type_package, object_type_module, object_type_name, object_type);

--- a/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/up.sql
@@ -1,11 +1,3 @@
--- Drop existing indices if they exist
-DROP INDEX IF EXISTS objects_history_owner;
-DROP INDEX IF EXISTS objects_history_coin_owner;
-DROP INDEX IF EXISTS objects_history_coin_only;
-DROP INDEX IF EXISTS objects_history_type;
-DROP INDEX IF EXISTS objects_history_package_module_name_full_type;
-DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type;
-
 -- Create new partial indices with object_status = 0 condition
 CREATE INDEX IF NOT EXISTS objects_history_owner_partial ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 
 WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL AND object_status = 0;

--- a/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/up.sql
@@ -7,20 +7,20 @@ DROP INDEX IF EXISTS objects_history_package_module_name_full_type;
 DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type;
 
 -- Create new partial indices with object_status = 0 condition
-CREATE INDEX IF NOT EXISTS objects_history_owner ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 
+CREATE INDEX IF NOT EXISTS objects_history_owner_partial ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 
 WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL AND object_status = 0;
 
-CREATE INDEX IF NOT EXISTS objects_history_coin_owner ON objects_history (checkpoint_sequence_number, owner_id, coin_type, object_id) 
+CREATE INDEX IF NOT EXISTS objects_history_coin_owner_partial ON objects_history (checkpoint_sequence_number, owner_id, coin_type, object_id) 
 WHERE coin_type IS NOT NULL AND owner_type = 1 AND object_status = 0;
 
-CREATE INDEX IF NOT EXISTS objects_history_coin_only ON objects_history (checkpoint_sequence_number, coin_type, object_id) 
+CREATE INDEX IF NOT EXISTS objects_history_coin_only_partial ON objects_history (checkpoint_sequence_number, coin_type, object_id) 
 WHERE coin_type IS NOT NULL AND object_status = 0;
 
-CREATE INDEX IF NOT EXISTS objects_history_type ON objects_history (checkpoint_sequence_number, object_type) 
+CREATE INDEX IF NOT EXISTS objects_history_type_partial ON objects_history (checkpoint_sequence_number, object_type) 
 WHERE object_status = 0;
 
-CREATE INDEX IF NOT EXISTS objects_history_package_module_name_full_type ON objects_history (checkpoint_sequence_number, object_type_package, object_type_module, object_type_name, object_type) 
+CREATE INDEX IF NOT EXISTS objects_history_package_module_name_full_type_partial ON objects_history (checkpoint_sequence_number, object_type_package, object_type_module, object_type_name, object_type) 
 WHERE object_status = 0;
 
-CREATE INDEX IF NOT EXISTS objects_history_owner_package_module_name_full_type ON objects_history (checkpoint_sequence_number, owner_id, object_type_package, object_type_module, object_type_name, object_type) 
+CREATE INDEX IF NOT EXISTS objects_history_owner_package_module_name_full_type_partial ON objects_history (checkpoint_sequence_number, owner_id, object_type_package, object_type_module, object_type_name, object_type) 
 WHERE object_status = 0;

--- a/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-08-025030_partial_index_instead/up.sql
@@ -1,0 +1,26 @@
+-- Drop existing indices if they exist
+DROP INDEX IF EXISTS objects_history_owner;
+DROP INDEX IF EXISTS objects_history_coin_owner;
+DROP INDEX IF EXISTS objects_history_coin_only;
+DROP INDEX IF EXISTS objects_history_type;
+DROP INDEX IF EXISTS objects_history_package_module_name_full_type;
+DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type;
+
+-- Create new partial indices with object_status = 0 condition
+CREATE INDEX IF NOT EXISTS objects_history_owner ON objects_history (checkpoint_sequence_number, owner_type, owner_id) 
+WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL AND object_status = 0;
+
+CREATE INDEX IF NOT EXISTS objects_history_coin_owner ON objects_history (checkpoint_sequence_number, owner_id, coin_type, object_id) 
+WHERE coin_type IS NOT NULL AND owner_type = 1 AND object_status = 0;
+
+CREATE INDEX IF NOT EXISTS objects_history_coin_only ON objects_history (checkpoint_sequence_number, coin_type, object_id) 
+WHERE coin_type IS NOT NULL AND object_status = 0;
+
+CREATE INDEX IF NOT EXISTS objects_history_type ON objects_history (checkpoint_sequence_number, object_type) 
+WHERE object_status = 0;
+
+CREATE INDEX IF NOT EXISTS objects_history_package_module_name_full_type ON objects_history (checkpoint_sequence_number, object_type_package, object_type_module, object_type_name, object_type) 
+WHERE object_status = 0;
+
+CREATE INDEX IF NOT EXISTS objects_history_owner_package_module_name_full_type ON objects_history (checkpoint_sequence_number, owner_id, object_type_package, object_type_module, object_type_name, object_type) 
+WHERE object_status = 0;


### PR DESCRIPTION
## Description 

we plan to remove deleted / wrapped objects from objects_snapshot, this prep pr is to make the consistency query no longer return deleted / wrapped objects as a whole, after the removal.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
