### PR TITLE
[Indexer] Save workload in benchmark

### DIFF
--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -46,22 +46,25 @@ pub struct CheckpointReader {
 
 #[derive(Clone)]
 pub struct ReaderOptions {
-    pub tick_interal_ms: u64,
+    pub tick_internal_ms: u64,
     pub timeout_secs: u64,
     /// number of maximum concurrent requests to the remote store. Increase it for backfills
     pub batch_size: usize,
     pub data_limit: usize,
     pub upper_limit: Option<CheckpointSequenceNumber>,
+    /// Whether to delete processed checkpoint files from the local directory.
+    pub gc_checkpoint_files: bool,
 }
 
 impl Default for ReaderOptions {
     fn default() -> Self {
         Self {
-            tick_interal_ms: 100,
+            tick_internal_ms: 100,
             timeout_secs: 5,
             batch_size: 10,
             data_limit: 0,
             upper_limit: None,
+            gc_checkpoint_files: true,
         }
     }
 }
@@ -294,9 +297,12 @@ impl CheckpointReader {
 
     /// Cleans the local directory by removing all processed checkpoint files.
     fn gc_processed_files(&mut self, watermark: CheckpointSequenceNumber) -> Result<()> {
-        info!("cleaning processed files, watermark is {}", watermark);
         self.data_limiter.gc(watermark);
         self.last_pruned_watermark = watermark;
+        if !self.options.gc_checkpoint_files {
+            return Ok(());
+        }
+        info!("cleaning processed files, watermark is {}", watermark);
         for entry in fs::read_dir(self.path.clone())? {
             let entry = entry?;
             let filename = entry.file_name();
@@ -384,7 +390,7 @@ impl CheckpointReader {
                 Some(gc_checkpoint_number) = self.processed_receiver.recv() => {
                     self.gc_processed_files(gc_checkpoint_number).expect("Failed to clean the directory");
                 }
-                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(self.options.tick_interal_ms), inotify_recv.recv())  => {
+                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(self.options.tick_internal_ms), inotify_recv.recv())  => {
                     self.sync().await.expect("Failed to read checkpoint files");
                 }
             }

--- a/crates/sui-data-ingestion-core/src/tests.rs
+++ b/crates/sui-data-ingestion-core/src/tests.rs
@@ -40,7 +40,7 @@ async fn run(
     duration: Option<Duration>,
 ) -> Result<ExecutorProgress> {
     let options = ReaderOptions {
-        tick_interal_ms: 10,
+        tick_internal_ms: 10,
         batch_size: 1,
         ..Default::default()
     };

--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -129,6 +129,11 @@ pub struct IngestionConfig {
         env = "CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT",
     )]
     pub checkpoint_download_queue_size_bytes: usize,
+
+    /// Whether to delete processed checkpoint files from the local directory,
+    /// when running Fullnode-colocated indexer.
+    #[arg(long, default_value_t = true)]
+    pub gc_checkpoint_files: bool,
 }
 
 impl IngestionConfig {
@@ -145,6 +150,7 @@ impl Default for IngestionConfig {
             checkpoint_download_timeout: Self::DEFAULT_CHECKPOINT_DOWNLOAD_TIMEOUT,
             checkpoint_download_queue_size_bytes:
                 Self::DEFAULT_CHECKPOINT_DOWNLOAD_QUEUE_SIZE_BYTES,
+            gc_checkpoint_files: true,
         }
     }
 }
@@ -409,6 +415,13 @@ pub struct BenchmarkConfig {
         help = "Whether to reset the database before running."
     )]
     pub reset_db: bool,
+    #[arg(
+        long,
+        help = "Path to workload directory. If not provided, a temporary directory will be created.\
+        If provided, synthetic workload generator will either load data from it if it exists or generate new data.\
+        This avoids repeat generation of the same data."
+    )]
+    pub workload_dir: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -59,6 +59,7 @@ impl Indexer {
             batch_size: config.checkpoint_download_queue_size,
             timeout_secs: config.checkpoint_download_timeout,
             data_limit: config.checkpoint_download_queue_size_bytes,
+            gc_checkpoint_files: config.gc_checkpoint_files,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Description 

Be able to save generated workload in a specified dir instead of temp dir.
This requires adding a flag to ask the reader to not gc files.

## Test plan 

Run locally
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
