### PR TITLE
Historical Volume Query (Deepbook)

### DIFF
--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -26,7 +26,8 @@ pub const GET_POOLS_PATH: &str = "/get_pools";
 pub const GET_24HR_VOLUME_PATH: &str = "/get_24hr_volume/:pool_ids";
 pub const GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_24hr_volume_by_balance_manager_id/:pool_id/:balance_manager_id";
-pub const GET_HISTORICAL_VOLUME_PATH: &str = "/get_historical_volume/:pool_ids/:start_time/:end_time";
+pub const GET_HISTORICAL_VOLUME_PATH: &str =
+    "/get_historical_volume/:pool_ids/:start_time/:end_time";
 pub const GET_NET_DEPOSITS: &str = "/get_net_deposits/:asset_ids/:timestamp";
 
 pub fn run_server(socket_address: SocketAddr, state: PgDeepbookPersistent) -> JoinHandle<()> {


### PR DESCRIPTION
## Description 

Historical volume query given start and end time in UNIX ms
Format: /get_historical_volume/:pool_ids/:start_time/:end_time

Sample Call: /get_historical_volume/0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407,0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22/1729948782000/1730148782000

Sample Response:
{"0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22":38570720000000,"0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407":1664402700000000}

## Test plan 

How did you test the new or updated feature?

Tested by running indexer locally

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
