### PR TITLE
Add honeypot coin warnings to Wallet

### DIFF
--- a/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
@@ -13,6 +13,13 @@ export type ScamOverlayProps = {
 	subtitle?: string;
 };
 
+export type WarningOverlayProps = {
+	onDismiss(): void;
+	open: boolean;
+	title?: string;
+	subtitles?: string[];
+};
+
 export function ScamOverlay({ open, onDismiss, title, subtitle }: ScamOverlayProps) {
 	if (!open) return null;
 	return (
@@ -29,6 +36,37 @@ export function ScamOverlay({ open, onDismiss, title, subtitle }: ScamOverlayPro
 								'This website has been flagged for malicious behavior. To protect your wallet from potential threats, please return to safety.'}
 						</div>
 					</div>
+				</div>
+
+				<div className="gap-2 mt-auto w-full items-stretch">
+					<Button variant="primary" text="I understand" onClick={onDismiss} />
+				</div>
+			</div>
+		</Portal>
+	);
+}
+
+export function WarningOverlay({ open, onDismiss, title, subtitles }: WarningOverlayProps) {
+	if (!open) return null;
+
+	return (
+		<Portal containerId="overlay-portal-container">
+			<div className="h-full w-full bg-issue-light flex flex-col p-4 justify-center items-center gap-4 absolute top-0 left-0 bottom-0 z-50">
+				<WarningSvg />
+				<div className="flex flex-col gap-2 text-center pb-4">
+					<Heading variant="heading2" weight="semibold" color="gray-90">
+						{title || 'Restricted coin(s) detected'}
+					</Heading>
+
+					{(
+						subtitles || [
+							'A coin in this transaction may have implemented restrictions on what you can do with it once in your wallet. Acquiring this coin may result in your inability to sell it or other adverse effects.',
+						]
+					).map((subtitle) => (
+						<div className="flex text-center font-medium text-pBody text-gray-90">
+							<div className="font-medium text-pBody text-gray-90">{subtitle}</div>
+						</div>
+					))}
 				</div>
 
 				<div className="gap-2 mt-auto w-full items-stretch">

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/types.ts
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/types.ts
@@ -15,6 +15,11 @@ export type DappPreflightResponse = {
 		title: string;
 		subtitle: string;
 	};
+	warnings: {
+		enabled: boolean;
+		title: string;
+		subtitles: string[];
+	};
 };
 
 export type Network = 'mainnet' | 'testnet' | 'devnet' | 'local';

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/useShowScamWarning.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/useShowScamWarning.tsx
@@ -37,7 +37,8 @@ export function useShowScamWarning({
 
 	return {
 		data,
-		isOpen: !!data?.block.enabled && !isError,
+		showScam: !!data?.block.enabled && !isError,
+		showWarning: !!data?.warnings.enabled && !isError,
 		isPending,
 		isError,
 	};

--- a/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
+++ b/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
@@ -15,7 +15,7 @@ import { txRequestsSelectors } from '../../redux/slices/transaction-requests';
 import { Button } from '../../shared/ButtonUI';
 import { UnlockAccountButton } from '../accounts/UnlockAccountButton';
 import { DAppInfoCard } from '../DAppInfoCard';
-import { ScamOverlay } from '../known-scam-overlay';
+import { ScamOverlay, WarningOverlay } from '../known-scam-overlay';
 import { RequestType } from '../known-scam-overlay/types';
 import { useShowScamWarning } from '../known-scam-overlay/useShowScamWarning';
 
@@ -83,7 +83,8 @@ export function UserApproveContainer({
 
 	const {
 		data,
-		isOpen,
+		showScam,
+		showWarning,
 		isPending: isDomainCheckLoading,
 		isError,
 	} = useShowScamWarning({
@@ -100,9 +101,15 @@ export function UserApproveContainer({
 	return (
 		<>
 			<ScamOverlay
-				open={isOpen}
+				open={showScam}
 				title={data?.block.title}
 				subtitle={data?.block.subtitle}
+				onDismiss={() => handleOnResponse(false)}
+			/>
+			<WarningOverlay
+				open={showWarning}
+				title={data?.warnings.title}
+				subtitles={data?.warnings.subtitles}
 				onDismiss={() => handleOnResponse(false)}
 			/>
 			<div className="flex flex-1 flex-col flex-nowrap h-full">


### PR DESCRIPTION
## Description 

This change along with the corresponding app-backend change, allows the Wallet to ask ask the app-backend via the dappPreFlight api if a coin in the proposed transaction is a honey pot coin.  

A honey pot coin is any coin that uses a deny_list.  For the very few legitimate use cases, we have a recognized package list we can add them to.

If dappPreFlight returns a honey pot warning, the wallet will now show a new warning UI to the user.

## Test plan 

The following scenarios cover all the change paths:
– Submitting a transaction to dappPreFlight with a honeypot coin.
– Submitting a transaction to dappPreFlight with multiple honeypot coins.
– Performing a Swap in the wallet (note the wallet only shows recognized coins in the swap UI).


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [X] REST API:

For the apps-backend.sui.io/v1/dapp-preflight, the type DappPreflightResponse now has an additional warning dict.
Thus DappPreflightResponse is now;
export type DappPreflightResponse = {
	block: {
		enabled: boolean;
		title: string;
		subtitle: string;
	};
	warnings: {
		enabled: boolean;
		title: string;
		subtitles: string[];
	};
};

Since the backed for this rest api is the app-backed that we are also changing, there is no additional risk.

