### PR TITLE
fix(indexer-alt): watermark update off-by-one

### DIFF
--- a/crates/sui-indexer-alt/migrations/2024-10-16-002409_tx_affected_objects/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-16-002409_tx_affected_objects/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS tx_affected_objects (
     tx_sequence_number          BIGINT       NOT NULL,
+    -- Object ID of the object touched by this transaction.
     affected                    BYTEA        NOT NULL,
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(affected, tx_sequence_number)

--- a/crates/sui-indexer-alt/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt/src/models/watermarks.rs
@@ -30,19 +30,6 @@ pub struct CommitterWatermark<'p> {
     pub tx_hi: i64,
 }
 
-/// Outcomes from extending one watermark with another.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum Ordering {
-    /// The watermark was in the future, so could not be added.
-    Future,
-
-    /// The added watermark was in the past, so the current watermark didn't change.
-    Past,
-
-    /// The added watermark was the successor to the current watermark, so was used in the update.
-    Next,
-}
-
 impl CommitterWatermark<'static> {
     /// Get the current high watermark for the pipeline.
     pub async fn get(
@@ -84,16 +71,6 @@ impl<'p> CommitterWatermark<'p> {
             .execute(conn)
             .await?
             > 0)
-    }
-
-    /// Compare `other` with the immediate successor of this watermark.
-    pub fn next_cmp(&self, other: &CommitterWatermark<'_>) -> Ordering {
-        let next = self.checkpoint_hi_inclusive + 1;
-        match other.checkpoint_hi_inclusive.cmp(&next) {
-            cmp::Ordering::Equal => Ordering::Next,
-            cmp::Ordering::Less => Ordering::Past,
-            cmp::Ordering::Greater => Ordering::Future,
-        }
     }
 }
 

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/watermark.rs
@@ -74,9 +74,9 @@ pub(super) fn watermark<H: Handler + 'static>(
         let mut poll = interval(config.watermark_interval);
         poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        // To correctly update the watermark, the committer tracks the watermark it last tried to
-        // write and the watermark parts for any checkpoints that have been written since then
-        // ("pre-committed"). After each batch is written, the committer will try to progress the
+        // To correctly update the watermark, the task tracks the watermark it last tried to write
+        // and the watermark parts for any checkpoints that have been written since then
+        // ("pre-committed"). After each batch is written, the task will try to progress the
         // watermark as much as possible without going over any holes in the sequence of
         // checkpoints (entirely missing watermarks, or incomplete watermarks).
         //

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -10,9 +10,22 @@ pub use processor::Processor;
 pub(crate) mod concurrent;
 mod processor;
 
+/// Tracing message for the watermark update will be logged at info level at least this many
+/// checkpoints.
+const LOUD_WATERMARK_UPDATE_INTERVAL: i64 = 5 * 10;
+
 /// Extra buffer added to channels between tasks in a pipeline. There does not need to be a huge
 /// capacity here because tasks already buffer rows to insert internally.
 const PIPELINE_BUFFER: usize = 5;
+
+/// Issue a warning every time the number of pending watermarks exceeds this number. This can
+/// happen if the pipeline was started with its initial checkpoint overridden to be strictly
+/// greater than its current watermark -- in that case, the pipeline will never be able to update
+/// its watermarks.
+///
+/// This may be a legitimate thing to do when backfilling a table, but in that case
+/// `--skip-watermarks` should be used.
+const WARN_PENDING_WATERMARKS: usize = 10000;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct PipelineConfig {


### PR DESCRIPTION
## Description

Fix a quirk of the watermark update logic in the concurrent pipeline, where we would never issue an update for just the genesis checkpoint.

This fix was identified while working on the sequential pipeline where watermark updates and row updates are coupled and we therefore cannot afford to ignore the first checkpoint (doing so would cause it to drop all the rows from the first checkpoint as well).

## Test plan

Run the indexer on just one checkpoint:

```
sui$ cargo run -p sui-indexer-alt --release --                                   \
  --database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_alt" \
  --remote-store-url https://checkpoints.mainnet.sui.io                          \
  --last-checkpoint 1
```

It will write a watermark.

## Stack

- #20050 
- #20051 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
