### PR TITLE
[move] Remove parsing aliases from `move-command-line-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7416,7 +7416,6 @@ dependencies = [
  "hex",
  "move-binary-format",
  "move-core-types",
- "num-bigint 0.4.4",
  "once_cell",
  "serde",
  "sha2 0.9.9",

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -5,10 +5,13 @@ use crate::test_adapter::{FakeID, SuiTestAdapter};
 use anyhow::{bail, ensure};
 use clap;
 use clap::{Args, Parser};
-use move_command_line_common::parser::{parse_u256, parse_u64};
-use move_command_line_common::values::{ParsableValue, ParsedValue};
-use move_command_line_common::{parser::Parser as MoveCLParser, values::ValueToken};
 use move_compiler::editions::Flavor;
+use move_core_types::parsing::{
+    parser::Parser as MoveCLParser,
+    parser::{parse_u256, parse_u64},
+    values::ValueToken,
+    values::{ParsableValue, ParsedValue},
+};
 use move_core_types::runtime_value::{MoveStruct, MoveValue};
 use move_core_types::u256::U256;
 use move_symbol_pool::Symbol;

--- a/crates/sui-transactional-test-runner/src/programmable_transaction_test_parser/parser.rs
+++ b/crates/sui-transactional-test-runner/src/programmable_transaction_test_parser/parser.rs
@@ -3,7 +3,7 @@
 
 use std::{borrow::BorrowMut, marker::PhantomData, str::FromStr};
 
-use move_command_line_common::{
+use move_core_types::parsing::{
     parser::{Parser, Token},
     types::{ParsedType, TypeToken},
 };

--- a/crates/sui-transactional-test-runner/src/programmable_transaction_test_parser/token.rs
+++ b/crates/sui-transactional-test-runner/src/programmable_transaction_test_parser/token.rs
@@ -4,8 +4,8 @@
 use std::fmt::{self, Display};
 
 use anyhow::bail;
-use move_command_line_common::parser::Token;
 use move_core_types::identifier;
+use move_core_types::parsing::parser::Token;
 
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub enum CommandToken {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -15,15 +15,14 @@ use fastcrypto::encoding::{Base64, Encoding};
 use fastcrypto::traits::ToFromBytes;
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
-use move_command_line_common::{
-    address::ParsedAddress, files::verify_and_create_named_address_mapping,
-};
+use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{
     editions::{Edition, Flavor},
     shared::{NumberFormat, NumericalAddress, PackageConfig, PackagePaths},
     Flags, FullyCompiledProgram,
 };
 use move_core_types::ident_str;
+use move_core_types::parsing::address::ParsedAddress;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -153,7 +153,7 @@ pub fn sui_framework_address_concat_string(suffix: &str) -> String {
 /// Parsing succeeds if and only if `s` matches one of these formats exactly, with no remaining
 /// suffix. This function is intended for use within the authority codebases.
 pub fn parse_sui_address(s: &str) -> anyhow::Result<SuiAddress> {
-    use move_command_line_common::address::ParsedAddress;
+    use move_core_types::parsing::address::ParsedAddress;
     Ok(ParsedAddress::parse(s)?
         .into_account_address(&resolve_address)?
         .into())
@@ -163,7 +163,7 @@ pub fn parse_sui_address(s: &str) -> anyhow::Result<SuiAddress> {
 /// module name (an identifier). Parsing succeeds if and only if `s` matches this format exactly,
 /// with no remaining input. This function is intended for use within the authority codebases.
 pub fn parse_sui_module_id(s: &str) -> anyhow::Result<ModuleId> {
-    use move_command_line_common::types::ParsedModuleId;
+    use move_core_types::parsing::types::ParsedModuleId;
     ParsedModuleId::parse(s)?.into_module_id(&resolve_address)
 }
 
@@ -172,7 +172,7 @@ pub fn parse_sui_module_id(s: &str) -> anyhow::Result<ModuleId> {
 /// format exactly, with no remaining input. This function is intended for use within the authority
 /// codebases.
 pub fn parse_sui_fq_name(s: &str) -> anyhow::Result<(ModuleId, String)> {
-    use move_command_line_common::types::ParsedFqName;
+    use move_core_types::parsing::types::ParsedFqName;
     ParsedFqName::parse(s)?.into_fq_name(&resolve_address)
 }
 
@@ -181,7 +181,7 @@ pub fn parse_sui_fq_name(s: &str) -> anyhow::Result<(ModuleId, String)> {
 /// brackets). Parsing succeeds if and only if `s` matches this format exactly, with no remaining
 /// input. This function is intended for use within the authority codebase.
 pub fn parse_sui_struct_tag(s: &str) -> anyhow::Result<StructTag> {
-    use move_command_line_common::types::ParsedStructType;
+    use move_core_types::parsing::types::ParsedStructType;
     ParsedStructType::parse(s)?.into_struct_tag(&resolve_address)
 }
 
@@ -189,7 +189,7 @@ pub fn parse_sui_struct_tag(s: &str) -> anyhow::Result<StructTag> {
 /// vector with a type parameter. Parsing succeeds if and only if `s` matches this format exactly,
 /// with no remaining input. This function is intended for use within the authority codebase.
 pub fn parse_sui_type_tag(s: &str) -> anyhow::Result<TypeTag> {
-    use move_command_line_common::types::ParsedType;
+    use move_core_types::parsing::types::ParsedType;
     ParsedType::parse(s)?.into_type_tag(&resolve_address)
 }
 

--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use move_command_line_common::{
+use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
     types::{ParsedFqName, ParsedModuleId, ParsedStructType, ParsedType},
 };

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -16,7 +16,7 @@ use miette::Severity;
 use move_binary_format::{
     binary_config::BinaryConfig, file_format::SignatureToken, CompiledModule,
 };
-use move_command_line_common::{
+use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
     parser::NumberFormat,
 };

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -3,7 +3,7 @@
 
 use std::iter::Peekable;
 
-use move_command_line_common::{
+use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
     parser::{parse_u128, parse_u16, parse_u256, parse_u32, parse_u64, parse_u8},
     types::{ParsedFqName, ParsedModuleId, ParsedStructType, ParsedType},

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1804,7 +1804,6 @@ dependencies = [
  "hex",
  "move-binary-format",
  "move-core-types",
- "num-bigint",
  "once_cell",
  "proptest",
  "serde",

--- a/external-crates/move/crates/move-cli/src/sandbox/cli.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/cli.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::Result;
 use clap::Parser;
-use move_command_line_common::values::ParsedValue;
+use move_core_types::parsing::values::ParsedValue;
 use move_core_types::{language_storage::TypeTag, transaction_argument::TransactionArgument};
 use move_package::compilation::package_layout::CompiledPackageLayout;
 use move_vm_test_utils::gas_schedule::CostTable;

--- a/external-crates/move/crates/move-command-line-common/Cargo.toml
+++ b/external-crates/move/crates/move-command-line-common/Cargo.toml
@@ -15,7 +15,6 @@ difference.workspace = true
 walkdir.workspace = true
 sha2.workspace = true
 hex.workspace = true
-num-bigint.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 dirs-next.workspace = true
@@ -27,9 +26,3 @@ move-binary-format.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-# Ok to do this since:
-# edition = 2021 ==> resolver = 2
-# * https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#summary
-# resolver = 2 ==> feature-resolver-version-2 which allows dev-dependencies to set features
-# * https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
-move-core-types = { workspace = true, features = ["fuzzing"] }

--- a/external-crates/move/crates/move-command-line-common/src/lib.rs
+++ b/external-crates/move/crates/move-command-line-common/src/lib.rs
@@ -11,8 +11,3 @@ pub mod error_bitset;
 pub mod files;
 pub mod interactive;
 pub mod testing;
-
-pub use move_core_types::parsing::address;
-pub use move_core_types::parsing::parser;
-pub use move_core_types::parsing::types;
-pub use move_core_types::parsing::values;

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -40,8 +40,8 @@ use crate::{
     },
     FullyCompiledProgram,
 };
-use move_command_line_common::parser::{parse_u16, parse_u256, parse_u32};
 use move_core_types::account_address::AccountAddress;
+use move_core_types::parsing::parser::{parse_u16, parse_u256, parse_u32};
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;

--- a/external-crates/move/crates/move-compiler/src/shared/ide.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/ide.rs
@@ -16,7 +16,7 @@ use crate::{
     unit_test::filter_test_members::UNIT_TEST_POISON_FUN_NAME,
 };
 
-use move_command_line_common::address::NumericalAddress;
+use move_core_types::parsing::address::NumericalAddress;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -62,7 +62,7 @@ pub use ast_debug::AstDebug;
 // Numbers
 //**************************************************************************************************
 
-pub use move_command_line_common::parser::{
+pub use move_core_types::parsing::parser::{
     parse_address_number as parse_address, parse_u128, parse_u16, parse_u256, parse_u32, parse_u64,
     parse_u8, NumberFormat,
 };
@@ -71,7 +71,7 @@ pub use move_command_line_common::parser::{
 // Address
 //**************************************************************************************************
 
-pub use move_command_line_common::address::NumericalAddress;
+pub use move_core_types::parsing::address::NumericalAddress;
 
 pub fn parse_named_address(s: &str) -> anyhow::Result<(String, NumericalAddress)> {
     let before_after = s.split('=').collect::<Vec<_>>();

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -47,7 +47,8 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
-use move_command_line_common::{address::NumericalAddress, files::FileHash};
+use move_command_line_common::files::FileHash;
+use move_core_types::parsing::address::NumericalAddress;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},

--- a/external-crates/move/crates/move-stdlib/src/lib.rs
+++ b/external-crates/move/crates/move-stdlib/src/lib.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use log::LevelFilter;
-use move_command_line_common::{
-    address::NumericalAddress,
-    files::{extension_equals, find_filenames, MOVE_EXTENSION},
-};
+use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXTENSION};
+use move_core_types::parsing::address::NumericalAddress;
 use std::{collections::BTreeMap, path::PathBuf};
 
 #[cfg(test)]

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -14,12 +14,9 @@ use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
 use move_command_line_common::{
-    address::ParsedAddress,
     env::read_bool_env_var,
     files::{MOVE_EXTENSION, MOVE_IR_EXTENSION},
     testing::{add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT},
-    types::ParsedType,
-    values::{ParsableValue, ParsedValue},
 };
 use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
@@ -27,6 +24,11 @@ use move_compiler::{
     editions::{Edition, Flavor},
     shared::{files::MappedFiles, NumericalAddress, PackageConfig},
     FullyCompiledProgram,
+};
+use move_core_types::parsing::{
+    address::ParsedAddress,
+    types::ParsedType,
+    values::{ParsableValue, ParsedValue},
 };
 use move_core_types::{
     account_address::AccountAddress,

--- a/external-crates/move/crates/move-transactional-test-runner/src/tasks.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/tasks.rs
@@ -6,14 +6,14 @@
 
 use anyhow::{anyhow, bail, Result};
 use clap::*;
-use move_command_line_common::{
+use move_command_line_common::files::{MOVE_EXTENSION, MOVE_IR_EXTENSION};
+use move_compiler::shared::NumericalAddress;
+use move_core_types::identifier::Identifier;
+use move_core_types::parsing::{
     address::ParsedAddress,
-    files::{MOVE_EXTENSION, MOVE_IR_EXTENSION},
     types::ParsedType,
     values::{ParsableValue, ParsedValue},
 };
-use move_compiler::shared::NumericalAddress;
-use move_core_types::identifier::Identifier;
 use std::{convert::TryInto, fmt::Debug, path::Path, str::FromStr};
 use tempfile::NamedTempFile;
 

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -15,10 +15,9 @@ use move_binary_format::{
     errors::{Location, VMError, VMResult},
     CompiledModule,
 };
-use move_command_line_common::{
-    address::ParsedAddress, files::verify_and_create_named_address_mapping,
-};
+use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{editions::Edition, shared::PackagePaths, FullyCompiledProgram};
+use move_core_types::parsing::address::ParsedAddress;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,


### PR DESCRIPTION
## Description 

Removes parsing aliases from `move-command-line-common` and update to use the `move_core_types::parsing` directly. 

## Test plan 

CI

