### PR TITLE
Deepbook Indexer Manager Balance

### DIFF
--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -29,6 +29,7 @@ pub const GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID: &str =
 pub const GET_HISTORICAL_VOLUME_PATH: &str =
     "/get_historical_volume/:pool_ids/:start_time/:end_time";
 pub const GET_NET_DEPOSITS: &str = "/get_net_deposits/:asset_ids/:timestamp";
+pub const GET_MANAGER_BALANCE: &str = "/get_manager_balance/:manager_id/:asset_ids";
 
 pub fn run_server(socket_address: SocketAddr, state: PgDeepbookPersistent) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -47,6 +48,7 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
             GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID,
             get(get_24hr_volume_by_balance_manager_id),
         )
+        .route(GET_MANAGER_BALANCE, get(get_manager_balance))
         .route(GET_NET_DEPOSITS, get(get_net_deposits))
         .with_state(state)
 }
@@ -185,6 +187,49 @@ async fn get_24hr_volume_by_balance_manager_id(
     }
 
     Ok(Json(vec![maker_vol, taker_vol]))
+}
+
+async fn get_manager_balance(
+    Path((manager_id, asset_ids)): Path<(String, String)>,
+    State(state): State<PgDeepbookPersistent>,
+) -> Result<Json<HashMap<String, i64>>, DeepBookError> {
+    let connection = &mut state.pool.get().await?;
+
+    // Construct SQL query to filter by both manager_id and asset_ids, including `deposit` explicitly
+    let query = format!(
+        "SELECT asset, SUM(CASE WHEN deposit THEN amount ELSE -amount END)::bigint AS amount, deposit FROM balances \
+        WHERE balance_manager_id = '{}' AND asset IN ({}) GROUP BY asset, deposit",
+        manager_id,
+        asset_ids.split(',')
+            .map(|asset| if asset.starts_with("0x") {
+                format!("'{}'", &asset[2..])
+            } else {
+                format!("'{}'", asset)
+            })
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
+
+    // Load query results
+    let results: Vec<BalancesSummary> = diesel::sql_query(query).load(connection).await?;
+
+    // Format the results into a HashMap as {coin_id: coin_balance}
+    let mut manager_balances = HashMap::new();
+    for result in results {
+        let mut asset = result.asset;
+        if !asset.starts_with("0x") {
+            asset.insert_str(0, "0x");
+        }
+        // Update balance based on deposit status
+        let balance = manager_balances.entry(asset).or_insert(0);
+        if result.deposit {
+            *balance += result.amount;
+        } else {
+            *balance -= result.amount;
+        }
+    }
+
+    Ok(Json(manager_balances))
 }
 
 #[debug_handler]


### PR DESCRIPTION
## Description 

Deepbook Indexer Manager Balance
Given balance_manager_id, returns the net deposit into the balance manager for each asset type.

Example call:
`/get_manager_balance/0x47dcbbc8561fe3d52198336855f0983878152a12524749e054357ac2e3573d58`

Example output:
`{"0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC":10998046154370,"0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP":47870100000000,"0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN":33792,"0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI":241269580872061}`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Read only endpoint in Deepbook Indexer
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
