### PR TITLE
[move][docgen] Render string constants for error constants

### DIFF
--- a/external-crates/move/crates/move-docgen/src/docgen.rs
+++ b/external-crates/move/crates/move-docgen/src/docgen.rs
@@ -9,7 +9,7 @@ use codespan::{ByteIndex, Span};
 use itertools::Itertools;
 use move_compiler::parser::keywords::{BUILTINS, CONTEXTUAL_KEYWORDS, KEYWORDS};
 use move_model::{
-    ast::ModuleName,
+    ast::{Attribute, ModuleName, Value},
     code_writer::{CodeWriter, CodeWriterLabel},
     emit, emitln,
     model::{
@@ -947,14 +947,29 @@ impl<'env> Docgen<'env> {
     /// Generates declaration for named constant
     fn named_constant_display(&self, const_env: &NamedConstantEnv<'_>) -> String {
         let name = self.name_string(const_env.get_name());
+        let is_error_const = const_env.get_attributes().iter().any(|attr| 
+            matches!(attr, Attribute::Apply(_, sym, _) if self.name_string(*sym).to_string() == "error".to_string())
+        );
+        let rendered_value = match (is_error_const, const_env.get_value()) {
+            (true, Value::ByteArray(bytes)) => {
+                if let Ok(s) = std::str::from_utf8(&bytes) {
+                    format!("b\"{s}\"")
+                } else {
+                    format!("{bytes:?}")
+                }
+            }
+            (_, value) => value.to_string(),
+        };
+        let error_const_annot = if is_error_const { "#[error]\n" } else { "" };
         format!(
-            "const {}: {} = {};",
+            "{}const {}: {} = {};",
+            error_const_annot,
             name,
             const_env.get_type().display(&TypeDisplayContext::WithEnv {
                 env: self.env,
                 type_param_names: None,
             }),
-            const_env.get_value(),
+            rendered_value,
         )
     }
 

--- a/external-crates/move/crates/move-docgen/src/docgen.rs
+++ b/external-crates/move/crates/move-docgen/src/docgen.rs
@@ -947,8 +947,8 @@ impl<'env> Docgen<'env> {
     /// Generates declaration for named constant
     fn named_constant_display(&self, const_env: &NamedConstantEnv<'_>) -> String {
         let name = self.name_string(const_env.get_name());
-        let is_error_const = const_env.get_attributes().iter().any(|attr| 
-            matches!(attr, Attribute::Apply(_, sym, _) if self.name_string(*sym).to_string() == "error".to_string())
+        let is_error_const = const_env.get_attributes().iter().any(|attr|
+            matches!(attr, Attribute::Apply(_, sym, _) if self.name_string(*sym).to_string() == *"error")
         );
         let rendered_value = match (is_error_const, const_env.get_value()) {
             (true, Value::ByteArray(bytes)) => {

--- a/external-crates/move/crates/move-docgen/tests/sources/const_string_test.move
+++ b/external-crates/move/crates/move-docgen/tests/sources/const_string_test.move
@@ -1,0 +1,15 @@
+#[allow(unused)]
+module 0x42::m {
+    #[error]
+    /// This is a doc comment above an error constant that should be rendered as a string
+    const AString: vector<u8> = b"Hello, world  🦀   ";
+
+    #[error]
+    /// This is a doc comment above an error constant that should not be rendered as a string
+    const ErrorNotString: u64 = 10;
+
+    const AStringNotError: vector<u8> = b"Hello, world  🦀   ";
+
+    const NotAString: vector<u8> = vector[1, 2, 3];
+}
+

--- a/external-crates/move/crates/move-docgen/tests/sources/const_string_test.spec_inline.md
+++ b/external-crates/move/crates/move-docgen/tests/sources/const_string_test.spec_inline.md
@@ -1,0 +1,56 @@
+
+<a name="0x42_m"></a>
+
+# Module `0x42::m`
+
+
+
+-  [Constants](#@Constants_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x42_m_AString"></a>
+
+This is a doc comment above an error constant that should be rendered as a string
+
+
+<pre><code>#[error]
+<b>const</b> <a href="const_string_test.md#0x42_m_AString">AString</a>: vector&lt;u8&gt; = b"Hello, world  🦀   ";
+</code></pre>
+
+
+
+<a name="0x42_m_AStringNotError"></a>
+
+
+
+<pre><code><b>const</b> <a href="const_string_test.md#0x42_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
+</code></pre>
+
+
+
+<a name="0x42_m_ErrorNotString"></a>
+
+This is a doc comment above an error constant that should not be rendered as a string
+
+
+<pre><code>#[error]
+<b>const</b> <a href="const_string_test.md#0x42_m_ErrorNotString">ErrorNotString</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x42_m_NotAString"></a>
+
+
+
+<pre><code><b>const</b> <a href="const_string_test.md#0x42_m_NotAString">NotAString</a>: vector&lt;u8&gt; = [1, 2, 3];
+</code></pre>

--- a/external-crates/move/crates/move-docgen/tests/sources/const_string_test.spec_inline_no_fold.md
+++ b/external-crates/move/crates/move-docgen/tests/sources/const_string_test.spec_inline_no_fold.md
@@ -1,0 +1,56 @@
+
+<a name="0x42_m"></a>
+
+# Module `0x42::m`
+
+
+
+-  [Constants](#@Constants_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x42_m_AString"></a>
+
+This is a doc comment above an error constant that should be rendered as a string
+
+
+<pre><code>#[error]
+<b>const</b> <a href="const_string_test.md#0x42_m_AString">AString</a>: vector&lt;u8&gt; = b"Hello, world  🦀   ";
+</code></pre>
+
+
+
+<a name="0x42_m_AStringNotError"></a>
+
+
+
+<pre><code><b>const</b> <a href="const_string_test.md#0x42_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
+</code></pre>
+
+
+
+<a name="0x42_m_ErrorNotString"></a>
+
+This is a doc comment above an error constant that should not be rendered as a string
+
+
+<pre><code>#[error]
+<b>const</b> <a href="const_string_test.md#0x42_m_ErrorNotString">ErrorNotString</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x42_m_NotAString"></a>
+
+
+
+<pre><code><b>const</b> <a href="const_string_test.md#0x42_m_NotAString">NotAString</a>: vector&lt;u8&gt; = [1, 2, 3];
+</code></pre>

--- a/external-crates/move/crates/move-docgen/tests/sources/const_string_test.spec_separate.md
+++ b/external-crates/move/crates/move-docgen/tests/sources/const_string_test.spec_separate.md
@@ -1,0 +1,56 @@
+
+<a name="0x42_m"></a>
+
+# Module `0x42::m`
+
+
+
+-  [Constants](#@Constants_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x42_m_AString"></a>
+
+This is a doc comment above an error constant that should be rendered as a string
+
+
+<pre><code>#[error]
+<b>const</b> <a href="const_string_test.md#0x42_m_AString">AString</a>: vector&lt;u8&gt; = b"Hello, world  🦀   ";
+</code></pre>
+
+
+
+<a name="0x42_m_AStringNotError"></a>
+
+
+
+<pre><code><b>const</b> <a href="const_string_test.md#0x42_m_AStringNotError">AStringNotError</a>: vector&lt;u8&gt; = [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 32, 32, 240, 159, 166, 128, 32, 32, 32];
+</code></pre>
+
+
+
+<a name="0x42_m_ErrorNotString"></a>
+
+This is a doc comment above an error constant that should not be rendered as a string
+
+
+<pre><code>#[error]
+<b>const</b> <a href="const_string_test.md#0x42_m_ErrorNotString">ErrorNotString</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x42_m_NotAString"></a>
+
+
+
+<pre><code><b>const</b> <a href="const_string_test.md#0x42_m_NotAString">NotAString</a>: vector&lt;u8&gt; = [1, 2, 3];
+</code></pre>

--- a/external-crates/move/crates/move-model/src/builder/model_builder.rs
+++ b/external-crates/move/crates/move-model/src/builder/model_builder.rs
@@ -74,6 +74,7 @@ pub(crate) struct ConstEntry {
     pub loc: Loc,
     pub ty: Type,
     pub value: Value,
+    pub attributes: Vec<Attribute>,
 }
 
 impl<'env> ModelBuilder<'env> {

--- a/external-crates/move/crates/move-model/src/builder/module_builder.rs
+++ b/external-crates/move/crates/move-model/src/builder/module_builder.rs
@@ -287,13 +287,20 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         let move_value =
             Constant::deserialize_constant(&compiled_module.constant_pool()[*const_idx as usize])
                 .unwrap();
+        let attributes = self.translate_attributes(&def.attributes);
         let mut et = ExpTranslator::new(self);
         let loc = et.to_loc(&def.loc);
         let ty = et.translate_type(&def.signature);
         let value = et.translate_from_move_value(&loc, &ty, &move_value);
-        et.parent
-            .parent
-            .define_const(qsym, ConstEntry { loc, ty, value });
+        et.parent.parent.define_const(
+            qsym,
+            ConstEntry {
+                loc,
+                ty,
+                value,
+                attributes,
+            },
+        );
     }
 
     fn decl_ana_struct(&mut self, name: &PA::DatatypeName, def: &EA::StructDefinition) {
@@ -626,12 +633,21 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             .iter()
             .filter(|(name, _)| name.module_name == self.module_name)
             .map(|(name, const_entry)| {
-                let ConstEntry { loc, value, ty } = const_entry.clone();
+                let ConstEntry {
+                    loc,
+                    value,
+                    ty,
+                    attributes,
+                } = const_entry.clone();
                 (
                     NamedConstantId::new(name.symbol),
-                    self.parent
-                        .env
-                        .create_named_constant_data(name.symbol, loc, ty, value),
+                    self.parent.env.create_named_constant_data(
+                        name.symbol,
+                        loc,
+                        ty,
+                        value,
+                        attributes,
+                    ),
                 )
             })
             .collect();

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -944,12 +944,14 @@ impl GlobalEnv {
         loc: Loc,
         typ: Type,
         value: Value,
+        attributes: Vec<Attribute>,
     ) -> NamedConstantData {
         NamedConstantData {
             name,
             loc,
             typ,
             value,
+            attributes,
         }
     }
 
@@ -2997,6 +2999,9 @@ pub struct NamedConstantData {
 
     /// The value of this constant
     value: Value,
+
+    /// Attributes attached to this constant
+    attributes: Vec<Attribute>,
 }
 
 #[derive(Debug)]
@@ -3036,6 +3041,11 @@ impl<'env> NamedConstantEnv<'env> {
     /// Returns the value of this constant
     pub fn get_value(&self) -> Value {
         self.data.value.clone()
+    }
+
+    /// Returns the attributes attached to this constant
+    pub fn get_attributes(&self) -> &[Attribute] {
+        &self.data.attributes
     }
 }
 


### PR DESCRIPTION
## Description 

This updates how constants annotated with `#[error]` are rendered in docgen. This also adds the `#[error]` annotation on them in the generated documentation.

Note that we don't try to render all bytearrays as strings, but only constants with the `#[error]` annotation to avoid rendering normal bytearrays strings. 

## Test plan 

Added a test to make sure we render error-annotated consts as we expect. 


