### PR TITLE
[bridge] add best effort agg

### DIFF
--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -1360,6 +1360,7 @@ mod tests {
                 sui_tx_digest,
                 sui_tx_event_index,
                 Ok(signed_action.clone()),
+                None,
             );
             signed_actions.insert(secret.public().into(), signed_action.into_sig().signature);
         }
@@ -1376,6 +1377,7 @@ mod tests {
                 sui_tx_digest,
                 sui_tx_event_index,
                 Err(BridgeError::RestAPIError("small issue".into())),
+                None,
             );
         }
     }

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -341,7 +341,7 @@ mod tests {
         );
         let sig = BridgeAuthoritySignInfo::new(&action, &secret);
         let signed_event = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig.clone());
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event.clone()));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event.clone()), None);
 
         // success
         client
@@ -362,7 +362,7 @@ mod tests {
         let wrong_sig = BridgeAuthoritySignInfo::new(&action2, &secret);
         let wrong_signed_action =
             SignedBridgeAction::new_from_data_and_sig(action2.clone(), wrong_sig.clone());
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await
@@ -372,7 +372,7 @@ mod tests {
         // The action matches but the signature is wrong, fail
         let wrong_signed_action =
             SignedBridgeAction::new_from_data_and_sig(action.clone(), wrong_sig);
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(wrong_signed_action), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await
@@ -389,7 +389,7 @@ mod tests {
             BridgeCommittee::new(vec![authority_blocklisted.clone(), authority2.clone()]).unwrap(),
         );
         client.update_committee(committee2);
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event), None);
 
         let err = client
             .request_sign_bridge_action(action.clone())
@@ -404,7 +404,7 @@ mod tests {
         // signed by a different authority in committee would fail
         let sig2 = BridgeAuthoritySignInfo::new(&action, &secret2);
         let signed_event2 = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig2.clone());
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event2));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event2), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await
@@ -416,7 +416,7 @@ mod tests {
         let secret3 = Arc::pin(kp3);
         let sig3 = BridgeAuthoritySignInfo::new(&action, &secret3);
         let signed_event3 = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig3);
-        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event3));
+        mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event3), None);
         let err = client
             .request_sign_bridge_action(action.clone())
             .await

--- a/crates/sui-bridge/src/server/mock_handler.rs
+++ b/crates/sui-bridge/src/server/mock_handler.rs
@@ -4,11 +4,6 @@
 //! A mock implementation for `BridgeRequestHandlerTrait`
 //! that handles requests according to preset behaviors.
 
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
-
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::crypto::BridgeAuthoritySignInfo;
 use crate::error::BridgeError;
@@ -19,7 +14,12 @@ use crate::types::SignedBridgeAction;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use axum::Json;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 use sui_types::digests::TransactionDigest;
+use tokio::time::Duration;
 
 use super::handler::BridgeRequestHandlerTrait;
 use super::make_router;
@@ -28,8 +28,11 @@ use super::make_router;
 #[derive(Clone)]
 pub struct BridgeRequestMockHandler {
     signer: Arc<ArcSwap<Option<BridgeAuthorityKeyPair>>>,
-    sui_token_events:
-        Arc<Mutex<HashMap<(TransactionDigest, u16), BridgeResult<SignedBridgeAction>>>>,
+    sui_token_events: Arc<
+        Mutex<
+            HashMap<(TransactionDigest, u16), (BridgeResult<SignedBridgeAction>, Option<Duration>)>,
+        >,
+    >,
     sui_token_events_requested: Arc<Mutex<HashMap<(TransactionDigest, u16), u64>>>,
 }
 
@@ -47,11 +50,12 @@ impl BridgeRequestMockHandler {
         tx_digest: TransactionDigest,
         idx: u16,
         response: BridgeResult<SignedBridgeAction>,
+        delay: Option<Duration>,
     ) {
         self.sui_token_events
             .lock()
             .unwrap()
-            .insert((tx_digest, idx), response);
+            .insert((tx_digest, idx), (response, delay));
     }
 
     pub fn get_sui_token_events_requested(
@@ -95,26 +99,29 @@ impl BridgeRequestHandlerTrait for BridgeRequestMockHandler {
     ) -> Result<Json<SignedBridgeAction>, BridgeError> {
         let tx_digest = TransactionDigest::from_str(&tx_digest_base58)
             .map_err(|_e| BridgeError::InvalidTxHash)?;
-        let preset = self.sui_token_events.lock().unwrap();
-        if !preset.contains_key(&(tx_digest, event_idx)) {
-            // Ok to panic in test
-            panic!(
-                "No preset handle_sui_tx_digest result for tx_digest: {}, event_idx: {}",
-                tx_digest, event_idx
-            );
+        let (result, delay) = {
+            let preset = self.sui_token_events.lock().unwrap();
+            if !preset.contains_key(&(tx_digest, event_idx)) {
+                // Ok to panic in test
+                panic!(
+                    "No preset handle_sui_tx_digest result for tx_digest: {}, event_idx: {}",
+                    tx_digest, event_idx
+                );
+            }
+            let mut requested = self.sui_token_events_requested.lock().unwrap();
+            let entry = requested.entry((tx_digest, event_idx)).or_default();
+            *entry += 1;
+            let (result, delay) = preset.get(&(tx_digest, event_idx)).unwrap();
+            (result.clone(), *delay)
+        };
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
         }
-        let mut requested = self.sui_token_events_requested.lock().unwrap();
-        let entry = requested.entry((tx_digest, event_idx)).or_default();
-        *entry += 1;
-        let result = preset.get(&(tx_digest, event_idx)).unwrap();
-        if let Err(e) = result {
-            return Err(e.clone());
-        }
-        let signed_action: &sui_types::message_envelope::Envelope<
+        let signed_action: sui_types::message_envelope::Envelope<
             crate::types::BridgeAction,
             crate::crypto::BridgeAuthoritySignInfo,
-        > = result.as_ref().unwrap();
-        Ok(Json(signed_action.clone()))
+        > = result?;
+        Ok(Json(signed_action))
     }
 
     async fn handle_governance_action(

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -504,11 +504,7 @@ async fn test_map_reducer() {
         |mut accumulated_state, authority_name, _authority_weight, _result| {
             Box::pin(async move {
                 accumulated_state.insert(authority_name);
-                if accumulated_state.len() <= 3 {
-                    ReduceOutput::Continue(accumulated_state)
-                } else {
-                    ReduceOutput::ContinueWithTimeout(accumulated_state, Duration::from_millis(10))
-                }
+                ReduceOutput::Continue(accumulated_state)
             })
         },
         // large delay


### PR DESCRIPTION
## Description 

This PR centers around `BestEffortConfig` and enables bridge sig aggregation towards minimized set of sigs. 

Code should be relatively straightforward. One thing to notice is once we get a valid set of sigs (may not be the one we like), we need to store it as a backup, in the case of the dream of "best set of sigs" would't come true, because of running of sigs, or too many errors.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
