### PR TITLE
Create GraphQl staging build for `ci` and `devnet` environments

### DIFF
--- a/docker/sui-graphql-rpc-staging/Dockerfile
+++ b/docker/sui-graphql-rpc-staging/Dockerfile
@@ -1,0 +1,33 @@
+# Build application
+#
+# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
+# and build the application.
+FROM rust:1.81-bullseye AS builder
+ARG PROFILE=release
+ENV PROFILE=$PROFILE
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+WORKDIR "$WORKDIR/sui"
+RUN apt-get update && apt-get install -y cmake clang libpq-dev
+
+COPY Cargo.toml Cargo.lock ./
+COPY consensus consensus
+COPY crates crates
+COPY sui-execution sui-execution
+COPY narwhal narwhal
+COPY external-crates external-crates
+
+RUN cargo build --profile ${PROFILE} --bin sui-graphql-rpc --features staging
+
+# Production Image
+FROM debian:bullseye-slim AS runtime
+WORKDIR "$WORKDIR/sui"
+# Both bench and release profiles copy from release dir
+RUN mkdir -p /opt/sui/bin
+COPY --from=builder /sui/target/release/sui-graphql-rpc /opt/sui/bin
+RUN apt-get update && apt-get install -y libpq5 ca-certificates libpq-dev postgresql
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/sui-graphql-rpc-staging/build.sh
+++ b/docker/sui-graphql-rpc-staging/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+# option to build using debug symbols
+if [ "$1" = "--debug-symbols" ]; then
+	PROFILE="bench"
+	echo "Building with full debug info enabled ... WARNING: binary size might significantly increase"
+	shift
+else
+	PROFILE="release"
+fi
+
+echo
+echo "Building sui-graphql-rpc docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	--build-arg PROFILE="$PROFILE" \
+	--features staging \
+	"$@"


### PR DESCRIPTION
## Description 
Create GraphQl staging build for `ci` and `devnet` environments.
See https://linear.app/mysten-labs/issue/DVX-329/devnet-and-ci-graphql-built-with-staging-feature-enabled for details

## Test plan 
Will be testing this after it lands