### PR TITLE
examples: fix custom indexer

### DIFF
--- a/examples/custom-indexer/rust/Cargo.toml
+++ b/examples/custom-indexer/rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.81"
+async-trait = "0.1.83"
 tokio = { version = "1.38.0", features = ["full"]}
 sui_types = { git = "https://github.com/mystenlabs/sui", package = "sui-types"}
 sui_data_ingestion_core = { git = "https://github.com/mystenlabs/sui", package = "sui-data-ingestion-core"}

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -17,7 +17,7 @@ struct CustomWorker;
 #[async_trait]
 impl Worker for CustomWorker {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
         // custom processing logic
         println!("Processing Local checkpoint: {}", checkpoint.checkpoint_summary.to_string());
         Ok(())

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -11,7 +11,7 @@ struct CustomWorker;
 #[async_trait]
 impl Worker for CustomWorker {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
         // custom processing logic
         // print out the checkpoint number
         println!("Processing checkpoint: {}", checkpoint.checkpoint_summary.to_string());


### PR DESCRIPTION
## Description 

The custom indexer example is broken:
```
error[E0195]: lifetime parameters or bounds on method `process_checkpoint` do not match the trait declaration
  --> remote_reader.rs:14:14
   |
14 |     async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match method in trait
```
This PR fixes it. 


## Test plan 

```
cd examples/custom-indexer/rust
cargo run  --bin local_reader --release
cargo run  --bin remote_reader --release
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
