### PR TITLE
[Consensus] enable amnesia recovery for mainnet

### DIFF
--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc};
 
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
@@ -130,14 +130,9 @@ impl ConsensusManagerTrait for MysticetiManager {
             .consensus_config()
             .expect("consensus_config should exist");
 
-        let mut parameters = Parameters {
+        let parameters = Parameters {
             db_path: self.get_store_path(epoch),
             ..consensus_config.parameters.clone().unwrap_or_default()
-        };
-
-        // Disable the automated last known block sync for mainnet for now
-        if epoch_store.get_chain_identifier().chain() == sui_protocol_config::Chain::Mainnet {
-            parameters.sync_last_known_own_block_timeout = Duration::ZERO;
         };
 
         let own_protocol_key = self.protocol_keypair.public();


### PR DESCRIPTION
## Description 

Enable amnesia recovery for mainnet

## Test plan 

Tested in PT and public testnet. Things look good to go.
CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
