### PR TITLE
[indexer] quick fix for events in descending order without cursor

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -974,10 +974,9 @@ impl IndexerReader {
                 )
                 .first::<i64>(&mut connection)
                 .await?;
-            (tx_seq, event_seq)
+            (tx_seq, event_seq as i64)
         } else if descending_order {
-            let max_tx_seq = u64::MAX as i64;
-            (max_tx_seq + 1, 0)
+            (i64::MAX, i64::MAX)
         } else {
             (-1, 0)
         };


### PR DESCRIPTION
## Description 

This PR fixes a bug where events queries in descending order without a cursor return no results 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
