### PR TITLE
[CLI] Add dev inspect to CLI

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2938,7 +2938,7 @@ async fn execute_dev_inspect(
     skip_checks: Option<bool>,
 ) -> Result<SuiClientCommandResult, anyhow::Error> {
     let client = context.get_client().await?;
-    let gas_budget = gas_budget.map(|x| sui_serde::BigInt::from(x));
+    let gas_budget = gas_budget.map(sui_serde::BigInt::from);
     let mut gas_objs = vec![];
     let gas_objects = if let Some(gas_payment) = gas_payment {
         for o in gas_payment.iter() {

--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -35,6 +35,7 @@ pub const SUMMARY: &str = "summary";
 pub const GAS_COIN: &str = "gas-coin";
 pub const JSON: &str = "json";
 pub const DRY_RUN: &str = "dry-run";
+pub const DEV_INSPECT: &str = "dev-inspect";
 pub const SERIALIZE_UNSIGNED: &str = "serialize-unsigned-transaction";
 pub const SERIALIZE_SIGNED: &str = "serialize-signed-transaction";
 
@@ -74,6 +75,7 @@ pub const COMMANDS: &[&str] = &[
     GAS_COIN,
     JSON,
     DRY_RUN,
+    DEV_INSPECT,
     SERIALIZE_UNSIGNED,
     SERIALIZE_SIGNED,
 ];
@@ -111,6 +113,7 @@ pub struct ProgramMetadata {
     pub gas_object_id: Option<Spanned<ObjectID>>,
     pub json_set: bool,
     pub dry_run_set: bool,
+    pub dev_inspect_set: bool,
     pub gas_budget: Option<Spanned<u64>>,
 }
 

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -41,6 +41,7 @@ struct ProgramParsingState {
     serialize_signed_set: bool,
     json_set: bool,
     dry_run_set: bool,
+    dev_inspect_set: bool,
     gas_object_id: Option<Spanned<ObjectID>>,
     gas_budget: Option<Spanned<u64>>,
 }
@@ -63,6 +64,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 serialize_signed_set: false,
                 json_set: false,
                 dry_run_set: false,
+                dev_inspect_set: false,
                 gas_object_id: None,
                 gas_budget: None,
             },
@@ -110,6 +112,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 L(T::Command, A::SUMMARY) => flag!(summary_set),
                 L(T::Command, A::JSON) => flag!(json_set),
                 L(T::Command, A::DRY_RUN) => flag!(dry_run_set),
+                L(T::Command, A::DEV_INSPECT) => flag!(dev_inspect_set),
                 L(T::Command, A::PREVIEW) => flag!(preview_set),
                 L(T::Command, A::WARN_SHADOWS) => flag!(warn_shadows_set),
                 L(T::Command, A::GAS_COIN) => {
@@ -207,6 +210,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                     gas_object_id: self.state.gas_object_id,
                     json_set: self.state.json_set,
                     dry_run_set: self.state.dry_run_set,
+                    dev_inspect_set: self.state.dev_inspect_set,
                     gas_budget: self.state.gas_budget,
                 },
             ))

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -150,6 +150,7 @@ impl PTB {
             gas: program_metadata.gas_object_id.map(|x| x.value),
             rest: Opts {
                 dry_run: program_metadata.dry_run_set,
+                dev_inspect: program_metadata.dev_inspect_set,
                 gas_budget: program_metadata.gas_budget.map(|x| x.value),
                 serialize_unsigned_transaction: program_metadata.serialize_unsigned_set,
                 serialize_signed_transaction: program_metadata.serialize_signed_set,
@@ -294,6 +295,10 @@ pub fn ptb_description() -> clap::Command {
         .arg(arg!(
             --"dry-run"
             "Perform a dry run of the PTB instead of executing it."
+        ))
+        .arg(arg!(
+            --"dev-inspect"
+            "Perform a dev-inspect of the PTB instead of executing it."
         ))
         .arg(arg!(
             --"gas-coin" <ID> ...

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
@@ -32,6 +32,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -72,6 +73,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -121,6 +123,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -189,6 +192,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -248,6 +252,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -322,6 +327,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -390,6 +396,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -449,6 +456,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -517,6 +525,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -576,6 +585,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -623,6 +633,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -689,6 +700,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -802,6 +814,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -892,6 +905,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -982,6 +996,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1023,6 +1038,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1089,6 +1105,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1140,6 +1157,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1191,6 +1209,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1276,6 +1295,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1333,6 +1353,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1396,6 +1417,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1428,6 +1450,7 @@ expression: parsed
             ),
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1452,6 +1475,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1476,6 +1500,7 @@ expression: parsed
             gas_object_id: None,
             json_set: true,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1500,6 +1525,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1524,6 +1550,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
@@ -32,6 +32,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -72,6 +73,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {

--- a/crates/sui/src/displays/dev_inspect.rs
+++ b/crates/sui/src/displays/dev_inspect.rs
@@ -25,15 +25,15 @@ impl<'a> Display for Pretty<'a, DevInspectResults> {
 
         if let Some(results) = &response.results {
             for result in results {
-                write!(f, "Execution Result")?;
-                write!(f, "  Mutable Reference Outputs")?;
+                writeln!(f, "Execution Result")?;
+                writeln!(f, "  Mutable Reference Outputs")?;
                 for m in result.mutable_reference_outputs.iter() {
                     writeln!(f, "    Sui Argument: {}", m.0)?;
                     writeln!(f, "    Sui TypeTag: {:?}", m.2)?;
                     writeln!(f, "    Bytes: {:?}", m.1)?;
                 }
 
-                write!(f, "  Return values")?;
+                writeln!(f, "  Return values")?;
                 for val in result.return_values.iter() {
                     writeln!(f, "    Sui TypeTag: {:?}", val.1)?;
                     writeln!(f, "    Bytes: {:?}", val.0)?;

--- a/crates/sui/src/displays/dev_inspect.rs
+++ b/crates/sui/src/displays/dev_inspect.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::displays::Pretty;
+use std::fmt::{Display, Formatter};
+use sui_json_rpc_types::{DevInspectResults, SuiTransactionBlockEffectsAPI};
+
+impl<'a> Display for Pretty<'a, DevInspectResults> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(response) = self;
+
+        if let Some(error) = &response.error {
+            writeln!(f, "Dev inspect failed: {}", error)?;
+            return Ok(());
+        }
+
+        writeln!(
+            f,
+            "Dev inspect completed, execution status: {}",
+            response.effects.status()
+        )?;
+
+        writeln!(f, "{}", response.effects)?;
+        write!(f, "{}", response.events)?;
+
+        if let Some(results) = &response.results {
+            for result in results {
+                write!(f, "Execution Result")?;
+                write!(f, "  Mutable Reference Outputs")?;
+                for m in result.mutable_reference_outputs.iter() {
+                    writeln!(f, "    Sui Argument: {}", m.0)?;
+                    writeln!(f, "    Sui TypeTag: {:?}", m.2)?;
+                    writeln!(f, "    Bytes: {:?}", m.1)?;
+                }
+
+                write!(f, "  Return values")?;
+                for val in result.return_values.iter() {
+                    writeln!(f, "    Sui TypeTag: {:?}", val.1)?;
+                    writeln!(f, "    Bytes: {:?}", val.0)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/sui/src/displays/mod.rs
+++ b/crates/sui/src/displays/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod dev_inspect;
 mod dry_run_tx_block;
 mod gas_cost_summary;
 mod ptb_preview;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2897,6 +2897,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: true,
             serialize_signed_transaction: false,
         },
@@ -2911,6 +2912,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: true,
         },
@@ -2926,6 +2928,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: true,
         },
@@ -3772,6 +3775,7 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: None,
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
         },


### PR DESCRIPTION
## Description 

This PR adds a `dev-inspect` flag to all executing-related commands.

## Test plan 

Existing tests.

```
sui client split-coin --coin-id 0x167f03292b0689800a149b62d6ac2f5163e1dd4995964195c521e0f3ff46183a --count 2 --dev-inspect
Dev inspect completed, execution status: success
╭───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Transaction Effects                                                                               │
├───────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Digest: EHA6riF3SUU7UCa6xi11yTs3pN8exdzhF8hoNfiTGFF6                                              │
│ Status: Success                                                                                   │
│ Executed Epoch: 1                                                                                 │
│                                                                                                   │
│ Created Objects:                                                                                  │
│  ┌──                                                                                              │
│  │ ID: 0x3232cf6376bd59392f453b3ec15d0a98178e35c9966c2e23e797ccbc84c342e0                         │
│  │ Owner: Account Address ( 0xa24c44f9e1f09e3675d39c50f6182b36e5e8a8c39b677666910c8091d681bd8c )  │
│  │ Version: 3                                                                                     │
│  │ Digest: BqjHeBCvAwT3GdpqEK2JoeGTjmRSD68i8nuRQ51k8UBk                                           │
│  └──                                                                                              │
│ Mutated Objects:                                                                                  │
│  ┌──                                                                                              │
│  │ ID: 0x167f03292b0689800a149b62d6ac2f5163e1dd4995964195c521e0f3ff46183a                         │
│  │ Owner: Account Address ( 0xa24c44f9e1f09e3675d39c50f6182b36e5e8a8c39b677666910c8091d681bd8c )  │
│  │ Version: 3                                                                                     │
│  │ Digest: 3XpnrJY6nBve6GGVepHyN9j3ht7KyvunQiJdhGy1rbLH                                           │
│  └──                                                                                              │
│  ┌──                                                                                              │
│  │ ID: 0x87b0a482a46961d091743e6669d797c836a49e9b8c6c8ba31b127d8c42ace233                         │
│  │ Owner: Account Address ( 0xa24c44f9e1f09e3675d39c50f6182b36e5e8a8c39b677666910c8091d681bd8c )  │
│  │ Version: 3                                                                                     │
│  │ Digest: 3PYdrT9b13m8zsG4gCcTiUEeJsEEvanmmCpZP6PE6BNc                                           │
│  └──                                                                                              │
│ Gas Object:                                                                                       │
│  ┌──                                                                                              │
│  │ ID: 0x87b0a482a46961d091743e6669d797c836a49e9b8c6c8ba31b127d8c42ace233                         │
│  │ Owner: Account Address ( 0xa24c44f9e1f09e3675d39c50f6182b36e5e8a8c39b677666910c8091d681bd8c )  │
│  │ Version: 3                                                                                     │
│  │ Digest: 3PYdrT9b13m8zsG4gCcTiUEeJsEEvanmmCpZP6PE6BNc                                           │
│  └──                                                                                              │
│ Gas Cost Summary:                                                                                 │
│    Storage Cost: 2964000 MIST                                                                     │
│    Computation Cost: 1000000 MIST                                                                 │
│    Storage Rebate: 978120 MIST                                                                    │
│    Non-refundable Storage Fee: 9880 MIST                                                          │
│                                                                                                   │
│ Transaction Dependencies:                                                                         │
│    AFFmrzPEf73hmgZkeEQbAMr2br6JKQZsiFUNoAPrDq94                                                   │
│    AJudmLDT8jJ6uyh1gqZVF5gZ61GwuKx882BJkbkJMrXa                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─────────────────────────────╮
│ No transaction block events │
╰─────────────────────────────╯
Execution Result  Mutable Reference Outputs    Sui Argument: Input(0)
    Sui TypeTag: SuiTypeTag("0x2::coin::Coin<0x2::sui::SUI>")
    Bytes: [22, 127, 3, 41, 43, 6, 137, 128, 10, 20, 155, 98, 214, 172, 47, 81, 99, 225, 221, 73, 149, 150, 65, 149, 197, 33, 224, 243, 255, 70, 24, 58, 0, 232, 118, 72, 23, 0, 0, 0]
  Return values
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: You can now pass `--dev-inspect` flag to all relevant `sui client` commands, similarly to the existing `--dry-run` flag.
- [ ] Rust SDK:
- [ ] REST API:
