### PR TITLE
[Rosetta] - skip balance change response in rosetta if symbol is empty

### DIFF
--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -651,7 +651,9 @@ impl Operations {
             .ok_or_else(|| anyhow!("Response balance changes should not be empty."))?
         {
             if let Ok(currency) = cache.get_currency(&balance_change.coin_type).await {
-                balance_changes.push((balance_change.clone(), currency));
+                if !currency.symbol.is_empty() {
+                    balance_changes.push((balance_change.clone(), currency));
+                }
             }
         }
 

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_no_symbol/Move.toml
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_no_symbol/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test_coin"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+[addresses]
+test_coin = "0x0"

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_no_symbol/sources/test_coin.move
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_no_symbol/sources/test_coin.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: test_coin
+module test_coin::test_coin {
+
+    use sui::coin;
+
+    public struct TEST_COIN has drop {}
+
+    fun init(witness: TEST_COIN, ctx: &mut TxContext) {
+        let (treasury, metadata) = coin::create_currency(
+            witness,
+            6,
+            b"",
+            b"",
+            b"",
+            option::none(),
+            ctx
+        );
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury, ctx.sender())
+    }
+}

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
@@ -131,8 +131,8 @@ pub async fn init_package(
     client: &SuiClient,
     keystore: &Keystore,
     sender: SuiAddress,
+    path: &Path,
 ) -> Result<InitRet> {
-    let path = Path::new("tests/custom_coins/test_coin");
     let path_buf = base::reroot_path(Some(path))?;
 
     let move_build_config = MoveBuildConfig::default();
@@ -266,7 +266,14 @@ async fn test_mint() {
     let keystore = &test_cluster.wallet.config.keystore;
 
     let sender = test_cluster.get_address_0();
-    let init_ret = init_package(&client, keystore, sender).await.unwrap();
+    let init_ret = init_package(
+        &client,
+        keystore,
+        sender,
+        Path::new("tests/custom_coins/test_coin"),
+    )
+    .await
+    .unwrap();
 
     let address1 = test_cluster.get_address_1();
     let address2 = test_cluster.get_address_2();


### PR DESCRIPTION
## Description 

This is a fix to disregard coin balance change response for coins with empty symbol.

## Test plan 

Unit test
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
