### PR TITLE
[wallet] Disconnect active origin on dapp-kit disconnect call

### DIFF
--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -25,6 +25,7 @@ import {
 import Permissions from '_src/background/Permissions';
 import Transactions from '_src/background/Transactions';
 import { FEATURES, growthbook } from '_src/shared/experimentation/features';
+import { isDisconnectApp } from '_src/shared/messaging/messages/payloads/permissions/DisconnectApp';
 import { isQredoConnectPayload } from '_src/shared/messaging/messages/payloads/QredoConnect';
 import {
 	isSignMessageRequest,
@@ -151,6 +152,8 @@ export class ContentScriptConnection extends Connection {
 					throw new Error('This feature is not implemented yet.');
 				}
 				await requestUserApproval(payload.args, this, msg);
+			} else if (isDisconnectApp(payload)) {
+				await Permissions.delete(this.origin);
 			} else {
 				throw new Error(`Unknown message, ${JSON.stringify(msg.payload)}`);
 			}

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -253,9 +253,11 @@ export class SuiWallet implements Wallet {
 	};
 
 	#disconnect: StandardDisconnectMethod = async () => {
+		this.#accounts = [];
+		this.#events.emit('change', { accounts: this.accounts });
 		this.#send<DisconnectApp, void>({
 			type: 'disconnect-app',
-			origin: window.location.origin,
+			origin: '', // origin is auto-discovered for wallet's disconnect.
 		});
 	};
 

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -22,6 +22,7 @@ import type {
 } from '_payloads/transactions';
 import { API_ENV } from '_src/shared/api-env';
 import type { NetworkEnvType } from '_src/shared/api-env';
+import { type DisconnectApp } from '_src/shared/messaging/messages/payloads/permissions/DisconnectApp';
 import {
 	isQredoConnectPayload,
 	type QredoConnectPayload,
@@ -40,6 +41,8 @@ import {
 	SUI_TESTNET_CHAIN,
 	type StandardConnectFeature,
 	type StandardConnectMethod,
+	type StandardDisconnectFeature,
+	type StandardDisconnectMethod,
 	type StandardEventsFeature,
 	type StandardEventsListeners,
 	type StandardEventsOnMethod,
@@ -119,6 +122,7 @@ export class SuiWallet implements Wallet {
 
 	get features(): StandardConnectFeature &
 		StandardEventsFeature &
+		StandardDisconnectFeature &
 		SuiFeatures &
 		QredoConnectFeature {
 		return {
@@ -129,6 +133,10 @@ export class SuiWallet implements Wallet {
 			'standard:events': {
 				version: '1.0.0',
 				on: this.#on,
+			},
+			'standard:disconnect': {
+				version: '1.0.0',
+				disconnect: this.#disconnect,
 			},
 			'sui:signTransactionBlock': {
 				version: '1.0.0',
@@ -242,6 +250,13 @@ export class SuiWallet implements Wallet {
 		await this.#connected();
 
 		return { accounts: this.accounts };
+	};
+
+	#disconnect: StandardDisconnectMethod = async () => {
+		this.#send<DisconnectApp, void>({
+			type: 'disconnect-app',
+			origin: window.location.origin,
+		});
 	};
 
 	#signTransactionBlock: SuiSignTransactionBlockMethod = async ({

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -253,8 +253,6 @@ export class SuiWallet implements Wallet {
 	};
 
 	#disconnect: StandardDisconnectMethod = async () => {
-		this.#accounts = [];
-		this.#events.emit('change', { accounts: this.accounts });
 		this.#send<DisconnectApp, void>({
 			type: 'disconnect-app',
 			origin: '', // origin is auto-discovered for wallet's disconnect.


### PR DESCRIPTION
## Description 

Currently, when disconnecting from any dapp, the internal connection of the wallet for the given origin is not reset, making the experience unpredictable and confusing (main UX confusion we've been facing on every single bug bash).

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
