### PR TITLE
graphql: ObjectOwner::Parent exposed as Owner

### DIFF
--- a/.changeset/hot-stingrays-press.md
+++ b/.changeset/hot-stingrays-press.md
@@ -1,0 +1,5 @@
+---
+'@mysten/graphql-transport': patch
+---
+
+Update GraphQL transport layer to accommodate change in schema

--- a/crates/sui-graphql-e2e-tests/tests/stable/call/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/call/dynamic_fields.exp
@@ -1,4 +1,4 @@
-processed 13 tasks
+processed 12 tasks
 
 init:
 A: object(0,0)
@@ -31,7 +31,7 @@ task 5, line 60:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, lines 62-85:
+task 6, lines 62-118:
 //# run-graphql
 Response: {
   "data": {
@@ -49,7 +49,14 @@ Response: {
               "bcs": "AA=="
             },
             "value": {
-              "__typename": "MoveValue"
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
+              "bcs": "AQAAAAAAAAA=",
+              "data": {
+                "Number": "1"
+              }
             }
           },
           {
@@ -63,7 +70,56 @@ Response: {
               "bcs": "AAAAAAAAAAA="
             },
             "value": {
-              "__typename": "MoveObject"
+              "__typename": "MoveObject",
+              "contents": {
+                "type": {
+                  "repr": "0x314faae908e1e1e6f5df9f3a03a4692a27cb974776f13551472d3831f5a964d9::m::Child"
+                },
+                "bcs": "79SK5tokongSfcWj2640StZoQwIktLuTsSSR/HV6Odc=",
+                "data": {
+                  "Struct": [
+                    {
+                      "name": "id",
+                      "value": {
+                        "UID": [
+                          239,
+                          212,
+                          138,
+                          230,
+                          218,
+                          36,
+                          162,
+                          120,
+                          18,
+                          125,
+                          197,
+                          163,
+                          219,
+                          174,
+                          52,
+                          74,
+                          214,
+                          104,
+                          67,
+                          2,
+                          36,
+                          180,
+                          187,
+                          147,
+                          177,
+                          36,
+                          145,
+                          252,
+                          117,
+                          122,
+                          57,
+                          215
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
             }
           },
           {
@@ -77,7 +133,14 @@ Response: {
               "bcs": "AA=="
             },
             "value": {
-              "__typename": "MoveValue"
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
+              "bcs": "AgAAAAAAAAA=",
+              "data": {
+                "Number": "2"
+              }
             }
           },
           {
@@ -91,38 +154,19 @@ Response: {
               "bcs": "AAAAAAAAAAA="
             },
             "value": {
-              "__typename": "MoveValue"
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
+              "bcs": "AAAAAAAAAAA=",
+              "data": {
+                "Number": "0"
+              }
             }
           }
         ]
       }
-    }
-  }
-}
-
-task 7, line 87:
-//# run Test::m::wrap --sender A --args object(2,0)
-created: object(7,0)
-mutated: object(0,0)
-wrapped: object(2,0)
-gas summary: computation_cost: 1000000, storage_cost: 2485200,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
-
-task 8, line 89:
-//# create-checkpoint
-Checkpoint created: 2
-
-task 9, lines 91-114:
-//# run-graphql
-Response: {
-  "data": {
-    "object": null
-  }
-}
-
-task 10, lines 116-141:
-//# run-graphql
-Response: {
-  "data": {
+    },
     "owner": {
       "dynamicFields": {
         "nodes": [
@@ -137,11 +181,14 @@ Response: {
               "bcs": "AA=="
             },
             "value": {
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
               "bcs": "AQAAAAAAAAA=",
               "data": {
                 "Number": "1"
-              },
-              "__typename": "MoveValue"
+              }
             }
           },
           {
@@ -155,7 +202,56 @@ Response: {
               "bcs": "AAAAAAAAAAA="
             },
             "value": {
-              "__typename": "MoveObject"
+              "__typename": "MoveObject",
+              "contents": {
+                "type": {
+                  "repr": "0x314faae908e1e1e6f5df9f3a03a4692a27cb974776f13551472d3831f5a964d9::m::Child"
+                },
+                "bcs": "79SK5tokongSfcWj2640StZoQwIktLuTsSSR/HV6Odc=",
+                "data": {
+                  "Struct": [
+                    {
+                      "name": "id",
+                      "value": {
+                        "UID": [
+                          239,
+                          212,
+                          138,
+                          230,
+                          218,
+                          36,
+                          162,
+                          120,
+                          18,
+                          125,
+                          197,
+                          163,
+                          219,
+                          174,
+                          52,
+                          74,
+                          214,
+                          104,
+                          67,
+                          2,
+                          36,
+                          180,
+                          187,
+                          147,
+                          177,
+                          36,
+                          145,
+                          252,
+                          117,
+                          122,
+                          57,
+                          215
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
             }
           },
           {
@@ -169,11 +265,14 @@ Response: {
               "bcs": "AA=="
             },
             "value": {
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
               "bcs": "AgAAAAAAAAA=",
               "data": {
                 "Number": "2"
-              },
-              "__typename": "MoveValue"
+              }
             }
           },
           {
@@ -187,11 +286,14 @@ Response: {
               "bcs": "AAAAAAAAAAA="
             },
             "value": {
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
               "bcs": "AAAAAAAAAAA=",
               "data": {
                 "Number": "0"
-              },
-              "__typename": "MoveValue"
+              }
             }
           }
         ]
@@ -200,7 +302,158 @@ Response: {
   }
 }
 
-task 11, lines 143-163:
+task 7, line 120:
+//# run Test::m::wrap --sender A --args object(2,0)
+created: object(7,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2485200,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 8, line 122:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 124-180:
+//# run-graphql
+Response: {
+  "data": {
+    "object": null,
+    "owner": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
+              "bcs": "AQAAAAAAAAA=",
+              "data": {
+                "Number": "1"
+              }
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject",
+              "contents": {
+                "type": {
+                  "repr": "0x314faae908e1e1e6f5df9f3a03a4692a27cb974776f13551472d3831f5a964d9::m::Child"
+                },
+                "bcs": "79SK5tokongSfcWj2640StZoQwIktLuTsSSR/HV6Odc=",
+                "data": {
+                  "Struct": [
+                    {
+                      "name": "id",
+                      "value": {
+                        "UID": [
+                          239,
+                          212,
+                          138,
+                          230,
+                          218,
+                          36,
+                          162,
+                          120,
+                          18,
+                          125,
+                          197,
+                          163,
+                          219,
+                          174,
+                          52,
+                          74,
+                          214,
+                          104,
+                          67,
+                          2,
+                          36,
+                          180,
+                          187,
+                          147,
+                          177,
+                          36,
+                          145,
+                          252,
+                          117,
+                          122,
+                          57,
+                          215
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
+              "bcs": "AgAAAAAAAAA=",
+              "data": {
+                "Number": "2"
+              }
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue",
+              "type": {
+                "repr": "u64"
+              },
+              "bcs": "AAAAAAAAAAA=",
+              "data": {
+                "Number": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10, lines 182-201:
 //# run-graphql
 Response: {
   "data": {
@@ -217,6 +470,9 @@ Response: {
         },
         "value": {
           "__typename": "MoveValue",
+          "type": {
+            "repr": "u64"
+          },
           "bcs": "AAAAAAAAAAA=",
           "data": {
             "Number": "0"
@@ -227,14 +483,63 @@ Response: {
   }
 }
 
-task 12, lines 165-176:
+task 11, lines 203-219:
 //# run-graphql
 Response: {
   "data": {
     "owner": {
       "dynamicObjectField": {
         "value": {
-          "__typename": "MoveObject"
+          "__typename": "MoveObject",
+          "contents": {
+            "type": {
+              "repr": "0x314faae908e1e1e6f5df9f3a03a4692a27cb974776f13551472d3831f5a964d9::m::Child"
+            },
+            "bcs": "79SK5tokongSfcWj2640StZoQwIktLuTsSSR/HV6Odc=",
+            "data": {
+              "Struct": [
+                {
+                  "name": "id",
+                  "value": {
+                    "UID": [
+                      239,
+                      212,
+                      138,
+                      230,
+                      218,
+                      36,
+                      162,
+                      120,
+                      18,
+                      125,
+                      197,
+                      163,
+                      219,
+                      174,
+                      52,
+                      74,
+                      214,
+                      104,
+                      67,
+                      2,
+                      36,
+                      180,
+                      187,
+                      147,
+                      177,
+                      36,
+                      145,
+                      252,
+                      117,
+                      122,
+                      57,
+                      215
+                    ]
+                  }
+                }
+              ]
+            }
+          }
         }
       }
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/call/dynamic_fields.move
@@ -60,23 +60,56 @@ module Test::m {
 //# create-checkpoint
 
 //# run-graphql
-{
+{ # Initially, the parent object should be accessible directly and as an
+  # "Owner".
   object(address: "@{obj_2_0}") {
     dynamicFields {
       nodes {
         name {
-          type {
-            repr
-          }
+          type { repr }
           data
           bcs
         }
         value {
-          ... on MoveObject {
-            __typename
-          }
+          __typename
           ... on MoveValue {
-            __typename
+            type { repr }
+            bcs
+            data
+          }
+          ... on MoveObject {
+            contents {
+              type { repr }
+              bcs
+              data
+            }
+          }
+        }
+      }
+    }
+  }
+
+  owner(address: "@{obj_2_0}") {
+    dynamicFields {
+      nodes {
+        name {
+          type { repr }
+          data
+          bcs
+        }
+        value {
+          __typename
+          ... on MoveValue {
+            type { repr }
+            bcs
+            data
+          }
+          ... on MoveObject {
+            contents {
+              type { repr }
+              bcs
+              data
+            }
           }
         }
       }
@@ -89,50 +122,56 @@ module Test::m {
 //# create-checkpoint
 
 //# run-graphql
-{
+{ # After it is wrapped, we can no longer fetch its latest version via `object`
+  # but we can still refer to it as an "Owner" and fetch its dynamic fields.
   object(address: "@{obj_2_0}") {
     dynamicFields {
       nodes {
         name {
-          type {
-            repr
-          }
+          type { repr }
           data
           bcs
         }
         value {
-          ... on MoveObject {
-            __typename
-          }
+          __typename
           ... on MoveValue {
-            __typename
+            type { repr }
+            bcs
+            data
+          }
+          ... on MoveObject {
+            contents {
+              type { repr }
+              bcs
+              data
+            }
           }
         }
       }
     }
   }
-}
 
-//# run-graphql
-{
   owner(address: "@{obj_2_0}") {
     dynamicFields {
       nodes {
         name {
-          type {
-            repr
-          }
+          type { repr }
           data
           bcs
         }
         value {
-          ... on MoveObject {
-            __typename
-          }
+          __typename
           ... on MoveValue {
+            type { repr }
             bcs
             data
-            __typename
+          }
+          ... on MoveObject {
+            contents {
+              type { repr }
+              bcs
+              data
+            }
           }
         }
       }
@@ -145,15 +184,14 @@ module Test::m {
   owner(address: "@{obj_2_0}") {
     dynamicField(name: {type: "u64", bcs: "AAAAAAAAAAA="}) {
       name {
-        type {
-          repr
-        }
+        type { repr }
         data
         bcs
       }
       value {
         ... on MoveValue {
           __typename
+          type { repr }
           bcs
           data
         }
@@ -169,6 +207,11 @@ module Test::m {
       value {
         ... on MoveObject {
           __typename
+          contents {
+            type { repr }
+            bcs
+            data
+          }
         }
       }
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/immutable_dof.exp
@@ -144,7 +144,9 @@ Response: {
   "data": {
     "object": {
       "owner": {
-        "parent": null
+        "parent": {
+          "address": "0x9958869e2da5c5af828a334520a81de2bec0861e171b575db12fb4987cb27a78"
+        }
       },
       "dynamicFields": {
         "nodes": []

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -3076,11 +3076,13 @@ type PageInfo {
 
 """
 If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
-the dynamic field, or the intermediate Field object itself). Also note that if the owner
-is a parent, then it's guaranteed to be an object.
+the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+
+Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+object could be wrapped and therefore not directly accessible.
 """
 type Parent {
-	parent: Object
+	parent: Owner
 }
 
 """

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -147,6 +147,7 @@ pub(crate) fn build_objects_query(
     // Similar to the snapshot query, construct the filtered inner query for the history table.
     let mut history_objs_inner = query!("SELECT * FROM objects_history");
     history_objs_inner = filter_fn(history_objs_inner);
+    history_objs_inner = filter!(history_objs_inner, "object_status = 0");
 
     let mut history_objs = match view {
         View::Consistent => {
@@ -167,16 +168,14 @@ pub(crate) fn build_objects_query(
                 newer
             );
             history_objs = filter!(history_objs, "newer.object_version IS NULL");
-            history_objs = filter!(history_objs, "object_status = 0");
             history_objs
         }
         View::Historical => {
             // The cursor pagination logic refers to the table with the `candidates` alias
-            let query = query!(
+            query!(
                 "SELECT candidates.* FROM ({}) candidates",
                 history_objs_inner
-            );
-            filter!(query, "object_status = 0")
+            )
         }
     };
 

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -174,8 +174,8 @@ impl Coin {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(&self.super_.super_).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(&self.super_.super_).owner().await
     }
 
     /// The transaction block that created this version of the object.

--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -162,8 +162,8 @@ impl CoinMetadata {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(&self.super_.super_).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(&self.super_.super_).owner().await
     }
 
     /// The transaction block that created this version of the object.

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -242,8 +242,8 @@ impl MoveObject {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(&self.super_).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(&self.super_).owner().await
     }
 
     /// The transaction block that created this version of the object.

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -308,8 +308,8 @@ impl MovePackage {
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
     /// Packages are always Immutable.
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(&self.super_).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(&self.super_).owner().await
     }
 
     /// The transaction block that published or upgraded this package.

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -163,11 +163,13 @@ pub(crate) struct Shared {
 }
 
 /// If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
-/// the dynamic field, or the intermediate Field object itself). Also note that if the owner
-/// is a parent, then it's guaranteed to be an object.
+/// the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+///
+/// Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+/// object could be wrapped and therefore not directly accessible.
 #[derive(SimpleObject, Clone)]
 pub(crate) struct Parent {
-    parent: Option<Object>,
+    parent: Option<Owner>,
 }
 
 /// An address-owned object is owned by a specific 32-byte address that is
@@ -439,8 +441,8 @@ impl Object {
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
     /// Immutable and Shared Objects do not have owners.
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(self).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(self).owner().await
     }
 
     /// The transaction block that created this version of the object.
@@ -580,7 +582,7 @@ impl ObjectImpl<'_> {
             .map(|native| native.digest().base58_encode())
     }
 
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
         use NativeOwner as O;
 
         let native = self.0.native_impl()?;
@@ -598,16 +600,14 @@ impl ObjectImpl<'_> {
             }
             O::Immutable => Some(ObjectOwner::Immutable(Immutable { dummy: None })),
             O::ObjectOwner(address) => {
-                let parent = Object::query(
-                    ctx,
-                    address.into(),
-                    Object::latest_at(self.0.checkpoint_viewed_at),
-                )
-                .await
-                .ok()
-                .flatten();
-
-                Some(ObjectOwner::Parent(Parent { parent }))
+                let address = SuiAddress::from(address);
+                Some(ObjectOwner::Parent(Parent {
+                    parent: Some(Owner {
+                        address,
+                        checkpoint_viewed_at: self.0.checkpoint_viewed_at,
+                        root_version: Some(self.0.root_version()),
+                    }),
+                }))
             }
             O::Shared {
                 initial_shared_version,

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -181,8 +181,8 @@ impl StakedSui {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(&self.super_.super_).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(&self.super_.super_).owner().await
     }
 
     /// The transaction block that created this version of the object.

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -219,8 +219,8 @@ impl SuinsRegistration {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
-        ObjectImpl(&self.super_.super_).owner(ctx).await
+    pub(crate) async fn owner(&self) -> Option<ObjectOwner> {
+        ObjectImpl(&self.super_.super_).owner().await
     }
 
     /// The transaction block that created this version of the object.

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -3081,11 +3081,13 @@ type PageInfo {
 
 """
 If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
-the dynamic field, or the intermediate Field object itself). Also note that if the owner
-is a parent, then it's guaranteed to be an object.
+the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+
+Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+object could be wrapped and therefore not directly accessible.
 """
 type Parent {
-	parent: Object
+	parent: Owner
 }
 
 """

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -3080,11 +3080,13 @@ type PageInfo {
 
 """
 If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
-the dynamic field, or the intermediate Field object itself). Also note that if the owner
-is a parent, then it's guaranteed to be an object.
+the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+
+Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+object could be wrapped and therefore not directly accessible.
 """
 type Parent {
-	parent: Object
+	parent: Owner
 }
 
 """
@@ -4801,3 +4803,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -3085,11 +3085,13 @@ type PageInfo {
 
 """
 If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
-the dynamic field, or the intermediate Field object itself). Also note that if the owner
-is a parent, then it's guaranteed to be an object.
+the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+
+Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+object could be wrapped and therefore not directly accessible.
 """
 type Parent {
-	parent: Object
+	parent: Owner
 }
 
 """
@@ -4818,3 +4820,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+

--- a/sdk/graphql-transport/src/generated/queries.ts
+++ b/sdk/graphql-transport/src/generated/queries.ts
@@ -1394,6 +1394,25 @@ export type EpochTransactionBlocksArgs = {
   scanLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type EpochConnection = {
+  __typename?: 'EpochConnection';
+  /** A list of edges. */
+  edges: Array<EpochEdge>;
+  /** A list of nodes. */
+  nodes: Array<Epoch>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type EpochEdge = {
+  __typename?: 'EpochEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Epoch;
+};
+
 export type Event = {
   __typename?: 'Event';
   /** The Base64 encoded BCS serialized bytes of the event. */
@@ -3278,12 +3297,7 @@ export enum ObjectKind {
    * The object is loaded from serialized data, such as the contents of a transaction that hasn't
    * been indexed yet.
    */
-  NotIndexed = 'NOT_INDEXED',
-  /**
-   * The object is deleted or wrapped and only partial information can be loaded from the
-   * indexer.
-   */
-  WrappedOrDeleted = 'WRAPPED_OR_DELETED'
+  NotIndexed = 'NOT_INDEXED'
 }
 
 /** The object's owner type: Immutable, Shared, Parent, or Address. */
@@ -3520,12 +3534,14 @@ export type PageInfo = {
 
 /**
  * If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
- * the dynamic field, or the intermediate Field object itself). Also note that if the owner
- * is a parent, then it's guaranteed to be an object.
+ * the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+ *
+ * Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+ * object could be wrapped and therefore not directly accessible.
  */
 export type Parent = {
   __typename?: 'Parent';
-  parent?: Maybe<Object>;
+  parent?: Maybe<Owner>;
 };
 
 /** A single transaction, or command, in the programmable transaction block. */
@@ -3717,6 +3733,7 @@ export type Query = {
   dryRunTransactionBlock: DryRunResult;
   /** Fetch epoch information by ID (defaults to the latest epoch). */
   epoch?: Maybe<Epoch>;
+  epochs: EpochConnection;
   /**
    * Query events that are emitted in the network.
    * We currently do not support filtering by emitting module and event type
@@ -3883,6 +3900,14 @@ export type QueryDryRunTransactionBlockArgs = {
 
 export type QueryEpochArgs = {
   id?: InputMaybe<Scalars['UInt53']['input']>;
+};
+
+
+export type QueryEpochsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -5433,7 +5458,7 @@ export type GetDynamicFieldObjectQueryVariables = Exact<{
 }>;
 
 
-export type GetDynamicFieldObjectQuery = { __typename?: 'Query', owner?: { __typename?: 'Owner', dynamicObjectField?: { __typename?: 'DynamicField', value?: { __typename: 'MoveObject', owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any, digest?: string | null, version: any, storageRebate?: any | null, owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared' } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null } } | null } | null } | null } | { __typename: 'Shared' } | null } | { __typename: 'MoveValue' } | null } | null } | null };
+export type GetDynamicFieldObjectQuery = { __typename?: 'Query', owner?: { __typename?: 'Owner', dynamicObjectField?: { __typename?: 'DynamicField', value?: { __typename: 'MoveObject', owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any, digest?: string | null, version: any, storageRebate?: any | null, owner?: { __typename: 'AddressOwner' } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared' } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null } } | null } | null } | null } | null } | { __typename: 'Shared' } | null } | { __typename: 'MoveValue' } | null } | null } | null };
 
 export type GetDynamicFieldsQueryVariables = Exact<{
   parentId: Scalars['SuiAddress']['input'];
@@ -5577,7 +5602,7 @@ export type GetOwnedObjectsQueryVariables = Exact<{
 }>;
 
 
-export type GetOwnedObjectsQuery = { __typename?: 'Query', address?: { __typename?: 'Address', objects: { __typename?: 'MoveObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: any, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } } | null };
+export type GetOwnedObjectsQuery = { __typename?: 'Query', address?: { __typename?: 'Address', objects: { __typename?: 'MoveObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: any, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } } | null };
 
 export type GetObjectQueryVariables = Exact<{
   id: Scalars['SuiAddress']['input'];
@@ -5591,7 +5616,7 @@ export type GetObjectQueryVariables = Exact<{
 }>;
 
 
-export type GetObjectQuery = { __typename?: 'Query', object?: { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
+export type GetObjectQuery = { __typename?: 'Query', object?: { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
 
 export type TryGetPastObjectQueryVariables = Exact<{
   id: Scalars['SuiAddress']['input'];
@@ -5606,7 +5631,7 @@ export type TryGetPastObjectQueryVariables = Exact<{
 }>;
 
 
-export type TryGetPastObjectQuery = { __typename?: 'Query', current?: { __typename?: 'Object', address: any, version: any } | null, object?: { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
+export type TryGetPastObjectQuery = { __typename?: 'Query', current?: { __typename?: 'Object', address: any, version: any } | null, object?: { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null } | null };
 
 export type MultiGetObjectsQueryVariables = Exact<{
   ids: Array<Scalars['SuiAddress']['input']> | Scalars['SuiAddress']['input'];
@@ -5622,17 +5647,17 @@ export type MultiGetObjectsQueryVariables = Exact<{
 }>;
 
 
-export type MultiGetObjectsQuery = { __typename?: 'Query', objects: { __typename?: 'ObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } };
+export type MultiGetObjectsQuery = { __typename?: 'Query', objects: { __typename?: 'ObjectConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<{ __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null }> } };
 
-export type Rpc_Object_FieldsFragment = { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
+export type Rpc_Object_FieldsFragment = { __typename?: 'Object', version: any, storageRebate?: any | null, digest?: string | null, objectId: any, asMoveObject?: { __typename?: 'MoveObject', hasPublicTransfer: boolean, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
 
-export type Rpc_Move_Object_FieldsFragment = { __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: any, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
+export type Rpc_Move_Object_FieldsFragment = { __typename?: 'MoveObject', bcs?: any | null, hasPublicTransfer?: boolean, storageRebate?: any | null, digest?: string | null, version: any, objectId: any, contents?: { __typename?: 'MoveValue', data: any, bcs: any, type: { __typename?: 'MoveType', repr: string, layout?: any | null, signature: any } } | null, owner?: { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null } | { __typename: 'Immutable' } | { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null } | { __typename: 'Shared', initialSharedVersion: any } | null, previousTransactionBlock?: { __typename?: 'TransactionBlock', digest?: string | null } | null, display?: Array<{ __typename?: 'DisplayEntry', key: string, value?: string | null, error?: string | null }> | null };
 
 type Rpc_Object_Owner_Fields_AddressOwner_Fragment = { __typename: 'AddressOwner', owner?: { __typename?: 'Owner', asObject?: { __typename?: 'Object', address: any } | null, asAddress?: { __typename?: 'Address', address: any } | null } | null };
 
 type Rpc_Object_Owner_Fields_Immutable_Fragment = { __typename: 'Immutable' };
 
-type Rpc_Object_Owner_Fields_Parent_Fragment = { __typename: 'Parent', parent?: { __typename?: 'Object', address: any } | null };
+type Rpc_Object_Owner_Fields_Parent_Fragment = { __typename: 'Parent', parent?: { __typename?: 'Owner', address: any } | null };
 
 type Rpc_Object_Owner_Fields_Shared_Fragment = { __typename: 'Shared', initialSharedVersion: any };
 
@@ -7138,30 +7163,32 @@ export const GetDynamicFieldObjectDocument = new TypedDocumentString(`
             __typename
             ... on Parent {
               parent {
-                address
-                digest
-                version
-                storageRebate
-                owner {
-                  __typename
-                  ... on Parent {
-                    parent {
-                      address
-                    }
-                  }
-                }
-                previousTransactionBlock {
+                asObject {
+                  address
                   digest
-                }
-                asMoveObject {
-                  contents {
-                    data
-                    type {
-                      repr
-                      layout
+                  version
+                  storageRebate
+                  owner {
+                    __typename
+                    ... on Parent {
+                      parent {
+                        address
+                      }
                     }
                   }
-                  hasPublicTransfer
+                  previousTransactionBlock {
+                    digest
+                  }
+                  asMoveObject {
+                    contents {
+                      data
+                      type {
+                        repr
+                        layout
+                      }
+                    }
+                    hasPublicTransfer
+                  }
                 }
               }
             }

--- a/sdk/graphql-transport/src/methods.ts
+++ b/sdk/graphql-transport/src/methods.ts
@@ -1020,7 +1020,7 @@ export const RPC_METHODS: {
 			(data) => {
 				return data.owner?.dynamicObjectField?.value?.__typename === 'MoveObject'
 					? data.owner.dynamicObjectField.value.owner?.__typename === 'Parent'
-						? data.owner.dynamicObjectField.value.owner.parent
+						? data.owner.dynamicObjectField.value.owner.parent?.asObject
 						: undefined
 					: undefined;
 			},

--- a/sdk/graphql-transport/src/queries/getDynamicFieldObject.graphql
+++ b/sdk/graphql-transport/src/queries/getDynamicFieldObject.graphql
@@ -17,34 +17,34 @@ query getDynamicFieldObject($parentId: SuiAddress!, $name: DynamicFieldName!) {
 						__typename
 						... on Parent {
 							parent {
-                asObject {
-                  address
-                  digest
-                  version
-                  storageRebate
-                  owner {
-                    __typename
-                    ... on Parent {
-                      parent {
-                        address
-                      }
-                    }
-                  }
-                  previousTransactionBlock {
-                    digest
-                  }
-                  asMoveObject {
-                    contents {
-                      data
-                      type {
-                        repr
-                        layout
-                      }
-                    }
-                    hasPublicTransfer
-                  }
-                }
-              }
+								asObject {
+									address
+									digest
+									version
+									storageRebate
+									owner {
+										__typename
+										... on Parent {
+											parent {
+												address
+											}
+										}
+									}
+									previousTransactionBlock {
+										digest
+									}
+									asMoveObject {
+										contents {
+											data
+											type {
+												repr
+												layout
+											}
+										}
+										hasPublicTransfer
+									}
+								}
+							}
 						}
 					}
 				}

--- a/sdk/graphql-transport/src/queries/getDynamicFieldObject.graphql
+++ b/sdk/graphql-transport/src/queries/getDynamicFieldObject.graphql
@@ -17,32 +17,34 @@ query getDynamicFieldObject($parentId: SuiAddress!, $name: DynamicFieldName!) {
 						__typename
 						... on Parent {
 							parent {
-								address
-								digest
-								version
-								storageRebate
-								owner {
-									__typename
-									... on Parent {
-										parent {
-											address
-										}
-									}
-								}
-								previousTransactionBlock {
-									digest
-								}
-								asMoveObject {
-									contents {
-										data
-										type {
-											repr
-											layout
-										}
-									}
-									hasPublicTransfer
-								}
-							}
+                asObject {
+                  address
+                  digest
+                  version
+                  storageRebate
+                  owner {
+                    __typename
+                    ... on Parent {
+                      parent {
+                        address
+                      }
+                    }
+                  }
+                  previousTransactionBlock {
+                    digest
+                  }
+                  asMoveObject {
+                    contents {
+                      data
+                      type {
+                        repr
+                        layout
+                      }
+                    }
+                    hasPublicTransfer
+                  }
+                }
+              }
 						}
 					}
 				}


### PR DESCRIPTION
## Description

Now that we no longer expose wrapped objects, we need a way to expose the addresses of object parents when they are other objects that have been wrapped.

## Test plan

Updated tests:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests
sui$ cargo nextest run -p sui-graphql-rpc
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Change `Parent.parent` from an `Object` to an `Owner`. Although it's guaranteed to be an object if it exists, it may be wrapped, in which case it will not exist. Exposing it as an Owner allows queries to extract its ID and also fetch other dynamic fields from it even if it is wrapped.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
