### PR TITLE
indexer: execute objects mutation & deletion in parallel

### DIFF
--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -371,6 +371,25 @@ pub struct IndexedObject {
 }
 
 impl IndexedObject {
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        let random_address = SuiAddress::random_for_testing_only();
+        IndexedObject {
+            checkpoint_sequence_number: rng.gen(),
+            object: Object::with_owner_for_testing(random_address),
+            df_kind: {
+                let random_value = rng.gen_range(0..3);
+                match random_value {
+                    0 => Some(DynamicFieldType::DynamicField),
+                    1 => Some(DynamicFieldType::DynamicObject),
+                    _ => None,
+                }
+            },
+        }
+    }
+}
+
+impl IndexedObject {
     pub fn from_object(
         checkpoint_sequence_number: CheckpointSequenceNumber,
         object: Object,
@@ -389,6 +408,17 @@ pub struct IndexedDeletedObject {
     pub object_id: ObjectID,
     pub object_version: u64,
     pub checkpoint_sequence_number: u64,
+}
+
+impl IndexedDeletedObject {
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        IndexedDeletedObject {
+            object_id: ObjectID::random(),
+            object_version: rng.gen(),
+            checkpoint_sequence_number: rng.gen(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -7,6 +7,7 @@ use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
 use simulacrum::Simulacrum;
 use sui_indexer::errors::IndexerError;
+use sui_indexer::handlers::TransactionObjectChangesToCommit;
 use sui_indexer::models::{
     objects::StoredObject, objects::StoredObjectSnapshot, transactions::StoredTransaction,
 };
@@ -14,6 +15,8 @@ use sui_indexer::schema::{objects, objects_snapshot, transactions};
 use sui_indexer::store::indexer_store::IndexerStore;
 use sui_indexer::test_utils::{set_up, wait_for_checkpoint, wait_for_objects_snapshot};
 use sui_indexer::types::EventIndex;
+use sui_indexer::types::IndexedDeletedObject;
+use sui_indexer::types::IndexedObject;
 use sui_indexer::types::TxIndex;
 use sui_types::base_types::SuiAddress;
 use sui_types::effects::TransactionEffectsAPI;
@@ -175,6 +178,26 @@ pub async fn test_objects_snapshot() -> Result<(), IndexerError> {
     );
     assert_eq!(snapshot_object.owner_type, Some(1));
     assert_eq!(snapshot_object.owner_id, Some(gas_owner_id.to_vec()));
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_objects_ingestion() -> Result<(), IndexerError> {
+    let tempdir = tempdir().unwrap();
+    let mut sim = Simulacrum::new();
+    let data_ingestion_path = tempdir.path().to_path_buf();
+    sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+    let (_, pg_store, _, _database) = set_up(Arc::new(sim), data_ingestion_path).await;
+
+    let mut objects = Vec::new();
+    for _ in 0..1000 {
+        objects.push(TransactionObjectChangesToCommit {
+            changed_objects: vec![IndexedObject::random()],
+            deleted_objects: vec![IndexedDeletedObject::random()],
+        });
+    }
+    pg_store.persist_objects(objects).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

- before this pr, deletion futures wait for mutation futures, this pr makes it parallel
- also added object ingestion tests

## Test plan 

object ingestion tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
