### PR TITLE
Add support for overages on congestion control limits, with accumulated debt tracking

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -462,7 +462,7 @@ mod test {
         let txn_count_limit; // When using transaction count as congestion control mode, the limit of transactions per object per commit.
         let max_deferral_rounds;
         let cap_factor_denominator;
-        let allow_overage;
+        let allow_overage_factor;
         {
             let mut rng = thread_rng();
             mode = if rng.gen_bool(0.33) {
@@ -481,7 +481,11 @@ mod test {
             } else {
                 rng.gen_range(1000..10000) // Large deferral round (testing liveness)
             };
-            allow_overage = rng.gen_bool(0.5);
+            allow_overage_factor = if rng.gen_bool(0.5) {
+                0
+            } else {
+                rng.gen_range(1..100)
+            };
 
             cap_factor_denominator = rng.gen_range(1..100);
         }
@@ -522,7 +526,9 @@ mod test {
                 },
             }
             config.set_max_deferral_rounds_for_congestion_control_for_testing(max_deferral_rounds);
-            config.set_congestion_control_allow_overage_for_testing(allow_overage);
+            config.set_max_txn_cost_overage_per_object_in_commit_for_testing(
+                allow_overage_factor * total_gas_limit,
+            );
             config
         });
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -462,6 +462,7 @@ mod test {
         let txn_count_limit; // When using transaction count as congestion control mode, the limit of transactions per object per commit.
         let max_deferral_rounds;
         let cap_factor_denominator;
+        let allow_overage;
         {
             let mut rng = thread_rng();
             mode = if rng.gen_bool(0.33) {
@@ -480,16 +481,16 @@ mod test {
             } else {
                 rng.gen_range(1000..10000) // Large deferral round (testing liveness)
             };
+            allow_overage = rng.gen_bool(0.5);
 
             cap_factor_denominator = rng.gen_range(1..100);
         }
 
         info!(
             "test_simulated_load_shared_object_congestion_control setup.
-             mode: {:?}, checkpoint_budget_factor: {:?},
-             max_deferral_rounds: {:?},
-             txn_count_limit: {:?}",
-            mode, checkpoint_budget_factor, max_deferral_rounds, txn_count_limit
+             mode: {mode:?}, checkpoint_budget_factor: {checkpoint_budget_factor:?},
+             max_deferral_rounds: {max_deferral_rounds:?},
+             txn_count_limit: {txn_count_limit:?}, allow_overage: {allow_overage:?}",
         );
 
         let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, mut config| {
@@ -521,6 +522,7 @@ mod test {
                 },
             }
             config.set_max_deferral_rounds_for_congestion_control_for_testing(max_deferral_rounds);
+            config.set_congestion_control_allow_overage_for_testing(allow_overage);
             config
         });
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -494,17 +494,17 @@ mod test {
             "test_simulated_load_shared_object_congestion_control setup.
              mode: {mode:?}, checkpoint_budget_factor: {checkpoint_budget_factor:?},
              max_deferral_rounds: {max_deferral_rounds:?},
-             txn_count_limit: {txn_count_limit:?}, allow_overage: {allow_overage:?}",
+             txn_count_limit: {txn_count_limit:?}, allow_overage_factor: {allow_overage_factor:?}",
         );
 
         let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, mut config| {
+            let total_gas_limit = checkpoint_budget_factor
+                * DEFAULT_VALIDATOR_GAS_PRICE
+                * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE;
             config.set_per_object_congestion_control_mode_for_testing(mode);
             match mode {
                 PerObjectCongestionControlMode::None => panic!("Congestion control mode cannot be None in test_simulated_load_shared_object_congestion_control"),
                 PerObjectCongestionControlMode::TotalGasBudget => {
-                    let total_gas_limit = checkpoint_budget_factor
-                        * DEFAULT_VALIDATOR_GAS_PRICE
-                        * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE;
                     config.set_max_accumulated_txn_cost_per_object_in_narwhal_commit_for_testing(total_gas_limit);
                     config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(total_gas_limit);
                 },
@@ -517,9 +517,6 @@ mod test {
                     );
                 },
                 PerObjectCongestionControlMode::TotalGasBudgetWithCap => {
-                    let total_gas_limit = checkpoint_budget_factor
-                        * DEFAULT_VALIDATOR_GAS_PRICE
-                        * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE;
                     config.set_max_accumulated_txn_cost_per_object_in_narwhal_commit_for_testing(total_gas_limit);
                     config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(total_gas_limit);
                     config.set_gas_budget_based_txn_cost_cap_factor_for_testing(total_gas_limit/cap_factor_denominator);

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2846,10 +2846,10 @@ impl AuthorityPerEpochStore {
             .protocol_config()
             .max_accumulated_txn_cost_per_object_in_mysticeti_commit_as_option()
             .unwrap_or(0);
-        let congestion_control_allow_overage = self
+        let max_txn_cost_overage_per_object_in_commit = self
             .protocol_config()
-            .congestion_control_allow_overage_as_option()
-            .unwrap_or(false);
+            .max_txn_cost_overage_per_object_in_commit_as_option()
+            .unwrap_or(0);
         let shared_object_congestion_tracker = SharedObjectCongestionTracker::new(
             tables.load_initial_object_debts(
                 consensus_commit_info.round,
@@ -2862,7 +2862,7 @@ impl AuthorityPerEpochStore {
                 .max_accumulated_txn_cost_per_object_in_mysticeti_commit_as_option(),
             self.protocol_config()
                 .gas_budget_based_txn_cost_cap_factor_as_option(),
-            congestion_control_allow_overage,
+            max_txn_cost_overage_per_object_in_commit,
         );
         let shared_object_using_randomness_congestion_tracker = SharedObjectCongestionTracker::new(
             tables.load_initial_object_debts(
@@ -2876,7 +2876,7 @@ impl AuthorityPerEpochStore {
                 .max_accumulated_txn_cost_per_object_in_mysticeti_commit_as_option(),
             self.protocol_config()
                 .gas_budget_based_txn_cost_cap_factor_as_option(),
-            congestion_control_allow_overage,
+            max_txn_cost_overage_per_object_in_commit,
         );
 
         // We always order transactions using randomness last.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2421,7 +2421,6 @@ impl AuthorityPerEpochStore {
     }
 
     pub fn get_reconfig_state_write_lock_guard(&self) -> RwLockWriteGuard<ReconfigState> {
-        // the below is copy-pasted placeholder
         self.reconfig_state_mem.write()
     }
 

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -3,6 +3,7 @@
 
 use crate::authority::transaction_deferral::DeferralKey;
 use narwhal_types::Round;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use sui_protocol_config::PerObjectCongestionControlMode;
 use sui_types::base_types::{ObjectID, TransactionDigest};
@@ -210,6 +211,23 @@ impl SharedObjectCongestionTracker {
             * self
                 .gas_budget_based_txn_cost_cap_factor
                 .expect("cap factor must be set if TotalGasBudgetWithCap mode is used.")
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum CongestionPerObjectDebt {
+    V1(Round, u64),
+}
+
+impl CongestionPerObjectDebt {
+    pub fn new(round: Round, debt: u64) -> Self {
+        Self::V1(round, debt)
+    }
+
+    pub fn into_v1(self) -> (Round, u64) {
+        match self {
+            Self::V1(round, debt) => (round, debt),
+        }
     }
 }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2302,7 +2302,7 @@ impl CheckpointService {
     ) -> SuiResult {
         use crate::authority::authority_per_epoch_store::ConsensusCommitOutput;
 
-        let mut output = ConsensusCommitOutput::new();
+        let mut output = ConsensusCommitOutput::new(0);
         epoch_store.write_pending_checkpoint(&mut output, &checkpoint)?;
         let mut batch = epoch_store.db_batch_for_test();
         output.write_to_batch(epoch_store, &mut batch)?;

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -896,7 +896,7 @@ mod tests {
             }
         }
         for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new();
+            let mut output = ConsensusCommitOutput::new(0);
             for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_message(&epoch_stores[j].name, dkg_message)
@@ -926,7 +926,7 @@ mod tests {
             }
         }
         for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new();
+            let mut output = ConsensusCommitOutput::new(0);
             for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_confirmation(&mut output, &epoch_stores[j].name, dkg_confirmation)
@@ -1028,7 +1028,7 @@ mod tests {
             }
         }
         for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new();
+            let mut output = ConsensusCommitOutput::new(0);
             for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_message(&epoch_stores[j].name, dkg_message)

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -298,7 +298,7 @@ async fn test_congestion_control_execution_cancellation() {
     // Initialize shared object queue so that any transaction touches shared_object_1 should result in congestion and cancellation.
     register_fail_point_arg("initial_congestion_tracker", move || {
         Some(SharedObjectCongestionTracker::new(
-            &[(shared_object_1.0, 10)],
+            [(shared_object_1.0, 10)],
             PerObjectCongestionControlMode::TotalGasBudget,
             Some(
                 test_setup

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -297,13 +297,17 @@ async fn test_congestion_control_execution_cancellation() {
 
     // Initialize shared object queue so that any transaction touches shared_object_1 should result in congestion and cancellation.
     register_fail_point_arg("initial_congestion_tracker", move || {
-        Some(
-            SharedObjectCongestionTracker::new_with_initial_value_for_test(
-                &[(shared_object_1.0, 10)],
-                PerObjectCongestionControlMode::TotalGasBudget,
-                Some(1000), // Not used.
+        Some(SharedObjectCongestionTracker::new(
+            &[(shared_object_1.0, 10)],
+            PerObjectCongestionControlMode::TotalGasBudget,
+            Some(
+                test_setup
+                    .protocol_config
+                    .max_accumulated_txn_cost_per_object_in_mysticeti_commit(),
             ),
-        )
+            Some(1000), // Not used.
+            false,
+        ))
     });
 
     // Runs a transaction that touches shared_object_1, shared_object_2 and a owned object.

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -306,7 +306,7 @@ async fn test_congestion_control_execution_cancellation() {
                     .max_accumulated_txn_cost_per_object_in_mysticeti_commit(),
             ),
             Some(1000), // Not used.
-            false,
+            0,          // Disable overage.
         ))
     });
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1811,6 +1811,7 @@
                 "max_tx_size_bytes": {
                   "u64": "131072"
                 },
+                "max_txn_cost_overage_per_object_in_commit": null,
                 "max_type_argument_depth": {
                   "u32": "16"
                 },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1245,9 +1245,9 @@ pub struct ProtocolConfig {
     /// Transactions will be cancelled after this many rounds.
     max_deferral_rounds_for_congestion_control: Option<u64>,
 
-    /// If true, congestion control will allow up to one transaction per object to exceed
-    /// the configured maximum accumulated cost.
-    congestion_control_allow_overage: Option<bool>,
+    /// If >0, congestion control will allow up to one transaction per object to exceed
+    /// the configured maximum accumulated cost by the given amount.
+    max_txn_cost_overage_per_object_in_commit: Option<u64>,
 
     /// Minimum interval of commit timestamps between consecutive checkpoints.
     min_checkpoint_interval_ms: Option<u64>,
@@ -2137,7 +2137,7 @@ impl ProtocolConfig {
 
             max_deferral_rounds_for_congestion_control: None,
 
-            congestion_control_allow_overage: None,
+            max_txn_cost_overage_per_object_in_commit: None,
 
             min_checkpoint_interval_ms: None,
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1245,6 +1245,10 @@ pub struct ProtocolConfig {
     /// Transactions will be cancelled after this many rounds.
     max_deferral_rounds_for_congestion_control: Option<u64>,
 
+    /// If true, congestion control will allow up to one transaction per object to exceed
+    /// the configured maximum accumulated cost.
+    congestion_control_allow_overage: Option<bool>,
+
     /// Minimum interval of commit timestamps between consecutive checkpoints.
     min_checkpoint_interval_ms: Option<u64>,
 
@@ -1260,7 +1264,8 @@ pub struct ProtocolConfig {
     bridge_should_try_to_finalize_committee: Option<bool>,
 
     /// The max accumulated txn execution cost per object in a mysticeti. Transactions
-    /// in a commit will be deferred once their touch shared objects hit this limit.
+    /// in a commit will be deferred once their touch shared objects hit this limit,
+    /// unless the selected congestion control mode allows overage.
     /// This config plays the same role as `max_accumulated_txn_cost_per_object_in_narwhal_commit`
     /// but for mysticeti commits due to that mysticeti has higher commit rate.
     max_accumulated_txn_cost_per_object_in_mysticeti_commit: Option<u64>,
@@ -2131,6 +2136,8 @@ impl ProtocolConfig {
             max_accumulated_txn_cost_per_object_in_narwhal_commit: None,
 
             max_deferral_rounds_for_congestion_control: None,
+
+            congestion_control_allow_overage: None,
 
             min_checkpoint_interval_ms: None,
 


### PR DESCRIPTION
## Description 

"Allow overage" mode allows up to one tx per-object per-commit to exceed
congestion control limits, as long as the limit was not already exceeded.
Accumulated debts are applied to future commits.

## Test plan 

Added tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
