### PR TITLE
[CLI] fix `sui keytool import` --alias command and default alias does not work

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -629,8 +629,15 @@ impl KeyToolCommand {
                 match SuiKeyPair::decode(&input_string) {
                     Ok(skp) => {
                         info!("Importing Bech32 encoded private key to keystore");
-                        let key = Key::from(&skp);
-                        keystore.add_key(alias, skp)?;
+                        let mut key = Key::from(&skp);
+                        keystore.add_key(alias.clone(), skp)?;
+
+                        let alias = match alias {
+                            Some(x) => x,
+                            None => keystore.get_alias_by_address(&key.sui_address)?,
+                        };
+
+                        key.alias = Some(alias);
                         CommandOutput::Import(key)
                     }
                     Err(_) => {
@@ -639,10 +646,17 @@ impl KeyToolCommand {
                             &input_string,
                             key_scheme,
                             derivation_path,
-                            alias,
+                            alias.clone(),
                         )?;
                         let skp = keystore.get_key(&sui_address)?;
-                        let key = Key::from(skp);
+                        let mut key = Key::from(skp);
+
+                        let alias = match alias {
+                            Some(x) => x,
+                            None => keystore.get_alias_by_address(&key.sui_address)?,
+                        };
+
+                        key.alias = Some(alias);
                         CommandOutput::Import(key)
                     }
                 }


### PR DESCRIPTION
## Description 

fix `sui keytool import` --alias command and default alias does not work

Before Fix：
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/4cb40d92-e266-4b6e-9c39-c05ac52d7a9d">

After Fix：

- **--alias**
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/b5c711e8-2a4d-4861-9965-30cde260e93f">

- **default alias**
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/4513db65-0e10-4179-b5f0-de188871cf78">

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui keytool import --alias` is now fixed and correctly records the provided alias. 
- [ ] Rust SDK:
- [ ] REST API:
