### PR TITLE
Must not wait on notify_read_effects after epoch ends, on a transaction that might be reverted

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -409,6 +409,7 @@ mod test {
             }
         });
         register_fail_point_async("consensus-delay", || delay_failpoint(10..20, 0.001));
+        register_fail_point_async("write_object_entry", || delay_failpoint(10..20, 0.001));
 
         register_fail_point_async("writeback-cache-commit", || delay_failpoint(10..20, 0.001));
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3177,9 +3177,15 @@ impl AuthorityState {
         );
 
         self.committee_store.insert_new_committee(&new_committee)?;
+
+        // Wait until no transactions are being executed.
         let mut execution_lock = self.execution_lock_for_reconfiguration().await;
 
+        // Terminate all epoch-specific tasks (those started with within_alive_epoch).
         cur_epoch_store.epoch_terminated().await;
+
+        // Safe to being reconfiguration now. No transactions are being executed,
+        // and no epoch-specific tasks are running.
 
         // TODO: revert_uncommitted_epoch_transactions will soon be unnecessary -
         // clear_state_end_of_epoch() can simply drop all uncommitted transactions

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -828,7 +828,7 @@ impl ValidatorService {
                             .await?
                     }
                     ConsensusTransactionKind::UserTransaction(tx) => {
-                        self.state.await_transaction_effects(*tx.digest()).await?
+                        self.state.await_transaction_effects(*tx.digest(), epoch_store).await?
                     }
                     _ => panic!("`handle_submit_to_consensus` received transaction that is not a CertifiedTransaction or UserTransaction"),
                 };

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -8,6 +8,7 @@ use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::authority::AuthorityStore;
 use crate::state_accumulator::AccumulatorStore;
 use crate::transaction_outputs::TransactionOutputs;
+use mysten_common::fatal;
 use sui_types::bridge::Bridge;
 
 use futures::{future::BoxFuture, FutureExt};
@@ -587,6 +588,12 @@ pub trait TransactionCacheRead: Send + Sync {
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, SuiResult<Vec<TransactionEffectsDigest>>>;
 
+    /// Wait until the effects of the given transactions are available and return them.
+    /// WARNING: If calling this on a transaction that could be reverted, you must be
+    /// sure that this function cannot be called during reconfiguration. The best way to
+    /// do this is to wrap your future in EpochStore::within_alien_epoch. Holding an
+    /// ExecutionLockReadGuard is dangerous, as it could prevent reconfiguration from
+    /// ever occurring!
     fn notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
@@ -597,7 +604,7 @@ pub trait TransactionCacheRead: Send + Sync {
             self.multi_get_effects(&digests).map(|effects| {
                 effects
                     .into_iter()
-                    .map(|e| e.expect("digests must exist"))
+                    .map(|e| e.unwrap_or_else(|| fatal!("digests must exist")))
                     .collect()
             })
         }

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -591,9 +591,10 @@ pub trait TransactionCacheRead: Send + Sync {
     /// Wait until the effects of the given transactions are available and return them.
     /// WARNING: If calling this on a transaction that could be reverted, you must be
     /// sure that this function cannot be called during reconfiguration. The best way to
-    /// do this is to wrap your future in EpochStore::within_alien_epoch. Holding an
-    /// ExecutionLockReadGuard is dangerous, as it could prevent reconfiguration from
-    /// ever occurring!
+    /// do this is to wrap your future in EpochStore::within_alive_epoch. Holding an
+    /// ExecutionLockReadGuard would also prevent reconfig from happening while waiting,
+    /// but this is very dangerous, as it could prevent reconfiguration from ever
+    /// occurring!
     fn notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -468,6 +468,9 @@ impl WritebackCache {
             .entry(*object_id)
             .or_default()
             .insert(version, object.clone());
+
+        fail_point_async!("write_object_entry");
+
         self.cached.object_by_id_cache.insert(
             *object_id,
             Arc::new(Mutex::new(LatestObjectCacheEntry::Object(version, object))),


### PR DESCRIPTION
Found this crash after adding the delay failpoint seen in this PR. I don't quite understand why that exposed this crash.