### PR TITLE
Get pool DEEP conversion in SDK

### DIFF
--- a/.changeset/curvy-walls-pull.md
+++ b/.changeset/curvy-walls-pull.md
@@ -1,0 +1,5 @@
+---
+'@mysten/deepbook-v3': patch
+---
+
+Deep conversion

--- a/sdk/deepbook-v3/src/client.ts
+++ b/sdk/deepbook-v3/src/client.ts
@@ -601,7 +601,7 @@ export class DeepBookClient {
 	/**
 	 * @description Get the DEEP price conversion for a pool
 	 * @param {string} poolKey Key of the pool
-	 * @returns {Promise<number>} Deep price conversion
+	 * @returns {Promise<{ asset_is_base: bool, deep_per_quote: number }>} Deep price conversion
 	 */
 	async getPoolDeepPrice(poolKey: string) {
 		const tx = new Transaction();

--- a/sdk/deepbook-v3/src/client.ts
+++ b/sdk/deepbook-v3/src/client.ts
@@ -601,7 +601,7 @@ export class DeepBookClient {
 	/**
 	 * @description Get the DEEP price conversion for a pool
 	 * @param {string} poolKey Key of the pool
-	 * @returns {Promise<number>} OrderDeepPrice for the pool
+	 * @returns {Promise<number>} Deep price conversion
 	 */
 	async getPoolDeepPrice(poolKey: string) {
 		const tx = new Transaction();

--- a/sdk/deepbook-v3/src/client.ts
+++ b/sdk/deepbook-v3/src/client.ts
@@ -597,4 +597,48 @@ export class DeepBookClient {
 			deep: Number((deepLocked / DEEP_SCALAR).toFixed(9)),
 		};
 	}
+
+	/**
+	 * @description Get the DEEP price conversion for a pool
+	 * @param {string} poolKey Key of the pool
+	 * @returns {Promise<number>} OrderDeepPrice for the pool
+	 */
+	async getPoolDeepPrice(poolKey: string) {
+		const tx = new Transaction();
+		const pool = this.#config.getPool(poolKey);
+		tx.add(this.deepBook.getPoolDeepPrice(poolKey));
+
+		const baseCoin = this.#config.getCoin(pool.baseCoin);
+		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
+		const deepCoin = this.#config.getCoin('DEEP');
+
+		const res = await this.client.devInspectTransactionBlock({
+			sender: normalizeSuiAddress(this.#address),
+			transactionBlock: tx,
+		});
+
+		const OrderDeepPrice = bcs.struct('OrderDeepPrice', {
+			asset_is_base: bcs.bool(),
+			deep_per_asset: bcs.u64(),
+		});
+
+		const poolDeepPriceBytes = res.results![0].returnValues![0][0];
+		const poolDeepPrice = OrderDeepPrice.parse(new Uint8Array(poolDeepPriceBytes));
+
+		if (poolDeepPrice.asset_is_base) {
+			return {
+				asset_is_base: poolDeepPrice.asset_is_base,
+				deep_per_base:
+					((Number(poolDeepPrice.deep_per_asset) / FLOAT_SCALAR) * baseCoin.scalar) /
+					deepCoin.scalar,
+			};
+		} else {
+			return {
+				asset_is_base: poolDeepPrice.asset_is_base,
+				deep_per_quote:
+					((Number(poolDeepPrice.deep_per_asset) / FLOAT_SCALAR) * quoteCoin.scalar) /
+					deepCoin.scalar,
+			};
+		}
+	}
 }

--- a/sdk/deepbook-v3/src/transactions/deepbook.ts
+++ b/sdk/deepbook-v3/src/transactions/deepbook.ts
@@ -667,4 +667,21 @@ export class DeepBookContract {
 			typeArguments: [baseCoin.type, quoteCoin.type],
 		});
 	};
+
+	/**
+	 * @description Get the DEEP price conversion for a pool
+	 * @param {string} poolKey The key to identify the pool
+	 * @returns A function that takes a Transaction object
+	 */
+	getPoolDeepPrice = (poolKey: string) => (tx: Transaction) => {
+		const pool = this.#config.getPool(poolKey);
+		const baseCoin = this.#config.getCoin(pool.baseCoin);
+		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
+
+		tx.moveCall({
+			target: `${this.#config.DEEPBOOK_PACKAGE_ID}::pool::get_order_deep_price`,
+			arguments: [tx.object(pool.address)],
+			typeArguments: [baseCoin.type, quoteCoin.type],
+		});
+	};
 }


### PR DESCRIPTION
## Description 

Get pool DEEP conversion in SDK

## Test plan 

How did you test the new or updated feature?

SDK on mainnet
Sample output: { asset_is_base: false, deep_per_quote: 28.613793980999997 }
This corresponds to the current DEEP price

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
