### PR TITLE
Update documentation to remove outdated  references for display

### DIFF
--- a/crates/sui-framework/docs/sui-framework/display.md
+++ b/crates/sui-framework/docs/sui-framework/display.md
@@ -208,7 +208,7 @@ don't match in their lengths.
 ## Function `new`
 
 Create an empty Display object. It can either be shared empty or filled
-with data right away via cheaper <code>set_owned</code> method.
+with data right away via <code>add</code> or <code>add_multiple</code> methods.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_new">new</a>&lt;T: key&gt;(pub: &<a href="package.md#0x2_package_Publisher">package::Publisher</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;

--- a/crates/sui-framework/packages/sui-framework/sources/display.move
+++ b/crates/sui-framework/packages/sui-framework/sources/display.move
@@ -74,7 +74,7 @@ public struct VersionUpdated<phantom T: key> has copy, drop {
 // === Initializer Methods ===
 
 /// Create an empty Display object. It can either be shared empty or filled
-/// with data right away via cheaper `set_owned` method.
+/// with data right away via `add` or `add_multiple` methods.
 public fun new<T: key>(pub: &Publisher, ctx: &mut TxContext): Display<T> {
     assert!(is_authorized<T>(pub), ENotOwner);
     create_internal(ctx)


### PR DESCRIPTION
## Description 

This PR removes an outdated reference to a non-existent `set_owned` function in the Display module documentation. The reference caused confusion as the function is not present or used in the current code. The documentation has been updated to reference the correct public functions, such as `add` and `add_multiple`, which handle field additions in the Display object.

No functional changes have been made to the code; the update is purely a documentation fix.

## Test plan 

No tests were required.

---

## Release notes

This change does not impact any of the following components:

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
