### PR TITLE
refactor(indexer-alt): make Handler concurrent-pipeline-specific

### DIFF
--- a/crates/sui-indexer-alt/migrations/2024-10-16-002409_tx_affected_objects/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-16-002409_tx_affected_objects/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS tx_affected_objects (
     tx_sequence_number          BIGINT       NOT NULL,
+    -- Object ID of the object touched by this transaction.
     affected                    BYTEA        NOT NULL,
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(affected, tx_sequence_number)

--- a/crates/sui-indexer-alt/src/handlers/ev_emit_mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_emit_mod.rs
@@ -7,19 +7,14 @@ use anyhow::Result;
 use diesel_async::RunQueryDsl;
 use sui_types::full_checkpoint_content::CheckpointData;
 
-use crate::{db, models::events::StoredEvEmitMod, schema::ev_emit_mod};
-
-use super::Handler;
-
+use crate::{
+    db, models::events::StoredEvEmitMod, pipeline::concurrent::Handler, pipeline::Processor,
+    schema::ev_emit_mod,
+};
 pub struct EvEmitMod;
 
-#[async_trait::async_trait]
-impl Handler for EvEmitMod {
+impl Processor for EvEmitMod {
     const NAME: &'static str = "ev_emit_mod";
-
-    const BATCH_SIZE: usize = 100;
-    const CHUNK_SIZE: usize = 1000;
-    const MAX_PENDING_SIZE: usize = 10000;
 
     type Value = StoredEvEmitMod;
 
@@ -49,6 +44,13 @@ impl Handler for EvEmitMod {
 
         Ok(values.into_iter().collect())
     }
+}
+
+#[async_trait::async_trait]
+impl Handler for EvEmitMod {
+    const BATCH_SIZE: usize = 100;
+    const CHUNK_SIZE: usize = 1000;
+    const MAX_PENDING_SIZE: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(ev_emit_mod::table)

--- a/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
@@ -7,19 +7,15 @@ use anyhow::{Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_types::full_checkpoint_content::CheckpointData;
 
-use crate::{db, models::events::StoredEvStructInst, schema::ev_struct_inst};
-
-use super::Handler;
+use crate::{
+    db, models::events::StoredEvStructInst, pipeline::concurrent::Handler, pipeline::Processor,
+    schema::ev_struct_inst,
+};
 
 pub struct EvStructInst;
 
-#[async_trait::async_trait]
-impl Handler for EvStructInst {
+impl Processor for EvStructInst {
     const NAME: &'static str = "ev_struct_inst";
-
-    const BATCH_SIZE: usize = 100;
-    const CHUNK_SIZE: usize = 1000;
-    const MAX_PENDING_SIZE: usize = 10000;
 
     type Value = StoredEvStructInst;
 
@@ -52,6 +48,13 @@ impl Handler for EvStructInst {
 
         Ok(values.into_iter().collect())
     }
+}
+
+#[async_trait::async_trait]
+impl Handler for EvStructInst {
+    const BATCH_SIZE: usize = 100;
+    const CHUNK_SIZE: usize = 1000;
+    const MAX_PENDING_SIZE: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(ev_struct_inst::table)

--- a/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
@@ -7,14 +7,14 @@ use anyhow::{Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_types::full_checkpoint_content::CheckpointData;
 
-use crate::{db, models::checkpoints::StoredCheckpoint, schema::kv_checkpoints};
-
-use super::Handler;
+use crate::{
+    db, models::checkpoints::StoredCheckpoint, pipeline::concurrent::Handler, pipeline::Processor,
+    schema::kv_checkpoints,
+};
 
 pub struct KvCheckpoints;
 
-#[async_trait::async_trait]
-impl Handler for KvCheckpoints {
+impl Processor for KvCheckpoints {
     const NAME: &'static str = "kv_checkpoints";
 
     type Value = StoredCheckpoint;
@@ -29,7 +29,10 @@ impl Handler for KvCheckpoints {
                 .with_context(|| format!("Serializing checkpoint {sequence_number} contents"))?,
         }])
     }
+}
 
+#[async_trait::async_trait]
+impl Handler for KvCheckpoints {
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(kv_checkpoints::table)
             .values(values)

--- a/crates/sui-indexer-alt/src/handlers/kv_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_objects.rs
@@ -7,20 +7,15 @@ use anyhow::{Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_types::full_checkpoint_content::CheckpointData;
 
-use crate::{db, models::objects::StoredObject, schema::kv_objects};
-
-use super::Handler;
+use crate::{
+    db, models::objects::StoredObject, pipeline::concurrent::Handler, pipeline::Processor,
+    schema::kv_objects,
+};
 
 pub struct KvObjects;
 
-#[async_trait::async_trait]
-impl Handler for KvObjects {
+impl Processor for KvObjects {
     const NAME: &'static str = "kv_objects";
-
-    const BATCH_SIZE: usize = 100;
-    const CHUNK_SIZE: usize = 1000;
-    const MAX_PENDING_SIZE: usize = 10000;
-
     type Value = StoredObject;
 
     fn process(checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
@@ -56,6 +51,13 @@ impl Handler for KvObjects {
             .chain(created_objects)
             .collect::<Result<Vec<_>, _>>()
     }
+}
+
+#[async_trait::async_trait]
+impl Handler for KvObjects {
+    const BATCH_SIZE: usize = 100;
+    const CHUNK_SIZE: usize = 1000;
+    const MAX_PENDING_SIZE: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(kv_objects::table)

--- a/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
@@ -7,19 +7,15 @@ use anyhow::{Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_types::full_checkpoint_content::CheckpointData;
 
-use crate::{db, models::transactions::StoredTransaction, schema::kv_transactions};
-
-use super::Handler;
+use crate::{
+    db, models::transactions::StoredTransaction, pipeline::concurrent::Handler,
+    pipeline::Processor, schema::kv_transactions,
+};
 
 pub struct KvTransactions;
 
-#[async_trait::async_trait]
-impl Handler for KvTransactions {
+impl Processor for KvTransactions {
     const NAME: &'static str = "kv_transactions";
-
-    const BATCH_SIZE: usize = 100;
-    const CHUNK_SIZE: usize = 1000;
-    const MAX_PENDING_SIZE: usize = 10000;
 
     type Value = StoredTransaction;
 
@@ -58,6 +54,13 @@ impl Handler for KvTransactions {
 
         Ok(values)
     }
+}
+
+#[async_trait::async_trait]
+impl Handler for KvTransactions {
+    const BATCH_SIZE: usize = 100;
+    const CHUNK_SIZE: usize = 1000;
+    const MAX_PENDING_SIZE: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(kv_transactions::table)

--- a/crates/sui-indexer-alt/src/handlers/mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/mod.rs
@@ -1,12 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
-use sui_types::full_checkpoint_content::CheckpointData;
-
-use crate::db;
-
 pub mod ev_emit_mod;
 pub mod ev_struct_inst;
 pub mod kv_checkpoints;
@@ -14,44 +8,3 @@ pub mod kv_objects;
 pub mod kv_transactions;
 pub mod tx_affected_objects;
 pub mod tx_balance_changes;
-
-/// Handlers implement the logic for a given indexing pipeline: How to process checkpoint data into
-/// rows for their table, and how to write those rows to the database.
-///
-/// The handler is also responsible for tuning the various parameters of the pipeline (provided as
-/// associated values). Reasonable defaults have been chosen to balance concurrency with memory
-/// usage, but each handle may choose to override these defaults, e.g.
-///
-/// - Handlers that produce many small rows may wish to increase their batch/chunk/max-pending
-///   sizes).
-/// - Handlers that do more work during processing may wish to increase their fanout so more of it
-///   can be done concurrently, to preserve throughput.
-#[async_trait::async_trait]
-pub trait Handler {
-    /// Used to identify the pipeline in logs and metrics.
-    const NAME: &'static str;
-
-    /// How much concurrency to use when processing checkpoint data.
-    const FANOUT: usize = 10;
-
-    /// If at least this many rows are pending, the committer will commit them eagerly.
-    const BATCH_SIZE: usize = 50;
-
-    /// If there are more than this many rows pending, the committer will only commit this many in
-    /// one operation.
-    const CHUNK_SIZE: usize = 200;
-
-    /// If there are more than this many rows pending, the committer applies backpressure.
-    const MAX_PENDING_SIZE: usize = 1000;
-
-    /// The type of value being inserted by the handler.
-    type Value: Send + Sync + 'static;
-
-    /// The processing logic for turning a checkpoint into rows of the table.
-    fn process(checkpoint: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>>;
-
-    /// Take a chunk of values and commit them to the database, returning the number of rows
-    /// affected.
-    async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>)
-        -> anyhow::Result<usize>;
-}

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
@@ -7,19 +7,15 @@ use anyhow::Result;
 use diesel_async::RunQueryDsl;
 use sui_types::{effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointData};
 
-use crate::{db, models::transactions::StoredTxAffectedObject, schema::tx_affected_objects};
-
-use super::Handler;
+use crate::{
+    db, models::transactions::StoredTxAffectedObject, pipeline::concurrent::Handler,
+    pipeline::Processor, schema::tx_affected_objects,
+};
 
 pub struct TxAffectedObjects;
 
-#[async_trait::async_trait]
-impl Handler for TxAffectedObjects {
+impl Processor for TxAffectedObjects {
     const NAME: &'static str = "tx_affected_objects";
-
-    const BATCH_SIZE: usize = 100;
-    const CHUNK_SIZE: usize = 1000;
-    const MAX_PENDING_SIZE: usize = 10000;
 
     type Value = StoredTxAffectedObject;
 
@@ -51,6 +47,13 @@ impl Handler for TxAffectedObjects {
 
         Ok(values)
     }
+}
+
+#[async_trait::async_trait]
+impl Handler for TxAffectedObjects {
+    const BATCH_SIZE: usize = 100;
+    const CHUNK_SIZE: usize = 1000;
+    const MAX_PENDING_SIZE: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(tx_affected_objects::table)

--- a/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
@@ -15,20 +15,15 @@ use sui_types::{
 use crate::{
     db,
     models::transactions::{BalanceChange, StoredTxBalanceChange},
+    pipeline::concurrent::Handler,
+    pipeline::Processor,
     schema::tx_balance_changes,
 };
 
-use super::Handler;
-
 pub struct TxBalanceChanges;
 
-#[async_trait::async_trait]
-impl Handler for TxBalanceChanges {
+impl Processor for TxBalanceChanges {
     const NAME: &'static str = "tx_balance_changes";
-
-    const BATCH_SIZE: usize = 100;
-    const CHUNK_SIZE: usize = 1000;
-    const MAX_PENDING_SIZE: usize = 10000;
 
     type Value = StoredTxBalanceChange;
 
@@ -58,6 +53,13 @@ impl Handler for TxBalanceChanges {
 
         Ok(values)
     }
+}
+
+#[async_trait::async_trait]
+impl Handler for TxBalanceChanges {
+    const BATCH_SIZE: usize = 100;
+    const CHUNK_SIZE: usize = 1000;
+    const MAX_PENDING_SIZE: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {
         Ok(diesel::insert_into(tx_balance_changes::table)

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -5,7 +5,6 @@ use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 
 use anyhow::{Context, Result};
 use db::{Db, DbConfig};
-use handlers::Handler;
 use ingestion::{IngestionConfig, IngestionService};
 use metrics::{IndexerMetrics, MetricsService};
 use models::watermarks::CommitterWatermark;
@@ -132,7 +131,7 @@ impl Indexer {
 
     /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,
     /// they will be idle until the ingestion service starts, and serves it checkpoint data.
-    pub async fn concurrent_pipeline<H: Handler + 'static>(&mut self) -> Result<()> {
+    pub async fn concurrent_pipeline<H: concurrent::Handler + 'static>(&mut self) -> Result<()> {
         if !self.enabled_pipelines.is_empty() && !self.enabled_pipelines.contains(H::NAME) {
             info!("Skipping pipeline {}", H::NAME);
             return Ok(());

--- a/crates/sui-indexer-alt/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt/src/models/watermarks.rs
@@ -30,19 +30,6 @@ pub struct CommitterWatermark<'p> {
     pub tx_hi: i64,
 }
 
-/// Outcomes from extending one watermark with another.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum Ordering {
-    /// The watermark was in the future, so could not be added.
-    Future,
-
-    /// The added watermark was in the past, so the current watermark didn't change.
-    Past,
-
-    /// The added watermark was the successor to the current watermark, so was used in the update.
-    Next,
-}
-
 impl CommitterWatermark<'static> {
     /// Get the current high watermark for the pipeline.
     pub async fn get(
@@ -84,16 +71,6 @@ impl<'p> CommitterWatermark<'p> {
             .execute(conn)
             .await?
             > 0)
-    }
-
-    /// Compare `other` with the immediate successor of this watermark.
-    pub fn next_cmp(&self, other: &CommitterWatermark<'_>) -> Ordering {
-        let next = self.checkpoint_hi_inclusive + 1;
-        match other.checkpoint_hi_inclusive.cmp(&next) {
-            cmp::Ordering::Equal => Ordering::Next,
-            cmp::Ordering::Less => Ordering::Past,
-            cmp::Ordering::Greater => Ordering::Future,
-        }
     }
 }
 

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
@@ -13,10 +13,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 use crate::{
-    handlers::Handler,
     metrics::IndexerMetrics,
-    pipeline::{Batched, Indexed, PipelineConfig, WatermarkPart},
+    pipeline::{Indexed, PipelineConfig, WatermarkPart},
 };
+
+use super::{Batched, Handler};
 
 /// Processed values that are waiting to be written to the database. This is an internal type used
 /// by the concurrent collector to hold data it is waiting to send to the committer.

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
@@ -13,10 +13,11 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     db::Db,
-    handlers::Handler,
     metrics::IndexerMetrics,
-    pipeline::{Batched, Break, PipelineConfig, WatermarkPart},
+    pipeline::{Break, PipelineConfig, WatermarkPart},
 };
+
+use super::{Batched, Handler};
 
 /// If the committer needs to retry a commit, it will wait this long initially.
 const INITIAL_RETRY_INTERVAL: Duration = Duration::from_millis(100);
@@ -92,7 +93,7 @@ pub(super) fn committer<H: Handler + 'static>(
                                 BE::transient(Break::Err(e.into()))
                             })?;
 
-                            let affected = H::commit(&values, &mut conn).await;
+                            let affected = H::commit(values.as_slice(), &mut conn).await;
                             let elapsed = guard.stop_and_record();
 
                             match affected {

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
@@ -17,11 +17,12 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     db::Db,
-    handlers::Handler,
     metrics::IndexerMetrics,
     models::watermarks::{CommitterWatermark, Ordering},
     pipeline::{PipelineConfig, WatermarkPart},
 };
+
+use super::Handler;
 
 /// Tracing message for the watermark update will be logged at info level at least this many
 /// checkpoints.

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
@@ -74,9 +74,9 @@ pub(super) fn watermark<H: Handler + 'static>(
         let mut poll = interval(config.watermark_interval);
         poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        // To correctly update the watermark, the committer tracks the watermark it last tried to
-        // write and the watermark parts for any checkpoints that have been written since then
-        // ("pre-committed"). After each batch is written, the committer will try to progress the
+        // To correctly update the watermark, the task tracks the watermark it last tried to write
+        // and the watermark parts for any checkpoints that have been written since then
+        // ("pre-committed"). After each batch is written, the task will try to progress the
         // watermark as much as possible without going over any holes in the sequence of
         // checkpoints (entirely missing watermarks, or incomplete watermarks).
         //

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -10,9 +10,22 @@ pub use processor::Processor;
 pub(crate) mod concurrent;
 mod processor;
 
+/// Tracing message for the watermark update will be logged at info level at least this many
+/// checkpoints.
+const LOUD_WATERMARK_UPDATE_INTERVAL: i64 = 5 * 10;
+
 /// Extra buffer added to channels between tasks in a pipeline. There does not need to be a huge
 /// capacity here because tasks already buffer rows to insert internally.
 const PIPELINE_BUFFER: usize = 5;
+
+/// Issue a warning every time the number of pending watermarks exceeds this number. This can
+/// happen if the pipeline was started with its initial checkpoint overridden to be strictly
+/// greater than its current watermark -- in that case, the pipeline will never be able to update
+/// its watermarks.
+///
+/// This may be a legitimate thing to do when backfilling a table, but in that case
+/// `--skip-watermarks` should be used.
+const WARN_PENDING_WATERMARKS: usize = 10000;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct PipelineConfig {

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -9,6 +9,7 @@ pub use processor::Processor;
 
 pub(crate) mod concurrent;
 mod processor;
+pub(crate) mod sequential;
 
 /// Tracing message for the watermark update will be logged at info level at least this many
 /// checkpoints.
@@ -98,6 +99,11 @@ impl<P: Processor> Indexed<P> {
             },
             values,
         }
+    }
+
+    /// Number of rows from this checkpoint
+    fn len(&self) -> usize {
+        self.values.len()
     }
 
     /// The checkpoint sequence number that this data is from

--- a/crates/sui-indexer-alt/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt/src/pipeline/processor.rs
@@ -11,9 +11,26 @@ use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
-use crate::{handlers::Handler, metrics::IndexerMetrics, pipeline::Break};
+use crate::{metrics::IndexerMetrics, pipeline::Break};
 
 use super::Indexed;
+
+/// Implementors of this trait are responsible for transforming checkpoint into rows for their
+/// table. The `FANOUT` associated value controls how many concurrent workers will be used to
+/// process checkpoint information.
+pub trait Processor {
+    /// Used to identify the pipeline in logs and metrics.
+    const NAME: &'static str;
+
+    /// How much concurrency to use when processing checkpoint data.
+    const FANOUT: usize = 10;
+
+    /// The type of value being inserted by the handler.
+    type Value: Send + Sync + 'static;
+
+    /// The processing logic for turning a checkpoint into rows of the table.
+    fn process(checkpoint: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>>;
+}
 
 /// The processor task is responsible for taking checkpoint data and breaking it down into rows
 /// ready to commit. It spins up a supervisor that waits on the `rx` channel for checkpoints, and
@@ -24,18 +41,18 @@ use super::Indexed;
 ///
 /// The task will shutdown if the `cancel` token is cancelled, or if any of the workers encounters
 /// an error -- there is no retry logic at this level.
-pub(super) fn processor<H: Handler + 'static>(
+pub(super) fn processor<P: Processor + 'static>(
     rx: mpsc::Receiver<Arc<CheckpointData>>,
-    tx: mpsc::Sender<Indexed<H>>,
+    tx: mpsc::Sender<Indexed<P>>,
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
     spawn_monitored_task!(async move {
-        info!(pipeline = H::NAME, "Starting processor");
+        info!(pipeline = P::NAME, "Starting processor");
 
         match ReceiverStream::new(rx)
             .map(Ok)
-            .try_for_each_concurrent(H::FANOUT, |checkpoint| {
+            .try_for_each_concurrent(P::FANOUT, |checkpoint| {
                 let tx = tx.clone();
                 let metrics = metrics.clone();
                 let cancel = cancel.clone();
@@ -46,15 +63,15 @@ pub(super) fn processor<H: Handler + 'static>(
 
                     metrics
                         .total_handler_checkpoints_received
-                        .with_label_values(&[H::NAME])
+                        .with_label_values(&[P::NAME])
                         .inc();
 
                     let guard = metrics
                         .handler_checkpoint_latency
-                        .with_label_values(&[H::NAME])
+                        .with_label_values(&[P::NAME])
                         .start_timer();
 
-                    let values = H::process(&checkpoint)?;
+                    let values = P::process(&checkpoint)?;
                     let elapsed = guard.stop_and_record();
 
                     let epoch = checkpoint.checkpoint_summary.epoch;
@@ -62,7 +79,7 @@ pub(super) fn processor<H: Handler + 'static>(
                     let tx_hi = checkpoint.checkpoint_summary.network_total_transactions;
 
                     debug!(
-                        pipeline = H::NAME,
+                        pipeline = P::NAME,
                         checkpoint = cp_sequence_number,
                         elapsed_ms = elapsed * 1000.0,
                         "Processed checkpoint",
@@ -70,12 +87,12 @@ pub(super) fn processor<H: Handler + 'static>(
 
                     metrics
                         .total_handler_checkpoints_processed
-                        .with_label_values(&[H::NAME])
+                        .with_label_values(&[P::NAME])
                         .inc();
 
                     metrics
                         .total_handler_rows_created
-                        .with_label_values(&[H::NAME])
+                        .with_label_values(&[P::NAME])
                         .inc_by(values.len() as u64);
 
                     tx.send(Indexed::new(epoch, cp_sequence_number, tx_hi, values))
@@ -88,15 +105,15 @@ pub(super) fn processor<H: Handler + 'static>(
             .await
         {
             Ok(()) => {
-                info!(pipeline = H::NAME, "Checkpoints done, stopping processor");
+                info!(pipeline = P::NAME, "Checkpoints done, stopping processor");
             }
 
             Err(Break::Cancel) => {
-                info!(pipeline = H::NAME, "Shutdown received, stopping processor");
+                info!(pipeline = P::NAME, "Shutdown received, stopping processor");
             }
 
             Err(Break::Err(e)) => {
-                error!(pipeline = H::NAME, "Error from handler: {e}");
+                error!(pipeline = P::NAME, "Error from handler: {e}");
                 cancel.cancel();
             }
         };

--- a/crates/sui-indexer-alt/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/committer.rs
@@ -1,0 +1,325 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cmp::Ordering, collections::BTreeMap, sync::Arc};
+
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use mysten_metrics::spawn_monitored_task;
+use tokio::{
+    sync::mpsc,
+    task::JoinHandle,
+    time::{interval, MissedTickBehavior},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    db::Db,
+    metrics::IndexerMetrics,
+    models::watermarks::CommitterWatermark,
+    pipeline::{Indexed, PipelineConfig, LOUD_WATERMARK_UPDATE_INTERVAL, WARN_PENDING_WATERMARKS},
+};
+
+use super::Handler;
+
+/// The committer task gathers rows into batches and writes them to the database.
+///
+/// Data arrives out of order, grouped by checkpoint, on `rx`. The task orders them and waits to
+/// write them until either a configural polling interval has passed (controlled by
+/// `config.collect_interval`), or `H::BATCH_SIZE` rows have been accumulated and we have received
+/// the next expected checkpoint.
+///
+/// Writes are performed on checkpoint boundaries (more than one checkpoint can be present in a
+/// single write), in a single transaction that includes all row updates and an update to the
+/// watermark table.
+///
+/// Upon successful write, the task sends its new watermark back to the ingestion service, to
+/// unblock its regulator.
+///
+/// The task can be shutdown using its `cancel` token or if either of its channels are closed.
+pub(super) fn committer<H: Handler + 'static>(
+    config: PipelineConfig,
+    watermark: Option<CommitterWatermark<'static>>,
+    mut rx: mpsc::Receiver<Indexed<H>>,
+    tx: mpsc::UnboundedSender<(&'static str, u64)>,
+    db: Db,
+    metrics: Arc<IndexerMetrics>,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    spawn_monitored_task!(async move {
+        // The `poll` interval controls the maximum time to wait between commits, regardless of the
+        // amount of data available.
+        let mut poll = interval(config.collect_interval);
+        poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // Buffer to gather the next batch to write. A checkpoint's data is only added to the batch
+        // when it is known to come from the next checkpoint after `watermark` (the current tip of
+        // the batch), and data from previous checkpoints will be discarded to avoid double writes.
+        //
+        // The batch may be non-empty at top of a tick of the committer's loop if the previous
+        // attempt at a write failed. Attempt is incremented every time a batch write fails, and is
+        // reset when it succeeds.
+        let mut attempt = 0;
+        let mut batch = H::Batch::default();
+        let mut batch_rows = 0;
+        let mut batch_checkpoints = 0;
+
+        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch,
+        // and whether that batch needs to be written out. By extension it also knows the next
+        // checkpoint to expect and add to the batch.
+        let mut watermark_needs_update = false;
+        let (mut watermark, mut next_checkpoint) = if let Some(watermark) = watermark {
+            let next = watermark.checkpoint_hi_inclusive + 1;
+            (watermark, next)
+        } else {
+            (CommitterWatermark::initial(H::NAME.into()), 0)
+        };
+
+        // The committer task will periodically output a log message at a higher log level to
+        // demonstrate that the pipeline is making progress.
+        let mut next_loud_watermark_update =
+            watermark.checkpoint_hi_inclusive + LOUD_WATERMARK_UPDATE_INTERVAL;
+
+        // Data for checkpoint that haven't been written yet. Note that `pending_rows` includes
+        // rows in `batch`.
+        let mut pending: BTreeMap<u64, Indexed<H>> = BTreeMap::new();
+        let mut pending_rows = 0;
+
+        info!(pipeline = H::NAME, ?watermark, "Starting committer");
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!(pipeline = H::NAME, "Shutdown received, stopping committer");
+                    break;
+                }
+
+                _ = poll.tick() => {
+                    if pending.len() > WARN_PENDING_WATERMARKS {
+                        warn!(
+                            pipeline = H::NAME,
+                            pending = pending.len(),
+                            "Pipeline has a large number of pending watermarks",
+                        );
+                    }
+
+                    let Ok(mut conn) = db.connect().await else {
+                        warn!(pipeline = H::NAME, "Failed to get connection for DB");
+                        continue;
+                    };
+
+                    let guard = metrics
+                        .collector_gather_latency
+                        .with_label_values(&[H::NAME])
+                        .start_timer();
+
+                    // Push data into the next batch as long as it's from contiguous checkpoints,
+                    // and we haven't gathered information from too many checkpoints already. We
+                    // don't worry about overall size because the handler may have optimized writes
+                    // by combining rows, but we will limit the number of checkpoints we try and
+                    // batch together as a way to impose some limit on the size of the batch (and
+                    // therefore the length of the write transaction).
+                    while batch_checkpoints < H::MAX_BATCH_CHECKPOINTS {
+                        let Some(entry) = pending.first_entry() else {
+                            break;
+                        };
+
+                        let indexed = entry.get();
+                        match next_checkpoint.cmp(&indexed.watermark.checkpoint_hi_inclusive) {
+                            // Next pending checkpoint is from the future.
+                            Ordering::Less => break,
+
+                            // This is the next checkpoint -- include it.
+                            Ordering::Equal => {
+                                let indexed = entry.remove();
+                                batch_rows += indexed.len();
+                                batch_checkpoints += 1;
+                                H::batch(&mut batch, indexed.values);
+                                watermark = indexed.watermark;
+                                watermark_needs_update = true;
+                                next_checkpoint += 1;
+                            }
+
+                            // Next pending checkpoint is in the past, ignore it to avoid double
+                            // writes.
+                            Ordering::Greater => {
+                                metrics
+                                    .total_watermarks_out_of_order
+                                    .with_label_values(&[H::NAME])
+                                    .inc();
+                                let indexed = entry.remove();
+                                pending_rows -= indexed.len();
+                                continue;
+                            }
+                        }
+                    }
+
+                    let elapsed = guard.stop_and_record();
+                    debug!(
+                        pipeline = H::NAME,
+                        elapsed_ms = elapsed * 1000.0,
+                        rows = batch_rows,
+                        pending = pending_rows,
+                        "Gathered batch",
+                    );
+
+                    metrics
+                        .collector_batch_size
+                        .with_label_values(&[H::NAME])
+                        .observe(batch_rows as f64);
+
+                    metrics
+                        .total_committer_batches_attempted
+                        .with_label_values(&[H::NAME])
+                        .inc();
+
+                    let guard = metrics
+                        .committer_commit_latency
+                        .with_label_values(&[H::NAME])
+                        .start_timer();
+
+                    // Write all the object updates out along with the watermark update, in a
+                    // single transaction. The handler's `commit` implementation is responsible for
+                    // chunking up the writes into a manageable size.
+                    let affected = conn.transaction::<_, anyhow::Error, _>(|conn| async {
+                        watermark.update(conn).await?;
+                        H::commit(&batch, conn).await
+                    }.scope_boxed()).await;
+
+                    // Drop the connection eagerly to avoid it holding on to references borrowed by
+                    // the transaction closure.
+                    drop(conn);
+
+                    let elapsed = guard.stop_and_record();
+
+                    let affected = match affected {
+                        Ok(affected) => affected,
+
+                        Err(e) => {
+                            warn!(
+                                pipeline = H::NAME,
+                                elapsed_ms = elapsed * 1000.0,
+                                attempt,
+                                committed = batch_rows,
+                                pending = pending_rows,
+                                "Error writing batch: {e}",
+                            );
+
+                            attempt += 1;
+                            continue;
+                        }
+                    };
+
+                    debug!(
+                        pipeline = H::NAME,
+                        elapsed_ms = elapsed * 1000.0,
+                        attempt,
+                        affected,
+                        committed = batch_rows,
+                        pending = pending_rows,
+                        "Wrote batch",
+                    );
+
+                    metrics
+                        .total_committer_batches_succeeded
+                        .with_label_values(&[H::NAME])
+                        .inc();
+
+                    metrics
+                        .total_committer_rows_committed
+                        .with_label_values(&[H::NAME])
+                        .inc_by(batch_rows as u64);
+
+                    metrics
+                        .total_committer_rows_affected
+                        .with_label_values(&[H::NAME])
+                        .inc_by(affected as u64);
+
+                    metrics
+                        .watermark_epoch
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.epoch_hi_inclusive);
+
+                    metrics
+                        .watermark_checkpoint
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.checkpoint_hi_inclusive);
+
+                    metrics
+                        .watermark_transaction
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.tx_hi);
+
+                    if watermark.checkpoint_hi_inclusive > next_loud_watermark_update {
+                        next_loud_watermark_update += LOUD_WATERMARK_UPDATE_INTERVAL;
+                        info!(
+                            pipeline = H::NAME,
+                            epoch = watermark.epoch_hi_inclusive,
+                            checkpoint = watermark.checkpoint_hi_inclusive,
+                            transaction = watermark.tx_hi,
+                            "Watermark",
+                        );
+                    } else {
+                        debug!(
+                            pipeline = H::NAME,
+                            epoch = watermark.epoch_hi_inclusive,
+                            checkpoint = watermark.checkpoint_hi_inclusive,
+                            transaction = watermark.tx_hi,
+                            "Watermark",
+                        );
+                    }
+
+                    if watermark_needs_update {
+                        // Ignore the result -- the ingestion service will close this channel
+                        // once it is done, but there may still be checkpoints buffered that need
+                        // processing.
+                        let _ = tx.send((H::NAME, watermark.checkpoint_hi_inclusive as u64));
+                    }
+
+                    let _ = std::mem::take(&mut batch);
+                    watermark_needs_update = false;
+                    pending_rows -= batch_rows;
+                    batch_checkpoints = 0;
+                    batch_rows = 0;
+                    attempt = 0;
+
+                    if pending_rows == 0 && rx.is_closed() && rx.is_empty() {
+                        info!(
+                            pipeline = H::NAME,
+                            ?watermark,
+                            "Processor closed channel, pending rows empty, stopping committer",
+                        );
+                        break;
+                    }
+                }
+
+                Some(indexed) = rx.recv() => {
+                    pending_rows += indexed.len();
+                    pending.insert(indexed.checkpoint(), indexed);
+
+                    // Once data has been inserted, check if we need to schedule a write before the
+                    // next polling interval. This is appropriate if there are a minimum number of
+                    // rows to write, and they are already in the batch, or we can process the next
+                    // checkpoint to extract them.
+
+                    if pending_rows < H::MIN_BATCH_ROWS {
+                        continue;
+                    }
+
+                    if batch_rows > 0 {
+                        poll.reset_immediately();
+                        continue;
+                    }
+
+                    let Some((_, next)) = pending.first_key_value() else {
+                        continue;
+                    };
+
+                    if next.watermark.checkpoint_hi_inclusive <= next_checkpoint {
+                        poll.reset_immediately();
+                    }
+                }
+            }
+        }
+    })
+}

--- a/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use sui_types::full_checkpoint_content::CheckpointData;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    db::{self, Db},
+    metrics::IndexerMetrics,
+    models::watermarks::CommitterWatermark,
+};
+
+use super::{processor::processor, PipelineConfig, Processor, PIPELINE_BUFFER};
+
+use self::committer::committer;
+
+mod committer;
+
+/// Handlers implement the logic for a given indexing pipeline: How to process checkpoint data (by
+/// implementing [Processor]) into rows for their table, how to combine multiple rows into a single
+/// DB operation, and then how to write those rows atomically to the database.
+///
+/// The handler is also responsible for tuning the various parameters of the pipeline (provided as
+/// associated values).
+///
+/// Sequential handlers can only be used in sequential pipelines, where checkpoint data is
+/// processed out-of-order, but then gathered and written in order. If multiple checkpoints are
+/// available, the pipeline will attempt to combine their writes taking advantage of batching to
+/// avoid emitting redundant writes.
+///
+/// Back-pressure is handled by setting a high watermark on the ingestion service: The pipeline
+/// notifies the ingestion service of the checkpoint it last successfully wrote to the database
+/// for, and in turn the ingestion service will only run ahead by its buffer size. This guarantees
+/// liveness and limits the amount of memory the pipeline can consume, by bounding the number of
+/// checkpoints that can be received before the next checkpoint.
+#[async_trait::async_trait]
+pub trait Handler: Processor {
+    /// If at least this many rows are pending, the committer will commit them eagerly.
+    const MIN_BATCH_ROWS: usize = 50;
+
+    /// Maximum number of checkpoints to try and write in a single batch. The larger this number
+    /// is, the more chances the pipeline has to merge redundant writes, but the longer each write
+    /// transaction is likely to be.
+    const MAX_BATCH_CHECKPOINTS: usize = 5 * 60;
+
+    /// A type to combine multiple `Self::Value`-s into. This can be used to avoid redundant writes
+    /// by combining multiple rows into one (e.g. if one row supersedes another, the latter can be
+    /// omitted).
+    type Batch: Default + Send + Sync + 'static;
+
+    /// Add `values` from processing a checkpoint to the current `batch`. Checkpoints are
+    /// guaranteed to be presented to the batch in checkpoint order.
+    fn batch(batch: &mut Self::Batch, values: Vec<Self::Value>);
+
+    /// Take a batch of values and commit them to the database, returning the number of rows
+    /// affected.
+    async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> anyhow::Result<usize>;
+}
+
+/// Start a new sequential (in-order) indexing pipeline, served by the handler, `H`. Starting
+/// strictly after the `watermark` (or from the beginning if no watermark was provided).
+///
+/// Each pipeline consists of a processor which takes checkpoint data and breaks it down into rows,
+/// ready for insertion, and a committer which orders the rows and combines them into batches to
+/// write to the database.
+///
+/// Commits are performed in checkpoint order, potentially involving multiple checkpoints at a
+/// time. The call to [Handler::commit] and the associated watermark update are performed in a
+/// transaction to ensure atomicity. Unlike in the case of concurrent pipelines, the data passed to
+/// [Handler::commit] is not chunked up, so the handler must perform this step itself, if
+/// necessary.
+///
+/// Watermarks are also shared with the ingestion service, which is guaranteed to bound the
+/// checkpoint height it pre-fetches to some constant additive factor above the pipeline's
+/// watermark.
+///
+/// Checkpoint data is fed into the pipeline through the `checkpoint_rx` channel, watermark updates
+/// are communicated to the ingestion service through the `watermark_tx` channel and internal
+/// channels are created to communicate between its various components. The pipeline can be
+/// shutdown using its `cancel` token, and will also shutdown if any of its input or output
+/// channels close, or any of its independent tasks fail.
+pub(crate) fn pipeline<H: Handler + 'static>(
+    initial_watermark: Option<CommitterWatermark<'static>>,
+    config: PipelineConfig,
+    db: Db,
+    checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
+    watermark_tx: mpsc::UnboundedSender<(&'static str, u64)>,
+    metrics: Arc<IndexerMetrics>,
+    cancel: CancellationToken,
+) -> (JoinHandle<()>, JoinHandle<()>) {
+    let (processor_tx, committer_rx) = mpsc::channel(H::FANOUT + PIPELINE_BUFFER);
+
+    let processor = processor::<H>(checkpoint_rx, processor_tx, metrics.clone(), cancel.clone());
+
+    let committer = committer::<H>(
+        config.clone(),
+        initial_watermark,
+        committer_rx,
+        watermark_tx,
+        db.clone(),
+        metrics.clone(),
+        cancel.clone(),
+    );
+
+    (processor, committer)
+}


### PR DESCRIPTION
## Description

Sequential pipelines need different parameters and processing logic than concurrent pipelines, so it no longer makes sense to share the `Handler` trait.

This change factors out the shared part as its own trait -- `Processor` -- and moves the rest into the `concurrent` module.

## Test plan

```
sui$ cargo build -p sui-indexer-alt
sui$ cargo nextest run -p sui-indexer-alt
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
