### PR TITLE
Rename `gas-profiler` feature flag to `tracing`

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -47,8 +47,8 @@ fn main() {
     // TODO: re-enable after we figure out how to eliminate crashes in prod because of this.
     // ProtocolConfig::poison_get_for_min_version();
 
-    move_vm_profiler::gas_profiler_feature_enabled! {
-        panic!("Cannot run the sui-node binary with gas-profiler feature enabled");
+    move_vm_profiler::tracing_feature_enabled! {
+        panic!("Cannot run the sui-node binary with tracing feature enabled");
     }
 
     let args = Args::parse();

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -101,8 +101,8 @@ harness = false
 [features]
 default = []
 test-utils = []
-gas-profiler = [
-    "move-vm-profiler/gas-profiler",
-    "move-vm-test-utils/gas-profiler",
+tracing = [
+    "move-vm-profiler/tracing",
+    "move-vm-test-utils/tracing",
 ]
 fuzzing = ["move-core-types/fuzzing"]

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -131,7 +131,7 @@ name = "ptb_files_tests"
 harness = false
 
 [features]
-gas-profiler = [
-    "sui-types/gas-profiler",
-    "sui-execution/gas-profiler",
+tracing = [
+    "sui-types/tracing",
+    "sui-execution/tracing",
 ]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -679,10 +679,10 @@ impl SuiClientCommands {
                 tx_digest,
                 profile_output,
             } => {
-                move_vm_profiler::gas_profiler_feature_disabled! {
+                move_vm_profiler::tracing_feature_disabled! {
                     bail!(
-                        "gas-profiler feature is not enabled, rebuild or reinstall with \
-                         --features gas-profiler"
+                        "tracing feature is not enabled, rebuild or reinstall with \
+                         --features tracing"
                     );
                 };
 

--- a/crates/sui/src/unit_tests/profiler_tests.rs
+++ b/crates/sui/src/unit_tests/profiler_tests.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// This test exists to make sure that the feature gating for all the code under `gas-profiler`
-/// remains fully connected such that if and only if we enable the feature here, the `gas-profiler`
+/// This test exists to make sure that the feature gating for all the code under `tracing`
+/// remains fully connected such that if and only if we enable the feature here, the `tracing`
 /// feature gets enabled anywhere.
 ///
 /// If this test fails, check for the following.
 ///
-/// Any crate that has code decorated with #[cfg(feature = "gas-profiler")] needs to have
-/// a feature declared in its Cargo.toml named `gas-profiler`. If moving / refactoring code with
+/// Any crate that has code decorated with #[cfg(feature = "tracing")] needs to have
+/// a feature declared in its Cargo.toml named `tracing`. If moving / refactoring code with
 /// this decorator from a crate to a different crate, it is likely needed to copy over some of the
 /// feature declaration defined in the original crate. Also ensure we do not include the feature in
 /// any dependency of the dependencies section so that the feature won't get partially enabled as
@@ -21,18 +21,18 @@
 /// defined in all the other crates that the decorated code in the current crate depends on.
 ///
 /// Note this crate will always have the feature enabled in testing due to the addition of
-/// `sui = { path = ".", features = ["gas-profiler"] }` to our dev-dependencies.
+/// `sui = { path = ".", features = ["tracing"] }` to our dev-dependencies.
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 #[test]
 fn test_macro_shows_feature_enabled() {
-    move_vm_profiler::gas_profiler_feature_disabled! {
+    move_vm_profiler::tracing_feature_disabled! {
         panic!("gas profile feature graph became disconnected");
     }
 }
 
 #[ignore]
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_profiler() {
     use std::fs;

--- a/external-crates/move/crates/move-cli/Cargo.toml
+++ b/external-crates/move/crates/move-cli/Cargo.toml
@@ -64,4 +64,4 @@ harness = false
 
 [features]
 tiered-gas = ["move-vm-test-utils/tiered-gas"]
-gas-profiler = ["move-vm-runtime/gas-profiler"]
+tracing = ["move-vm-runtime/tracing"]

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/run.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/run.rs
@@ -83,7 +83,7 @@ pub fn run(
         // script fun. parse module, extract script ID to pass to VM
         let module = CompiledModule::deserialize_with_defaults(&bytecode)
             .map_err(|e| anyhow!("Error deserializing module: {:?}", e))?;
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             use move_vm_types::gas::GasMeter;
 

--- a/external-crates/move/crates/move-cli/tests/tracing_testsuite.rs
+++ b/external-crates/move/crates/move-cli/tests/tracing_testsuite.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 #[allow(unused_variables)]
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     {
         use move_cli::sandbox::commands::test;
         use std::path::PathBuf;

--- a/external-crates/move/crates/move-unit-test/Cargo.toml
+++ b/external-crates/move/crates/move-unit-test/Cargo.toml
@@ -51,4 +51,4 @@ name = "move_unit_test_testsuite"
 harness = false
 
 [features]
-gas-profiler = []
+tracing = []

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -262,7 +262,7 @@ impl SharedTestingConfig {
         let mut session =
             move_vm.new_session_with_extensions(&self.starting_storage_state, extensions);
         let mut gas_meter = GasStatus::new(&self.cost_table, Gas::new(self.execution_bound));
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             use move_vm_types::gas::GasMeter;
             gas_meter.set_profiler(GasProfiler::init_default_cfg(

--- a/external-crates/move/crates/move-vm-config/Cargo.toml
+++ b/external-crates/move/crates/move-vm-config/Cargo.toml
@@ -12,4 +12,4 @@ move-binary-format.workspace = true
 once_cell.workspace = true
 
 [features]
-gas-profiler = []
+tracing = []

--- a/external-crates/move/crates/move-vm-config/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-config/src/runtime.rs
@@ -4,13 +4,13 @@
 use crate::verifier::{VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN};
 use move_binary_format::binary_config::BinaryConfig;
 use move_binary_format::file_format_common::VERSION_MAX;
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 use once_cell::sync::Lazy;
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 const MOVE_VM_PROFILER_ENV_VAR_NAME: &str = "MOVE_VM_PROFILE";
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 static PROFILER_ENABLED: Lazy<bool> =
     Lazy::new(|| std::env::var(MOVE_VM_PROFILER_ENV_VAR_NAME).is_ok());
 
@@ -88,7 +88,7 @@ pub struct VMProfilerConfig {
     pub use_long_function_name: bool,
 }
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 impl std::default::Default for VMProfilerConfig {
     fn default() -> Self {
         Self {
@@ -99,7 +99,7 @@ impl std::default::Default for VMProfilerConfig {
     }
 }
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 impl VMProfilerConfig {
     pub fn get_default_config_if_enabled() -> Option<VMProfilerConfig> {
         if *PROFILER_ENABLED {

--- a/external-crates/move/crates/move-vm-integration-tests/Cargo.toml
+++ b/external-crates/move/crates/move-vm-integration-tests/Cargo.toml
@@ -32,11 +32,11 @@ move-ir-to-bytecode.workspace = true
 
 [features]
 default = []
-gas-profiler = [
-    "move-vm-config/gas-profiler",
-    "move-vm-runtime/gas-profiler",
-    "move-vm-profiler/gas-profiler",
-    "move-vm-test-utils/gas-profiler",
+tracing = [
+    "move-vm-config/tracing",
+    "move-vm-runtime/tracing",
+    "move-vm-profiler/tracing",
+    "move-vm-test-utils/tracing",
 ]
 
 [[bin]]

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
@@ -23,7 +23,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag, TypeTag},
     vm_status::StatusCode,
 };
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 use move_vm_profiler::GasProfiler;
 use move_vm_runtime::{
     move_vm::MoveVM,
@@ -33,7 +33,7 @@ use move_vm_test_utils::{
     gas_schedule::{Gas, GasStatus, INITIAL_COST_SCHEDULE},
     InMemoryStorage,
 };
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 use move_vm_types::gas::GasMeter;
 use std::time::Instant;
 
@@ -555,7 +555,7 @@ fn run_with_module(
         .into_iter()
         .map(|tag| session.load_type(&tag))
         .collect::<VMResult<Vec<_>>>();
-    move_vm_profiler::gas_profiler_feature_enabled! {
+    move_vm_profiler::tracing_feature_enabled! {
         gas.set_profiler(GasProfiler::init(
             &session.vm_config().profiler_config,
             entry_name.to_string(),

--- a/external-crates/move/crates/move-vm-profiler/Cargo.toml
+++ b/external-crates/move/crates/move-vm-profiler/Cargo.toml
@@ -15,4 +15,4 @@ tracing.workspace = true
 move-vm-config.workspace = true
 
 [features]
-gas-profiler = ["move-vm-config/gas-profiler"]
+tracing = ["move-vm-config/tracing"]

--- a/external-crates/move/crates/move-vm-profiler/src/lib.rs
+++ b/external-crates/move/crates/move-vm-profiler/src/lib.rs
@@ -4,7 +4,7 @@ use move_vm_config::runtime::VMProfilerConfig;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 use tracing::info;
 
 #[derive(Debug, Clone, Serialize)]
@@ -62,7 +62,7 @@ pub struct GasProfiler {
     finished: bool,
 }
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 impl GasProfiler {
     // Used by profiler viz tool
     const OPEN_FRAME_IDENT: &'static str = "O";
@@ -70,7 +70,7 @@ impl GasProfiler {
 
     const TOP_LEVEL_FRAME_NAME: &'static str = "root";
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn init(config: &Option<VMProfilerConfig>, name: String, start_gas: u64) -> Self {
         let mut prof = GasProfiler {
             exporter: "speedscope@1.15.2".to_string(),
@@ -101,7 +101,7 @@ impl GasProfiler {
         prof
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn init_default_cfg(name: String, start_gas: u64) -> Self {
         Self::init(
             &VMProfilerConfig::get_default_config_if_enabled(),
@@ -110,22 +110,22 @@ impl GasProfiler {
         )
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn short_name(s: &String) -> String {
         s.split("::").last().unwrap_or(s).to_string()
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     fn is_metered(&self) -> bool {
         (self.profiles[0].end_value != 0) && (self.start_gas != 0)
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     fn start_gas(&self) -> u64 {
         self.start_gas
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     fn add_frame(
         &mut self,
         frame_name: String,
@@ -146,7 +146,7 @@ impl GasProfiler {
         }
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn open_frame(&mut self, frame_name: String, metadata: String, gas_start: u64) {
         if self.config.is_none() || self.start_gas == 0 {
             return;
@@ -162,7 +162,7 @@ impl GasProfiler {
         });
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn close_frame(&mut self, frame_name: String, metadata: String, gas_end: u64) {
         if self.config.is_none() || self.start_gas == 0 {
             return;
@@ -178,7 +178,7 @@ impl GasProfiler {
         self.profiles[0].end_value = start - gas_end;
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn to_file(&self) {
         use std::ffi::{OsStr, OsString};
         use std::fs::File;
@@ -218,7 +218,7 @@ impl GasProfiler {
         info!("Gas profile written to file: {}", p.display());
     }
 
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     pub fn finish(&mut self) {
         if self.finished {
             return;
@@ -231,7 +231,7 @@ impl GasProfiler {
     }
 }
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 impl Drop for GasProfiler {
     fn drop(&mut self) {
         self.finish();
@@ -241,7 +241,7 @@ impl Drop for GasProfiler {
 #[macro_export]
 macro_rules! profile_open_frame {
     ($gas_meter:expr, $frame_name:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         {
             let gas_rem = $gas_meter.remaining_gas().into();
             move_vm_profiler::profile_open_frame_impl!(
@@ -256,7 +256,7 @@ macro_rules! profile_open_frame {
 #[macro_export]
 macro_rules! profile_open_frame_impl {
     ($profiler:expr, $frame_name:expr, $gas_rem:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         {
             if let Some(profiler) = $profiler {
                 if let Some(config) = &profiler.config {
@@ -275,7 +275,7 @@ macro_rules! profile_open_frame_impl {
 #[macro_export]
 macro_rules! profile_close_frame {
     ($gas_meter:expr, $frame_name:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         {
             let gas_rem = $gas_meter.remaining_gas().into();
             move_vm_profiler::profile_close_frame_impl!(
@@ -290,7 +290,7 @@ macro_rules! profile_close_frame {
 #[macro_export]
 macro_rules! profile_close_frame_impl {
     ($profiler:expr, $frame_name:expr, $gas_rem:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         {
             if let Some(profiler) = $profiler {
                 if let Some(config) = &profiler.config {
@@ -309,7 +309,7 @@ macro_rules! profile_close_frame_impl {
 #[macro_export]
 macro_rules! profile_open_instr {
     ($gas_meter:expr, $frame_name:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         {
             let gas_rem = $gas_meter.remaining_gas().into();
             if let Some(profiler) = $gas_meter.get_profiler_mut() {
@@ -326,7 +326,7 @@ macro_rules! profile_open_instr {
 #[macro_export]
 macro_rules! profile_close_instr {
     ($gas_meter:expr, $frame_name:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         {
             let gas_rem = $gas_meter.remaining_gas().into();
             if let Some(profiler) = $gas_meter.get_profiler_mut() {
@@ -343,39 +343,39 @@ macro_rules! profile_close_instr {
 #[macro_export]
 macro_rules! profile_dump_file {
     ($profiler:expr) => {
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         $profiler.to_file()
     };
 }
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 #[macro_export]
-macro_rules! gas_profiler_feature_enabled {
+macro_rules! tracing_feature_enabled {
     ($($tt:tt)*) => {
-        if cfg!(feature = "gas-profiler") {
+        if cfg!(feature = "tracing") {
             $($tt)*
         }
     };
 }
 
-#[cfg(not(feature = "gas-profiler"))]
+#[cfg(not(feature = "tracing"))]
 #[macro_export]
-macro_rules! gas_profiler_feature_enabled {
+macro_rules! tracing_feature_enabled {
     ( $( $tt:tt )* ) => {};
 }
 
-#[cfg(not(feature = "gas-profiler"))]
+#[cfg(not(feature = "tracing"))]
 #[macro_export]
-macro_rules! gas_profiler_feature_disabled {
+macro_rules! tracing_feature_disabled {
     ($($tt:tt)*) => {
-        if !cfg!(feature = "gas-profiler") {
+        if !cfg!(feature = "tracing") {
             $($tt)*
         }
     };
 }
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 #[macro_export]
-macro_rules! gas_profiler_feature_disabled {
+macro_rules! tracing_feature_disabled {
     ( $( $tt:tt )* ) => {};
 }

--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -43,7 +43,7 @@ failpoints = ["fail/failpoints"]
 debugging = []
 testing = []
 lazy_natives = []
-gas-profiler = [
-    "move-vm-config/gas-profiler",
-    "move-vm-profiler/gas-profiler",
+tracing = [
+    "move-vm-config/tracing",
+    "move-vm-profiler/tracing",
 ]

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -497,7 +497,7 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(

--- a/external-crates/move/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/session.rs
@@ -101,7 +101,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
@@ -134,7 +134,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         gas_meter: &mut impl GasMeter,
         tracer: Option<&mut MoveTraceBuilder>,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
@@ -144,7 +144,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
             }
         }
 
-        let tracer = if cfg!(feature = "gas-profiler") {
+        let tracer = if cfg!(feature = "tracing") {
             tracer
         } else {
             None

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/mod.rs
@@ -1,9 +1,9 @@
 pub(crate) mod tracer;
 
-#[cfg(feature = "gas-profiler")]
+#[cfg(feature = "tracing")]
 pub(crate) const TRACING_ENABLED: bool = true;
 
-#[cfg(not(feature = "gas-profiler"))]
+#[cfg(not(feature = "tracing"))]
 pub(crate) const TRACING_ENABLED: bool = false;
 
 #[macro_export]

--- a/external-crates/move/crates/move-vm-test-utils/Cargo.toml
+++ b/external-crates/move/crates/move-vm-test-utils/Cargo.toml
@@ -24,4 +24,4 @@ move-vm-profiler.workspace = true
 [features]
 default = [ ]
 tiered-gas = []
-gas-profiler = []
+tracing = []

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/Cargo.toml
@@ -41,7 +41,7 @@ failpoints = ["fail/failpoints"]
 debugging = []
 testing = []
 lazy_natives = []
-gas-profiler = [
-    "move-vm-config/gas-profiler",
-    "move-vm-profiler/gas-profiler",
+tracing = [
+    "move-vm-config/tracing",
+    "move-vm-profiler/tracing",
 ]

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs
@@ -211,7 +211,7 @@ impl Interpreter {
                 }
                 ExitCode::Call(fh_idx) => {
                     let func = resolver.function_from_handle(fh_idx);
-                    #[cfg(feature = "gas-profiler")]
+                    #[cfg(feature = "tracing")]
                     let func_name = func.pretty_string();
                     profile_open_frame!(gas_meter, func_name.clone());
 
@@ -253,7 +253,7 @@ impl Interpreter {
                         .instantiate_generic_function(idx, current_frame.ty_args())
                         .map_err(|e| set_err_info!(current_frame, e))?;
                     let func = resolver.function_from_instantiation(idx);
-                    #[cfg(feature = "gas-profiler")]
+                    #[cfg(feature = "tracing")]
                     let func_name = func.pretty_string();
                     profile_open_frame!(gas_meter, func_name.clone());
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/Cargo.toml
@@ -41,7 +41,7 @@ failpoints = ["fail/failpoints"]
 debugging = []
 testing = []
 lazy_natives = []
-gas-profiler = [
-    "move-vm-config/gas-profiler",
-    "move-vm-profiler/gas-profiler",
+tracing = [
+    "move-vm-config/tracing",
+    "move-vm-profiler/tracing",
 ]

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs
@@ -214,7 +214,7 @@ impl Interpreter {
                 }
                 ExitCode::Call(fh_idx) => {
                     let func = resolver.function_from_handle(fh_idx);
-                    #[cfg(feature = "gas-profiler")]
+                    #[cfg(feature = "tracing")]
                     let func_name = func.pretty_string();
                     profile_open_frame!(gas_meter, func_name.clone());
 
@@ -255,7 +255,7 @@ impl Interpreter {
                         .instantiate_generic_function(idx, current_frame.ty_args())
                         .map_err(|e| set_err_info!(current_frame, e))?;
                     let func = resolver.function_from_instantiation(idx);
-                    #[cfg(feature = "gas-profiler")]
+                    #[cfg(feature = "tracing")]
                     let func_name = func.pretty_string();
                     profile_open_frame!(gas_meter, func_name.clone());
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -492,7 +492,7 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
@@ -99,7 +99,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/Cargo.toml
@@ -41,7 +41,7 @@ failpoints = ["fail/failpoints"]
 debugging = []
 testing = []
 lazy_natives = []
-gas-profiler = [
-    "move-vm-config/gas-profiler",
-    "move-vm-profiler/gas-profiler",
+tracing = [
+    "move-vm-config/tracing",
+    "move-vm-profiler/tracing",
 ]

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/interpreter.rs
@@ -212,7 +212,7 @@ impl Interpreter {
                 }
                 ExitCode::Call(fh_idx) => {
                     let func = resolver.function_from_handle(fh_idx);
-                    #[cfg(feature = "gas-profiler")]
+                    #[cfg(feature = "tracing")]
                     let func_name = func.pretty_string();
                     profile_open_frame!(gas_meter, func_name.clone());
 
@@ -255,7 +255,7 @@ impl Interpreter {
                         .instantiate_generic_function(idx, current_frame.ty_args())
                         .map_err(|e| set_err_info!(current_frame, e))?;
                     let func = resolver.function_from_instantiation(idx);
-                    #[cfg(feature = "gas-profiler")]
+                    #[cfg(feature = "tracing")]
                     let func_name = func.pretty_string();
                     profile_open_frame!(gas_meter, func_name.clone());
 

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/runtime.rs
@@ -482,7 +482,7 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/session.rs
@@ -99,7 +99,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
-        move_vm_profiler::gas_profiler_feature_enabled! {
+        move_vm_profiler::tracing_feature_enabled! {
             use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(

--- a/external-crates/tests.sh
+++ b/external-crates/tests.sh
@@ -4,4 +4,4 @@ cd move
 echo "Excluding prover Move tests"
 cargo nextest run -E '!package(move-prover) and !test(prove) and !test(run_all::simple_build_with_docs/args.txt) and !test(run_test::nested_deps_bad_parent/Move.toml)' --workspace --no-fail-fast
 echo "Running tracing-specific tests"
-cargo nextest run -p move-cli --features gas-profiler
+cargo nextest run -p move-cli --features tracing

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -51,16 +51,16 @@ petgraph = "0.5.1"
 
 [features]
 default = []
-gas-profiler = [
-    "sui-adapter-latest/gas-profiler",
-    "sui-adapter-v0/gas-profiler",
-    "sui-adapter-v1/gas-profiler",
-  "sui-adapter-v2/gas-profiler",
-#   "sui-adapter-$CUT/gas-profiler",
-    "move-vm-runtime-v0/gas-profiler",
-    "move-vm-runtime-v1/gas-profiler",
-    "move-vm-runtime-latest/gas-profiler",
-  "move-vm-runtime-v2/gas-profiler",
-#   "move-vm-runtime-$CUT/gas-profiler",
-    "move-vm-config/gas-profiler",
+tracing = [
+    "sui-adapter-latest/tracing",
+    "sui-adapter-v0/tracing",
+    "sui-adapter-v1/tracing",
+  "sui-adapter-v2/tracing",
+#   "sui-adapter-$CUT/tracing",
+    "move-vm-runtime-v0/tracing",
+    "move-vm-runtime-v1/tracing",
+    "move-vm-runtime-latest/tracing",
+  "move-vm-runtime-v2/tracing",
+#   "move-vm-runtime-$CUT/tracing",
+    "move-vm-config/tracing",
 ]

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -40,9 +40,9 @@ parking_lot.workspace = true
 move-package.workspace = true
 
 [features]
-gas-profiler = [
-    "sui-types/gas-profiler",
-    "move-vm-runtime/gas-profiler",
-    "move-vm-profiler/gas-profiler",
-    "move-vm-config/gas-profiler",
+tracing = [
+    "sui-types/tracing",
+    "move-vm-runtime/tracing",
+    "move-vm-profiler/tracing",
+    "move-vm-config/tracing",
 ]

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -4,7 +4,7 @@
 pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     use move_vm_config::runtime::VMProfilerConfig;
     use std::path::PathBuf;
     use std::{collections::BTreeMap, sync::Arc};
@@ -44,9 +44,9 @@ mod checked {
         protocol_config: &ProtocolConfig,
         _enable_profiler: Option<PathBuf>,
     ) -> Result<MoveVM, SuiError> {
-        #[cfg(not(feature = "gas-profiler"))]
+        #[cfg(not(feature = "tracing"))]
         let vm_profiler_config = None;
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         let vm_profiler_config = _enable_profiler.clone().map(|path| VMProfilerConfig {
             full_path: path,
             track_bytecode_instructions: false,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -194,7 +194,7 @@ mod checked {
 
             // Set the profiler if in CLI
             #[skip_checked_arithmetic]
-            move_vm_profiler::gas_profiler_feature_enabled! {
+            move_vm_profiler::tracing_feature_enabled! {
                 use move_vm_profiler::GasProfiler;
                 use move_vm_types::gas::GasMeter;
 

--- a/sui-execution/v0/sui-adapter/Cargo.toml
+++ b/sui-execution/v0/sui-adapter/Cargo.toml
@@ -40,9 +40,9 @@ parking_lot.workspace = true
 move-package.workspace = true
 
 [features]
-gas-profiler = [
-    "sui-types/gas-profiler",
-    "move-vm-runtime/gas-profiler",
-    "move-vm-profiler/gas-profiler",
-    "move-vm-config/gas-profiler",
+tracing = [
+    "sui-types/tracing",
+    "move-vm-runtime/tracing",
+    "move-vm-profiler/tracing",
+    "move-vm-config/tracing",
 ]

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -5,7 +5,7 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     use move_vm_config::runtime::VMProfilerConfig;
     use std::path::PathBuf;
     use std::{collections::BTreeMap, sync::Arc};
@@ -45,9 +45,9 @@ mod checked {
         protocol_config: &ProtocolConfig,
         _enable_profiler: Option<PathBuf>,
     ) -> Result<MoveVM, SuiError> {
-        #[cfg(not(feature = "gas-profiler"))]
+        #[cfg(not(feature = "tracing"))]
         let vm_profiler_config = None;
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         let vm_profiler_config = _enable_profiler.clone().map(|path| VMProfilerConfig {
             full_path: path,
             track_bytecode_instructions: false,

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -199,7 +199,7 @@ mod checked {
 
             // Set the profiler if in CLI
             #[skip_checked_arithmetic]
-            move_vm_profiler::gas_profiler_feature_enabled! {
+            move_vm_profiler::tracing_feature_enabled! {
                 use move_vm_profiler::GasProfiler;
                 use move_vm_types::gas::GasMeter;
 

--- a/sui-execution/v1/sui-adapter/Cargo.toml
+++ b/sui-execution/v1/sui-adapter/Cargo.toml
@@ -39,9 +39,9 @@ parking_lot.workspace = true
 move-package.workspace = true
 
 [features]
-gas-profiler = [
-    "sui-types/gas-profiler",
-    "move-vm-runtime/gas-profiler",
-    "move-vm-profiler/gas-profiler",
-    "move-vm-config/gas-profiler",
+tracing = [
+    "sui-types/tracing",
+    "move-vm-runtime/tracing",
+    "move-vm-profiler/tracing",
+    "move-vm-config/tracing",
 ]

--- a/sui-execution/v1/sui-adapter/src/adapter.rs
+++ b/sui-execution/v1/sui-adapter/src/adapter.rs
@@ -5,7 +5,7 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     use move_vm_config::runtime::VMProfilerConfig;
     use std::path::PathBuf;
     use std::{collections::BTreeMap, sync::Arc};
@@ -45,9 +45,9 @@ mod checked {
         protocol_config: &ProtocolConfig,
         _enable_profiler: Option<PathBuf>,
     ) -> Result<MoveVM, SuiError> {
-        #[cfg(not(feature = "gas-profiler"))]
+        #[cfg(not(feature = "tracing"))]
         let vm_profiler_config = None;
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         let vm_profiler_config = _enable_profiler.clone().map(|path| VMProfilerConfig {
             full_path: path,
             track_bytecode_instructions: false,

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -190,7 +190,7 @@ mod checked {
 
             // Set the profiler if feature is enabled
             #[skip_checked_arithmetic]
-            move_vm_profiler::gas_profiler_feature_enabled! {
+            move_vm_profiler::tracing_feature_enabled! {
                 use move_vm_profiler::GasProfiler;
                 use move_vm_types::gas::GasMeter;
 

--- a/sui-execution/v2/sui-adapter/Cargo.toml
+++ b/sui-execution/v2/sui-adapter/Cargo.toml
@@ -39,9 +39,9 @@ parking_lot.workspace = true
 move-package.workspace = true
 
 [features]
-gas-profiler = [
-    "sui-types/gas-profiler",
-    "move-vm-runtime/gas-profiler",
-    "move-vm-profiler/gas-profiler",
-    "move-vm-config/gas-profiler",
+tracing = [
+    "sui-types/tracing",
+    "move-vm-runtime/tracing",
+    "move-vm-profiler/tracing",
+    "move-vm-config/tracing",
 ]

--- a/sui-execution/v2/sui-adapter/src/adapter.rs
+++ b/sui-execution/v2/sui-adapter/src/adapter.rs
@@ -4,7 +4,7 @@
 pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    #[cfg(feature = "gas-profiler")]
+    #[cfg(feature = "tracing")]
     use move_vm_config::runtime::VMProfilerConfig;
     use std::path::PathBuf;
     use std::{collections::BTreeMap, sync::Arc};
@@ -44,9 +44,9 @@ mod checked {
         protocol_config: &ProtocolConfig,
         _enable_profiler: Option<PathBuf>,
     ) -> Result<MoveVM, SuiError> {
-        #[cfg(not(feature = "gas-profiler"))]
+        #[cfg(not(feature = "tracing"))]
         let vm_profiler_config = None;
-        #[cfg(feature = "gas-profiler")]
+        #[cfg(feature = "tracing")]
         let vm_profiler_config = _enable_profiler.clone().map(|path| VMProfilerConfig {
             full_path: path,
             track_bytecode_instructions: false,

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -194,7 +194,7 @@ mod checked {
 
             // Set the profiler if in CLI
             #[skip_checked_arithmetic]
-            move_vm_profiler::gas_profiler_feature_enabled! {
+            move_vm_profiler::tracing_feature_enabled! {
                 use move_vm_profiler::GasProfiler;
                 use move_vm_types::gas::GasMeter;
 


### PR DESCRIPTION
## Description 

Renames the `gas-profiler` feature flag to `tracing`. Otherwise everything else is unchanged.

If you were previously building with `--features gas-profiler` you should use `--features tracing` and everything should work and behave as before.

Renamings performed:
1. `gas-profiler` => `tracing`
2. `gas_profiler_feature` => `tracing_feature`

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: The `gas-profiler` Rust feature flag was renamed to `tracing`. If you were previously building the Sui CLI from source with `--features gas-profiler` this will no longer work, and you should instead use `--features tracing`. This will enable the same features as before. 
- [ ] Rust SDK:
- [ ] REST API:
