### PR TITLE
indexer: support force start and end checkpoints

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -238,6 +238,8 @@ impl Cluster for LocalNewCluster {
                 None,
                 Some(data_ingestion_path.path().to_path_buf()),
                 None, /* cancel */
+                None, /* start_checkpoint */
+                None, /* end_checkpoint */
             )
             .await;
             cancellation_tokens.push(writer_token.drop_guard());

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -187,6 +187,8 @@ pub async fn serve_executor(
         retention_config,
         Some(data_ingestion_path),
         Some(cancellation_token.clone()),
+        None,
+        None,
     )
     .await;
 

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -132,6 +132,8 @@ pub async fn start_network_cluster() -> NetworkCluster {
         None,
         Some(data_ingestion_path.path().to_path_buf()),
         Some(cancellation_token.clone()),
+        None, /* start_checkpoint */
+        None, /* end_checkpoint */
     )
     .await;
 

--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -114,6 +114,16 @@ pub struct IngestionConfig {
     )]
     pub checkpoint_download_queue_size: usize,
 
+    /// Start checkpoint to ingest from, this is optional and if not provided, the ingestion will
+    /// start from the next checkpoint after the latest committed checkpoint.
+    #[arg(long, env = "START_CHECKPOINT")]
+    pub start_checkpoint: Option<u64>,
+
+    /// End checkpoint to ingest until, this is optional and if not provided, the ingestion will
+    /// continue until u64::MAX.
+    #[arg(long, env = "END_CHECKPOINT")]
+    pub end_checkpoint: Option<u64>,
+
     #[arg(
         long,
         default_value_t = Self::DEFAULT_CHECKPOINT_DOWNLOAD_TIMEOUT,
@@ -141,6 +151,8 @@ impl Default for IngestionConfig {
     fn default() -> Self {
         Self {
             sources: Default::default(),
+            start_checkpoint: None,
+            end_checkpoint: None,
             checkpoint_download_queue_size: Self::DEFAULT_CHECKPOINT_DOWNLOAD_QUEUE_SIZE,
             checkpoint_download_timeout: Self::DEFAULT_CHECKPOINT_DOWNLOAD_TIMEOUT,
             checkpoint_download_queue_size_bytes:

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -50,10 +50,20 @@ const CHECKPOINT_QUEUE_SIZE: usize = 100;
 pub async fn new_handlers(
     state: PgIndexerStore,
     metrics: IndexerMetrics,
-    next_checkpoint_sequence_number: CheckpointSequenceNumber,
     cancel: CancellationToken,
     committed_checkpoints_tx: Option<watch::Sender<Option<IndexerProgress>>>,
-) -> Result<CheckpointHandler, IndexerError> {
+    start_checkpoint_opt: Option<CheckpointSequenceNumber>,
+    end_checkpoint_opt: Option<CheckpointSequenceNumber>,
+) -> Result<(CheckpointHandler, u64), IndexerError> {
+    let start_checkpoint = match start_checkpoint_opt {
+        Some(start_checkpoint) => start_checkpoint,
+        None => state
+            .get_latest_checkpoint_sequence_number()
+            .await?
+            .map(|seq| seq.saturating_add(1))
+            .unwrap_or_default(),
+    };
+
     let checkpoint_queue_size = std::env::var("CHECKPOINT_QUEUE_SIZE")
         .unwrap_or(CHECKPOINT_QUEUE_SIZE.to_string())
         .parse::<usize>()
@@ -73,14 +83,14 @@ pub async fn new_handlers(
         state_clone,
         metrics_clone,
         indexed_checkpoint_receiver,
-        next_checkpoint_sequence_number,
         cancel.clone(),
-        committed_checkpoints_tx
+        committed_checkpoints_tx,
+        start_checkpoint,
+        end_checkpoint_opt,
     ));
-    Ok(CheckpointHandler::new(
-        state,
-        metrics,
-        indexed_checkpoint_sender,
+    Ok((
+        CheckpointHandler::new(state, metrics, indexed_checkpoint_sender),
+        start_checkpoint,
     ))
 }
 

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -48,13 +48,6 @@ impl Indexer {
         );
         info!("Sui Indexer Writer config: {config:?}",);
 
-        let primary_watermark = store
-            .get_latest_checkpoint_sequence_number()
-            .await
-            .expect("Failed to get latest tx checkpoint sequence number from DB")
-            .map(|seq| seq + 1)
-            .unwrap_or_default();
-
         let extra_reader_options = ReaderOptions {
             batch_size: config.checkpoint_download_queue_size,
             timeout_secs: config.checkpoint_download_timeout,
@@ -68,6 +61,8 @@ impl Indexer {
             metrics.clone(),
             snapshot_config,
             cancel.clone(),
+            config.start_checkpoint,
+            config.end_checkpoint,
         )
         .await?;
 
@@ -89,6 +84,16 @@ impl Indexer {
 
         let mut exit_senders = vec![];
         let mut executors = vec![];
+
+        let (worker, primary_watermark) = new_handlers(
+            store,
+            metrics,
+            cancel.clone(),
+            committed_checkpoints_tx,
+            config.start_checkpoint,
+            config.end_checkpoint,
+        )
+        .await?;
         // Ingestion task watermarks are snapshotted once on indexer startup based on the
         // corresponding watermark table before being handed off to the ingestion task.
         let progress_store = ShimIndexerProgressStore::new(vec![
@@ -100,14 +105,7 @@ impl Indexer {
             2,
             DataIngestionMetrics::new(&Registry::new()),
         );
-        let worker = new_handlers(
-            store,
-            metrics,
-            primary_watermark,
-            cancel.clone(),
-            committed_checkpoints_tx,
-        )
-        .await?;
+
         let worker_pool = WorkerPool::new(
             worker,
             "primary".to_string(),

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -720,6 +720,8 @@ async fn start(
             None,
             Some(data_ingestion_path.clone()),
             None,
+            None, /* start_checkpoint */
+            None, /* end_checkpoint */
         )
         .await;
         info!("Indexer started in writer mode");

--- a/crates/test-cluster/src/test_indexer_handle.rs
+++ b/crates/test-cluster/src/test_indexer_handle.rs
@@ -46,6 +46,8 @@ impl IndexerHandle {
             None,
             Some(data_ingestion_path.clone()),
             None,
+            None,
+            None,
         )
         .await;
         cancellation_tokens.push(writer_token.drop_guard());


### PR DESCRIPTION
## Description 

useful for benchmark so that we can replay the same traffic again and again wo DB ops

## Test plan 

- ci to make sure it does not break other ingestion
- added an ingestion test for the new start and end functions

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
