### PR TITLE
[consensus] support fastpath certification of transactions

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -9,6 +9,7 @@ use consensus_config::AuthorityIndex;
 use futures::{ready, stream, task, Stream, StreamExt};
 use parking_lot::RwLock;
 use sui_macros::fail_point_async;
+use tap::TapFallible;
 use tokio::{sync::broadcast, time::sleep};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
@@ -26,6 +27,7 @@ use crate::{
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
     synchronizer::SynchronizerHandle,
+    transaction_certifier::TransactionCertifier,
     CommitIndex, Round,
 };
 
@@ -40,6 +42,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     core_dispatcher: Arc<C>,
     rx_block_broadcaster: broadcast::Receiver<ExtendedBlock>,
     subscription_counter: Arc<SubscriptionCounter>,
+    txn_certifier: TransactionCertifier,
     dag_state: Arc<RwLock<DagState>>,
     store: Arc<dyn Store>,
 }
@@ -52,6 +55,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         synchronizer: Arc<SynchronizerHandle>,
         core_dispatcher: Arc<C>,
         rx_block_broadcaster: broadcast::Receiver<ExtendedBlock>,
+        txn_certifier: TransactionCertifier,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
     ) -> Self {
@@ -67,6 +71,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             core_dispatcher,
             rx_block_broadcaster,
             subscription_counter,
+            txn_certifier,
             dag_state,
             store,
         }
@@ -103,17 +108,18 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let peer_hostname = &self.context.committee.authority(peer).hostname;
 
         // Reject blocks failing validations.
-        let verification_result = self.block_verifier.verify_and_vote(&signed_block);
-        if let Err(e) = verification_result {
-            self.context
-                .metrics
-                .node_metrics
-                .invalid_blocks
-                .with_label_values(&[peer_hostname, "handle_send_block", e.name()])
-                .inc();
-            info!("Invalid block from {}: {}", peer, e);
-            return Err(e);
-        }
+        let reject_txn_votes = self
+            .block_verifier
+            .verify_and_vote(&signed_block)
+            .tap_err(|e| {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .invalid_blocks
+                    .with_label_values(&[peer_hostname, "handle_send_block", e.name()])
+                    .inc();
+                info!("Invalid block from {}: {}", peer, e);
+            })?;
         let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block.block);
         let block_ref = verified_block.reference();
         debug!("Received block {} via send block.", block_ref);
@@ -167,7 +173,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // commit sync loop will trigger fetching.
         self.commit_vote_monitor.observe_block(&verified_block);
 
-        // Reject blocks when local commit index is lagging too far from quorum commit index.
+        // Reject blocks when local commit index is lagging too far from quorum commit index,
+        // to avoid the memory overhead from suspended blocks.
         //
         // IMPORTANT: this must be done after observing votes from the block, otherwise
         // observed quorum commit will no longer progress.
@@ -210,6 +217,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
+        // The block is verified and current, so it can be processed in the fastpath.
+        if self.context.protocol_config.mysticeti_fastpath() {
+            self.txn_certifier
+                .add_voted_blocks(vec![(verified_block.clone(), reject_txn_votes)]);
+        }
+
+        // Try to accept to block into the DAG.
         let missing_ancestors = self
             .core_dispatcher
             .add_blocks(vec![verified_block])
@@ -708,11 +722,13 @@ mod tests {
         storage::mem_store::MemStore,
         synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
+        transaction_certifier::TransactionCertifier,
         Round,
     };
     use async_trait::async_trait;
     use bytes::Bytes;
     use consensus_config::AuthorityIndex;
+    use mysten_metrics::monitored_mpsc;
     use parking_lot::{Mutex, RwLock};
     use std::collections::BTreeSet;
     use std::sync::Arc;
@@ -862,14 +878,19 @@ mod tests {
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier.clone(),
+            txn_certifier.clone(),
             dag_state.clone(),
             false,
         );
@@ -880,6 +901,7 @@ mod tests {
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
+            txn_certifier,
             dag_state,
             store,
         ));
@@ -925,14 +947,19 @@ mod tests {
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier.clone(),
+            txn_certifier.clone(),
             dag_state.clone(),
             true,
         );
@@ -943,6 +970,7 @@ mod tests {
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
+            txn_certifier,
             dag_state.clone(),
             store,
         ));

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -40,7 +40,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     block_verifier: Arc<dyn BlockVerifier>,
     synchronizer: Arc<SynchronizerHandle>,
     core_dispatcher: Arc<C>,
-    rx_block_broadcaster: broadcast::Receiver<ExtendedBlock>,
+    rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
     subscription_counter: Arc<SubscriptionCounter>,
     txn_certifier: TransactionCertifier,
     dag_state: Arc<RwLock<DagState>>,
@@ -54,7 +54,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         synchronizer: Arc<SynchronizerHandle>,
         core_dispatcher: Arc<C>,
-        rx_block_broadcaster: broadcast::Receiver<ExtendedBlock>,
+        rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
         txn_certifier: TransactionCertifier,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
@@ -69,7 +69,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             commit_vote_monitor,
             synchronizer,
             core_dispatcher,
-            rx_block_broadcaster,
+            rx_block_broadcast,
             subscription_counter,
             txn_certifier,
             dag_state,
@@ -223,7 +223,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .add_voted_blocks(vec![(verified_block.clone(), reject_txn_votes)]);
         }
 
-        // Try to accept to block into the DAG.
+        // Try to accept the block into the DAG.
         let missing_ancestors = self
             .core_dispatcher
             .add_blocks(vec![verified_block])
@@ -335,7 +335,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let broadcasted_blocks = BroadcastedBlockStream::new(
             peer,
-            self.rx_block_broadcaster.resubscribe(),
+            self.rx_block_broadcast.resubscribe(),
             self.subscription_counter.clone(),
         );
 

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -42,7 +42,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     core_dispatcher: Arc<C>,
     rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
     subscription_counter: Arc<SubscriptionCounter>,
-    txn_certifier: TransactionCertifier,
+    transaction_certifier: TransactionCertifier,
     dag_state: Arc<RwLock<DagState>>,
     store: Arc<dyn Store>,
 }
@@ -55,7 +55,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         synchronizer: Arc<SynchronizerHandle>,
         core_dispatcher: Arc<C>,
         rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
-        txn_certifier: TransactionCertifier,
+        transaction_certifier: TransactionCertifier,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
     ) -> Self {
@@ -71,7 +71,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             core_dispatcher,
             rx_block_broadcast,
             subscription_counter,
-            txn_certifier,
+            transaction_certifier,
             dag_state,
             store,
         }
@@ -219,7 +219,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // The block is verified and current, so it can be processed in the fastpath.
         if self.context.protocol_config.mysticeti_fastpath() {
-            self.txn_certifier
+            self.transaction_certifier
                 .add_voted_blocks(vec![(verified_block.clone(), reject_txn_votes)]);
         }
 
@@ -882,7 +882,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let synchronizer = Synchronizer::start(
             network_client,
@@ -890,7 +890,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier.clone(),
-            txn_certifier.clone(),
+            transaction_certifier.clone(),
             dag_state.clone(),
             false,
         );
@@ -901,7 +901,7 @@ mod tests {
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
-            txn_certifier,
+            transaction_certifier,
             dag_state,
             store,
         ));
@@ -951,7 +951,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let synchronizer = Synchronizer::start(
             network_client,
@@ -959,7 +959,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier.clone(),
-            txn_certifier.clone(),
+            transaction_certifier.clone(),
             dag_state.clone(),
             true,
         );
