### PR TITLE
add Client-Request-Method header to all TS SDK requests

### DIFF
--- a/.changeset/dull-lobsters-punch.md
+++ b/.changeset/dull-lobsters-punch.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Adds a custom header; 'Client-Request-Method' which will contain the method name used in each outgoing jsonrpc request

--- a/sdk/typescript/src/client/http-transport.ts
+++ b/sdk/typescript/src/client/http-transport.ts
@@ -95,6 +95,7 @@ export class SuiHTTPTransport implements SuiTransport {
 				'Client-Sdk-Type': 'typescript',
 				'Client-Sdk-Version': PACKAGE_VERSION,
 				'Client-Target-Api-Version': TARGETED_RPC_VERSION,
+				'Client-Request-Method': input.method,
 				...this.#options.rpc?.headers,
 			},
 			body: JSON.stringify({

--- a/sdk/typescript/test/unit/client/http-transport.test.ts
+++ b/sdk/typescript/test/unit/client/http-transport.test.ts
@@ -62,6 +62,7 @@ describe('SuiHTTPTransport', () => {
 					'Client-Sdk-Type': 'typescript',
 					'Client-Sdk-Version': PACKAGE_VERSION,
 					'Client-Target-Api-Version': TARGETED_RPC_VERSION,
+					'Client-Request-Method': 'getAllBalances',
 				},
 				method: 'POST',
 			});


### PR DESCRIPTION
## Description 
This will be used by the new edge proxy for routing execute transaction requests to fullnodes with lower consensus latency

## Test plan 

unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
