### PR TITLE
[move-compiler] Re-organize warning filters

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use move_compiler::{
-    diagnostics as diag,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{self as E, ModuleIdent},
     naming::ast as N,
     parser::ast::{self as P, ConstantName},
@@ -661,7 +661,7 @@ impl TypingAnalysisContext<'_> {
 
 impl<'a> TypingVisitorContext for TypingAnalysisContext<'a> {
     // Nothing to do -- we're not producing errors.
-    fn push_warning_filter_scope(&mut self, _filter: diag::WarningFilters) {}
+    fn push_warning_filter_scope(&mut self, _filter: WarningFilters) {}
 
     // Nothing to do -- we're not producing errors.
     fn pop_warning_filter_scope(&mut self) {}

--- a/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    diagnostics::WarningFilters,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{Attributes, Friend, ModuleIdent, Mutability, TargetKind},
     hlir::ast::{
         BaseType, Command, Command_, EnumDefinition, FunctionSignature, Label, SingleType,

--- a/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
@@ -15,12 +15,10 @@ pub mod visitor;
 mod optimize;
 
 use crate::{
+    diagnostics::warning_filters::WarningFiltersScope,
     expansion::ast::{Attributes, ModuleIdent, Mutability},
     hlir::ast::{FunctionSignature, Label, SingleType, Var, Visibility},
-    shared::{
-        program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, Name,
-        WarningFiltersScope,
-    },
+    shared::{program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, Name},
 };
 use cfg::*;
 use move_ir_types::location::Loc;

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -10,14 +10,15 @@ use crate::{
         visitor::{CFGIRVisitor, CFGIRVisitorConstructor, CFGIRVisitorContext},
     },
     diag,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
+    },
     expansion::ast::{Attributes, ModuleIdent, Mutability},
     hlir::ast::{self as H, BlockLabel, Label, Value, Value_, Var},
     ice_assert,
     parser::ast::{ConstantName, FunctionName},
-    shared::{
-        program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv, WarningFiltersScope,
-    },
+    shared::{program_info::TypingProgramInfo, unique_map::UniqueMap, CompilationEnv},
     FullyCompiledProgram,
 };
 use cfgir::ast::LoopInfo;

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -11,7 +11,7 @@ use crate::{
         CFGContext,
     },
     command_line::compiler::Visitor,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{warning_filters::WarningFilters, Diagnostic, Diagnostics},
     expansion::ast::ModuleIdent,
     hlir::ast::{self as H, Command, Exp, LValue, LValue_, Label, ModuleCall, Type, Type_, Var},
     parser::ast::{ConstantName, DatatypeName, FunctionName},
@@ -328,7 +328,7 @@ macro_rules! simple_visitor {
 
         pub struct Context<'a> {
             env: &'a crate::shared::CompilationEnv,
-            warning_filters_scope: crate::shared::WarningFiltersScope,
+            warning_filters_scope: crate::diagnostics::warning_filters::WarningFiltersScope,
         }
 
         impl crate::cfgir::visitor::CFGIRVisitorConstructor for $visitor {
@@ -356,7 +356,10 @@ macro_rules! simple_visitor {
         }
 
         impl crate::cfgir::visitor::CFGIRVisitorContext for Context<'_> {
-            fn push_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
+            fn push_warning_filter_scope(
+                &mut self,
+                filters: crate::diagnostics::warning_filters::WarningFilters,
+            ) {
                 self.warning_filters_scope.push(filters)
             }
 

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -10,7 +10,8 @@ use crate::{
     command_line::{DEFAULT_OUTPUT_DIR, MOVE_COMPILED_INTERFACES_DIR},
     compiled_unit::{self, AnnotatedCompiledUnit},
     diagnostics::{
-        codes::{Severity, WarningFilter},
+        codes::Severity,
+        warning_filters::{WarningFilter, WarningFilters},
         *,
     },
     editions::Edition,

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -6,8 +6,6 @@
 // Main types
 //**************************************************************************************************
 
-use crate::shared::FILTER_ALL;
-
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum Severity {
     Note = 0,
@@ -20,8 +18,6 @@ pub enum Severity {
 /// A an optional prefix to distinguish between different types of warnings (internal vs. possibly
 /// multiple externally provided ones).
 pub type ExternalPrefix = Option<&'static str>;
-/// The name for a well-known filter.
-pub type WellKnownFilterName = &'static str;
 /// The ID for a diagnostic, consisting of an optional prefix, a category, and a code.
 pub type DiagnosticsID = (ExternalPrefix, u8, u8);
 
@@ -53,26 +49,6 @@ pub(crate) trait DiagnosticCode: Copy {
             message,
         }
     }
-}
-
-#[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
-/// Represents a single annotation for a diagnostic filter
-pub enum WarningFilter {
-    /// Filters all warnings
-    All(ExternalPrefix),
-    /// Filters all warnings of a specific category. Only known filters have names.
-    Category {
-        prefix: ExternalPrefix,
-        category: u8,
-        name: Option<WellKnownFilterName>,
-    },
-    /// Filters a single warning, as defined by codes below. Only known filters have names.
-    Code {
-        prefix: ExternalPrefix,
-        category: u8,
-        code: u8,
-        name: Option<WellKnownFilterName>,
-    },
 }
 
 //**************************************************************************************************
@@ -386,45 +362,6 @@ codes!(
         PathAutocomplete: { msg: "IDE path autocomplete", severity: Note },
     ],
 );
-
-//**************************************************************************************************
-// Warning Filter
-//**************************************************************************************************
-
-impl WarningFilter {
-    pub fn to_str(self) -> Option<&'static str> {
-        match self {
-            Self::All(_) => Some(FILTER_ALL),
-            Self::Category { name, .. } | Self::Code { name, .. } => name,
-        }
-    }
-
-    pub fn code(
-        prefix: ExternalPrefix,
-        category: u8,
-        code: u8,
-        name: Option<WellKnownFilterName>,
-    ) -> Self {
-        Self::Code {
-            prefix,
-            category,
-            code,
-            name,
-        }
-    }
-
-    pub fn category(
-        prefix: ExternalPrefix,
-        category: u8,
-        name: Option<WellKnownFilterName>,
-    ) -> Self {
-        Self::Category {
-            prefix,
-            category,
-            name,
-        }
-    }
-}
 
 //**************************************************************************************************
 // impls

--- a/external-crates/move/crates/move-compiler/src/diagnostics/warning_filters.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/warning_filters.rs
@@ -1,0 +1,442 @@
+use crate::{
+    diagnostics::{
+        codes::{Category, DiagnosticInfo, ExternalPrefix, Severity, UnusedItem},
+        Diagnostic, DiagnosticCode,
+    },
+    shared::{known_attributes, AstDebug},
+};
+use move_symbol_pool::Symbol;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub const FILTER_ALL: &str = "all";
+pub const FILTER_UNUSED: &str = "unused";
+pub const FILTER_MISSING_PHANTOM: &str = "missing_phantom";
+pub const FILTER_UNUSED_USE: &str = "unused_use";
+pub const FILTER_UNUSED_VARIABLE: &str = "unused_variable";
+pub const FILTER_UNUSED_ASSIGNMENT: &str = "unused_assignment";
+pub const FILTER_UNUSED_TRAILING_SEMI: &str = "unused_trailing_semi";
+pub const FILTER_UNUSED_ATTRIBUTE: &str = "unused_attribute";
+pub const FILTER_UNUSED_TYPE_PARAMETER: &str = "unused_type_parameter";
+pub const FILTER_UNUSED_FUNCTION: &str = "unused_function";
+pub const FILTER_UNUSED_STRUCT_FIELD: &str = "unused_field";
+pub const FILTER_UNUSED_CONST: &str = "unused_const";
+pub const FILTER_DEAD_CODE: &str = "dead_code";
+pub const FILTER_UNUSED_LET_MUT: &str = "unused_let_mut";
+pub const FILTER_UNUSED_MUT_REF: &str = "unused_mut_ref";
+pub const FILTER_UNUSED_MUT_PARAM: &str = "unused_mut_parameter";
+pub const FILTER_IMPLICIT_CONST_COPY: &str = "implicit_const_copy";
+pub const FILTER_DUPLICATE_ALIAS: &str = "duplicate_alias";
+pub const FILTER_DEPRECATED: &str = "deprecated_usage";
+pub const FILTER_IDE_PATH_AUTOCOMPLETE: &str = "ide_path_autocomplete";
+pub const FILTER_IDE_DOT_AUTOCOMPLETE: &str = "ide_dot_autocomplete";
+
+macro_rules! known_code_filter {
+    ($name:ident, $category:ident::$code:ident) => {{
+        use crate::diagnostics::codes::*;
+        (
+            move_symbol_pool::Symbol::from($name),
+            std::collections::BTreeSet::from([
+                crate::diagnostics::warning_filters::WarningFilter::Code {
+                    prefix: None,
+                    category: Category::$category as u8,
+                    code: $category::$code as u8,
+                    name: Some($name),
+                },
+            ]),
+        )
+    }};
+}
+pub(crate) use known_code_filter;
+
+//**************************************************************************************************
+// Types
+//**************************************************************************************************
+
+/// None for the default 'allow'.
+/// Some(prefix) for a custom set of warnings, e.g. 'allow(lint(_))'.
+pub type FilterPrefix = Option<Symbol>;
+pub type FilterName = Symbol;
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct WarningFiltersScope {
+    scopes: Vec<WarningFilters>,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+/// Used to filter out diagnostics, specifically used for warning suppression
+pub struct WarningFilters {
+    filters: BTreeMap<ExternalPrefix, UnprefixedWarningFilters>,
+    for_dependency: bool, // if false, the filters are used for source code
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+/// Filters split by category and code
+enum UnprefixedWarningFilters {
+    /// Remove all warnings
+    All,
+    Specified {
+        /// Remove all diags of this category with optional known name
+        categories: BTreeMap<u8, Option<WellKnownFilterName>>,
+        /// Remove specific diags with optional known filter name
+        codes: BTreeMap<(u8, u8), Option<WellKnownFilterName>>,
+    },
+    /// No filter
+    Empty,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
+/// Represents a single annotation for a diagnostic filter
+pub enum WarningFilter {
+    /// Filters all warnings
+    All(ExternalPrefix),
+    /// Filters all warnings of a specific category. Only known filters have names.
+    Category {
+        prefix: ExternalPrefix,
+        category: u8,
+        name: Option<WellKnownFilterName>,
+    },
+    /// Filters a single warning, as defined by codes below. Only known filters have names.
+    Code {
+        prefix: ExternalPrefix,
+        category: u8,
+        code: u8,
+        name: Option<WellKnownFilterName>,
+    },
+}
+
+/// The name for a well-known filter.
+pub type WellKnownFilterName = &'static str;
+
+//**************************************************************************************************
+// impls
+//**************************************************************************************************
+
+impl WarningFiltersScope {
+    /// Unsafe and should be used only for internal purposes, such as ide annotations
+    pub(crate) const EMPTY: &'static Self = &WarningFiltersScope { scopes: vec![] };
+
+    pub(crate) fn new(top_level_warning_filter: Option<WarningFilters>) -> Self {
+        Self {
+            scopes: top_level_warning_filter.into_iter().collect(),
+        }
+    }
+
+    pub fn push(&mut self, filters: WarningFilters) {
+        self.scopes.push(filters)
+    }
+
+    pub fn pop(&mut self) {
+        self.scopes.pop().unwrap();
+    }
+
+    pub fn is_filtered(&self, diag: &Diagnostic) -> bool {
+        self.scopes.iter().any(|filters| filters.is_filtered(diag))
+    }
+
+    pub fn is_filtered_for_dependency(&self) -> bool {
+        self.scopes.iter().any(|filters| filters.for_dependency())
+    }
+}
+
+impl WarningFilters {
+    pub const fn new_for_source() -> Self {
+        Self {
+            filters: BTreeMap::new(),
+            for_dependency: false,
+        }
+    }
+
+    pub const fn new_for_dependency() -> Self {
+        Self {
+            filters: BTreeMap::new(),
+            for_dependency: true,
+        }
+    }
+
+    pub fn is_filtered(&self, diag: &Diagnostic) -> bool {
+        self.is_filtered_by_info(&diag.info)
+    }
+
+    fn is_filtered_by_info(&self, info: &DiagnosticInfo) -> bool {
+        let prefix = info.external_prefix();
+        self.filters
+            .get(&prefix)
+            .is_some_and(|filters| filters.is_filtered_by_info(info))
+    }
+
+    pub fn union(&mut self, other: &Self) {
+        for (prefix, filters) in &other.filters {
+            self.filters
+                .entry(*prefix)
+                .or_insert_with(UnprefixedWarningFilters::new)
+                .union(filters);
+        }
+        // if there is a dependency code filter on the stack, it means we are filtering dependent
+        // code and this information must be preserved when stacking up additional filters (which
+        // involves union of the current filter with the new one)
+        self.for_dependency = self.for_dependency || other.for_dependency;
+    }
+
+    pub fn add(&mut self, filter: WarningFilter) {
+        let (prefix, category, code, name) = match filter {
+            WarningFilter::All(prefix) => {
+                self.filters.insert(prefix, UnprefixedWarningFilters::All);
+                return;
+            }
+            WarningFilter::Category {
+                prefix,
+                category,
+                name,
+            } => (prefix, category, None, name),
+            WarningFilter::Code {
+                prefix,
+                category,
+                code,
+                name,
+            } => (prefix, category, Some(code), name),
+        };
+        self.filters
+            .entry(prefix)
+            .or_insert(UnprefixedWarningFilters::Empty)
+            .add(category, code, name)
+    }
+
+    pub fn unused_warnings_filter_for_test() -> Self {
+        Self {
+            filters: BTreeMap::from([(
+                None,
+                UnprefixedWarningFilters::unused_warnings_filter_for_test(),
+            )]),
+            for_dependency: false,
+        }
+    }
+
+    pub fn for_dependency(&self) -> bool {
+        self.for_dependency
+    }
+}
+
+impl UnprefixedWarningFilters {
+    pub fn new() -> Self {
+        Self::Empty
+    }
+
+    fn is_filtered_by_info(&self, info: &DiagnosticInfo) -> bool {
+        match self {
+            Self::All => info.severity() <= Severity::Warning,
+            Self::Specified { categories, codes } => {
+                info.severity() <= Severity::Warning
+                    && (categories.contains_key(&info.category())
+                        || codes.contains_key(&(info.category(), info.code())))
+            }
+            Self::Empty => false,
+        }
+    }
+
+    pub fn union(&mut self, other: &Self) {
+        match (self, other) {
+            // if self is empty, just take the other filter
+            (s @ Self::Empty, _) => *s = other.clone(),
+            // if other is empty, or self is ALL, no change to the filter
+            (_, Self::Empty) => (),
+            (Self::All, _) => (),
+            // if other is all, self is now all
+            (s, Self::All) => *s = Self::All,
+            // category and code level union
+            (
+                Self::Specified { categories, codes },
+                Self::Specified {
+                    categories: other_categories,
+                    codes: other_codes,
+                },
+            ) => {
+                categories.extend(other_categories);
+                // remove any codes covered by the category level filter
+                codes.extend(
+                    other_codes
+                        .iter()
+                        .filter(|((category, _), _)| !categories.contains_key(category)),
+                );
+            }
+        }
+    }
+
+    /// Add a specific filter to the filter map.
+    /// If filter_code is None, then the filter applies to all codes in the filter_category.
+    fn add(
+        &mut self,
+        filter_category: u8,
+        filter_code: Option<u8>,
+        filter_name: Option<WellKnownFilterName>,
+    ) {
+        match self {
+            Self::All => (),
+            Self::Empty => {
+                *self = Self::Specified {
+                    categories: BTreeMap::new(),
+                    codes: BTreeMap::new(),
+                };
+                self.add(filter_category, filter_code, filter_name)
+            }
+            Self::Specified { categories, .. } if categories.contains_key(&filter_category) => (),
+            Self::Specified { categories, codes } => {
+                if let Some(filter_code) = filter_code {
+                    codes.insert((filter_category, filter_code), filter_name);
+                } else {
+                    categories.insert(filter_category, filter_name);
+                    codes.retain(|(category, _), _| *category != filter_category);
+                }
+            }
+        }
+    }
+
+    pub fn unused_warnings_filter_for_test() -> Self {
+        let filtered_codes = [
+            (UnusedItem::Function, FILTER_UNUSED_FUNCTION),
+            (UnusedItem::StructField, FILTER_UNUSED_STRUCT_FIELD),
+            (UnusedItem::FunTypeParam, FILTER_UNUSED_TYPE_PARAMETER),
+            (UnusedItem::Constant, FILTER_UNUSED_CONST),
+            (UnusedItem::MutReference, FILTER_UNUSED_MUT_REF),
+            (UnusedItem::MutParam, FILTER_UNUSED_MUT_PARAM),
+        ]
+        .into_iter()
+        .map(|(item, filter)| {
+            let info = item.into_info();
+            ((info.category(), info.code()), Some(filter))
+        })
+        .collect();
+        Self::Specified {
+            categories: BTreeMap::new(),
+            codes: filtered_codes,
+        }
+    }
+}
+
+impl WarningFilter {
+    pub fn to_str(self) -> Option<&'static str> {
+        match self {
+            Self::All(_) => Some(FILTER_ALL),
+            Self::Category { name, .. } | Self::Code { name, .. } => name,
+        }
+    }
+
+    pub fn code(
+        prefix: ExternalPrefix,
+        category: u8,
+        code: u8,
+        name: Option<WellKnownFilterName>,
+    ) -> Self {
+        Self::Code {
+            prefix,
+            category,
+            code,
+            name,
+        }
+    }
+
+    pub fn category(
+        prefix: ExternalPrefix,
+        category: u8,
+        name: Option<WellKnownFilterName>,
+    ) -> Self {
+        Self::Category {
+            prefix,
+            category,
+            name,
+        }
+    }
+
+    pub fn compiler_known_filters() -> BTreeMap<FilterName, BTreeSet<WarningFilter>> {
+        BTreeMap::from([
+            (
+                FILTER_ALL.into(),
+                BTreeSet::from([WarningFilter::All(None)]),
+            ),
+            (
+                FILTER_UNUSED.into(),
+                BTreeSet::from([WarningFilter::Category {
+                    prefix: None,
+                    category: Category::UnusedItem as u8,
+                    name: Some(FILTER_UNUSED),
+                }]),
+            ),
+            known_code_filter!(FILTER_MISSING_PHANTOM, Declarations::InvalidNonPhantomUse),
+            known_code_filter!(FILTER_UNUSED_USE, UnusedItem::Alias),
+            known_code_filter!(FILTER_UNUSED_VARIABLE, UnusedItem::Variable),
+            known_code_filter!(FILTER_UNUSED_ASSIGNMENT, UnusedItem::Assignment),
+            known_code_filter!(FILTER_UNUSED_TRAILING_SEMI, UnusedItem::TrailingSemi),
+            known_code_filter!(FILTER_UNUSED_ATTRIBUTE, UnusedItem::Attribute),
+            known_code_filter!(FILTER_UNUSED_FUNCTION, UnusedItem::Function),
+            known_code_filter!(FILTER_UNUSED_STRUCT_FIELD, UnusedItem::StructField),
+            (
+                FILTER_UNUSED_TYPE_PARAMETER.into(),
+                BTreeSet::from([
+                    WarningFilter::Code {
+                        prefix: None,
+                        category: Category::UnusedItem as u8,
+                        code: UnusedItem::StructTypeParam as u8,
+                        name: Some(FILTER_UNUSED_TYPE_PARAMETER),
+                    },
+                    WarningFilter::Code {
+                        prefix: None,
+                        category: Category::UnusedItem as u8,
+                        code: UnusedItem::FunTypeParam as u8,
+                        name: Some(FILTER_UNUSED_TYPE_PARAMETER),
+                    },
+                ]),
+            ),
+            known_code_filter!(FILTER_UNUSED_CONST, UnusedItem::Constant),
+            known_code_filter!(FILTER_DEAD_CODE, UnusedItem::DeadCode),
+            known_code_filter!(FILTER_UNUSED_LET_MUT, UnusedItem::MutModifier),
+            known_code_filter!(FILTER_UNUSED_MUT_REF, UnusedItem::MutReference),
+            known_code_filter!(FILTER_UNUSED_MUT_PARAM, UnusedItem::MutParam),
+            known_code_filter!(FILTER_IMPLICIT_CONST_COPY, TypeSafety::ImplicitConstantCopy),
+            known_code_filter!(FILTER_DUPLICATE_ALIAS, Declarations::DuplicateAlias),
+            known_code_filter!(FILTER_DEPRECATED, TypeSafety::DeprecatedUsage),
+        ])
+    }
+
+    pub fn ide_known_filters() -> BTreeMap<FilterName, BTreeSet<WarningFilter>> {
+        BTreeMap::from([
+            known_code_filter!(FILTER_IDE_PATH_AUTOCOMPLETE, IDE::PathAutocomplete),
+            known_code_filter!(FILTER_IDE_DOT_AUTOCOMPLETE, IDE::DotAutocomplete),
+        ])
+    }
+}
+
+impl AstDebug for WarningFilters {
+    fn ast_debug(&self, w: &mut crate::shared::ast_debug::AstWriter) {
+        for (prefix, filters) in &self.filters {
+            let prefix_str = prefix.unwrap_or(known_attributes::DiagnosticAttribute::ALLOW);
+            match filters {
+                UnprefixedWarningFilters::All => w.write(format!(
+                    "#[{}({})]",
+                    prefix_str,
+                    WarningFilter::All(*prefix).to_str().unwrap(),
+                )),
+                UnprefixedWarningFilters::Specified { categories, codes } => {
+                    w.write(format!("#[{}(", prefix_str));
+                    let items = categories
+                        .iter()
+                        .map(|(cat, n)| WarningFilter::Category {
+                            prefix: *prefix,
+                            category: *cat,
+                            name: *n,
+                        })
+                        .chain(codes.iter().map(|((cat, code), n)| WarningFilter::Code {
+                            prefix: *prefix,
+                            category: *cat,
+                            code: *code,
+                            name: *n,
+                        }));
+                    w.list(items, ",", |w, filter| {
+                        w.write(filter.to_str().unwrap());
+                        false
+                    });
+                    w.write(")]")
+                }
+                UnprefixedWarningFilters::Empty => (),
+            }
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    diagnostics::WarningFilters,
+    diagnostics::warning_filters::WarningFilters,
     parser::ast::{
         self as P, Ability, Ability_, BinOp, BlockLabel, ConstantName, DatatypeName, Field,
         FunctionName, ModuleName, QuantKind, UnaryOp, Var, VariantName, ENTRY_MODIFIER,

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -4,7 +4,12 @@
 
 use crate::{
     diag,
-    diagnostics::{codes::WarningFilter, Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{
+        warning_filters::{
+            WarningFilter, WarningFilters, WarningFiltersScope, FILTER_ALL, FILTER_UNUSED,
+        },
+        Diagnostic, Diagnostics,
+    },
     editions::{self, Edition, FeatureGate, Flavor},
     expansion::{
         alias_map_builder::{

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    diagnostics::WarningFilters,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{
         ability_modifiers_ast_debug, AbilitySet, Attributes, Friend, ModuleIdent, Mutability,
         TargetKind,

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     diag,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
+    },
     expansion::ast::ModuleIdent,
     ice,
     naming::ast::{self as N, BlockLabel},

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -4,7 +4,10 @@
 
 use crate::{
     debug_display, debug_display_verbose, diag,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
+    },
     editions::{FeatureGate, Flavor},
     expansion::ast::{self as E, Fields, ModuleIdent, Mutability, TargetKind},
     hlir::{

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -6,6 +6,7 @@
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
+use crate::diagnostics::warning_filters::{WarningFilters, WarningFiltersScope};
 use crate::linters::StyleCodes;
 use crate::{
     cfgir::{
@@ -13,10 +14,10 @@ use crate::{
         visitor::{CFGIRVisitorConstructor, CFGIRVisitorContext},
     },
     diag,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{Diagnostic, Diagnostics},
     editions::FeatureGate,
     hlir::ast as H,
-    shared::{CompilationEnv, WarningFiltersScope},
+    shared::CompilationEnv,
 };
 
 pub struct AssertAbortNamedConstants;

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -6,8 +6,10 @@ use move_symbol_pool::Symbol;
 use crate::{
     cfgir::visitor::CFGIRVisitor,
     command_line::compiler::Visitor,
-    diagnostics::codes::WarningFilter,
-    diagnostics::codes::{custom, DiagnosticInfo, Severity},
+    diagnostics::{
+        codes::{custom, DiagnosticInfo, Severity},
+        warning_filters::WarningFilter,
+    },
     typing::visitor::TypingVisitor,
 };
 

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    diagnostics::WarningFilters,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{
         ability_constraints_ast_debug, ability_modifiers_ast_debug, AbilitySet, Attributes,
         DottedUsage, Fields, Friend, ImplicitUseFunCandidate, ModuleIdent, Mutability, TargetKind,

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::diagnostics::{Diagnostic, Diagnostics, WarningFilters};
+use crate::diagnostics::warning_filters::{WarningFilters, WarningFiltersScope};
+use crate::diagnostics::{Diagnostic, Diagnostics};
 use crate::expansion::ast::{self as E, ModuleIdent};
 use crate::naming::ast as N;
 use crate::parser::ast::{FunctionName, Visibility};

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -7,7 +7,8 @@ use crate::{
     diagnostics::{
         self,
         codes::{self, *},
-        Diagnostic, Diagnostics, WarningFilters,
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
     },
     editions::FeatureGate,
     expansion::{

--- a/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use crate::{
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{Fields, ModuleIdent},
     naming::ast as N,
     parser::ast::{Ability_, DatatypeName, Field},
@@ -271,7 +272,7 @@ fn add_private_transfers(
         transferred: &'a mut BTreeMap<(ModuleIdent, DatatypeName), TransferKind>,
     }
     impl<'a> TypingVisitorContext for TransferVisitor<'a> {
-        fn push_warning_filter_scope(&mut self, _: crate::diagnostics::WarningFilters) {
+        fn push_warning_filter_scope(&mut self, _: WarningFilters) {
             unreachable!("no warning filters in function bodies")
         }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -7,12 +7,12 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::shared::WarningFiltersScope;
 use crate::{
     diag,
     diagnostics::{
         codes::{custom, DiagnosticInfo, Severity},
-        Diagnostic, Diagnostics, WarningFilters,
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
     },
     expansion::ast as E,
     naming::ast as N,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     cfgir::visitor::AbstractInterpreterVisitor,
     command_line::compiler::Visitor,
-    diagnostics::codes::WarningFilter,
+    diagnostics::warning_filters::WarningFilter,
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
     linters::{LintLevel, LinterDiagnosticCategory, ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX},

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -8,14 +8,17 @@ use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
+    },
     editions::Flavor,
     expansion::ast::{AbilitySet, Fields, ModuleIdent, Mutability, TargetKind, Visibility},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, TypeName_, Type_, Var,
     },
     parser::ast::{Ability_, DatatypeName, FunctionName},
-    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier, WarningFiltersScope},
+    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier},
     sui_mode::*,
     typing::{
         ast::{self as T, ModuleCall},

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    diagnostics::WarningFilters,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{
         Address, Attributes, Fields, Friend, ModuleIdent, Mutability, TargetKind, Value, Visibility,
     },

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -6,7 +6,8 @@ use crate::{
     debug_display, diag,
     diagnostics::{
         codes::{NameResolution, TypeSafety},
-        Diagnostic, Diagnostics, WarningFilters,
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
     },
     editions::FeatureGate,
     expansion::ast::{AbilitySet, ModuleIdent, ModuleIdent_, Mutability, Visibility},

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     diag,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::{ModuleIdent, Value_},
     ice,
     naming::ast::BuiltinTypeName_,
@@ -70,7 +71,7 @@ impl TypingMutVisitorContext for MatchCompiler<'_, '_> {
         }
     }
 
-    fn push_warning_filter_scope(&mut self, filter: crate::diagnostics::WarningFilters) {
+    fn push_warning_filter_scope(&mut self, filter: WarningFilters) {
         self.context.push_warning_filter_scope(filter);
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     command_line::compiler::Visitor,
-    diagnostics::WarningFilters,
+    diagnostics::warning_filters::WarningFilters,
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::{ConstantName, DatatypeName, FunctionName, VariantName},
@@ -578,13 +578,16 @@ macro_rules! simple_visitor {
 
         pub struct Context<'a> {
             env: &'a crate::shared::CompilationEnv,
-            warning_filters_scope: crate::shared::WarningFiltersScope,
+            warning_filters_scope: crate::diagnostics::warning_filters::WarningFiltersScope,
         }
 
         impl crate::typing::visitor::TypingVisitorConstructor for $visitor {
             type Context<'a> = Context<'a>;
 
-            fn context<'a>(env: &'a crate::shared::CompilationEnv, _program: &crate::typing::ast::Program) -> Self::Context<'a> {
+            fn context<'a>(
+                env: &'a crate::shared::CompilationEnv,
+                _program: &crate::typing::ast::Program,
+            ) -> Self::Context<'a> {
                 let warning_filters_scope = env.top_level_warning_filter_scope().clone();
                 Context {
                     env,
@@ -606,7 +609,10 @@ macro_rules! simple_visitor {
         }
 
         impl crate::typing::visitor::TypingVisitorContext for Context<'_> {
-            fn push_warning_filter_scope(&mut self, filters: crate::diagnostics::WarningFilters) {
+            fn push_warning_filter_scope(
+                &mut self,
+                filters: crate::diagnostics::warning_filters::WarningFilters,
+            ) {
                 self.warning_filters_scope.push(filters)
             }
 

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -5,7 +5,10 @@
 use crate::{
     cfgir::ast as G,
     diag,
-    diagnostics::{Diagnostic, Diagnostics, WarningFilters},
+    diagnostics::{
+        warning_filters::{WarningFilters, WarningFiltersScope},
+        Diagnostic, Diagnostics,
+    },
     expansion::ast::{
         self as E, Address, Attribute, AttributeValue, Attributes, ModuleAccess_, ModuleIdent,
         ModuleIdent_,
@@ -16,7 +19,7 @@ use crate::{
     shared::{
         known_attributes::{self, TestingAttribute},
         unique_map::UniqueMap,
-        CompilationEnv, Identifier, NumericalAddress, WarningFiltersScope,
+        CompilationEnv, Identifier, NumericalAddress,
     },
     unit_test::{
         ExpectedFailure, ExpectedMoveError, ModuleTestPlan, MoveErrorType, TestArgument, TestCase,

--- a/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
@@ -10,6 +10,7 @@ use move_command_line_common::{
 };
 use move_compiler::{
     command_line::compiler::move_check_for_errors,
+    diagnostics::warning_filters::WarningFilters,
     diagnostics::*,
     editions::{Edition, Flavor},
     linters::{self, LintLevel},

--- a/external-crates/move/crates/move-model/src/lib.rs
+++ b/external-crates/move/crates/move-model/src/lib.rs
@@ -23,7 +23,7 @@ use move_binary_format::file_format::{
 use move_compiler::{
     self,
     compiled_unit::{self, AnnotatedCompiledUnit},
-    diagnostics::{Diagnostics, WarningFilters},
+    diagnostics::{warning_filters::WarningFilters, Diagnostics},
     expansion::ast::{self as E, ModuleIdent, ModuleIdent_, TargetKind},
     parser::ast as P,
     shared::{parse_named_address, unique_map::UniqueMap, NumericalAddress, PackagePaths},

--- a/external-crates/move/crates/move-model/tests/testsuite.rs
+++ b/external-crates/move/crates/move-model/tests/testsuite.rs
@@ -5,7 +5,7 @@
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use move_binary_format::file_format::{FunctionDefinitionIndex, StructDefinitionIndex};
 use move_command_line_common::testing::EXP_EXT;
-use move_compiler::{diagnostics::WarningFilters, shared::PackagePaths};
+use move_compiler::{diagnostics::warning_filters::WarningFilters, shared::PackagePaths};
 use move_model::{run_bytecode_model_builder, run_model_builder};
 use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 use std::path::Path;

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -8,7 +8,7 @@ use move_command_line_common::files::{
 };
 use move_compiler::command_line::DEFAULT_OUTPUT_DIR;
 use move_compiler::editions::Edition;
-use move_compiler::{diagnostics::WarningFilters, shared::PackageConfig};
+use move_compiler::{diagnostics::warning_filters::WarningFilters, shared::PackageConfig};
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use std::fs::File;

--- a/external-crates/move/crates/move-stackless-bytecode/tests/testsuite.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/testsuite.rs
@@ -5,7 +5,7 @@
 use anyhow::anyhow;
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use move_command_line_common::testing::EXP_EXT;
-use move_compiler::{diagnostics::WarningFilters, shared::PackagePaths};
+use move_compiler::{diagnostics::warning_filters::WarningFilters, shared::PackagePaths};
 use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
 use move_stackless_bytecode::{

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -20,7 +20,7 @@ use move_command_line_common::{
 };
 use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
-    diagnostics::{Diagnostics, WarningFilters},
+    diagnostics::{warning_filters::WarningFilters, Diagnostics},
     editions::{Edition, Flavor},
     shared::{files::MappedFiles, NumericalAddress, PackageConfig},
     FullyCompiledProgram,


### PR DESCRIPTION
## Description 

- Re-organize warning filters. It should make it a bit cleaner to refactor diagnostic reporting 

## Test plan 

- ran tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