@@ -970,7 +970,7 @@ mod tests {
             synchronizer,
             core_dispatcher.clone(),
             rx_block_broadcast,
-            txn_certifier,
+            transaction_certifier,
             dag_state.clone(),
             store,
         ));

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -106,7 +106,9 @@ impl BaseCommitter {
         // There can be at most one leader with enough support for each round, otherwise it means
         // the BFT assumption is broken.
         if leaders_with_enough_support.len() > 1 {
-            panic!("[{self}] More than one certified block for {leader}")
+            panic!(
+                "[{self}] More than one candidate for {leader}: {leaders_with_enough_support:?}"
+            );
         }
 
         leaders_with_enough_support
@@ -321,7 +323,7 @@ impl BaseCommitter {
 
         // There can be at most one certified leader, otherwise it means the BFT assumption is broken.
         if certified_leader_blocks.len() > 1 {
-            panic!("More than one certified block at wave {wave} from leader {leader_slot}")
+            panic!("More than one certified leader at wave {wave} in {leader_slot}: {certified_leader_blocks:?}");
         }
 
         // We commit the target leader if it has a certificate that is an ancestor of the anchor.

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -343,6 +343,7 @@ pub type CommitVote = CommitRef;
 pub struct CommittedSubDag {
     /// A reference to the leader of the sub-dag
     pub leader: BlockRef,
+    // TODO: refactor blocks and rejected_transactions_by_block to CertifiedBlock.
     /// All the committed blocks that are part of this sub-dag
     pub blocks: Vec<VerifiedBlock>,
     /// Indices of rejected transactions in each block.

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -306,7 +306,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
 
             debug!(
-                "Fetched certified blocks for commit range {:?}: {}",
+                "Fetched blocks for commit range {:?}: {}",
                 fetched_commit_range,
                 commits
                     .commits()
@@ -647,7 +647,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             let forward_drift = Duration::from_millis(forward_drift);
             if forward_drift >= inner.context.parameters.max_forward_time_drift {
                 warn!(
-                    "Local clock is behind a quorum of peers: local ts {}, certified block ts {}",
+                    "Local clock is behind a quorum of peers: local ts {}, committed block ts {}",
                     now_ms,
                     block.timestamp_ms()
                 );

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -59,6 +59,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
+    transaction_certifier::TransactionCertifier,
     CommitConsumerMonitor, CommitIndex,
 };
 
@@ -111,8 +112,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
         core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
-        network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
+        transaction_certifier: TransactionCertifier,
+        network_client: Arc<C>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
         let inner = Arc::new(Inner {
@@ -120,8 +122,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
             core_thread_dispatcher,
             commit_vote_monitor,
             commit_consumer_monitor,
-            network_client,
             block_verifier,
+            transaction_certifier,
+            network_client,
             dag_state,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
@@ -536,7 +539,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .await?;
 
         // 2. Verify the response contains blocks that can certify the last returned commit,
-        // and the returned commits are chained by digest, so earlier commits are certified
+        // and the returned commits are chained by digests, so earlier commits are certified
         // as well.
         let (commits, vote_blocks) = Handle::current()
             .spawn_blocking({
@@ -655,7 +658,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             sleep(forward_drift).await;
         }
 
-        // 9. Now create the Certified commits by assigning the blocks to each commit and retaining the commit votes history.
+        // 9. Now create certified commits by assigning the blocks to each commit.
         let mut certified_commits = Vec::new();
         for commit in &commits {
             let blocks = commit
@@ -668,6 +671,23 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 })
                 .collect::<Vec<_>>();
             certified_commits.push(CertifiedCommit::new_certified(commit.clone(), blocks));
+        }
+
+        // 10. Add blocks in certified commits to the transaction certifier.
+        if inner.context.protocol_config.mysticeti_fastpath() {
+            inner.transaction_certifier.run_gc();
+        }
+        for commit in &certified_commits {
+            for block in commit.blocks() {
+                // Only account for reject votes in the block, since they may vote on uncommitted
+                // blocks or transactions. It is unnecessary to vote on the committed blocks
+                // themselves.
+                if inner.context.protocol_config.mysticeti_fastpath() {
+                    inner
+                        .transaction_certifier
+                        .add_voted_blocks(vec![(block.clone(), vec![])]);
+                }
+            }
         }
 
         Ok(CertifiedCommits::new(certified_commits, vote_blocks))
@@ -709,8 +729,9 @@ struct Inner<C: NetworkClient> {
     core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
-    network_client: Arc<C>,
     block_verifier: Arc<dyn BlockVerifier>,
+    transaction_certifier: TransactionCertifier,
+    network_client: Arc<C>,
     dag_state: Arc<RwLock<DagState>>,
 }
 
@@ -772,13 +793,18 @@ impl<C: NetworkClient> Inner<C> {
                 bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedBlock)?;
             // Only block signatures need to be verified, to verify commit votes.
             // But the blocks will be sent to Core, so they need to be fully verified.
-            self.block_verifier.verify_and_vote(&block)?;
+            let reject_transaction_votes = self.block_verifier.verify_and_vote(&block)?;
+            let block = VerifiedBlock::new_verified(block, serialized);
+            if self.context.protocol_config.mysticeti_fastpath() {
+                self.transaction_certifier
+                    .add_voted_blocks(vec![(block.clone(), reject_transaction_votes)]);
+            }
             for vote in block.commit_votes() {
                 if *vote == end_commit_ref {
                     stake_aggregator.add(block.author(), &self.context.committee);
                 }
             }
-            vote_blocks.push(VerifiedBlock::new_verified(block, serialized));
+            vote_blocks.push(block);
         }
 
         // Check if the end commit has enough votes.
@@ -805,6 +831,7 @@ mod tests {
 
     use bytes::Bytes;
     use consensus_config::{AuthorityIndex, Parameters};
+    use mysten_metrics::monitored_mpsc;
     use parking_lot::RwLock;
 
     use crate::{
@@ -819,6 +846,7 @@ mod tests {
         error::ConsensusResult,
         network::{BlockStream, NetworkClient},
         storage::mem_store::MemStore,
+        transaction_certifier::TransactionCertifier,
         CommitConsumerMonitor, CommitDigest, CommitRef, Round,
     };
 
@@ -906,6 +934,10 @@ mod tests {
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
+        let transaction_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
         let mut commit_syncer = CommitSyncer::new(
@@ -913,8 +945,9 @@ mod tests {
             core_thread_dispatcher,
             commit_vote_monitor.clone(),
             commit_consumer_monitor.clone(),
-            network_client,
             block_verifier,
+            transaction_certifier,
+            network_client,
             dag_state,
         );
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -48,8 +48,8 @@ use crate::{
 };
 #[cfg(test)]
 use crate::{
-    block_verifier::NoopBlockVerifier, storage::mem_store::MemStore, CommitConsumer,
-    TransactionClient,
+    block::CertifiedBlocksOutput, block_verifier::NoopBlockVerifier, storage::mem_store::MemStore,
+    CommitConsumer, TransactionClient,
 };
 
 // Maximum number of commit votes to include in a block.
@@ -1353,12 +1353,12 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
 
 #[cfg(test)]
 pub(crate) struct CoreTextFixture {
-    pub core: Core,
-    pub signal_receivers: CoreSignalsReceivers,
-    pub block_receiver: broadcast::Receiver<ExtendedBlock>,
-    #[allow(unused)]
-    pub commit_receiver: UnboundedReceiver<CommittedSubDag>,
-    pub store: Arc<MemStore>,
+    pub(crate) core: Core,
+    pub(crate) signal_receivers: CoreSignalsReceivers,
+    pub(crate) block_receiver: broadcast::Receiver<ExtendedBlock>,
+    pub(crate) _commit_output_receiver: UnboundedReceiver<CommittedSubDag>,
+    pub(crate) _blocks_output_receiver: UnboundedReceiver<CertifiedBlocksOutput>,
+    pub(crate) store: Arc<MemStore>,
 }
 
 #[cfg(test)]
@@ -1397,7 +1397,8 @@ impl CoreTextFixture {
         // Need at least one subscriber to the block broadcast channel.
         let block_receiver = signal_receivers.block_broadcast_receiver();
 
-        let (commit_consumer, commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
+        let (commit_consumer, commit_output_receiver, blocks_output_receiver) =
+            CommitConsumer::new(0);
         let commit_observer = CommitObserver::new(
             context.clone(),
             commit_consumer,
@@ -1425,7 +1426,8 @@ impl CoreTextFixture {
             core,
             signal_receivers,
             block_receiver,
-            commit_receiver,
+            _commit_output_receiver: commit_output_receiver,
+            _blocks_output_receiver: blocks_output_receiver,
             store,
         }
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -735,10 +735,21 @@ impl DagState {
         blocks.first().cloned().unwrap()
     }
 
+    // The round which the next block will be proposed at. This increases monotonically.
+    // With the local DAG, proposing at a higher round is impossible for anyone including this authority.
+    // The round may be skipped without proposing if blocks from higher rounds arrive before
+    // a block gets proposed.
+    pub(crate) fn next_propose_round(&self) -> Round {
+        self.threshold_clock
+            .get_round()
+            .max(self.get_last_proposed_block().round() + 1)
+    }
+
     pub(crate) fn threshold_clock_round(&self) -> Round {
         self.threshold_clock.get_round()
     }
 
+    // The timestamp of when quorum threshold was last reached in the threshold clock.
     pub(crate) fn threshold_clock_quorum_ts(&self) -> Instant {
         self.threshold_clock.get_quorum_ts()
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -735,16 +735,6 @@ impl DagState {
         blocks.first().cloned().unwrap()
     }
 
-    // The round which the next block will be proposed at. This increases monotonically.
-    // With the local DAG, proposing at a higher round is impossible for anyone including this authority.
-    // The round may be skipped without proposing if blocks from higher rounds arrive before
-    // a block gets proposed.
-    pub(crate) fn next_propose_round(&self) -> Round {
-        self.threshold_clock
-            .get_round()
-            .max(self.get_last_proposed_block().round() + 1)
-    }
-
     pub(crate) fn threshold_clock_round(&self) -> Round {
         self.threshold_clock.get_round()
     }

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -52,10 +52,13 @@ mod test_dag;
 mod test_dag_builder;
 #[cfg(test)]
 mod test_dag_parser;
+mod transaction_certifier;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;
-pub use block::{BlockAPI, BlockRef, Round, TransactionIndex};
+pub use block::{
+    BlockAPI, BlockRef, CertifiedBlock, CertifiedBlocksOutput, Round, TransactionIndex,
+};
 /// Exported API for testing.
 pub use block::{TestBlock, Transaction, VerifiedBlock};
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -45,6 +45,7 @@ mod universal_committer;
 #[path = "tests/randomized_tests.rs"]
 mod randomized_tests;
 
+mod proposed_block_handler;
 mod round_prober;
 #[cfg(test)]
 mod test_dag;

--- a/consensus/core/src/proposed_block_handler.rs
+++ b/consensus/core/src/proposed_block_handler.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use tokio::sync::broadcast;
+use tracing::{trace, warn};
+
+use crate::{block::ExtendedBlock, transaction_certifier::TransactionCertifier};
+
+/// Runs async processing logic for proposed blocks.
+/// Currently it only call transaction certifier with proposed blocks.
+/// In future, flushing dag state before proposing can be moved here.
+pub(crate) struct ProposedBlockHandler {
+    rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
+    transaction_certifier: TransactionCertifier,
+}
+
+impl ProposedBlockHandler {
+    pub(crate) fn new(
+        rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
+        transaction_certifier: TransactionCertifier,
+    ) -> Self {
+        Self {
+            rx_block_broadcast,
+            transaction_certifier,
+        }
+    }
+
+    pub(crate) async fn run(&mut self) {
+        loop {
+            match self.rx_block_broadcast.recv().await {
+                Ok(extended_block) => self.handle_proposed_block(extended_block),
+                Err(broadcast::error::RecvError::Closed) => {
+                    trace!("Handler is shutting down!");
+                    return;
+                }
+                Err(broadcast::error::RecvError::Lagged(e)) => {
+                    warn!("Handler is lagging! {e}");
+                    // Re-run the loop to receive again.
+                    continue;
+                }
+            };
+        }
+    }
+
+    fn handle_proposed_block(&self, extended_block: ExtendedBlock) {
+        self.transaction_certifier
+            .add_proposed_block(extended_block.block.clone());
+    }
+}

--- a/consensus/core/src/proposed_block_handler.rs
+++ b/consensus/core/src/proposed_block_handler.rs
@@ -8,7 +8,8 @@ use crate::{block::ExtendedBlock, transaction_certifier::TransactionCertifier};
 
 /// Runs async processing logic for proposed blocks.
 /// Currently it only call transaction certifier with proposed blocks.
-/// In future, flushing dag state before proposing can be moved here.
+/// In future, more logic related to proposing should be moved here, for example
+/// flushing dag state.
 pub(crate) struct ProposedBlockHandler {
     rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
     transaction_certifier: TransactionCertifier,
@@ -43,6 +44,8 @@ impl ProposedBlockHandler {
     }
 
     fn handle_proposed_block(&self, extended_block: ExtendedBlock) {
+        // Run GC first to remove blocks that do not need be voted on.
+        self.transaction_certifier.run_gc();
         self.transaction_certifier
             .add_proposed_block(extended_block.block.clone());
     }

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -10,9 +10,11 @@ pub(crate) trait CommitteeThreshold {
     fn threshold(committee: &Committee) -> Stake;
 }
 
+#[derive(Default)]
 pub(crate) struct QuorumThreshold;
 
-#[allow(unused)]
+#[cfg(test)]
+#[derive(Default)]
 pub(crate) struct ValidityThreshold;
 
 impl CommitteeThreshold for QuorumThreshold {
@@ -24,6 +26,7 @@ impl CommitteeThreshold for QuorumThreshold {
     }
 }
 
+#[cfg(test)]
 impl CommitteeThreshold for ValidityThreshold {
     fn is_threshold(committee: &Committee, amount: Stake) -> bool {
         committee.reached_validity(amount)
@@ -33,6 +36,7 @@ impl CommitteeThreshold for ValidityThreshold {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct StakeAggregator<T> {
     votes: BTreeSet<AuthorityIndex>,
     stake: Stake,
@@ -56,6 +60,17 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
             self.stake += committee.stake(vote);
         }
         T::is_threshold(committee, self.stake)
+    }
+
+    /// Adds a vote for the specified authority index to the aggregator. It is guaranteed to count
+    /// the vote only once for an authority.
+    /// The method returns true when the vote comes from a new authority and is counted.
+    pub(crate) fn add_unique(&mut self, vote: AuthorityIndex, committee: &Committee) -> bool {
+        if self.votes.insert(vote) {
+            self.stake += committee.stake(vote);
+            return true;
+        }
+        false
     }
 
     pub(crate) fn stake(&self) -> Stake {
@@ -91,6 +106,27 @@ mod tests {
         assert!(!aggregator.add(AuthorityIndex::new_for_test(1), &committee));
         assert!(aggregator.add(AuthorityIndex::new_for_test(2), &committee));
         assert!(aggregator.add(AuthorityIndex::new_for_test(3), &committee));
+    }
+
+    #[test]
+    fn test_add_unique_quorum_threshold() {
+        let committee = local_committee_and_keys(0, vec![1, 1, 1, 1]).0;
+        let mut aggregator = StakeAggregator::<QuorumThreshold>::new();
+
+        assert!(aggregator.add_unique(AuthorityIndex::new_for_test(0), &committee));
+        assert!(!aggregator.reached_threshold(&committee));
+
+        assert!(aggregator.add_unique(AuthorityIndex::new_for_test(1), &committee));
+        assert!(!aggregator.reached_threshold(&committee));
+
+        assert!(!aggregator.add_unique(AuthorityIndex::new_for_test(1), &committee));
+        assert!(!aggregator.reached_threshold(&committee));
+
+        assert!(aggregator.add_unique(AuthorityIndex::new_for_test(2), &committee));
+        assert!(aggregator.reached_threshold(&committee));
+
+        assert!(aggregator.add_unique(AuthorityIndex::new_for_test(3), &committee));
+        assert!(aggregator.reached_threshold(&committee));
     }
 
     #[test]

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -27,7 +27,10 @@ use tokio::{
 };
 use tracing::{debug, error, info, trace, warn};
 
-use crate::{authority_service::COMMIT_LAG_MULTIPLIER, core_thread::CoreThreadDispatcher};
+use crate::{
+    authority_service::COMMIT_LAG_MULTIPLIER, core_thread::CoreThreadDispatcher,
+    transaction_certifier::TransactionCertifier,
+};
 use crate::{
     block::{BlockRef, SignedBlock, VerifiedBlock},
     block_verifier::BlockVerifier,
@@ -243,17 +246,19 @@ pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThread
     fetch_own_last_block_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
+    transaction_certifier: TransactionCertifier,
     inflight_blocks_map: Arc<InflightBlocksMap>,
     commands_sender: Sender<Command>,
 }
 
 impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C, V, D> {
-    pub fn start(
+    pub(crate) fn start(
         network_client: Arc<C>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         block_verifier: Arc<V>,
+        transaction_certifier: TransactionCertifier,
         dag_state: Arc<RwLock<DagState>>,
         sync_last_known_own_block: bool,
     ) -> Arc<SynchronizerHandle> {
@@ -274,6 +279,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 index,
                 network_client.clone(),
                 block_verifier.clone(),
+                transaction_certifier.clone(),
                 commit_vote_monitor.clone(),
                 context.clone(),
                 core_dispatcher.clone(),
@@ -305,6 +311,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 fetch_own_last_block_task: JoinSet::new(),
                 network_client,
                 block_verifier,
+                transaction_certifier,
                 inflight_blocks_map,
                 commands_sender: commands_sender_clone,
                 dag_state,
@@ -433,6 +440,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         peer_index: AuthorityIndex,
         network_client: Arc<C>,
         block_verifier: Arc<V>,
+        transaction_certifier: TransactionCertifier,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
@@ -460,6 +468,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 blocks_guard,
                                 core_dispatcher.clone(),
                                 block_verifier.clone(),
+                                transaction_certifier.clone(),
                                 commit_vote_monitor.clone(),
                                 context.clone(),
                                 commands_sender.clone(),
@@ -495,11 +504,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
+        transaction_certifier: TransactionCertifier,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         context: Arc<Context>,
         commands_sender: Sender<Command>,
         sync_method: &str,
     ) -> ConsensusResult<()> {
+        if serialized_blocks.is_empty() {
+            return Ok(());
+        }
+
         // The maximum number of blocks that can be additionally fetched from the one requested - those
         // are potentially missing ancestors.
         const MAX_ADDITIONAL_BLOCKS: usize = 10;
@@ -515,7 +529,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let context = context.clone();
-                move || Self::verify_blocks(serialized_blocks, block_verifier, &context, peer_index)
+                move || {
+                    Self::verify_blocks(
+                        serialized_blocks,
+                        block_verifier,
+                        transaction_certifier,
+                        &context,
+                        peer_index,
+                    )
+                }
             })
             .await
             .expect("Spawn blocking should not fail")?;
@@ -613,18 +635,18 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     fn verify_blocks(
         serialized_blocks: Vec<Bytes>,
         block_verifier: Arc<V>,
+        transaction_certifier: TransactionCertifier,
         context: &Context,
         peer_index: AuthorityIndex,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let mut verified_blocks = Vec::new();
-
+        let mut voted_blocks = Vec::new();
         for serialized_block in serialized_blocks {
             let signed_block: SignedBlock =
                 bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
 
             // TODO: cache received and verified block refs to avoid duplicated work.
-            let verification_result = block_verifier.verify_and_vote(&signed_block);
-            if let Err(e) = verification_result {
+            let reject_txn_votes = block_verifier.verify_and_vote(&signed_block).tap_err(|e| {
                 // TODO: we might want to use a different metric to track the invalid "served" blocks
                 // from the invalid "proposed" ones.
                 let hostname = context.committee.authority(peer_index).hostname.clone();
@@ -634,9 +656,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     .invalid_blocks
                     .with_label_values(&[&hostname, "synchronizer", e.clone().name()])
                     .inc();
-                warn!("Invalid block received from {}: {}", peer_index, e);
-                return Err(e);
-            }
+                info!("Invalid block received from {}: {}", peer_index, e);
+            })?;
             let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
 
             // Dropping is ok because the block will be refetched.
@@ -652,7 +673,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 continue;
             }
 
-            verified_blocks.push(verified_block);
+            verified_blocks.push(verified_block.clone());
+            voted_blocks.push((verified_block, reject_txn_votes));
+        }
+
+        if context.protocol_config.mysticeti_fastpath() {
+            transaction_certifier.add_voted_blocks(voted_blocks);
         }
 
         Ok(verified_blocks)
@@ -857,6 +883,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let block_verifier = self.block_verifier.clone();
+        let transaction_certifier = self.transaction_certifier.clone();
         let commit_vote_monitor = self.commit_vote_monitor.clone();
         let core_dispatcher = self.core_dispatcher.clone();
         let blocks_to_fetch = self.inflight_blocks_map.clone();
@@ -914,7 +941,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 for (blocks_guard, fetched_blocks, peer) in results {
                     total_fetched += fetched_blocks.len();
 
-                    if let Err(err) = Self::process_fetched_blocks(fetched_blocks, peer, blocks_guard, core_dispatcher.clone(), block_verifier.clone(), commit_vote_monitor.clone(), context.clone(), commands_sender.clone(), "periodic").await {
+                    if let Err(err) = Self::process_fetched_blocks(fetched_blocks, peer, blocks_guard, core_dispatcher.clone(), block_verifier.clone(), transaction_certifier.clone(), commit_vote_monitor.clone(), context.clone(), commands_sender.clone(), "periodic").await {
                         warn!("Error occurred while processing fetched blocks from peer {peer}: {err}");
                     }
                 }
@@ -1097,6 +1124,7 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use consensus_config::{AuthorityIndex, Parameters};
+    use mysten_metrics::monitored_mpsc;
     use parking_lot::RwLock;
     use tokio::{sync::Mutex, time::sleep};
 
@@ -1104,6 +1132,7 @@ mod tests {
         authority_service::COMMIT_LAG_MULTIPLIER,
         core_thread::MockCoreThreadDispatcher,
         synchronizer::{MAX_BLOCKS_PER_FETCH, SYNC_MISSING_BLOCK_ROUND_THRESHOLD},
+        transaction_certifier::TransactionCertifier,
     };
     use crate::{
         block::{BlockDigest, BlockRef, Round, TestBlock, VerifiedBlock},
@@ -1347,8 +1376,12 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let network_client = Arc::new(MockNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
 
         let handle = Synchronizer::start(
             network_client.clone(),
@@ -1356,6 +1389,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
+            txn_certifier,
             dag_state,
             false,
         );
@@ -1395,8 +1429,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
 
         let handle = Synchronizer::start(
             network_client.clone(),
@@ -1404,6 +1442,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
+            txn_certifier,
             dag_state,
             false,
         );
@@ -1454,8 +1493,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
 
         // Create some test blocks
         let expected_blocks = (0..10)
@@ -1496,6 +1539,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
+            txn_certifier,
             dag_state,
             false,
         );
@@ -1529,8 +1573,12 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         // AND stub some missing blocks. The highest accepted round is 0. Create some blocks that are below and above the threshold sync.
@@ -1593,6 +1641,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier.clone(),
+            txn_certifier,
             dag_state.clone(),
             false,
         );
@@ -1616,8 +1665,12 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         // AND stub some missing blocks. The highest accepted round is 0. Create blocks that are above the threshold sync.
@@ -1676,6 +1729,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier,
+            txn_certifier,
             dag_state.clone(),
             false,
         );
@@ -1731,9 +1785,13 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let txn_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let our_index = AuthorityIndex::new_for_test(0);
 
         // Create some test blocks
@@ -1805,6 +1863,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
+            txn_certifier,
             dag_state,
             true,
         );

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1380,7 +1380,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
 
         let handle = Synchronizer::start(
@@ -1389,7 +1389,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
-            txn_certifier,
+            transaction_certifier,
             dag_state,
             false,
         );
@@ -1433,7 +1433,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
 
         let handle = Synchronizer::start(
@@ -1442,7 +1442,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
-            txn_certifier,
+            transaction_certifier,
             dag_state,
             false,
         );
@@ -1497,7 +1497,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
 
         // Create some test blocks
@@ -1539,7 +1539,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
-            txn_certifier,
+            transaction_certifier,
             dag_state,
             false,
         );
@@ -1577,7 +1577,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
@@ -1641,7 +1641,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier.clone(),
-            txn_certifier,
+            transaction_certifier,
             dag_state.clone(),
             false,
         );
@@ -1669,7 +1669,7 @@ mod tests {
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
@@ -1729,7 +1729,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
             block_verifier,
-            txn_certifier,
+            transaction_certifier,
             dag_state.clone(),
             false,
         );
@@ -1790,7 +1790,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let txn_certifier =
+        let transaction_certifier =
             TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let our_index = AuthorityIndex::new_for_test(0);
 
@@ -1863,7 +1863,7 @@ mod tests {
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
-            txn_certifier,
+            transaction_certifier,
             dag_state,
             true,
         );

--- a/consensus/core/src/transaction_certifier.rs
+++ b/consensus/core/src/transaction_certifier.rs
@@ -1,0 +1,814 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use consensus_config::Committee;
+use mysten_metrics::monitored_mpsc::UnboundedSender;
+use parking_lot::RwLock;
+
+use crate::{
+    block::GENESIS_ROUND,
+    context::Context,
+    dag_state::DagState,
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
+    BlockAPI as _, BlockRef, CertifiedBlock, CertifiedBlocksOutput, Round, TransactionIndex,
+    VerifiedBlock,
+};
+
+/// TransactionCertifier tries to certify transactions and send them to execute on the fastpath.
+///
+/// A transaction is certified if a quorum of authorities voted to accept it. A block is certified
+/// if every transaction in the block is either certified or rejected. Output of TransactionCertifier
+/// is batched by certified blocks. Once a certified block is sent to output, it is assumed external
+/// clients can start receiving execution confirmations on fastpath transactions in the block.
+///
+/// The invariant is that if a quorum of authorities certified a transaction, then the
+/// transaction must also be finalized via consensus commit eventually. The reverse is not
+/// necessarily true though, because fastpath execution is only an optimistic latency optimization.
+/// The implementation here takes advantage of this fact. By narrowing the scope of fastpath
+/// execution, post-commit finalization can be made simpler, more efficient and more robust.
+#[derive(Clone)]
+pub(crate) struct TransactionCertifier {
+    // The state of blocks being voted on and certified.
+    certifier_state: Arc<RwLock<CertifierState>>,
+    // The state of the DAG.
+    dag_state: Arc<RwLock<DagState>>,
+    // An unbounded channel to send certified blocks to the block handler
+    // as part of the consensus output.
+    certified_blocks_sender: UnboundedSender<CertifiedBlocksOutput>,
+}
+
+impl TransactionCertifier {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
+        certified_blocks_sender: UnboundedSender<CertifiedBlocksOutput>,
+    ) -> Self {
+        Self {
+            certifier_state: Arc::new(RwLock::new(CertifierState::new(context))),
+            dag_state,
+            certified_blocks_sender,
+        }
+    }
+
+    /// Process own votes on input blocks and votes contained in the input blocks.
+    /// Newly certified blocks are sent to the output channel.
+    ///
+    /// NOTE: blocks from commit sync do not need to be added, because transactions
+    /// arrived via commit sync should not need to be executed on the fastpath.
+    // TODO: add own proposed blocks, even though the contained votes have been processed.
+    pub(crate) fn add_voted_blocks(
+        &self,
+        voted_blocks: Vec<(VerifiedBlock, Vec<TransactionIndex>)>,
+    ) {
+        let certified_blocks = self.certifier_state.write().add_voted_blocks(voted_blocks);
+        if certified_blocks.is_empty() {
+            return;
+        }
+
+        // Only send a block at round R to execute on fastpath if the next round to propose is <= R+2.
+        // So if a quorum of authorities sends a block to fastpath and returns the effect digests to a client,
+        // the quorum is also promising they can only propose at round <= R+2. Then every block at round R+3
+        // must have a link to a certificate of the fastpath block.
+        let next_propose_round = self.dag_state.read().next_propose_round();
+        let certified_blocks: Vec<_> = certified_blocks
+            .into_iter()
+            .filter(|b| b.block.round() + 2 >= next_propose_round)
+            .collect();
+        if certified_blocks.is_empty() {
+            return;
+        }
+
+        if let Err(e) = self.certified_blocks_sender.send(CertifiedBlocksOutput {
+            blocks: certified_blocks,
+        }) {
+            tracing::warn!("Failed to send certified blocks: {:?}", e);
+        }
+    }
+
+    /// Updates the GC round and cleans up obsolete internal state.
+    // TODO: use GC to clean up CertifierState.
+    #[allow(unused)]
+    pub(crate) fn update_gc_round(&self, gc_round: Round) {
+        self.certifier_state.write().update_gc_round(gc_round);
+    }
+}
+
+/// CertifierState keeps track of votes received by each transaction and block,
+/// and helps determine if votes reach a quorum. Votes can start accumulating even
+/// before the target block is received by this authority.
+struct CertifierState {
+    context: Arc<Context>,
+
+    // Blocks received by this authority and votes on those blocks.
+    votes: BTreeMap<BlockRef, VoteInfo>,
+
+    // Highest round where blocks are GC'ed.
+    gc_round: Round,
+}
+
+impl CertifierState {
+    fn new(context: Arc<Context>) -> Self {
+        Self {
+            context,
+            votes: BTreeMap::new(),
+            gc_round: GENESIS_ROUND,
+        }
+    }
+
+    fn add_voted_blocks(
+        &mut self,
+        voted_blocks: Vec<(VerifiedBlock, Vec<TransactionIndex>)>,
+    ) -> Vec<CertifiedBlock> {
+        let mut certified_blocks = vec![];
+        for (voted_block, reject_txn_votes) in voted_blocks {
+            let blocks = self.add_voted_block(voted_block, reject_txn_votes);
+            certified_blocks.extend(blocks);
+        }
+        certified_blocks
+    }
+
+    fn add_voted_block(
+        &mut self,
+        voted_block: VerifiedBlock,
+        reject_txn_votes: Vec<TransactionIndex>,
+    ) -> Vec<CertifiedBlock> {
+        let mut certified_blocks = vec![];
+
+        if voted_block.round() <= self.gc_round {
+            // Block is outside of GC bound.
+            return vec![];
+        }
+
+        let vote_info = self.votes.entry(voted_block.reference()).or_default();
+        if vote_info.block.is_some() {
+            // Input block has already been processed and added to the state.
+            return vec![];
+        }
+        vote_info.block = Some(voted_block.clone());
+        vote_info.own_reject_txn_votes = Some(reject_txn_votes.clone());
+
+        // Add own reject txn votes for the block.
+        for reject in &reject_txn_votes {
+            vote_info
+                .reject_txn_votes
+                .entry(*reject)
+                .or_default()
+                .add_unique(self.context.own_index, &self.context.committee);
+        }
+
+        // Add own accept votes for the block.
+        vote_info
+            .accept_block_votes
+            .add_unique(self.context.own_index, &self.context.committee);
+
+        // Check if the input block is now certified after the updates above.
+        // NOTE: votes can already exist for the block and its transactions.
+        if let Some(certified_block) = vote_info.take_certified_output(&self.context.committee) {
+            certified_blocks.push(certified_block);
+        }
+
+        // Update reject votes from the block first. Otherwise another block can get certified when it should not be.
+        for block_votes in voted_block.transaction_votes() {
+            if block_votes.block_ref.round <= self.gc_round {
+                // Block is outside of GC bound.
+                continue;
+            }
+            let vote_info = self.votes.entry(block_votes.block_ref).or_default();
+            for reject in &block_votes.rejects {
+                vote_info
+                    .reject_txn_votes
+                    .entry(*reject)
+                    .or_default()
+                    .add_unique(voted_block.author(), &self.context.committee);
+            }
+            if let Some(certified_block) = vote_info.take_certified_output(&self.context.committee)
+            {
+                certified_blocks.push(certified_block);
+            }
+        }
+
+        // Update accept votes from the block after updating reject votes.
+        // Only parent round blocks receive accept votes on the fastpath.
+        for ancestor in voted_block.ancestors() {
+            if ancestor.round + 1 != voted_block.round() || ancestor.round <= self.gc_round {
+                // Ancestor is not a parent or outside of GC bound.
+                continue;
+            }
+            let vote_info = self.votes.entry(*ancestor).or_default();
+            vote_info
+                .accept_block_votes
+                .add_unique(voted_block.author(), &self.context.committee);
+            if let Some(certified_block) = vote_info.take_certified_output(&self.context.committee)
+            {
+                certified_blocks.push(certified_block);
+            }
+        }
+
+        certified_blocks
+    }
+
+    #[allow(unused)]
+    fn update_gc_round(&mut self, gc_round: Round) {
+        self.gc_round = gc_round;
+        while let Some((block_ref, _)) = self.votes.first_key_value() {
+            if block_ref.round <= self.gc_round {
+                self.votes.pop_first();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// VoteInfo keeps track of votes received for each transaction of this block,
+/// possibly even before the block is received by this authority.
+struct VoteInfo {
+    // Content of the block.
+    // None if the blocks has not been received.
+    block: Option<VerifiedBlock>,
+    // Rejection votes by this authority on this block.
+    // None if the block has not been received.
+    // The purpose is to help propagate votes from receiving a block to after the block is
+    // in a consensus commit.
+    own_reject_txn_votes: Option<Vec<TransactionIndex>>,
+    // Accumulates implicit accept votes for all transactions.
+    accept_block_votes: StakeAggregator<QuorumThreshold>,
+    // Accumulates reject votes per transaction.
+    reject_txn_votes: BTreeMap<TransactionIndex, StakeAggregator<QuorumThreshold>>,
+    // Whether this block has been certified already.
+    is_certified: bool,
+}
+
+impl VoteInfo {
+    fn new() -> Self {
+        Self {
+            block: None,
+            own_reject_txn_votes: None,
+            accept_block_votes: StakeAggregator::new(),
+            reject_txn_votes: BTreeMap::new(),
+            is_certified: false,
+        }
+    }
+
+    // If this block can now be certified but has not been sent to output, returns the output.
+    // Otherwise, returns None.
+    fn take_certified_output(&mut self, committee: &Committee) -> Option<CertifiedBlock> {
+        if self.is_certified {
+            // Skip if already certified.
+            return None;
+        }
+        let Some(block) = self.block.as_ref() else {
+            // Skip if the block has not been received.
+            return None;
+        };
+        if !self.accept_block_votes.reached_threshold(committee) {
+            // Skip if the block is not certified.
+            return None;
+        }
+        let mut rejected = vec![];
+        for (idx, reject_txn_votes) in &self.reject_txn_votes {
+            // The transaction is certified to be rejected.
+            if reject_txn_votes.reached_threshold(committee) {
+                rejected.push(*idx);
+                continue;
+            }
+            // If a transaction does not have a quorum of accept votes minus the reject votes,
+            // it is neither rejected nor certified. In this case the whole block cannot
+            // be considered as certified.
+
+            // accept_block_votes can be < reject_txn_votes on the transaction when reject_txn_votes
+            // come from blocks more than 1 round higher, which do not add to the
+            // accept votes of the block.
+            //
+            // Also, the accept votes used to certify a transactions is undercounted here.
+            // If a block has accept votes from a quorum of authorities A, B and C, but one transaction
+            // has a reject vote from D, the transaction and block are technically certified
+            // and can be sent to fastpath. However, the computation here will not certify the transaction
+            // or the block, which is fine because the fastpath certification is optimistic.
+            // The definite status of the transaction will be decided during post commit finalization.
+            if self
+                .accept_block_votes
+                .stake()
+                .saturating_sub(reject_txn_votes.stake())
+                < committee.quorum_threshold()
+            {
+                return None;
+            }
+        }
+        // The block is certified.
+        self.is_certified = true;
+        Some(CertifiedBlock {
+            block: block.clone(),
+            rejected,
+        })
+    }
+}
+
+impl Default for VoteInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeSet;
+
+    use consensus_config::AuthorityIndex;
+    use itertools::Itertools;
+    use rand::seq::SliceRandom as _;
+
+    use crate::{
+        block::BlockTransactionVotes, context::Context, test_dag_builder::DagBuilder, TestBlock,
+        Transaction,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_vote_info_basic() {
+        let (context, _) = Context::new_for_test(7);
+        let committee = &context.committee;
+
+        // No accept votes.
+        {
+            let mut vote_info = VoteInfo::new();
+            let block = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+            vote_info.block = Some(block.clone());
+            vote_info.own_reject_txn_votes = Some(vec![]);
+
+            assert!(vote_info.take_certified_output(committee).is_none());
+        }
+
+        // Accept votes but not enough.
+        {
+            let mut vote_info = VoteInfo::new();
+            let block = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+            vote_info.block = Some(block.clone());
+            vote_info.own_reject_txn_votes = Some(vec![]);
+            for i in 0..4 {
+                vote_info
+                    .accept_block_votes
+                    .add_unique(AuthorityIndex::new_for_test(i), committee);
+            }
+
+            assert!(vote_info.take_certified_output(committee).is_none());
+        }
+
+        // Enough accept votes but no block.
+        {
+            let mut vote_info = VoteInfo::new();
+            for i in 0..5 {
+                vote_info
+                    .accept_block_votes
+                    .add_unique(AuthorityIndex::new_for_test(i), committee);
+            }
+
+            assert!(vote_info.take_certified_output(committee).is_none());
+        }
+
+        // A quorum of accept votes and block exists.
+        {
+            let mut vote_info = VoteInfo::new();
+            let block = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+            vote_info.block = Some(block.clone());
+            vote_info.own_reject_txn_votes = Some(vec![]);
+            for i in 0..4 {
+                vote_info
+                    .accept_block_votes
+                    .add_unique(AuthorityIndex::new_for_test(i), committee);
+            }
+
+            // The block is not certified.
+            assert!(vote_info.take_certified_output(committee).is_none());
+
+            // Add 1 more accept vote from a different authority.
+            vote_info
+                .accept_block_votes
+                .add_unique(AuthorityIndex::new_for_test(4), committee);
+
+            // The block is now certified.
+            let certified_block = vote_info.take_certified_output(committee).unwrap();
+            assert_eq!(certified_block.block.reference(), block.reference());
+
+            // Certified block cannot be taken again.
+            assert!(vote_info.take_certified_output(committee).is_none());
+        }
+
+        // A quorum of accept and reject votes.
+        {
+            let mut vote_info = VoteInfo::new();
+            let block = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+            vote_info.block = Some(block.clone());
+            vote_info.own_reject_txn_votes = Some(vec![]);
+            // Add 5 accept votes which form a quorum.
+            for i in 0..5 {
+                vote_info
+                    .accept_block_votes
+                    .add_unique(AuthorityIndex::new_for_test(i), committee);
+            }
+            // For transactions 3 - 7 ..
+            for reject_tx_idx in 3..8 {
+                vote_info
+                    .reject_txn_votes
+                    .insert(reject_tx_idx, StakeAggregator::new());
+                // .. add 5 reject votes which form a quorum.
+                for authority_idx in 0..5 {
+                    vote_info
+                        .reject_txn_votes
+                        .get_mut(&reject_tx_idx)
+                        .unwrap()
+                        .add_unique(AuthorityIndex::new_for_test(authority_idx), committee);
+                }
+            }
+
+            // The block is certified.
+            let certified_block = vote_info.take_certified_output(committee).unwrap();
+            assert_eq!(certified_block.block.reference(), block.reference());
+
+            // Certified block cannot be taken again.
+            assert!(vote_info.take_certified_output(committee).is_none());
+        }
+
+        // A transaction in the block is neither rejected nor certified.
+        {
+            let mut vote_info = VoteInfo::new();
+            let block = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+            vote_info.block = Some(block.clone());
+            vote_info.own_reject_txn_votes = Some(vec![]);
+            // Add 5 accept votes which form a quorum.
+            for i in 0..5 {
+                vote_info
+                    .accept_block_votes
+                    .add_unique(AuthorityIndex::new_for_test(i), committee);
+            }
+            // For transactions 3 - 5 ..
+            for reject_tx_idx in 3..6 {
+                vote_info
+                    .reject_txn_votes
+                    .insert(reject_tx_idx, StakeAggregator::new());
+                // .. add 5 reject votes which form a quorum.
+                for authority_idx in 0..5 {
+                    vote_info
+                        .reject_txn_votes
+                        .get_mut(&reject_tx_idx)
+                        .unwrap()
+                        .add_unique(AuthorityIndex::new_for_test(authority_idx), committee);
+                }
+            }
+            // For transaction 6, add 4 reject votes which do not form a quorum.
+            vote_info.reject_txn_votes.insert(6, StakeAggregator::new());
+            for authority_idx in 0..4 {
+                vote_info
+                    .reject_txn_votes
+                    .get_mut(&6)
+                    .unwrap()
+                    .add_unique(AuthorityIndex::new_for_test(authority_idx), committee);
+            }
+
+            // The block is not certified.
+            assert!(vote_info.take_certified_output(committee).is_none());
+
+            // Add 1 more accept vote from a different authority for transaction 6.
+            vote_info
+                .reject_txn_votes
+                .get_mut(&6)
+                .unwrap()
+                .add_unique(AuthorityIndex::new_for_test(4), committee);
+
+            // The block is now certified.
+            let certified_block = vote_info.take_certified_output(committee).unwrap();
+            assert_eq!(certified_block.block.reference(), block.reference());
+
+            // Certified block cannot be taken again.
+            assert!(vote_info.take_certified_output(committee).is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_certify_basic() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let mut all_blocks = vec![];
+
+        // Round 1: blocks from all authorities are fully connected to the genesis blocks.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layer(1).num_transactions(4).build();
+        all_blocks.extend(dag_builder.all_blocks());
+
+        // Round 1: no block is certified yet.
+        let mut certifier = CertifierState::new(context.clone());
+        let certified_blocks =
+            certifier.add_voted_blocks(all_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+        assert!(certified_blocks.is_empty());
+
+        // Round 2: A, B & C blocks at round 2 are connected to only A, B & C blocks at round 1.
+        // A & B blocks reject transaction 2 from the round 1 C block.
+        let transactions = (0..4)
+            .map(|_| Transaction::new(vec![0_u8; 16]))
+            .collect::<Vec<_>>();
+        let ancestors = dag_builder
+            .all_blocks()
+            .iter()
+            .filter_map(|b| {
+                if b.author().value() < 3 {
+                    Some(b.reference())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        let round_1_block_with_rejected_txn = all_blocks[2].clone();
+        assert_eq!(round_1_block_with_rejected_txn.author().value(), 2);
+        for author in 0..3 {
+            let mut block = TestBlock::new(2, author)
+                .set_ancestors(ancestors.clone())
+                .set_transactions(transactions.clone());
+            if author < 2 {
+                block = block.set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: round_1_block_with_rejected_txn.reference(),
+                    rejects: vec![2],
+                }]);
+            }
+            all_blocks.push(VerifiedBlock::new_for_test(block.build()));
+        }
+
+        // Round 2: A & B round 1 blocks are certified.
+        let mut certifier = CertifierState::new(context.clone());
+        let certified_blocks =
+            certifier.add_voted_blocks(all_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+        assert_eq!(certified_blocks.len(), 2);
+        assert_eq!(
+            certified_blocks[0].block.reference(),
+            all_blocks[0].reference()
+        );
+        assert_eq!(
+            certified_blocks[1].block.reference(),
+            all_blocks[1].reference()
+        );
+
+        // Round 3: all blocks connected to round 2 blocks and round 1 D block,
+        let ancestors = all_blocks
+            .iter()
+            .filter_map(|b| {
+                if b.round() == 1 && b.author().value() == 3 {
+                    Some(b.reference())
+                } else if b.round() == 2 {
+                    assert_ne!(b.author().value(), 3);
+                    Some(b.reference())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(ancestors.len(), 4, "Ancestors {:?}", ancestors);
+        let round_2_block_with_rejected_txn = all_blocks.last().unwrap().clone();
+        for author in 0..4 {
+            let mut block = TestBlock::new(3, author)
+                .set_ancestors(ancestors.clone())
+                .set_transactions(transactions.clone());
+            let mut votes = vec![BlockTransactionVotes {
+                block_ref: round_2_block_with_rejected_txn.reference(),
+                rejects: vec![2],
+            }];
+            if author == 3 {
+                votes.push(BlockTransactionVotes {
+                    block_ref: round_1_block_with_rejected_txn.reference(),
+                    rejects: vec![2],
+                });
+            }
+            block = block.set_transaction_votes(votes);
+            all_blocks.push(VerifiedBlock::new_for_test(block.build()));
+        }
+
+        // Round 3: add another equivocating block from C, that does not contain reject votes.
+        let block = TestBlock::new(3, 3)
+            .set_ancestors(ancestors.clone())
+            .set_transactions(transactions.clone());
+        all_blocks.push(VerifiedBlock::new_for_test(block.build()));
+
+        // Round 3: A, B & C round 1 & round 2 blocks are certified.
+        //
+        // Notably: D at round 1 is not certified because its accept votes are > 1 round higher.
+        // And C at round 1 is now certified because of the new reject vote from D at round 3.
+        let mut certifier = CertifierState::new(context.clone());
+        let mut certified_blocks =
+            certifier.add_voted_blocks(all_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+        certified_blocks.sort_by_key(|b| b.block.reference());
+        assert_eq!(
+            certified_blocks.len(),
+            6,
+            "Certified blocks {}",
+            certified_blocks
+                .iter()
+                .map(|b| b.block.reference().to_string())
+                .join(",")
+        );
+        assert_eq!(
+            certified_blocks[0].block.reference(),
+            all_blocks[0].reference()
+        );
+        assert_eq!(
+            certified_blocks[1].block.reference(),
+            all_blocks[1].reference()
+        );
+        assert_eq!(
+            certified_blocks[2].block.reference(),
+            all_blocks[2].reference()
+        );
+        assert_eq!(
+            certified_blocks[3].block.reference(),
+            all_blocks[4].reference()
+        );
+        assert_eq!(
+            certified_blocks[4].block.reference(),
+            all_blocks[5].reference()
+        );
+        assert_eq!(
+            certified_blocks[5].block.reference(),
+            all_blocks[6].reference()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_certify_with_own_votes() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context.with_authority_index(AuthorityIndex::new_for_test(3)));
+
+        // Round 1: blocks from all authorities are fully connected to the genesis blocks.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layer(1).num_transactions(4).build();
+        let round_1_blocks = dag_builder.all_blocks();
+
+        // Round 2: A, B & C blocks at round 2 are connected to only A, B & C blocks at round 1.
+        // A & B blocks reject round 1 B block txn 1 and C block txn 2.
+        let transactions = (0..4)
+            .map(|_| Transaction::new(vec![0_u8; 16]))
+            .collect::<Vec<_>>();
+        let ancestors = round_1_blocks
+            .iter()
+            .map(|b| b.reference())
+            .collect::<Vec<_>>();
+        let mut round_2_blocks = vec![];
+        for author in 0..3 {
+            let mut block = TestBlock::new(2, author)
+                .set_ancestors(ancestors.clone())
+                .set_transactions(transactions.clone());
+            if author < 2 {
+                block = block.set_transaction_votes(vec![
+                    BlockTransactionVotes {
+                        block_ref: round_1_blocks[1].reference(),
+                        rejects: vec![1, 2],
+                    },
+                    BlockTransactionVotes {
+                        block_ref: round_1_blocks[2].reference(),
+                        rejects: vec![2, 3],
+                    },
+                ]);
+            }
+            round_2_blocks.push(VerifiedBlock::new_for_test(block.build()));
+        }
+
+        // No block should be certified with just round 2 blocks, even if their votes reach quorum.
+        let mut certifier = CertifierState::new(context.clone());
+        let certified_blocks = certifier
+            .add_voted_blocks(round_2_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+        assert!(certified_blocks.is_empty());
+
+        // Add round 1 A block.
+        let certified_blocks =
+            certifier.add_voted_blocks(vec![(round_1_blocks[0].clone(), vec![])]);
+        // The block should be certified.
+        assert_eq!(certified_blocks.len(), 1);
+        assert_eq!(
+            certified_blocks[0].block.reference(),
+            round_1_blocks[0].reference()
+        );
+
+        // Add round 1 B block with transaction 2 that still cannot be determined.
+        let certified_blocks =
+            certifier.add_voted_blocks(vec![(round_1_blocks[1].clone(), vec![1])]);
+        assert!(certified_blocks.is_empty());
+
+        // Add round 1 C block with all transactions determined via voting by this authority (3).
+        let certified_blocks =
+            certifier.add_voted_blocks(vec![(round_1_blocks[2].clone(), vec![2, 3])]);
+        // The block should be certified.
+        assert_eq!(certified_blocks.len(), 1);
+        assert_eq!(
+            certified_blocks[0].block.reference(),
+            round_1_blocks[2].reference()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_certify_fully_connected() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities: u32 = 7;
+        let (context, _) = Context::new_for_test(num_authorities as usize);
+        let context = Arc::new(context);
+
+        // Create fully connected blocks up to num_rounds.
+        let num_rounds = 20;
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=num_rounds).build();
+        let mut all_blocks = dag_builder.all_blocks();
+
+        // All blocks less than num_rounds are expected to be certified.
+        let expected_block_refs = all_blocks
+            .iter()
+            .filter_map(|b| {
+                if b.round() < num_rounds {
+                    Some(b.reference())
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeSet<_>>();
+
+        // Add the blocks to certifier in random order.
+        all_blocks.shuffle(&mut rand::thread_rng());
+        let mut certifier = CertifierState::new(context.clone());
+        let certified_blocks =
+            certifier.add_voted_blocks(all_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+
+        // Take the certified blocks and ensure no transaction is rejected.
+        for b in &certified_blocks {
+            assert!(b.rejected.is_empty());
+        }
+
+        // Ensure the certified blocks are the expected ones.
+        let certified_block_refs = certified_blocks
+            .iter()
+            .map(|b| b.block.reference())
+            .collect::<BTreeSet<_>>();
+
+        let diff = expected_block_refs
+            .difference(&certified_block_refs)
+            .collect::<Vec<_>>();
+        assert!(diff.is_empty(), "Blocks {:?} are not certified", diff);
+
+        let diff = certified_block_refs
+            .difference(&expected_block_refs)
+            .collect::<Vec<_>>();
+        assert!(
+            diff.is_empty(),
+            "Certified blocks {:?} are unexpected",
+            diff
+        );
+    }
+
+    // TODO: add reject votes.
+    #[tokio::test]
+    async fn test_certify_randomized() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities: u32 = 7;
+        let (context, _) = Context::new_for_test(num_authorities as usize);
+        let context = Arc::new(context);
+
+        // Create minimal connected blocks up to num_rounds.
+        let num_rounds = 50;
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=num_rounds)
+            .min_ancestor_links(false, None)
+            .build();
+        let all_blocks = dag_builder.all_blocks();
+
+        // Get the certified blocks, which depends on the structure of the minimum connected DAG.
+        let mut certifier = CertifierState::new(context.clone());
+        let mut expected_certified_blocks =
+            certifier.add_voted_blocks(all_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+        expected_certified_blocks.sort_by_key(|b| b.block.reference());
+
+        // Adding all blocks to certifier in random order should still produce the same set of certified blocks.
+        for _ in 0..100 {
+            // Add the blocks to certifier in random order.
+            let mut all_blocks = all_blocks.clone();
+            all_blocks.shuffle(&mut rand::thread_rng());
+            let mut certifier = CertifierState::new(context.clone());
+
+            // Take the certified blocks.
+            let mut actual_certified_blocks = certifier
+                .add_voted_blocks(all_blocks.iter().map(|b| (b.clone(), vec![])).collect());
+            actual_certified_blocks.sort_by_key(|b| b.block.reference());
+
+            // Ensure the certified blocks are the expected ones.
+            assert_eq!(
+                actual_certified_blocks.len(),
+                expected_certified_blocks.len()
+            );
+            for (actual, expected) in actual_certified_blocks
+                .iter()
+                .zip(expected_certified_blocks.iter())
+            {
+                assert_eq!(actual.block.reference(), expected.block.reference());
+                assert_eq!(actual.rejected, expected.rejected);
+            }
+        }
+    }
+}

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -305,8 +305,9 @@ pub struct AuthorityMetrics {
     pub consensus_committed_user_transactions: IntGaugeVec,
     pub consensus_calculated_throughput: IntGauge,
     pub consensus_calculated_throughput_profile: IntGauge,
-    pub consensus_transaction_handler_processed: IntCounterVec,
-    pub consensus_transaction_handler_fastpath_executions: IntCounter,
+    pub consensus_block_handler_block_processed: IntCounter,
+    pub consensus_block_handler_txn_processed: IntCounterVec,
+    pub consensus_block_handler_fastpath_executions: IntCounter,
 
     pub limits_metrics: Arc<LimitsMetrics>,
 
@@ -759,14 +760,19 @@ impl AuthorityMetrics {
                 "The current active calculated throughput profile",
                 registry
             ).unwrap(),
-            consensus_transaction_handler_processed: register_int_counter_vec_with_registry!(
-                "consensus_transaction_handler_processed",
-                "Number of transactions processed by consensus transaction handler, by whether they are certified or rejected.",
+            consensus_block_handler_block_processed: register_int_counter_with_registry!(
+                "consensus_block_handler_block_processed",
+                "Number of blocks processed by consensus block handler.",
+                registry
+            ).unwrap(),
+            consensus_block_handler_txn_processed: register_int_counter_vec_with_registry!(
+                "consensus_block_handler_txn_processed",
+                "Number of transactions processed by consensus block handler, by whether they are certified or rejected.",
                 &["outcome"],
                 registry
             ).unwrap(),
-            consensus_transaction_handler_fastpath_executions: register_int_counter_with_registry!(
-                "consensus_transaction_handler_fastpath_executions",
+            consensus_block_handler_fastpath_executions: register_int_counter_with_registry!(
+                "consensus_block_handler_fastpath_executions",
                 "Number of fastpath transactions sent for execution by consensus transaction handler",
                 registry,
             ).unwrap(),


### PR DESCRIPTION
## Description 

This PR adds a `TransactionCertifier` component. It keeps track of votes on transactions and support certifying them for fastpath. Blocks and local votes are added to `TransactionCertifier` from block handler, block sync, and proposed block handler.

## Test plan 

CI
