### PR TITLE
indexer-alt: concurrent writes

### DIFF
--- a/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
@@ -35,7 +35,7 @@ pub(super) fn broadcaster(
 
         match ReceiverStream::new(checkpoint_rx)
             .map(Ok)
-            .try_for_each_concurrent(/* limit */ config.concurrency, |cp| {
+            .try_for_each_concurrent(/* limit */ config.ingest_concurrency, |cp| {
                 let client = client.clone();
                 let metrics = metrics.clone();
                 let subscribers = subscribers.clone();

--- a/crates/sui-indexer-alt/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt/src/ingestion/mod.rs
@@ -51,11 +51,11 @@ pub struct IngestionConfig {
 
     /// Maximum size of checkpoint backlog across all workers downstream of the ingestion service.
     #[arg(long, default_value_t = 5000)]
-    buffer_size: usize,
+    checkpoint_buffer_size: usize,
 
     /// Maximum number of checkpoints to attempt to fetch concurrently.
     #[arg(long, default_value_t = 200)]
-    concurrency: usize,
+    ingest_concurrency: usize,
 
     /// Polling interval to retry fetching checkpoints that do not exist.
     #[arg(
@@ -109,7 +109,7 @@ impl IngestionService {
         mpsc::Receiver<Arc<CheckpointData>>,
         mpsc::UnboundedSender<(&'static str, u64)>,
     ) {
-        let (sender, receiver) = mpsc::channel(self.config.buffer_size);
+        let (sender, receiver) = mpsc::channel(self.config.checkpoint_buffer_size);
         self.subscribers.push(sender);
         (receiver, self.ingest_hi_tx.clone())
     }
@@ -147,11 +147,11 @@ impl IngestionService {
             return Err(Error::NoSubscribers);
         }
 
-        let (checkpoint_tx, checkpoint_rx) = mpsc::channel(config.concurrency);
+        let (checkpoint_tx, checkpoint_rx) = mpsc::channel(config.ingest_concurrency);
 
         let regulator = regulator(
             checkpoints,
-            config.buffer_size,
+            config.checkpoint_buffer_size,
             ingest_hi_rx,
             checkpoint_tx,
             cancel.clone(),
@@ -186,16 +186,16 @@ mod tests {
 
     async fn test_ingestion(
         uri: String,
-        buffer_size: usize,
-        concurrency: usize,
+        checkpoint_buffer_size: usize,
+        ingest_concurrency: usize,
         cancel: CancellationToken,
     ) -> IngestionService {
         IngestionService::new(
             IngestionConfig {
                 remote_store_url: Some(Url::parse(&uri).unwrap()),
                 local_ingestion_path: None,
-                buffer_size,
-                concurrency,
+                checkpoint_buffer_size,
+                ingest_concurrency,
                 retry_interval: Duration::from_millis(200),
             },
             Arc::new(test_metrics()),

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -150,7 +150,7 @@ impl Indexer {
             .map_or(0, |w| w.checkpoint_hi_inclusive as u64 + 1)
             .min(self.first_checkpoint_from_watermark);
 
-        let (processor, committer, watermark) = concurrent::pipeline::<H>(
+        let (processor, collector, committer, watermark) = concurrent::pipeline::<H>(
             watermark,
             self.pipeline_config.clone(),
             self.db.clone(),
@@ -160,6 +160,7 @@ impl Indexer {
         );
 
         self.handles.push(processor);
+        self.handles.push(collector);
         self.handles.push(committer);
         self.handles.push(watermark);
 

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
@@ -149,7 +149,7 @@ pub(super) fn collector<H: Handler + 'static>(
 
                     if pending_rows > 0 {
                         poll.reset_immediately();
-                    } else if rx.is_closed() {
+                    } else if rx.is_closed() && rx.is_empty() {
                         info!(
                             pipeline = H::NAME,
                             "Processor closed channel, pending rows empty, stopping collector",

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use mysten_metrics::spawn_monitored_task;
+use tokio::{
+    sync::mpsc,
+    task::JoinHandle,
+    time::{interval, MissedTickBehavior},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+use crate::{
+    handlers::Handler,
+    metrics::IndexerMetrics,
+    pipeline::{Batched, Indexed, PipelineConfig},
+};
+
+/// The collector task is responsible for gathering rows into batches which it then sends to a
+/// committer task to write to the database. The task publishes batches in the following
+/// circumstances:
+///
+/// - If `H::BATCH_SIZE` rows are pending, it will immediately schedule a batch to be gathered.
+///
+/// - If after sending one batch there is more data to be sent, it will immediately schedule the
+///   next batch to be gathered (Each batch will contain at most `H::CHUNK_SIZ` rows).
+///
+/// - Otherwise, it will check for any data to write out at a regular interval (controlled by
+///   `config.collect_interval`).
+///
+/// This task will shutdown if canceled via the `cancel` token, or if any of its channels are
+/// closed.
+pub(super) fn collector<H: Handler + 'static>(
+    config: PipelineConfig,
+    mut rx: mpsc::Receiver<Indexed<H>>,
+    tx: mpsc::Sender<Batched<H>>,
+    metrics: Arc<IndexerMetrics>,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    spawn_monitored_task!(async move {
+        // The `poll` interval controls the maximum time to wait between collecting batches,
+        // regardless of number of rows pending.
+        let mut poll = interval(config.collect_interval);
+        poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // Data for checkpoints that haven't been written yet.
+        let mut pending: BTreeMap<u64, Indexed<H>> = BTreeMap::new();
+        let mut pending_rows = 0;
+
+        info!(pipeline = H::NAME, "Starting collector");
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!(pipeline = H::NAME, "Shutdown received, stopping collector");
+                    break;
+                }
+
+                // Time to create another batch and push it to the committer.
+                _ = poll.tick() => {
+                    let guard = metrics
+                        .collector_gather_latency
+                        .with_label_values(&[H::NAME])
+                        .start_timer();
+
+                    let mut batch = Batched::new();
+                    while !batch.is_full() {
+                        let Some(mut entry) = pending.first_entry() else {
+                            break;
+                        };
+
+                        let indexed = entry.get_mut();
+                        indexed.batch_into(&mut batch);
+                        if indexed.is_empty() {
+                            entry.remove();
+                        }
+                    }
+
+                    pending_rows -= batch.len();
+                    let elapsed = guard.stop_and_record();
+                    debug!(
+                        pipeline = H::NAME,
+                        elapsed_ms = elapsed * 1000.0,
+                        rows = batch.len(),
+                        pending = pending_rows,
+                        "Gathered batch",
+                    );
+
+                    metrics
+                        .total_collector_batches_created
+                        .with_label_values(&[H::NAME])
+                        .inc();
+
+                    metrics
+                        .collector_batch_size
+                        .with_label_values(&[H::NAME])
+                        .observe(batch.len() as f64);
+
+                    if tx.send(batch).await.is_err() {
+                        info!(pipeline = H::NAME, "Committer closed channel, stopping collector");
+                        break;
+                    }
+
+                    if pending_rows > 0 {
+                        poll.reset_immediately();
+                    } else if rx.is_closed() {
+                        info!(
+                            pipeline = H::NAME,
+                            "Processor closed channel, pending rows empty, stopping collector",
+                        );
+                        break;
+                    }
+                }
+
+                Some(indexed) = rx.recv(), if pending_rows < H::MAX_PENDING_SIZE => {
+                    metrics
+                        .total_collector_rows_received
+                        .with_label_values(&[H::NAME])
+                        .inc_by(indexed.values.len() as u64);
+
+                    pending_rows += indexed.values.len();
+                    pending.insert(indexed.checkpoint(), indexed);
+
+                    if pending_rows >= H::BATCH_SIZE {
+                        poll.reset_immediately()
+                    }
+                }
+            }
+        }
+    })
+}

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
@@ -1,14 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, mem, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
+use backoff::ExponentialBackoff;
+use futures::TryStreamExt;
 use mysten_metrics::spawn_monitored_task;
-use tokio::{
-    sync::mpsc,
-    task::JoinHandle,
-    time::{interval, MissedTickBehavior},
-};
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -16,263 +15,166 @@ use crate::{
     db::Db,
     handlers::Handler,
     metrics::IndexerMetrics,
-    models::watermarks::CommitterWatermark,
-    pipeline::{Indexed, PipelineConfig},
+    pipeline::{Batched, Break, PipelineConfig, WatermarkPart},
 };
 
-/// The committer will wait at least this long between commits for any given pipeline.
-const COOLDOWN_INTERVAL: Duration = Duration::from_millis(20);
+/// If the committer needs to retry a commit, it will wait this long initially.
+const INITIAL_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
-/// The committer will wait at least this long between attempts to commit a failed batch.
-const RETRY_INTERVAL: Duration = Duration::from_millis(100);
+/// If the commiter needs to retry a commit, it will wait at most this long between retries.
+const MAX_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
-/// The committer task is responsible for gathering rows to write to the database. It is a single
-/// work loop that gathers checkpoint-wise row information, and periodically writes them out to the
-/// database.
+/// The committer task is responsible for writing batches of rows to the database. It receives
+/// batches on `rx` and writes them out to the `db` concurrently (`config.write_concurrency`
+/// controls the degree of fan-out).
 ///
-/// The period between writes is controlled by the following factors:
+/// The writing of each batch will be repeatedly retried on an exponential back-off until it
+/// succeeds. Once the write succeeds, the [WatermarkPart]s for that batch are sent on `tx` to the
+/// watermark task.
 ///
-/// - Time since the last write (controlled by `config.commit_interval`). If there are rows pending
-///   and this interval has elapsed since the last attempted commit, the committer will attempt
-///   another write.
-///
-/// - Time since last attempted write (controlled by `COOLDOWN_INTERVAL` and `RETRY_INTERVAL`). If
-///   there was a recent successful write, the next write will wait at least `COOLDOWN_INTERVAL`,
-///   and if there was a recent unsuccessful write, the next write will wait at least
-///   `RETRY_INTERVAL`. This is to prevent one committer from hogging the database.
-///
-/// - Number of pending rows. If this exceeds `H::BATCH_SIZE`, the committer will attempt to write
-///   out at most `H::CHUNK_SIZE` worth of rows to the DB.
-///
-/// If a write fails, the committer will save the batch it meant to write and try to write them
-/// again at the next opportunity, potentially adding more rows to the batch if more have arrived
-/// in the interim.
-///
-/// On every successful write of a batch, the committer sends the checkpoint watermarks associated
-/// with the batch to the `watermark_tx` channel, where they will be used to update the watermarks
-/// table associated with this pipeline.
-///
-/// This task will shutdown if canceled via the `cancel` token, or if the channel it receives data
-/// on has been closed by the handler for some reason.
+/// This task will shutdown via its `cancel`lation token, or if its receiver or sender channels are
+/// closed.
 pub(super) fn committer<H: Handler + 'static>(
     config: PipelineConfig,
-    mut indexed_rx: mpsc::Receiver<Indexed<H>>,
-    watermark_tx: mpsc::Sender<Vec<CommitterWatermark<'static>>>,
+    rx: mpsc::Receiver<Batched<H>>,
+    tx: mpsc::Sender<Vec<WatermarkPart>>,
     db: Db,
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
     spawn_monitored_task!(async move {
-        // The `poll` interval controls the maximum time to wait between commits, regardless of the
-        // amount of data available.
-        let mut poll = interval(config.commit_interval);
-        let mut cool = interval(COOLDOWN_INTERVAL);
-
-        // We don't care about keeping a regular cadence -- these intervals are used to guarantee
-        // things are spaced at out relative to each other.
-        poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        cool.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-        // Buffer to gather the next batch to write. This may be non-empty at the top of a tick of
-        // the committer's loop if the previous attempt at a write failed. Attempt is incremented
-        // every time a batch write fails, and is reset when it succeeds.
-        let mut attempt = 0;
-        let mut batch_values = vec![];
-        let mut batch_watermarks = vec![];
-
-        // Data for checkpoints that haven't been written yet. Note that `pending_rows` includes
-        // rows in `batch`.
-        let mut pending: BTreeMap<u64, Indexed<H>> = BTreeMap::new();
-        let mut pending_rows = 0;
-
         info!(pipeline = H::NAME, "Starting committer");
 
-        loop {
-            tokio::select! {
-                // Break ties in favour of operations that reduce the size of the buffer.
-                //
-                // TODO (experiment): Do we need this? It adds some complexity/subtlety to this
-                // work loop, so if we don't notice a big difference, we should get rid of it.
-                biased;
+        match ReceiverStream::new(rx)
+            .map(Ok)
+            .try_for_each_concurrent(config.write_concurrency, |Batched { values, watermark }| {
+                let values = Arc::new(values);
+                let tx = tx.clone();
+                let db = db.clone();
+                let metrics = metrics.clone();
+                let cancel = cancel.clone();
 
-                _ = cancel.cancelled() => {
-                    info!(pipeline = H::NAME, "Shutdown received, stopping committer");
-                    break;
-                }
+                // Repeatedly try to get a connection to the DB and write the batch. Use an
+                // exponential backoff in case the failure is due to contention over the DB
+                // connection pool.
+                let backoff = ExponentialBackoff {
+                    initial_interval: INITIAL_RETRY_INTERVAL,
+                    current_interval: INITIAL_RETRY_INTERVAL,
+                    max_interval: MAX_RETRY_INTERVAL,
+                    max_elapsed_time: None,
+                    ..Default::default()
+                };
 
-                // Time to write out another batch of rows, and update the watermark, if we can.
-                _ = poll.tick() => {
-                    let Ok(mut conn) = db.connect().await else {
-                        warn!(pipeline = H::NAME, "Committer failed to get connection for DB");
-                        cool.reset();
-                        continue;
-                    };
+                use backoff::Error as BE;
+                let commit = move || {
+                    let values = values.clone();
+                    let db = db.clone();
+                    let metrics = metrics.clone();
+                    async move {
+                        metrics
+                            .total_committer_batches_attempted
+                            .with_label_values(&[H::NAME])
+                            .inc();
 
-                    let guard = metrics
-                        .committer_gather_latency
-                        .with_label_values(&[H::NAME])
-                        .start_timer();
+                        let affected = if values.is_empty() {
+                            0
+                        } else {
+                            let guard = metrics
+                                .committer_commit_latency
+                                .with_label_values(&[H::NAME])
+                                .start_timer();
 
-                    while batch_values.len() < H::CHUNK_SIZE {
-                        let Some(mut entry) = pending.first_entry() else {
-                            break;
+                            let mut conn = db.connect().await.map_err(|e| {
+                                warn!(
+                                    pipeline = H::NAME,
+                                    "Committed failed to get connection for DB"
+                                );
+                                BE::transient(Break::Err(e.into()))
+                            })?;
+
+                            let affected = H::commit(&values, &mut conn).await;
+                            let elapsed = guard.stop_and_record();
+
+                            match affected {
+                                Ok(affected) => {
+                                    debug!(
+                                        pipeline = H::NAME,
+                                        elapsed_ms = elapsed * 1000.0,
+                                        affected,
+                                        committed = values.len(),
+                                        "Wrote batch",
+                                    );
+
+                                    affected
+                                }
+
+                                Err(e) => {
+                                    warn!(
+                                        pipeline = H::NAME,
+                                        elapsed_ms = elapsed * 1000.0,
+                                        committed = values.len(),
+                                        "Error writing batch: {e}",
+                                    );
+
+                                    return Err(BE::transient(Break::Err(e)));
+                                }
+                            }
                         };
 
-                        let indexed = entry.get_mut();
-                        let values = &mut indexed.values;
-                        if batch_values.len() + values.len() > H::CHUNK_SIZE {
-                            let mut for_batch = values.split_off(H::CHUNK_SIZE - batch_values.len());
-                            std::mem::swap(values, &mut for_batch);
-                            batch_values.extend(for_batch);
-                            break;
-                        } else {
-                            let (watermark, values) = entry.remove().into_batch();
-                            batch_values.extend(values);
-                            batch_watermarks.push(watermark);
-                        }
+                        metrics
+                            .total_committer_batches_succeeded
+                            .with_label_values(&[H::NAME])
+                            .inc();
+
+                        metrics
+                            .total_committer_rows_committed
+                            .with_label_values(&[H::NAME])
+                            .inc_by(values.len() as u64);
+
+                        metrics
+                            .total_committer_rows_affected
+                            .with_label_values(&[H::NAME])
+                            .inc_by(affected as u64);
+
+                        Ok(())
                     }
+                };
 
-                    let elapsed = guard.stop_and_record();
-                    debug!(
-                        pipeline = H::NAME,
-                        elapsed_ms = elapsed * 1000.0,
-                        rows = batch_values.len(),
-                        pending = pending_rows,
-                        "Gathered batch",
-                    );
+                async move {
+                    tokio::select! {
+                        _ = cancel.cancelled() => {
+                            return Err(Break::Cancel);
+                        }
 
-                    // TODO (experiment): Switch to COPY FROM, which should offer faster inserts?
-                    //
-                    // Note that COPY FROM cannot handle conflicts -- we need a way to gracefully
-                    // fail over to `INSERT INTO ... ON CONFLICT DO NOTHING` if we encounter a
-                    // conflict, and in that case, we are also subject to the same constraints on
-                    // number of bind parameters as we had before.
-                    //
-                    // Postgres 17 supports an ON_ERROR option for COPY FROM which can ignore bad
-                    // rows, but CloudSQL does not support Postgres 17 yet, and this directive only
-                    // works if the FORMAT is set to TEXT or CSV, which are less efficient over the
-                    // wire.
-                    //
-                    // The hope is that in the steady state, there will not be conflicts (they
-                    // should only show up during backfills, or when we are handing off between
-                    // indexers), so we can use a fallback mechanism for those cases but rely on
-                    // COPY FROM most of the time.
-                    //
-                    // Note that the introduction of watermarks also complicates hand-over between
-                    // two indexers writing to the same table: They cannot both update the
-                    // watermark. One needs to subordinate to the other (or we need to set the
-                    // watermark to the max of what is currently set and what was about to be
-                    // written).
-
-                    metrics
-                        .total_committer_batches_attempted
-                        .with_label_values(&[H::NAME])
-                        .inc();
-
-                    metrics
-                        .committer_batch_size
-                        .with_label_values(&[H::NAME])
-                        .observe(batch_values.len() as f64);
-
-                    let guard = metrics
-                        .committer_commit_latency
-                        .with_label_values(&[H::NAME])
-                        .start_timer();
-
-                    // TODO (experiment): Parallelize batch writes?
-                    //
-                    // Previous findings suggest that having about 5 parallel committers per table
-                    // yields the best performance. Is that still true for this new architecture?
-                    // If we go down this route, we should consider factoring that work out into a
-                    // separate task that also handles the watermark.
-
-                    let affected = if batch_values.is_empty() {
-                        0
-                    } else {
-                        match H::commit(&batch_values, &mut conn).await {
-                            Ok(affected) => affected,
-
-                            Err(e) => {
-                                let elapsed = guard.stop_and_record();
-
-                                error!(
-                                    pipeline = H::NAME,
-                                    elapsed_ms = elapsed * 1000.0,
-                                    attempt,
-                                    committed = batch_values.len(),
-                                    pending = pending_rows,
-                                    "Error writing batch: {e}",
-                                );
-
-                                cool.reset_after(RETRY_INTERVAL);
-                                attempt += 1;
-                                continue;
-                            }
+                        // Double check that the commit actually went through, (this backoff should
+                        // not produce any permanent errors, but if it does, we need to shutdown
+                        // the pipeline).
+                        commit = backoff::future::retry(backoff, commit) => {
+                            let () = commit?;
                         }
                     };
 
-                    let elapsed = guard.stop_and_record();
-
-                    metrics
-                        .total_committer_rows_committed
-                        .with_label_values(&[H::NAME])
-                        .inc_by(batch_values.len() as u64);
-
-                    metrics
-                        .total_committer_rows_affected
-                        .with_label_values(&[H::NAME])
-                        .inc_by(affected as u64);
-
-                    debug!(
-                        pipeline = H::NAME,
-                        elapsed_ms = elapsed * 1000.0,
-                        attempt,
-                        affected,
-                        committed = batch_values.len(),
-                        pending = pending_rows,
-                        "Wrote batch",
-                    );
-
-                    pending_rows -= batch_values.len();
-                    batch_values.clear();
-                    attempt = 0;
-
-                    if config.skip_watermark {
-                        batch_watermarks.clear();
-                    } else if watermark_tx.send(mem::take(&mut batch_watermarks)).await.is_err() {
-                        info!(pipeline = H::NAME, "Watermark closed channel, stopping committer");
-                        break;
+                    if !config.skip_watermark && tx.send(watermark).await.is_err() {
+                        info!(pipeline = H::NAME, "Watermark closed channel");
+                        return Err(Break::Cancel);
                     }
 
-                    // TODO (amnn): Test this behaviour (requires tempdb and migrations).
-                    if pending_rows == 0 && indexed_rx.is_closed() {
-                        info!(pipeline = H::NAME, "Handler closed channel, pending rows empty, stopping committer");
-                        break;
-                    }
-
-                    cool.reset();
+                    Ok(())
                 }
+            })
+            .await
+        {
+            Ok(()) => {
+                info!(pipeline = H::NAME, "Batches done, stopping committer");
+            }
 
-                // If there are enough pending rows, and we've expended the cooldown, reset the
-                // commit polling interval so that on the next iteration of the loop, we will write
-                // out another batch.
-                //
-                // TODO (experiment): Do we need this cooldown to deal with contention on the
-                // connection pool? It's possible that this is just going to eat into our
-                // throughput.
-                _ = cool.tick(), if pending_rows > H::BATCH_SIZE => {
-                    poll.reset_immediately();
-                }
+            Err(Break::Cancel) => {
+                info!(pipeline = H::NAME, "Shutdown received, stopping committer");
+            }
 
-                Some(indexed) = indexed_rx.recv(), if pending_rows < H::MAX_PENDING_SIZE => {
-                    metrics
-                        .total_committer_rows_received
-                        .with_label_values(&[H::NAME])
-                        .inc_by(indexed.values.len() as u64);
-
-                    pending_rows += indexed.values.len();
-                    pending.insert(indexed.cp_sequence_number, indexed);
-                }
+            Err(Break::Err(e)) => {
+                error!(pipeline = H::NAME, "Error from committer: {e}");
+                cancel.cancel();
             }
         }
     })

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
@@ -3,18 +3,19 @@
 
 use std::sync::Arc;
 
-use committer::committer;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
-use watermark::watermark;
 
 use crate::{
     db::Db, handlers::Handler, metrics::IndexerMetrics, models::watermarks::CommitterWatermark,
 };
 
-use super::{processor::processor, PipelineConfig, COMMITTER_BUFFER};
+use super::{processor::processor, PipelineConfig, PIPELINE_BUFFER};
 
+use self::{collector::collector, committer::committer, watermark::watermark};
+
+mod collector;
 mod committer;
 mod watermark;
 
@@ -22,17 +23,21 @@ mod watermark;
 /// strictly after the `watermark` (or from the beginning if no watermark was provided).
 ///
 /// Each pipeline consists of a processor task which takes checkpoint data and breaks it down into
-/// rows, ready for insertion, and a committer which writes those rows out to the database.
+/// rows, ready for insertion, a collector which batches those rows into an appropriate size for
+/// the database, a committer which writes the rows out concurrently, and a watermark task to
+/// update the high watermark.
+///
 /// Committing is performed out-of-order: the pipeline may write out checkpoints out-of-order,
 /// either because it received the checkpoints out-of-order or because of variance in processing
 /// time.
 ///
-/// The committer also maintains a row in the `watermarks` table for the pipeline which tracks the
+/// The pipeline also maintains a row in the `watermarks` table for the pipeline which tracks the
 /// watermark below which all data has been committed (modulo pruning).
 ///
-/// Checkpoint data is fed into the pipeline through the `checkpoint_rx` channel, and an internal
-/// channel is created to communicate checkpoint-wise data to the committer. The pipeline can be
-/// shutdown using its `cancel` token.
+/// Checkpoint data is fed into the pipeline through the `checkpoint_rx` channel, and internal
+/// channels are created to communicate between its various components. The pipeline can be
+/// shutdown using its `cancel` token, and will also shutdown if any of its independent tasks
+/// reports an issue.
 pub fn pipeline<H: Handler + 'static>(
     initial_watermark: Option<CommitterWatermark<'static>>,
     config: PipelineConfig,
@@ -40,16 +45,30 @@ pub fn pipeline<H: Handler + 'static>(
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
-) -> (JoinHandle<()>, JoinHandle<()>, JoinHandle<()>) {
-    let (processor_tx, committer_rx) = mpsc::channel(H::FANOUT + COMMITTER_BUFFER);
-    let (watermark_tx, watermark_rx) = mpsc::channel(COMMITTER_BUFFER);
+) -> (
+    JoinHandle<()>,
+    JoinHandle<()>,
+    JoinHandle<()>,
+    JoinHandle<()>,
+) {
+    let (processor_tx, collector_rx) = mpsc::channel(H::FANOUT + PIPELINE_BUFFER);
+    let (collector_tx, committer_rx) = mpsc::channel(config.write_concurrency + PIPELINE_BUFFER);
+    let (committer_tx, watermark_rx) = mpsc::channel(config.write_concurrency + PIPELINE_BUFFER);
 
     let processor = processor::<H>(checkpoint_rx, processor_tx, metrics.clone(), cancel.clone());
+
+    let collector = collector::<H>(
+        config.clone(),
+        collector_rx,
+        collector_tx,
+        metrics.clone(),
+        cancel.clone(),
+    );
 
     let committer = committer::<H>(
         config.clone(),
         committer_rx,
-        watermark_tx,
+        committer_tx,
         db.clone(),
         metrics.clone(),
         cancel.clone(),
@@ -57,5 +76,5 @@ pub fn pipeline<H: Handler + 'static>(
 
     let watermark = watermark::<H>(initial_watermark, config, watermark_rx, db, metrics, cancel);
 
-    (processor, committer, watermark)
+    (processor, collector, committer, watermark)
 }

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
@@ -236,8 +236,8 @@ pub(super) fn watermark<H: Handler + 'static>(
                         }
                     }
 
-                    if rx.is_closed() {
-                        info!(pipeline = H::NAME, "Committer closed channel, stopping watermark task");
+                    if rx.is_closed() && rx.is_empty() {
+                        info!(pipeline = H::NAME, ?watermark, "Committer closed channel, stopping watermark task");
                         break;
                     }
                 }

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
@@ -89,10 +89,11 @@ pub(super) fn watermark<H: Handler + 'static>(
             watermark.checkpoint_hi_inclusive + LOUD_WATERMARK_UPDATE_INTERVAL;
 
         info!(pipeline = H::NAME, ?watermark, "Starting watermark task");
+
         loop {
             tokio::select! {
                 _ = cancel.cancelled() => {
-                    info!(pipeline = H::NAME, "Shutdown received, stopping watermark");
+                    info!(pipeline = H::NAME, "Shutdown received, stopping watermark task");
                     break;
                 }
 
@@ -236,7 +237,7 @@ pub(super) fn watermark<H: Handler + 'static>(
                     }
 
                     if rx.is_closed() {
-                        info!(pipeline = H::NAME, "Committer closed channel, stopping watermark");
+                        info!(pipeline = H::NAME, "Committer closed channel, stopping watermark task");
                         break;
                     }
                 }

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -10,10 +10,19 @@ mod processor;
 
 /// Extra buffer added to channels between tasks in a pipeline. There does not need to be a huge
 /// capacity here because tasks already buffer rows to insert internally.
-const COMMITTER_BUFFER: usize = 5;
+const PIPELINE_BUFFER: usize = 5;
+
+/// The maximum number of watermarks that can show up in a single batch. This limit exists to deal
+/// with pipelines that produce no data for a majority of checkpoints -- the size of these
+/// pipeline's batches will be dominated by watermark updates.
+const MAX_WATERMARK_UPDATES: usize = 10_000;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct PipelineConfig {
+    /// Number of concurrent writers per pipeline
+    #[arg(long, default_value_t = 5)]
+    write_concurrency: usize,
+
     /// The collector will check for pending data at least this often
     #[arg(
         long,
@@ -37,30 +46,137 @@ pub struct PipelineConfig {
     skip_watermark: bool,
 }
 
-/// A batch of processed values associated with a single checkpoint. This is an internal type used
-/// to communicate between the handler and the committer parts of the pipeline.
+/// Processed values associated with a single checkpoint. This is an internal type used to
+/// communicate between the processor and the collector parts of the pipeline.
 struct Indexed<H: Handler> {
-    /// Epoch this data is from
-    epoch: u64,
-    /// Checkpoint this data is from
-    cp_sequence_number: u64,
-    /// Max (exclusive) transaction sequence number in this batch
-    tx_hi: u64,
     /// Values to be inserted into the database from this checkpoint
     values: Vec<H::Value>,
+    /// The watermark associated with this checkpoint and the part of it that is left to commit
+    watermark: WatermarkPart,
+}
+
+/// Values ready to be written to the database. This is an internal type used to communicate
+/// between the collector and the committer parts of the pipeline.
+struct Batched<H: Handler> {
+    /// The rows to write
+    values: Vec<H::Value>,
+    /// Proportions of all the watermarks that are represented in this chunk
+    watermark: Vec<WatermarkPart>,
+}
+
+/// A representation of the proportion of a watermark.
+#[derive(Debug)]
+struct WatermarkPart {
+    /// The watermark itself
+    watermark: CommitterWatermark<'static>,
+    /// The number of rows from this watermark that are in this part
+    batch_rows: usize,
+    /// The total number of rows from this watermark
+    total_rows: usize,
+}
+
+/// Internal type used by workers to propagate errors or shutdown signals up to their
+/// supervisor.
+#[derive(thiserror::Error, Debug)]
+enum Break {
+    #[error("Shutdown received")]
+    Cancel,
+
+    #[error(transparent)]
+    Err(#[from] anyhow::Error),
 }
 
 impl<H: Handler> Indexed<H> {
-    /// Split apart the information in this indexed checkpoint into its watermark and the values to
-    /// add to the database.
-    fn into_batch(self) -> (CommitterWatermark<'static>, Vec<H::Value>) {
-        let watermark = CommitterWatermark {
-            pipeline: H::NAME.into(),
-            epoch_hi_inclusive: self.epoch as i64,
-            checkpoint_hi_inclusive: self.cp_sequence_number as i64,
-            tx_hi: self.tx_hi as i64,
-        };
+    fn new(epoch: u64, cp_sequence_number: u64, tx_hi: u64, values: Vec<H::Value>) -> Self {
+        Self {
+            watermark: WatermarkPart {
+                watermark: CommitterWatermark {
+                    pipeline: H::NAME.into(),
+                    epoch_hi_inclusive: epoch as i64,
+                    checkpoint_hi_inclusive: cp_sequence_number as i64,
+                    tx_hi: tx_hi as i64,
+                },
+                batch_rows: values.len(),
+                total_rows: values.len(),
+            },
+            values,
+        }
+    }
 
-        (watermark, self.values)
+    /// The checkpoint sequence number that this data is from
+    fn checkpoint(&self) -> u64 {
+        self.watermark.watermark.checkpoint_hi_inclusive as u64
+    }
+
+    /// Whether there are values left to commit from this indexed checkpoint.
+    fn is_empty(&self) -> bool {
+        debug_assert!(self.watermark.batch_rows == 0);
+        self.values.is_empty()
+    }
+
+    /// Adds data from this indexed checkpoint to the `batch`, honoring the handler's bounds on
+    /// chunk size.
+    fn batch_into(&mut self, batch: &mut Batched<H>) {
+        if batch.values.len() + self.values.len() > H::CHUNK_SIZE {
+            let mut for_batch = self.values.split_off(H::CHUNK_SIZE - batch.values.len());
+            std::mem::swap(&mut self.values, &mut for_batch);
+            batch.watermark.push(self.watermark.take(for_batch.len()));
+            batch.values.extend(for_batch);
+        } else {
+            batch.watermark.push(self.watermark.take(self.values.len()));
+            batch.values.extend(std::mem::take(&mut self.values));
+        }
+    }
+}
+
+impl<H: Handler> Batched<H> {
+    fn new() -> Self {
+        Self {
+            values: vec![],
+            watermark: vec![],
+        }
+    }
+
+    /// Number of rows in this batch.
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// The batch is full if it has more than enough values to write to the database, or more than
+    /// enough watermarks to update.
+    fn is_full(&self) -> bool {
+        self.values.len() >= H::CHUNK_SIZE || self.watermark.len() >= MAX_WATERMARK_UPDATES
+    }
+}
+
+impl WatermarkPart {
+    fn checkpoint(&self) -> u64 {
+        self.watermark.checkpoint_hi_inclusive as u64
+    }
+
+    /// Check if all the rows from this watermark are represented in this part.
+    fn is_complete(&self) -> bool {
+        self.batch_rows == self.total_rows
+    }
+
+    /// Add the rows from `other` to this part.
+    fn add(&mut self, other: WatermarkPart) {
+        debug_assert_eq!(self.checkpoint(), other.checkpoint());
+        self.batch_rows += other.batch_rows;
+    }
+
+    /// Record that `rows` have been taken from this part.
+    fn take(&mut self, rows: usize) -> WatermarkPart {
+        debug_assert!(
+            self.batch_rows >= rows,
+            "Can't take more rows than are available"
+        );
+
+        self.batch_rows -= rows;
+        WatermarkPart {
+            watermark: self.watermark.clone(),
+            batch_rows: rows,
+            total_rows: self.total_rows,
+        }
     }
 }

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -23,7 +23,7 @@ pub struct PipelineConfig {
     )]
     collect_interval: Duration,
 
-    /// Watermark task will check for pending watermarks this often.
+    /// Watermark task will check for pending watermarks this often
     #[arg(
         long,
         default_value = "500",

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -14,14 +14,14 @@ const COMMITTER_BUFFER: usize = 5;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct PipelineConfig {
-    /// Committer will check for pending data at least this often
+    /// The collector will check for pending data at least this often
     #[arg(
         long,
         default_value = "500",
         value_name = "MILLISECONDS",
         value_parser = |s: &str| s.parse().map(Duration::from_millis),
     )]
-    commit_interval: Duration,
+    collect_interval: Duration,
 
     /// Watermark task will check for pending watermarks this often.
     #[arg(

--- a/crates/sui-indexer-alt/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt/src/pipeline/processor.rs
@@ -42,7 +42,8 @@ pub(super) fn processor<H: Handler + 'static>(
     }
 
     spawn_monitored_task!(async move {
-        info!(pipeline = H::NAME, "Starting handler");
+        info!(pipeline = H::NAME, "Starting processor");
+
         match ReceiverStream::new(rx)
             .map(Ok)
             .try_for_each_concurrent(H::FANOUT, |checkpoint| {
@@ -103,11 +104,11 @@ pub(super) fn processor<H: Handler + 'static>(
             .await
         {
             Ok(()) => {
-                info!(pipeline = H::NAME, "Checkpoints done, stopping handler");
+                info!(pipeline = H::NAME, "Checkpoints done, stopping processor");
             }
 
             Err(Break::Cancel) => {
-                info!(pipeline = H::NAME, "Shutdown received, stopping handler");
+                info!(pipeline = H::NAME, "Shutdown received, stopping processor");
             }
 
             Err(Break::Err(e)) => {


### PR DESCRIPTION
## Description 

This PR primarily adds support for concurrent writes, but it also includes (in separate commits) some docs and comment fixes, and a bug fix for early termination of the watermark task which was detected while building out the concurrent write support.

## Test plan

The early termination issue was easiest to reproduce by running a single pipeline that ended with a large number of empty checkpoints, eg. `ev_struct_inst` up to checkpoint 5000. Without this change, it would drop the last 100 or so (empty) checkpoints, and with it, it will reliably update the watermark to 5000 before exiting:

```
sui$ cargo run -p sui-indexer-alt --release --                                   \
  --database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_alt" \
  --remote-store-url https://checkpoints.mainnet.sui.io/                         \
  --last-checkpoint 5000 --pipeline ev_struct_inst
```

Concurrent write support was tested similarly, by running the pipeline in its entirety, and separately, on checkpoint ranges 0 to 5,000 and 9,000,000 to 9,002,000.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
