### PR TITLE
[db] allow putting larger layer in higher levels

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2523,7 +2523,6 @@ impl DBOptions {
         // Switch to universal compactions.
         self.options
             .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
-        self.options.set_num_levels(1);
         let mut compaction_options = rocksdb::UniversalCompactOptions::default();
         compaction_options.set_max_size_amplification_percent(10000);
         compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);


### PR DESCRIPTION
## Description 

A followup to #19770. For cfs larger than 250GB, they need to be able to shard the files.

## Test plan 

Applied the new setting to other large cfs (transactions, effects) on fullnodes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
