### PR TITLE
[gql][mvr] Named typed queries go through the package resolver

### DIFF
--- a/crates/sui-graphql-rpc/tests/move_registry_e2e.rs
+++ b/crates/sui-graphql-rpc/tests/move_registry_e2e.rs
@@ -215,16 +215,12 @@ fn test_results(
     );
 
     assert_eq!(
-        query_result["data"]["v1_type"]["layout"]["struct"]["type"]
-            .as_str()
-            .unwrap(),
+        query_result["data"]["v1_type"]["repr"].as_str().unwrap(),
         format!("{}{}", v1, DEMO_TYPE)
     );
 
     assert_eq!(
-        query_result["data"]["v2_type"]["layout"]["struct"]["type"]
-            .as_str()
-            .unwrap(),
+        query_result["data"]["v2_type"]["repr"].as_str().unwrap(),
         format!("{}{}", v2, DEMO_TYPE_V2)
     );
 
@@ -233,6 +229,13 @@ fn test_results(
             .as_str()
             .unwrap(),
         format!("{}{}", v3, DEMO_TYPE_V3)
+    );
+
+    assert_eq!(
+        query_result["data"]["v3_type"]["layout"]["struct"]["type"]
+            .as_str()
+            .unwrap(),
+        query_result["data"]["v3_type"]["repr"].as_str().unwrap()
     );
 }
 
@@ -519,5 +522,5 @@ fn name_query(name: &str) -> String {
 }
 
 fn type_query(named_type: &str) -> String {
-    format!(r#"typeByName(name: "{}") {{ layout }}"#, named_type)
+    format!(r#"typeByName(name: "{}") {{ layout, repr }}"#, named_type)
 }


### PR DESCRIPTION
## Description 

Make sure named type queries go through the package resolver so `repr` has the correct type (not using latest).

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
