### PR TITLE
Enable gas-budget-based congestion control with overage & absolute cap

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5911,6 +5911,7 @@ async fn test_consensus_handler_per_object_congestion_control(
         }
     }
     protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(1000); // Set to a large number so that we don't hit this limit.
+    protocol_config.set_max_txn_cost_overage_per_object_in_commit_for_testing(0);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)
@@ -6139,6 +6140,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     protocol_config
         .set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(100_000_000);
     protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(2);
+    protocol_config.set_max_txn_cost_overage_per_object_in_commit_for_testing(0);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -192,6 +192,7 @@ const MAX_PROTOCOL_VERSION: u64 = 68;
 // Version 67: Re-enable distributed vote scoring in mainnet.
 // Version 68: Add G1Uncompressed group to group ops.
 //             Update to Move stdlib.
+//             Enable gas based congestion control with overage.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1250,10 +1251,7 @@ pub struct ProtocolConfig {
     /// The maximum number of transactions included in a consensus block.
     consensus_max_num_transactions_in_block: Option<u64>,
 
-    /// The max accumulated txn execution cost per object in a Narwhal commit. Transactions
-    /// in a checkpoint will be deferred once their touch shared objects hit this limit.
-    /// This config is meant to be used when consensus protocol is Narwhal, where each
-    /// consensus commit corresponding to 1 checkpoint (or 2 if randomness is enabled)
+    /// DEPRECATED. Do not use.
     max_accumulated_txn_cost_per_object_in_narwhal_commit: Option<u64>,
 
     /// The max number of consensus rounds a transaction can be deferred due to shared object congestion.
@@ -2909,6 +2907,15 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.uncompressed_g1_group_elements = true;
                     }
+
+                    cfg.feature_flags.per_object_congestion_control_mode =
+                        PerObjectCongestionControlMode::TotalGasBudgetWithCap;
+                    cfg.gas_budget_based_txn_cost_cap_factor = Some(400_000);
+                    cfg.max_accumulated_txn_cost_per_object_in_mysticeti_commit = Some(18_500_000);
+                    cfg.max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit =
+                        Some(3_700_000); // 20% of above
+                    cfg.max_txn_cost_overage_per_object_in_commit = Some(u64::MAX);
+                    cfg.gas_budget_based_txn_cost_absolute_cap_commit_count = Some(50);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_68.snap
@@ -45,7 +45,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  per_object_congestion_control_mode: TotalTxCount
+  per_object_congestion_control_mode: TotalGasBudgetWithCap
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
@@ -326,10 +326,13 @@ consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
-max_accumulated_txn_cost_per_object_in_mysticeti_commit: 3
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_68.snap
@@ -45,7 +45,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  per_object_congestion_control_mode: TotalTxCount
+  per_object_congestion_control_mode: TotalGasBudgetWithCap
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
@@ -326,10 +326,13 @@ consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
-max_accumulated_txn_cost_per_object_in_mysticeti_commit: 3
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_68.snap
@@ -47,7 +47,7 @@ feature_flags:
   enable_group_ops_native_functions: true
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
-  per_object_congestion_control_mode: TotalTxCount
+  per_object_congestion_control_mode: TotalGasBudgetWithCap
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
@@ -337,10 +337,13 @@ consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
-max_accumulated_txn_cost_per_object_in_mysticeti_commit: 3
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 


### PR DESCRIPTION
## Description 

- Changes congestion control mode to use gas budget with cap.
- Sets a separate (lower) limit for randomness-using tx.
- Allows up to one tx per-commit per-object to exceed the budget, with accumulated debt tracking.
- Adds absolute capped cost at a multiple of per-commit budget.

## Test plan 

Unit tests & simtests in PRs adding these `ProtocolConfig` parameters.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enables gas-budget-based congestion control with allowed overage & absolute cap
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
