### PR TITLE
[move] Unify `debugging` and `tracing` feature flags for tracing in the VM

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -39,8 +39,6 @@ move-compiler.workspace = true
 default = []
 fuzzing = ["move-vm-types/fuzzing"]
 failpoints = ["fail/failpoints"]
-# Enable tracing and debugging also for release builds. By default, it is only enabled for debug builds.
-debugging = []
 testing = []
 lazy_natives = []
 tracing = [

--- a/external-crates/move/crates/move-vm-runtime/src/lib.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/lib.rs
@@ -24,7 +24,7 @@ mod tracing;
 mod tracing2;
 
 // Only include debugging functionality in debug builds
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 mod debug;
 
 #[cfg(test)]

--- a/external-crates/move/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/loader.rs
@@ -2203,7 +2203,7 @@ impl Function {
         )
     }
 
-    #[cfg(any(debug_assertions, feature = "debugging"))]
+    #[cfg(any(debug_assertions, feature = "tracing"))]
     pub(crate) fn pretty_short_string(&self) -> String {
         let id = &self.module;
         format!(

--- a/external-crates/move/crates/move-vm-runtime/src/tracing.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing.rs
@@ -2,10 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 use crate::debug::DebugContext;
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 use ::{
     move_binary_format::file_format::Bytecode,
     move_vm_types::values::Locals,
@@ -20,31 +20,31 @@ use ::{
     },
 };
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 use crate::{
     interpreter::Interpreter,
     loader::{Function, Loader},
 };
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 const MOVE_VM_STEPPING_ENV_VAR_NAME: &str = "MOVE_VM_STEP";
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 static FILE_PATH: Lazy<String> = Lazy::new(|| {
     env::var(MOVE_VM_TRACING_ENV_VAR_NAME).unwrap_or_else(|_| "move_vm_trace.trace".to_string())
 });
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 static TRACING_ENABLED: Lazy<bool> = Lazy::new(|| env::var(MOVE_VM_TRACING_ENV_VAR_NAME).is_ok());
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 static DEBUGGING_ENABLED: Lazy<bool> =
     Lazy::new(|| env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok());
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     Mutex::new(
         OpenOptions::new()
@@ -55,11 +55,11 @@ static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     )
 });
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 static DEBUG_CONTEXT: Lazy<Mutex<DebugContext>> = Lazy::new(|| Mutex::new(DebugContext::new()));
 
 // Only include in debug builds
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(any(debug_assertions, feature = "tracing"))]
 pub(crate) fn trace(
     function_desc: &Function,
     locals: &Locals,
@@ -93,7 +93,7 @@ pub(crate) fn trace(
 macro_rules! trace {
     ($function_desc:expr, $locals:expr, $pc:expr, $instr:tt, $resolver:expr, $interp:expr) => {
         // Only include this code in debug releases
-        #[cfg(any(debug_assertions, feature = "debugging"))]
+        #[cfg(any(debug_assertions, feature = "tracing"))]
         $crate::tracing::trace(
             &$function_desc,
             $locals,


### PR DESCRIPTION
## Description 

This unifies the old tracing under the `tracing` flag, and removes the `debugging` feature flag from the VM (one less feature flag 🎉). Otherwise behavior is kept the exact same.

## Test plan 

Tested manually + CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
