### PR TITLE
indexer: drop objects_history full indices

### DIFF
--- a/crates/sui-indexer/migrations/pg/2024-10-25-153629_remove_objects_history_full_indices/down.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-25-153629_remove_objects_history_full_indices/down.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS objects_history_owner ON objects_history (checkpoint_sequence_number, owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS objects_history_coin_owner ON objects_history (checkpoint_sequence_number, owner_id, coin_type, object_id) WHERE coin_type IS NOT NULL AND owner_type = 1;
+CREATE INDEX IF NOT EXISTS objects_history_coin_only ON objects_history (checkpoint_sequence_number, coin_type, object_id) WHERE coin_type IS NOT NULL;
+CREATE INDEX IF NOT EXISTS objects_history_type ON objects_history (checkpoint_sequence_number, object_type);
+CREATE INDEX IF NOT EXISTS objects_history_package_module_name_full_type ON objects_history (checkpoint_sequence_number, object_type_package, object_type_module, object_type_name, object_type);
+CREATE INDEX IF NOT EXISTS objects_history_owner_package_module_name_full_type ON objects_history (checkpoint_sequence_number, owner_id, object_type_package, object_type_module, object_type_name, object_type);

--- a/crates/sui-indexer/migrations/pg/2024-10-25-153629_remove_objects_history_full_indices/up.sql
+++ b/crates/sui-indexer/migrations/pg/2024-10-25-153629_remove_objects_history_full_indices/up.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS objects_history_owner;
+DROP INDEX IF EXISTS objects_history_coin_owner;
+DROP INDEX IF EXISTS objects_history_coin_only;
+DROP INDEX IF EXISTS objects_history_type;
+DROP INDEX IF EXISTS objects_history_package_module_name_full_type;
+DROP INDEX IF EXISTS objects_history_owner_package_module_name_full_type;


### PR DESCRIPTION
## Description 

the partial indices have been in prod for tnt and mnt, we can now drop the full indices.
I will proactively drop them CONCURRENTLY before the release so that the release migration run will be fast.

## Test plan 

local run of diesel migrations

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
