### PR TITLE
[suiop][env] add load-env subcommand

### DIFF
--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -56,6 +56,7 @@ futures.workspace = true
 thiserror.workspace = true
 strsim = "0.11.1"
 futures-timer = "3.0.3"
+tempfile.workspace = true
 
 
 [dev-dependencies]

--- a/crates/suiop-cli/src/cli/env/mod.rs
+++ b/crates/suiop-cli/src/cli/env/mod.rs
@@ -2,6 +2,7 @@ use crate::run_cmd;
 use anyhow::Result;
 use clap::Parser;
 use inquire::Select;
+use std::io::Write;
 use tracing::{debug, info};
 
 /// Load an environment from pulumi
@@ -35,11 +36,19 @@ pub fn setup_pulumi_environment(environment_name: &str) -> Result<()> {
     let output_str = String::from_utf8_lossy(&output.stdout);
     let output_json: serde_json::Value = serde_json::from_str(&output_str)?;
     let env_vars = &output_json["environmentVariables"];
+    // Open a file to write environment variables
+    let home_dir = std::env::var("HOME").expect("HOME environment variable not set");
+    let suiop_dir = format!("{}/.suiop", home_dir);
+    std::fs::create_dir_all(&suiop_dir).expect("Failed to create .suiop directory");
+    let env_file_path = format!("{}/env_vars", suiop_dir);
+    let mut env_file =
+        std::fs::File::create(&env_file_path).expect("Failed to create env_vars file");
+
     if let serde_json::Value::Object(env_vars) = env_vars {
         for (key, value) in env_vars {
             if let Some(value_str) = value.as_str() {
-                std::env::set_var(&key, value_str);
-                info!("setting environment variable {}", key);
+                writeln!(env_file, "{}={}", key, value_str)?;
+                info!("writing environment variable {}", key);
                 debug!("={}", value_str);
             } else {
                 info!(
@@ -52,6 +61,9 @@ pub fn setup_pulumi_environment(environment_name: &str) -> Result<()> {
         info!("Environment variables are not in the expected format.");
         debug!("env: {:?}", output_json);
     }
-    info!("finished loading environment");
+    info!(
+        "finished loading environment. use `source {}` to load them into your shell",
+        env_file_path
+    );
     Ok(())
 }

--- a/crates/suiop-cli/src/cli/env/mod.rs
+++ b/crates/suiop-cli/src/cli/env/mod.rs
@@ -1,0 +1,57 @@
+use crate::run_cmd;
+use anyhow::Result;
+use clap::Parser;
+use inquire::Select;
+use tracing::{debug, info};
+
+/// Load an environment from pulumi
+///
+/// if no environment name is provided, the user will be prompted to select one from the list
+#[derive(Parser, Debug)]
+pub struct LoadEnvironmentArgs {
+    /// the optional name of the environment to load
+    environment_name: Option<String>,
+}
+
+pub fn load_environment_cmd(args: &LoadEnvironmentArgs) -> Result<()> {
+    setup_pulumi_environment(&args.environment_name.clone().unwrap_or_else(|| {
+        let output = run_cmd(vec!["pulumi", "env", "ls"], None).expect("Running pulumi env ls");
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        let options: Vec<&str> = output_str.lines().collect();
+
+        if options.is_empty() {
+            panic!("No environments found. Make sure you are logged into the correct pulumi org.");
+        }
+
+        Select::new("Select an environment:", options)
+            .prompt()
+            .expect("Failed to select environment")
+            .to_owned()
+    }))
+}
+
+pub fn setup_pulumi_environment(environment_name: &str) -> Result<()> {
+    let output = run_cmd(vec!["pulumi", "env", "open", environment_name], None)?;
+    let output_str = String::from_utf8_lossy(&output.stdout);
+    let output_json: serde_json::Value = serde_json::from_str(&output_str)?;
+    let env_vars = &output_json["environmentVariables"];
+    if let serde_json::Value::Object(env_vars) = env_vars {
+        for (key, value) in env_vars {
+            if let Some(value_str) = value.as_str() {
+                std::env::set_var(&key, value_str);
+                info!("setting environment variable {}", key);
+                debug!("={}", value_str);
+            } else {
+                info!(
+                    "Failed to set environment variable: {}. Value is not a string.",
+                    key
+                );
+            }
+        }
+    } else {
+        info!("Environment variables are not in the expected format.");
+        debug!("env: {:?}", output_json);
+    }
+    info!("finished loading environment");
+    Ok(())
+}

--- a/crates/suiop-cli/src/cli/env/mod.rs
+++ b/crates/suiop-cli/src/cli/env/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::run_cmd;
 use anyhow::Result;
 use clap::Parser;

--- a/crates/suiop-cli/src/cli/incidents/notion.rs
+++ b/crates/suiop-cli/src/cli/incidents/notion.rs
@@ -116,6 +116,7 @@ impl Notion {
     pub fn new() -> Self {
         let token = env::var("NOTION_API_TOKEN")
             .expect("Please set the NOTION_API_TOKEN environment variable");
+        debug!("using notion token {}", token);
         let client = NotionApi::new(token.clone()).expect("Failed to create Notion API client");
         Self { client, token }
     }
@@ -145,8 +146,12 @@ impl Notion {
 
         if !response.status().is_success() {
             return Err(anyhow::anyhow!(
-                "Request failed with status: {}",
-                response.status()
+                "Request failed with status: {}, response: {}",
+                response.status(),
+                response
+                    .text()
+                    .await
+                    .unwrap_or("no response text".to_owned())
             ));
         }
 

--- a/crates/suiop-cli/src/cli/incidents/pd/mod.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd/mod.rs
@@ -11,6 +11,7 @@ use reqwest::header::AUTHORIZATION;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::env;
+use tracing::debug;
 
 use super::incident::Incident;
 
@@ -49,15 +50,18 @@ pub async fn fetch_incidents(
 ) -> Result<Vec<PagerDutyIncident>> {
     let url = "https://api.pagerduty.com/incidents";
 
+    let api_key = env::var("PD_API_KEY").expect("please set the PD_API_KEY env var");
+    if api_key.is_empty() {
+        panic!("PD_API_KEY is not set");
+    }
+
+    debug!("fetching incidents from pagerduty with {}", api_key);
     let mut headers = HeaderMap::new();
     headers.insert(
         AUTHORIZATION,
-        format!(
-            "Token token={}",
-            env::var("PD_API_KEY").expect("please set the PD_API_KEY env var")
-        )
-        .parse()
-        .expect("header parsing"),
+        format!("Token token={}", api_key)
+            .parse()
+            .expect("header parsing"),
     );
     headers.insert(
         ACCEPT,

--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -3,6 +3,7 @@
 
 mod ci;
 pub mod docker;
+mod env;
 mod iam;
 mod incidents;
 pub mod lib;
@@ -13,6 +14,7 @@ mod slack;
 
 pub use ci::{ci_cmd, CIArgs};
 pub use docker::{docker_cmd, DockerArgs};
+pub use env::{load_environment_cmd, LoadEnvironmentArgs};
 pub use iam::{iam_cmd, IAMArgs};
 pub use incidents::{incidents_cmd, IncidentsArgs};
 pub use pulumi::{pulumi_cmd, PulumiArgs};

--- a/crates/suiop-cli/src/cli/slack/mod.rs
+++ b/crates/suiop-cli/src/cli/slack/mod.rs
@@ -32,7 +32,12 @@ fn get_serialize_filepath(subname: &str) -> PathBuf {
 /// Serialize the obj into ~/.suiop/{subname} so we can cache it across
 /// executions
 pub fn serialize_to_file<T: Serialize>(subname: &str, obj: &Vec<T>) -> Result<()> {
-    let file = File::create(get_serialize_filepath(subname).as_path())?;
+    let filepath = get_serialize_filepath(subname);
+    // Ensure the parent directory exists
+    if let Some(parent) = filepath.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = File::create(filepath.as_path())?;
     serde_json::to_writer(file, obj)?;
     Ok(())
 }
@@ -70,6 +75,7 @@ impl Slack {
         let token = std::env::var("SLACK_BOT_TOKEN").expect(
             "Please set SLACK_BOT_TOKEN env var ('slack bot token (incidentbot)' in 1password)",
         );
+        debug!("using slack token {}", token);
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::AUTHORIZATION,

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -5,8 +5,8 @@ use anyhow::Result;
 use clap::Parser;
 use suioplib::{
     cli::{
-        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, pulumi_cmd, service_cmd, CIArgs, DockerArgs,
-        IAMArgs, IncidentsArgs, PulumiArgs, ServiceArgs,
+        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_cmd, pulumi_cmd, service_cmd,
+        CIArgs, DockerArgs, IAMArgs, IncidentsArgs, LoadEnvironmentArgs, PulumiArgs, ServiceArgs,
     },
     DEBUG_MODE,
 };
@@ -38,6 +38,8 @@ pub(crate) enum Resource {
     Service(ServiceArgs),
     #[clap()]
     CI(CIArgs),
+    #[clap(name="load-env", aliases = ["e", "env"])]
+    LoadEnvironment(LoadEnvironmentArgs),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -75,6 +77,9 @@ async fn main() -> Result<()> {
         }
         Resource::CI(args) => {
             ci_cmd(&args).await?;
+        }
+        Resource::LoadEnvironment(args) => {
+            load_environment_cmd(&args)?;
         }
     }
 

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -10,7 +10,7 @@ use suioplib::{
     },
     DEBUG_MODE,
 };
-use tracing::info;
+use tracing::{debug, info, warn};
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
     FmtSubscriber,
@@ -53,6 +53,24 @@ async fn main() -> Result<()> {
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    // Load environment variables from ~/.suiop/env_vars
+    debug!("loading environment variables");
+    let home_dir = std::env::var("HOME").expect("HOME environment variable not set");
+    let env_file_path = std::path::Path::new(&home_dir)
+        .join(".suiop")
+        .join("env_vars");
+
+    if let Ok(env_contents) = std::fs::read_to_string(env_file_path) {
+        for line in env_contents.lines() {
+            if let Some((key, value)) = line.split_once('=') {
+                debug!("setting environment variable {}={}", key, value);
+                std::env::set_var(key.trim(), value.trim());
+            }
+        }
+    } else {
+        warn!("Warning: Could not read ~/.suiop/env_vars file. Environment variables not loaded.");
+    }
 
     if *DEBUG_MODE {
         info!("Debug mode enabled");


### PR DESCRIPTION
## Description 

Let users load pulumi ESC envs into their current shell by name. The user can supply an env name or select one from pulumi's listing.

## Test plan 

```
suiop-cli [jkj/suiop-load-env●●] cargo run -- help  
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.49s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop help`
Usage: suiop <COMMAND>

Commands:
  docker     
  iam        
  incidents  
  pulumi     
  service    
  ci         
  load-env   Load an environment from pulumi
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```
```
suiop-cli [jkj/suiop-load-env●●] cargo run -- load-env --help
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.52s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop load-env --help`
Load an environment from pulumi

if no environment name is provided, the user will be prompted to select one from the list

Usage: suiop load-env [ENVIRONMENT_NAME]

Arguments:
  [ENVIRONMENT_NAME]
          the optional name of the environment to load

Options:
  -h, --help
          Print help (see a summary with '-h')
```
```
suiop-cli [jkj/suiop-load-env●●] cargo run -- load-env mysten/incident-management/im-tooling
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop load-env mysten/incident-management/im-tooling`
2024-10-22T12:31:41.094852Z  INFO suioplib::cli::env: setting environment variable NOTION_API_TOKEN
2024-10-22T12:31:41.094988Z  INFO suioplib::cli::env: setting environment variable PD_API_KEY
2024-10-22T12:31:41.094993Z  INFO suioplib::cli::env: setting environment variable SLACK_BOT_TOKEN
2024-10-22T12:31:41.094998Z  INFO suioplib::cli::env: finished loading environment
```
```
suiop-cli [jkj/suiop-load-env●●] cargo run -- load-env                                      
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.51s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop load-env`
> Select an environment: mysten/default/gcp-app-env
2024-10-22T12:31:51.335249Z  INFO suioplib::cli::env: setting environment variable AWS_ACCESS_KEY_ID
2024-10-22T12:31:51.335369Z  INFO suioplib::cli::env: setting environment variable AWS_SECRET_ACCESS_KEY
2024-10-22T12:31:51.335381Z  INFO suioplib::cli::env: setting environment variable AWS_SESSION_TOKEN
2024-10-22T12:31:51.335391Z  INFO suioplib::cli::env: setting environment variable CLOUDSDK_AUTH_ACCESS_TOKEN
2024-10-22T12:31:51.335398Z  INFO suioplib::cli::env: setting environment variable CLOUDSDK_CORE_PROJECT
2024-10-22T12:31:51.335407Z  INFO suioplib::cli::env: setting environment variable GOOGLE_OAUTH_ACCESS_TOKEN
2024-10-22T12:31:51.335415Z  INFO suioplib::cli::env: Failed to set environment variable: GOOGLE_PROJECT. Value is not a string.
2024-10-22T12:31:51.335422Z  INFO suioplib::cli::env: setting environment variable TOKEN_EXPIRY
2024-10-22T12:31:51.335430Z  INFO suioplib::cli::env: finished loading environment
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
