### PR TITLE
[core/authority] support forwarding certificates to others

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -186,6 +186,9 @@ pub struct NodeConfig {
     pub firewall_config: Option<RemoteFirewallConfig>,
 
     #[serde(default)]
+    pub trusted_certificate_forwarder: Vec<Multiaddr>,
+
+    #[serde(default)]
     pub execution_cache: ExecutionCacheConfig,
 
     // step 1 in removing the old state accumulator

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -186,7 +186,7 @@ pub struct NodeConfig {
     pub firewall_config: Option<RemoteFirewallConfig>,
 
     #[serde(default)]
-    pub trusted_certificate_forwarder: Vec<Multiaddr>,
+    pub trusted_certificate_forwarders: Vec<Multiaddr>,
 
     #[serde(default)]
     pub execution_cache: ExecutionCacheConfig,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -341,7 +341,7 @@ pub struct ValidatorService {
     metrics: Arc<ValidatorServiceMetrics>,
     traffic_controller: Option<Arc<TrafficController>>,
     client_id_source: Option<ClientIdSource>,
-    trusted_certificate_forwarder: Vec<NetworkAuthorityClient>,
+    trusted_certificate_forwarders: Vec<NetworkAuthorityClient>,
 }
 
 impl ValidatorService {
@@ -352,7 +352,7 @@ impl ValidatorService {
         traffic_controller_metrics: TrafficControllerMetrics,
         policy_config: Option<PolicyConfig>,
         firewall_config: Option<RemoteFirewallConfig>,
-        trusted_certificate_forwarder: Vec<Multiaddr>,
+        trusted_certificate_forwarders: Vec<Multiaddr>,
     ) -> Self {
         Self {
             state,
@@ -366,7 +366,7 @@ impl ValidatorService {
                 ))
             }),
             client_id_source: policy_config.map(|policy| policy.client_id_source),
-            trusted_certificate_forwarder: trusted_certificate_forwarder
+            trusted_certificate_forwarders: trusted_certificate_forwarders
                 .iter()
                 .map(NetworkAuthorityClient::connect_lazy)
                 .collect(),
@@ -384,7 +384,7 @@ impl ValidatorService {
             metrics,
             traffic_controller: None,
             client_id_source: None,
-            trusted_certificate_forwarder: vec![],
+            trusted_certificate_forwarders: vec![],
         }
     }
 
@@ -409,7 +409,7 @@ impl ValidatorService {
     }
 
     fn forward_transaction(&self, transaction: &Transaction) {
-        for client in self.trusted_certificate_forwarder.clone() {
+        for client in self.trusted_certificate_forwarders.clone() {
             let transaction = transaction.clone();
             spawn_monitored_task!(async move {
                 let result = tokio::time::timeout(
@@ -434,7 +434,7 @@ impl ValidatorService {
             metrics,
             traffic_controller: _,
             client_id_source: _,
-            trusted_certificate_forwarder: _,
+            trusted_certificate_forwarders: _,
         } = self.clone();
         let transaction = request.into_inner();
         let epoch_store = state.load_epoch_store_one_call_per_task();
@@ -513,7 +513,7 @@ impl ValidatorService {
             metrics,
             traffic_controller: _,
             client_id_source: _,
-            trusted_certificate_forwarder: _,
+            trusted_certificate_forwarders: _,
         } = self.clone();
         let epoch_store = state.load_epoch_store_one_call_per_task();
         if !epoch_store.protocol_config().mysticeti_fastpath() {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1463,7 +1463,7 @@ impl SuiNode {
             TrafficControllerMetrics::new(prometheus_registry),
             config.policy_config.clone(),
             config.firewall_config.clone(),
-            config.trusted_certificate_forwarder.clone(),
+            config.trusted_certificate_forwarders.clone(),
         );
 
         let mut server_conf = mysten_network::config::Config::new();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1463,6 +1463,7 @@ impl SuiNode {
             TrafficControllerMetrics::new(prometheus_registry),
             config.policy_config.clone(),
             config.firewall_config.clone(),
+            config.trusted_certificate_forwarder.clone(),
         );
 
         let mut server_conf = mysten_network::config::Config::new();

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -43,7 +43,7 @@ pub struct ValidatorConfigBuilder {
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
     state_accumulator_v2: bool,
-    trusted_certificate_forwarder: Vec<Multiaddr>,
+    trusted_certificate_forwarders: Vec<Multiaddr>,
 }
 
 impl ValidatorConfigBuilder {
@@ -117,11 +117,11 @@ impl ValidatorConfigBuilder {
         self
     }
 
-    pub fn with_trusted_certificate_forwarder(
+    pub fn with_trusted_certificate_forwarders(
         mut self,
-        trusted_certificate_forwarder: Vec<Multiaddr>,
+        trusted_certificate_forwarders: Vec<Multiaddr>,
     ) -> Self {
-        self.trusted_certificate_forwarder = trusted_certificate_forwarder;
+        self.trusted_certificate_forwarders = trusted_certificate_forwarders;
         self
     }
 
@@ -256,7 +256,7 @@ impl ValidatorConfigBuilder {
             enable_validator_tx_finalizer: true,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,
-            trusted_certificate_forwarder: self.trusted_certificate_forwarder,
+            trusted_certificate_forwarders: self.trusted_certificate_forwarders,
         }
     }
 
@@ -558,7 +558,7 @@ impl FullnodeConfigBuilder {
             enable_validator_tx_finalizer: false,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,
-            trusted_certificate_forwarder: vec![],
+            trusted_certificate_forwarders: vec![],
         }
     }
 }

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -43,6 +43,7 @@ pub struct ValidatorConfigBuilder {
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
     state_accumulator_v2: bool,
+    trusted_certificate_forwarder: Vec<Multiaddr>,
 }
 
 impl ValidatorConfigBuilder {
@@ -113,6 +114,14 @@ impl ValidatorConfigBuilder {
 
     pub fn with_state_accumulator_v2_enabled(mut self, enabled: bool) -> Self {
         self.state_accumulator_v2 = enabled;
+        self
+    }
+
+    pub fn with_trusted_certificate_forwarder(
+        mut self,
+        trusted_certificate_forwarder: Vec<Multiaddr>,
+    ) -> Self {
+        self.trusted_certificate_forwarder = trusted_certificate_forwarder;
         self
     }
 
@@ -247,6 +256,7 @@ impl ValidatorConfigBuilder {
             enable_validator_tx_finalizer: true,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,
+            trusted_certificate_forwarder: self.trusted_certificate_forwarder,
         }
     }
 
@@ -548,6 +558,7 @@ impl FullnodeConfigBuilder {
             enable_validator_tx_finalizer: false,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,
+            trusted_certificate_forwarder: vec![],
         }
     }
 }

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -164,6 +164,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -336,6 +337,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -508,6 +510,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -680,6 +683,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -852,6 +856,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1024,6 +1029,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1196,6 +1202,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+    trusted-certificate-forwarders: []
     execution-cache:
       writeback-cache:
         max_cache_size: ~


### PR DESCRIPTION
## Description 

This PR allows validators to specify `trusted_certificate_forwarder` in config to forward received certificates to other trusted GRPC servers. This is used to facilitate MEV. 

## Test plan 

How did you test the new or updated feature?


Create a local network and add a trusted certificate forwader: 
```rust
let mut builder = ValidatorConfigBuilder::new()
    .with_trusted_certificate_forwarder(vec![
           "/ip4/127.0.0.1/tcp/1080/http".parse().unwrap()
    ]);
```

Start a local network:
```
 ./target/debug/sui start --with-faucet --force-regenesis
```

Then, send a tx to the validator (e.g., `./target/debug/sui client  faucet --url http://localhost:9123/v1/gas`)

The port 1080 on 127.0.0.1 shall receive the certificate. 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
