### PR TITLE
CLI generate-struct-layouts fix

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -88,11 +88,12 @@ impl Build {
         if generate_struct_layouts {
             let layout_str = serde_yaml::to_string(&pkg.generate_struct_layouts()).unwrap();
             // store under <package_path>/build/<package_name>/layouts/struct_layouts.yaml
-            let layout_filename = rerooted_path
+            let dir_name = rerooted_path
                 .join("build")
                 .join(pkg.package.compiled_package_info.package_name.as_str())
-                .join(LAYOUTS_DIR)
-                .join(STRUCT_LAYOUTS_FILENAME);
+                .join(LAYOUTS_DIR);
+            let layout_filename = dir_name.join(STRUCT_LAYOUTS_FILENAME);
+            fs::create_dir_all(dir_name)?;
             fs::write(layout_filename, layout_str)?
         }
 


### PR DESCRIPTION
Depending on the platform, "write" function may fail if the full directory path does not exist. So we have to create it before.

## Description 

According to this doc https://doc.rust-lang.org/std/fs/fn.write.html "write" function may fail if the full directory path does not exist. And it does on macOS with an error "No such file or directory (os error 2)". I added a create_dir_all call before, to create dir first.

## Test plan 

build --generate-struct-layouts flag must work on all platforms. It did not work on macOS Sequoia

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixed an issue on the `sui move` command regarding writing into a non existing directory. 
- [ ] Rust SDK:
- [ ] REST API:
