### PR TITLE
[mvr] fix named types across versions

### DIFF
--- a/.changeset/brave-peaches-kick.md
+++ b/.changeset/brave-peaches-kick.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Move Registry: Make sure requests go through the package resolver route for named types resolution


### PR DESCRIPTION
## Description 

The previous `repr` field is not going through the package layout resolver on GQL so it would return wrong output across package upgrades.

## Test plan 

Tested locally for now. Will be adding live resolution tests with some demo packages on mainnet/testnet when:
1. We have the final mainnet deployment of the SC.
2. We are not worried about GQL's uptime (I don't want to introduce flakiness on CI)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
