### PR TITLE
pick(19807): subscriptions: reinstate EventFilter::Any

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3976,6 +3976,14 @@ impl AuthorityState {
                     limit,
                     descending,
                 )?,
+            // not using "_ =>" because we want to make sure we remember to add new variants here
+            EventFilter::Any(_) => {
+                return Err(SuiError::UserInputError {
+                    error: UserInputError::Unsupported(
+                        "'Any' queries are not supported by the fullnode.".to_string(),
+                    ),
+                })
+            }
         };
 
         // skip one event if exclusive cursor is provided,

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1042,7 +1042,7 @@ impl IndexerReader {
                     // Processed above
                     unreachable!()
                 }
-                EventFilter::TimeRange { .. } => {
+                EventFilter::TimeRange { .. } | EventFilter::Any(_) => {
                     return Err(IndexerError::NotSupportedError(
                         "This type of EventFilter is not supported.".to_owned(),
                     ));

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -205,6 +205,10 @@ fn try_into_byte(v: &Value) -> Option<u8> {
 pub enum EventFilter {
     /// Return all events.
     All([Box<EventFilter>; 0]),
+
+    /// Return events that match any of the given filters. Only supported on event subscriptions.
+    Any(Vec<EventFilter>),
+
     /// Query by sender address.
     Sender(SuiAddress),
     /// Return events emitted by the given transaction.
@@ -263,6 +267,7 @@ impl Filter<SuiEvent> for EventFilter {
         let _scope = monitored_scope("EventFilter::matches");
         match self {
             EventFilter::All([]) => true,
+            EventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
             EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
             EventFilter::Sender(sender) => &item.sender == sender,
             EventFilter::MoveModule { package, module } => {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6121,6 +6121,22 @@
             "additionalProperties": false
           },
           {
+            "description": "Return events that match any of the given filters. Only supported on event subscriptions.",
+            "type": "object",
+            "required": [
+              "Any"
+            ],
+            "properties": {
+              "Any": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EventFilter"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by sender address.",
             "type": "object",
             "required": [


### PR DESCRIPTION
## Description

Temporarily re-enable `EventFilter::Any` as it is still in use in some places. This is a partial revert of #19617.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Temporarily re-enable `EventFilter::Any` as a kind of event subscription filter. Note that subscriptions are deprecated. This means they are not officially supported, nor actively maintained.
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
