### PR TITLE
jsonrpc: don't explicitly remove old tables

### DIFF
--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -255,6 +255,7 @@ pub struct IndexStoreTables {
 
     #[default_options_override_fn = "coin_index_table_default_config"]
     #[deprecated]
+    #[allow(unused)]
     coin_index: DBMap<CoinIndexKey, CoinInfo>,
     #[default_options_override_fn = "coin_index_table_default_config"]
     coin_index_2: DBMap<CoinIndexKey2, CoinInfo>,
@@ -339,19 +340,6 @@ impl IndexStoreTables {
 
         // Commit to the DB that the indexes have been initialized
         self.meta.insert(&(), &metadata)?;
-
-        // Clear old, deprecated and unused column families
-        if !self.coin_index.is_empty() {
-            self.coin_index.unsafe_clear()?;
-        }
-
-        if !self.loaded_child_object_versions.is_empty() {
-            self.loaded_child_object_versions.unsafe_clear()?;
-        }
-
-        if !self.timestamps.is_empty() {
-            self.timestamps.unsafe_clear()?;
-        }
 
         Ok(())
     }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -981,7 +981,14 @@ impl<K, V> DBMap<K, V> {
     }
 
     fn report_metrics(rocksdb: &Arc<RocksDB>, cf_name: &str, db_metrics: &Arc<DBMetrics>) {
-        let cf = rocksdb.cf_handle(cf_name).expect("Failed to get cf");
+        let Some(cf) = rocksdb.cf_handle(cf_name) else {
+            tracing::warn!(
+                "unable to report metrics for cf {cf_name:?} in db {:?}",
+                rocksdb.db_name()
+            );
+            return;
+        };
+
         db_metrics
             .cf_metrics
             .rocksdb_total_sst_files_size


### PR DESCRIPTION
Don't explicitly remove old jsonrpc index tables as well as remove a possible panic when reporting rocksdb metrics.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
