### PR TITLE
[indexer] Backfill first_tx_sequence_number on epochs and update epoch writes

### DIFF
--- a/crates/sui-indexer/src/backfill/backfill_instances/sql_backfills/epochs_first_tx_sequence_number.sh
+++ b/crates/sui-indexer/src/backfill/backfill_instances/sql_backfills/epochs_first_tx_sequence_number.sh
@@ -1,0 +1,15 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+INDEXER=${INDEXER:-"sui-indexer"}
+DB=${DB:-"postgres://postgres:postgrespw@localhost:5432/postgres"}
+"$INDEXER" --database-url "$DB" run-back-fill "$1" "$2" sql "WITH running_sum AS (
+    SELECT
+        epoch,
+        COALESCE(SUM(epoch_total_transactions) OVER (ORDER BY epoch ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), 0) as calculated_first_tx
+    FROM epochs
+)
+UPDATE epochs e
+SET first_tx_sequence_number = r.calculated_first_tx
+FROM running_sum r
+WHERE e.epoch = r.epoch" e.epoch

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -203,20 +203,20 @@ impl CheckpointHandler {
             );
         }
 
-        // At some point while committing data in epoch X - 1, we will encounter a new epoch X. We
-        // want to retrieve X - 2's network total transactions to calculate the number of
-        // transactions that occurred in epoch X - 1.
+        // At some point while committing data in epoch X - 1, we will encounter a new epoch X.
+        // Retrieve current epoch's first_tx_sequence_number to calculate `epoch_total_transactions`
+        // for epoch X - 1.
         let first_tx_sequence_number = match system_state_summary.epoch {
             // If first epoch change, this number is 0
             1 => Ok(0),
             _ => {
-                let last_epoch = system_state_summary.epoch - 2;
+                let last_epoch = system_state_summary.epoch - 1;
                 state
-                    .get_network_total_transactions_by_end_of_epoch(last_epoch)
+                    .get_first_tx_sequence_number_of_epoch(last_epoch)
                     .await?
                     .ok_or_else(|| {
                         IndexerError::PersistentStorageDataCorruptionError(format!(
-                            "Network total transactions for epoch {} not found",
+                            "Expected first_tx_sequence_number for epoch {} not found",
                             last_epoch
                         ))
                     })

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -106,7 +106,7 @@ pub trait IndexerStore: Clone + Sync + Send + 'static {
 
     async fn prune_epoch(&self, epoch: u64) -> Result<(), IndexerError>;
 
-    async fn get_network_total_transactions_by_end_of_epoch(
+    async fn get_first_tx_sequence_number_of_epoch(
         &self,
         epoch: u64,
     ) -> Result<Option<u64>, IndexerError>;


### PR DESCRIPTION
## Description 

Backfilled production dbs on testnet and mainnet, and update committer so that epoch writes now rely on itself instead of checkpoints table

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
