### PR TITLE
[cli][ptb] Fix type resolution for primitive type instantiations in PTB CLI

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1871,7 +1871,7 @@ fn get_signature_types(
                 .signature_at(func.parameters)
                 .0
                 .iter()
-                .map(|s| primitive_type(module, &[], s).1)
+                .map(|s| primitive_type(module, &[], s))
                 .collect(),
         )
     } else {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -50,6 +50,7 @@ use move_binary_format::file_format::SignatureToken;
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::resolve_struct;
 use move_core_types::account_address::AccountAddress;
+use move_core_types::annotated_value as A;
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::ModuleId;
@@ -438,6 +439,14 @@ pub fn is_primitive_type_tag(t: &TypeTag) -> bool {
             let resolved_struct = (address, module.as_ident_str(), name.as_ident_str());
             // is id or..
             if resolved_struct == RESOLVED_SUI_ID {
+                return true;
+            }
+            // is utf8 string
+            if resolved_struct == RESOLVED_UTF8_STR {
+                return true;
+            }
+            // is ascii string
+            if resolved_struct == RESOLVED_ASCII_STR {
                 return true;
             }
             // is option of a primitive
@@ -892,6 +901,36 @@ pub const RESOLVED_UTF8_STR: (&AccountAddress, &IdentStr, &IdentStr) = (
 
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("tx_context");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("TxContext");
+
+pub fn move_ascii_str_layout() -> A::MoveStructLayout {
+    A::MoveStructLayout {
+        type_: StructTag {
+            address: MOVE_STDLIB_ADDRESS,
+            module: STD_ASCII_MODULE_NAME.to_owned(),
+            name: STD_ASCII_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        },
+        fields: Box::new(vec![A::MoveFieldLayout::new(
+            ident_str!("bytes").into(),
+            A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8)),
+        )]),
+    }
+}
+
+pub fn move_utf8_str_layout() -> A::MoveStructLayout {
+    A::MoveStructLayout {
+        type_: StructTag {
+            address: MOVE_STDLIB_ADDRESS,
+            module: STD_UTF8_MODULE_NAME.to_owned(),
+            name: STD_UTF8_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        },
+        fields: Box::new(vec![A::MoveFieldLayout::new(
+            ident_str!("bytes").into(),
+            A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8)),
+        )]),
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct TxContext {

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -443,13 +443,13 @@ impl<'a> PTBBuilder<'a> {
         sp!(loc, arg): Spanned<PTBArg>,
         param: &SignatureToken,
     ) -> PTBResult<Tx::Argument> {
-        let (is_primitive, layout) = primitive_type(view, ty_args, param);
+        let layout = primitive_type(view, ty_args, param);
 
         // If it's a primitive value, see if we've already resolved this argument. Otherwise, we
         // need to resolve it.
-        if is_primitive {
+        if let Some(layout) = layout {
             return self
-                .resolve(loc.wrap(arg), ToPure::new_from_layout(layout.unwrap()))
+                .resolve(loc.wrap(arg), ToPure::new_from_layout(layout))
                 .await;
         }
 

--- a/crates/sui/tests/ptb_files/resolution/type_param_resolution.ptb
+++ b/crates/sui/tests/ptb_files/resolution/type_param_resolution.ptb
@@ -1,0 +1,4 @@
+--move-call 0x2::table::new<address, u64>
+--assign table
+--move-call 0x2::table::add<address, u64> table @0x2 0
+--transfer-objects [table] @0x0

--- a/crates/sui/tests/snapshots/ptb_files_tests__type_param_resolution.ptb.snap
+++ b/crates/sui/tests/snapshots/ptb_files_tests__type_param_resolution.ptb.snap
@@ -1,0 +1,22 @@
+---
+source: crates/sui/tests/ptb_files_tests.rs
+expression: "results.join(\"\\n\")"
+---
+ === PREVIEW === 
+╭───────────────────────────────────────────────────────────────╮
+│ PTB Preview                                                   │
+├──────────────────┬────────────────────────────────────────────┤
+│ command          │ values                                     │
+├──────────────────┼────────────────────────────────────────────┤
+│ move-call        │ 0x2::table::new<address, u64>              │
+│ assign           │ table                                      │
+│ move-call        │ 0x2::table::add<address, u64> table @0x2 0 │
+│ transfer-objects │ [table] @0x0                               │
+╰──────────────────┴────────────────────────────────────────────╯
+ === BUILT PTB === 
+Input 0: Pure([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2])
+Input 1: Pure([0, 0, 0, 0, 0, 0, 0, 0])
+Input 2: Pure([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+Command 0: MoveCall(0x0000000000000000000000000000000000000000000000000000000000000002::table::new<address,u64>())
+Command 1: MoveCall(0x0000000000000000000000000000000000000000000000000000000000000002::table::add<address,u64>(Result(0),Input(0),Input(1)))
+Command 2: TransferObjects([Result(0)],Input(2))


### PR DESCRIPTION
## Description 

Fixes an issue where type layouts were not always returned for all primitive types, and simplifies the APIs around this a bit.

## Test plan 

Added a repro test and made sure it passed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Bugfix to allow resolving generic type parameters instantiated with primitive types in the CLI PTB builder.
- [ ] Rust SDK: 
- [ ] REST API:
