### PR TITLE
[indexer] test events query forward and backward pagination using indexer backed rpc in cluster test

### DIFF
--- a/crates/sui-indexer/tests/json_rpc_tests.rs
+++ b/crates/sui-indexer/tests/json_rpc_tests.rs
@@ -230,5 +230,14 @@ async fn test_events() -> Result<(), anyhow::Error> {
     assert_eq!(2, result.data.len());
     assert_eq!(backward_paginated_events[1..], result.data[..]);
 
+    // check that the forward and backward paginated events are in reverse order
+    assert_eq!(
+        forward_paginated_events
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>(),
+        backward_paginated_events
+    );
+
     Ok(())
 }

--- a/crates/sui-indexer/tests/json_rpc_tests.rs
+++ b/crates/sui-indexer/tests/json_rpc_tests.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+
 use sui_json_rpc_api::{CoinReadApiClient, IndexerApiClient, ReadApiClient};
 use sui_json_rpc_types::{
-    CoinPage, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
+    CoinPage, EventFilter, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
 };
 use sui_swarm_config::genesis_config::DEFAULT_GAS_AMOUNT;
+use sui_test_transaction_builder::publish_package;
+use sui_types::{event::EventID, transaction::CallArg};
 use test_cluster::TestClusterBuilder;
 
 #[tokio::test]
@@ -136,6 +140,95 @@ async fn test_get_coins() -> Result<(), anyhow::Error> {
         .await?;
     assert_eq!(0, result.data.len(), "{:?}", result);
     assert!(!result.has_next_page);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_events() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new()
+        .with_indexer_backed_rpc()
+        .build()
+        .await;
+
+    // publish package
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/move_test_code");
+    let move_package = publish_package(&cluster.wallet, path).await.0;
+
+    // execute a transaction to generate events
+    let function = "emit_3";
+    let arguments = vec![CallArg::Pure(bcs::to_bytes(&5u64).unwrap())];
+    let transaction = cluster
+        .test_transaction_builder()
+        .await
+        .move_call(move_package, "events_queries", function, arguments)
+        .build();
+    let signed_transaction = cluster.wallet.sign_transaction(&transaction);
+    cluster.execute_transaction(signed_transaction).await;
+
+    // query for events
+    let http_client = cluster.rpc_client();
+
+    // start with ascending order
+    let event_filter = EventFilter::All([]);
+    let mut cursor: Option<EventID> = None;
+    let mut limit = None;
+    let mut descending_order = Some(false);
+    let result = http_client
+        .query_events(event_filter.clone(), cursor, limit, descending_order)
+        .await?;
+    assert_eq!(3, result.data.len());
+    assert!(!result.has_next_page);
+    let forward_paginated_events = result.data;
+
+    // Fetch the initial event
+    limit = Some(1);
+    let result = http_client
+        .query_events(event_filter.clone(), cursor, limit, descending_order)
+        .await?;
+    assert_eq!(1, result.data.len());
+    assert!(result.has_next_page);
+    assert_eq!(forward_paginated_events[0], result.data[0]);
+
+    // Fetch remaining events
+    cursor = result.next_cursor;
+    limit = None;
+    let result = http_client
+        .query_events(event_filter.clone(), cursor, limit, descending_order)
+        .await?;
+    assert_eq!(2, result.data.len());
+    assert_eq!(forward_paginated_events[1..], result.data[..]);
+
+    // now descending order - make sure to reset parameters
+    cursor = None;
+    descending_order = Some(true);
+    limit = None;
+    let result = http_client
+        .query_events(event_filter.clone(), cursor, limit, descending_order)
+        .await?;
+    assert_eq!(3, result.data.len());
+    assert!(!result.has_next_page);
+    let backward_paginated_events = result.data;
+
+    // Fetch the initial event
+    limit = Some(1);
+    let result = http_client
+        .query_events(event_filter.clone(), cursor, limit, descending_order)
+        .await?;
+    assert_eq!(1, result.data.len());
+    assert!(result.has_next_page);
+    assert_eq!(backward_paginated_events[0], result.data[0]);
+    assert_eq!(forward_paginated_events[2], result.data[0]);
+
+    // Fetch remaining events
+    cursor = result.next_cursor;
+    limit = None;
+    let result = http_client
+        .query_events(event_filter.clone(), cursor, limit, descending_order)
+        .await?;
+    assert_eq!(2, result.data.len());
+    assert_eq!(backward_paginated_events[1..], result.data[..]);
 
     Ok(())
 }

--- a/crates/sui-indexer/tests/move_test_code/Move.toml
+++ b/crates/sui-indexer/tests/move_test_code/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "move_test_code"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+move_test_code = "0x0"

--- a/crates/sui-indexer/tests/move_test_code/sources/events.move
+++ b/crates/sui-indexer/tests/move_test_code/sources/events.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+
+module move_test_code::events_queries {
+    use sui::event;
+
+    public struct EventA has copy, drop {
+        new_value: u64
+    }
+
+    public entry fun emit_1(value: u64) {
+        event::emit(EventA { new_value: value })
+    }
+
+    public entry fun emit_2(value: u64) {
+        event::emit(EventA { new_value: value });
+        event::emit(EventA { new_value: value + 1})
+    }
+
+        public entry fun emit_3(value: u64) {
+        event::emit(EventA { new_value: value });
+        event::emit(EventA { new_value: value + 1});
+        event::emit(EventA { new_value: value + 2});
+    }
+}


### PR DESCRIPTION
## Description 

Add an e2e test that creates a package to emit events, and then execute a transaction to emit them. Then query indexer-backed rpc for expected behavior. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
