### PR TITLE
[move-compiler] Remove WarningFiltersScope from CompilationEnv

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -661,7 +661,7 @@ impl TypingAnalysisContext<'_> {
 
 impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
     // Nothing to do -- we're not producing errors.
-    fn add_warning_filter_scope(&mut self, _filter: diag::WarningFilters) {}
+    fn push_warning_filter_scope(&mut self, _filter: diag::WarningFilters) {}
 
     // Nothing to do -- we're not producing errors.
     fn pop_warning_filter_scope(&mut self) {}

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1875,7 +1875,7 @@ pub fn get_compiled_pkg(
         eprintln!("compiled to parsed AST");
         let (compiler, parsed_program) = compiler.into_ast();
         parsed_ast = Some(parsed_program.clone());
-        mapped_files.extend_with_duplicates(compiler.compilation_env_ref().mapped_files().clone());
+        mapped_files.extend_with_duplicates(compiler.compilation_env().mapped_files().clone());
 
         // extract typed AST
         let compilation_result = compiler.at_parser(parsed_program).run::<PASS_TYPING>();
@@ -1890,17 +1890,17 @@ pub fn get_compiled_pkg(
             }
         };
         eprintln!("compiled to typed AST");
-        let (mut compiler, typed_program) = compiler.into_ast();
+        let (compiler, typed_program) = compiler.into_ast();
         typed_ast = Some(typed_program.clone());
         compiler_info = Some(CompilerInfo::from(
-            compiler.compilation_env().ide_information.clone(),
+            compiler.compilation_env().ide_information().clone(),
         ));
         edition = Some(compiler.compilation_env().edition(Some(root_pkg_name)));
 
         // compile to CFGIR for accurate diags
         eprintln!("compiling to CFGIR");
         let compilation_result = compiler.at_typing(typed_program).run::<PASS_CFGIR>();
