### PR TITLE
[Consensus] Send gc'ed and committed blocks via transaction output

### DIFF
--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -181,8 +181,12 @@ impl DagBuilder {
                 fn gc_enabled(&self) -> bool {
                     self.context.protocol_config.gc_depth() > 0
                 }
+
+                fn set_committed(&mut self, block_ref: &BlockRef) {
+                    // Do nothing
+                }
             }
-            let storage = FooStorage {
+            let mut storage = FooStorage {
                 context: self.context.clone(),
                 blocks: self.blocks.clone(),
                 gc_round: leader_block
@@ -194,7 +198,7 @@ impl DagBuilder {
             let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
                 leader_block,
                 self.last_committed_rounds.clone(),
-                storage,
+                &mut storage,
             );
 
             // Update the last committed rounds


### PR DESCRIPTION
## Description 

A draft PR on what the GC'ed blocks detection could be done in DagState and sending the via the transaction output channel.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
