### PR TITLE
[Indexer] Add --skip-migrations option to --reset-database

### DIFF
--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -186,6 +186,10 @@ pub enum Command {
     ResetDatabase {
         #[clap(long)]
         force: bool,
+        /// If true, only drop all tables but do not run the migrations.
+        /// That is, no tables will exist in the DB after the reset.
+        #[clap(long, default_value_t = false)]
+        skip_migrations: bool,
     },
     /// Run through the migration scripts.
     RunMigrations,


### PR DESCRIPTION
## Description 

This is useful when I need to manually run migrations. 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
