### PR TITLE
easy(indexer-alt): assorted docs changes

### DIFF
--- a/crates/sui-indexer-alt/migrations/2024-10-16-002409_tx_affected_objects/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-16-002409_tx_affected_objects/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS tx_affected_objects (
     tx_sequence_number          BIGINT       NOT NULL,
+    -- Object ID of the object touched by this transaction.
     affected                    BYTEA        NOT NULL,
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(affected, tx_sequence_number)

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
@@ -74,9 +74,9 @@ pub(super) fn watermark<H: Handler + 'static>(
         let mut poll = interval(config.watermark_interval);
         poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        // To correctly update the watermark, the committer tracks the watermark it last tried to
-        // write and the watermark parts for any checkpoints that have been written since then
-        // ("pre-committed"). After each batch is written, the committer will try to progress the
+        // To correctly update the watermark, the task tracks the watermark it last tried to write
+        // and the watermark parts for any checkpoints that have been written since then
+        // ("pre-committed"). After each batch is written, the task will try to progress the
         // watermark as much as possible without going over any holes in the sequence of
         // checkpoints (entirely missing watermarks, or incomplete watermarks).
         //


### PR DESCRIPTION
## Description 

Pulling out a couple of doc comment changes that I noticed while working on larger changes.

## Test plan 

:eyes:

## Stack

- #20050

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
