### PR TITLE
Cherrypick: Remove assert preventing disabling random beacon on mainnet/testnet

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -908,18 +908,6 @@ impl AuthorityPerEpochStore {
             randomness_reporter: OnceCell::new(),
         });
 
-        if matches!(chain_identifier.chain(), Chain::Mainnet | Chain::Testnet) {
-            // If we disable randomness, and if the release in which it was disabled did not have
-            // the commit that added this comment, we will need to revert this commit. This is
-            // because the previous release will have been writing to the deprecated
-            // assigned_shared_object_versions table.
-            //
-            // If we disable randomness *after* this commit has been shipped to all networks, then
-            // we can simply remove this assert, as we will no longer switch back and forth between
-            // the two tables.
-            assert!(s.randomness_state_enabled());
-        }
-
         s.update_buffer_stake_metric();
         s
     }


### PR DESCRIPTION
## Description 

This is safe because the corresponding commit is now in a mainnet release. The assert prevents current full nodes from starting from epochs before random beacon was enabled.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): restores ability to launch fullnode from epochs before random beacon was enabled
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
