### PR TITLE
Enable signed Discovery messages by default

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -323,7 +323,7 @@ pub struct DiscoveryConfig {
     /// If true, Discovery will require all provided peer information to be signed
     /// by the originating peer.
     ///
-    /// If unspecified, this will default to false.
+    /// If unspecified, this will default to true.
     pub enable_node_info_signatures: Option<bool>,
 }
 
@@ -353,7 +353,7 @@ impl DiscoveryConfig {
     }
 
     pub fn enable_node_info_signatures(&self) -> bool {
-        self.enable_node_info_signatures.unwrap_or(false)
+        self.enable_node_info_signatures.unwrap_or(true)
     }
 }
 


### PR DESCRIPTION
## Description 

Followup to PR #19587.

## Test plan 

As tested in first PR.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Adds authentication signatures to Discovery protocol messages.
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
