### PR TITLE
[kv store] bigtable: add support for reversed scans

### DIFF
--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 pub use bigtable::client::BigTableClient;
 pub use bigtable::worker::KvWorker;
+use sui_types::base_types::ObjectID;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::digests::{CheckpointDigest, TransactionDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -31,6 +32,8 @@ pub trait KeyValueStoreReader {
         &mut self,
         digest: CheckpointDigest,
     ) -> Result<Option<Checkpoint>>;
+    async fn get_latest_checkpoint(&mut self) -> Result<CheckpointSequenceNumber>;
+    async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>>;
 }
 
 #[async_trait]


### PR DESCRIPTION
## Description 

added two APIs as reference examples: `get_latest_checkpoint` and `get_latest_object`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
