### PR TITLE
sui-move: drop duplicate `--path` options

### DIFF
--- a/crates/sui-move/src/main.rs
+++ b/crates/sui-move/src/main.rs
@@ -26,10 +26,18 @@ struct Args {
     #[clap(long = "path", short = 'p', global = true)]
     pub package_path: Option<PathBuf>,
     /// If true, run the Move bytecode verifier on the bytecode from a successful build
-    #[clap(long = "path", short = 'p', global = true)]
+    #[clap(
+        long,
+        default_value_if("package_path", builder::ArgPredicate::IsPresent, Some("true")),
+        global = true
+    )]
     pub run_bytecode_verifier: bool,
     /// If true, print build diagnostics to stderr--no printing if false
-    #[clap(long = "path", short = 'p', global = true)]
+    #[clap(
+        long,
+        default_value_if("package_path", builder::ArgPredicate::IsPresent, Some("true")),
+        global = true
+    )]
     pub print_diags_to_stderr: bool,
     /// Package build options
     #[clap(flatten)]

--- a/crates/sui-move/src/main.rs
+++ b/crates/sui-move/src/main.rs
@@ -26,18 +26,10 @@ struct Args {
     #[clap(long = "path", short = 'p', global = true)]
     pub package_path: Option<PathBuf>,
     /// If true, run the Move bytecode verifier on the bytecode from a successful build
-    #[clap(
-        long,
-        default_value_if("package_path", builder::ArgPredicate::IsPresent, Some("true")),
-        global = true
-    )]
+    #[clap(long, global = true)]
     pub run_bytecode_verifier: bool,
     /// If true, print build diagnostics to stderr--no printing if false
-    #[clap(
-        long,
-        default_value_if("package_path", builder::ArgPredicate::IsPresent, Some("true")),
-        global = true
-    )]
+    #[clap(long, global = true)]
     pub print_diags_to_stderr: bool,
     /// Package build options
     #[clap(flatten)]


### PR DESCRIPTION
## Description 

Use `default_value_if` to instead of using the same alias, and avoid to have panic in debug build.
Fix #20003 

## Test plan 

Reuse existing test cases

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: add `--run-bytecode-verifier` and `--print-diags-to-stderr` for `sui-move`
- [ ] Rust SDK:
- [ ] REST API:
