### PR TITLE
[indexer-alt] Run one pipeline at a time

### DIFF
--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -3,15 +3,7 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use sui_indexer_alt::{
-    args::Args,
-    handlers::{
-        ev_emit_mod::EvEmitMod, ev_struct_inst::EvStructInst, kv_checkpoints::KvCheckpoints,
-        kv_objects::KvObjects, kv_transactions::KvTransactions,
-        tx_affected_objects::TxAffectedObjects, tx_balance_changes::TxBalanceChanges,
-    },
-    Indexer,
-};
+use sui_indexer_alt::{args::Args, Indexer};
 use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
@@ -25,15 +17,7 @@ async fn main() -> Result<()> {
 
     let cancel = CancellationToken::new();
 
-    let mut indexer = Indexer::new(args.indexer_config, cancel.clone()).await?;
-
-    indexer.concurrent_pipeline::<EvEmitMod>().await?;
-    indexer.concurrent_pipeline::<EvStructInst>().await?;
-    indexer.concurrent_pipeline::<KvCheckpoints>().await?;
-    indexer.concurrent_pipeline::<KvObjects>().await?;
-    indexer.concurrent_pipeline::<KvTransactions>().await?;
-    indexer.concurrent_pipeline::<TxAffectedObjects>().await?;
-    indexer.concurrent_pipeline::<TxBalanceChanges>().await?;
+    let indexer = Indexer::new(args.indexer_config, cancel.clone()).await?;
 
     let h_indexer = indexer.run().await.context("Failed to start indexer")?;
 

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use crate::{handlers::Handler, models::watermarks::CommitterWatermark};
+use std::time::Duration;
 
 pub mod concurrent;
 mod processor;
@@ -14,6 +13,8 @@ const COMMITTER_BUFFER: usize = 5;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct PipelineConfig {
+    #[command(subcommand)]
+    pub pipeline: PipelineName,
     /// Committer will check for pending data at least this often
     #[arg(
         long,
@@ -35,6 +36,18 @@ pub struct PipelineConfig {
     /// Avoid writing to the watermark table
     #[arg(long)]
     skip_watermark: bool,
+}
+
+/// Each enum variant can also take pipeline-specific configuration.
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum PipelineName {
+    EvEmitMod,
+    EvStructInst,
+    KvCheckpoints,
+    KvObjects,
+    KvTransactions,
+    TxAffectedObjects,
+    TxBalanceChanges,
 }
 
 /// A batch of processed values associated with a single checkpoint. This is an internal type used


### PR DESCRIPTION
## Description 

This should be the default mode of running indexer pipeline, for the following reasons:
1. It is naturally scalable since we could run each pipeline on different host with operational ease.
2. We should measure throughput using this as a starting point, instead of starting with the full set and divide as throughout drops. This represents the most scalable setup and the best number will give us confidence in one go.
3. It allows easy extension of custom indexers.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