-        let mut compiler = match compilation_result {
+        let compiler = match compilation_result {
             Ok(v) => v,
             Err((_pass, diags)) => {
                 let failure = false;

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -196,7 +196,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
         let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
         let (_, compiler) =
             diagnostics::unwrap_or_report_pass_diagnostics(&files, comments_and_compiler_res);
-        let (mut compiler, cfgir) = compiler.into_ast();
+        let (compiler, cfgir) = compiler.into_ast();
         let compilation_env = compiler.compilation_env();
         let built_test_plan = construct_test_plan(compilation_env, Some(root_package), &cfgir);
         let mapped_files = compilation_env.mapped_files().clone();

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     diagnostics::Diagnostics,
     expansion::ast::Mutability,
     hlir::ast::{self as H, *},
-    shared::{unique_map::UniqueMap, CompilationEnv},
+    shared::unique_map::UniqueMap,
 };
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -168,11 +168,7 @@ fn exp(state: &mut LivenessState, parent_e: &Exp) {
 /// - Reports an error if an assignment/let was not used
 ///   Switches it to an `Ignore` if it has the drop ability (helps with error messages for borrows)
 
-pub fn last_usage(
-    compilation_env: &mut CompilationEnv,
-    context: &super::CFGContext,
-    cfg: &mut MutForwardCFG,
-) {
+pub fn last_usage(context: &super::CFGContext, cfg: &mut MutForwardCFG) {
     let super::CFGContext {
         infinite_loop_starts,
         ..
@@ -183,7 +179,7 @@ pub fn last_usage(
             .get(lbl)
             .unwrap_or_else(|| panic!("ICE no liveness states for {}", lbl));
         let command_states = per_command_states.get(lbl).unwrap();
-        last_usage::block(compilation_env, final_invariant, command_states, block)
+        last_usage::block(context, final_invariant, command_states, block)
     }
 }
 
@@ -191,30 +187,29 @@ mod last_usage {
     use move_proc_macros::growing_stack;
 
     use crate::{
-        cfgir::liveness::state::LivenessState,
+        cfgir::{liveness::state::LivenessState, CFGContext},
         diag,
         hlir::{
             ast::*,
             translate::{display_var, DisplayVar},
         },
-        shared::*,
     };
     use std::collections::{BTreeSet, VecDeque};
 
     struct Context<'a, 'b> {
-        env: &'a mut CompilationEnv,
+        outer: &'a CFGContext<'a>,
         next_live: &'b BTreeSet<Var>,
         dropped_live: BTreeSet<Var>,
     }
 
     impl<'a, 'b> Context<'a, 'b> {
         fn new(
-            env: &'a mut CompilationEnv,
+            outer: &'a CFGContext<'a>,
             next_live: &'b BTreeSet<Var>,
             dropped_live: BTreeSet<Var>,
         ) -> Self {
             Context {
-                env,
+                outer,
                 next_live,
                 dropped_live,
             }
@@ -222,7 +217,7 @@ mod last_usage {
     }
 
     pub fn block(
-        compilation_env: &mut CompilationEnv,
+        context: &CFGContext,
         final_invariant: &LivenessState,
         command_states: &VecDeque<LivenessState>,
         block: &mut BasicBlock,
@@ -245,10 +240,7 @@ mod last_usage {
                 .difference(next_data)
                 .cloned()
                 .collect::<BTreeSet<_>>();
-            command(
-                &mut Context::new(compilation_env, next_data, dropped_live),
-                cmd,
-            )
+            command(&mut Context::new(context, next_data, dropped_live), cmd)
         }
     }
 
@@ -300,7 +292,7 @@ mod last_usage {
                                      '_{vstr}')",
                                 );
                                 context
-                                    .env
+                                    .outer
                                     .add_diag(diag!(UnusedItem::Assignment, (l.loc, msg)));
                             }
                             *unused_assignment = true;

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -6,6 +6,7 @@ pub mod state;
 
 use super::absint::*;
 use crate::{
+    cfgir::CFGContext,
     diag,
     diagnostics::{Diagnostic, Diagnostics},
     editions::Edition,
@@ -16,15 +17,10 @@ use crate::{
     },
     naming::ast::{self as N, TParam},
     parser::ast::{Ability_, DatatypeName},
-    shared::{
-        program_info::{DatatypeKind, TypingProgramInfo},
-        unique_map::UniqueMap,
-        *,
-    },
+    shared::{program_info::DatatypeKind, unique_map::UniqueMap, *},
 };
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
-use move_symbol_pool::Symbol;
 use state::*;
 use std::collections::BTreeMap;
 
@@ -33,9 +29,7 @@ use std::collections::BTreeMap;
 //**************************************************************************************************
 
 struct LocalsSafety<'a> {
-    env: &'a CompilationEnv,
-    info: &'a TypingProgramInfo,
-    package: Option<Symbol>,
+    context: &'a CFGContext<'a>,
     local_types: &'a UniqueMap<Var, (Mutability, SingleType)>,
     signature: &'a FunctionSignature,
     unused_mut: BTreeMap<Var, Loc>,
@@ -43,9 +37,7 @@ struct LocalsSafety<'a> {
 
 impl<'a> LocalsSafety<'a> {
     fn new(
-        env: &'a CompilationEnv,
-        info: &'a TypingProgramInfo,
-        package: Option<Symbol>,
+        context: &'a CFGContext<'a>,
         local_types: &'a UniqueMap<Var, (Mutability, SingleType)>,
         signature: &'a FunctionSignature,
     ) -> Self {
@@ -60,9 +52,7 @@ impl<'a> LocalsSafety<'a> {
             })
             .collect();
         Self {
-            env,
-            info,
-            package,
+            context,
             local_types,
             signature,
             unused_mut,
@@ -71,9 +61,7 @@ impl<'a> LocalsSafety<'a> {
 }
 
 struct Context<'a, 'b> {
-    env: &'a CompilationEnv,
-    info: &'a TypingProgramInfo,
-    package: Option<Symbol>,
+    outer: &'a CFGContext<'a>,
     local_types: &'a UniqueMap<Var, (Mutability, SingleType)>,
     unused_mut: &'a mut BTreeMap<Var, Loc>,
     local_states: &'b mut LocalStates,
@@ -83,15 +71,12 @@ struct Context<'a, 'b> {
 
 impl<'a, 'b> Context<'a, 'b> {
     fn new(locals_safety: &'a mut LocalsSafety, local_states: &'b mut LocalStates) -> Self {
-        let env = locals_safety.env;
-        let info = locals_safety.info;
+        let outer = locals_safety.context;
         let local_types = locals_safety.local_types;
         let signature = locals_safety.signature;
         let unused_mut = &mut locals_safety.unused_mut;
         Self {
-            env,
-            info,
-            package: locals_safety.package,
+            outer,
             local_types,
             unused_mut,
             local_states,
@@ -154,18 +139,18 @@ impl<'a, 'b> Context<'a, 'b> {
     //     .unwrap();
 
     fn datatype_decl_loc(&self, m: &ModuleIdent, n: &DatatypeName) -> Loc {
-        let kind = self.info.datatype_kind(m, n);
+        let kind = self.outer.info.datatype_kind(m, n);
         match kind {
-            DatatypeKind::Struct => self.info.struct_declared_loc(m, n),
-            DatatypeKind::Enum => self.info.enum_declared_loc(m, n),
+            DatatypeKind::Struct => self.outer.info.struct_declared_loc(m, n),
+            DatatypeKind::Enum => self.outer.info.enum_declared_loc(m, n),
         }
     }
 
     fn datatype_declared_abilities(&self, m: &ModuleIdent, n: &DatatypeName) -> &'a AbilitySet {
-        let kind = self.info.datatype_kind(m, n);
+        let kind = self.outer.info.datatype_kind(m, n);
         match kind {
-            DatatypeKind::Struct => self.info.struct_declared_abilities(m, n),
-            DatatypeKind::Enum => self.info.enum_declared_abilities(m, n),
+            DatatypeKind::Struct => self.outer.info.struct_declared_abilities(m, n),
+            DatatypeKind::Enum => self.outer.info.enum_declared_abilities(m, n),
         }
     }
 }
@@ -189,7 +174,6 @@ impl<'a> TransferFunctions for LocalsSafety<'a> {
 impl<'a> AbstractInterpreter for LocalsSafety<'a> {}
 
 pub fn verify(
-    compilation_env: &mut CompilationEnv,
     context: &super::CFGContext,
     cfg: &super::cfg::MutForwardCFG,
 ) -> BTreeMap<Label, LocalStates> {
@@ -197,22 +181,16 @@ pub fn verify(
         signature, locals, ..
     } = context;
     let initial_state = LocalStates::initial(&signature.parameters, locals);
-    let mut locals_safety = LocalsSafety::new(
-        compilation_env,
-        context.info,
-        context.package,
-        locals,
-        signature,
-    );
+    let mut locals_safety = LocalsSafety::new(context, locals, signature);
     let (final_state, ds) = locals_safety.analyze_function(cfg, initial_state);
-    unused_let_muts(compilation_env, locals, locals_safety.unused_mut);
-    compilation_env.add_diags(ds);
+    unused_let_muts(context, locals, locals_safety.unused_mut);
+    context.add_diags(ds);
     final_state
 }
 
 /// Generates warnings for unused mut declarations
 fn unused_let_muts<T>(
-    env: &mut CompilationEnv,
+    context: &CFGContext,
     locals: &UniqueMap<Var, T>,
     unused_mut_locals: BTreeMap<Var, Loc>,
 ) {
@@ -226,7 +204,7 @@ fn unused_let_muts<T>(
             let decl_loc = *locals.get_loc(&v).unwrap();
             let decl_msg = format!("The variable '{vstr}' is never used mutably");
             let mut_msg = "Consider removing the 'mut' declaration here";
-            env.add_diag(diag!(
+            context.add_diag(diag!(
                 UnusedItem::MutModifier,
                 (decl_loc, decl_msg),
                 (mut_loc, mut_msg)
@@ -524,7 +502,7 @@ fn check_mutability(
         let usage_msg = format!("Invalid {usage} of immutable variable '{vstr}'");
         let decl_msg =
             format!("To use the variable mutably, it must be declared 'mut', e.g. 'mut {vstr}'");
-        if context.env.edition(context.package) == Edition::E2024_MIGRATION {
+        if context.outer.env.edition(context.outer.package) == Edition::E2024_MIGRATION {
             context.add_diag(diag!(Migration::NeedsLetMut, (decl_loc, decl_msg.clone())))
         } else {
             let mut diag = diag!(

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     naming::ast::{self as N, TParam},
     parser::ast::{Ability_, DatatypeName},
-    shared::{program_info::DatatypeKind, unique_map::UniqueMap, *},
+    shared::{program_info::DatatypeKind, unique_map::UniqueMap},
 };
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;

--- a/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
@@ -17,7 +17,10 @@ mod optimize;
 use crate::{
     expansion::ast::{Attributes, ModuleIdent, Mutability},
     hlir::ast::{FunctionSignature, Label, SingleType, Var, Visibility},
-    shared::{program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, Name},
+    shared::{
+        program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, Name,
+        WarningFiltersScope,
+    },
 };
 use cfg::*;
 use move_ir_types::location::Loc;
@@ -26,6 +29,8 @@ use optimize::optimize;
 use std::collections::BTreeSet;
 
 pub struct CFGContext<'a> {
+    pub env: &'a mut CompilationEnv,
+    pub warning_filters_scope: WarningFiltersScope,
     pub info: &'a TypingProgramInfo,
     pub package: Option<Symbol>,
     pub module: ModuleIdent,
@@ -43,16 +48,22 @@ pub enum MemberName {
     Function(Name),
 }
 
-pub fn refine_inference_and_verify(
-    env: &mut CompilationEnv,
-    context: &CFGContext,
-    cfg: &mut MutForwardCFG,
-) {
-    liveness::last_usage(env, context, cfg);
-    let locals_states = locals::verify(env, context, cfg);
+pub fn refine_inference_and_verify(context: &CFGContext, cfg: &mut MutForwardCFG) {
+    liveness::last_usage(context, cfg);
+    let locals_states = locals::verify(context, cfg);
 
     liveness::release_dead_refs(context, &locals_states, cfg);
-    borrows::verify(env, context, cfg);
+    borrows::verify(context, cfg);
+}
+
+impl CFGContext<'_> {
+    fn add_diag(&self, diag: crate::diagnostics::Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    fn add_diags(&self, diags: crate::diagnostics::Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
 }
 
 impl MemberName {

--- a/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
@@ -29,7 +29,7 @@ use optimize::optimize;
 use std::collections::BTreeSet;
 
 pub struct CFGContext<'a> {
-    pub env: &'a mut CompilationEnv,
+    pub env: &'a CompilationEnv,
     pub warning_filters_scope: WarningFiltersScope,
     pub info: &'a TypingProgramInfo,
     pub package: Option<Symbol>,

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
@@ -43,7 +43,7 @@ const MOVE_2024_OPTIMIZATIONS: &[Optimization] = &[
 
 #[growing_stack]
 pub fn optimize(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     package: Option<Symbol>,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, (Mutability, SingleType)>,

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -10,11 +10,14 @@ use crate::{
         visitor::{CFGIRVisitor, CFGIRVisitorConstructor, CFGIRVisitorContext},
     },
     diag,
-    diagnostics::Diagnostics,
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     expansion::ast::{Attributes, ModuleIdent, Mutability},
     hlir::ast::{self as H, BlockLabel, Label, Value, Value_, Var},
+    ice_assert,
     parser::ast::{ConstantName, FunctionName},
-    shared::{program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv},
+    shared::{
+        program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, WarningFiltersScope,
+    },
     FullyCompiledProgram,
 };
 use cfgir::ast::LoopInfo;
@@ -44,6 +47,7 @@ enum NamedBlockType {
 struct Context<'env> {
     env: &'env mut CompilationEnv,
     info: &'env TypingProgramInfo,
+    warning_filters_scope: WarningFiltersScope,
     current_package: Option<Symbol>,
     label_count: usize,
     named_blocks: UniqueMap<BlockLabel, (Label, Label)>,
@@ -53,14 +57,32 @@ struct Context<'env> {
 
 impl<'env> Context<'env> {
     pub fn new(env: &'env mut CompilationEnv, info: &'env TypingProgramInfo) -> Self {
+        let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         Context {
             env,
+            warning_filters_scope,
             info,
             current_package: None,
             label_count: 0,
             named_blocks: UniqueMap::new(),
             loop_bounds: BTreeMap::new(),
         }
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    pub fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.warning_filters_scope.pop()
     }
 
     fn new_label(&mut self) -> Label {
@@ -170,10 +192,10 @@ fn module(
         constants: hconstants,
     } = mdef;
     context.current_package = package_name;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let constants = constants(context, module_ident, hconstants);
     let functions = hfunctions.map(|name, f| function(context, module_ident, name, f));
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     context.current_package = None;
     (
         module_ident,
@@ -238,7 +260,7 @@ fn constants(
                     "Cyclic constant defined here",
                 ));
             }
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             cycle_nodes.append(&mut scc.into_iter().collect());
         }
     }
@@ -251,7 +273,7 @@ fn constants(
             .filter(|node| !cycle_nodes.contains(node) && graph.contains_node(*node))
             .collect();
         for node in neighbors {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 BytecodeGeneration::UnfoldableConstant,
                 (
                     *consts.get_loc(&node).unwrap(),
@@ -402,7 +424,7 @@ fn constant(
         value: (locals, block),
     } = c;
 
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let final_value = constant_(
         context,
         constant_values,
@@ -427,7 +449,7 @@ fn constant(
         _ => None,
     };
 
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     G::Constant {
         warning_filter,
         index,
@@ -483,8 +505,10 @@ fn constant_(
         infinite_loop_starts: &fake_infinite_loop_starts,
     };
     cfgir::refine_inference_and_verify(context.env, &function_context, &mut cfg);
-    assert!(
+    ice_assert!(
+        context.env,
         num_previous_errors == context.env.count_diags(),
+        full_loc,
         "{}",
         ICE_MSG
     );
@@ -498,7 +522,7 @@ fn constant_(
     );
 
     if blocks.len() != 1 {
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             BytecodeGeneration::UnfoldableConstant,
             (full_loc, CANNOT_FOLD)
         ));
@@ -510,7 +534,7 @@ fn constant_(
         let e = match cmd_ {
             C::IgnoreAndPop { exp, .. } => exp,
             _ => {
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     BytecodeGeneration::UnfoldableConstant,
                     (*cloc, CANNOT_FOLD)
                 ));
@@ -532,7 +556,7 @@ fn check_constant_value(context: &mut Context, e: &H::Exp) {
     use H::UnannotatedExp_ as E;
     match &e.exp.value {
         E::Value(_) => (),
-        _ => context.env.add_diag(diag!(
+        _ => context.add_diag(diag!(
             BytecodeGeneration::UnfoldableConstant,
             (e.exp.loc, CANNOT_FOLD)
         )),
@@ -579,7 +603,7 @@ fn function(
         signature,
         body,
     } = f;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let body = function_body(
         context,
         module,
@@ -590,7 +614,7 @@ fn function(
         &signature,
         body,
     );
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     G::Function {
         warning_filter,
         index,
@@ -627,7 +651,7 @@ fn function_body(
 
             let (mut cfg, infinite_loop_starts, diags) =
                 MutForwardCFG::new(start, &mut blocks, binfo);
-            context.env.add_diags(diags);
+            context.add_diags(diags);
 
             let function_context = super::CFGContext {
                 info: context.info,
@@ -978,6 +1002,7 @@ fn visit_program(context: &mut Context, prog: &mut G::Program) {
 struct AbsintVisitor;
 struct AbsintVisitorContext<'a> {
     env: &'a mut CompilationEnv,
+    warning_filters_scope: WarningFiltersScope,
     info: Arc<TypingProgramInfo>,
     current_package: Option<Symbol>,
 }
@@ -986,8 +1011,10 @@ impl CFGIRVisitorConstructor for AbsintVisitor {
     type Context<'a> = AbsintVisitorContext<'a>;
 
     fn context<'a>(env: &'a mut CompilationEnv, program: &G::Program) -> Self::Context<'a> {
+        let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         AbsintVisitorContext {
             env,
+            warning_filters_scope,
             info: program.info.clone(),
             current_package: None,
         }
@@ -995,12 +1022,12 @@ impl CFGIRVisitorConstructor for AbsintVisitor {
 }
 
 impl<'a> CFGIRVisitorContext for AbsintVisitorContext<'a> {
-    fn add_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
-        self.env.add_warning_filter_scope(filter)
+    fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
     }
 
     fn pop_warning_filter_scope(&mut self) {
-        self.env.pop_warning_filter_scope()
+        self.warning_filters_scope.pop()
     }
 
     fn visit_module_custom(&mut self, _ident: ModuleIdent, mdef: &G::ModuleDefinition) -> bool {
@@ -1050,7 +1077,7 @@ impl<'a> CFGIRVisitorContext for AbsintVisitorContext<'a> {
         for v in &self.env.visitors().abs_int {
             ds.extend(v.verify(self.env, &function_context, &cfg));
         }
-        self.env.add_diags(ds);
+        self.add_diags(ds);
         true
     }
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -1026,6 +1026,7 @@ impl CFGIRVisitorConstructor for AbsintVisitor {
 }
 
 impl AbsintVisitorContext<'_> {
+    #[allow(unused)]
     fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -45,7 +45,7 @@ enum NamedBlockType {
 }
 
 struct Context<'env> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     info: &'env TypingProgramInfo,
     warning_filters_scope: WarningFiltersScope,
     current_package: Option<Symbol>,
@@ -56,7 +56,7 @@ struct Context<'env> {
 }
 
 impl<'env> Context<'env> {
-    pub fn new(env: &'env mut CompilationEnv, info: &'env TypingProgramInfo) -> Self {
+    pub fn new(env: &'env CompilationEnv, info: &'env TypingProgramInfo) -> Self {
         let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         Context {
             env,
@@ -143,7 +143,7 @@ impl<'env> Context<'env> {
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     _pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: H::Program,
 ) -> G::Program {
@@ -1005,7 +1005,7 @@ fn visit_program(context: &mut Context, prog: &mut G::Program) {
 
 struct AbsintVisitor;
 struct AbsintVisitorContext<'a> {
-    env: &'a mut CompilationEnv,
+    env: &'a CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
     info: Arc<TypingProgramInfo>,
     current_package: Option<Symbol>,
@@ -1014,7 +1014,7 @@ struct AbsintVisitorContext<'a> {
 impl CFGIRVisitorConstructor for AbsintVisitor {
     type Context<'a> = AbsintVisitorContext<'a>;
 
-    fn context<'a>(env: &'a mut CompilationEnv, program: &G::Program) -> Self::Context<'a> {
+    fn context<'a>(env: &'a CompilationEnv, program: &G::Program) -> Self::Context<'a> {
         let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         AbsintVisitorContext {
             env,

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -69,11 +69,11 @@ impl<'env> Context<'env> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
@@ -1027,11 +1027,11 @@ impl CFGIRVisitorConstructor for AbsintVisitor {
 
 impl AbsintVisitorContext<'_> {
     #[allow(unused)]
-    fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
+    fn add_diag(&self, diag: crate::diagnostics::Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
-    fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
+    fn add_diags(&self, diags: crate::diagnostics::Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -77,7 +77,7 @@ impl<'env> Context<'env> {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -192,7 +192,7 @@ fn module(
         constants: hconstants,
     } = mdef;
     context.current_package = package_name;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let constants = constants(context, module_ident, hconstants);
     let functions = hfunctions.map(|name, f| function(context, module_ident, name, f));
     context.pop_warning_filter_scope();
@@ -424,7 +424,7 @@ fn constant(
         value: (locals, block),
     } = c;
 
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let final_value = constant_(
         context,
         constant_values,
@@ -605,7 +605,7 @@ fn function(
         signature,
         body,
     } = f;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let body = function_body(
         context,
         module,
@@ -1037,7 +1037,7 @@ impl AbsintVisitorContext<'_> {
 }
 
 impl<'a> CFGIRVisitorContext for AbsintVisitorContext<'a> {
-    fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -61,7 +61,7 @@ pub trait CFGIRVisitorConstructor: Send {
 }
 
 pub trait CFGIRVisitorContext {
-    fn add_warning_filter_scope(&mut self, filters: WarningFilters);
+    fn push_warning_filter_scope(&mut self, filters: WarningFilters);
     fn pop_warning_filter_scope(&mut self);
 
     fn visit_module_custom(&mut self, _ident: ModuleIdent, _mdef: &G::ModuleDefinition) -> bool {
@@ -73,7 +73,7 @@ pub trait CFGIRVisitorContext {
     /// required.
     fn visit(&mut self, program: &G::Program) {
         for (mident, mdef) in program.modules.key_cloned_iter() {
-            self.add_warning_filter_scope(mdef.warning_filter.clone());
+            self.push_warning_filter_scope(mdef.warning_filter.clone());
             if self.visit_module_custom(mident, mdef) {
                 self.pop_warning_filter_scope();
                 continue;
@@ -112,7 +112,7 @@ pub trait CFGIRVisitorContext {
         struct_name: DatatypeName,
         sdef: &H::StructDefinition,
     ) {
-        self.add_warning_filter_scope(sdef.warning_filter.clone());
+        self.push_warning_filter_scope(sdef.warning_filter.clone());
         if self.visit_struct_custom(module, struct_name, sdef) {
             self.pop_warning_filter_scope();
             return;
@@ -134,7 +134,7 @@ pub trait CFGIRVisitorContext {
         enum_name: DatatypeName,
         edef: &H::EnumDefinition,
     ) {
-        self.add_warning_filter_scope(edef.warning_filter.clone());
+        self.push_warning_filter_scope(edef.warning_filter.clone());
         if self.visit_enum_custom(module, enum_name, edef) {
             self.pop_warning_filter_scope();
             return;
@@ -156,7 +156,7 @@ pub trait CFGIRVisitorContext {
         constant_name: ConstantName,
         cdef: &G::Constant,
     ) {
-        self.add_warning_filter_scope(cdef.warning_filter.clone());
+        self.push_warning_filter_scope(cdef.warning_filter.clone());
         if self.visit_constant_custom(module, constant_name, cdef) {
             self.pop_warning_filter_scope();
             return;
@@ -178,7 +178,7 @@ pub trait CFGIRVisitorContext {
         function_name: FunctionName,
         fdef: &G::Function,
     ) {
-        self.add_warning_filter_scope(fdef.warning_filter.clone());
+        self.push_warning_filter_scope(fdef.warning_filter.clone());
         if self.visit_function_custom(module, function_name, fdef) {
             self.pop_warning_filter_scope();
             return;
@@ -356,7 +356,7 @@ macro_rules! simple_visitor {
         }
 
         impl crate::cfgir::visitor::CFGIRVisitorContext for Context<'_> {
-            fn add_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
+            fn push_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
                 self.warning_filters_scope.push(filters)
             }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -345,12 +345,12 @@ macro_rules! simple_visitor {
 
         impl Context<'_> {
             #[allow(unused)]
-            fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
+            fn add_diag(&self, diag: crate::diagnostics::Diagnostic) {
                 self.env.add_diag(&self.warning_filters_scope, diag);
             }
 
             #[allow(unused)]
-            fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
+            fn add_diags(&self, diags: crate::diagnostics::Diagnostics) {
                 self.env.add_diags(&self.warning_filters_scope, diags);
             }
         }

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -338,7 +338,8 @@ macro_rules! simple_visitor {
         impl crate::cfgir::visitor::CFGIRVisitorConstructor for $visitor {
             type Context<'a> = Context<'a>;
 
-            fn context<'a>(env: &'a mut crate::shared::CompilationEnv, _program: &crate::cfgir::ast::Program) -> Self::Context<'a> {
+            fn context<'a>(env: &'a mut crate::shared::CompilationEnv, _program: &G::Program) -> Self::Context<'a> {
+                let warning_filters_scope = env.top_level_warning_filter_scope().clone();
                 Context {
                     env,
                 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -24,7 +24,7 @@ pub type AbsIntVisitorObj = Box<dyn AbstractInterpreterVisitor>;
 pub type CFGIRVisitorObj = Box<dyn CFGIRVisitor>;
 
 pub trait CFGIRVisitor: Send + Sync {
-    fn visit(&self, env: &mut CompilationEnv, program: &G::Program);
+    fn visit(&self, env: &CompilationEnv, program: &G::Program);
 
     fn visitor(self) -> Visitor
     where
@@ -52,9 +52,9 @@ pub trait AbstractInterpreterVisitor: Send + Sync {
 pub trait CFGIRVisitorConstructor: Send {
     type Context<'a>: Sized + CFGIRVisitorContext;
 
-    fn context<'a>(env: &'a mut CompilationEnv, program: &G::Program) -> Self::Context<'a>;
+    fn context<'a>(env: &'a CompilationEnv, program: &G::Program) -> Self::Context<'a>;
 
-    fn visit(env: &mut CompilationEnv, program: &G::Program) {
+    fn visit(env: &CompilationEnv, program: &G::Program) {
         let mut context = Self::context(env, program);
         context.visit(program);
     }
@@ -317,7 +317,7 @@ impl<V: CFGIRVisitor + 'static> From<V> for CFGIRVisitorObj {
 }
 
 impl<V: CFGIRVisitorConstructor + Send + Sync> CFGIRVisitor for V {
-    fn visit(&self, env: &mut CompilationEnv, program: &G::Program) {
+    fn visit(&self, env: &CompilationEnv, program: &G::Program) {
         Self::visit(env, program)
     }
 }
@@ -333,7 +333,7 @@ macro_rules! simple_visitor {
         impl crate::cfgir::visitor::CFGIRVisitorConstructor for $visitor {
             type Context<'a> = Context<'a>;
 
-            fn context<'a>(env: &'a mut crate::shared::CompilationEnv, _program: &crate::cfgir::ast::Program) -> Self::Context<'a> {
+            fn context<'a>(env: &'a crate::shared::CompilationEnv, _program: &crate::cfgir::ast::Program) -> Self::Context<'a> {
                 let warning_filters_scope = env.top_level_warning_filter_scope().clone();
                 Context {
                     env,

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -376,11 +376,14 @@ impl Compiler {
             interface_files_dir_opt,
             &compiled_module_named_address_mapping,
         )?;
-        let mut compilation_env =
-            CompilationEnv::new(flags, visitors, save_hooks, package_configs, default_config);
-        if let Some(filter) = warning_filter {
-            compilation_env.add_warning_filter_scope(filter);
-        }
+        let mut compilation_env = CompilationEnv::new(
+            flags,
+            visitors,
+            save_hooks,
+            warning_filter,
+            package_configs,
+            default_config,
+        );
         for (prefix, filters) in known_warning_filters {
             compilation_env.add_custom_known_filters(prefix, filters)?;
         }

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -388,8 +388,7 @@ impl Compiler {
             compilation_env.add_custom_known_filters(prefix, filters)?;
         }
 
-        let (source_text, pprog, comments) =
-            parse_program(&mut compilation_env, maps, targets, deps)?;
+        let (source_text, pprog, comments) = parse_program(&compilation_env, maps, targets, deps)?;
 
         for (fhash, (fname, contents)) in &source_text {
             // TODO better support for bytecode interface file paths
@@ -483,12 +482,12 @@ impl<const P: Pass> SteppedCompiler<P> {
             "Invalid pass for run_to. Target pass precedes the current pass"
         );
         let Self {
-            mut compilation_env,
+            compilation_env,
             pre_compiled_lib,
             program,
         } = self;
         let new_prog = run(
-            &mut compilation_env,
+            &compilation_env,
             pre_compiled_lib.clone(),
             program.unwrap(),
             TARGET,
@@ -657,9 +656,9 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
     };
 
     let (empty_compiler, ast) = stepped.into_ast();
-    let mut compilation_env = empty_compiler.compilation_env;
+    let compilation_env = empty_compiler.compilation_env;
     let start = PassResult::Parser(ast);
-    match run(&mut compilation_env, None, start, PASS_COMPILATION) {
+    match run(&compilation_env, None, start, PASS_COMPILATION) {
         Err((_pass, errors)) => Ok(Err((files, errors))),
         Ok(PassResult::Compilation(compiled, _)) => Ok(Ok(FullyCompiledProgram {
             files,

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -501,10 +501,7 @@ impl<const P: Pass> SteppedCompiler<P> {
         })
     }
 
-    pub fn compilation_env(&mut self) -> &mut CompilationEnv {
-        &mut self.compilation_env
-    }
-    pub fn compilation_env_ref(&self) -> &CompilationEnv {
+    pub fn compilation_env(&self) -> &CompilationEnv {
         &self.compilation_env
     }
 }
@@ -889,7 +886,7 @@ pub fn move_check_for_errors(
     ) -> Result<(Vec<AnnotatedCompiledUnit>, Diagnostics), (Pass, Diagnostics)> {
         let (_, compiler) = comments_and_compiler_res?;
 
-        let (mut compiler, cfgir) = compiler.run::<PASS_CFGIR>()?.into_ast();
+        let (compiler, cfgir) = compiler.run::<PASS_CFGIR>()?.into_ast();
         let compilation_env = compiler.compilation_env();
         if compilation_env.flags().is_testing() {
             unit_test::plan_builder::construct_test_plan(compilation_env, None, &cfgir);
@@ -925,7 +922,7 @@ impl PassResult {
         }
     }
 
-    pub fn save(&self, compilation_env: &mut CompilationEnv) {
+    pub fn save(&self, compilation_env: &CompilationEnv) {
         match self {
             PassResult::Parser(prog) => {
                 compilation_env.save_parser_ast(prog);
@@ -952,14 +949,14 @@ impl PassResult {
 }
 
 fn run(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     cur: PassResult,
     until: Pass,
 ) -> Result<PassResult, (Pass, Diagnostics)> {
     #[growing_stack]
     fn rec(
-        compilation_env: &mut CompilationEnv,
+        compilation_env: &CompilationEnv,
         pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
         cur: PassResult,
         until: Pass,

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -106,11 +106,6 @@ enum UnprefixedWarningFilters {
     Empty,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct WarningFiltersScope {
-    scopes: Vec<WarningFilters>,
-}
-
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]
 enum MigrationChange {
     AddMut,
@@ -973,30 +968,6 @@ impl UnprefixedWarningFilters {
             categories: BTreeMap::new(),
             codes: filtered_codes,
         }
-    }
-}
-
-impl WarningFiltersScope {
-    pub fn new(top_level_warning_filter: Option<WarningFilters>) -> Self {
-        Self {
-            scopes: top_level_warning_filter.into_iter().collect(),
-        }
-    }
-
-    pub fn push(&mut self, filters: WarningFilters) {
-        self.scopes.push(filters)
-    }
-
-    pub fn pop(&mut self) {
-        self.scopes.pop();
-    }
-
-    pub fn is_filtered(&self, diag: &Diagnostic) -> bool {
-        self.scopes.iter().any(|filters| filters.is_filtered(diag))
-    }
-
-    pub fn is_filtered_for_dependency(&self) -> bool {
-        self.scopes.iter().any(|filters| filters.for_dependency())
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -776,7 +776,7 @@ macro_rules! ice {
 macro_rules! ice_assert {
     ($env: expr, $cond: expr, $loc: expr, $($arg:tt)*) => {{
         if !$cond {
-            $env.add_diag($crate::ice!((
+            $env.add_error_diag($crate::ice!((
                 $loc,
                 format!($($arg)*),
             )));

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -78,7 +78,7 @@ pub fn check_feature_or_error(
     loc: Loc,
 ) -> bool {
     if !edition.supports(feature) {
-        env.add_diag(create_feature_error(edition, feature, loc));
+        env.add_error_diag(create_feature_error(edition, feature, loc));
         false
     } else {
         true

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -72,7 +72,7 @@ pub const UPGRADE_NOTE: &str =
 /// Returns true if the feature is present in the given edition.
 /// Adds an error to the environment.
 pub fn check_feature_or_error(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     edition: Edition,
     feature: FeatureGate,
     loc: Loc,

--- a/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs
@@ -103,7 +103,7 @@ impl NameCase {
 
 #[allow(clippy::result_unit_err)]
 pub fn check_valid_address_name(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     sp!(_, ln_): &P::LeadingNameAccess,
 ) -> Result<(), ()> {
     use P::LeadingNameAccess_ as LN;
@@ -120,11 +120,7 @@ pub fn valid_local_variable_name(s: Symbol) -> bool {
 }
 
 #[allow(clippy::result_unit_err)]
-pub fn check_valid_function_parameter_name(
-    env: &mut CompilationEnv,
-    is_macro: Option<Loc>,
-    v: &Var,
-) {
+pub fn check_valid_function_parameter_name(env: &CompilationEnv, is_macro: Option<Loc>, v: &Var) {
     const SYNTAX_IDENTIFIER_NOTE: &str =
         "'macro' parameters start with '$' to indicate that their arguments are not evaluated \
         before the macro is expanded, meaning the entire expression is substituted. \
@@ -165,7 +161,7 @@ pub fn check_valid_function_parameter_name(
     let _ = check_restricted_name_all_cases(env, NameCase::Variable, &v.0);
 }
 
-pub fn check_valid_local_name(env: &mut CompilationEnv, v: &Var) {
+pub fn check_valid_local_name(env: &CompilationEnv, v: &Var) {
     if !is_valid_local_variable_name(v.value()) {
         let msg = format!(
             "Invalid local name '{}'. Local variable names must start with 'a'..'z', '_', \
@@ -182,7 +178,7 @@ fn is_valid_local_variable_name(s: Symbol) -> bool {
 }
 
 pub fn check_valid_module_member_name(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     member: ModuleMemberKind,
     name: Name,
 ) -> Option<Name> {
@@ -193,7 +189,7 @@ pub fn check_valid_module_member_name(
 }
 
 pub fn check_valid_module_member_alias(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     member: ModuleMemberKind,
     alias: Name,
 ) -> Option<Name> {
@@ -209,7 +205,7 @@ pub fn check_valid_module_member_alias(
 }
 
 fn check_valid_module_member_name_impl(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     member: ModuleMemberKind,
     n: &Name,
     case: NameCase,
@@ -272,7 +268,7 @@ fn check_valid_module_member_name_impl(
 
 #[allow(clippy::result_unit_err)]
 pub fn check_valid_type_parameter_name(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     is_macro: Option<Loc>,
     n: &Name,
 ) -> Result<(), ()> {
@@ -353,7 +349,7 @@ pub fn is_valid_datatype_or_constant_name(s: &str) -> bool {
 // Checks for a restricted name in any decl case
 // Self and vector are not allowed
 pub fn check_restricted_name_all_cases(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     case: NameCase,
     n: &Name,
 ) -> Result<(), ()> {
@@ -393,7 +389,7 @@ pub fn check_restricted_name_all_cases(
 }
 
 fn check_restricted_names(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     case: NameCase,
     sp!(loc, n_): &Name,
     all_names: &BTreeSet<Symbol>,

--- a/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/name_validation.rs
@@ -144,7 +144,7 @@ pub fn check_valid_function_parameter_name(
                 (macro_loc, macro_msg),
             );
             diag.add_note(SYNTAX_IDENTIFIER_NOTE);
-            env.add_diag(diag);
+            env.add_error_diag(diag);
         }
     } else if is_syntax_identifier {
         let msg = format!(
@@ -153,14 +153,14 @@ pub fn check_valid_function_parameter_name(
         );
         let mut diag = diag!(Declarations::InvalidName, (v.loc(), msg));
         diag.add_note(SYNTAX_IDENTIFIER_NOTE);
-        env.add_diag(diag);
+        env.add_error_diag(diag);
     } else if !is_valid_local_variable_name(v.value()) {
         let msg = format!(
             "Invalid parameter name '{}'. Local variable names must start with 'a'..'z', '_', \
             or be a valid name quoted with backticks (`name`)",
             v,
         );
-        env.add_diag(diag!(Declarations::InvalidName, (v.loc(), msg)));
+        env.add_error_diag(diag!(Declarations::InvalidName, (v.loc(), msg)));
     }
     let _ = check_restricted_name_all_cases(env, NameCase::Variable, &v.0);
 }
@@ -172,7 +172,7 @@ pub fn check_valid_local_name(env: &mut CompilationEnv, v: &Var) {
             or be a valid name quoted with backticks (`name`)",
             v,
         );
-        env.add_diag(diag!(Declarations::InvalidName, (v.loc(), msg)));
+        env.add_error_diag(diag!(Declarations::InvalidName, (v.loc(), msg)));
     }
     let _ = check_restricted_name_all_cases(env, NameCase::Variable, &v.0);
 }
@@ -231,7 +231,7 @@ fn check_valid_module_member_name_impl(
                     n,
                     upper_first_letter(case.name()),
                 );
-                env.add_diag(diag!(Declarations::InvalidName, (n.loc, msg)));
+                env.add_error_diag(diag!(Declarations::InvalidName, (n.loc, msg)));
                 return Err(());
             }
         }
@@ -243,7 +243,7 @@ fn check_valid_module_member_name_impl(
                     n,
                     upper_first_letter(case.name()),
                 );
-                env.add_diag(diag!(Declarations::InvalidName, (n.loc, msg)));
+                env.add_error_diag(diag!(Declarations::InvalidName, (n.loc, msg)));
                 return Err(());
             }
         }
@@ -279,7 +279,7 @@ pub fn check_valid_type_parameter_name(
     // TODO move these names to a more central place?
     if n.value == symbol!("_") {
         let diag = restricted_name_error(NameCase::TypeParameter, n.loc, "_");
-        env.add_diag(diag);
+        env.add_error_diag(diag);
         return Err(());
     }
 
@@ -302,7 +302,7 @@ pub fn check_valid_type_parameter_name(
                 (macro_loc, macro_msg),
             );
             diag.add_note(SYNTAX_IDENTIFIER_NOTE);
-            env.add_diag(diag);
+            env.add_error_diag(diag);
         } else {
             let next_char = n.value.chars().nth(1).unwrap();
             if !next_char.is_ascii_alphabetic() {
@@ -314,7 +314,7 @@ pub fn check_valid_type_parameter_name(
                 );
                 let mut diag = diag!(Declarations::InvalidName, (n.loc, msg));
                 diag.add_note(SYNTAX_IDENTIFIER_NOTE);
-                env.add_diag(diag);
+                env.add_error_diag(diag);
             }
         }
     } else if is_syntax_ident {
@@ -325,7 +325,7 @@ pub fn check_valid_type_parameter_name(
         );
         let mut diag = diag!(Declarations::InvalidName, (n.loc, msg));
         diag.add_note(SYNTAX_IDENTIFIER_NOTE);
-        env.add_diag(diag);
+        env.add_error_diag(diag);
     }
 
     // TODO move these names to a more central place?
@@ -373,7 +373,7 @@ pub fn check_restricted_name_all_cases(
                     case.name(),
                     n,
                 );
-                env.add_diag(diag!(Declarations::InvalidName, (n.loc, msg)));
+                env.add_error_diag(diag!(Declarations::InvalidName, (n.loc, msg)));
                 return Err(());
             }
         }
@@ -385,7 +385,7 @@ pub fn check_restricted_name_all_cases(
     if n_str == ModuleName::SELF_NAME
         || (!can_be_vector && n_str == crate::naming::ast::BuiltinTypeName_::VECTOR)
     {
-        env.add_diag(restricted_name_error(case, n.loc, n_str));
+        env.add_error_diag(restricted_name_error(case, n.loc, n_str));
         Err(())
     } else {
         Ok(())
@@ -399,7 +399,7 @@ fn check_restricted_names(
     all_names: &BTreeSet<Symbol>,
 ) -> Result<(), ()> {
     if all_names.contains(n_) {
-        env.add_diag(restricted_name_error(case, *loc, n_));
+        env.add_error_diag(restricted_name_error(case, *loc, n_));
         Err(())
     } else {
         Ok(())

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -764,9 +764,7 @@ impl PathExpander for Move2024PathExpander {
     fn ide_autocomplete_suggestion(&mut self, context: &mut DefnContext, loc: Loc) {
         if context.env.ide_mode() {
             let info = self.aliases.get_ide_alias_information();
-            context
-                .env
-                .add_ide_annotation(loc, IDEAnnotation::PathAutocompleteInfo(Box::new(info)));
+            context.add_ide_annotation(loc, IDEAnnotation::PathAutocompleteInfo(Box::new(info)));
         }
     }
 }
@@ -1222,7 +1220,7 @@ impl PathExpander for LegacyPathExpander {
                 info.members.insert((*name, *mident, *member));
             }
             let annotation = IDEAnnotation::PathAutocompleteInfo(Box::new(info));
-            context.env.add_ide_annotation(loc, annotation)
+            context.add_ide_annotation(loc, annotation)
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -247,7 +247,7 @@ impl Move2024PathExpander {
                 NR::Address(name.loc, make_address(context, name, name.loc, address))
             }
             Some(AliasEntry::TypeParam(_)) => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     name.loc,
                     "ICE alias map misresolved name as type param"
                 )));
@@ -270,7 +270,7 @@ impl Move2024PathExpander {
                             NR::ModuleAccess(name.loc, mident, mem)
                         }
                         AliasEntry::TypeParam(_) => {
-                            context.env.add_diag(ice!((
+                            context.add_diag(ice!((
                                 name.loc,
                                 "ICE alias map misresolved name as type param"
                             )));
@@ -318,7 +318,7 @@ impl Move2024PathExpander {
                             .join(",");
                         diag.add_note(format!("Type arguments are used with the enum, as '{mident}::{name}<{tys}>::{variant}'"))
                     }
-                    context.env.add_diag(diag);
+                    context.add_diag(diag);
                 }
             }
         }
@@ -326,7 +326,7 @@ impl Move2024PathExpander {
         fn check_is_macro(context: &mut DefnContext, is_macro: &Option<Loc>, result: &NR) {
             if let NR::Address(_, _) | NR::ModuleIdent(_, _) = result {
                 if let Some(loc) = is_macro {
-                    context.env.add_diag(diag!(
+                    context.add_diag(diag!(
                         NameResolution::InvalidTypeParameter,
                         (
                             *loc,
@@ -385,7 +385,7 @@ impl Move2024PathExpander {
                             && root.tyargs.is_none() =>
                     {
                         if let Some(address) = top_level_address_opt(context, root.name) {
-                            context.env.add_diag(diag!(
+                            context.add_diag(diag!(
                                 Migration::NeedsGlobalQualification,
                                 (root.name.loc, "Must globally qualify name")
                             ));
@@ -467,9 +467,7 @@ impl Move2024PathExpander {
                             is_macro = entry.is_macro;
                         }
                         NR::UnresolvedName(_, _) => {
-                            context
-                                .env
-                                .add_diag(ice!((loc, "ICE access chain expansion failed")));
+                            context.add_diag(ice!((loc, "ICE access chain expansion failed")));
                             break;
                         }
                         NR::ResolutionFailure(_, _) => break,
@@ -523,13 +521,13 @@ impl PathExpander for Move2024PathExpander {
                 // an error if they both resolve (to different things)
                 PV::ModuleAccess(access_chain) => {
                     ice_assert!(
-                        context.env,
+                        context,
                         access_chain.value.tyargs().is_none(),
                         loc,
                         "Found tyargs"
                     );
                     ice_assert!(
-                        context.env,
+                        context,
                         access_chain.value.is_macro().is_none(),
                         loc,
                         "Found macro"
@@ -553,7 +551,6 @@ impl PathExpander for Move2024PathExpander {
                                 m_res.err_name()
                             );
                             context
-                                .env
                                 .add_diag(diag!(Attributes::AmbiguousAttributeValue, (loc, msg)));
                             return None;
                         }
@@ -561,7 +558,7 @@ impl PathExpander for Move2024PathExpander {
                     match result {
                         NR::ModuleIdent(_, mident) => {
                             if context.module_members.get(&mident).is_none() {
-                                context.env.add_diag(diag!(
+                                context.add_diag(diag!(
                                     NameResolution::UnboundModule,
                                     (loc, format!("Unbound module '{}'", mident))
                                 ));
@@ -581,11 +578,11 @@ impl PathExpander for Move2024PathExpander {
                         }
                         NR::Address(_, a) => EV::Address(a),
                         result @ NR::ResolutionFailure(_, _) => {
-                            context.env.add_diag(access_chain_resolution_error(result));
+                            context.add_diag(access_chain_resolution_error(result));
                             return None;
                         }
                         NR::IncompleteChain(loc) => {
-                            context.env.add_diag(access_chain_incomplete_error(loc));
+                            context.add_diag(access_chain_incomplete_error(loc));
                             return None;
                         }
                     }
@@ -628,7 +625,7 @@ impl PathExpander for Move2024PathExpander {
                             access,
                         );
                         diag.add_note("Variants may not be used as types. Use the enum instead.");
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         // We could try to use the member access to try to keep going.
                         return None;
                     }
@@ -637,7 +634,7 @@ impl PathExpander for Move2024PathExpander {
                         (access, tyargs, is_macro)
                     }
                     NR::Address(_, _) => {
-                        context.env.add_diag(unexpected_access_error(
+                        context.add_diag(unexpected_access_error(
                             resolved_name.loc(),
                             resolved_name.name(),
                             access,
@@ -658,15 +655,15 @@ impl PathExpander for Move2024PathExpander {
                                 base_str, realized_str
                             ));
                         }
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         return None;
                     }
                     result @ NR::ResolutionFailure(_, _) => {
-                        context.env.add_diag(access_chain_resolution_error(result));
+                        context.add_diag(access_chain_resolution_error(result));
                         return None;
                     }
                     NR::IncompleteChain(loc) => {
-                        context.env.add_diag(access_chain_incomplete_error(loc));
+                        context.add_diag(access_chain_incomplete_error(loc));
                         return None;
                     }
                 }
@@ -692,7 +689,7 @@ impl PathExpander for Move2024PathExpander {
                             (access, tyargs, is_macro)
                         }
                         NR::Address(_, _) | NR::ModuleIdent(_, _) => {
-                            context.env.add_diag(unexpected_access_error(
+                            context.add_diag(unexpected_access_error(
                                 resolved_name.loc(),
                                 resolved_name.name(),
                                 access,
@@ -700,18 +697,18 @@ impl PathExpander for Move2024PathExpander {
                             return None;
                         }
                         result @ NR::ResolutionFailure(_, _) => {
-                            context.env.add_diag(access_chain_resolution_error(result));
+                            context.add_diag(access_chain_resolution_error(result));
                             return None;
                         }
                         NR::IncompleteChain(loc) => {
-                            context.env.add_diag(access_chain_incomplete_error(loc));
+                            context.add_diag(access_chain_incomplete_error(loc));
                             return None;
                         }
                     }
                 }
             },
             Access::Module => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     loc,
                     "ICE module access should never resolve to a module member"
                 )));
@@ -734,11 +731,11 @@ impl PathExpander for Move2024PathExpander {
         match resolved_name {
             NR::ModuleIdent(_, mident) => Some(mident),
             NR::UnresolvedName(_, name) => {
-                context.env.add_diag(unbound_module_error(name));
+                context.add_diag(unbound_module_error(name));
                 None
             }
             NR::Address(_, _) => {
-                context.env.add_diag(unexpected_access_error(
+                context.add_diag(unexpected_access_error(
                     resolved_name.loc(),
                     "address".to_string(),
                     Access::Module,
@@ -746,7 +743,7 @@ impl PathExpander for Move2024PathExpander {
                 None
             }
             NR::ModuleAccess(_, _, _) | NR::Variant(_, _, _) => {
-                context.env.add_diag(unexpected_access_error(
+                context.add_diag(unexpected_access_error(
                     resolved_name.loc(),
                     "module member".to_string(),
                     Access::Module,
@@ -754,11 +751,11 @@ impl PathExpander for Move2024PathExpander {
                 None
             }
             result @ NR::ResolutionFailure(_, _) => {
-                context.env.add_diag(access_chain_resolution_error(result));
+                context.add_diag(access_chain_resolution_error(result));
                 None
             }
             NR::IncompleteChain(loc) => {
-                context.env.add_diag(access_chain_incomplete_error(loc));
+                context.add_diag(access_chain_incomplete_error(loc));
                 None
             }
         }
@@ -929,12 +926,12 @@ impl PathExpander for LegacyPathExpander {
                     if self.aliases.module_alias_get(&name).is_some() =>
                 {
                     self.ide_autocomplete_suggestion(context, loc);
-                    ice_assert!(context.env, tyargs.is_none(), loc, "Found tyargs");
-                    ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
+                    ice_assert!(context, tyargs.is_none(), loc, "Found tyargs");
+                    ice_assert!(context, is_macro.is_none(), loc, "Found macro");
                     let sp!(_, mident_) = self.aliases.module_alias_get(&name).unwrap();
                     let mident = sp(ident_loc, mident_);
                     if context.module_members.get(&mident).is_none() {
-                        context.env.add_diag(diag!(
+                        context.add_diag(diag!(
                             NameResolution::UnboundModule,
                             (ident_loc, format!("Unbound module '{}'", mident))
                         ));
@@ -942,14 +939,14 @@ impl PathExpander for LegacyPathExpander {
                     EV::Module(mident)
                 }
                 PV::ModuleAccess(sp!(ident_loc, PN::Path(path))) => {
-                    ice_assert!(context.env, !path.has_tyargs(), loc, "Found tyargs");
-                    ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
+                    ice_assert!(context, !path.has_tyargs(), loc, "Found tyargs");
+                    ice_assert!(context, path.is_macro().is_none(), loc, "Found macro");
                     match (&path.root.name, &path.entries[..]) {
                         (sp!(aloc, LN::AnonymousAddress(a)), [n]) => {
                             let addr = Address::anonymous(*aloc, *a);
                             let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n.name)));
                             if context.module_members.get(&mident).is_none() {
-                                context.env.add_diag(diag!(
+                                context.add_diag(diag!(
                                     NameResolution::UnboundModule,
                                     (ident_loc, format!("Unbound module '{}'", mident))
                                 ));
@@ -971,7 +968,7 @@ impl PathExpander for LegacyPathExpander {
                             let mident =
                                 sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2.name)));
                             if context.module_members.get(&mident).is_none() {
-                                context.env.add_diag(diag!(
+                                context.add_diag(diag!(
                                     NameResolution::UnboundModule,
                                     (ident_loc, format!("Unbound module '{}'", mident))
                                 ));
@@ -1007,7 +1004,7 @@ impl PathExpander for LegacyPathExpander {
 
         let tn_: ModuleAccessResult = match (access, ptn_) {
             (Access::Pattern, _) => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     loc,
                     "Attempted to expand a variant with the legacy path expander"
                 )));
@@ -1018,7 +1015,7 @@ impl PathExpander for LegacyPathExpander {
                 single_entry!(name, tyargs, is_macro),
             ) => {
                 if access == Access::Type {
-                    ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
+                    ice_assert!(context, is_macro.is_none(), loc, "Found macro");
                 }
                 self.ide_autocomplete_suggestion(context, loc);
                 let access = match self.aliases.member_alias_get(&name) {
@@ -1042,7 +1039,7 @@ impl PathExpander for LegacyPathExpander {
                 make_access_result(sp(name.loc, EN::Name(name)), tyargs, is_macro)
             }
             (Access::Module, single_entry!(_name, _tyargs, _is_macro)) => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     loc,
                     "ICE path resolution produced an impossible path for a module"
                 )));
@@ -1050,13 +1047,13 @@ impl PathExpander for LegacyPathExpander {
             }
             (_, PN::Path(mut path)) => {
                 if access == Access::Type {
-                    ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
+                    ice_assert!(context, path.is_macro().is_none(), loc, "Found macro");
                 }
                 match (&path.root.name, &path.entries[..]) {
                     // Error cases
                     (sp!(aloc, LN::AnonymousAddress(_)), [_]) => {
                         let diag = unexpected_address_module_error(loc, *aloc, access);
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         return None;
                     }
                     (sp!(_aloc, LN::GlobalAddress(_)), [_]) => {
@@ -1069,7 +1066,7 @@ impl PathExpander for LegacyPathExpander {
                             loc,
                             "Paths that start with `::` are not valid in legacy move.",
                         ));
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         return None;
                     }
                     // Others
@@ -1077,7 +1074,7 @@ impl PathExpander for LegacyPathExpander {
                         self.ide_autocomplete_suggestion(context, n1.loc);
                         if let Some(mident) = self.aliases.module_alias_get(n1) {
                             let n2_name = n2.name;
-                            let (tyargs, is_macro) = if !(path.has_tyargs_last()) {
+                            let (tyargs, is_macro) = if !path.has_tyargs_last() {
                                 let mut diag = diag!(
                                     Syntax::InvalidName,
                                     (path.tyargs_loc().unwrap(), "Invalid type argument position")
@@ -1085,7 +1082,7 @@ impl PathExpander for LegacyPathExpander {
                                 diag.add_note(
                                     "Type arguments may only be used with module members",
                                 );
-                                context.env.add_diag(diag);
+                                context.add_diag(diag);
                                 (None, path.is_macro())
                             } else {
                                 (path.take_tyargs(), path.is_macro())
@@ -1096,7 +1093,7 @@ impl PathExpander for LegacyPathExpander {
                                 is_macro.copied(),
                             )
                         } else {
-                            context.env.add_diag(diag!(
+                            context.add_diag(diag!(
                                 NameResolution::UnboundModule,
                                 (n1.loc, format!("Unbound module alias '{}'", n1))
                             ));
@@ -1120,7 +1117,7 @@ impl PathExpander for LegacyPathExpander {
                                 (path.tyargs_loc().unwrap(), "Invalid type argument position")
                             );
                             diag.add_note("Type arguments may only be used with module members");
-                            context.env.add_diag(diag);
+                            context.add_diag(diag);
                             (None, path.is_macro())
                         } else {
                             (path.take_tyargs(), path.is_macro())
@@ -1129,14 +1126,14 @@ impl PathExpander for LegacyPathExpander {
                     }
                     (_ln, []) => {
                         let diag = ice!((loc, "Found a root path with no additional entries"));
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         return None;
                     }
                     (ln, [_n1, _n2, ..]) => {
                         self.ide_autocomplete_suggestion(context, ln.loc);
                         let mut diag = diag!(Syntax::InvalidName, (loc, "Too many name segments"));
                         diag.add_note("Names may only have 0, 1, or 2 segments separated by '::'");
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         return None;
                     }
                 }
@@ -1153,11 +1150,11 @@ impl PathExpander for LegacyPathExpander {
         use P::NameAccessChain_ as PN;
         match pn_ {
             PN::Single(single) => {
-                ice_assert!(context.env, single.tyargs.is_none(), loc, "Found tyargs");
-                ice_assert!(context.env, single.is_macro.is_none(), loc, "Found macro");
+                ice_assert!(context, single.tyargs.is_none(), loc, "Found tyargs");
+                ice_assert!(context, single.is_macro.is_none(), loc, "Found macro");
                 match self.aliases.module_alias_get(&single.name) {
                     None => {
-                        context.env.add_diag(diag!(
+                        context.add_diag(diag!(
                             NameResolution::UnboundModule,
                             (
                                 single.name.loc,
@@ -1170,8 +1167,8 @@ impl PathExpander for LegacyPathExpander {
                 }
             }
             PN::Path(path) => {
-                ice_assert!(context.env, !path.has_tyargs(), loc, "Found tyargs");
-                ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
+                ice_assert!(context, !path.has_tyargs(), loc, "Found tyargs");
+                ice_assert!(context, path.is_macro().is_none(), loc, "Found macro");
                 match (&path.root.name, &path.entries[..]) {
                     (ln, [n]) => {
                         let pmident_ = P::ModuleIdent_ {
@@ -1182,9 +1179,7 @@ impl PathExpander for LegacyPathExpander {
                     }
                     // Error cases
                     (_ln, []) => {
-                        context
-                            .env
-                            .add_diag(ice!((loc, "Found path with no path entries")));
+                        context.add_diag(ice!((loc, "Found path with no path entries")));
                         None
                     }
                     (ln, [n, m, ..]) => {
@@ -1199,7 +1194,7 @@ impl PathExpander for LegacyPathExpander {
                             module: ModuleName(n.name),
                         };
                         let _ = module_ident(context, sp(ident_loc, pmident_));
-                        context.env.add_diag(diag!(
+                        context.add_diag(diag!(
                             NameResolution::NamePositionMismatch,
                                 if path.entries.len() < 3 {
                                     (m.name.loc, "Unexpected module member access. Expected a module identifier only")

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -521,13 +521,13 @@ impl PathExpander for Move2024PathExpander {
                 // an error if they both resolve (to different things)
                 PV::ModuleAccess(access_chain) => {
                     ice_assert!(
-                        context,
+                        context.env,
                         access_chain.value.tyargs().is_none(),
                         loc,
                         "Found tyargs"
                     );
                     ice_assert!(
-                        context,
+                        context.env,
                         access_chain.value.is_macro().is_none(),
                         loc,
                         "Found macro"
@@ -926,8 +926,8 @@ impl PathExpander for LegacyPathExpander {
                     if self.aliases.module_alias_get(&name).is_some() =>
                 {
                     self.ide_autocomplete_suggestion(context, loc);
-                    ice_assert!(context, tyargs.is_none(), loc, "Found tyargs");
-                    ice_assert!(context, is_macro.is_none(), loc, "Found macro");
+                    ice_assert!(context.env, tyargs.is_none(), loc, "Found tyargs");
+                    ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
                     let sp!(_, mident_) = self.aliases.module_alias_get(&name).unwrap();
                     let mident = sp(ident_loc, mident_);
                     if context.module_members.get(&mident).is_none() {
@@ -939,8 +939,8 @@ impl PathExpander for LegacyPathExpander {
                     EV::Module(mident)
                 }
                 PV::ModuleAccess(sp!(ident_loc, PN::Path(path))) => {
-                    ice_assert!(context, !path.has_tyargs(), loc, "Found tyargs");
-                    ice_assert!(context, path.is_macro().is_none(), loc, "Found macro");
+                    ice_assert!(context.env, !path.has_tyargs(), loc, "Found tyargs");
+                    ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
                     match (&path.root.name, &path.entries[..]) {
                         (sp!(aloc, LN::AnonymousAddress(a)), [n]) => {
                             let addr = Address::anonymous(*aloc, *a);
@@ -1015,7 +1015,7 @@ impl PathExpander for LegacyPathExpander {
                 single_entry!(name, tyargs, is_macro),
             ) => {
                 if access == Access::Type {
-                    ice_assert!(context, is_macro.is_none(), loc, "Found macro");
+                    ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
                 }
                 self.ide_autocomplete_suggestion(context, loc);
                 let access = match self.aliases.member_alias_get(&name) {
@@ -1047,7 +1047,7 @@ impl PathExpander for LegacyPathExpander {
             }
             (_, PN::Path(mut path)) => {
                 if access == Access::Type {
-                    ice_assert!(context, path.is_macro().is_none(), loc, "Found macro");
+                    ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
                 }
                 match (&path.root.name, &path.entries[..]) {
                     // Error cases
@@ -1150,8 +1150,8 @@ impl PathExpander for LegacyPathExpander {
         use P::NameAccessChain_ as PN;
         match pn_ {
             PN::Single(single) => {
-                ice_assert!(context, single.tyargs.is_none(), loc, "Found tyargs");
-                ice_assert!(context, single.is_macro.is_none(), loc, "Found macro");
+                ice_assert!(context.env, single.tyargs.is_none(), loc, "Found tyargs");
+                ice_assert!(context.env, single.is_macro.is_none(), loc, "Found macro");
                 match self.aliases.module_alias_get(&single.name) {
                     None => {
                         context.add_diag(diag!(
@@ -1167,8 +1167,8 @@ impl PathExpander for LegacyPathExpander {
                 }
             }
             PN::Path(path) => {
-                ice_assert!(context, !path.has_tyargs(), loc, "Found tyargs");
-                ice_assert!(context, path.is_macro().is_none(), loc, "Found macro");
+                ice_assert!(context.env, !path.has_tyargs(), loc, "Found tyargs");
+                ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
                 match (&path.root.name, &path.entries[..]) {
                     (ln, [n]) => {
                         let pmident_ = P::ModuleIdent_ {

--- a/external-crates/move/crates/move-compiler/src/expansion/primitive_definers.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/primitive_definers.rs
@@ -61,12 +61,16 @@ fn check_prim_definer(
     let Some(sp!(attr_loc, attr_)) = defines_prim_attr else {
         return;
     };
+    let warning_filters = env.top_level_warning_filter_scope();
     let Attribute_::Parameterized(_, params) = attr_ else {
         let msg = format!(
             "Expected a primitive type parameterization, e.g. '{}(<type>)'",
             DefinesPrimitive::DEFINES_PRIM
         );
-        env.add_diag(diag!(Attributes::InvalidUsage, (*attr_loc, msg)));
+        env.add_diag(
+            warning_filters,
+            diag!(Attributes::InvalidUsage, (*attr_loc, msg)),
+        );
         return;
     };
     if params.len() != 1 {
@@ -74,7 +78,10 @@ fn check_prim_definer(
             "Expected a single primitive type parameterization, e.g. '{}(<type>)'",
             DefinesPrimitive::DEFINES_PRIM
         );
-        env.add_diag(diag!(Attributes::InvalidUsage, (*attr_loc, msg)));
+        env.add_diag(
+            warning_filters,
+            diag!(Attributes::InvalidUsage, (*attr_loc, msg)),
+        );
         return;
     }
     let (_, _, sp!(param_loc, param_)) = params.into_iter().next().unwrap();
@@ -83,7 +90,10 @@ fn check_prim_definer(
             "Expected a primitive type parameterization, e.g. '{}(<type>)'",
             DefinesPrimitive::DEFINES_PRIM
         );
-        env.add_diag(diag!(Attributes::InvalidUsage, (*param_loc, msg)));
+        env.add_diag(
+            warning_filters,
+            diag!(Attributes::InvalidUsage, (*param_loc, msg)),
+        );
         return;
     };
     let Some(prim) = BuiltinTypeName_::resolve(name.value.as_str()) else {
@@ -92,18 +102,24 @@ fn check_prim_definer(
             DefinesPrimitive::DEFINES_PRIM,
             name,
         );
-        env.add_diag(diag!(Attributes::InvalidUsage, (name.loc, msg)));
+        env.add_diag(
+            warning_filters,
+            diag!(Attributes::InvalidUsage, (name.loc, msg)),
+        );
         return;
     };
 
     if let Some(prev) = definers.get(&prim) {
         if !allow_shadowing {
             let msg = format!("Duplicate definer annotated for primitive type '{}'", prim);
-            env.add_diag(diag!(
-                Attributes::InvalidUsage,
-                (*attr_loc, msg),
-                (prev.loc, "Previously declared here")
-            ));
+            env.add_diag(
+                warning_filters,
+                diag!(
+                    Attributes::InvalidUsage,
+                    (*attr_loc, msg),
+                    (prev.loc, "Previously declared here")
+                ),
+            );
         }
     } else {
         definers.insert(prim, mident);

--- a/external-crates/move/crates/move-compiler/src/expansion/primitive_definers.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/primitive_definers.rs
@@ -20,7 +20,7 @@ use super::ast::Attribute_;
 /// Gather primitive defines from module declarations, erroring on duplicates for a given base
 /// type or for unknown base types.
 pub fn modules(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     pre_compiled_lib_opt: Option<Arc<FullyCompiledProgram>>,
     modules: &UniqueMap<ModuleIdent, ModuleDefinition>,
 ) {
@@ -49,7 +49,7 @@ pub fn modules(
 }
 
 fn check_prim_definer(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     allow_shadowing: bool,
     definers: &mut BTreeMap<BuiltinTypeName_, crate::expansion::ast::ModuleIdent>,
     mident: ModuleIdent,

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -266,6 +266,7 @@ impl<'env, 'map> Context<'env, 'map> {
         self.defn_context.add_diag(diag);
     }
 
+    #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.defn_context.add_diags(diags);
     }

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -282,8 +282,8 @@ impl<'env, 'map> Context<'env, 'map> {
         self.defn_context.add_ide_annotation(loc, info);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
-        self.defn_context.add_warning_filter_scope(filters)
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.defn_context.push_warning_filter_scope(filters)
     }
 
     pub fn pop_warning_filter_scope(&mut self) {
@@ -309,7 +309,7 @@ impl DefnContext<'_, '_> {
             .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }
 
-    pub(super) fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub(super) fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -877,7 +877,7 @@ fn module_(
     let config = context.env().package_config(package_name);
     warning_filter.union(&config.warning_filter);
 
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     assert!(context.address.is_none());
     assert!(address.is_none());
     set_module_address(context, &name, module_address);
@@ -1876,7 +1876,7 @@ fn struct_def_(
     } = pstruct;
     let attributes = flatten_attributes(context, AttributePosition::Struct, attributes);
     let warning_filter = warning_filter(context, &attributes);
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let type_parameters = datatype_type_parameters(context, pty_params);
     context.push_type_parameters(type_parameters.iter().map(|tp| &tp.name));
     let abilities = ability_set(context, "modifier", abilities_vec);
@@ -1958,7 +1958,7 @@ fn enum_def_(
     } = penum;
     let attributes = flatten_attributes(context, AttributePosition::Enum, attributes);
     let warning_filter = warning_filter(context, &attributes);
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let type_parameters = datatype_type_parameters(context, pty_params);
     context.push_type_parameters(type_parameters.iter().map(|tp| &tp.name));
     let abilities = ability_set(context, "modifier", abilities_vec);
@@ -2132,7 +2132,7 @@ fn constant_(
     } = pconstant;
     let attributes = flatten_attributes(context, AttributePosition::Constant, pattributes);
     let warning_filter = warning_filter(context, &attributes);
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let signature = type_(context, psignature);
     let value = *exp(context, Box::new(pvalue));
     let constant = E::Constant {
@@ -2181,7 +2181,7 @@ fn function_(
     } = pfunction;
     let attributes = flatten_attributes(context, AttributePosition::Function, pattributes);
     let warning_filter = warning_filter(context, &attributes);
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     if let (Some(entry_loc), Some(macro_loc)) = (entry, macro_) {
         let e_msg = format!(
             "Invalid function declaration. \

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     diag,
-    diagnostics::{codes::WarningFilter, Diagnostic, WarningFilters},
+    diagnostics::{codes::WarningFilter, Diagnostic, Diagnostics, WarningFilters},
     editions::{self, Edition, FeatureGate, Flavor},
     expansion::{
         alias_map_builder::{
@@ -69,6 +69,7 @@ pub(super) struct DefnContext<'env, 'map> {
     pub(super) address_conflicts: BTreeSet<Symbol>,
     pub(super) current_package: Option<Symbol>,
     pub(super) is_source_definition: bool,
+    warning_filters_scope: WarningFiltersScope,
 }
 
 struct Context<'env, 'map> {
@@ -92,6 +93,7 @@ impl<'env, 'map> Context<'env, 'map> {
                 all_filter_alls.add(f);
             }
         }
+        let warning_filters_scope = compilation_env.top_level_warning_filter_scope().clone();
         let defn_context = DefnContext {
             env: compilation_env,
             named_address_mapping: None,
@@ -99,6 +101,7 @@ impl<'env, 'map> Context<'env, 'map> {
             module_members,
             current_package: None,
             is_source_definition: false,
+            warning_filters_scope,
         };
         Context {
             defn_context,
@@ -141,7 +144,7 @@ impl<'env, 'map> Context<'env, 'map> {
             .unwrap()
             .push_alias_scope(loc, new_scope);
         match res {
-            Err(diag) => self.env().add_diag(*diag),
+            Err(diag) => self.add_diag(*diag),
             Ok(unnecessaries) => unnecessary_alias_errors(self, unnecessaries),
         }
     }
@@ -242,7 +245,7 @@ impl<'env, 'map> Context<'env, 'map> {
 
     pub fn spec_deprecated(&mut self, loc: Loc, is_error: bool) {
         let diag = self.spec_deprecated_diag(loc, is_error);
-        self.env().add_diag(diag);
+        self.add_diag(diag);
     }
 
     pub fn spec_deprecated_diag(&mut self, loc: Loc, is_error: bool) -> Diagnostic {
@@ -257,6 +260,40 @@ impl<'env, 'map> Context<'env, 'map> {
                 "Specification blocks are deprecated and are no longer used"
             )
         )
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.defn_context.add_diag(diag);
+    }
+
+    pub fn add_diags(&mut self, diags: Diagnostics) {
+        self.defn_context.add_diags(diags);
+    }
+
+    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.defn_context.add_warning_filter_scope(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.defn_context.pop_warning_filter_scope()
+    }
+}
+
+impl DefnContext<'_, '_> {
+    pub(super) fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    pub(super) fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub(super) fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
+    }
+
+    pub(super) fn pop_warning_filter_scope(&mut self) {
+        self.warning_filters_scope.pop()
     }
 }
 
@@ -297,7 +334,7 @@ fn unnecessary_alias_error(context: &mut Context, unnecessary: UnnecessaryAlias)
         // nothing to point to for the default case
         diag.add_secondary_label((prev, "The same alias was previously declared here"))
     }
-    context.env().add_diag(diag);
+    context.add_diag(diag);
 }
 
 /// We mark named addresses as having a conflict if there is not a bidirectional mapping between
@@ -408,6 +445,7 @@ pub fn program(
 ) -> E::Program {
     let address_conflicts = compute_address_conflicts(pre_compiled_lib.clone(), &prog);
 
+    let warning_filters_scope = compilation_env.top_level_warning_filter_scope().clone();
     let mut member_computation_context = DefnContext {
         env: compilation_env,
         named_address_mapping: None,
@@ -415,6 +453,7 @@ pub fn program(
         address_conflicts,
         current_package: None,
         is_source_definition: false,
+        warning_filters_scope,
     };
 
     let module_members = {
@@ -477,7 +516,7 @@ pub fn program(
 
             // should never fail
             if let Err(diag) = path_expander.push_alias_scope(Loc::invalid(), aliases) {
-                context.env().add_diag(*diag);
+                context.add_diag(*diag);
             }
 
             context.defn_context.named_address_mapping = Some(named_address_map);
@@ -511,7 +550,7 @@ pub fn program(
             let aliases = named_addr_map_to_alias_map_builder(&mut context, named_address_map);
             // should never fail
             if let Err(diag) = path_expander.push_alias_scope(Loc::invalid(), aliases) {
-                context.env().add_diag(*diag);
+                context.add_diag(*diag);
             }
             context.defn_context.named_address_mapping = Some(named_address_map);
             context.path_expander = Some(Box::new(path_expander));
@@ -611,7 +650,7 @@ fn top_level_address_(
         // This should have been handled elsewhere in alias resolution for user-provided paths, and
         // should never occur in compiler-generated ones.
         P::LeadingNameAccess_::GlobalAddress(name) => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 "Found an address in top-level address position that uses a global name"
             )));
@@ -622,7 +661,7 @@ fn top_level_address_(
                 Some(addr) => make_address(context, name, loc, addr),
                 None => {
                     if name_res.is_ok() {
-                        context.env.add_diag(address_without_value_error(
+                        context.add_diag(address_without_value_error(
                             suggest_declaration,
                             loc,
                             &name,
@@ -650,7 +689,7 @@ pub(super) fn top_level_address_opt(
         // This should have been handled elsewhere in alias resolution for user-provided paths, and
         // should never occur in compiler-generated ones.
         P::LeadingNameAccess_::GlobalAddress(_) => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 "Found an address in top-level address position that uses a global name"
             )));
@@ -730,7 +769,7 @@ fn check_module_address(
             } else {
                 "Multiple addresses specified for module"
             };
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (other_loc, msg),
                 (loc, "Address previously specified here")
@@ -750,7 +789,7 @@ fn duplicate_module(
     let old_mident = module_map.get_key(&mident).unwrap();
     let dup_msg = format!("Duplicate definition for module '{}'", mident);
     let prev_msg = format!("Module previously defined here, with '{}'", old_mident);
-    context.env().add_diag(diag!(
+    context.add_diag(diag!(
         Declarations::DuplicateItem,
         (mident.loc, dup_msg),
         (old_loc, prev_msg),
@@ -791,9 +830,7 @@ fn set_module_address(
                  address 'module <address>::{}''",
                 module_name
             );
-            context
-                .env()
-                .add_diag(diag!(Declarations::InvalidModule, (loc, msg)));
+            context.add_diag(diag!(Declarations::InvalidModule, (loc, msg)));
             Address::anonymous(loc, NumericalAddress::DEFAULT_ERROR_ADDRESS)
         }
     })
@@ -819,9 +856,7 @@ fn module_(
     let config = context.env().package_config(package_name);
     warning_filter.union(&config.warning_filter);
 
-    context
-        .env()
-        .add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     assert!(context.address.is_none());
     assert!(address.is_none());
     set_module_address(context, &name, module_address);
@@ -831,9 +866,7 @@ fn module_(
             "Invalid module name '{}'. Module names cannot start with '_'",
             name,
         );
-        context
-            .env()
-            .add_diag(diag!(Declarations::InvalidName, (name.loc(), msg)));
+        context.add_diag(diag!(Declarations::InvalidName, (name.loc(), msg)));
     }
 
     let name_loc = name.0.loc;
@@ -906,7 +939,7 @@ fn module_(
         functions,
         warning_filter,
     };
-    context.env().pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     (current_module, def)
 }
 
@@ -936,15 +969,13 @@ fn check_visibility_modifiers(
             let loc = friend_decl.loc;
             let diag = if edition == Edition::E2024_MIGRATION {
                 for aloc in &friend_decl.attr_locs {
-                    context
-                        .env()
-                        .add_diag(diag!(Migration::RemoveFriend, (*aloc, friend_msg)));
+                    context.add_diag(diag!(Migration::RemoveFriend, (*aloc, friend_msg)));
                 }
                 diag!(Migration::RemoveFriend, (loc, friend_msg))
             } else {
                 diag!(Editions::DeprecatedFeature, (loc, friend_msg))
             };
-            context.env().add_diag(diag);
+            context.add_diag(diag);
         }
         for (_, _, function) in functions {
             let E::Visibility::Friend(loc) = function.visibility else {
@@ -955,7 +986,7 @@ fn check_visibility_modifiers(
             } else {
                 diag!(Editions::DeprecatedFeature, (loc, pub_msg))
             };
-            context.env().add_diag(diag);
+            context.add_diag(diag);
         }
     }
 
@@ -985,7 +1016,7 @@ fn check_visibility_modifiers(
         );
         let package_definition_msg = format!("'{}' visibility used here", E::Visibility::PACKAGE);
         for (_, _, friend) in friends {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::InvalidVisibilityModifier,
                 (friend.loc, friend_error_msg.clone()),
                 (
@@ -1007,7 +1038,7 @@ fn check_visibility_modifiers(
         for (_, _, function) in functions {
             match function.visibility {
                 E::Visibility::Friend(loc) => {
-                    context.env().add_diag(diag!(
+                    context.add_diag(diag!(
                         Declarations::InvalidVisibilityModifier,
                         (loc, friend_error_msg.clone()),
                         (
@@ -1017,7 +1048,7 @@ fn check_visibility_modifiers(
                     ));
                 }
                 E::Visibility::Package(loc) => {
-                    context.env().add_diag(diag!(
+                    context.add_diag(diag!(
                         Declarations::InvalidVisibilityModifier,
                         (loc, package_error_msg.clone()),
                         (
@@ -1058,9 +1089,7 @@ fn known_attributes(
                 e.g. #[{ext}({n})]",
                 ext = known_attributes::ExternalAttribute::EXTERNAL
             );
-            context
-                .env()
-                .add_diag(diag!(Declarations::UnknownAttribute, (loc, msg)));
+            context.add_diag(diag!(Declarations::UnknownAttribute, (loc, msg)));
             None
         }
         sp!(loc, E::AttributeName_::Known(n)) => {
@@ -1111,9 +1140,7 @@ fn unique_attributes(
                     let msg = format!(
                         "Known attribute '{known}' is not expected in a nested attribute position"
                     );
-                    context
-                        .env()
-                        .add_diag(diag!(Declarations::InvalidAttribute, (nloc, msg)));
+                    context.add_diag(diag!(Declarations::InvalidAttribute, (nloc, msg)));
                     continue;
                 }
 
@@ -1133,7 +1160,7 @@ fn unique_attributes(
                         "Expected to be used with one of the following: {}",
                         all_expected
                     );
-                    context.env().add_diag(diag!(
+                    context.add_diag(diag!(
                         Declarations::InvalidAttribute,
                         (nloc, msg),
                         (nloc, expected_msg)
@@ -1151,7 +1178,7 @@ fn unique_attributes(
         }
         if let Err((_, old_loc)) = attr_map.add(sp(nloc, name_), sp(loc, attr_)) {
             let msg = format!("Duplicate attribute '{}' attached to the same item", name_);
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (loc, msg),
                 (old_loc, "Attribute previously given here"),
@@ -1235,9 +1262,7 @@ fn warning_filter(context: &mut Context, attributes: &E::Attributes) -> WarningF
                         DiagnosticAttribute::ALLOW,
                         n
                     );
-                    context
-                        .env()
-                        .add_diag(diag!(Declarations::InvalidAttribute, (inner_attr_loc, msg)));
+                    context.add_diag(diag!(Declarations::InvalidAttribute, (inner_attr_loc, msg)));
                     (None, vec![*n])
                 }
             };
@@ -1262,9 +1287,7 @@ fn warning_filter(context: &mut Context, attributes: &E::Attributes) -> WarningF
                         )
                     }
                 };
-                context
-                    .env()
-                    .add_diag(diag!(Attributes::ValueWarning, (nloc, msg)));
+                context.add_diag(diag!(Attributes::ValueWarning, (nloc, msg)));
                 continue;
             };
             for f in filters {
@@ -1295,9 +1318,7 @@ fn get_allow_attribute_inners<'a>(
                 .to_str()
                 .unwrap(),
             );
-            context
-                .env()
-                .add_diag(diag!(Attributes::ValueWarning, (allow_attr.loc, msg)));
+            context.add_diag(diag!(Attributes::ValueWarning, (allow_attr.loc, msg)));
             None
         }
     }
@@ -1322,9 +1343,7 @@ fn prefixed_warning_filters(
                     prefix,
                     n
                 );
-                context
-                    .env()
-                    .add_diag(diag!(Attributes::ValueWarning, (*loc, msg)));
+                context.add_diag(diag!(Attributes::ValueWarning, (*loc, msg)));
                 *n
             }
         })
@@ -1534,7 +1553,7 @@ fn use_(
                     otherwise they must internal to declared scope.",
                         P::Visibility::PUBLIC
                     );
-                    context.env().add_diag(diag!(
+                    context.add_diag(diag!(
                         Declarations::InvalidUseFun,
                         (loc, msg),
                         (vis_loc, vis_msg)
@@ -1592,7 +1611,7 @@ fn module_use(
         P::ModuleUse::Module(alias_opt) => {
             let mident = module_ident(&mut context.defn_context, in_mident);
             if !context.defn_context.module_members.contains_key(&mident) {
-                context.env().add_diag(unbound_module(&mident));
+                context.add_diag(unbound_module(&mident));
                 return;
             };
             let alias = alias_opt
@@ -1605,7 +1624,7 @@ fn module_use(
             let members = match context.defn_context.module_members.get(&mident) {
                 Some(members) => members,
                 None => {
-                    context.env().add_diag(unbound_module(&mident));
+                    context.add_diag(unbound_module(&mident));
                     return;
                 }
             };
@@ -1644,7 +1663,7 @@ fn module_use(
                             "Invalid 'use'. Unbound member '{}' in module '{}'",
                             member, mident
                         );
-                        context.env().add_diag(diag!(
+                        context.add_diag(diag!(
                             NameResolution::UnboundModuleMember,
                             (member.loc, msg),
                             (mloc, format!("Module '{}' declared here", mident)),
@@ -1686,7 +1705,7 @@ fn module_use(
         P::ModuleUse::Partial { .. } => {
             let mident = module_ident(&mut context.defn_context, in_mident);
             if !context.defn_context.module_members.contains_key(&mident) {
-                context.env().add_diag(unbound_module(&mident));
+                context.add_diag(unbound_module(&mident));
                 return;
             };
             add_module_alias!(mident, mident.value.module.0)
@@ -1721,28 +1740,18 @@ fn explicit_use_fun(
     } = pexplicit;
     let access_result!(function, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::ApplyPositional, *function)?;
+    ice_assert!(context, tyargs.is_none(), loc, "'use fun' with tyargs");
     ice_assert!(
-        context.env(),
-        tyargs.is_none(),
-        loc,
-        "'use fun' with tyargs"
-    );
-    ice_assert!(
-        context.env(),
+        context,
         is_macro.is_none(),
         loc,
         "Found a 'use fun' as a macro"
     );
     let access_result!(ty, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::Type, *ty)?;
+    ice_assert!(context, tyargs.is_none(), loc, "'use fun' with tyargs");
     ice_assert!(
-        context.env(),
-        tyargs.is_none(),
-        loc,
-        "'use fun' with tyargs"
-    );
-    ice_assert!(
-        context.env(),
+        context,
         is_macro.is_none(),
         loc,
         "Found a 'use fun' as a macro"
@@ -1762,7 +1771,7 @@ fn duplicate_module_alias(context: &mut Context, old_loc: Loc, alias: Name) {
         "Duplicate module alias '{}'. Module aliases must be unique within a given namespace",
         alias
     );
-    context.env().add_diag(diag!(
+    context.add_diag(diag!(
         Declarations::DuplicateItem,
         (alias.loc, msg),
         (old_loc, "Alias previously defined here"),
@@ -1774,7 +1783,7 @@ fn duplicate_module_member(context: &mut Context, old_loc: Loc, alias: Name) {
         "Duplicate module member or alias '{}'. Top level names in a namespace must be unique",
         alias
     );
-    context.env().add_diag(diag!(
+    context.add_diag(diag!(
         Declarations::DuplicateItem,
         (alias.loc, msg),
         (old_loc, "Alias previously defined here"),
@@ -1803,7 +1812,7 @@ fn unused_alias(context: &mut Context, _kind: &str, alias: Name) {
             alias
         ));
     }
-    context.env().add_diag(diag);
+    context.add_diag(diag);
 }
 
 //**************************************************************************************************
@@ -1836,9 +1845,7 @@ fn struct_def_(
     } = pstruct;
     let attributes = flatten_attributes(context, AttributePosition::Struct, attributes);
     let warning_filter = warning_filter(context, &attributes);
-    context
-        .env()
-        .add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let type_parameters = datatype_type_parameters(context, pty_params);
     context.push_type_parameters(type_parameters.iter().map(|tp| &tp.name));
     let abilities = ability_set(context, "modifier", abilities_vec);
@@ -1853,7 +1860,7 @@ fn struct_def_(
         fields,
     };
     context.pop_alias_scope(None);
-    context.env().pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     (name, sdef)
 }
 
@@ -1874,7 +1881,7 @@ fn struct_fields(
     for (idx, (field, pt)) in pfields_vec.into_iter().enumerate() {
         let t = type_(context, pt);
         if let Err((field, old_loc)) = field_map.add(field, (idx, t)) {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (
                     field.loc(),
@@ -1920,9 +1927,7 @@ fn enum_def_(
     } = penum;
     let attributes = flatten_attributes(context, AttributePosition::Enum, attributes);
     let warning_filter = warning_filter(context, &attributes);
-    context
-        .env()
-        .add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let type_parameters = datatype_type_parameters(context, pty_params);
     context.push_type_parameters(type_parameters.iter().map(|tp| &tp.name));
     let abilities = ability_set(context, "modifier", abilities_vec);
@@ -1937,7 +1942,7 @@ fn enum_def_(
         variants,
     };
     context.pop_alias_scope(None);
-    context.env().pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     (name, edef)
 }
 
@@ -1949,7 +1954,7 @@ fn enum_variants(
 ) -> UniqueMap<VariantName, E::VariantDefinition> {
     let mut variants = UniqueMap::new();
     if pvariants.is_empty() {
-        context.env().add_diag(diag!(
+        context.add_diag(diag!(
             Declarations::InvalidEnum,
             (eloc, "An 'enum' must define at least one variant")
         ))
@@ -1962,7 +1967,7 @@ fn enum_variants(
                 "Duplicate definition for variant '{}' in enum '{}'",
                 vname, ename
             );
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (loc, msg),
                 (old_loc.1, "Variant previously defined here")
@@ -2000,7 +2005,7 @@ fn variant_fields(
     for (idx, (field, pt)) in pfields_vec.into_iter().enumerate() {
         let t = type_(context, pt);
         if let Err((field, old_loc)) = field_map.add(field, (idx, t)) {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (
                     field.loc(),
@@ -2034,7 +2039,7 @@ fn friend(
                      unique",
                     mident
                 );
-                context.env().add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::DuplicateItem,
                     (friend.loc, msg),
                     (old_friend.loc, "Friend previously declared here"),
@@ -2096,9 +2101,7 @@ fn constant_(
     } = pconstant;
     let attributes = flatten_attributes(context, AttributePosition::Constant, pattributes);
     let warning_filter = warning_filter(context, &attributes);
-    context
-        .env()
-        .add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let signature = type_(context, psignature);
     let value = *exp(context, Box::new(pvalue));
     let constant = E::Constant {
@@ -2109,7 +2112,7 @@ fn constant_(
         signature,
         value,
     };
-    context.env().pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     (name, constant)
 }
 
@@ -2147,9 +2150,7 @@ fn function_(
     } = pfunction;
     let attributes = flatten_attributes(context, AttributePosition::Function, pattributes);
     let warning_filter = warning_filter(context, &attributes);
-    context
-        .env()
-        .add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     if let (Some(entry_loc), Some(macro_loc)) = (entry, macro_) {
         let e_msg = format!(
             "Invalid function declaration. \
@@ -2157,7 +2158,7 @@ fn function_(
             are fully-expanded inline during compilation"
         );
         let m_msg = format!("Function declared as '{MACRO_MODIFIER}' here");
-        context.env().add_diag(diag!(
+        context.add_diag(diag!(
             Declarations::InvalidFunction,
             (entry_loc, e_msg),
             (macro_loc, m_msg),
@@ -2169,7 +2170,7 @@ fn function_(
             '{NATIVE_MODIFIER}' functions cannot be '{MACRO_MODIFIER}'",
         );
         let m_msg = format!("Function declared as '{MACRO_MODIFIER}' here");
-        context.env().add_diag(diag!(
+        context.add_diag(diag!(
             Declarations::InvalidFunction,
             (*native_loc, n_msg),
             (macro_loc, m_msg),
@@ -2208,7 +2209,7 @@ fn function_(
         body,
     };
     context.pop_alias_scope(None);
-    context.env().pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     (name, fdef)
 }
 
@@ -2267,7 +2268,7 @@ fn ability_set(context: &mut Context, case: &str, abilities_vec: Vec<Ability>) -
     for ability in abilities_vec {
         let loc = ability.loc;
         if let Err(prev_loc) = set.add(ability) {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (loc, format!("Duplicate '{}' ability {}", ability, case)),
                 (prev_loc, "Ability previously given here")
@@ -2501,9 +2502,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
         PE::Name(pn) if pn.value.has_tyargs() => {
             let msg = "Expected name to be followed by a brace-enclosed list of field expressions \
                 or a parenthesized list of arguments for a function call";
-            context
-                .env()
-                .add_diag(diag!(NameResolution::NamePositionMismatch, (loc, msg)));
+            context.add_diag(diag!(NameResolution::NamePositionMismatch, (loc, msg)));
             EE::UnresolvedError
         }
         PE::Name(pn) => {
@@ -2680,7 +2679,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
                     consider updating your Move edition to '{valid_editions}'"
                 ));
                 diag.add_note(editions::UPGRADE_NOTE);
-                context.env().add_diag(diag);
+                context.add_diag(diag);
                 EE::UnresolvedError
             } else {
                 match exp_dotted(context, Box::new(sp(loc, pdotted_))) {
@@ -2772,9 +2771,7 @@ fn exp_cast(context: &mut Context, in_parens: bool, plhs: Box<P::Exp>, pty: P::T
                 .check_feature(current_package, FeatureGate::NoParensCast, loc);
         if supports_feature && ambiguous_cast(&plhs) {
             let msg = "Potentially ambiguous 'as'. Add parentheses to disambiguate";
-            context
-                .env()
-                .add_diag(diag!(Syntax::AmbiguousCast, (loc, msg)));
+            context.add_diag(diag!(Syntax::AmbiguousCast, (loc, msg)));
         }
     }
     EE::Cast(exp(context, plhs), type_(context, pty))
@@ -2804,9 +2801,7 @@ fn maybe_labeled_exp(
         _ => {
             let msg = "Invalid label. Labels can only be used on 'while', 'loop', or block '{{}}' \
                  expressions";
-            context
-                .env()
-                .add_diag(diag!(Syntax::InvalidLabel, (loc, msg)));
+            context.add_diag(diag!(Syntax::InvalidLabel, (loc, msg)));
             E::Exp_::UnresolvedError
         }
     };
@@ -2820,7 +2815,7 @@ fn ensure_unique_label(
     label_opt: Option<BlockLabel>,
 ) {
     if let Some(old_label) = label_opt {
-        context.env().add_diag(diag!(
+        context.add_diag(diag!(
             Syntax::InvalidLabel,
             (loc, "Multiple labels for a single expression"),
             (old_label.0.loc, "Label previously given here"),
@@ -2866,7 +2861,7 @@ fn move_or_copy_path_(context: &mut Context, case: PathCase, pe: Box<P::Exp>) ->
             if !matches!(&inner.value, E::Exp_::Name(_, _)) {
                 let cmsg = format!("Invalid '{}' of expression", case.case());
                 let emsg = "Expected a name or path access, e.g. 'x' or 'e.f'";
-                context.env().add_diag(diag!(
+                context.add_diag(diag!(
                     Syntax::InvalidMoveOrCopy,
                     (cloc, cmsg),
                     (inner.loc, emsg)
@@ -2937,7 +2932,7 @@ fn check_ellipsis_usage(context: &mut Context, ellipsis_locs: &[Loc]) {
             diag.add_secondary_label((*loc, "Ellipsis pattern used again here"));
         }
         diag.add_note("An ellipsis pattern can only appear once in a constructor's pattern.");
-        context.env().add_diag(diag);
+        context.add_diag(diag);
     }
 }
 
@@ -2971,7 +2966,7 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
             EM::Variant(_, _) | EM::ModuleAccess(_, _) => Some(name),
             EM::Name(_) if identifier_okay => Some(name),
             EM::Name(_) => {
-                context.env().add_diag(diag!(
+                context.add_diag(diag!(
                     Syntax::UnexpectedToken,
                     (
                         name.loc,
@@ -2996,7 +2991,7 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
         } = context.name_access_chain_to_module_access(Access::Pattern, name_chain)?;
         let name = head_ctor_okay(context, access, identifier_okay)?;
         if let Some(loc) = is_macro {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Syntax::InvalidMacro,
                 (loc, "Macros are not allowed in patterns.")
             ));
@@ -3102,14 +3097,14 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
                                 resolve this constant's name",
                             );
                         }
-                        context.env().add_diag(diag);
+                        context.add_diag(diag);
                         error_pattern!()
                     } else {
                         if let Some(_tys) = pts_opt {
                             let msg = "Invalid type arguments on a pattern variable";
                             let mut diag = diag!(Declarations::InvalidName, (name.loc, msg));
                             diag.add_note("Type arguments cannot appear on pattern variables");
-                            context.env().add_diag(diag);
+                            context.add_diag(diag);
                         }
                         sp(loc, EP::Binder(mutability(context, loc, mut_), Var(name)))
                     }
@@ -3119,7 +3114,7 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
                         let msg = "'mut' can only be used with variable bindings in patterns";
                         let nmsg =
                             "Expected a valid 'enum' variant, 'struct', or 'const', not a variable";
-                        context.env().add_diag(diag!(
+                        context.add_diag(diag!(
                             Declarations::InvalidName,
                             (mloc, msg),
                             (head_ctor_name.loc, nmsg)
@@ -3153,7 +3148,7 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
         ),
         PP::At(x, inner) => {
             if x.is_underscore() {
-                context.env().add_diag(diag!(
+                context.add_diag(diag!(
                     NameResolution::InvalidPattern,
                     (x.loc(), "Can't use '_' as a binder in an '@' pattern")
                 ));
@@ -3180,42 +3175,42 @@ pub(super) fn value(context: &mut DefnContext, sp!(loc, pvalue_): P::Value) -> O
         PV::Num(s) if s.ends_with("u8") => match parse_u8(&s[..s.len() - 2]) {
             Ok((u, _format)) => EV::U8(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(loc, "'u8'"));
+                context.add_diag(num_too_big_error(loc, "'u8'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u16") => match parse_u16(&s[..s.len() - 3]) {
             Ok((u, _format)) => EV::U16(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(loc, "'u16'"));
+                context.add_diag(num_too_big_error(loc, "'u16'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u32") => match parse_u32(&s[..s.len() - 3]) {
             Ok((u, _format)) => EV::U32(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(loc, "'u32'"));
+                context.add_diag(num_too_big_error(loc, "'u32'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u64") => match parse_u64(&s[..s.len() - 3]) {
             Ok((u, _format)) => EV::U64(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(loc, "'u64'"));
+                context.add_diag(num_too_big_error(loc, "'u64'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u128") => match parse_u128(&s[..s.len() - 4]) {
             Ok((u, _format)) => EV::U128(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(loc, "'u128'"));
+                context.add_diag(num_too_big_error(loc, "'u128'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u256") => match parse_u256(&s[..s.len() - 4]) {
             Ok((u, _format)) => EV::U256(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(loc, "'u256'"));
+                context.add_diag(num_too_big_error(loc, "'u256'"));
                 return None;
             }
         },
@@ -3223,7 +3218,7 @@ pub(super) fn value(context: &mut DefnContext, sp!(loc, pvalue_): P::Value) -> O
         PV::Num(s) => match parse_u256(&s) {
             Ok((u, _format)) => EV::InferredNum(u),
             Err(_) => {
-                context.env.add_diag(num_too_big_error(
+                context.add_diag(num_too_big_error(
                     loc,
                     "the largest possible integer type, 'u256'",
                 ));
@@ -3234,14 +3229,14 @@ pub(super) fn value(context: &mut DefnContext, sp!(loc, pvalue_): P::Value) -> O
         PV::HexString(s) => match hex_string::decode(loc, &s) {
             Ok(v) => EV::Bytearray(v),
             Err(e) => {
-                context.env.add_diag(*e);
+                context.add_diag(*e);
                 return None;
             }
         },
         PV::ByteString(s) => match byte_string::decode(loc, &s) {
             Ok(v) => EV::Bytearray(v),
             Err(e) => {
-                context.env.add_diags(e);
+                context.add_diags(e);
                 return None;
             }
         },
@@ -3278,7 +3273,7 @@ fn named_fields<T>(
     let mut fmap = UniqueMap::new();
     for (idx, (field, x)) in xs.into_iter().enumerate() {
         if let Err((field, old_loc)) = fmap.add(field, (idx, x)) {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::DuplicateItem,
                 (loc, format!("Invalid {}", case)),
                 (
@@ -3313,7 +3308,7 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
         PB::Unpack(ptn, pfields) => {
             let access_result!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, *ptn)?;
-            ice_assert!(context.env(), is_macro.is_none(), loc, "Found macro in lhs");
+            ice_assert!(context, is_macro.is_none(), loc, "Found macro in lhs");
             let tys_opt = optional_sp_types(context, ptys_opt);
             let fields = match pfields {
                 FieldBindings::Named(named_bindings) => {
@@ -3395,7 +3390,7 @@ fn lvalues(context: &mut Context, e: Box<P::Exp>) -> Option<LValue> {
             L::FieldMutate(dotted)
         }
         PE::Index(_, _) => {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Syntax::InvalidLValue,
                 (
                     loc,
@@ -3422,14 +3417,14 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                         "If you are trying to unpack a struct, try adding fields, e.g.'{} {{}}'",
                         name
                     ));
-                    context.env().add_diag(diag);
+                    context.add_diag(diag);
                     None
                 }
                 Some(access_result!(_, _ptys_opt, Some(_))) => {
                     let msg = "Unexpected assignment of name with macro invocation";
                     let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                     diag.add_note("Macro invocation '!' must appear on an invocation");
-                    context.env().add_diag(diag);
+                    context.add_diag(diag);
                     None
                 }
                 Some(access_result!(sp!(_, name @ M::Name(_)), None, None)) => {
@@ -3442,7 +3437,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                         "If you are trying to unpack a struct, try adding fields, e.g.'{} {{}}'",
                         name
                     ));
-                    context.env().add_diag(diag);
+                    context.add_diag(diag);
                     None
                 }
                 Some(access_result!(sp!(loc, M::Variant(_, _)), _tys_opt, _is_macro)) => {
@@ -3454,7 +3449,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                         let msg = "Unexpected assignment of variant";
                         let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                         diag.add_note("If you are trying to unpack an enum variant, use 'match'");
-                        context.env().add_diag(diag);
+                        context.add_diag(diag);
                         None
                     } else {
                         assert!(context.env().has_errors());
@@ -3467,12 +3462,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
         PE::Pack(pn, pfields) => {
             let access_result!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
-            ice_assert!(
-                context.env(),
-                is_macro.is_none(),
-                loc,
-                "Marked a bind as a macro"
-            );
+            ice_assert!(context, is_macro.is_none(), loc, "Marked a bind as a macro");
             let tys_opt = optional_sp_types(context, ptys_opt);
             let efields = assign_unpack_fields(context, loc, pfields)?;
             Some(sp(
@@ -3487,12 +3477,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                 .check_feature(pkg, FeatureGate::PositionalFields, loc);
             let access_result!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
-            ice_assert!(
-                context.env(),
-                is_macro.is_none(),
-                loc,
-                "Marked a bind as a macro"
-            );
+            ice_assert!(context, is_macro.is_none(), loc, "Marked a bind as a macro");
             let tys_opt = optional_sp_types(context, ptys_opt);
             let pfields: Option<_> = exprs
                 .into_iter()
@@ -3504,7 +3489,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
             ))
         }
         _ => {
-            context.env().add_diag(diag!(
+            context.add_diag(diag!(
                 Syntax::InvalidLValue,
                 (
                     loc,

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -65,7 +65,7 @@ type ModuleMembers = BTreeMap<Name, ModuleMemberKind>;
 pub(super) struct DefnContext<'env, 'map> {
     pub(super) named_address_mapping: Option<&'map NamedAddressMap>,
     pub(super) module_members: UniqueMap<ModuleIdent, ModuleMembers>,
-    pub(super) env: &'env mut CompilationEnv,
+    pub(super) env: &'env CompilationEnv,
     pub(super) address_conflicts: BTreeSet<Symbol>,
     pub(super) current_package: Option<Symbol>,
     pub(super) is_source_definition: bool,
@@ -83,7 +83,7 @@ struct Context<'env, 'map> {
 
 impl<'env, 'map> Context<'env, 'map> {
     fn new(
-        compilation_env: &'env mut CompilationEnv,
+        compilation_env: &'env CompilationEnv,
         module_members: UniqueMap<ModuleIdent, ModuleMembers>,
         address_conflicts: BTreeSet<Symbol>,
     ) -> Self {
@@ -111,7 +111,7 @@ impl<'env, 'map> Context<'env, 'map> {
         }
     }
 
-    fn env(&mut self) -> &mut CompilationEnv {
+    fn env(&mut self) -> &CompilationEnv {
         self.defn_context.env
     }
 
@@ -439,7 +439,7 @@ fn default_aliases(context: &mut Context) -> AliasMapBuilder {
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: P::Program,
 ) -> E::Program {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -33,6 +33,7 @@ use crate::{
         NATIVE_MODIFIER,
     },
     shared::{
+        ide::{IDEAnnotation, IDEInfo},
         known_attributes::AttributePosition,
         string_utils::{is_pascal_case, is_upper_snake_case},
         unique_map::UniqueMap,
@@ -271,6 +272,16 @@ impl<'env, 'map> Context<'env, 'map> {
         self.defn_context.add_diags(diags);
     }
 
+    #[allow(unused)]
+    pub fn extend_ide_info(&mut self, info: IDEInfo) {
+        self.defn_context.extend_ide_info(info);
+    }
+
+    #[allow(unused)]
+    pub fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+        self.defn_context.add_ide_annotation(loc, info);
+    }
+
     pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.defn_context.add_warning_filter_scope(filters)
     }
@@ -287,6 +298,15 @@ impl DefnContext<'_, '_> {
 
     pub(super) fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub(super) fn extend_ide_info(&mut self, info: IDEInfo) {
+        self.env.extend_ide_info(&self.warning_filters_scope, info);
+    }
+
+    pub(super) fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+        self.env
+            .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }
 
     pub(super) fn add_warning_filter_scope(&mut self, filters: WarningFilters) {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -263,22 +263,22 @@ impl<'env, 'map> Context<'env, 'map> {
         )
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.defn_context.add_diag(diag);
     }
 
     #[allow(unused)]
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.defn_context.add_diags(diags);
     }
 
     #[allow(unused)]
-    pub fn extend_ide_info(&mut self, info: IDEInfo) {
+    pub fn extend_ide_info(&self, info: IDEInfo) {
         self.defn_context.extend_ide_info(info);
     }
 
     #[allow(unused)]
-    pub fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+    pub fn add_ide_annotation(&self, loc: Loc, info: IDEAnnotation) {
         self.defn_context.add_ide_annotation(loc, info);
     }
 
@@ -292,19 +292,19 @@ impl<'env, 'map> Context<'env, 'map> {
 }
 
 impl DefnContext<'_, '_> {
-    pub(super) fn add_diag(&mut self, diag: Diagnostic) {
+    pub(super) fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
-    pub(super) fn add_diags(&mut self, diags: Diagnostics) {
+    pub(super) fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub(super) fn extend_ide_info(&mut self, info: IDEInfo) {
+    pub(super) fn extend_ide_info(&self, info: IDEInfo) {
         self.env.extend_ide_info(&self.warning_filters_scope, info);
     }
 
-    pub(super) fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+    pub(super) fn add_ide_annotation(&self, loc: Loc, info: IDEAnnotation) {
         self.env
             .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1740,18 +1740,28 @@ fn explicit_use_fun(
     } = pexplicit;
     let access_result!(function, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::ApplyPositional, *function)?;
-    ice_assert!(context, tyargs.is_none(), loc, "'use fun' with tyargs");
     ice_assert!(
-        context,
+        context.env(),
+        tyargs.is_none(),
+        loc,
+        "'use fun' with tyargs"
+    );
+    ice_assert!(
+        context.env(),
         is_macro.is_none(),
         loc,
         "Found a 'use fun' as a macro"
     );
     let access_result!(ty, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::Type, *ty)?;
-    ice_assert!(context, tyargs.is_none(), loc, "'use fun' with tyargs");
     ice_assert!(
-        context,
+        context.env(),
+        tyargs.is_none(),
+        loc,
+        "'use fun' with tyargs"
+    );
+    ice_assert!(
+        context.env(),
         is_macro.is_none(),
         loc,
         "Found a 'use fun' as a macro"
@@ -3308,7 +3318,7 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
         PB::Unpack(ptn, pfields) => {
             let access_result!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, *ptn)?;
-            ice_assert!(context, is_macro.is_none(), loc, "Found macro in lhs");
+            ice_assert!(context.env(), is_macro.is_none(), loc, "Found macro in lhs");
             let tys_opt = optional_sp_types(context, ptys_opt);
             let fields = match pfields {
                 FieldBindings::Named(named_bindings) => {
@@ -3462,7 +3472,12 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
         PE::Pack(pn, pfields) => {
             let access_result!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
-            ice_assert!(context, is_macro.is_none(), loc, "Marked a bind as a macro");
+            ice_assert!(
+                context.env(),
+                is_macro.is_none(),
+                loc,
+                "Marked a bind as a macro"
+            );
             let tys_opt = optional_sp_types(context, ptys_opt);
             let efields = assign_unpack_fields(context, loc, pfields)?;
             Some(sp(
@@ -3477,7 +3492,12 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                 .check_feature(pkg, FeatureGate::PositionalFields, loc);
             let access_result!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
-            ice_assert!(context, is_macro.is_none(), loc, "Marked a bind as a macro");
+            ice_assert!(
+                context.env(),
+                is_macro.is_none(),
+                loc,
+                "Marked a bind as a macro"
+            );
             let tys_opt = optional_sp_types(context, ptys_opt);
             let pfields: Option<_> = exprs
                 .into_iter()

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -209,6 +209,7 @@ impl<'env> Context<'env> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     diag,
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     expansion::ast::ModuleIdent,
     ice,
     naming::ast::{self as N, BlockLabel},
@@ -189,6 +190,7 @@ impl ControlFlow {
 
 struct Context<'env> {
     env: &'env mut CompilationEnv,
+    warning_filters_scope: WarningFiltersScope,
     // loops: Vec<BlockLabel>,
 }
 
@@ -196,7 +198,27 @@ impl<'env> Context<'env> {
     pub fn new(env: &'env mut CompilationEnv) -> Self {
         // let loops = vec![];
         // Context { env , loops }
-        Context { env }
+        let warning_filters_scope = env.top_level_warning_filter_scope().clone();
+        Context {
+            env,
+            warning_filters_scope,
+        }
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    pub fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.warning_filters_scope.pop()
     }
 
     fn maybe_report_value_error(&mut self, error: &mut ControlFlow) -> bool {
@@ -208,8 +230,7 @@ impl<'env> Context<'env> {
                 reported,
             } if !*reported => {
                 *reported = true;
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (*loc, VALUE_UNREACHABLE_MSG)));
+                self.add_diag(diag!(UnusedItem::DeadCode, (*loc, VALUE_UNREACHABLE_MSG)));
                 true
             }
             CF::Divergent { .. } | CF::None | CF::Possible => false,
@@ -225,8 +246,7 @@ impl<'env> Context<'env> {
                 reported,
             } if !*reported => {
                 *reported = true;
-                self.env
-                    .add_diag(diag!(UnusedItem::DeadCode, (*loc, DIVERGENT_MSG)));
+                self.add_diag(diag!(UnusedItem::DeadCode, (*loc, DIVERGENT_MSG)));
                 true
             }
             CF::Divergent { .. } | CF::None | CF::Possible => false,
@@ -250,7 +270,7 @@ impl<'env> Context<'env> {
                 if let Some(next_loc) = next_stmt {
                     diag.add_secondary_label((*next_loc, UNREACHABLE_MSG));
                 }
-                self.env.add_diag(diag);
+                self.add_diag(diag);
                 true
             }
             CF::Divergent { .. } | CF::None | CF::Possible => false,
@@ -271,7 +291,7 @@ impl<'env> Context<'env> {
                     reported,
                 } if !*reported => {
                     *reported = true;
-                    self.env.add_diag(diag!(
+                    self.add_diag(diag!(
                         UnusedItem::TrailingSemi,
                         (tail_exp.exp.loc, SEMI_MSG),
                         (*loc, DIVERGENT_MSG),
@@ -356,16 +376,14 @@ fn modules(context: &mut Context, modules: &UniqueMap<ModuleIdent, T::ModuleDefi
 }
 
 fn module(context: &mut Context, mdef: &T::ModuleDefinition) {
-    context
-        .env
-        .add_warning_filter_scope(mdef.warning_filter.clone());
+    context.add_warning_filter_scope(mdef.warning_filter.clone());
     for (_, cname, cdef) in &mdef.constants {
         constant(context, cname, cdef);
     }
     for (_, fname, fdef) in &mdef.functions {
         function(context, fname, fdef);
     }
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 }
 
 //**************************************************************************************************
@@ -378,9 +396,9 @@ fn function(context: &mut Context, _name: &Symbol, f: &T::Function) {
         body,
         ..
     } = f;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     function_body(context, body);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 }
 
 fn function_body(context: &mut Context, sp!(_, tb_): &T::FunctionBody) {
@@ -395,9 +413,7 @@ fn function_body(context: &mut Context, sp!(_, tb_): &T::FunctionBody) {
 //**************************************************************************************************
 
 fn constant(context: &mut Context, _name: &Symbol, cdef: &T::Constant) {
-    context
-        .env
-        .add_warning_filter_scope(cdef.warning_filter.clone());
+    context.add_warning_filter_scope(cdef.warning_filter.clone());
     let eloc = cdef.value.exp.loc;
     let tseq = {
         let mut v = VecDeque::new();
@@ -408,7 +424,7 @@ fn constant(context: &mut Context, _name: &Symbol, cdef: &T::Constant) {
         v
     };
     body(context, &tseq);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 }
 
 //**************************************************************************************************
@@ -452,9 +468,7 @@ fn tail(context: &mut Context, e: &T::Exp) -> ControlFlow {
             |context, flow| context.maybe_report_tail_error(flow),
         ),
         E::VariantMatch(..) => {
-            context
-                .env
-                .add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
+            context.add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
             CF::None
         }
 
@@ -508,7 +522,7 @@ fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Control
             None => ControlFlow::None,
             Some(sp!(_, S::Seq(last))) => tail(context, last),
             Some(sp!(loc, _)) => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     *loc,
                     "ICE last sequence item should have been an exp in dead code analysis"
                 )));
@@ -560,9 +574,7 @@ fn value(context: &mut Context, e: &T::Exp) -> ControlFlow {
             |context, flow| context.maybe_report_value_error(flow),
         ),
         E::VariantMatch(_subject, _, _arms) => {
-            context
-                .env
-                .add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
+            context.add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
             CF::None
         }
         E::While(..) => statement(context, e),
@@ -618,7 +630,7 @@ fn value(context: &mut Context, e: &T::Exp) -> ControlFlow {
                         context.maybe_report_value_error(&mut flow);
                     }
                     T::ExpListItem::Splat(_, _, _) => {
-                        context.env.add_diag(ice!((
+                        context.add_diag(ice!((
                             *eloc,
                             "ICE splat exp unsupported by dead code analysis"
                         )));
@@ -686,7 +698,7 @@ fn value_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Contro
             None => ControlFlow::None,
             Some(sp!(_, S::Seq(last))) => value(context, last),
             Some(sp!(loc, _)) => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     *loc,
                     "ICE last sequence item should have been an exp in dead code analysis"
                 )));
@@ -739,9 +751,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> ControlFlow {
             |_, _| false,
         ),
         E::VariantMatch(_subject, _, _arms) => {
-            context
-                .env
-                .add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
+            context.add_diag(ice!((*eloc, "Found variant match in detect_dead_code")));
             CF::None
         }
         E::While(name, test, body) => {
@@ -826,9 +836,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> ControlFlow {
         // odds and ends -- things we need to deal with but that don't do much
         // -----------------------------------------------------------------------------------------
         E::Use(_) => {
-            context
-                .env
-                .add_diag(ice!((*eloc, "ICE found unexpanded use")));
+            context.add_diag(ice!((*eloc, "ICE found unexpanded use")));
             CF::None
         }
     }

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -214,7 +214,7 @@ impl<'env> Context<'env> {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -377,7 +377,7 @@ fn modules(context: &mut Context, modules: &UniqueMap<ModuleIdent, T::ModuleDefi
 }
 
 fn module(context: &mut Context, mdef: &T::ModuleDefinition) {
-    context.add_warning_filter_scope(mdef.warning_filter.clone());
+    context.push_warning_filter_scope(mdef.warning_filter.clone());
     for (_, cname, cdef) in &mdef.constants {
         constant(context, cname, cdef);
     }
@@ -397,7 +397,7 @@ fn function(context: &mut Context, _name: &Symbol, f: &T::Function) {
         body,
         ..
     } = f;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     function_body(context, body);
     context.pop_warning_filter_scope();
 }
@@ -414,7 +414,7 @@ fn function_body(context: &mut Context, sp!(_, tb_): &T::FunctionBody) {
 //**************************************************************************************************
 
 fn constant(context: &mut Context, _name: &Symbol, cdef: &T::Constant) {
-    context.add_warning_filter_scope(cdef.warning_filter.clone());
+    context.push_warning_filter_scope(cdef.warning_filter.clone());
     let eloc = cdef.value.exp.loc;
     let tseq = {
         let mut v = VecDeque::new();

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -205,12 +205,12 @@ impl<'env> Context<'env> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -189,13 +189,13 @@ impl ControlFlow {
 }
 
 struct Context<'env> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
     // loops: Vec<BlockLabel>,
 }
 
 impl<'env> Context<'env> {
-    pub fn new(env: &'env mut CompilationEnv) -> Self {
+    pub fn new(env: &'env CompilationEnv) -> Self {
         // let loops = vec![];
         // Context { env , loops }
         let warning_filters_scope = env.top_level_warning_filter_scope().clone();
@@ -364,7 +364,7 @@ fn infinite_loop(loc: Loc) -> ControlFlow {
 // Entry
 //**************************************************************************************************
 
-pub fn program(compilation_env: &mut CompilationEnv, prog: &T::Program) {
+pub fn program(compilation_env: &CompilationEnv, prog: &T::Program) {
     let mut context = Context::new(compilation_env);
     modules(&mut context, &prog.modules);
 }

--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -724,7 +724,7 @@ fn make_arm_unpack(
                 let Some((queue_entries, unpack)) =
                     arm_variant_unpack(context, None, ploc, m, e, tys, v, fs, entry)
                 else {
-                    context.hlir_context.env.add_diag(ice!((
+                    context.hlir_context.add_diag(ice!((
                         ploc,
                         "Did not build an arm unpack for a value variant"
                     )));
@@ -750,7 +750,7 @@ fn make_arm_unpack(
                 let Some((queue_entries, unpack)) =
                     arm_struct_unpack(context, None, ploc, m, s, tys, fs, entry)
                 else {
-                    context.hlir_context.env.add_diag(ice!((
+                    context.hlir_context.add_diag(ice!((
                         ploc,
                         "Did not build an arm unpack for a value struct"
                     )));

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -176,6 +176,7 @@ impl<'env> Context<'env> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -128,7 +128,7 @@ pub(super) struct HLIRDebugFlags {
 }
 
 pub(super) struct Context<'env> {
-    pub env: &'env mut CompilationEnv,
+    pub env: &'env CompilationEnv,
     pub info: Arc<TypingProgramInfo>,
     pub debug: HLIRDebugFlags,
     warning_filters_scope: WarningFiltersScope,
@@ -144,7 +144,7 @@ pub(super) struct Context<'env> {
 
 impl<'env> Context<'env> {
     pub fn new(
-        env: &'env mut CompilationEnv,
+        env: &'env CompilationEnv,
         _pre_compiled_lib_opt: Option<Arc<FullyCompiledProgram>>,
         prog: &T::Program,
     ) -> Self {
@@ -270,7 +270,7 @@ impl<'env> Context<'env> {
 }
 
 impl MatchContext<true> for Context<'_> {
-    fn env(&mut self) -> &mut CompilationEnv {
+    fn env(&mut self) -> &CompilationEnv {
         self.env
     }
 
@@ -308,7 +308,7 @@ impl MatchContext<true> for Context<'_> {
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: T::Program,
 ) -> H::Program {

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     debug_display, debug_display_verbose, diag,
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     editions::{FeatureGate, Flavor},
     expansion::ast::{self as E, Fields, ModuleIdent, Mutability, TargetKind},
     hlir::{
@@ -130,6 +131,7 @@ pub(super) struct Context<'env> {
     pub env: &'env mut CompilationEnv,
     pub info: Arc<TypingProgramInfo>,
     pub debug: HLIRDebugFlags,
+    warning_filters_scope: WarningFiltersScope,
     current_package: Option<Symbol>,
     function_locals: UniqueMap<H::Var, (Mutability, H::SingleType)>,
     signature: Option<H::FunctionSignature>,
@@ -154,8 +156,10 @@ impl<'env> Context<'env> {
             match_specialization: false,
             match_work_queue: false,
         };
+        let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         Context {
             env,
+            warning_filters_scope,
             info: prog.info.clone(),
             debug,
             current_package: None,
@@ -166,6 +170,22 @@ impl<'env> Context<'env> {
             named_block_binders: UniqueMap::new(),
             named_block_types: UniqueMap::new(),
         }
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    pub fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.warning_filters_scope.pop()
     }
 
     pub fn has_empty_locals(&self) -> bool {
@@ -337,7 +357,7 @@ fn module(
         constants: tconstants,
     } = mdef;
     context.current_package = package_name;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let structs = tstructs.map(|name, s| struct_def(context, name, s));
     let enums = tenums.map(|name, s| enum_def(context, name, s));
 
@@ -353,7 +373,7 @@ fn module(
     gen_unused_warnings(context, target_kind, &structs);
 
     context.current_package = None;
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     (
         module_ident,
         H::ModuleDefinition {
@@ -391,10 +411,10 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
         body,
     } = f;
     assert!(macro_.is_none(), "ICE macros filtered above");
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let signature = function_signature(context, signature);
     let body = function_body(context, &signature, _name, body);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     H::Function {
         warning_filter,
         index,
@@ -499,7 +519,7 @@ fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H:
         signature: tsignature,
         value: tvalue,
     } = cdef;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let signature = base_type(context, tsignature);
     let eloc = tvalue.exp.loc;
     let tseq = {
@@ -513,7 +533,7 @@ fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H:
         return_type: H::Type_::base(signature.clone()),
     };
     let (locals, body) = function_body_defined(context, &function_signature, loc, tseq);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     H::Constant {
         warning_filter,
         index,
@@ -542,9 +562,9 @@ fn struct_def(
         type_parameters,
         fields,
     } = sdef;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let fields = struct_fields(context, fields);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     H::StructDefinition {
         warning_filter,
         index,
@@ -586,13 +606,13 @@ fn enum_def(
         type_parameters,
         variants,
     } = edef;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     let variants = variants.map(|_, defn| H::VariantDefinition {
         index: defn.index,
         loc: defn.loc,
         fields: variant_fields(context, defn.fields),
     });
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     H::EnumDefinition {
         warning_filter,
         index,
@@ -648,7 +668,7 @@ fn base_type(context: &mut Context, sp!(loc, nb_): N::Type) -> H::BaseType {
     use N::Type_ as NT;
     let b_ = match nb_ {
         NT::Var(_) => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 format!(
                     "ICE type inf. var not expanded: {}",
@@ -658,7 +678,7 @@ fn base_type(context: &mut Context, sp!(loc, nb_): N::Type) -> H::BaseType {
             return error_base_type(loc);
         }
         NT::Apply(None, _, _) => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 format!("ICE kind not expanded: {}", debug_display_verbose!(nb_))
             )));
@@ -669,7 +689,7 @@ fn base_type(context: &mut Context, sp!(loc, nb_): N::Type) -> H::BaseType {
         NT::UnresolvedError => HB::UnresolvedError,
         NT::Anything => HB::Unreachable,
         NT::Ref(_, _) | NT::Unit | NT::Fun(_, _) => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 format!(
                     "ICE base type constraint failed: {}",
@@ -716,7 +736,7 @@ fn type_(context: &mut Context, sp!(loc, ty_): N::Type) -> H::Type {
     let t_ = match ty_ {
         NT::Unit => HT::Unit,
         NT::Apply(None, _, _) => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 format!("ICE kind not expanded: {}", debug_display_verbose!(ty_))
             )));
@@ -972,9 +992,7 @@ fn tail(
         | E::Continue(_)
         | E::Assign(_, _, _)
         | E::Mutate(_, _) => {
-            context
-                .env
-                .add_diag(ice!((eloc, "ICE statement mishandled in HLIR lowering")));
+            context.add_diag(ice!((eloc, "ICE statement mishandled in HLIR lowering")));
             None
         }
 
@@ -1004,9 +1022,7 @@ fn tail_block(
         None => None,
         Some(sp!(_, S::Seq(last))) => tail(context, block, expected_type, *last),
         Some(sp!(loc, _)) => {
-            context
-                .env
-                .add_diag(ice!((loc, "ICE statement mishandled in HLIR lowering")));
+            context.add_diag(ice!((loc, "ICE statement mishandled in HLIR lowering")));
             None
         }
     }
@@ -1068,18 +1084,14 @@ fn value(
             let [cond_item, code_item]: [TI; 2] = match arguments.exp.value {
                 E::ExpList(arg_list) => arg_list.try_into().unwrap(),
                 _ => {
-                    context
-                        .env
-                        .add_diag(ice!((eloc, "ICE type checking assert failed")));
+                    context.add_diag(ice!((eloc, "ICE type checking assert failed")));
                     return error_exp(eloc);
                 }
             };
             let (econd, ecode) = match (cond_item, code_item) {
                 (TI::Single(econd, _), TI::Single(ecode, _)) => (econd, ecode),
                 _ => {
-                    context
-                        .env
-                        .add_diag(ice!((eloc, "ICE type checking assert failed")));
+                    context.add_diag(ice!((eloc, "ICE type checking assert failed")));
                     return error_exp(eloc);
                 }
             };
@@ -1106,18 +1118,14 @@ fn value(
             let [cond_item, code_item]: [TI; 2] = match arguments.exp.value {
                 E::ExpList(arg_list) => arg_list.try_into().unwrap(),
                 _ => {
-                    context
-                        .env
-                        .add_diag(ice!((eloc, "ICE type checking assert failed")));
+                    context.add_diag(ice!((eloc, "ICE type checking assert failed")));
                     return error_exp(eloc);
                 }
             };
             let (econd, ecode) = match (cond_item, code_item) {
                 (TI::Single(econd, _), TI::Single(ecode, _)) => (econd, ecode),
                 _ => {
-                    context
-                        .env
-                        .add_diag(ice!((eloc, "ICE type checking assert failed")));
+                    context.add_diag(ice!((eloc, "ICE type checking assert failed")));
                     return error_exp(eloc);
                 }
             };
@@ -1514,7 +1522,7 @@ fn value(
                     var,
                 } => var,
                 _ => {
-                    context.env.add_diag(ice!((
+                    context.add_diag(ice!((
                         eloc,
                         format!(
                             "ICE invalid bind_exp for single value: {}",
@@ -1538,7 +1546,7 @@ fn value(
                 | Some(bt @ sp!(_, BT::U128))
                 | Some(bt @ sp!(_, BT::U256)) => *bt,
                 _ => {
-                    context.env.add_diag(ice!((
+                    context.add_diag(ice!((
                         eloc,
                         format!(
                             "ICE typing failed for cast: {} : {}",
@@ -1603,9 +1611,7 @@ fn value(
         | E::Continue(_)
         | E::Assign(_, _, _)
         | E::Mutate(_, _) => {
-            context
-                .env
-                .add_diag(ice!((eloc, "ICE statement mishandled in HLIR lowering")));
+            context.add_diag(ice!((eloc, "ICE statement mishandled in HLIR lowering")));
             error_exp(eloc)
         }
 
@@ -1613,7 +1619,7 @@ fn value(
         // odds and ends -- things we need to deal with but that don't do much
         // -----------------------------------------------------------------------------------------
         E::Use(_) => {
-            context.env.add_diag(ice!((eloc, "ICE unexpanded use")));
+            context.add_diag(ice!((eloc, "ICE unexpanded use")));
             error_exp(eloc)
         }
         E::UnresolvedError => {
@@ -1637,15 +1643,11 @@ fn value_block(
     match last_exp {
         Some(sp!(_, S::Seq(last))) => value(context, block, expected_type, *last),
         Some(sp!(loc, _)) => {
-            context
-                .env
-                .add_diag(ice!((loc, "ICE last sequence item should be an exp")));
+            context.add_diag(ice!((loc, "ICE last sequence item should be an exp")));
             error_exp(loc)
         }
         None => {
-            context
-                .env
-                .add_diag(ice!((seq_loc, "ICE empty sequence in value position")));
+            context.add_diag(ice!((seq_loc, "ICE empty sequence in value position")));
             error_exp(seq_loc)
         }
     }
@@ -1980,7 +1982,7 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         // odds and ends -- things we need to deal with but that don't do much
         // -----------------------------------------------------------------------------------------
         E::Use(_) => {
-            context.env.add_diag(ice!((eloc, "ICE unexpanded use")));
+            context.add_diag(ice!((eloc, "ICE unexpanded use")));
         }
     }
 }
@@ -2503,7 +2505,7 @@ fn bind_value_in_block(
         match lvalue {
             H::LValue_::Var { .. } => (),
             lv => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     *loc,
                     format!(
                         "ICE tried bind_value for non-var lvalue {}",
@@ -2603,9 +2605,7 @@ fn process_value(context: &mut Context, sp!(loc, ev_): E::Value) -> H::Value {
     use H::Value_ as HV;
     let v_ = match ev_ {
         EV::InferredNum(_) => {
-            context
-                .env
-                .add_diag(ice!((loc, "ICE not expanded to value")));
+            context.add_diag(ice!((loc, "ICE not expanded to value")));
             HV::U64(0)
         }
         EV::Address(a) => HV::Address(a.into_addr_bytes()),
@@ -2941,7 +2941,7 @@ fn needs_freeze(
                         format!("Expected type: {}", debug_display_verbose!(_expected))
                     ),
                 );
-                context.env.add_diag(diag);
+                context.add_diag(diag);
             }
             Freeze::NotNeeded
         }
@@ -2982,7 +2982,7 @@ fn freeze(context: &mut Context, expected_type: &H::Type, e: H::Exp) -> (Block, 
                                 "ICE list item has Multple type: {}",
                                 debug_display_verbose!(e.ty)
                             );
-                            context.env.add_diag(ice!((e.ty.loc, msg)));
+                            context.add_diag(ice!((e.ty.loc, msg)));
                             H::SingleType_::base(error_base_type(e.ty.loc))
                         }
                     })
@@ -3044,9 +3044,7 @@ fn gen_unused_warnings(
     let is_sui_mode = context.env.package_config(context.current_package).flavor == Flavor::Sui;
 
     for (_, sname, sdef) in structs {
-        context
-            .env
-            .add_warning_filter_scope(sdef.warning_filter.clone());
+        context.add_warning_filter_scope(sdef.warning_filter.clone());
 
         let has_key = sdef.abilities.has_ability_(Ability_::Key);
 
@@ -3062,13 +3060,11 @@ fn gen_unused_warnings(
                     .is_some_and(|names| names.contains(&f.value()))
                 {
                     let msg = format!("The '{}' field of the '{sname}' type is unused", f.value());
-                    context
-                        .env
-                        .add_diag(diag!(UnusedItem::StructField, (f.loc(), msg)));
+                    context.add_diag(diag!(UnusedItem::StructField, (f.loc(), msg)));
                 }
             }
         }
 
-        context.env.pop_warning_filter_scope();
+        context.pop_warning_filter_scope();
     }
 }

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -181,7 +181,7 @@ impl<'env> Context<'env> {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -358,7 +358,7 @@ fn module(
         constants: tconstants,
     } = mdef;
     context.current_package = package_name;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let structs = tstructs.map(|name, s| struct_def(context, name, s));
     let enums = tenums.map(|name, s| enum_def(context, name, s));
 
@@ -412,7 +412,7 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
         body,
     } = f;
     assert!(macro_.is_none(), "ICE macros filtered above");
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let signature = function_signature(context, signature);
     let body = function_body(context, &signature, _name, body);
     context.pop_warning_filter_scope();
@@ -520,7 +520,7 @@ fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H:
         signature: tsignature,
         value: tvalue,
     } = cdef;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let signature = base_type(context, tsignature);
     let eloc = tvalue.exp.loc;
     let tseq = {
@@ -563,7 +563,7 @@ fn struct_def(
         type_parameters,
         fields,
     } = sdef;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let fields = struct_fields(context, fields);
     context.pop_warning_filter_scope();
     H::StructDefinition {
@@ -607,7 +607,7 @@ fn enum_def(
         type_parameters,
         variants,
     } = edef;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let variants = variants.map(|_, defn| H::VariantDefinition {
         index: defn.index,
         loc: defn.loc,
@@ -3045,7 +3045,7 @@ fn gen_unused_warnings(
     let is_sui_mode = context.env.package_config(context.current_package).flavor == Flavor::Sui;
 
     for (_, sname, sdef) in structs {
-        context.add_warning_filter_scope(sdef.warning_filter.clone());
+        context.push_warning_filter_scope(sdef.warning_filter.clone());
 
         let has_key = sdef.abilities.has_ability_(Ability_::Key);
 

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -172,12 +172,12 @@ impl<'env> Context<'env> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -13,7 +13,7 @@ use crate::{
         visitor::{CFGIRVisitorConstructor, CFGIRVisitorContext},
     },
     diag,
-    diagnostics::WarningFilters,
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     editions::FeatureGate,
     hlir::ast as H,
     shared::{CompilationEnv, WarningFiltersScope},
@@ -46,30 +46,19 @@ impl CFGIRVisitorConstructor for AssertAbortNamedConstants {
 }
 
 impl Context<'_> {
-    fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
+    fn add_diag(&mut self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
+    fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
-    }
-}
-
-impl Context<'_> {
-    fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
-        self.env.add_diag(diag);
-    }
-
-    #[allow(unused)]
-    fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
-        self.env.add_diags(diags);
     }
 }
 
 impl CFGIRVisitorContext for Context<'_> {
     fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
-        self.env.add_warning_filter_scope(filters)
+        self.warning_filters_scope.push(filters)
     }
 
     fn pop_warning_filter_scope(&mut self) {

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -50,6 +50,7 @@ impl Context<'_> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -46,12 +46,12 @@ impl CFGIRVisitorConstructor for AssertAbortNamedConstants {
 }
 
 impl Context<'_> {
-    fn add_diag(&mut self, diag: Diagnostic) {
+    fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    fn add_diags(&mut self, diags: Diagnostics) {
+    fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 }

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -57,7 +57,7 @@ impl Context<'_> {
 }
 
 impl CFGIRVisitorContext for Context<'_> {
-    fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -23,14 +23,14 @@ pub struct AssertAbortNamedConstants;
 
 pub struct Context<'a> {
     package_name: Option<Symbol>,
-    env: &'a mut CompilationEnv,
+    env: &'a CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
 }
 
 impl CFGIRVisitorConstructor for AssertAbortNamedConstants {
     type Context<'a> = Context<'a>;
 
-    fn context<'a>(env: &'a mut CompilationEnv, program: &G::Program) -> Self::Context<'a> {
+    fn context<'a>(env: &'a CompilationEnv, program: &G::Program) -> Self::Context<'a> {
         let package_name = program
             .modules
             .iter()

--- a/external-crates/move/crates/move-compiler/src/linters/redundant_ref_deref.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/redundant_ref_deref.rs
@@ -5,6 +5,7 @@
 // It identifies and reports unnecessary temporary borrow followed by a deref, suggesting either
 // removal or conversion to `copy`.
 
+use crate::cfgir::visitor::simple_visitor;
 use crate::linters::StyleCodes;
 use crate::{
     diag,

--- a/external-crates/move/crates/move-compiler/src/linters/redundant_ref_deref.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/redundant_ref_deref.rs
@@ -5,7 +5,6 @@
 // It identifies and reports unnecessary temporary borrow followed by a deref, suggesting either
 // removal or conversion to `copy`.
 
-use crate::cfgir::visitor::simple_visitor;
 use crate::linters::StyleCodes;
 use crate::{
     diag,

--- a/external-crates/move/crates/move-compiler/src/linters/unnecessary_conditional.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unnecessary_conditional.rs
@@ -15,7 +15,12 @@ use crate::{
     },
 };
 
+<<<<<<< HEAD
 simple_visitor!(
+=======
+pub struct UnnecessaryConditional;
+simple_visitor! {
+>>>>>>> be261b7bda (linters)
     UnnecessaryConditional,
     fn visit_exp_custom(&mut self, exp: &T::Exp) -> bool {
         let UnannotatedExp_::IfElse(_, etrue, efalse) = &exp.exp.value else {

--- a/external-crates/move/crates/move-compiler/src/linters/unnecessary_conditional.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unnecessary_conditional.rs
@@ -15,12 +15,7 @@ use crate::{
     },
 };
 
-<<<<<<< HEAD
 simple_visitor!(
-=======
-pub struct UnnecessaryConditional;
-simple_visitor! {
->>>>>>> be261b7bda (linters)
     UnnecessaryConditional,
     fn visit_exp_custom(&mut self, exp: &T::Exp) -> bool {
         let UnannotatedExp_::IfElse(_, etrue, efalse) = &exp.exp.value else {

--- a/external-crates/move/crates/move-compiler/src/naming/fake_natives.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/fake_natives.rs
@@ -24,6 +24,7 @@ pub fn function(
     function_name: FunctionName,
     function: &N::Function,
 ) {
+    let warning_filters = env.top_level_warning_filter_scope();
     let loc = match function
         .attributes
         .get_loc_(&NativeAttribute::BytecodeInstruction.into())
@@ -45,7 +46,7 @@ pub fn function(
             (loc, attr_msg),
             (function_name.loc(), name_msg),
         );
-        env.add_diag(diag);
+        env.add_diag(warning_filters, diag);
     }
     match &function.body.value {
         N::FunctionBody_::Native => (),
@@ -55,7 +56,7 @@ pub fn function(
                 NativeAttribute::BYTECODE_INSTRUCTION
             );
             let diag = diag!(Attributes::InvalidBytecodeInst, (loc, attr_msg));
-            env.add_diag(diag);
+            env.add_diag(warning_filters, diag);
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/naming/fake_natives.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/fake_natives.rs
@@ -24,7 +24,6 @@ pub fn function(
     function_name: FunctionName,
     function: &N::Function,
 ) {
-    let warning_filters = env.top_level_warning_filter_scope();
     let loc = match function
         .attributes
         .get_loc_(&NativeAttribute::BytecodeInstruction.into())
@@ -46,7 +45,7 @@ pub fn function(
             (loc, attr_msg),
             (function_name.loc(), name_msg),
         );
-        env.add_diag(warning_filters, diag);
+        env.add_error_diag(diag);
     }
     match &function.body.value {
         N::FunctionBody_::Native => (),
@@ -56,7 +55,7 @@ pub fn function(
                 NativeAttribute::BYTECODE_INSTRUCTION
             );
             let diag = diag!(Attributes::InvalidBytecodeInst, (loc, attr_msg));
-            env.add_diag(warning_filters, diag);
+            env.add_error_diag(diag);
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/naming/fake_natives.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/fake_natives.rs
@@ -19,7 +19,7 @@ use move_symbol_pool::symbol;
 
 /// verify fake native attribute usage usage
 pub fn function(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     module: ModuleIdent,
     function_name: FunctionName,
     function: &N::Function,

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -37,12 +37,12 @@ impl<'env, 'info> Context<'env, 'info> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -41,6 +41,7 @@ impl<'env, 'info> Context<'env, 'info> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -16,7 +16,7 @@ use move_proc_macros::growing_stack;
 //**************************************************************************************************
 
 struct Context<'env, 'info> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     info: &'info NamingProgramInfo,
     warning_filters_scope: WarningFiltersScope,
     current_module: ModuleIdent,
@@ -24,7 +24,7 @@ struct Context<'env, 'info> {
 
 impl<'env, 'info> Context<'env, 'info> {
     fn new(
-        env: &'env mut CompilationEnv,
+        env: &'env CompilationEnv,
         info: &'info NamingProgramInfo,
         current_module: ModuleIdent,
     ) -> Self {
@@ -58,7 +58,7 @@ impl<'env, 'info> Context<'env, 'info> {
 // Entry
 //**************************************************************************************************
 
-pub fn program(env: &mut CompilationEnv, info: &mut NamingProgramInfo, inner: &mut N::Program_) {
+pub fn program(env: &CompilationEnv, info: &mut NamingProgramInfo, inner: &mut N::Program_) {
     let N::Program_ { modules } = inner;
     for (mident, mdef) in modules.key_cloned_iter_mut() {
         module(env, info, mident, mdef);
@@ -79,7 +79,7 @@ pub fn program(env: &mut CompilationEnv, info: &mut NamingProgramInfo, inner: &m
 }
 
 fn module(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     info: &mut NamingProgramInfo,
     mident: ModuleIdent,
     mdef: &mut N::ModuleDefinition,

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -46,7 +46,7 @@ impl<'env, 'info> Context<'env, 'info> {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -86,7 +86,7 @@ fn module(
     mdef: &mut N::ModuleDefinition,
 ) {
     let context = &mut Context::new(env, info, mident);
-    context.add_warning_filter_scope(mdef.warning_filter.clone());
+    context.push_warning_filter_scope(mdef.warning_filter.clone());
     use_funs(context, &mut mdef.use_funs);
     for (_, _, c) in &mut mdef.constants {
         constant(context, c);
@@ -98,13 +98,13 @@ fn module(
 }
 
 fn constant(context: &mut Context, c: &mut N::Constant) {
-    context.add_warning_filter_scope(c.warning_filter.clone());
+    context.push_warning_filter_scope(c.warning_filter.clone());
     exp(context, &mut c.value);
     context.pop_warning_filter_scope();
 }
 
 fn function(context: &mut Context, function: &mut N::Function) {
-    context.add_warning_filter_scope(function.warning_filter.clone());
+    context.push_warning_filter_scope(function.warning_filter.clone());
     if let N::FunctionBody_::Defined(seq) = &mut function.body.value {
         sequence(context, seq)
     }

--- a/external-crates/move/crates/move-compiler/src/naming/syntax_methods.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/syntax_methods.rs
@@ -147,7 +147,7 @@ fn attr_param_from_str(loc: Loc, name_str: &str) -> Option<SyntaxMethodPrekind> 
 
 /// Resolve the mapping for a function + syntax attribute into a SyntaxMethodKind.
 fn resolve_syntax_method_prekind(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     sp!(loc, attr_): &Attribute,
 ) -> Option<BTreeSet<SyntaxMethodPrekind>> {
     match attr_ {

--- a/external-crates/move/crates/move-compiler/src/naming/syntax_methods.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/syntax_methods.rs
@@ -68,7 +68,7 @@ pub(super) fn resolve_syntax_attributes(
     if let Some(macro_loc) = function.macro_ {
         let msg = "Syntax attributes may not appear on macro definitions";
         let fn_msg = "This function is a macro";
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             Declarations::InvalidSyntaxMethod,
             (attr_loc, msg),
             (macro_loc, fn_msg)
@@ -125,7 +125,7 @@ fn prev_syntax_defn_error(
         kind_string, type_name
     );
     let prev_msg = "This syntax method was previously defined here.";
-    context.env.add_diag(diag!(
+    context.add_diag(diag!(
         Declarations::InvalidAttribute,
         (sloc, msg),
         (prev.loc, prev_msg)
@@ -157,7 +157,7 @@ fn resolve_syntax_method_prekind(
                 SyntaxAttribute::SYNTAX,
                 SyntaxAttribute::INDEX
             );
-            env.add_diag(diag!(Declarations::InvalidAttribute, (*loc, msg)));
+            env.add_error_diag(diag!(Declarations::InvalidAttribute, (*loc, msg)));
             None
         }
         Attribute_::Parameterized(_, inner) => {
@@ -169,7 +169,7 @@ fn resolve_syntax_method_prekind(
                             if let Some(prev_kind) = kinds.replace(kind) {
                                 let msg = "Repeated syntax method identifier".to_string();
                                 let prev = "Initially defined here".to_string();
-                                env.add_diag(diag!(
+                                env.add_error_diag(diag!(
                                     Declarations::InvalidAttribute,
                                     (loc, msg),
                                     (prev_kind.loc, prev)
@@ -177,7 +177,7 @@ fn resolve_syntax_method_prekind(
                             }
                         } else {
                             let msg = format!("Invalid syntax method identifier '{}'", name);
-                            env.add_diag(diag!(Declarations::InvalidAttribute, (loc, msg)));
+                            env.add_error_diag(diag!(Declarations::InvalidAttribute, (loc, msg)));
                         }
                     }
                     Attribute_::Assigned(n, _) => {
@@ -186,7 +186,7 @@ fn resolve_syntax_method_prekind(
                             SyntaxAttribute::SYNTAX,
                             n
                         );
-                        env.add_diag(diag!(Declarations::InvalidAttribute, (loc, msg)));
+                        env.add_error_diag(diag!(Declarations::InvalidAttribute, (loc, msg)));
                     }
                     Attribute_::Parameterized(n, _) => {
                         let msg = format!(
@@ -194,7 +194,7 @@ fn resolve_syntax_method_prekind(
                             SyntaxAttribute::SYNTAX,
                             n
                         );
-                        env.add_diag(diag!(Declarations::InvalidAttribute, (loc, msg)));
+                        env.add_error_diag(diag!(Declarations::InvalidAttribute, (loc, msg)));
                     }
                 }
             }
@@ -221,7 +221,7 @@ fn determine_valid_kind(
                     SyntaxAttribute::INDEX,
                 );
                 let ty_msg = "This type is not a reference";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::InvalidAttribute,
                     (sloc, msg),
                     (subject_type.loc, ty_msg)
@@ -231,9 +231,7 @@ fn determine_valid_kind(
         }
         SyntaxMethodPrekind_::For => {
             let msg = "'for' syntax attributes are not currently supported";
-            context
-                .env
-                .add_diag(diag!(Declarations::InvalidAttribute, (sloc, msg),));
+            context.add_diag(diag!(Declarations::InvalidAttribute, (sloc, msg),));
             return None;
         }
         // SyntaxMethodPrekind_::For => match mut_opt {
@@ -243,9 +241,7 @@ fn determine_valid_kind(
         // },
         SyntaxMethodPrekind_::Assign => {
             let msg = "'assign' syntax attributes are not currently supported";
-            context
-                .env
-                .add_diag(diag!(Declarations::InvalidAttribute, (sloc, msg),));
+            context.add_diag(diag!(Declarations::InvalidAttribute, (sloc, msg),));
             return None;
         } // SyntaxMethodPrekind_::Assign => match mut_opt {
           //     Some((loc, true)) => SK::Assign,
@@ -255,7 +251,7 @@ fn determine_valid_kind(
           //         SyntaxAttribute::INDEX,
           //     );
           //         let ty_msg = "This type is not a reference";
-          //         context.env.add_diag(diag!(
+          //         context.add_diag(diag!(
           //             Declarations::InvalidAttribute,
           //             (sloc, msg),
           //             (*ty_loc, msg)
@@ -287,7 +283,7 @@ fn determine_subject_type_name(
                     let msg = "Invalid type for syntax method definition";
                     let mut diag = diag!(Declarations::InvalidSyntaxMethod, (*loc, msg));
                     diag.add_note("Syntax methods may only be defined for single base types");
-                    context.env.add_diag(diag);
+                    context.add_diag(diag);
                     return None;
                 }
                 N::TypeName_::Builtin(sp!(_, bt_)) => context.env.primitive_definer(*bt_),
@@ -296,7 +292,7 @@ fn determine_subject_type_name(
             if Some(cur_module) == defining_module {
                 Some(type_name.clone())
             } else {
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::InvalidSyntaxMethod,
                     (*ann_loc, INVALID_MODULE_MSG),
                     (*loc, INVALID_MODULE_TYPE_MSG)
@@ -314,7 +310,7 @@ fn determine_subject_type_name(
                 "But '{}' was declared as a type parameter here",
                 param.user_specified_name
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::InvalidSyntaxMethod,
                 (*ann_loc, msg),
                 (*loc, tmsg)
@@ -329,7 +325,7 @@ fn determine_subject_type_name(
             let msg = "Invalid type for syntax method definition";
             let mut diag = diag!(Declarations::InvalidSyntaxMethod, (*loc, msg));
             diag.add_note("Syntax methods may only be defined for single base types");
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             None
         }
     }
@@ -349,7 +345,7 @@ fn valid_return_type(
                 let msg = format!("Invalid {} annotation", SyntaxAttribute::SYNTAX);
                 let tmsg =
                     "This syntax method must return an immutable reference to match its subject type";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::InvalidSyntaxMethod,
                     (*loc, msg),
                     (ty.loc, tmsg),
@@ -362,7 +358,7 @@ fn valid_return_type(
                     SyntaxAttribute::SYNTAX
                 );
                 let tmsg = "This is not an immutable reference";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::InvalidSyntaxMethod,
                     (*loc, msg),
                     (ty.loc, tmsg),
@@ -379,7 +375,7 @@ fn valid_return_type(
                 let msg = format!("Invalid {} annotation", SyntaxAttribute::SYNTAX);
                 let tmsg =
                     "This syntax method must return a mutable reference to match its subject type";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::InvalidSyntaxMethod,
                     (*loc, msg),
                     (ty.loc, tmsg),
@@ -392,7 +388,7 @@ fn valid_return_type(
                     SyntaxAttribute::SYNTAX
                 );
                 let tmsg = "This is not a mutable reference";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Declarations::InvalidSyntaxMethod,
                     (*loc, msg),
                     (ty.loc, tmsg),
@@ -426,7 +422,7 @@ fn valid_index_return_type(
                 SyntaxAttribute::SYNTAX
             );
             let tmsg = "Unit type occurs as the return type for this function";
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::InvalidSyntaxMethod,
                 (*kind_loc, msg),
                 (*tloc, tmsg)
@@ -439,7 +435,7 @@ fn valid_index_return_type(
                 SyntaxAttribute::SYNTAX
             );
             let tmsg = "But a function type appears in this return type";
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Declarations::InvalidSyntaxMethod,
                 (*kind_loc, msg),
                 (*tloc, tmsg)
@@ -466,9 +462,7 @@ fn get_first_type(
             "Invalid attribute. {} is only valid if the function takes at least one parameter",
             SyntaxAttribute::SYNTAX
         );
-        context
-            .env
-            .add_diag(diag!(Declarations::InvalidAttribute, (*attr_loc, msg)));
+        context.add_diag(diag!(Declarations::InvalidAttribute, (*attr_loc, msg)));
         None
     }
 }

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -527,7 +527,7 @@ pub(super) struct OuterContext {
 }
 
 pub(super) struct Context<'outer, 'env> {
-    pub env: &'env mut CompilationEnv,
+    pub env: &'env CompilationEnv,
     outer: &'outer OuterContext,
     unscoped_types: Vec<BTreeMap<Symbol, ResolvedType>>,
     warning_filters_scope: WarningFiltersScope,
@@ -565,7 +565,7 @@ macro_rules! resolve_from_module_access {
 
 impl OuterContext {
     fn new(
-        compilation_env: &mut CompilationEnv,
+        compilation_env: &CompilationEnv,
         pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
         prog: &E::Program,
     ) -> Self {
@@ -587,7 +587,7 @@ impl OuterContext {
 
 impl<'outer, 'env> Context<'outer, 'env> {
     fn new(
-        env: &'env mut CompilationEnv,
+        env: &'env CompilationEnv,
         outer: &'outer OuterContext,
         current_package: Option<Symbol>,
         current_module: ModuleIdent,
@@ -1640,7 +1640,7 @@ fn arity_string(arity: usize) -> &'static str {
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: E::Program,
 ) -> N::Program {
@@ -1654,7 +1654,7 @@ pub fn program(
 }
 
 fn modules(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     outer: &OuterContext,
     modules: UniqueMap<ModuleIdent, E::ModuleDefinition>,
 ) -> UniqueMap<ModuleIdent, N::ModuleDefinition> {
@@ -1662,7 +1662,7 @@ fn modules(
 }
 
 fn module(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     outer: &OuterContext,
     ident: ModuleIdent,
     mdef: E::ModuleDefinition,

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -24,7 +24,10 @@ use crate::{
         self as P, ConstantName, DatatypeName, Field, FunctionName, VariantName, MACRO_MODIFIER,
     },
     shared::{
-        ide::EllipsisMatchEntries, program_info::NamingProgramInfo, unique_map::UniqueMap, *,
+        ide::{EllipsisMatchEntries, IDEAnnotation, IDEInfo},
+        program_info::NamingProgramInfo,
+        unique_map::UniqueMap,
+        *,
     },
     FullyCompiledProgram,
 };
@@ -618,6 +621,16 @@ impl<'outer, 'env> Context<'outer, 'env> {
     #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    #[allow(unused)]
+    pub fn extend_ide_info(&mut self, info: IDEInfo) {
+        self.env.extend_ide_info(&self.warning_filters_scope, info);
+    }
+
+    pub fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+        self.env
+            .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }
 
     pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
@@ -3443,7 +3456,7 @@ fn expand_positional_ellipsis<T>(
                     let entries = (0..=missing).map(|_| "_".into()).collect::<Vec<_>>();
                     let info = EllipsisMatchEntries::Positional(entries);
                     let info = ide::IDEAnnotation::EllipsisMatchEntries(Box::new(info));
-                    context.env.add_ide_annotation(eloc, info);
+                    context.add_ide_annotation(eloc, info);
                 }
                 result
             }
@@ -3480,7 +3493,7 @@ fn expand_named_ellipsis<T>(
         let entries = fields.iter().map(|field| field.value()).collect::<Vec<_>>();
         let info = EllipsisMatchEntries::Named(entries);
         let info = ide::IDEAnnotation::EllipsisMatchEntries(Box::new(info));
-        context.env.add_ide_annotation(ellipsis_loc, info);
+        context.add_ide_annotation(ellipsis_loc, info);
     }
 
     let start_idx = args.len();

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -614,21 +614,21 @@ impl<'outer, 'env> Context<'outer, 'env> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
     #[allow(unused)]
-    pub fn extend_ide_info(&mut self, info: IDEInfo) {
+    pub fn extend_ide_info(&self, info: IDEInfo) {
         self.env.extend_ide_info(&self.warning_filters_scope, info);
     }
 
-    pub fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+    pub fn add_ide_annotation(&self, loc: Loc, info: IDEAnnotation) {
         self.env
             .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -633,7 +633,7 @@ impl<'outer, 'env> Context<'outer, 'env> {
             .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -1695,7 +1695,7 @@ fn module(
         constants: econstants,
     } = mdef;
     let context = &mut Context::new(env, outer, package_name, ident);
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let mut use_funs = use_funs(context, euse_funs);
     let mut syntax_methods = N::SyntaxMethods::new();
     let friends = efriends.filter_map(|mident, f| friend(context, mident, f));
@@ -2042,7 +2042,7 @@ fn function(
     assert!(context.nominal_block_id == 0);
     assert!(context.used_fun_tparams.is_empty());
     assert!(context.used_locals.is_empty());
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     context.local_scopes = vec![BTreeMap::new()];
     context.local_count = BTreeMap::new();
     context.translating_fun = true;
@@ -2171,7 +2171,7 @@ fn struct_def(
         type_parameters,
         fields,
     } = sdef;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let type_parameters = datatype_type_parameters(context, type_parameters);
     let fields = struct_fields(context, fields);
     context.pop_warning_filter_scope();
@@ -2229,7 +2229,7 @@ fn enum_def(
         type_parameters,
         variants,
     } = edef;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     let type_parameters = datatype_type_parameters(context, type_parameters);
     let variants = enum_variants(context, variants);
     context.pop_warning_filter_scope();
@@ -2301,7 +2301,7 @@ fn constant(context: &mut Context, _name: ConstantName, econstant: E::Constant) 
     assert!(context.local_scopes.is_empty());
     assert!(context.local_count.is_empty());
     assert!(context.used_locals.is_empty());
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     context.local_scopes = vec![BTreeMap::new()];
     let signature = type_(context, TypeAnnotation::ConstantSignature, esignature);
     let value = *exp(context, Box::new(evalue));

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -615,6 +615,7 @@ impl<'outer, 'env> Context<'outer, 'env> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -482,10 +482,7 @@ impl<'input> Lexer<'input> {
     // At the end of parsing, checks whether there are any unmatched documentation comments,
     // producing errors if so. Otherwise returns a map from file position to associated
     // documentation.
-    pub fn check_and_get_doc_comments(
-        &mut self,
-        env: &CompilationEnv,
-    ) -> MatchedFileCommentMap {
+    pub fn check_and_get_doc_comments(&mut self, env: &CompilationEnv) -> MatchedFileCommentMap {
         let msg = "Documentation comment cannot be matched to a language item";
         let diags = self
             .doc_comments

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -495,7 +495,8 @@ impl<'input> Lexer<'input> {
                 diag!(Syntax::InvalidDocComment, (loc, msg))
             })
             .collect();
-        env.add_diags(diags);
+        let warning_filters = env.top_level_warning_filter_scope();
+        env.add_diags(warning_filters, diags);
         std::mem::take(&mut self.matched_doc_comments)
     }
 

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -484,7 +484,7 @@ impl<'input> Lexer<'input> {
     // documentation.
     pub fn check_and_get_doc_comments(
         &mut self,
-        env: &mut CompilationEnv,
+        env: &CompilationEnv,
     ) -> MatchedFileCommentMap {
         let msg = "Documentation comment cannot be matched to a language item";
         let diags = self

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -25,7 +25,7 @@ use vfs::VfsPath;
 /// Parses program's targets and dependencies, both of which are read from different virtual file
 /// systems (vfs and deps_out_vfs, respectively).
 pub(crate) fn parse_program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     named_address_maps: NamedAddressMaps,
     mut targets: Vec<IndexedVfsPackagePath>,
     mut deps: Vec<IndexedVfsPackagePath>,
@@ -113,7 +113,7 @@ fn ensure_targets_deps_dont_intersect(
 
 fn parse_file(
     path: &VfsPath,
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     files: &mut MappedFiles,
     package: Option<Symbol>,
 ) -> anyhow::Result<(

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -126,8 +126,9 @@ fn parse_file(
     let file_hash = FileHash::new(&source_buffer);
     let fname = Symbol::from(path.as_str());
     let source_str = Arc::from(source_buffer);
+    let warning_filters = compilation_env.top_level_warning_filter_scope();
     if let Err(ds) = verify_string(file_hash, &source_str) {
-        compilation_env.add_diags(ds);
+        compilation_env.add_diags(warning_filters, ds);
         files.add(file_hash, fname, source_str);
         return Ok((vec![], MatchedFileCommentMap::new(), file_hash));
     }
@@ -135,7 +136,7 @@ fn parse_file(
     {
         Ok(defs_and_comments) => defs_and_comments,
         Err(ds) => {
-            compilation_env.add_diags(ds);
+            compilation_env.add_diags(warning_filters, ds);
             (vec![], MatchedFileCommentMap::new())
         }
     };

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -71,7 +71,7 @@ impl<'env, 'lexer, 'input> Context<'env, 'lexer, 'input> {
         }
     }
 
-    fn add_diag(&mut self, diag: Diagnostic) {
+    fn add_diag(&self, diag: Diagnostic) {
         let warning_filters = self.env.top_level_warning_filter_scope();
         self.env.add_diag(warning_filters, diag);
     }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -22,14 +22,14 @@ use move_symbol_pool::{symbol, Symbol};
 
 struct Context<'env, 'lexer, 'input> {
     current_package: Option<Symbol>,
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     tokens: &'lexer mut Lexer<'input>,
     stop_set: TokenSet,
 }
 
 impl<'env, 'lexer, 'input> Context<'env, 'lexer, 'input> {
     fn new(
-        env: &'env mut CompilationEnv,
+        env: &'env CompilationEnv,
         tokens: &'lexer mut Lexer<'input>,
         package_name: Option<Symbol>,
     ) -> Self {
@@ -4685,7 +4685,7 @@ fn parse_file_def(
 /// result as either a pair of FileDefinition and doc comments or some Diagnostics. The `file` name
 /// is used to identify source locations in error messages.
 pub fn parse_file_string(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     file_hash: FileHash,
     input: &str,
     package: Option<Symbol>,

--- a/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
@@ -56,6 +56,7 @@ impl FilterContext for Context<'_> {
         // expansion
         // Ideally we would just have a warning filter scope here
         // (but again, need expansion for that)
+        let top_warning_filter_scope = self.env.top_level_warning_filter_scope();
         let silence_warning =
             !self.is_source_def || self.env.package_config(self.current_package).is_dependency;
         if !silence_warning {
@@ -64,8 +65,10 @@ impl FilterContext for Context<'_> {
                     "The '{}' attribute has been deprecated along with specification blocks",
                     VerificationAttribute::VERIFY_ONLY
                 );
-                self.env
-                    .add_diag(diag!(Uncategorized::DeprecatedWillBeRemoved, (*loc, msg)));
+                self.env.add_diag(
+                    top_warning_filter_scope,
+                    diag!(Uncategorized::DeprecatedWillBeRemoved, (*loc, msg)),
+                );
             }
         }
         should_remove

--- a/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/verification_attribute_filter.rs
@@ -15,13 +15,13 @@ use crate::{
 };
 
 struct Context<'env> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     is_source_def: bool,
     current_package: Option<Symbol>,
 }
 
 impl<'env> Context<'env> {
-    fn new(env: &'env mut CompilationEnv) -> Self {
+    fn new(env: &'env CompilationEnv) -> Self {
         Self {
             env,
             is_source_def: false,
@@ -82,7 +82,7 @@ impl FilterContext for Context<'_> {
 // This filters out all AST elements annotated with verify-only annotated from `prog`
 // if the `verify` flag in `compilation_env` is not set. If the `verify` flag is set,
 // no filtering is performed.
-pub fn program(compilation_env: &mut CompilationEnv, prog: P::Program) -> P::Program {
+pub fn program(compilation_env: &CompilationEnv, prog: P::Program) -> P::Program {
     let mut context = Context::new(compilation_env);
     filter_program(&mut context, prog)
 }

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -67,7 +67,7 @@ pub struct ArmResult {
 /// A shared match context trait for use with counterexample generation in Typing and match
 /// compilation in HLIR lowering.
 pub trait MatchContext<const AFTER_TYPING: bool> {
-    fn env(&mut self) -> &mut CompilationEnv;
+    fn env(&mut self) -> &CompilationEnv;
     fn env_ref(&self) -> &CompilationEnv;
     fn new_match_var(&mut self, name: String, loc: Loc) -> N::Var;
     fn program_info(&self) -> &ProgramInfo<AFTER_TYPING>;

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -481,7 +481,7 @@ impl PatternMatrix {
                 // Make a match pattern that only holds guard binders
                 let guard_binders = guard_binders.union_with(&const_binders, |k, _, x| {
                     let msg = "Match compilation made a binder for this during const compilation";
-                    context.env().add_diag(ice!((k.loc, msg)));
+                    context.env().add_error_diag(ice!((k.loc, msg)));
                     *x
                 });
                 let pat = apply_pattern_subst(pat, &guard_binders);

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -696,7 +696,7 @@ impl WarningFiltersScope {
     }
 
     pub fn pop(&mut self) {
-        self.scopes.pop();
+        self.scopes.pop().unwrap();
     }
 
     pub fn is_filtered(&self, diag: &Diagnostic) -> bool {

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -675,20 +675,25 @@ impl CompilationEnv {
         self.flags.ide_mode()
     }
 
-    pub fn extend_ide_info(&self, info: IDEInfo) {
+    pub fn extend_ide_info(&self, warning_filters: &WarningFiltersScope, info: IDEInfo) {
         if self.flags().ide_test_mode() {
             for entry in info.annotations.iter() {
                 let diag = entry.clone().into();
-                self.add_diag(WarningFiltersScope::EMPTY, diag);
+                self.add_diag(warning_filters, diag);
             }
         }
         self.ide_information.write().unwrap().extend(info);
     }
 
-    pub fn add_ide_annotation(&self, loc: Loc, info: IDEAnnotation) {
+    pub fn add_ide_annotation(
+        &self,
+        warning_filters: &WarningFiltersScope,
+        loc: Loc,
+        info: IDEAnnotation,
+    ) {
         if self.flags().ide_test_mode() {
             let diag = (loc, info.clone()).into();
-            self.add_diag(WarningFiltersScope::EMPTY, diag);
+            self.add_diag(warning_filters, diag);
         }
         self.ide_information
             .write()

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -695,6 +695,10 @@ impl CompilationEnv {
             .unwrap()
             .add_ide_annotation(loc, info);
     }
+
+    pub fn ide_information(&self) -> std::sync::RwLockReadGuard<'_, IDEInfo> {
+        self.ide_information.read().unwrap()
+    }
 }
 
 impl WarningFiltersScope {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
@@ -20,7 +20,7 @@ use crate::{
     expansion::ast::{ModuleIdent, TargetKind},
     hlir::ast::{self as H, Exp, Label, ModuleCall, SingleType, Type, Type_, Var},
     parser::ast::Ability_,
-    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier},
+    shared::{program_info::TypingProgramInfo, Identifier},
     sui_mode::{OBJECT_NEW, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT},
 };
 use std::collections::BTreeMap;

--- a/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
@@ -94,7 +94,6 @@ impl SimpleAbsIntConstructor for IDLeakVerifier {
     type AI<'a> = IDLeakVerifierAI<'a>;
 
     fn new<'a>(
-        env: &CompilationEnv,
         context: &'a CFGContext<'a>,
         cfg: &ImmForwardCFG,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,
@@ -102,7 +101,7 @@ impl SimpleAbsIntConstructor for IDLeakVerifier {
         let module = &context.module;
         let minfo = context.info.module(module);
         let package_name = minfo.package;
-        let config = env.package_config(package_name);
+        let config = context.env.package_config(package_name);
         if config.flavor != Flavor::Sui {
             // Skip if not sui
             return None;

--- a/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
@@ -271,7 +271,7 @@ fn add_private_transfers(
         transferred: &'a mut BTreeMap<(ModuleIdent, DatatypeName), TransferKind>,
     }
     impl<'a> TypingVisitorContext for TransferVisitor<'a> {
-        fn add_warning_filter_scope(&mut self, _: crate::diagnostics::WarningFilters) {
+        fn push_warning_filter_scope(&mut self, _: crate::diagnostics::WarningFilters) {
             unreachable!("no warning filters in function bodies")
         }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
@@ -271,6 +271,14 @@ fn add_private_transfers(
         transferred: &'a mut BTreeMap<(ModuleIdent, DatatypeName), TransferKind>,
     }
     impl<'a> TypingVisitorContext for TransferVisitor<'a> {
+        fn add_diag(&mut self, _: crate::diagnostics::Diagnostic) {
+            unreachable!("no diags")
+        }
+
+        fn add_diags(&mut self, _: crate::diagnostics::Diagnostics) {
+            unreachable!("no diags")
+        }
+
         fn add_warning_filter_scope(&mut self, _: crate::diagnostics::WarningFilters) {
             unreachable!("no warning filters in function bodies")
         }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
@@ -271,14 +271,6 @@ fn add_private_transfers(
         transferred: &'a mut BTreeMap<(ModuleIdent, DatatypeName), TransferKind>,
     }
     impl<'a> TypingVisitorContext for TransferVisitor<'a> {
-        fn add_diag(&mut self, _: crate::diagnostics::Diagnostic) {
-            unreachable!("no diags")
-        }
-
-        fn add_diags(&mut self, _: crate::diagnostics::Diagnostics) {
-            unreachable!("no diags")
-        }
-
         fn add_warning_filter_scope(&mut self, _: crate::diagnostics::WarningFilters) {
             unreachable!("no warning filters in function bodies")
         }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -26,6 +26,7 @@ const COIN_FIELD_DIAG: DiagnosticInfo = custom(
     "sub-optimal 'sui::coin::Coin' field type",
 );
 
+<<<<<<< HEAD
 simple_visitor!(
     CoinFieldVisitor,
     fn visit_module_custom(&mut self, _ident: ModuleIdent, mdef: &T::ModuleDefinition) -> bool {
@@ -41,6 +42,22 @@ simple_visitor!(
     ) -> bool {
         if sdef.attributes.is_test_or_test_only() {
             return false;
+=======
+pub struct CoinFieldVisitor;
+
+impl TypingVisitor for CoinFieldVisitor {
+    fn visit(&self, env: &mut CompilationEnv, program: &T::Program) {
+        for (_, _, mdef) in program.modules.iter() {
+            if mdef.attributes.is_test_or_test_only() {
+                continue;
+            }
+            env.add_warning_filter_scope(mdef.warning_filter.clone());
+            mdef.structs
+                .iter()
+                .filter(|(_, _, sdef)| !sdef.attributes.is_test_or_test_only())
+                .for_each(|(sloc, sname, sdef)| struct_def(env, *sname, sdef, sloc));
+            env.pop_warning_filter_scope();
+>>>>>>> 185cdf3961 (Make visitors more parallel friendly)
         }
 
         if let N::StructFields::Defined(_, sfields) = &sdef.fields {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -26,7 +26,6 @@ const COIN_FIELD_DIAG: DiagnosticInfo = custom(
     "sub-optimal 'sui::coin::Coin' field type",
 );
 
-<<<<<<< HEAD
 simple_visitor!(
     CoinFieldVisitor,
     fn visit_module_custom(&mut self, _ident: ModuleIdent, mdef: &T::ModuleDefinition) -> bool {
@@ -42,22 +41,6 @@ simple_visitor!(
     ) -> bool {
         if sdef.attributes.is_test_or_test_only() {
             return false;
-=======
-pub struct CoinFieldVisitor;
-
-impl TypingVisitor for CoinFieldVisitor {
-    fn visit(&self, env: &mut CompilationEnv, program: &T::Program) {
-        for (_, _, mdef) in program.modules.iter() {
-            if mdef.attributes.is_test_or_test_only() {
-                continue;
-            }
-            env.add_warning_filter_scope(mdef.warning_filter.clone());
-            mdef.structs
-                .iter()
-                .filter(|(_, _, sdef)| !sdef.attributes.is_test_or_test_only())
-                .for_each(|(sloc, sname, sdef)| struct_def(env, *sname, sdef, sloc));
-            env.pop_warning_filter_scope();
->>>>>>> 185cdf3961 (Make visitors more parallel friendly)
         }
 
         if let N::StructFields::Defined(_, sfields) = &sdef.fields {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -29,7 +29,7 @@ use crate::{
         BaseType_, Label, ModuleCall, SingleType, SingleType_, Type, TypeName_, Type_, Var,
     },
     parser::ast::Ability_,
-    shared::{CompilationEnv, Identifier},
+    shared::Identifier,
 };
 use std::collections::BTreeMap;
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -87,7 +87,6 @@ impl SimpleAbsIntConstructor for CustomStateChangeVerifier {
     type AI<'a> = CustomStateChangeVerifierAI;
 
     fn new<'a>(
-        _env: &CompilationEnv,
         context: &'a CFGContext<'a>,
         cfg: &ImmForwardCFG,
         init_state: &mut State,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -97,12 +97,12 @@ impl TypingVisitorConstructor for FreezeWrappedVisitor {
 }
 
 impl Context<'_> {
-    fn add_diag(&mut self, diag: Diagnostic) {
+    fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    fn add_diags(&mut self, diags: Diagnostics) {
+    fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -75,7 +75,7 @@ type WrappingFields =
 pub struct FreezeWrappedVisitor;
 
 pub struct Context<'a> {
-    env: &'a mut CompilationEnv,
+    env: &'a CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
     program_info: Arc<TypingProgramInfo>,
     /// Memoizes information about struct fields wrapping other objects as they are discovered
@@ -85,7 +85,7 @@ pub struct Context<'a> {
 impl TypingVisitorConstructor for FreezeWrappedVisitor {
     type Context<'a> = Context<'a>;
 
-    fn context<'a>(env: &'a mut CompilationEnv, program: &T::Program) -> Self::Context<'a> {
+    fn context<'a>(env: &'a CompilationEnv, program: &T::Program) -> Self::Context<'a> {
         let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         Context {
             env,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -155,7 +155,7 @@ impl<'a> TypingVisitorContext for Context<'a> {
         false
     }
 
-    fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -98,12 +98,12 @@ impl TypingVisitorConstructor for FreezeWrappedVisitor {
 
 impl Context<'_> {
     fn add_diag(&mut self, diag: Diagnostic) {
-        self.env.add_diag(diag);
+        self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
     fn add_diags(&mut self, diags: Diagnostics) {
-        self.env.add_diags(diags);
+        self.env.add_diags(&self.warning_filters_scope, diags);
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -80,7 +80,6 @@ impl SimpleAbsIntConstructor for SelfTransferVerifier {
     type AI<'a> = SelfTransferVerifierAI;
 
     fn new<'a>(
-        _env: &CompilationEnv,
         context: &'a CFGContext<'a>,
         cfg: &ImmForwardCFG,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -23,7 +23,6 @@ use crate::{
     },
     hlir::ast::{Label, ModuleCall, Type, Type_, Var},
     parser::ast::Ability_,
-    shared::CompilationEnv,
 };
 use std::collections::BTreeMap;
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -32,7 +32,7 @@ use crate::{
     parser::ast::{Ability_, DatatypeName},
     shared::{
         program_info::{DatatypeKind, TypingProgramInfo},
-        CompilationEnv, Identifier,
+        Identifier,
     },
     sui_mode::{
         info::{SuiInfo, TransferKind},

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -96,7 +96,6 @@ impl SimpleAbsIntConstructor for ShareOwnedVerifier {
     type AI<'a> = ShareOwnedVerifierAI<'a>;
 
     fn new<'a>(
-        _env: &CompilationEnv,
         context: &'a CFGContext<'a>,
         cfg: &ImmForwardCFG,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -8,14 +8,14 @@ use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
-    diagnostics::{Diagnostic, WarningFilters},
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     editions::Flavor,
     expansion::ast::{AbilitySet, Fields, ModuleIdent, Mutability, TargetKind, Visibility},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, TypeName_, Type_, Var,
     },
     parser::ast::{Ability_, DatatypeName, FunctionName},
-    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier},
+    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier, WarningFiltersScope},
     sui_mode::*,
     typing::{
         ast::{self as T, ModuleCall},
@@ -44,6 +44,7 @@ impl TypingVisitorConstructor for SuiTypeChecks {
 #[allow(unused)]
 pub struct Context<'a> {
     env: &'a mut CompilationEnv,
+    warning_filters_scope: WarningFiltersScope,
     info: Arc<TypingProgramInfo>,
     sui_transfer_ident: Option<ModuleIdent>,
     current_module: Option<ModuleIdent>,
@@ -59,8 +60,10 @@ impl<'a> Context<'a> {
             .key_cloned_iter()
             .find(|(m, _)| m.value.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME))
             .map(|(m, _)| m);
+        let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         Context {
             env,
+            warning_filters_scope,
             info,
             sui_transfer_ident: sui_module_ident,
             current_module: None,
@@ -98,12 +101,20 @@ const OTW_NOTE: &str = "One-time witness types are structs with the following re
 //**************************************************************************************************
 
 impl<'a> TypingVisitorContext for Context<'a> {
-    fn add_warning_filter_scope(&mut self, filter: WarningFilters) {
-        self.env.add_warning_filter_scope(filter)
+    fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
     }
 
     fn pop_warning_filter_scope(&mut self) {
-        self.env.pop_warning_filter_scope()
+        self.warning_filters_scope.pop()
     }
 
     fn visit_module_custom(&mut self, ident: ModuleIdent, mdef: &T::ModuleDefinition) -> bool {
@@ -205,9 +216,7 @@ fn struct_def(context: &mut Context, name: DatatypeName, sdef: &N::StructDefinit
     };
     if let Some(loc) = invalid_first_field {
         // no fields or an invalid 'id' field
-        context
-            .env
-            .add_diag(invalid_object_id_field_diag(key_loc, loc, name));
+        context.add_diag(invalid_object_id_field_diag(key_loc, loc, name));
         return;
     };
 
@@ -223,7 +232,7 @@ fn struct_def(context: &mut Context, name: DatatypeName, sdef: &N::StructDefinit
         );
         let mut diag = invalid_object_id_field_diag(key_loc, *id_field_loc, name);
         diag.add_secondary_label((id_field_type.loc, actual));
-        context.env.add_diag(diag);
+        context.add_diag(diag);
     }
 }
 
@@ -261,7 +270,7 @@ fn enum_def(context: &mut Context, name: DatatypeName, edef: &N::EnumDefinition)
         let msg = format!("Invalid object '{name}'");
         let key_msg = format!("Enums cannot have the '{}' ability.", Ability_::Key);
         let diag = diag!(OBJECT_DECL_DIAG, (name.loc(), msg), (key_loc, key_msg));
-        context.env.add_diag(diag);
+        context.add_diag(diag);
     };
 }
 
@@ -309,17 +318,16 @@ fn init_visibility(
     entry: Option<Loc>,
 ) {
     match visibility {
-        Visibility::Public(loc) | Visibility::Friend(loc) | Visibility::Package(loc) => {
-            context.env.add_diag(diag!(
+        Visibility::Public(loc) | Visibility::Friend(loc) | Visibility::Package(loc) => context
+            .add_diag(diag!(
                 INIT_FUN_DIAG,
                 (name.loc(), "Invalid 'init' function declaration"),
                 (loc, "'init' functions must be internal to their module"),
-            ))
-        }
+            )),
         Visibility::Internal => (),
     }
     if let Some(entry) = entry {
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             INIT_FUN_DIAG,
             (name.loc(), "Invalid 'init' function declaration"),
             (entry, "'init' functions cannot be 'entry' functions"),
@@ -335,7 +343,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
     } = signature;
     if !type_parameters.is_empty() {
         let tp_loc = type_parameters[0].user_specified_name.loc;
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             INIT_FUN_DIAG,
             (name.loc(), "Invalid 'init' function declaration"),
             (tp_loc, "'init' functions cannot have type parameters"),
@@ -346,7 +354,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
             "'init' functions must have a return type of {}",
             error_format_(&Type_::Unit, &Subst::empty())
         );
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             INIT_FUN_DIAG,
             (name.loc(), "Invalid 'init' function declaration"),
             (return_type.loc, msg),
@@ -368,7 +376,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
             m = TX_CONTEXT_MODULE_NAME,
             t = TX_CONTEXT_TYPE_NAME,
         );
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             INIT_FUN_DIAG,
             (name.loc(), "Invalid 'init' function declaration"),
             (last_loc, msg),
@@ -397,7 +405,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
             (otw_loc, otw_msg),
         );
         diag.add_note(OTW_NOTE);
-        context.env.add_diag(diag)
+        context.add_diag(diag)
     } else if parameters.len() > 1 {
         // if there is more than one parameter, the first must be the OTW
         let (_, first_var, first_ty) = parameters.first().unwrap();
@@ -421,7 +429,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
                 (first_ty.loc, msg)
             );
             diag.add_note(OTW_NOTE);
-            context.env.add_diag(diag)
+            context.add_diag(diag)
         } else if let Some(sdef) = info
             .module(context.current_module())
             .structs
@@ -439,7 +447,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
     if parameters.len() > 2 {
         // no init function can take more than 2 parameters (the OTW and the TxContext)
         let (_, third_var, _) = &parameters[2];
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             INIT_FUN_DIAG,
             (name.loc(), "Invalid 'init' function declaration"),
             (
@@ -474,7 +482,7 @@ fn check_otw_type(
     let mut valid = true;
     if let Some(tp) = sdef.type_parameters.first() {
         let msg = "One-time witness types cannot have type parameters";
-        context.env.add_diag(otw_diag(diag!(
+        context.add_diag(otw_diag(diag!(
             OTW_DECL_DIAG,
             (name.loc(), "Invalid one-time witness declaration"),
             (tp.param.user_specified_name.loc, msg),
@@ -496,7 +504,7 @@ fn check_otw_type(
                     (loc, format!("Found more than one field. {msg_base}"))
                 }
             };
-            context.env.add_diag(otw_diag(diag!(
+            context.add_diag(otw_diag(diag!(
                 OTW_DECL_DIAG,
                 (name.loc(), "Invalid one-time witness declaration"),
                 (invalid_loc, invalid_msg),
@@ -527,7 +535,7 @@ fn check_otw_type(
             "One-time witness types can only have the have the '{}' ability",
             Ability_::Drop
         );
-        context.env.add_diag(otw_diag(diag!(
+        context.add_diag(otw_diag(diag!(
             OTW_DECL_DIAG,
             (name.loc(), "Invalid one-time witness declaration"),
             (loc, msg),
@@ -691,7 +699,7 @@ fn entry_param_ty(
                 .to_owned()
         };
         let emsg = format!("'{name}' was declared 'entry' here");
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             ENTRY_FUN_SIGNATURE_DIAG,
             (param.loc, pmsg),
             (param_ty.loc, tmsg),
@@ -843,7 +851,7 @@ fn entry_return(
         Type_::Ref(_, _) => {
             let fmsg = format!("Invalid return type for entry function '{}'", name);
             let tmsg = "Expected a non-reference type";
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 ENTRY_FUN_SIGNATURE_DIAG,
                 (entry_loc, fmsg),
                 (*tloc, tmsg)
@@ -917,7 +925,7 @@ fn invalid_entry_return_ty<'a>(
         declared_abilities,
         ty_args,
     );
-    context.env.add_diag(diag)
+    context.add_diag(diag)
 }
 
 //**************************************************************************************************
@@ -941,7 +949,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
                     consider extracting the logic into a new function and \
                     calling that instead.",
                 );
-                context.env.add_diag(diag)
+                context.add_diag(diag)
             }
             if module.value.is(SUI_ADDR_NAME, EVENT_MODULE_NAME)
                 && name.value() == EVENT_FUNCTION_NAME
@@ -965,7 +973,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
                     cannot be created manually, but are passed as an argument 'init'";
                 let mut diag = diag!(OTW_USAGE_DIAG, (e.exp.loc, msg));
                 diag.add_note(OTW_NOTE);
-                context.env.add_diag(diag)
+                context.add_diag(diag)
             }
         }
         _ => (),
@@ -1005,7 +1013,7 @@ fn check_event_emit(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
             "The type {} is not declared in the current module",
             error_format(first_ty, &Subst::empty()),
         );
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             EVENT_EMIT_CALL_DIAG,
             (loc, msg),
             (first_ty.loc, ty_msg)
@@ -1083,6 +1091,6 @@ fn check_private_transfer(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
             );
             diag.add_secondary_label((store_loc, store_msg))
         }
-        context.env.add_diag(diag)
+        context.add_diag(diag)
     }
 }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -32,7 +32,7 @@ pub struct SuiTypeChecks;
 
 impl TypingVisitorConstructor for SuiTypeChecks {
     type Context<'a> = Context<'a>;
-    fn context<'a>(env: &'a mut CompilationEnv, program: &T::Program) -> Self::Context<'a> {
+    fn context<'a>(env: &'a CompilationEnv, program: &T::Program) -> Self::Context<'a> {
         Context::new(env, program.info.clone())
     }
 }
@@ -43,7 +43,7 @@ impl TypingVisitorConstructor for SuiTypeChecks {
 
 #[allow(unused)]
 pub struct Context<'a> {
-    env: &'a mut CompilationEnv,
+    env: &'a CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
     info: Arc<TypingProgramInfo>,
     sui_transfer_ident: Option<ModuleIdent>,
@@ -54,7 +54,7 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    fn new(env: &'a mut CompilationEnv, info: Arc<TypingProgramInfo>) -> Self {
+    fn new(env: &'a CompilationEnv, info: Arc<TypingProgramInfo>) -> Self {
         let sui_module_ident = info
             .modules
             .key_cloned_iter()

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -77,6 +77,7 @@ impl<'a> Context<'a> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -73,12 +73,12 @@ impl<'a> Context<'a> {
         }
     }
 
-    fn add_diag(&mut self, diag: Diagnostic) {
+    fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    fn add_diags(&mut self, diags: Diagnostics) {
+    fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -73,6 +73,14 @@ impl<'a> Context<'a> {
         }
     }
 
+    fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
     fn set_module(&mut self, current_module: ModuleIdent) {
         self.current_module = Some(current_module);
         self.otw_name = Some(Symbol::from(
@@ -101,14 +109,6 @@ const OTW_NOTE: &str = "One-time witness types are structs with the following re
 //**************************************************************************************************
 
 impl<'a> TypingVisitorContext for Context<'a> {
-    fn add_diag(&mut self, diag: Diagnostic) {
-        self.env.add_diag(&self.warning_filters_scope, diag);
-    }
-
-    fn add_diags(&mut self, diags: Diagnostics) {
-        self.env.add_diags(&self.warning_filters_scope, diags);
-    }
-
     fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -110,7 +110,7 @@ const OTW_NOTE: &str = "One-time witness types are structs with the following re
 //**************************************************************************************************
 
 impl<'a> TypingVisitorContext for Context<'a> {
-    fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/context.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/context.rs
@@ -27,7 +27,7 @@ pub type DatatypeDeclarations =
 /// Compilation context for a single compilation unit (module).
 /// Contains all of the dependencies actually used in the module
 pub struct Context<'a> {
-    pub env: &'a mut CompilationEnv,
+    pub env: &'a CompilationEnv,
     current_package: Option<Symbol>,
     current_module: Option<&'a ModuleIdent>,
     seen_datatypes: BTreeSet<(ModuleIdent, DatatypeName)>,
@@ -36,7 +36,7 @@ pub struct Context<'a> {
 
 impl<'a> Context<'a> {
     pub fn new(
-        env: &'a mut CompilationEnv,
+        env: &'a CompilationEnv,
         current_package: Option<Symbol>,
         current_module: Option<&'a ModuleIdent>,
     ) -> Self {

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -38,7 +38,7 @@ type CollectedInfos = UniqueMap<FunctionName, CollectedInfo>;
 type CollectedInfo = (Vec<(Mutability, Var, H::SingleType)>, Attributes);
 
 fn extract_decls(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: &G::Program,
 ) -> (
@@ -127,7 +127,7 @@ fn extract_decls(
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: G::Program,
 ) -> Vec<AnnotatedCompiledUnit> {
@@ -153,7 +153,7 @@ pub fn program(
 }
 
 fn module(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     ident: ModuleIdent,
     mdef: G::ModuleDefinition,
     dependency_orderings: &HashMap<ModuleIdent, usize>,

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -227,7 +227,7 @@ fn module(
         match move_ir_to_bytecode::compiler::compile_module(ir_module, deps) {
             Ok(res) => res,
             Err(e) => {
-                compilation_env.add_diag(diag!(
+                compilation_env.add_error_diag(diag!(
                     Bug::BytecodeGeneration,
                     (ident_loc, format!("IR ERROR: {}", e))
                 ));

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -361,20 +361,6 @@ pub fn single_item(e: Exp) -> ExpListItem {
     ExpListItem::Single(e, ty)
 }
 
-pub fn splat_item(env: &mut CompilationEnv, splat_loc: Loc, e: Exp) -> ExpListItem {
-    let ss = match &e.ty {
-        sp!(_, Type_::Unit) => vec![],
-        sp!(_, Type_::Apply(_, sp!(_, TypeName_::Multiple(_)), ss)) => ss.clone(),
-        _ => {
-            let mut diag = ice!((splat_loc, "ICE called `splat_item` on a non-list type"));
-            diag.add_note(format!("Expression: {}", debug_display!(e)));
-            env.add_diag(diag);
-            vec![]
-        }
-    };
-    ExpListItem::Splat(splat_loc, e, ss)
-}
-
 pub fn pat(ty: Type, pat: UnannotatedPat) -> MatchPattern {
     MatchPattern { ty, pat }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -3,23 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    debug_display,
     diagnostics::WarningFilters,
     expansion::ast::{
         Address, Attributes, Fields, Friend, ModuleIdent, Mutability, TargetKind, Value, Visibility,
     },
-    ice,
     naming::ast::{
         BlockLabel, EnumDefinition, FunctionSignature, Neighbor, StructDefinition, SyntaxMethods,
-        Type, TypeName_, Type_, UseFuns, Var,
+        Type, Type_, UseFuns, Var,
     },
     parser::ast::{
         BinOp, ConstantName, DatatypeName, Field, FunctionName, UnaryOp, VariantName,
         ENTRY_MODIFIER, MACRO_MODIFIER, NATIVE_MODIFIER,
     },
-    shared::{
-        ast_debug::*, program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, Name,
-    },
+    shared::{ast_debug::*, program_info::TypingProgramInfo, unique_map::UniqueMap, Name},
 };
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -220,19 +220,19 @@ impl<'env> Context<'env> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub fn extend_ide_info(&mut self, info: IDEInfo) {
+    pub fn extend_ide_info(&self, info: IDEInfo) {
         self.env.extend_ide_info(&self.warning_filters_scope, info);
     }
 
-    pub fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+    pub fn add_ide_annotation(&self, loc: Loc, info: IDEAnnotation) {
         self.env
             .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -237,7 +237,7 @@ impl<'env> Context<'env> {
             .add_ide_annotation(&self.warning_filters_scope, loc, info);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -91,7 +91,7 @@ pub(super) struct TypingDebugFlags {
 pub struct Context<'env> {
     pub modules: NamingProgramInfo,
     macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
-    pub env: &'env mut CompilationEnv,
+    pub env: &'env CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
     pub(super) debug: TypingDebugFlags,
 
@@ -180,7 +180,7 @@ impl UseFunsScope {
 
 impl<'env> Context<'env> {
     pub fn new(
-        env: &'env mut CompilationEnv,
+        env: &'env CompilationEnv,
         _pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
         info: NamingProgramInfo,
     ) -> Self {
@@ -865,7 +865,7 @@ impl<'env> Context<'env> {
 }
 
 impl MatchContext<false> for Context<'_> {
-    fn env(&mut self) -> &mut CompilationEnv {
+    fn env(&mut self) -> &CompilationEnv {
         self.env
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -228,6 +228,15 @@ impl<'env> Context<'env> {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
+    pub fn extend_ide_info(&mut self, info: IDEInfo) {
+        self.env.extend_ide_info(&self.warning_filters_scope, info);
+    }
+
+    pub fn add_ide_annotation(&mut self, loc: Loc, info: IDEAnnotation) {
+        self.env
+            .add_ide_annotation(&self.warning_filters_scope, loc, info);
+    }
+
     pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -6,7 +6,7 @@ use crate::{
     debug_display, diag,
     diagnostics::{
         codes::{NameResolution, TypeSafety},
-        Diagnostic,
+        Diagnostic, Diagnostics, WarningFilters,
     },
     editions::FeatureGate,
     expansion::ast::{AbilitySet, ModuleIdent, ModuleIdent_, Mutability, Visibility},
@@ -92,6 +92,7 @@ pub struct Context<'env> {
     pub modules: NamingProgramInfo,
     macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
     pub env: &'env mut CompilationEnv,
+    warning_filters_scope: WarningFiltersScope,
     pub(super) debug: TypingDebugFlags,
 
     deprecations: Deprecations,
@@ -191,6 +192,7 @@ impl<'env> Context<'env> {
             function_translation: false,
             type_elaboration: false,
         };
+        let warning_filters_scope = env.top_level_warning_filter_scope().clone();
         Context {
             use_funs: vec![global_use_funs],
             subst: Subst::empty(),
@@ -206,6 +208,7 @@ impl<'env> Context<'env> {
             macros: UniqueMap::new(),
             named_block_map: BTreeMap::new(),
             env,
+            warning_filters_scope,
             debug,
             next_match_var_id: 0,
             new_friends: BTreeSet::new(),
@@ -215,6 +218,22 @@ impl<'env> Context<'env> {
             ide_info: IDEInfo::new(),
             deprecations,
         }
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    pub fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.warning_filters_scope.pop()
     }
 
     pub fn set_macros(
@@ -266,7 +285,7 @@ impl<'env> Context<'env> {
                     let (target_m, target_f) = &use_fun.target_function;
                     let msg =
                         format!("{case} method alias '{tn}.{method}' for '{target_m}::{target_f}'");
-                    self.env.add_diag(diag!(
+                    self.add_diag(diag!(
                         Declarations::DuplicateAlias,
                         (use_fun.loc, msg),
                         (prev_loc, "The same alias was previously declared here")
@@ -306,18 +325,18 @@ impl<'env> Context<'env> {
                     UseFunKind::Explicit => {
                         let msg =
                             format!("Unused 'use fun' of '{tn}.{method}'. Consider removing it");
-                        self.env.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
+                        self.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
                     }
                     UseFunKind::UseAlias => {
                         let msg = format!("Unused 'use' of alias '{method}'. Consider removing it");
-                        self.env.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
+                        self.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
                     }
                     UseFunKind::FunctionDeclaration => {
                         let diag = ice!((
                             *loc,
                             "ICE fun declaration 'use' funs should never be added to 'use' funs"
                         ));
-                        self.env.add_diag(diag);
+                        self.add_diag(diag);
                     }
                 }
             }
@@ -411,7 +430,7 @@ impl<'env> Context<'env> {
                 };
                 diag.add_secondary_label((*prev_loc, msg));
             }
-            self.env.add_diag(diag);
+            self.add_diag(diag);
             false
         } else {
             self.macro_expansion
@@ -433,7 +452,7 @@ impl<'env> Context<'env> {
                     loc,
                     "ICE macro expansion stack should have a call when leaving a macro expansion"
                 ));
-                self.env.add_diag(diag);
+                self.add_diag(diag);
                 return false;
             }
         };
@@ -471,7 +490,7 @@ impl<'env> Context<'env> {
                         loc,
                         "ICE macro expansion stack should have a lambda when leaving a lambda",
                     ));
-                    self.env.add_diag(diag);
+                    self.add_diag(diag);
                 }
             }
         }
@@ -507,8 +526,7 @@ impl<'env> Context<'env> {
         self.lambda_expansion = vec![];
 
         if !self.ide_info.is_empty() {
-            self.env
-                .add_diag(ice!((loc, "IDE info should be cleared after each item")));
+            self.add_diag(ice!((loc, "IDE info should be cleared after each item")));
             self.ide_info = IDEInfo::new();
         }
     }
@@ -575,15 +593,14 @@ impl<'env> Context<'env> {
     pub fn declare_local(&mut self, _: Mutability, var: Var, ty: Type) {
         if let Err((_, prev_loc)) = self.locals.add(var, ty) {
             let msg = format!("ICE duplicate {var:?}. Should have been made unique in naming");
-            self.env
-                .add_diag(ice!((var.loc, msg), (prev_loc, "Previously declared here")));
+            self.add_diag(ice!((var.loc, msg), (prev_loc, "Previously declared here")));
         }
     }
 
     pub fn get_local_type(&mut self, var: &Var) -> Type {
         if !self.locals.contains_key(var) {
             let msg = format!("ICE unbound {var:?}. Should have failed in naming");
-            self.env.add_diag(ice!((var.loc, msg)));
+            self.add_diag(ice!((var.loc, msg)));
             return self.error_type(var.loc);
         }
 
@@ -659,7 +676,8 @@ impl<'env> Context<'env> {
             if deprecation.location == AttributePosition::Module && in_same_module {
                 return;
             }
-            deprecation.emit_deprecation_warning(self.env, name, method_opt);
+            let diags = deprecation.deprecation_warnings(name, method_opt);
+            self.add_diags(diags);
         }
     }
 
@@ -1102,7 +1120,7 @@ fn debug_abilities_info(context: &mut Context, ty: &Type) -> (Option<Loc>, Abili
                 loc,
                 "ICE did not call unfold_type before debug_abiliites_info"
             ));
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             (None, AbilitySet::all(loc), vec![])
         }
         T::UnresolvedError | T::Anything => (None, AbilitySet::all(loc), vec![]),
@@ -1238,7 +1256,7 @@ pub fn make_struct_field_type(
         N::StructFields::Native(nloc) => {
             let nloc = *nloc;
             let msg = format!("Unbound field '{}' for native struct '{}::{}'", field, m, n);
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 NameResolution::UnboundField,
                 (loc, msg),
                 (nloc, "Struct declared 'native' here")
@@ -1249,7 +1267,7 @@ pub fn make_struct_field_type(
     };
     match fields_map.get(field).cloned() {
         None => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 NameResolution::UnboundField,
                 (loc, format!("Unbound field '{}' in '{}::{}'", field, m, n)),
             ));
@@ -1364,7 +1382,7 @@ pub fn make_constant_type(
         let msg = format!("Invalid access of '{}::{}'", m, c);
         let internal_msg = "Constants are internal to their module, and cannot can be accessed \
                             outside of their module";
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             TypeSafety::Visibility,
             (loc, msg),
             (defined_loc, internal_msg)
@@ -1396,7 +1414,7 @@ pub fn make_method_call_type(
                     loc,
                     format!("ICE method on tuple type {}", debug_display!(tn))
                 ));
-                context.env.add_diag(diag);
+                context.add_diag(diag);
                 return None;
             }
             TypeName_::Builtin(sp!(_, bt_)) => context.env.primitive_definer(*bt_),
@@ -1433,7 +1451,7 @@ pub fn make_method_call_type(
                 No known method '{method}' on type '{lhs_ty_str}'"
             );
             let fmsg = format!("The function '{m}::{method}' exists, {arg_msg}");
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::InvalidMethodCall,
                 (loc, msg),
                 (first_ty_loc, fmsg)
@@ -1451,7 +1469,7 @@ pub fn make_method_call_type(
             };
             let fmsg =
                 format!("No local 'use fun' alias was found for '{lhs_ty_str}.{method}'{decl_msg}");
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::InvalidMethodCall,
                 (loc, msg),
                 (method.loc, fmsg)
@@ -1739,7 +1757,7 @@ fn report_visibility_error_(
                 diag.add_secondary_label((call.invocation, "While expanding this macro"));
             }
             _ => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     call_loc,
                     "Error when dealing with macro visibilities"
                 )));
@@ -1752,7 +1770,7 @@ fn report_visibility_error_(
             "Visibility inside of expanded macros is resolved in the scope of the caller.",
         );
     }
-    context.env.add_diag(diag);
+    context.add_diag(diag);
 }
 
 pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
@@ -1777,7 +1795,7 @@ pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
         arity,
         given_len
     );
-    context.env.add_diag(diag!(
+    context.add_diag(diag!(
         code,
         (loc, cmsg),
         (argloc, format!("Found {} argument(s) here", given_len)),
@@ -1873,7 +1891,7 @@ fn solve_ability_constraint(
                 format!("'{}' constraint declared here", constraint),
             ));
         }
-        context.env.add_diag(diag)
+        context.add_diag(diag)
     }
 }
 
@@ -1973,7 +1991,7 @@ fn solve_builtin_type_constraint(
         }
         _ => {
             let tmsg = mk_tmsg();
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::BuiltinOperation,
                 (loc, format!("Invalid argument to '{}'", op)),
                 (tloc, tmsg)
@@ -1991,7 +2009,7 @@ fn solve_base_type_constraint(context: &mut Context, loc: Loc, msg: String, ty: 
         Unit | Ref(_, _) | Apply(_, sp!(_, Multiple(_)), _) => {
             let tystr = error_format(ty, &context.subst);
             let tmsg = format!("Expected a single non-reference type, but found: {}", tystr);
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::ExpectedBaseType,
                 (loc, msg),
                 (tyloc, tmsg)
@@ -2012,7 +2030,7 @@ fn solve_single_type_constraint(context: &mut Context, loc: Loc, msg: String, ty
                 "Expected a single type, but found expression list type: {}",
                 error_format(ty, &context.subst)
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::ExpectedSingleType,
                 (loc, msg),
                 (tyloc, tmsg)
@@ -2363,7 +2381,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
             arity,
             args_len
         );
-        context.env.add_diag(diag!(code, (loc, msg)));
+        context.add_diag(diag!(code, (loc, msg)));
     }
 
     while ty_args.len() > arity {

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, BTreeSet};
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     modules: &mut UniqueMap<ModuleIdent, T::ModuleDefinition>,
 ) {
     let imm_modules = &modules;
@@ -63,7 +63,7 @@ enum DepType {
 }
 
 struct Context<'a, 'env> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     modules: &'a UniqueMap<ModuleIdent, T::ModuleDefinition>,
     // A union of uses and friends for modules (used for cyclyc dependency checking)
     // - if A uses B,    add edge A -> B
@@ -79,7 +79,7 @@ struct Context<'a, 'env> {
 
 impl<'a, 'env> Context<'a, 'env> {
     fn new(
-        env: &'env mut CompilationEnv,
+        env: &'env CompilationEnv,
         modules: &'a UniqueMap<ModuleIdent, T::ModuleDefinition>,
     ) -> Self {
         Context {

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -38,7 +38,7 @@ pub fn program(
         Err(cycle_node) => {
             let cycle_ident = *cycle_node.node_id();
             let error = cycle_error(&module_neighbors, cycle_ident);
-            compilation_env.add_diag(error);
+            compilation_env.add_error_diag(error);
         }
         Ok(ordered_ids) => {
             for (order, mident) in ordered_ids.iter().rev().enumerate() {
@@ -372,7 +372,7 @@ fn lvalue(context: &mut Context, sp!(loc, lv_): &T::LValue) {
             }
         }
         L::BorrowUnpackVariant(..) | L::UnpackVariant(..) => {
-            context.env.add_diag(ice!((
+            context.env.add_error_diag(ice!((
                 *loc,
                 "variant unpacking shouldn't occur before match expansion"
             )));
@@ -420,7 +420,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
             }
         }
         E::VariantMatch(..) => {
-            context.env.add_diag(ice!((
+            context.env.add_error_diag(ice!((
                 e.exp.loc,
                 "shouldn't find variant match before HLIR lowering"
             )));

--- a/external-crates/move/crates/move-compiler/src/typing/deprecation_warnings.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/deprecation_warnings.rs
@@ -195,7 +195,7 @@ fn deprecations(
         .last()
         .expect("Verified deprecations is not empty above");
 
-    let mut make_invalid_deprecation_diag = || {
+    let make_invalid_deprecation_diag = || {
         let mut diag = diag!(
             Attributes::InvalidUsage,
             (

--- a/external-crates/move/crates/move-compiler/src/typing/deprecation_warnings.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/deprecation_warnings.rs
@@ -44,7 +44,7 @@ pub struct Deprecations {
 impl Deprecations {
     /// Index the modules and their members for deprecation attributes and register each
     /// deprecation attribute for use later on.
-    pub fn new(env: &mut CompilationEnv, info: &NamingProgramInfo) -> Self {
+    pub fn new(env: &CompilationEnv, info: &NamingProgramInfo) -> Self {
         let mut deprecated_members = HashMap::new();
 
         for (mident, module_info) in info.modules.key_cloned_iter() {
@@ -167,7 +167,7 @@ impl Deprecation {
 // #[deprecated] attributes (malformed, or multiple on the member), add an error diagnostic to
 // `env` and return None.
 fn deprecations(
-    env: &mut CompilationEnv,
+    env: &CompilationEnv,
     attr_position: AttributePosition,
     attrs: &E::Attributes,
     source_location: Loc,

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -69,14 +69,14 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
                         ty.loc,
                         "ICE unfold_type_base failed to expand type inf. var"
                     ));
-                    context.env.add_diag(diag);
+                    context.env.add_error_diag(diag);
                     sp(loc, UnresolvedError)
                 }
                 sp!(loc, Anything) => {
                     let msg = "Could not infer this type. Try adding an annotation";
                     context
                         .env
-                        .add_diag(diag!(TypeSafety::UninferredType, (ty.loc, msg)));
+                        .add_error_diag(diag!(TypeSafety::UninferredType, (ty.loc, msg)));
                     sp(loc, UnresolvedError)
                 }
                 sp!(loc, Fun(_, _)) if !context.in_macro_function => {
@@ -96,7 +96,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
                 ty.loc,
                 format!("ICE expanding pre-expanded type {}", debug_display!(aty))
             ));
-            context.env.add_diag(diag);
+            context.env.add_error_diag(diag);
             *ty = sp(ty.loc, UnresolvedError)
         }
         Apply(None, _, _) => {
@@ -108,7 +108,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
                 }
                 _ => {
                     let diag = ice!((ty.loc, "ICE type-apply switched to non-apply"));
-                    context.env.add_diag(diag);
+                    context.env.add_error_diag(diag);
                     *ty = sp(ty.loc, UnresolvedError)
                 }
             }
@@ -134,7 +134,7 @@ fn unexpected_lambda_type(context: &mut Context, loc: Loc) {
             Lambdas can only be used with 'macro' functions, as parameters or direct arguments";
         context
             .env
-            .add_diag(diag!(TypeSafety::UnexpectedFunctionType, (loc, msg)));
+            .add_error_diag(diag!(TypeSafety::UnexpectedFunctionType, (loc, msg)));
     }
 }
 
@@ -248,7 +248,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
             }
         }
         E::VariantMatch(subject, _, arms) => {
-            context.env.add_diag(ice!((
+            context.env.add_error_diag(ice!((
                 e.exp.loc,
                 "shouldn't find variant match before match compilation"
             )));
@@ -357,7 +357,7 @@ fn inferred_numerical_value(
             "Annotating the literal might help inference: '{value}{type}'",
             type=fix_bt,
         );
-        context.env.add_diag(diag!(
+        context.env.add_error_diag(diag!(
             TypeSafety::InvalidNum,
             (eloc, "Invalid numerical literal"),
             (ty.loc, msg),

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -140,7 +140,7 @@ impl<'a> Context<'a> {
 //**************************************************************************************************
 
 pub fn modules(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     modules: &UniqueMap<ModuleIdent, T::ModuleDefinition>,
 ) {
     let tparams = modules
@@ -171,7 +171,7 @@ macro_rules! scc_edges {
 }
 
 fn module<'a>(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     tparams: &'a BTreeMap<ModuleIdent, BTreeMap<FunctionName, &'a Vec<TParam>>>,
     mname: ModuleIdent,
     module: &T::ModuleDefinition,

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -188,7 +188,7 @@ fn module<'a>(
     petgraph_scc(&graph)
         .into_iter()
         .filter(|scc| scc_edges!(&graph, scc).any(|(_, e, _)| e == Edge::Nested))
-        .for_each(|scc| compilation_env.add_diag(cycle_error(context, &graph, scc)))
+        .for_each(|scc| compilation_env.add_error_diag(cycle_error(context, &graph, scc)))
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -1061,7 +1061,6 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             if context.core.env.ide_mode() {
                 context
                     .core
-                    .env
                     .add_ide_annotation(*eloc, IDEAnnotation::ExpandedLambda);
             }
             *e_ = block;

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -64,7 +64,7 @@ pub(crate) fn call(
     let reloc_clever_errors = match &context.macro_expansion[0] {
         core::MacroExpansion::Call(call) => call.invocation,
         core::MacroExpansion::Argument { .. } => {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 call_loc,
                 "ICE top level macro scope should never be an argument"
             )));
@@ -92,7 +92,7 @@ pub(crate) fn call(
                 return None;
             }
             Err(Some(diag)) => {
-                context.env.add_diag(*diag);
+                context.add_diag(*diag);
                 return None;
             }
         };
@@ -288,9 +288,7 @@ fn bind_lambda(
                 "Unable to bind lambda to parameter '{}'. The lambda must be passed directly",
                 param.name
             );
-            context
-                .env
-                .add_diag(diag!(TypeSafety::CannotExpandMacro, (arg.loc, msg)));
+            context.add_diag(diag!(TypeSafety::CannotExpandMacro, (arg.loc, msg)));
             None
         }
     }
@@ -747,9 +745,7 @@ fn report_unused_argument(context: &mut core::Context, loc: EvalStrategy<Loc, Lo
     };
     let msg = "Unused macro argument. \
     Its expression will not be type checked and it will not evaluated";
-    context
-        .env
-        .add_diag(diag!(UnusedItem::DeadCode, (loc, msg)));
+    context.add_diag(diag!(UnusedItem::DeadCode, (loc, msg)));
 }
 
 fn types(context: &mut Context, tys: &mut [Type]) {
@@ -1104,7 +1100,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
         N::Exp_::VarCall(sp!(_, v_), _) if context.by_name_args.contains_key(v_) => {
             context.mark_used(v_);
             let (arg, _expected_ty) = context.by_name_args.get(v_).unwrap();
-            context.core.env.add_diag(diag!(
+            context.core.add_diag(diag!(
                 TypeSafety::CannotExpandMacro,
                 (*eloc, "Cannot call non-lambda argument"),
                 (arg.loc, "Expected a lambda argument")

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -622,9 +622,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
         if !unused.is_empty() {
             let arms = unused.into_iter().map(PS::Value).collect::<Vec<_>>();
             let info = MissingMatchArmsInfo { arms };
-            context
-                .env
-                .add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
+            context.add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
         }
     }
 
@@ -635,9 +633,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
             let info = MissingMatchArmsInfo {
                 arms: vec![PS::Wildcard],
             };
-            context
-                .env
-                .add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
+            context.add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
         }
     }
 
@@ -684,9 +680,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
             let info = MissingMatchArmsInfo {
                 arms: vec![suggestion],
             };
-            context
-                .env
-                .add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
+            context.add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
         } else {
             // If there's a default arm, no suggestion is necessary.
             if matrix.has_default_arm() {
@@ -752,9 +746,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
                 arms.push(suggestion);
             }
             let info = MissingMatchArmsInfo { arms };
-            context
-                .env
-                .add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
+            context.add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
         }
     }
 
@@ -790,9 +782,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
             let info = MissingMatchArmsInfo {
                 arms: vec![PS::Wildcard],
             };
-            context
-                .env
-                .add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
+            context.add_ide_annotation(loc, IDEAnnotation::MissingMatchArms(Box::new(info)));
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -70,8 +70,8 @@ impl TypingMutVisitorContext for MatchCompiler<'_, '_> {
         }
     }
 
-    fn add_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
-        self.context.add_warning_filter_scope(filter);
+    fn push_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
+        self.context.push_warning_filter_scope(filter);
     }
 
     fn pop_warning_filter_scope(&mut self) {

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -71,11 +71,11 @@ impl TypingMutVisitorContext for MatchCompiler<'_, '_> {
     }
 
     fn add_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
-        self.context.env.add_warning_filter_scope(filter);
+        self.context.add_warning_filter_scope(filter);
     }
 
     fn pop_warning_filter_scope(&mut self) {
-        self.context.env.pop_warning_filter_scope();
+        self.context.pop_warning_filter_scope();
     }
 }
 
@@ -564,7 +564,7 @@ fn find_counterexample_impl(
         } else {
             // An error case: no entry on the fringe but no
             if !context.env.has_errors() {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     matrix.loc,
                     "Non-empty matrix with non errors but no type"
                 )));
@@ -593,7 +593,7 @@ fn find_counterexample_impl(
         if has_guards {
             diag.add_note("Match arms with guards are not considered for coverage.");
         }
-        context.env.add_diag(diag);
+        context.add_diag(diag);
         true
     } else {
         false
@@ -657,7 +657,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
             // If the matrix _is_ empty, we suggest adding an unpack.
             let is_positional = context.modules.struct_is_positional(&mident, &name);
             let Some(fields) = context.modules.struct_fields(&mident, &name) else {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     loc,
                     "Tried to look up fields for this struct and found none"
                 )));
@@ -722,7 +722,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
                     .modules
                     .enum_variant_fields(&mident, &name, &variant)
                 else {
-                    context.env.add_diag(ice!((
+                    context.add_diag(ice!((
                         loc,
                         "Tried to look up fields for this enum and found none"
                     )));
@@ -759,7 +759,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
     }
 
     let Some(ty) = matrix.tys.first() else {
-        context.env.add_diag(ice!((
+        context.add_diag(ice!((
             loc,
             "Pattern matrix with no types handed to IDE function"
         )));
@@ -778,7 +778,7 @@ fn ide_report_missing_arms(context: &mut Context, loc: Loc, matrix: &PatternMatr
     } else {
         if !context.env.has_errors() {
             // It's unclear how we got here, so report an ICE and suggest a wildcard.
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 loc,
                 format!(
                     "Found non-matchable type {} as match subject",

--- a/external-crates/move/crates/move-compiler/src/typing/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_compilation.rs
@@ -61,8 +61,8 @@ impl TypingVisitorContext for MatchCompiler<'_, '_> {
         }
     }
 
-    fn add_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
-        self.context.env.add_warning_filter_scope(filter);
+    fn push_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
+        self.context.env.push_warning_filter_scope(filter);
     }
 
     fn pop_warning_filter_scope(&mut self) {

--- a/external-crates/move/crates/move-compiler/src/typing/recursive_datatypes.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/recursive_datatypes.rs
@@ -79,7 +79,7 @@ fn module(compilation_env: &mut CompilationEnv, mname: ModuleIdent, module: &T::
     petgraph_scc(&graph)
         .into_iter()
         .filter(|scc| scc.len() > 1 || graph.contains_edge(scc[0], scc[0]))
-        .for_each(|scc| compilation_env.add_diag(cycle_error(context, &graph, scc[0])))
+        .for_each(|scc| compilation_env.add_error_diag(cycle_error(context, &graph, scc[0])))
 }
 
 fn struct_def(context: &mut Context, sname: DatatypeName, sdef: &N::StructDefinition) {

--- a/external-crates/move/crates/move-compiler/src/typing/recursive_datatypes.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/recursive_datatypes.rs
@@ -54,7 +54,7 @@ impl Context {
 //**************************************************************************************************
 
 pub fn modules(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     modules: &UniqueMap<ModuleIdent, T::ModuleDefinition>,
 ) {
     modules
@@ -62,7 +62,7 @@ pub fn modules(
         .for_each(|(mname, m)| module(compilation_env, mname, m))
 }
 
-fn module(compilation_env: &mut CompilationEnv, mname: ModuleIdent, module: &T::ModuleDefinition) {
+fn module(compilation_env: &CompilationEnv, mname: ModuleIdent, module: &T::ModuleDefinition) {
     let context = &mut Context::new(mname);
     module
         .structs

--- a/external-crates/move/crates/move-compiler/src/typing/syntax_methods.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/syntax_methods.rs
@@ -73,7 +73,7 @@ fn validate_index_syntax_methods(
         diag.add_note(
             "Index operations on the same type must take the name number of type arguments",
         );
-        context.env.add_diag(diag);
+        context.add_diag(diag);
         return false;
     }
 
@@ -92,7 +92,7 @@ fn validate_index_syntax_methods(
             (index_mut.loc, index_mut_msg),
         );
         diag.add_note("Index operations on the same type must take the name number of parameters");
-        context.env.add_diag(diag);
+        context.add_diag(diag);
         return false;
     }
 
@@ -121,7 +121,7 @@ fn validate_index_syntax_methods(
                 diag.add_note(
                     "Index operations on use the same abilities for their type parameters",
                 );
-                context.env.add_diag(diag);
+                context.add_diag(diag);
                 valid = false;
             }
         }
@@ -142,7 +142,7 @@ fn validate_index_syntax_methods(
                 diag.add_note(
                     "Index operations on use the same abilities for their type parameters",
                 );
-                context.env.add_diag(diag);
+                context.add_diag(diag);
                 valid = false;
             }
         }
@@ -200,7 +200,7 @@ fn validate_index_syntax_methods(
             let N::Type_::Ref(false, inner) =
                 core::ready_tvars(&subst, subject_ref_type.clone()).value
             else {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     index_finfo.signature.return_type.loc,
                     "This index function got to type verification with an invalid type"
                 )));
@@ -228,7 +228,7 @@ fn validate_index_syntax_methods(
             diag.add_note(
                 "These functions must take the same subject type, differing only by mutability",
             );
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             valid = false;
         }
     } else {
@@ -262,7 +262,7 @@ fn validate_index_syntax_methods(
                 &mut_finfo.signature.type_parameters,
             );
             diag.add_note("Index operation non-subject parameter types must match exactly");
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             valid = false;
         }
     }
@@ -282,7 +282,7 @@ fn validate_index_syntax_methods(
         let index_msg = format!("This index function returns type {}", ty_str(index_type));
         let N::Type_::Ref(false, inner) = core::ready_tvars(&subst, index_ty.return_.clone()).value
         else {
-            context.env.add_diag(ice!((
+            context.add_diag(ice!((
                 index_finfo.signature.return_type.loc,
                 "This index function got to type verification with an invalid type"
             )));
@@ -308,7 +308,7 @@ fn validate_index_syntax_methods(
             &mut_finfo.signature.type_parameters,
         );
         diag.add_note("These functions must return the same type, differing only by mutability");
-        context.env.add_diag(diag);
+        context.add_diag(diag);
         valid = false;
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -226,7 +226,7 @@ fn module(
     } = mdef;
     context.current_module = Some(ident);
     context.current_package = package_name;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     context.add_use_funs_scope(use_funs);
     structs
         .iter_mut()
@@ -238,7 +238,7 @@ fn module(
     assert!(context.constraints.is_empty());
     context.current_package = None;
     let use_funs = context.pop_use_funs_scope();
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     let typed_module = T::ModuleDefinition {
         loc,
         warning_filter,
@@ -289,7 +289,7 @@ fn function(context: &mut Context, name: FunctionName, f: N::Function) -> T::Fun
         mut signature,
         body: n_body,
     } = f;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
     assert!(context.constraints.is_empty());
     context.reset_for_module_item(name.loc());
     context.current_function = Some(name);
@@ -310,7 +310,7 @@ fn function(context: &mut Context, name: FunctionName, f: N::Function) -> T::Fun
     finalize_ide_info(context);
     context.current_function = None;
     context.in_macro_function = false;
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
     T::Function {
         warning_filter,
         index,
@@ -394,7 +394,7 @@ fn constant(context: &mut Context, name: ConstantName, nconstant: N::Constant) -
         signature,
         value: nvalue,
     } = nconstant;
-    context.env.add_warning_filter_scope(warning_filter.clone());
+    context.add_warning_filter_scope(warning_filter.clone());
 
     process_attributes(context, &attributes);
 
@@ -426,7 +426,7 @@ fn constant(context: &mut Context, name: ConstantName, nconstant: N::Constant) -
     if context.env.ide_mode() {
         finalize_ide_info(context);
     }
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 
     T::Constant {
         warning_filter,
@@ -503,9 +503,7 @@ mod check_valid_constant {
             core::error_format(ty, &Subst::empty()),
             format_comma(tys),
         );
-        context
-            .env
-            .add_diag(diag!(code, (sloc, fmsg()), (loc, tmsg)))
+        context.add_diag(diag!(code, (sloc, fmsg()), (loc, tmsg)))
     }
 
     pub fn exp(context: &mut Context, e: &T::Exp) {
@@ -591,7 +589,7 @@ mod check_valid_constant {
                 "'match' expressions are"
             }
             E::VariantMatch(_subject, _, _arms) => {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     *loc,
                     "shouldn't find variant match before match compilation"
                 )));
@@ -644,7 +642,7 @@ mod check_valid_constant {
                 "Enum variants are"
             }
         };
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             TypeSafety::UnsupportedConstant,
             (*loc, format!("{} not supported in constants", error_case))
         ));
@@ -691,9 +689,7 @@ mod check_valid_constant {
             }
         };
         let msg = format!("{} are not supported in constants", error_case);
-        context
-            .env
-            .add_diag(diag!(TypeSafety::UnsupportedConstant, (*loc, msg),))
+        context.add_diag(diag!(TypeSafety::UnsupportedConstant, (*loc, msg),))
     }
 }
 
@@ -704,9 +700,7 @@ mod check_valid_constant {
 fn struct_def(context: &mut Context, sloc: Loc, s: &mut N::StructDefinition) {
     assert!(context.constraints.is_empty());
     context.reset_for_module_item(sloc);
-    context
-        .env
-        .add_warning_filter_scope(s.warning_filter.clone());
+    context.add_warning_filter_scope(s.warning_filter.clone());
 
     let field_map = match &mut s.fields {
         N::StructFields::Native(_) => return,
@@ -749,15 +743,13 @@ fn struct_def(context: &mut Context, sloc: Loc, s: &mut N::StructDefinition) {
         expand::type_(context, &mut idx_ty.1);
     }
     check_type_params_usage(context, &s.type_parameters, field_map);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 }
 
 fn enum_def(context: &mut Context, enum_: &mut N::EnumDefinition) {
     assert!(context.constraints.is_empty());
 
-    context
-        .env
-        .add_warning_filter_scope(enum_.warning_filter.clone());
+    context.add_warning_filter_scope(enum_.warning_filter.clone());
 
     let enum_abilities = &enum_.abilities;
     let enum_type_params = &enum_.type_parameters;
@@ -770,7 +762,7 @@ fn enum_def(context: &mut Context, enum_: &mut N::EnumDefinition) {
     }
 
     check_variant_type_params_usage(context, enum_type_params, field_types);
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 }
 
 fn variant_def(
@@ -1031,7 +1023,7 @@ fn invalid_phantom_use_error(
         }
     };
     let decl_msg = format!("'{}' declared here as phantom", &param.user_specified_name);
-    context.env.add_diag(diag!(
+    context.add_diag(diag!(
         Declarations::InvalidPhantomUse,
         (ty_loc, msg),
         (param.user_specified_name.loc, decl_msg),
@@ -1050,9 +1042,7 @@ fn check_non_phantom_param_usage(
                 "Unused type parameter '{}'. Consider declaring it as phantom",
                 name
             );
-            context
-                .env
-                .add_diag(diag!(UnusedItem::StructTypeParam, (name.loc, msg)))
+            context.add_diag(diag!(UnusedItem::StructTypeParam, (name.loc, msg)))
         }
         Some(false) => {
             let msg = format!(
@@ -1060,9 +1050,7 @@ fn check_non_phantom_param_usage(
                  adding a phantom declaration here",
                 name
             );
-            context
-                .env
-                .add_diag(diag!(Declarations::InvalidNonPhantomUse, (name.loc, msg)))
+            context.add_diag(diag!(Declarations::InvalidNonPhantomUse, (name.loc, msg)))
         }
         Some(true) => {}
     }
@@ -1248,7 +1236,7 @@ fn subtype_impl<T: ToString, F: FnOnce() -> T>(
         Err(e) => {
             context.subst = subst;
             let diag = typing_error(context, /* from_subtype */ true, loc, msg, e);
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             Err(rhs)
         }
         Ok((next_subst, ty)) => {
@@ -1298,7 +1286,7 @@ fn join_opt<T: ToString, F: FnOnce() -> T>(
         Err(e) => {
             context.subst = subst;
             let diag = typing_error(context, /* from_subtype */ false, loc, msg, e);
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             None
         }
         Ok((next_subst, ty)) => {
@@ -1350,7 +1338,7 @@ fn invariant_impl<T: ToString, F: FnOnce() -> T>(
         Err(e) => {
             context.subst = subst;
             let diag = typing_error(context, /* from_subtype */ false, loc, msg, e);
-            context.env.add_diag(diag);
+            context.add_diag(diag);
             Err(rhs)
         }
         Ok((next_subst, ty)) => {
@@ -1681,9 +1669,7 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                 .check_feature(context.current_package, FeatureGate::Lambda, eloc)
             {
                 let msg = "Lambdas can only be used directly as arguments to 'macro' functions";
-                context
-                    .env
-                    .add_diag(diag!(TypeSafety::UnexpectedLambda, (eloc, msg)))
+                context.add_diag(diag!(TypeSafety::UnexpectedLambda, (eloc, msg)))
             }
             (context.error_type(eloc), TE::UnresolvedError)
         }
@@ -2043,9 +2029,7 @@ fn binop(
         }
 
         Range | Implies | Iff => {
-            context
-                .env
-                .add_diag(ice!((loc, "ICE unexpect specification operator")));
+            context.add_diag(ice!((loc, "ICE unexpect specification operator")));
             (context.error_type(loc), context.error_type(loc))
         }
     };
@@ -2323,9 +2307,7 @@ fn match_pattern_(
                      matched in the module in which they are declared",
                     &m, &struct_,
                 );
-                context
-                    .env
-                    .add_diag(diag!(TypeSafety::Visibility, (loc, msg)));
+                context.add_diag(diag!(TypeSafety::Visibility, (loc, msg)));
             }
             let bt = rtype!(bt);
             let pat_ = if field_error {
@@ -2808,7 +2790,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
     match core::ready_tvars(&context.subst, ty) {
         sp!(_, UnresolvedError) => context.error_type(loc),
         sp!(tloc, Anything) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::UninferredType,
                 (loc, msg()),
                 (tloc, UNINFERRED_MSG),
@@ -2816,7 +2798,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
             context.error_type(loc)
         }
         sp!(tloc, Var(i)) if !context.subst.is_num_var(i) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::UninferredType,
                 (loc, msg()),
                 (tloc, UNINFERRED_MSG),
@@ -2829,9 +2811,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
                     "Invalid access of field '{field}' on the struct '{m}::{n}'. The field '{field}' can only \
                     be accessed within the module '{m}' since it defines '{n}'"
                 );
-                context
-                    .env
-                    .add_diag(diag!(TypeSafety::Visibility, (loc, msg)));
+                context.add_diag(diag!(TypeSafety::Visibility, (loc, msg)));
             }
             match context.datatype_kind(&m, &n) {
                 DatatypeKind::Struct => {
@@ -2843,9 +2823,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
                          structs, not enums",
                         field, &m, &n
                     );
-                    context
-                        .env
-                        .add_diag(diag!(TypeSafety::ExpectedSpecificType, (loc, msg)));
+                    context.add_diag(diag!(TypeSafety::ExpectedSpecificType, (loc, msg)));
                     context.error_type(loc)
                 }
             }
@@ -2855,7 +2833,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
                 "Expected a struct type in the current module but got: {}",
                 core::error_format(&t, &context.subst)
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::ExpectedSpecificType,
                 (loc, msg()),
                 (t.loc, smsg),
@@ -2883,7 +2861,7 @@ fn add_struct_field_types<T>(
                  constructed/deconstructed, and their fields cannot be dirctly accessed",
                 verb, m, n
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::InvalidNativeUsage,
                 (loc, msg),
                 (nloc, "Struct declared 'native' here")
@@ -2894,15 +2872,13 @@ fn add_struct_field_types<T>(
     for (_, f_, _) in &fields_ty {
         if fields.get_(f_).is_none() {
             let msg = format!("Missing {} for field '{}' in '{}::{}'", verb, f_, m, n);
-            context
-                .env
-                .add_diag(diag!(TypeSafety::TooFewArguments, (loc, msg)))
+            context.add_diag(diag!(TypeSafety::TooFewArguments, (loc, msg)))
         }
     }
     fields.map(|f, (idx, x)| {
         let fty = match fields_ty.remove(&f) {
             None => {
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     NameResolution::UnboundField,
                     (loc, format!("Unbound field '{}' in '{}::{}'", &f, m, n))
                 ));
@@ -2947,15 +2923,13 @@ fn add_variant_field_types<T>(
                 "Missing {} for field '{}' in '{}::{}::{}'",
                 verb, f_, m, n, v
             );
-            context
-                .env
-                .add_diag(diag!(TypeSafety::TooFewArguments, (loc, msg)))
+            context.add_diag(diag!(TypeSafety::TooFewArguments, (loc, msg)))
         }
     }
     fields.map(|f, (idx, x)| {
         let fty = match fields_ty.remove(&f) {
             None => {
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     NameResolution::UnboundField,
                     (
                         loc,
@@ -2992,7 +2966,7 @@ fn find_index_funs(context: &mut Context, loc: Loc, ty: &Type) -> Option<IndexSy
     match ty {
         sp!(_, T::UnresolvedError) => None,
         sp!(tloc, T::Anything) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::UninferredType,
                 (loc, msg()),
                 (*tloc, UNINFERRED_MSG),
@@ -3000,7 +2974,7 @@ fn find_index_funs(context: &mut Context, loc: Loc, ty: &Type) -> Option<IndexSy
             None
         }
         sp!(tloc, T::Var(_)) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::UninferredType,
                 (loc, msg()),
                 (*tloc, UNINFERRED_MSG),
@@ -3010,9 +2984,7 @@ fn find_index_funs(context: &mut Context, loc: Loc, ty: &Type) -> Option<IndexSy
         sp!(_, T::Apply(_, type_name, _)) => {
             let index_opt = core::find_index_funs(context, type_name);
             if index_opt.is_none() {
-                context
-                    .env
-                    .add_diag(diag!(Declarations::MissingSyntaxMethod, (loc, msg()),));
+                context.add_diag(diag!(Declarations::MissingSyntaxMethod, (loc, msg()),));
             }
             index_opt
         }
@@ -3021,7 +2993,7 @@ fn find_index_funs(context: &mut Context, loc: Loc, ty: &Type) -> Option<IndexSy
                 "Expected a struct or builtin type but got: {}",
                 core::error_format(ty, &context.subst)
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 TypeSafety::ExpectedSpecificType,
                 (loc, msg()),
                 (ty.loc, smsg),
@@ -3055,9 +3027,7 @@ fn resolve_index_funs_and_type(
         return (None, context.error_type(loc));
     };
     let Some((m, f)) = index.get_name_for_typing() else {
-        context
-            .env
-            .add_diag(diag!(Declarations::MissingSyntaxMethod, (loc, msg()),));
+        context.add_diag(diag!(Declarations::MissingSyntaxMethod, (loc, msg()),));
         return (None, context.error_type(loc));
     };
     // NOTE: We don't do a visibility check here because we _just_ care about computing the return
@@ -3193,9 +3163,7 @@ fn process_exp_dotted(
             sp!(_, Type_::Ref(_, base)) => *base,
             ty @ sp!(_, Type_::UnresolvedError) => ty,
             _ => {
-                context
-                    .env
-                    .add_diag(ice!((dloc, "Index should have failed in naming")));
+                context.add_diag(ice!((dloc, "Index should have failed in naming")));
                 sp(dloc, Type_::UnresolvedError)
             }
         };
@@ -3242,9 +3210,7 @@ fn process_exp_dotted(
                 inner
             }
             N::ExpDotted_::DotAutocomplete(_loc, ndot) => {
-                context
-                    .env
-                    .add_diag(ice!((dloc, "Found a dot autocomplete where unsupported")));
+                context.add_diag(ice!((dloc, "Found a dot autocomplete where unsupported")));
                 // Keep going after the ICE.
                 process_exp_dotted_inner(context, constraint_verb, *ndot)
             }
@@ -3342,7 +3308,7 @@ fn resolve_exp_dotted(
                     },
                 ),
                 TE::Constant(_, _) if edotted.accessors.is_empty() => {
-                    context.env.add_diag(diag!(
+                    context.add_diag(diag!(
                         TypeSafety::InvalidMoveOp,
                         (loc, "Invalid 'move'. Cannot 'move' constants")
                     ));
@@ -3350,7 +3316,7 @@ fn resolve_exp_dotted(
                 }
                 TE::UnresolvedError => make_exp(edotted.base.ty, TE::UnresolvedError),
                 _ if edotted.accessors.is_empty() => {
-                    context.env.add_diag(diag!(
+                    context.add_diag(diag!(
                         TypeSafety::InvalidMoveOp,
                         (loc, "Invalid 'move'. Expected a variable or path.")
                     ));
@@ -3366,9 +3332,7 @@ fn resolve_exp_dotted(
                         borrow_exp_dotted(context, error_loc, false, edotted);
                         let msg = "Invalid 'move'. 'move' works only with \
                         variables, e.g. 'move x'. 'move' on a path access is not supported";
-                        context
-                            .env
-                            .add_diag(diag!(TypeSafety::InvalidMoveOp, (loc, msg)));
+                        context.add_diag(diag!(TypeSafety::InvalidMoveOp, (loc, msg)));
                         make_error(context)
                     } else {
                         make_error(context)
@@ -3397,9 +3361,7 @@ fn resolve_exp_dotted(
                     TE::UnresolvedError => make_exp(edotted.base.ty, TE::UnresolvedError),
                     _ => {
                         let msg = "Invalid 'copy'. Expected a variable or path.".to_owned();
-                        context
-                            .env
-                            .add_diag(diag!(TypeSafety::InvalidCopyOp, (loc, msg)));
+                        context.add_diag(diag!(TypeSafety::InvalidCopyOp, (loc, msg)));
                         make_error(context)
                     }
                 }
@@ -3484,7 +3446,7 @@ fn borrow_exp_dotted(
         };
         // lhs is immutable and current borrow is mutable
         if !cur_mut && expected_mut {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 ReferenceSafety::RefTrans,
                 (loc, "Invalid mutable borrow from an immutable reference"),
                 (tyloc, "Immutable because of this position"),
@@ -3550,7 +3512,6 @@ fn borrow_exp_dotted(
                     } else {
                         let msg = "Could not find a mutable index 'syntax' method";
                         context
-                            .env
                             .add_diag(diag!(Declarations::MissingSyntaxMethod, (index_loc, msg),));
                         exp = make_error_exp(context, index_loc);
                         break;
@@ -3559,9 +3520,7 @@ fn borrow_exp_dotted(
                     index.target_function
                 } else {
                     let msg = "Could not find an immutable index 'syntax' method";
-                    context
-                        .env
-                        .add_diag(diag!(Declarations::MissingSyntaxMethod, (index_loc, msg),));
+                    context.add_diag(diag!(Declarations::MissingSyntaxMethod, (index_loc, msg),));
                     exp = make_error_exp(context, index_loc);
                     break;
                 };
@@ -3577,7 +3536,7 @@ fn borrow_exp_dotted(
                         core::error_format(&ret_ty, &context.subst),
                         core::error_format(&mut_type, &context.subst)
                     );
-                    context.env.add_diag(ice!((loc, msg)));
+                    context.add_diag(ice!((loc, msg)));
                     exp = make_error_exp(context, index_loc);
                     break;
                 }
@@ -3619,7 +3578,7 @@ fn exp_dotted_to_owned(
             }
         }
     } else {
-        context.env.add_diag(ice!((
+        context.add_diag(ice!((
             ed.loc,
             "Attempted to make a dotted path with no dots"
         )));
@@ -3627,15 +3586,11 @@ fn exp_dotted_to_owned(
     };
     let case = match usage {
         DottedUsage::Move(_) => {
-            context
-                .env
-                .add_diag(ice!((ed.loc, "Invalid dotted usage 'move' in to_owned")));
+            context.add_diag(ice!((ed.loc, "Invalid dotted usage 'move' in to_owned")));
             return make_error_exp(context, ed.loc);
         }
         DottedUsage::Borrow(_) => {
-            context
-                .env
-                .add_diag(ice!((ed.loc, "Invalid dotted usage 'borrow' in to_owned")));
+            context.add_diag(ice!((ed.loc, "Invalid dotted usage 'borrow' in to_owned")));
             return make_error_exp(context, ed.loc);
         }
         DottedUsage::Use => "implicit copy",
@@ -3726,9 +3681,7 @@ fn warn_on_constant_borrow(context: &mut Context, loc: Loc, e: &T::Exp) {
     if matches!(&e.exp.value, TE::Constant(_, _)) {
         let msg = "This access will make a new copy of the constant. \
                    Consider binding the value to a variable first to make this copy explicit";
-        context
-            .env
-            .add_diag(diag!(TypeSafety::ImplicitConstantCopy, (loc, msg)))
+        context.add_diag(diag!(TypeSafety::ImplicitConstantCopy, (loc, msg)))
     }
 }
 
@@ -3875,7 +3828,7 @@ fn type_to_type_name_(
                     return None;
                 }
                 Ty::Ref(_, _) | Ty::Var(_) => {
-                    context.env.add_diag(ice!((
+                    context.add_diag(ice!((
                         loc,
                         "Typing did not unfold type before resolving type name"
                     )));
@@ -3884,7 +3837,7 @@ fn type_to_type_name_(
                 Ty::Apply(_, _, _) => unreachable!(),
             };
             if report_error {
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     TypeSafety::InvalidMethodCall,
                     (loc, format!("Invalid {error_msg}")),
                     (ty.loc, msg),
@@ -4022,7 +3975,7 @@ fn annotated_error_const(context: &mut Context, e: &mut T::Exp, abort_or_assert_
             the '#[error]' attribute is added to them."
                 .to_string(),
         );
-        context.env.add_diag(err);
+        context.add_diag(err);
 
         e.ty = context.error_type(e.ty.loc);
         e.exp = sp(e.exp.loc, T::UnannotatedExp_::UnresolvedError);
@@ -4272,7 +4225,7 @@ fn check_call_target(
     } else {
         "Normal (non-'macro') function is declared here"
     };
-    context.env.add_diag(diag!(
+    context.add_diag(diag!(
         TypeSafety::InvalidCallTarget,
         (macro_call_loc, call_msg),
         (decl_loc, decl_msg),
@@ -4496,7 +4449,7 @@ fn expand_macro(
     {
         None => {
             if !(context.env.has_errors() || context.env.ide_mode()) {
-                context.env.add_diag(ice!((
+                context.add_diag(ice!((
                     call_loc,
                     "No macro found, but name resolution passed."
                 )));
@@ -4625,24 +4578,18 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
     }
 
     let is_sui_mode = context.env.package_config(mdef.package_name).flavor == Flavor::Sui;
-    context
-        .env
-        .add_warning_filter_scope(mdef.warning_filter.clone());
+    context.add_warning_filter_scope(mdef.warning_filter.clone());
 
     for (loc, name, c) in &mdef.constants {
-        context
-            .env
-            .add_warning_filter_scope(c.warning_filter.clone());
+        context.add_warning_filter_scope(c.warning_filter.clone());
 
         let members = context.used_module_members.get(mident);
         if members.is_none() || !members.unwrap().contains(name) {
             let msg = format!("The constant '{name}' is never used. Consider removing it.");
-            context
-                .env
-                .add_diag(diag!(UnusedItem::Constant, (loc, msg)))
+            context.add_diag(diag!(UnusedItem::Constant, (loc, msg)))
         }
 
-        context.env.pop_warning_filter_scope();
+        context.pop_warning_filter_scope();
     }
 
     for (loc, name, fun) in &mdef.functions {
@@ -4658,9 +4605,7 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
             // a Sui-specific filter to avoid signaling that the init function is unused
             continue;
         }
-        context
-            .env
-            .add_warning_filter_scope(fun.warning_filter.clone());
+        context.add_warning_filter_scope(fun.warning_filter.clone());
 
         let members = context.used_module_members.get(mident);
         if fun.entry.is_none()
@@ -4673,12 +4618,10 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
                 "The non-'public', non-'entry' function '{name}' is never called. \
                 Consider removing it."
             );
-            context
-                .env
-                .add_diag(diag!(UnusedItem::Function, (loc, msg)))
+            context.add_diag(diag!(UnusedItem::Function, (loc, msg)))
         }
-        context.env.pop_warning_filter_scope();
+        context.pop_warning_filter_scope();
     }
 
-    context.env.pop_warning_filter_scope();
+    context.pop_warning_filter_scope();
 }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -53,7 +53,7 @@ use std::{
 //**************************************************************************************************
 
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: N::Program,
 ) -> T::Program {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -226,7 +226,7 @@ fn module(
     } = mdef;
     context.current_module = Some(ident);
     context.current_package = package_name;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     context.add_use_funs_scope(use_funs);
     structs
         .iter_mut()
@@ -289,7 +289,7 @@ fn function(context: &mut Context, name: FunctionName, f: N::Function) -> T::Fun
         mut signature,
         body: n_body,
     } = f;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
     assert!(context.constraints.is_empty());
     context.reset_for_module_item(name.loc());
     context.current_function = Some(name);
@@ -394,7 +394,7 @@ fn constant(context: &mut Context, name: ConstantName, nconstant: N::Constant) -
         signature,
         value: nvalue,
     } = nconstant;
-    context.add_warning_filter_scope(warning_filter.clone());
+    context.push_warning_filter_scope(warning_filter.clone());
 
     process_attributes(context, &attributes);
 
@@ -700,7 +700,7 @@ mod check_valid_constant {
 fn struct_def(context: &mut Context, sloc: Loc, s: &mut N::StructDefinition) {
     assert!(context.constraints.is_empty());
     context.reset_for_module_item(sloc);
-    context.add_warning_filter_scope(s.warning_filter.clone());
+    context.push_warning_filter_scope(s.warning_filter.clone());
 
     let field_map = match &mut s.fields {
         N::StructFields::Native(_) => return,
@@ -749,7 +749,7 @@ fn struct_def(context: &mut Context, sloc: Loc, s: &mut N::StructDefinition) {
 fn enum_def(context: &mut Context, enum_: &mut N::EnumDefinition) {
     assert!(context.constraints.is_empty());
 
-    context.add_warning_filter_scope(enum_.warning_filter.clone());
+    context.push_warning_filter_scope(enum_.warning_filter.clone());
 
     let enum_abilities = &enum_.abilities;
     let enum_type_params = &enum_.type_parameters;
@@ -4578,10 +4578,10 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
     }
 
     let is_sui_mode = context.env.package_config(mdef.package_name).flavor == Flavor::Sui;
-    context.add_warning_filter_scope(mdef.warning_filter.clone());
+    context.push_warning_filter_scope(mdef.warning_filter.clone());
 
     for (loc, name, c) in &mdef.constants {
-        context.add_warning_filter_scope(c.warning_filter.clone());
+        context.push_warning_filter_scope(c.warning_filter.clone());
 
         let members = context.used_module_members.get(mident);
         if members.is_none() || !members.unwrap().contains(name) {
@@ -4605,7 +4605,7 @@ fn unused_module_members(context: &mut Context, mident: &ModuleIdent_, mdef: &T:
             // a Sui-specific filter to avoid signaling that the init function is unused
             continue;
         }
-        context.add_warning_filter_scope(fun.warning_filter.clone());
+        context.push_warning_filter_scope(fun.warning_filter.clone());
 
         let members = context.used_module_members.get(mident);
         if fun.entry.is_none()

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -270,7 +270,7 @@ fn finalize_ide_info(context: &mut Context) {
     for (_loc, ann) in info.iter_mut() {
         expand::ide_annotation(context, ann);
     }
-    context.env.extend_ide_info(info);
+    context.extend_ide_info(info);
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -44,7 +44,7 @@ pub enum LValueKind {
 }
 
 pub trait TypingVisitorContext {
-    fn add_warning_filter_scope(&mut self, filters: WarningFilters);
+    fn push_warning_filter_scope(&mut self, filters: WarningFilters);
     fn pop_warning_filter_scope(&mut self);
 
     /// Indicates if types should be visited during the traversal of other forms (struct and enum
@@ -75,7 +75,7 @@ pub trait TypingVisitorContext {
     }
 
     fn visit_module(&mut self, ident: ModuleIdent, mdef: &T::ModuleDefinition) {
-        self.add_warning_filter_scope(mdef.warning_filter.clone());
+        self.push_warning_filter_scope(mdef.warning_filter.clone());
         if self.visit_module_custom(ident, mdef) {
             self.pop_warning_filter_scope();
             return;
@@ -116,7 +116,7 @@ pub trait TypingVisitorContext {
         struct_name: DatatypeName,
         sdef: &N::StructDefinition,
     ) {
-        self.add_warning_filter_scope(sdef.warning_filter.clone());
+        self.push_warning_filter_scope(sdef.warning_filter.clone());
         if self.visit_struct_custom(module, struct_name, sdef) {
             self.pop_warning_filter_scope();
             return;
@@ -149,7 +149,7 @@ pub trait TypingVisitorContext {
         enum_name: DatatypeName,
         edef: &N::EnumDefinition,
     ) {
-        self.add_warning_filter_scope(edef.warning_filter.clone());
+        self.push_warning_filter_scope(edef.warning_filter.clone());
         if self.visit_enum_custom(module, enum_name, edef) {
             self.pop_warning_filter_scope();
             return;
@@ -209,7 +209,7 @@ pub trait TypingVisitorContext {
         constant_name: ConstantName,
         cdef: &T::Constant,
     ) {
-        self.add_warning_filter_scope(cdef.warning_filter.clone());
+        self.push_warning_filter_scope(cdef.warning_filter.clone());
         if self.visit_constant_custom(module, constant_name, cdef) {
             self.pop_warning_filter_scope();
             return;
@@ -233,7 +233,7 @@ pub trait TypingVisitorContext {
         function_name: FunctionName,
         fdef: &T::Function,
     ) {
-        self.add_warning_filter_scope(fdef.warning_filter.clone());
+        self.push_warning_filter_scope(fdef.warning_filter.clone());
         if self.visit_function_custom(module, function_name, fdef) {
             self.pop_warning_filter_scope();
             return;
@@ -606,7 +606,7 @@ macro_rules! simple_visitor {
         }
 
         impl crate::typing::visitor::TypingVisitorContext for Context<'_> {
-            fn add_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
+            fn push_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
                 self.warning_filters_scope.push(filters)
             }
 
@@ -640,7 +640,7 @@ pub trait TypingMutVisitorConstructor: Send + Sync {
 }
 
 pub trait TypingMutVisitorContext {
-    fn add_warning_filter_scope(&mut self, filter: WarningFilters);
+    fn push_warning_filter_scope(&mut self, filter: WarningFilters);
     fn pop_warning_filter_scope(&mut self);
 
     /// Indicates if types should be visited during the traversal of other forms (struct and enum
@@ -675,7 +675,7 @@ pub trait TypingMutVisitorContext {
     }
 
     fn visit_module(&mut self, ident: ModuleIdent, mdef: &mut T::ModuleDefinition) {
-        self.add_warning_filter_scope(mdef.warning_filter.clone());
+        self.push_warning_filter_scope(mdef.warning_filter.clone());
         if self.visit_module_custom(ident, mdef) {
             self.pop_warning_filter_scope();
             return;
@@ -716,7 +716,7 @@ pub trait TypingMutVisitorContext {
         struct_name: DatatypeName,
         sdef: &mut N::StructDefinition,
     ) {
-        self.add_warning_filter_scope(sdef.warning_filter.clone());
+        self.push_warning_filter_scope(sdef.warning_filter.clone());
         if self.visit_struct_custom(module, struct_name, sdef) {
             self.pop_warning_filter_scope();
             return;
@@ -749,7 +749,7 @@ pub trait TypingMutVisitorContext {
         enum_name: DatatypeName,
         edef: &mut N::EnumDefinition,
     ) {
-        self.add_warning_filter_scope(edef.warning_filter.clone());
+        self.push_warning_filter_scope(edef.warning_filter.clone());
         if self.visit_enum_custom(module, enum_name, edef) {
             self.pop_warning_filter_scope();
             return;
@@ -807,7 +807,7 @@ pub trait TypingMutVisitorContext {
         constant_name: ConstantName,
         cdef: &mut T::Constant,
     ) {
-        self.add_warning_filter_scope(cdef.warning_filter.clone());
+        self.push_warning_filter_scope(cdef.warning_filter.clone());
         if self.visit_constant_custom(module, constant_name, cdef) {
             self.pop_warning_filter_scope();
             return;
@@ -831,7 +831,7 @@ pub trait TypingMutVisitorContext {
         function_name: FunctionName,
         fdef: &mut T::Function,
     ) {
-        self.add_warning_filter_scope(fdef.warning_filter.clone());
+        self.push_warning_filter_scope(fdef.warning_filter.clone());
         if self.visit_function_custom(module, function_name, fdef) {
             self.pop_warning_filter_scope();
             return;

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -591,6 +591,7 @@ macro_rules! simple_visitor {
                     warning_filters_scope,
                 }
             }
+        }
 
         impl Context<'_> {
             #[allow(unused)]

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     command_line::compiler::Visitor,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::WarningFilters,
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::{ConstantName, DatatypeName, FunctionName, VariantName},
@@ -42,50 +42,6 @@ pub enum LValueKind {
     Bind,
     Assign,
 }
-
-macro_rules! simple_visitor {
-    ($visitor:ty, $($overrides:item)*) => {
-        pub struct Context<'a> {
-            env: &'a mut crate::shared::CompilationEnv,
-            warning_filters_scope: crate::shared::WarningFiltersScope,
-        }
-
-        impl crate::typing::visitor::TypingVisitorConstructor for $visitor {
-            type Context<'a> = Context<'a>;
-
-            fn context<'a>(env: &'a mut  crate::shared::CompilationEnv, _program: &T::Program) -> Self::Context<'a> {
-                let warning_filters_scope = env.top_level_warning_filter_scope().clone();
-                Context {
-                    env,
-                    warning_filters_scope,
-                }
-            }
-        }
-
-        impl Context<'_> {
-            fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
-                self.env.add_diag(&self.warning_filters_scope, diag);
-            }
-
-            fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
-                self.env.add_diags(&self.warning_filters_scope, diags);
-            }
-        }
-
-        impl crate::typing::visitor::TypingVisitorContext for Context<'_> {
-            fn add_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
-                self.warning_filters_scope.push(filters)
-            }
-
-            fn pop_warning_filter_scope(&mut self) {
-                self.warning_filters_scope.pop()
-            }
-
-            $($overrides)*
-        }
-    }
-}
-pub(crate) use simple_visitor;
 
 pub trait TypingVisitorContext {
     fn add_warning_filter_scope(&mut self, filters: WarningFilters);
@@ -630,12 +586,6 @@ macro_rules! simple_visitor {
             fn context<'a>(env: &'a mut crate::shared::CompilationEnv, _program: &crate::typing::ast::Program) -> Self::Context<'a> {
                 Context {
                     env,
-                }
-            }
-        }
-
-        impl Context<'_> {
-            #[allow(unused)]
             fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
                 self.env.add_diag(diag);
             }

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -577,7 +577,8 @@ macro_rules! simple_visitor {
         pub struct $visitor;
 
         pub struct Context<'a> {
-            env: &'a mut crate::shared::CompilationEnv,
+            env: &'a crate::shared::CompilationEnv,
+            warning_filters_scope: crate::shared::WarningFiltersScope,
         }
 
         impl crate::typing::visitor::TypingVisitorConstructor for $visitor {
@@ -587,27 +588,27 @@ macro_rules! simple_visitor {
                 let warning_filters_scope = env.top_level_warning_filter_scope().clone();
                 Context {
                     env,
-                    warning_filters_scope
+                    warning_filters_scope,
                 }
             }
 
             fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
-                self.env.add_diag(diag);
+                self.env.add_diag(&self.warning_filters_scope, diag);
             }
 
             #[allow(unused)]
             fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
-                self.env.add_diags(diags);
+                self.env.add_diags(&self.warning_filters_scope, diags);
             }
         }
 
         impl crate::typing::visitor::TypingVisitorContext for Context<'_> {
             fn add_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
-                self.env.add_warning_filter_scope(filters)
+                self.warning_filters_scope.push(filters)
             }
 
             fn pop_warning_filter_scope(&mut self) {
-                self.env.pop_warning_filter_scope()
+                self.warning_filters_scope.pop()
             }
 
             $($overrides)*

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -592,6 +592,8 @@ macro_rules! simple_visitor {
                 }
             }
 
+        impl Context<'_> {
+            #[allow(unused)]
             fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
                 self.env.add_diag(&self.warning_filters_scope, diag);
             }

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -595,12 +595,12 @@ macro_rules! simple_visitor {
 
         impl Context<'_> {
             #[allow(unused)]
-            fn add_diag(&mut self, diag: crate::diagnostics::Diagnostic) {
+            fn add_diag(&self, diag: crate::diagnostics::Diagnostic) {
                 self.env.add_diag(&self.warning_filters_scope, diag);
             }
 
             #[allow(unused)]
-            fn add_diags(&mut self, diags: crate::diagnostics::Diagnostics) {
+            fn add_diags(&self, diags: crate::diagnostics::Diagnostics) {
                 self.env.add_diags(&self.warning_filters_scope, diags);
             }
         }

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     command_line::compiler::Visitor,
-    diagnostics::WarningFilters,
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::{ConstantName, DatatypeName, FunctionName, VariantName},

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -145,7 +145,7 @@ fn check_has_unit_test_module(
                 P::Definition::Module(P::ModuleDefinition { name, .. }) => name.0.loc,
                 P::Definition::Address(P::AddressDefinition { loc, .. }) => *loc,
             };
-            compilation_env.add_diag(diag!(
+            compilation_env.add_error_diag(diag!(
                 Attributes::InvalidTest,
                 (
                     loc,

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -18,13 +18,13 @@ use crate::{
 use std::sync::Arc;
 
 struct Context<'env> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     is_source_def: bool,
     current_package: Option<Symbol>,
 }
 
 impl<'env> Context<'env> {
-    fn new(env: &'env mut CompilationEnv) -> Self {
+    fn new(env: &'env CompilationEnv) -> Self {
         Self {
             env,
             is_source_def: false,
@@ -92,7 +92,7 @@ pub const UNIT_TEST_POISON_FUN_NAME: Symbol = symbol!("unit_test_poison");
 // in `compilation_env` is not set. If the test flag is set, no filtering is performed, and instead
 // a test plan is created for use by the testing framework.
 pub fn program(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: P::Program,
 ) -> P::Program {
@@ -127,7 +127,7 @@ fn has_unit_test_module(prog: &P::Program) -> bool {
 }
 
 fn check_has_unit_test_module(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
     prog: &P::Program,
 ) -> bool {

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -5,6 +5,7 @@
 use crate::{
     cfgir::ast as G,
     diag,
+    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
     expansion::ast::{
         self as E, Address, Attribute, AttributeValue, Attributes, ModuleAccess_, ModuleIdent,
         ModuleIdent_,
@@ -15,7 +16,7 @@ use crate::{
     shared::{
         known_attributes::{self, TestingAttribute},
         unique_map::UniqueMap,
-        CompilationEnv, Identifier, NumericalAddress,
+        CompilationEnv, Identifier, NumericalAddress, WarningFiltersScope,
     },
     unit_test::{
         ExpectedFailure, ExpectedMoveError, ModuleTestPlan, MoveErrorType, TestArgument, TestCase,
@@ -34,6 +35,7 @@ use std::collections::BTreeMap;
 
 struct Context<'env> {
     env: &'env mut CompilationEnv,
+    warning_filters_scope: WarningFiltersScope,
     constants: UniqueMap<ModuleIdent, UniqueMap<ConstantName, (Loc, Option<u64>, Attributes)>>,
 }
 
@@ -48,10 +50,28 @@ impl<'env> Context<'env> {
                 (constant.loc, v_opt, constant.attributes.clone())
             })
         });
+        let warning_filters_scope = compilation_env.top_level_warning_filter_scope().clone();
         Self {
             env: compilation_env,
+            warning_filters_scope,
             constants,
         }
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.env.add_diag(&self.warning_filters_scope, diag);
+    }
+
+    pub fn add_diags(&mut self, diags: Diagnostics) {
+        self.env.add_diags(&self.warning_filters_scope, diags);
+    }
+
+    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+        self.warning_filters_scope.push(filters)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.warning_filters_scope.pop()
     }
 
     fn resolve_address(&self, addr: &Address) -> NumericalAddress {
@@ -85,7 +105,15 @@ pub fn construct_test_plan(
         prog.modules
             .key_cloned_iter()
             .flat_map(|(module_ident, module_def)| {
-                construct_module_test_plan(&mut context, package_filter, module_ident, module_def)
+                context.add_warning_filter_scope(module_def.warning_filter.clone());
+                let plan = construct_module_test_plan(
+                    &mut context,
+                    package_filter,
+                    module_ident,
+                    module_def,
+                );
+                context.pop_warning_filter_scope();
+                plan
             })
             .collect(),
     )
@@ -104,8 +132,11 @@ fn construct_module_test_plan(
         .functions
         .iter()
         .filter_map(|(loc, fn_name, func)| {
-            build_test_info(context, loc, fn_name, func)
-                .map(|test_case| (fn_name.to_string(), test_case))
+            context.add_warning_filter_scope(func.warning_filter.clone());
+            let info = build_test_info(context, loc, fn_name, func)
+                .map(|test_case| (fn_name.to_string(), test_case));
+            context.pop_warning_filter_scope();
+            info
         })
         .collect();
 
@@ -143,7 +174,7 @@ fn build_test_info<'func>(
                 let fn_msg = "Only functions defined as a test with #[test] can also have an \
                               #[expected_failure] attribute";
                 let abort_msg = "Attributed as #[expected_failure] here";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Attributes::InvalidUsage,
                     (fn_loc, fn_msg),
                     (abort_attribute.loc, abort_msg),
@@ -154,7 +185,7 @@ fn build_test_info<'func>(
         (Some(test_attribute), Some(random_test_attribute)) => {
             let msg = "Function annotated as both #[test] and #[random_test]. You need to declare \
                        it as either one or the other";
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidUsage,
                 (random_test_attribute.loc, msg),
                 (test_attribute.loc, PREVIOUSLY_ANNOTATED_MSG),
@@ -170,7 +201,7 @@ fn build_test_info<'func>(
     if let Some(test_only_attribute) = test_only_attribute_opt {
         let msg = "Function annotated as both #[test] and #[test_only]. You need to declare \
                    it as either one or the other";
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             Attributes::InvalidUsage,
             (test_only_attribute.loc, msg),
             (test_attribute.loc, PREVIOUSLY_ANNOTATED_MSG),
@@ -205,7 +236,7 @@ fn build_test_info<'func>(
                             "Supported builti-in types are: bool, u8, u16, u32, u64, \
                             u128, u256, address, and vector<T> where T is a built-in type",
                         );
-                        context.env.add_diag(diag);
+                        context.add_diag(diag);
                         return None;
                     }
                 };
@@ -214,7 +245,7 @@ fn build_test_info<'func>(
             None => {
                 let missing_param_msg = "Missing test parameter assignment in test. Expected a \
                                          parameter to be assigned in this attribute";
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Attributes::InvalidTest,
                     (test_attribute.loc, missing_param_msg),
                     (vloc, "Corresponding to this parameter"),
@@ -227,7 +258,7 @@ fn build_test_info<'func>(
     if is_random_test && arguments.is_empty() {
         let msg = "No parameters to generate for random test. A #[random_test] function must \
                    have at least one parameter to generate.";
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             Attributes::InvalidTest,
             (test_attribute.loc, msg),
             (fn_loc, IN_THIS_TEST_MSG),
@@ -266,7 +297,7 @@ fn parse_test_attribute(
 
     match test_attribute {
         EA::Name(_) | EA::Parameterized(_, _) if depth > 0 => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidTest,
                 (*aloc, "Unexpected nested attribute in test declaration"),
             ));
@@ -281,7 +312,7 @@ fn parse_test_attribute(
         }
         EA::Assigned(nm, attr_value) => {
             if depth != 1 {
-                context.env.add_diag(diag!(
+                context.add_diag(diag!(
                     Attributes::InvalidTest,
                     (*aloc, "Unexpected nested attribute in test declaration"),
                 ));
@@ -291,7 +322,7 @@ fn parse_test_attribute(
             let value = match convert_attribute_value_to_move_value(context, attr_value) {
                 Some(move_value) => move_value,
                 None => {
-                    context.env.add_diag(diag!(
+                    context.add_diag(diag!(
                         Attributes::InvalidValue,
                         (*assign_loc, "Unsupported attribute value"),
                         (*aloc, "Assigned in this attribute"),
@@ -338,7 +369,7 @@ fn parse_failure_attribute(
             let invalid_assignment_msg = "Invalid expected failure code assignment";
             let expected_msg =
                 "Expect an #[expected_failure(...)] attribute for error specification";
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (assign_loc, invalid_assignment_msg),
                 (*aloc, expected_msg),
@@ -369,9 +400,7 @@ fn parse_failure_attribute(
                     expected_failure_kind_vec.len(),
                     TestingAttribute::expected_failure_cases().to_vec().join(", ")
                 );
-                context
-                    .env
-                    .add_diag(diag!(Attributes::InvalidValue, (*aloc, invalid_attr_msg)));
+                context.add_diag(diag!(Attributes::InvalidValue, (*aloc, invalid_attr_msg)));
                 return None;
             }
             let (expected_failure_kind, (attr_loc, attr)) =
@@ -400,7 +429,7 @@ fn parse_failure_attribute(
                             attribute.",
                             TestingAttribute::ERROR_LOCATION
                         );
-                        context.env.add_diag(diag!(
+                        context.add_diag(diag!(
                             Attributes::ValueWarning,
                             (attr_loc, BAD_ABORT_VALUE_WARNING),
                             (value_loc, tip)
@@ -500,7 +529,7 @@ fn parse_failure_attribute(
                         );
                         let no_code =
                             format!("No status code associated with value '{move_error_type}'");
-                        context.env.add_diag(diag!(
+                        context.add_diag(diag!(
                             Attributes::InvalidValue,
                             (value_name_loc, bad_value),
                             (major_value_loc, no_code)
@@ -541,9 +570,7 @@ fn parse_failure_attribute(
                     "Unused attribute for {}",
                     TestingAttribute::ExpectedFailure.name()
                 );
-                context
-                    .env
-                    .add_diag(diag!(UnusedItem::Attribute, (loc, msg)));
+                context.add_diag(diag!(UnusedItem::Attribute, (loc, msg)));
             }
             Some(ExpectedFailure::ExpectedWithError(ExpectedMoveError(
                 status_code,
@@ -571,7 +598,7 @@ fn check_attribute_unassigned(
                 "Expected no assigned value, e.g. '{}', for expected failure attribute",
                 kind
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (attr_loc, "Unsupported attribute in this location"),
                 (loc, msg)
@@ -598,7 +625,7 @@ fn get_assigned_attribute(
                 "Expected assigned value, e.g. '{}=...', for expected failure attribute",
                 kind
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (attr_loc, "Unsupported attribute in this location"),
                 (loc, msg)
@@ -615,7 +642,7 @@ fn convert_location(context: &mut Context, attr_loc: Loc, attr: Attribute) -> Op
     match value {
         sp!(vloc, EAV::Module(module)) => convert_module_id(context, vloc, &module),
         sp!(vloc, _) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (loc, INVALID_VALUE),
                 (vloc, "Expected a module identifier, e.g. 'std::vector'")
@@ -645,7 +672,7 @@ fn convert_constant_value_u64_constant_or_value(
     let modules_constants = context.constants().get(module).unwrap();
     let constant = match modules_constants.get_(&member.value) {
         None => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (vloc, INVALID_VALUE),
                 (
@@ -667,7 +694,7 @@ fn convert_constant_value_u64_constant_or_value(
                 "Constant '{module}::{member}' has a non-u64 value. \
                 Only 'u64' values are permitted"
             );
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (vloc, INVALID_VALUE),
                 (*cloc, msg),
@@ -680,7 +707,7 @@ fn convert_constant_value_u64_constant_or_value(
 
 fn convert_module_id(context: &mut Context, vloc: Loc, module: &ModuleIdent) -> Option<ModuleId> {
     if !context.constants.contains_key(module) {
-        context.env.add_diag(diag!(
+        context.add_diag(diag!(
             Attributes::InvalidValue,
             (vloc, INVALID_VALUE),
             (module.loc, format!("Unbound module '{module}'")),
@@ -693,7 +720,7 @@ fn convert_module_id(context: &mut Context, vloc: Loc, module: &ModuleIdent) -> 
             value: sp!(_, a), ..
         } => a.into_inner(),
         Address::NamedUnassigned(addr) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (vloc, INVALID_VALUE),
                 (*mloc, format!("Unbound address '{addr}'")),
@@ -722,7 +749,7 @@ fn convert_attribute_value_u64(
         | sp!(vloc, EAV::Value(sp!(_, EV::U32(_))))
         | sp!(vloc, EAV::Value(sp!(_, EV::U128(_))))
         | sp!(vloc, EAV::Value(sp!(_, EV::U256(_)))) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (loc, INVALID_VALUE),
                 (*vloc, "Annotated non-u64 literals are not permitted"),
@@ -730,7 +757,7 @@ fn convert_attribute_value_u64(
             None
         }
         sp!(vloc, _) => {
-            context.env.add_diag(diag!(
+            context.add_diag(diag!(
                 Attributes::InvalidValue,
                 (loc, INVALID_VALUE),
                 (*vloc, "Unsupported value in this assignment"),
@@ -765,9 +792,7 @@ fn check_location<T>(
             "Expected '{}' following '{attr}'",
             TestingAttribute::ERROR_LOCATION
         );
-        context
-            .env
-            .add_diag(diag!(Attributes::InvalidUsage, (loc, msg)));
+        context.add_diag(diag!(Attributes::InvalidUsage, (loc, msg)));
     }
     location
 }

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -58,12 +58,12 @@ impl<'env> Context<'env> {
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
+    pub fn add_diag(&self, diag: Diagnostic) {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
     #[allow(unused)]
-    pub fn add_diags(&mut self, diags: Diagnostics) {
+    pub fn add_diags(&self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -67,7 +67,7 @@ impl<'env> Context<'env> {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }
 
-    pub fn add_warning_filter_scope(&mut self, filters: WarningFilters) {
+    pub fn push_warning_filter_scope(&mut self, filters: WarningFilters) {
         self.warning_filters_scope.push(filters)
     }
 
@@ -106,7 +106,7 @@ pub fn construct_test_plan(
         prog.modules
             .key_cloned_iter()
             .flat_map(|(module_ident, module_def)| {
-                context.add_warning_filter_scope(module_def.warning_filter.clone());
+                context.push_warning_filter_scope(module_def.warning_filter.clone());
                 let plan = construct_module_test_plan(
                     &mut context,
                     package_filter,
@@ -133,7 +133,7 @@ fn construct_module_test_plan(
         .functions
         .iter()
         .filter_map(|(loc, fn_name, func)| {
-            context.add_warning_filter_scope(func.warning_filter.clone());
+            context.push_warning_filter_scope(func.warning_filter.clone());
             let info = build_test_info(context, loc, fn_name, func)
                 .map(|test_case| (fn_name.to_string(), test_case));
             context.pop_warning_filter_scope();

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -34,13 +34,13 @@ use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 struct Context<'env> {
-    env: &'env mut CompilationEnv,
+    env: &'env CompilationEnv,
     warning_filters_scope: WarningFiltersScope,
     constants: UniqueMap<ModuleIdent, UniqueMap<ConstantName, (Loc, Option<u64>, Attributes)>>,
 }
 
 impl<'env> Context<'env> {
-    fn new(compilation_env: &'env mut CompilationEnv, prog: &G::Program) -> Self {
+    fn new(compilation_env: &'env CompilationEnv, prog: &G::Program) -> Self {
         let constants = prog.modules.ref_map(|_mident, module| {
             module.constants.ref_map(|_name, constant| {
                 let v_opt = constant.value.as_ref().and_then(|v| match v {
@@ -92,7 +92,7 @@ impl<'env> Context<'env> {
 // Constructs a test plan for each module in `prog`. This also validates the structure of the
 // attributes as the test plan is constructed.
 pub fn construct_test_plan(
-    compilation_env: &mut CompilationEnv,
+    compilation_env: &CompilationEnv,
     package_filter: Option<Symbol>,
     prog: &G::Program,
 ) -> Option<Vec<ModuleTestPlan>> {

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -62,6 +62,7 @@ impl<'env> Context<'env> {
         self.env.add_diag(&self.warning_filters_scope, diag);
     }
 
+    #[allow(unused)]
     pub fn add_diags(&mut self, diags: Diagnostics) {
         self.env.add_diags(&self.warning_filters_scope, diags);
     }

--- a/external-crates/move/crates/move-unit-test/src/lib.rs
+++ b/external-crates/move/crates/move-unit-test/src/lib.rs
@@ -187,7 +187,7 @@ impl UnitTestingConfig {
         let (_, compiler) =
             diagnostics::unwrap_or_report_pass_diagnostics(&files, comments_and_compiler_res);
 
-        let (mut compiler, cfgir) = compiler.into_ast();
+        let (compiler, cfgir) = compiler.into_ast();
         let compilation_env = compiler.compilation_env();
         let test_plan = unit_test::plan_builder::construct_test_plan(compilation_env, None, &cfgir);
         let mapped_files = compilation_env.mapped_files().clone();


### PR DESCRIPTION
## Description 

- To make the compiler more parallel friendly, the warning filter scope needs to be local to the environment it is in
- Conceptually, CompilationEnv was always the wrong place for this, and trying to add parallelism just exposed this
- Added a RwLock around Diagnostics to help with linters. It was a bit hard to tie the knot without doing this as a part of this PR

## Test plan 

- Ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
