### PR TITLE
[move][move-2024][matching] Preserve int subject annotation during match pattern typing

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1612,7 +1612,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                 }
             };
             let result_type = core::make_tvar(context, aloc);
-            let earms = match_arms(context, &subject_type, &result_type, narms_, &ref_mut);
+            let earms = match_arms(context, &esubject.ty.clone(), &result_type, narms_, &ref_mut);
             (result_type, TE::Match(esubject, sp(aloc, earms)))
         }
         NE::While(name, nb, nloop) => {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1612,13 +1612,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                 }
             };
             let result_type = core::make_tvar(context, aloc);
-            let earms = match_arms(
-                context,
-                &esubject.ty.clone(),
-                &result_type,
-                narms_,
-                &ref_mut,
-            );
+            let earms = match_arms(context, &esubject.ty, &result_type, narms_, &ref_mut);
             (result_type, TE::Match(esubject, sp(aloc, earms)))
         }
         NE::While(name, nb, nloop) => {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1612,7 +1612,13 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                 }
             };
             let result_type = core::make_tvar(context, aloc);
-            let earms = match_arms(context, &esubject.ty.clone(), &result_type, narms_, &ref_mut);
+            let earms = match_arms(
+                context,
+                &esubject.ty.clone(),
+                &result_type,
+                narms_,
+                &ref_mut,
+            );
             (result_type, TE::Match(esubject, sp(aloc, earms)))
         }
         NE::While(name, nb, nloop) => {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_complex.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_complex.move
@@ -1,0 +1,14 @@
+module a::m;
+
+fun t0() {
+    let x = 2 + 5;
+    match (x) { _ => {} }
+}
+
+fun t1() {
+    match ({ 2 + 3 + 4}) { _ => {} }
+}
+
+fun t2() {
+    match ({ let x = 2 + 3; x + 4}) { _ => {} }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_mut_ref_type.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_mut_ref_type.move
@@ -1,0 +1,5 @@
+module a::m;
+
+fun t() {
+    match (&mut 10) { _ => {} }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_ref_type.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_ref_type.move
@@ -1,0 +1,5 @@
+module a::m;
+
+fun t() {
+    match (&10) { _ => {} }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_subject.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/inferred_int_subject.move
@@ -1,0 +1,5 @@
+module a::m;
+
+fun t() {
+    match (10) { _ => {} }
+}


### PR DESCRIPTION
## Description 

Preserve int subject annotation during match pattern typing

## Test plan 

New tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
