### PR TITLE
[sui-benchmark] Add expected failure payloads

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -43,12 +43,16 @@ use tokio::task::{JoinHandle, JoinSet};
 use tokio::{time, time::Instant};
 use tracing::{debug, error, info, warn};
 
+use crate::workloads::workload::FailureType;
+use sui_types::utils::to_sender_signed_transaction;
+
 use super::Interval;
 use super::{BenchmarkStats, StressStats};
 pub struct BenchMetrics {
     pub benchmark_duration: IntGauge,
     pub num_success: IntCounterVec,
     pub num_error: IntCounterVec,
+    pub num_expected_error: IntCounterVec,
     pub num_submitted: IntCounterVec,
     pub num_in_flight: GaugeVec,
     pub latency_s: HistogramVec,
@@ -75,6 +79,13 @@ impl BenchMetrics {
             num_success: register_int_counter_vec_with_registry!(
                 "num_success",
                 "Total number of transaction success",
+                &["workload"],
+                registry,
+            )
+            .unwrap(),
+            num_expected_error: register_int_counter_vec_with_registry!(
+                "num_expected_error",
+                "Total number of transaction errors that were expected",
                 &["workload"],
                 registry,
             )
@@ -171,6 +182,8 @@ enum NextOp {
     },
     // The transaction failed and could not be retried
     Failure,
+    // The transaction failed as expected
+    ExpectedFailure(Box<dyn Payload>),
     Retry(RetryType),
 }
 
@@ -373,6 +386,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                 duration: Duration::ZERO,
                 num_error_txes: 0,
                 num_success_txes: 0,
+                num_expected_error_txes: 0,
                 num_success_cmds: 0,
                 total_gas_used: 0,
                 latency_ms: HistogramWrapper {
@@ -681,6 +695,7 @@ async fn run_bench_worker(
     let request_delay_micros = 1_000_000 / worker.target_qps;
     let mut num_success_txes = 0;
     let mut num_error_txes = 0;
+    let mut num_expected_error_txes = 0;
     let mut num_success_cmds = 0;
     let mut num_no_gas = 0;
     let mut num_in_flight: u64 = 0;
@@ -708,6 +723,7 @@ async fn run_bench_worker(
      -> NextOp {
         match result {
             Ok(effects) => {
+                assert!(payload.get_failure_type().is_none());
                 let latency = start.elapsed();
                 let time_from_start = total_benchmark_start_time.elapsed();
 
@@ -758,36 +774,47 @@ async fn run_bench_worker(
                 }
 
                 payload.make_new_payload(&effects);
-                NextOp::Response {
+                return NextOp::Response {
                     latency,
                     num_commands,
                     payload,
                     gas_used: effects.gas_used(),
-                }
+                };
             }
             Err(err) => {
                 error!("{}", err);
-                if err
-                    .downcast::<QuorumDriverError>()
-                    .and_then(|err| {
-                        if matches!(
-                            err,
-                            QuorumDriverError::NonRecoverableTransactionError { .. }
-                        ) {
-                            Err(err.into())
+                match payload.get_failure_type() {
+                    Some(_) => {
+                        metrics_cloned
+                            .num_expected_error
+                            .with_label_values(&[&payload.to_string()])
+                            .inc();
+                        NextOp::ExpectedFailure(payload)
+                    }
+                    None => {
+                        if err
+                            .downcast::<QuorumDriverError>()
+                            .and_then(|err| {
+                                if matches!(
+                                    err,
+                                    QuorumDriverError::NonRecoverableTransactionError { .. }
+                                ) {
+                                    Err(err.into())
+                                } else {
+                                    Ok(())
+                                }
+                            })
+                            .is_err()
+                        {
+                            NextOp::Failure
                         } else {
-                            Ok(())
+                            metrics_cloned
+                                .num_error
+                                .with_label_values(&[&payload.to_string(), "rpc"])
+                                .inc();
+                            NextOp::Retry(Box::new((transaction, payload)))
                         }
-                    })
-                    .is_err()
-                {
-                    NextOp::Failure
-                } else {
-                    metrics_cloned
-                        .num_error
-                        .with_label_values(&[&payload.to_string(), "rpc"])
-                        .inc();
-                    NextOp::Retry(Box::new((transaction, payload)))
+                    }
                 }
             }
         }
@@ -841,6 +868,7 @@ async fn run_bench_worker(
                         bench_stats: BenchmarkStats {
                             duration:stat_start_time.elapsed(),
                             num_error_txes,
+                            num_expected_error_txes,
                             num_success_txes,
                             num_success_cmds,
                             latency_ms:HistogramWrapper{
@@ -855,6 +883,7 @@ async fn run_bench_worker(
                 }
                 num_success_txes = 0;
                 num_error_txes = 0;
+                num_expected_error_txes = 0;
                 num_success_cmds = 0;
                 num_no_gas = 0;
                 num_submitted = 0;
@@ -899,6 +928,11 @@ async fn run_bench_worker(
                     metrics_cloned.num_in_flight.with_label_values(&[&payload.to_string()]).inc();
                     metrics_cloned.num_submitted.with_label_values(&[&payload.to_string()]).inc();
                     let tx = payload.make_transaction();
+                    let tx = if let Some(failure_type) = payload.get_failure_type() {
+                        apply_failure(tx, failure_type)
+                    } else {
+                        tx
+                    };
                     let start = Arc::new(Instant::now());
                     // TODO: clone committee for each request is not ideal.
                     let committee = worker.proxy.clone_committee();
@@ -924,6 +958,15 @@ async fn run_bench_worker(
                         error!("Permanent failure to execute payload. May result in gas objects being leaked");
                         num_error_txes += 1;
                         // Update total benchmark progress
+                        if update_progress(1) {
+                            break;
+                        }
+                    }
+                    NextOp::ExpectedFailure(payload) => {
+                        num_expected_error_txes += 1;
+                        num_in_flight -= 1;
+                        free_pool.push_back(payload);
+                        // Update progress and check if benchmark is finished
                         if update_progress(1) {
                             break;
                         }
@@ -958,6 +1001,7 @@ async fn run_bench_worker(
             bench_stats: BenchmarkStats {
                 duration: stat_start_time.elapsed(),
                 num_error_txes,
+                num_expected_error_txes,
                 num_success_txes,
                 num_success_cmds,
                 total_gas_used: worker_gas_used,
@@ -992,6 +1036,7 @@ async fn run_bench_worker(
                 payload,
             } => payload,
             NextOp::Retry(b) => b.1,
+            NextOp::ExpectedFailure(payload) => payload,
         };
         free_pool.push_back(p);
     }
@@ -1070,4 +1115,38 @@ fn stress_stats_collector(
             }
         }
     })
+}
+
+pub fn apply_failure(mut transaction: Transaction, failure_type: FailureType) -> Transaction {
+    let data = transaction.data().clone();
+
+    // TODO(william) make this work
+    match failure_type {
+        FailureType::InvalidSignature => {
+            let data = transaction.data().clone();
+            let invalid_keypair = SuiKeyPair::Ed25519(Ed25519KeyPair::generate(&mut OsRng));
+            let invalid_signature =
+                Signature::new_secure(data.intent_message().value.digest(), &invalid_keypair);
+            let new_data = SenderSignedData::new(
+                data.intent_message().clone(),
+                vec![invalid_signature],
+                data.gas().clone(),
+            );
+            to_sender_signed_transaction(new_data, transaction.tx_signatures()[0].as_ref())
+        }
+        FailureType::LowGasBudget => {
+            let data = transaction.data().clone();
+            let new_data = SenderSignedData::new(
+                data.intent_message().clone(),
+                data.tx_signatures().to_vec(),
+                GasData {
+                    payment: data.gas().payment.clone(),
+                    owner: data.gas().owner,
+                    price: data.gas().price,
+                    budget: 1, // Set to minimum possible value to ensure failure
+                },
+            );
+            to_sender_signed_transaction(new_data, transaction.tx_signatures()[0].as_ref())
+        }
+    }
 }

--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -124,6 +124,8 @@ pub struct BenchmarkStats {
     pub duration: Duration,
     /// Number of transactions that ended in an error
     pub num_error_txes: u64,
+    /// Number of transactions that ended in an error but were expected
+    pub num_expected_error_txes: u64,
     /// Number of transactions that were executed successfully
     pub num_success_txes: u64,
     /// Total number of commands in transactions that executed successfully
@@ -137,6 +139,7 @@ impl BenchmarkStats {
     pub fn update(&mut self, duration: Duration, sample_stat: &BenchmarkStats) {
         self.duration = duration;
         self.num_error_txes += sample_stat.num_error_txes;
+        self.num_expected_error_txes += sample_stat.num_expected_error_txes;
         self.num_success_txes += sample_stat.num_success_txes;
         self.num_success_cmds += sample_stat.num_success_cmds;
         self.total_gas_used += sample_stat.total_gas_used;
@@ -155,6 +158,7 @@ impl BenchmarkStats {
                 "tps",
                 "cps",
                 "error%",
+                "expected error%",
                 "latency (min)",
                 "latency (p50)",
                 "latency (p99)",
@@ -168,6 +172,10 @@ impl BenchmarkStats {
         row.add_cell(Cell::new(
             (100 * self.num_error_txes) as f32
                 / (self.num_error_txes + self.num_success_txes) as f32,
+        ));
+        row.add_cell(Cell::new(
+            (100 * self.num_expected_error_txes) as f32
+                / (self.num_expected_error_txes + self.num_success_txes) as f32,
         ));
         row.add_cell(Cell::new(self.latency_ms.histogram.min()));
         row.add_cell(Cell::new(self.latency_ms.histogram.value_at_quantile(0.5)));

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -742,10 +742,9 @@ impl ValidatorProxy for FullNodeProxy {
                 .await
             {
                 Ok(resp) => {
-                    let effects = ExecutionEffects::SuiTransactionBlockEffects(
+                    return Ok(ExecutionEffects::SuiTransactionBlockEffects(
                         resp.effects.expect("effects field should not be None"),
-                    );
-                    return Ok(effects);
+                    ));
                 }
                 Err(err) => {
                     error!(

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -181,6 +181,9 @@ pub enum RunSpec {
         // relative weight of randomness transactions in the benchmark workload
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
         randomness: Vec<u32>,
+        // relative weight of expected failure transactions in the benchmark workload
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        expected_failure: Vec<u32>,
 
         // --- workload-specific options --- (TODO: use subcommands or similar)
         // 100 for max hotness i.e all requests target
@@ -210,6 +213,12 @@ pub enum RunSpec {
         // Default is (0-0.5) implying random load at 50% load. See `AdversarialPayloadType` enum for `adversarial_type`
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = ["0-1.0".to_string()])]
         adversarial_cfg: Vec<String>,
+        // type and load % of expected failure transactions in the benchmark workload.
+        // Format is "{expected_failure_type}-{load_factor}".
+        // `load_factor` is a number between 0.0 and 1.0 which dictates how much load per tx
+        // Default is (0-0.5) implying random load at 50% load. See `FailureType` enum for `expected_failure_type`
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = ["0-1.0".to_string()])]
+        expected_failure_cfg: Vec<String>,
 
         // --- generic options ---
         // Target qps

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -213,12 +213,10 @@ pub enum RunSpec {
         // Default is (0-0.5) implying random load at 50% load. See `AdversarialPayloadType` enum for `adversarial_type`
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = ["0-1.0".to_string()])]
         adversarial_cfg: Vec<String>,
-        // type and load % of expected failure transactions in the benchmark workload.
-        // Format is "{expected_failure_type}-{load_factor}".
-        // `load_factor` is a number between 0.0 and 1.0 which dictates how much load per tx
-        // Default is (0-0.5) implying random load at 50% load. See `FailureType` enum for `expected_failure_type`
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = ["0-1.0".to_string()])]
-        expected_failure_cfg: Vec<String>,
+        // type of expected failure transactions in the benchmark workload.
+        // See `ExpectedFailureType` enum for `expected_failure_type`
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        expected_failure_type: Vec<u32>,
 
         // --- generic options ---
         // Target qps

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -10,7 +10,7 @@ use crate::in_memory_wallet::move_call_pt_impl;
 use crate::in_memory_wallet::InMemoryWallet;
 use crate::system_state_observer::{SystemState, SystemStateObserver};
 use crate::workloads::payload::Payload;
-use crate::workloads::{Gas, GasCoinConfig};
+use crate::workloads::{workload::ExpectedFailureType, Gas, GasCoinConfig};
 use crate::ProgrammableTransactionBuilder;
 use crate::{convert_move_call_args, BenchMoveCallArg, ExecutionEffects, ValidatorProxy};
 use anyhow::anyhow;
@@ -188,6 +188,10 @@ impl Payload for AdversarialTestPayload {
                 .as_ref()
                 .expect("Protocol config not in system state"),
         )
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -5,7 +5,7 @@ use crate::drivers::Interval;
 use crate::in_memory_wallet::InMemoryWallet;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
-use crate::workloads::workload::{Workload, STORAGE_COST_PER_COIN};
+use crate::workloads::workload::{ExpectedFailureType, Workload, STORAGE_COST_PER_COIN};
 use crate::workloads::workload::{WorkloadBuilder, ESTIMATED_COMPUTATION_COST};
 use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
 use crate::{ExecutionEffects, ValidatorProxy};
@@ -115,6 +115,10 @@ impl Payload for BatchPaymentTestPayload {
                 .reference_gas_price,
             gas_budget,
         )
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -4,7 +4,7 @@
 use crate::drivers::Interval;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
-use crate::workloads::workload::{Workload, WorkloadBuilder};
+use crate::workloads::workload::{ExpectedFailureType, Workload, WorkloadBuilder};
 use crate::workloads::workload::{
     ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COIN,
 };
@@ -79,6 +79,10 @@ impl Payload for DelegationTestPayload {
                     .reference_gas_price,
             ),
         }
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/expected_failure.rs
+++ b/crates/sui-benchmark/src/workloads/expected_failure.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::drivers::Interval;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;

--- a/crates/sui-benchmark/src/workloads/expected_failure.rs
+++ b/crates/sui-benchmark/src/workloads/expected_failure.rs
@@ -1,36 +1,31 @@
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use async_trait::async_trait;
-use rand::seq::IteratorRandom;
-use tracing::error;
-
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use crate::drivers::Interval;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
-use crate::workloads::workload::WorkloadBuilder;
 use crate::workloads::workload::{
-    ExpectedFailureType, Workload, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING,
+    ExpectedFailureType, WorkloadBuilder, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING,
     STORAGE_COST_PER_COIN,
 };
-use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
-use crate::{ExecutionEffects, ValidatorProxy};
+use crate::workloads::{Gas, GasCoinConfig, Workload, WorkloadBuilderInfo, WorkloadParams};
+use crate::ExecutionEffects;
+use crate::ValidatorProxy;
+use anyhow::anyhow;
+use async_trait::async_trait;
+use rand::seq::IteratorRandom;
+use regex::Regex;
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
 use sui_core::test_utils::make_transfer_object_transaction;
-use sui_types::{
-    base_types::{ObjectRef, SuiAddress},
-    crypto::{get_key_pair, AccountKeyPair},
-    transaction::Transaction,
-};
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::{AccountKeyPair, Ed25519SuiSignature};
+use sui_types::signature::GenericSignature;
+use sui_types::{base_types::ObjectRef, crypto::get_key_pair, transaction::Transaction};
+use tracing::debug;
 
-/// TODO: This should be the amount that is being transferred instead of MAX_GAS.
-/// Number of mist sent to each address on each batch transfer
-const _TRANSFER_AMOUNT: u64 = 1;
-
-#[derive(Debug)]
-pub struct TransferObjectTestPayload {
+#[derive(Debug, Clone)]
+pub struct ExpectedFailurePayload {
+    failure_type: ExpectedFailureType,
     transfer_object: ObjectRef,
     transfer_from: SuiAddress,
     transfer_to: SuiAddress,
@@ -38,38 +33,71 @@ pub struct TransferObjectTestPayload {
     system_state_observer: Arc<SystemStateObserver>,
 }
 
-impl Payload for TransferObjectTestPayload {
-    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
-        if !effects.is_ok() {
-            effects.print_gas_summary();
-            error!("Transfer tx failed... Status: {:?}", effects.status());
-        }
+#[derive(Debug, Clone)]
+pub struct ExpectedFailurePayloadCfg {
+    pub failure_type: ExpectedFailureType,
+    pub load_factor: f32,
+}
 
-        let recipient = self.gas.iter().find(|x| x.1 != self.transfer_to).unwrap().1;
-        let updated_gas: Vec<Gas> = self
-            .gas
-            .iter()
-            .map(|x| {
-                if x.1 == self.transfer_from {
-                    (effects.gas_object().0, self.transfer_from, x.2.clone())
-                } else {
-                    x.clone()
-                }
-            })
-            .collect();
-        self.transfer_object = effects
-            .mutated()
-            .iter()
-            .find(|(object_ref, _)| object_ref.0 == self.transfer_object.0)
-            .map(|x| x.0)
-            .unwrap();
-        self.transfer_from = self.transfer_to;
-        self.transfer_to = recipient;
-        self.gas = updated_gas;
+impl FromStr for ExpectedFailurePayloadCfg {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Matches regex for two numbers delimited by a hyphen, where the left number must be positive
+        // and the right number must be a float between 0.0 inclusive and 1.0 inclusive
+        let re = Regex::new(
+            r"^(?:0|[1-9]\d*)-(?:0(?:\.\d+)?|1(?:\.0+)?|[1-9](?:\d*(?:\.\d+)?)?|\.\d+)$",
+        )
+        .unwrap();
+        if !re.is_match(s) {
+            return Err(anyhow!("invalid load config"));
+        };
+        let toks = s.split('-').collect::<Vec<_>>();
+        let failure_type = ExpectedFailureType::from_str(toks[0])?;
+        let load_factor = toks[1].parse::<f32>().unwrap();
+
+        if !(0.0..=1.0).contains(&load_factor) {
+            return Err(anyhow!("invalid load factor. Valid range is [0.0, 1.0]"));
+        };
+
+        Ok(ExpectedFailurePayloadCfg {
+            failure_type,
+            load_factor,
+        })
     }
+}
+impl Copy for ExpectedFailurePayloadCfg {}
+
+impl ExpectedFailurePayload {
+    fn create_failing_transaction(&self, mut tx: Transaction) -> Transaction {
+        match self.failure_type {
+            ExpectedFailureType::InvalidSignature => {
+                let signatures = tx.tx_signatures_mut_for_testing();
+                signatures.pop();
+                signatures.push(GenericSignature::Signature(
+                    sui_types::crypto::Signature::Ed25519SuiSignature(
+                        Ed25519SuiSignature::default(),
+                    ),
+                ));
+                tx
+            }
+            ExpectedFailureType::Random => unreachable!(),
+        }
+    }
+}
+
+impl Payload for ExpectedFailurePayload {
+    fn make_new_payload(&mut self, _effects: &ExecutionEffects) {
+        // This should never be called, as an expected failure payload
+        // should fail (thereby having no effects) and be retried. Note
+        // that since these are failures rather than Move level errors,
+        // no gas should be consumed, nor any objects mutated.
+        unreachable!()
+    }
+
     fn make_transaction(&mut self) -> Transaction {
         let (gas_obj, _, keypair) = self.gas.iter().find(|x| x.1 == self.transfer_from).unwrap();
-        make_transfer_object_transaction(
+        let tx = make_transfer_object_transaction(
             self.transfer_object,
             *gas_obj,
             self.transfer_from,
@@ -79,32 +107,36 @@ impl Payload for TransferObjectTestPayload {
                 .state
                 .borrow()
                 .reference_gas_price,
-        )
+        );
+        self.create_failing_transaction(tx)
     }
+
     fn get_failure_type(&self) -> Option<ExpectedFailureType> {
-        None
+        Some(self.failure_type)
     }
 }
 
-impl std::fmt::Display for TransferObjectTestPayload {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "transfer_object")
+impl fmt::Display for ExpectedFailurePayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ExpectedFailurePayload({:?})", self.failure_type)
     }
 }
 
 #[derive(Debug)]
-pub struct TransferObjectWorkloadBuilder {
+pub struct ExpectedFailureWorkloadBuilder {
+    expected_failure_cfg: ExpectedFailurePayloadCfg,
     num_transfer_accounts: u64,
     num_payloads: u64,
 }
 
-impl TransferObjectWorkloadBuilder {
+impl ExpectedFailureWorkloadBuilder {
     pub fn from(
         workload_weight: f32,
         target_qps: u64,
         num_workers: u64,
         in_flight_ratio: u64,
         num_transfer_accounts: u64,
+        expected_failure_cfg: ExpectedFailurePayloadCfg,
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
@@ -122,9 +154,10 @@ impl TransferObjectWorkloadBuilder {
                 group,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
-                TransferObjectWorkloadBuilder {
-                    num_transfer_accounts,
+                ExpectedFailureWorkloadBuilder {
+                    expected_failure_cfg,
                     num_payloads: max_ops,
+                    num_transfer_accounts,
                 },
             ));
             let builder_info = WorkloadBuilderInfo {
@@ -137,7 +170,7 @@ impl TransferObjectWorkloadBuilder {
 }
 
 #[async_trait]
-impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
+impl WorkloadBuilder<dyn Payload> for ExpectedFailureWorkloadBuilder {
     async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
         vec![]
     }
@@ -184,28 +217,36 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
         _init_gas: Vec<Gas>,
         payload_gas: Vec<Gas>,
     ) -> Box<dyn Workload<dyn Payload>> {
-        Box::<dyn Workload<dyn Payload>>::from(Box::new(TransferObjectWorkload {
+        debug!(
+            "Using `{:?}` expected failure workloads at {}% load factor",
+            self.expected_failure_cfg.failure_type,
+            self.expected_failure_cfg.load_factor * 100.0
+        );
+
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(ExpectedFailureWorkload {
             num_tokens: self.num_payloads,
             payload_gas,
+            expected_failure_cfg: self.expected_failure_cfg,
         }))
     }
 }
 
 #[derive(Debug)]
-pub struct TransferObjectWorkload {
+pub struct ExpectedFailureWorkload {
     num_tokens: u64,
     payload_gas: Vec<Gas>,
+    expected_failure_cfg: ExpectedFailurePayloadCfg,
 }
 
 #[async_trait]
-impl Workload<dyn Payload> for TransferObjectWorkload {
+impl Workload<dyn Payload> for ExpectedFailureWorkload {
     async fn init(
         &mut self,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         _system_state_observer: Arc<SystemStateObserver>,
     ) {
-        return;
     }
+
     async fn make_test_payloads(
         &self,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
@@ -238,7 +279,8 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
             .map(|(g, t)| {
                 let from = t.1;
                 let to = g.iter().find(|x| x.1 != from).unwrap().1;
-                Box::new(TransferObjectTestPayload {
+                Box::new(ExpectedFailurePayload {
+                    failure_type: self.expected_failure_cfg.failure_type,
                     transfer_object: t.0,
                     transfer_from: from,
                     transfer_to: to,

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -4,6 +4,7 @@
 pub mod adversarial;
 pub mod batch_payment;
 pub mod delegation;
+pub mod expected_failure;
 pub mod payload;
 pub mod randomness;
 pub mod shared_counter;

--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{workloads::FailureType, ExecutionEffects};
+use crate::{workloads::ExpectedFailureType, ExecutionEffects};
 use std::fmt::Display;
 use sui_types::transaction::Transaction;
 
@@ -12,7 +12,7 @@ use sui_types::transaction::Transaction;
 pub trait Payload: Send + Sync + std::fmt::Debug + Display {
     fn make_new_payload(&mut self, effects: &ExecutionEffects);
     fn make_transaction(&mut self) -> Transaction;
-    fn get_failure_type(&self) -> Option<FailureType> {
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
         None // Default implementation returns None
     }
 }

--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ExecutionEffects;
+use crate::{workloads::FailureType, ExecutionEffects};
 use std::fmt::Display;
 use sui_types::transaction::Transaction;
 
@@ -12,4 +12,7 @@ use sui_types::transaction::Transaction;
 pub trait Payload: Send + Sync + std::fmt::Debug + Display {
     fn make_new_payload(&mut self, effects: &ExecutionEffects);
     fn make_transaction(&mut self) -> Transaction;
+    fn get_failure_type(&self) -> Option<FailureType> {
+        None // Default implementation returns None
+    }
 }

--- a/crates/sui-benchmark/src/workloads/randomness.rs
+++ b/crates/sui-benchmark/src/workloads/randomness.rs
@@ -6,7 +6,7 @@ use crate::system_state_observer::SystemStateObserver;
 use crate::util::publish_basics_package;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::{
-    Workload, WorkloadBuilder, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING,
+    ExpectedFailureType, Workload, WorkloadBuilder, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING,
 };
 use crate::workloads::GasCoinConfig;
 use crate::workloads::{Gas, WorkloadBuilderInfo, WorkloadParams};
@@ -57,6 +57,9 @@ impl Payload for RandomnessTestPayload {
         TestTransactionBuilder::new(self.gas.1, self.gas.0, rgp)
             .call_emit_random(self.package_id, self.randomness_initial_shared_version)
             .build_and_sign(self.gas.2.as_ref())
+    }
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -6,8 +6,8 @@ use crate::system_state_observer::SystemStateObserver;
 use crate::util::publish_basics_package;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::{
-    Workload, WorkloadBuilder, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING,
-    STORAGE_COST_PER_COUNTER,
+    ExpectedFailureType, Workload, WorkloadBuilder, ESTIMATED_COMPUTATION_COST,
+    MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COUNTER,
 };
 use crate::workloads::GasCoinConfig;
 use crate::workloads::{Gas, WorkloadBuilderInfo, WorkloadParams};
@@ -71,6 +71,9 @@ impl Payload for SharedCounterTestPayload {
                 self.counter_initial_shared_version,
             )
             .build_and_sign(self.gas.2.as_ref())
+    }
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
@@ -6,8 +6,8 @@ use crate::system_state_observer::SystemStateObserver;
 use crate::util::publish_basics_package;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::{
-    Workload, WorkloadBuilder, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING,
-    STORAGE_COST_PER_COUNTER,
+    ExpectedFailureType, Workload, WorkloadBuilder, ESTIMATED_COMPUTATION_COST,
+    MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COUNTER,
 };
 use crate::workloads::GasCoinConfig;
 use crate::workloads::{Gas, WorkloadBuilderInfo, WorkloadParams};
@@ -117,6 +117,9 @@ impl Payload for SharedCounterDeletionTestPayload {
             _ => panic!("Invalid transaction selector"),
         }
         .build_and_sign(self.gas.2.as_ref())
+    }
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -23,6 +23,13 @@ pub const STORAGE_COST_PER_COUNTER: u64 = 341 * 76 * 100;
 /// Used to estimate the budget required for each transaction.
 pub const ESTIMATED_COMPUTATION_COST: u64 = 1_000_000;
 
+#[derive(Debug, Clone, Copy)]
+pub enum FailureType {
+    InvalidSignature,
+    LowGasBudget,
+    // Add other failure types as needed
+}
+
 #[async_trait]
 pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {
     async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig>;

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -5,8 +5,14 @@ use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
 use crate::workloads::{Gas, GasCoinConfig};
 use crate::ValidatorProxy;
+use anyhow::anyhow;
 use async_trait::async_trait;
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
+use std::str::FromStr;
 use std::sync::Arc;
+use strum::{EnumCount, IntoEnumIterator};
+use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 use sui_types::gas_coin::MIST_PER_SUI;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
@@ -23,11 +29,55 @@ pub const STORAGE_COST_PER_COUNTER: u64 = 341 * 76 * 100;
 /// Used to estimate the budget required for each transaction.
 pub const ESTIMATED_COMPUTATION_COST: u64 = 1_000_000;
 
-#[derive(Debug, Clone, Copy)]
-pub enum FailureType {
+#[derive(Debug, EnumCountMacro, EnumIter, Clone, Copy)]
+pub enum ExpectedFailureType {
+    Random = 0,
     InvalidSignature,
-    LowGasBudget,
-    // Add other failure types as needed
+    // TODO: Add other failure types
+}
+
+impl TryFrom<u32> for ExpectedFailureType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(rand::random()),
+            _ => ExpectedFailureType::iter()
+                .nth(value as usize)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Invalid failure type specifier. Valid options are {} to {}",
+                        0,
+                        ExpectedFailureType::COUNT
+                    )
+                }),
+        }
+    }
+}
+
+impl FromStr for ExpectedFailureType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v = u32::from_str(s).map(ExpectedFailureType::try_from);
+
+        if let Ok(Ok(q)) = v {
+            return Ok(q);
+        }
+
+        Err(anyhow!(
+            "Invalid input string. Valid values are 0 to {}",
+            ExpectedFailureType::COUNT
+        ))
+    }
+}
+
+impl Distribution<ExpectedFailureType> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ExpectedFailureType {
+        // Exclude the "Random" variant
+        let n = rng.gen_range(1..ExpectedFailureType::COUNT);
+        ExpectedFailureType::iter().nth(n).unwrap()
+    }
 }
 
 #[async_trait]

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -17,9 +17,36 @@ use std::sync::Arc;
 use tracing::info;
 
 use super::adversarial::{AdversarialPayloadCfg, AdversarialWorkloadBuilder};
+use super::expected_failure::{ExpectedFailurePayloadCfg, ExpectedFailureWorkloadBuilder};
 use super::randomness::RandomnessWorkloadBuilder;
 use super::shared_object_deletion::SharedCounterDeletionWorkloadBuilder;
 
+pub struct WorkloadWeights {
+    pub shared_counter: u32,
+    pub transfer_object: u32,
+    pub delegation: u32,
+    pub batch_payment: u32,
+    pub shared_deletion: u32,
+    pub adversarial: u32,
+    pub expected_failure: u32,
+    pub randomness: u32,
+}
+
+pub struct WorkloadConfig {
+    pub group: u32,
+    pub num_workers: u64,
+    pub num_transfer_accounts: u64,
+    pub weights: WorkloadWeights,
+    pub adversarial_cfg: AdversarialPayloadCfg,
+    pub expected_failure_cfg: ExpectedFailurePayloadCfg,
+    pub batch_payment_size: u32,
+    pub shared_counter_hotness_factor: u32,
+    pub num_shared_counters: Option<u64>,
+    pub shared_counter_max_tip: u64,
+    pub target_qps: u64,
+    pub in_flight_ratio: u64,
+    pub duration: Interval,
+}
 pub struct WorkloadConfiguration;
 
 impl WorkloadConfiguration {
@@ -40,12 +67,14 @@ impl WorkloadConfiguration {
                 delegation,
                 batch_payment,
                 adversarial,
+                expected_failure,
                 randomness,
                 shared_counter_hotness_factor,
                 num_shared_counters,
                 shared_counter_max_tip,
                 batch_payment_size,
                 adversarial_cfg,
+                expected_failure_cfg,
                 target_qps,
                 num_workers,
                 in_flight_ratio,
@@ -60,28 +89,36 @@ impl WorkloadConfiguration {
                 // benchmark group will run in the same time for the same duration.
                 for workload_group in 0..num_of_benchmark_groups {
                     let i = workload_group as usize;
-                    let builders = Self::create_workload_builders(
-                        workload_group,
-                        num_workers[i],
-                        opts.num_transfer_accounts,
-                        shared_counter[i],
-                        transfer_object[i],
-                        delegation[i],
-                        batch_payment[i],
-                        shared_deletion[i],
-                        adversarial[i],
-                        AdversarialPayloadCfg::from_str(&adversarial_cfg[i]).unwrap(),
-                        randomness[i],
-                        batch_payment_size[i],
-                        shared_counter_hotness_factor[i],
-                        num_shared_counters.as_ref().map(|n| n[i]),
-                        shared_counter_max_tip[i],
-                        target_qps[i],
-                        in_flight_ratio[i],
-                        duration[i],
-                        system_state_observer.clone(),
-                    )
-                    .await;
+                    let config = WorkloadConfig {
+                        group: workload_group,
+                        num_workers: num_workers[i],
+                        num_transfer_accounts: opts.num_transfer_accounts,
+                        weights: WorkloadWeights {
+                            shared_counter: shared_counter[i],
+                            transfer_object: transfer_object[i],
+                            delegation: delegation[i],
+                            batch_payment: batch_payment[i],
+                            shared_deletion: shared_deletion[i],
+                            adversarial: adversarial[i],
+                            expected_failure: expected_failure[i],
+                            randomness: randomness[i],
+                        },
+                        adversarial_cfg: AdversarialPayloadCfg::from_str(&adversarial_cfg[i])
+                            .unwrap(),
+                        expected_failure_cfg: ExpectedFailurePayloadCfg::from_str(
+                            &expected_failure_cfg[i],
+                        )
+                        .unwrap(),
+                        batch_payment_size: batch_payment_size[i],
+                        shared_counter_hotness_factor: shared_counter_hotness_factor[i],
+                        num_shared_counters: num_shared_counters.as_ref().map(|n| n[i]),
+                        shared_counter_max_tip: shared_counter_max_tip[i],
+                        target_qps: target_qps[i],
+                        in_flight_ratio: in_flight_ratio[i],
+                        duration: duration[i],
+                    };
+                    let builders =
+                        Self::create_workload_builders(config, system_state_observer.clone()).await;
                     workload_builders.extend(builders);
                 }
 
@@ -139,37 +176,35 @@ impl WorkloadConfiguration {
     }
 
     pub async fn create_workload_builders(
-        workload_group: u32,
-        num_workers: u64,
-        num_transfer_accounts: u64,
-        shared_counter_weight: u32,
-        transfer_object_weight: u32,
-        delegation_weight: u32,
-        batch_payment_weight: u32,
-        shared_deletion_weight: u32,
-        adversarial_weight: u32,
-        adversarial_cfg: AdversarialPayloadCfg,
-        randomness_weight: u32,
-        batch_payment_size: u32,
-        shared_counter_hotness_factor: u32,
-        num_shared_counters: Option<u64>,
-        shared_counter_max_tip: u64,
-        target_qps: u64,
-        in_flight_ratio: u64,
-        duration: Interval,
+        WorkloadConfig {
+            group,
+            num_workers,
+            num_transfer_accounts,
+            weights,
+            adversarial_cfg,
+            expected_failure_cfg,
+            batch_payment_size,
+            shared_counter_hotness_factor,
+            num_shared_counters,
+            shared_counter_max_tip,
+            target_qps,
+            in_flight_ratio,
+            duration,
+        }: WorkloadConfig,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Option<WorkloadBuilderInfo>> {
-        let total_weight = shared_counter_weight
-            + shared_deletion_weight
-            + transfer_object_weight
-            + delegation_weight
-            + batch_payment_weight
-            + adversarial_weight
-            + randomness_weight;
+        let total_weight = weights.shared_counter
+            + weights.shared_deletion
+            + weights.transfer_object
+            + weights.delegation
+            + weights.batch_payment
+            + weights.adversarial
+            + weights.randomness
+            + weights.expected_failure;
         let reference_gas_price = system_state_observer.state.borrow().reference_gas_price;
         let mut workload_builders = vec![];
         let shared_workload = SharedCounterWorkloadBuilder::from(
-            shared_counter_weight as f32 / total_weight as f32,
+            weights.shared_counter as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
@@ -178,11 +213,11 @@ impl WorkloadConfiguration {
             shared_counter_max_tip,
             reference_gas_price,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(shared_workload);
         let shared_deletion_workload = SharedCounterDeletionWorkloadBuilder::from(
-            shared_deletion_weight as f32 / total_weight as f32,
+            weights.shared_deletion as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
@@ -190,58 +225,69 @@ impl WorkloadConfiguration {
             shared_counter_max_tip,
             reference_gas_price,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(shared_deletion_workload);
         let transfer_workload = TransferObjectWorkloadBuilder::from(
-            transfer_object_weight as f32 / total_weight as f32,
+            weights.transfer_object as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             num_transfer_accounts,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(transfer_workload);
         let delegation_workload = DelegationWorkloadBuilder::from(
-            delegation_weight as f32 / total_weight as f32,
+            weights.delegation as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(delegation_workload);
         let batch_payment_workload = BatchPaymentWorkloadBuilder::from(
-            batch_payment_weight as f32 / total_weight as f32,
+            weights.batch_payment as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             batch_payment_size,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(batch_payment_workload);
         let adversarial_workload = AdversarialWorkloadBuilder::from(
-            adversarial_weight as f32 / total_weight as f32,
+            weights.adversarial as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             adversarial_cfg,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(adversarial_workload);
         let randomness_workload = RandomnessWorkloadBuilder::from(
-            randomness_weight as f32 / total_weight as f32,
+            weights.randomness as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             reference_gas_price,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(randomness_workload);
+        let expected_failure_workload = ExpectedFailureWorkloadBuilder::from(
+            weights.expected_failure as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+            num_transfer_accounts,
+            expected_failure_cfg,
+            duration,
+            group,
+        );
+        workload_builders.push(expected_failure_workload);
 
         workload_builders
     }

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -9,7 +9,7 @@ use crate::workloads::batch_payment::BatchPaymentWorkloadBuilder;
 use crate::workloads::delegation::DelegationWorkloadBuilder;
 use crate::workloads::shared_counter::SharedCounterWorkloadBuilder;
 use crate::workloads::transfer_object::TransferObjectWorkloadBuilder;
-use crate::workloads::{GroupID, WorkloadBuilderInfo, WorkloadInfo};
+use crate::workloads::{ExpectedFailureType, GroupID, WorkloadBuilderInfo, WorkloadInfo};
 use anyhow::Result;
 use std::collections::BTreeMap;
 use std::str::FromStr;
@@ -74,7 +74,7 @@ impl WorkloadConfiguration {
                 shared_counter_max_tip,
                 batch_payment_size,
                 adversarial_cfg,
-                expected_failure_cfg,
+                expected_failure_type,
                 target_qps,
                 num_workers,
                 in_flight_ratio,
@@ -105,10 +105,10 @@ impl WorkloadConfiguration {
                         },
                         adversarial_cfg: AdversarialPayloadCfg::from_str(&adversarial_cfg[i])
                             .unwrap(),
-                        expected_failure_cfg: ExpectedFailurePayloadCfg::from_str(
-                            &expected_failure_cfg[i],
-                        )
-                        .unwrap(),
+                        expected_failure_cfg: ExpectedFailurePayloadCfg {
+                            failure_type: ExpectedFailureType::try_from(expected_failure_type[i])
+                                .unwrap(),
+                        },
                         batch_payment_size: batch_payment_size[i],
                         shared_counter_hotness_factor: shared_counter_hotness_factor[i],
                         num_shared_counters: num_shared_counters.as_ref().map(|n| n[i]),

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -565,7 +565,7 @@ mod test {
 
         let expected_tps = target_qps * num_workers;
         let error_policy_type = PolicyType::FreqThreshold(FreqThresholdConfig {
-            client_threshold: expected_tps - 10,
+            client_threshold: expected_tps / 2,
             window_size_secs: 5,
             update_interval_secs: 1,
             ..Default::default()
@@ -585,19 +585,18 @@ mod test {
         let network_config = ConfigBuilder::new_with_temp_dir()
             .committee_size(NonZeroUsize::new(4).unwrap())
             .with_policy_config(Some(policy_config))
+            .with_epoch_duration(5000)
             .build();
         let test_cluster = Arc::new(
             TestClusterBuilder::new()
                 .set_network_config(network_config)
-                .with_epoch_duration_ms(5000)
                 .build()
                 .await,
         );
 
         let mut simulated_load_config = SimulatedLoadConfig::default();
         {
-            let mut rng = thread_rng();
-            simulated_load_config.expected_failure_weight = if rng.gen_bool(0.5) { 5 } else { 50 };
+            simulated_load_config.expected_failure_weight = 20;
             simulated_load_config.expected_failure_config.failure_type =
                 ExpectedFailureType::try_from(0).unwrap();
             info!("Simulated load config: {:?}", simulated_load_config);


### PR DESCRIPTION
## Description 

Introduce a new payload type into the benchmark tool - `ExpectedFailurePayload`. 

This payload type is configured with some expected failure type (currently only one implemented - user signature failure - but others can be added with minimal scaffolding) such that `payload.make_transaction()` generates a transaction that will fail in this manner.  Note that the failures that this payload type is concerned with are failures to execute the transaction itself, rather than during execution by the MoveVM. In other words, it is expected that the failure mode will not consume gas or produce effects.

Note that for this reason, its failure mode is inverted. It will be tallied for metrics purposes as an `error` if it succeeds and tallied as an `expected_error` (which is a success) if it fails. 

Also note that transaction responses for this type are handled by producing a `NextOp::Retry` (with some additional logging/metrics) since it is functionally equivalent to a retryable error. 

## Test plan 

Ran the following:
```
SIM_STRESS_TEST_QPS=200 SIM_STRESS_TEST_WORKERS=20 RUST_LOG=debug cargo simtest --nocapture test_simulated_load_expected_failure_traffic_control
```

Observed the following in logs
```
2022-01-03T02:05:47.734507Z  INFO node{id=1 name="client"}: simtest::test: crates/sui-benchmark/tests/simtest.rs:1088: end of test BenchmarkStats { duration: 50.000002242s, num_error_txes: 0, num_expected_error_txes: 8049, num_success_txes: 348, num_success_cmds: 1977, total_gas_used: 3215776400, latency_ms: HistogramWrapper { histogram: Histogram { auto_resize: false, highest_trackable_value: 120000, lowest_discernible_value: 1, significant_value_digits: 3, bucket_count: 7, sub_bucket_count: 2048, sub_bucket_half_count: 1024, sub_bucket_half_count_magnitude: 10, sub_bucket_mask: 2047, leading_zero_count_base: 53, unit_magnitude: 0, unit_magnitude_mask: 0, max_value: 14359, min_non_zero_value: 72, total_count: 348, counts: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 8, 12, 9, 20, 25, 22, 19
...
```

[Also ran in PTN](https://metrics.sui.io/d/adl51ctsvmkg0a/traffic-control-dos-protection-dashboard?from=2024-10-31T19:00:50.548Z&to=2024-10-31T20:20:03.673Z&timezone=browser&var-network=private-testnet&var-host=$__all&var-fullnode=$__all)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
