### PR TITLE
[DB] remove min level to compress

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2524,7 +2524,6 @@ pub fn default_db_options() -> DBOptions {
     opt.set_table_cache_num_shard_bits(10);
 
     // LSM compression settings
-    opt.set_min_level_to_compress(2);
     opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
     opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
     opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);


### PR DESCRIPTION
## Description 

Lz4 should be cheap enough to enable on level 1.

## Test plan

PT: looks like disk usage growth at the start is lower, while validator CPU usage doesn't seem to change.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
