### PR TITLE
[Faucet] Add faucet version metrics for Grafana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13551,6 +13551,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "axum 0.7.5",
+ "bin-version",
  "clap",
  "eyre",
  "futures",

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 anyhow.workspace = true
 async-trait.workspace = true
 axum.workspace = true
+bin-version.workspace = true
 clap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -12,6 +12,9 @@ use tracing::info;
 const CONCURRENCY_LIMIT: usize = 30;
 const PROM_PORT_ADDR: &str = "0.0.0.0:9184";
 
+// Define the `GIT_REVISION` and `VERSION` consts
+bin_version::bin_version!();
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // initialize tracing
@@ -38,6 +41,10 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("Starting Prometheus HTTP endpoint at {}", prom_binding);
     let registry_service = mysten_metrics::start_prometheus_server(prom_binding);
     let prometheus_registry = registry_service.default_registry();
+    prometheus_registry
+        .register(mysten_metrics::uptime_metric("faucet", VERSION, "unknown"))
+        .unwrap();
+
     let app_state = Arc::new(AppState {
         faucet: SimpleFaucet::new(
             context,


### PR DESCRIPTION
## Description 

This PR adds the faucet version metrics so that it can be displayed in Grafana.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
