### PR TITLE
Fix lint with `cargo xclippy`

### DIFF
--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs
@@ -20,8 +20,6 @@ use move_core_types::{
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_config::runtime::VMRuntimeLimitsConfig;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_profiler::{
     profile_close_frame, profile_close_instr, profile_open_frame, profile_open_instr,
 };

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs
@@ -19,8 +19,6 @@ use move_core_types::{
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_config::runtime::VMRuntimeLimitsConfig;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_profiler::{
     profile_close_frame, profile_close_instr, profile_open_frame, profile_open_instr,
 };

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/interpreter.rs
@@ -19,8 +19,6 @@ use move_core_types::{
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_config::runtime::VMRuntimeLimitsConfig;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_profiler::{
     profile_close_frame, profile_close_instr, profile_open_frame, profile_open_instr,
 };


### PR DESCRIPTION
## Description 

`cargo xclippy` has `--all-features` enabled. Seeing these warnings:

```
warning: unused import: `move_vm_profiler::GasProfiler`
  --> external-crates/move/move-execution/v2/crates/move-vm-runtime/src/interpreter.rs:23:5
   |
23 | use move_vm_profiler::GasProfiler;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `move_vm_profiler::GasProfiler`
  --> external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs:23:5
   |
23 | use move_vm_profiler::GasProfiler;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `move_vm_profiler::GasProfiler`
  --> external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs:24:5
   |
24 | use move_vm_profiler::GasProfiler;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
