### PR TITLE
Lower per object queue age and length thresholds

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -876,7 +876,7 @@ pub struct AuthorityOverloadConfig {
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
-    Duration::from_secs(1)
+    Duration::from_millis(200)
 }
 
 fn default_overload_monitor_interval() -> Duration {
@@ -912,7 +912,7 @@ fn default_max_transaction_manager_queue_length() -> usize {
 }
 
 fn default_max_transaction_manager_per_object_queue_length() -> usize {
-    100
+    20
 }
 
 impl Default for AuthorityOverloadConfig {

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -147,8 +147,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -163,7 +163,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -319,8 +319,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -335,7 +335,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -491,8 +491,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -507,7 +507,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -663,8 +663,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -679,7 +679,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -835,8 +835,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -851,7 +851,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1007,8 +1007,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -1023,7 +1023,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1179,8 +1179,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 200000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -1195,7 +1195,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache:
       writeback-cache:
         max_cache_size: ~


### PR DESCRIPTION
## Description 

The original limits on the object queue are set with 1s checkpoint interval. Having the oldest transaction on an object queued for 1s is almost tolerable. In hindsight it should be lower than the checkpoint interval to ensure healthy system. Now checkpoint interval is targeting 0.2s - 0.25s, so lowering the limits further to 0.2s, to ensure smooth checkpoint constructions.

## Test plan 

CI
PT
Reading `num_rejected_cert_during_overload` metric from validators.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
