### PR TITLE
[GraphQL] Serialize bcs bytes of `TransactionData` instead of `SenderSignedData`

### DIFF
--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -4214,7 +4214,7 @@ type TransactionBlock {
 	"""
 	expiration: Epoch
 	"""
-	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	Serialized form of this transaction's `TransactionData`, BCS serialized and Base64 encoded.
 	"""
 	bcs: Base64
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block/mod.rs
@@ -198,17 +198,18 @@ impl TransactionBlock {
             .extend()
     }
 
-    /// Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+    /// Serialized form of this transaction's `TransactionData`, BCS serialized and Base64 encoded.
     async fn bcs(&self) -> Option<Base64> {
         match &self.inner {
-            TransactionBlockInner::Stored { stored_tx, .. } => {
-                Some(Base64::from(&stored_tx.raw_transaction))
+            TransactionBlockInner::Stored { native, .. } => Some(Base64::from(
+                &bcs::to_bytes(native.transaction_data()).unwrap(),
+            )),
+            TransactionBlockInner::Executed { tx_data, .. } => Some(Base64::from(
+                &bcs::to_bytes(tx_data.transaction_data()).unwrap(),
+            )),
+            TransactionBlockInner::DryRun { tx_data, .. } => {
+                Some(Base64::from(&bcs::to_bytes(tx_data).unwrap()))
             }
-            TransactionBlockInner::Executed { tx_data, .. } => {
-                bcs::to_bytes(&tx_data).ok().map(Base64::from)
-            }
-            // Dry run transaction does not have signatures so no sender signed data.
-            TransactionBlockInner::DryRun { .. } => None,
         }
     }
 }

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -4219,7 +4219,7 @@ type TransactionBlock {
 	"""
 	expiration: Epoch
 	"""
-	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	Serialized form of this transaction's `TransactionData`, BCS serialized and Base64 encoded.
 	"""
 	bcs: Base64
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -4218,7 +4218,7 @@ type TransactionBlock {
 	"""
 	expiration: Epoch
 	"""
-	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	Serialized form of this transaction's `TransactionData`, BCS serialized and Base64 encoded.
 	"""
 	bcs: Base64
 }
@@ -4806,3 +4806,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -4223,7 +4223,7 @@ type TransactionBlock {
 	"""
 	expiration: Epoch
 	"""
-	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	Serialized form of this transaction's `TransactionData`, BCS serialized and Base64 encoded.
 	"""
 	bcs: Base64
 }
@@ -4823,3 +4823,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+

--- a/sdk/graphql-transport/src/mappers/transaction-block.ts
+++ b/sdk/graphql-transport/src/mappers/transaction-block.ts
@@ -73,7 +73,8 @@ export function mapGraphQLTransactionBlockToRpcTransactionBlock(
 					transaction:
 						transactionBlock.rawTransaction &&
 						mapTransactionBlockToInput(
-							bcs.SenderSignedData.parse(fromBase64(transactionBlock.rawTransaction))[0],
+							bcs.TransactionData.parse(fromBase64(transactionBlock.rawTransaction)),
+							transactionBlock.signatures,
 						),
 				}
 			: {}),
@@ -169,10 +170,12 @@ function mapObjectChanges(
 }
 
 export function mapTransactionBlockToInput(
-	data: typeof bcs.SenderSignedTransaction.$inferType,
+	data: typeof bcs.TransactionData.$inferType,
+	signatures: any[] | null | undefined,
 ): SuiTransactionBlock | null {
-	const txData = data.intentMessage.value.V1;
-
+	const txData = data.V1;
+	console.log('Signatures:', signatures);
+	const sigs: string[] = (signatures ?? []).filter((sig): sig is string => typeof sig === 'string');
 	const programableTransaction =
 		'ProgrammableTransaction' in txData.kind ? txData.kind.ProgrammableTransaction : null;
 
@@ -181,7 +184,7 @@ export function mapTransactionBlockToInput(
 	}
 
 	return {
-		txSignatures: data.txSignatures,
+		txSignatures: sigs,
 		data: {
 			gasData: {
 				budget: txData.gasData.budget,

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -364,7 +364,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -380,7 +380,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -397,7 +397,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 		const graphQLTransactionBlock = await graphQLClient!.getTransactionBlock({
@@ -408,7 +408,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -426,7 +426,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 		const [graphQLTransactionBlock] = await graphQLClient!.multiGetTransactionBlocks({
@@ -439,7 +439,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -589,7 +589,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				showEvents: true,
 				showInput: true,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -604,7 +604,7 @@ describe('GraphQL SuiClient compatibility', () => {
 					showEvents: true,
 					showInput: true,
 					showObjectChanges: true,
-					showRawInput: true,
+					showRawInput: false,
 				},
 			})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -364,7 +364,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		});
 
@@ -380,7 +380,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		});
 
@@ -397,7 +397,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 		const graphQLTransactionBlock = await graphQLClient!.getTransactionBlock({
@@ -408,7 +408,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		});
 
@@ -426,7 +426,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		});
 		const [graphQLTransactionBlock] = await graphQLClient!.multiGetTransactionBlocks({
@@ -439,7 +439,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		});
 
@@ -589,7 +589,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				showEvents: true,
 				showInput: true,
 				showObjectChanges: true,
-				showRawInput: false,
+				showRawInput: true,
 			},
 		});
 
@@ -604,7 +604,7 @@ describe('GraphQL SuiClient compatibility', () => {
 					showEvents: true,
 					showInput: true,
 					showObjectChanges: true,
-					showRawInput: false,
+					showRawInput: true,
 				},
 			})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -589,7 +589,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				showEvents: true,
 				showInput: true,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -604,7 +604,7 @@ describe('GraphQL SuiClient compatibility', () => {
 					showEvents: true,
 					showInput: true,
 					showObjectChanges: true,
-					showRawInput: true,
+					showRawInput: false,
 				},
 			})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -364,7 +364,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -380,7 +380,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -397,7 +397,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		})) as SuiTransactionBlockResponse & { rawEffects: unknown };
 		const graphQLTransactionBlock = await graphQLClient!.getTransactionBlock({
@@ -408,7 +408,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 
@@ -426,7 +426,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 		const [graphQLTransactionBlock] = await graphQLClient!.multiGetTransactionBlocks({
@@ -439,7 +439,7 @@ describe('GraphQL SuiClient compatibility', () => {
 				// TODO inputs missing valueType
 				showInput: false,
 				showObjectChanges: true,
-				showRawInput: true,
+				showRawInput: false,
 			},
 		});
 


### PR DESCRIPTION
## Description 

This PR modifies which data is serialized to bcs for `TransactionBlock` type. Instead of serializing to bcs `SenderSignedData`, which includes signatures and intent message, it only serializes the transaction data.

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: The `bcs` field of `TransactionBlock` has new data. Instead of serializing to `bcs` from `SenderSignedData`, which includes signatures and intent message, it only serializes the `TransactionData` object.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
