### PR TITLE
sui-field-count: const instead of fn and use it in sui-indexer-alt

### DIFF
--- a/crates/sui-field-count-derive/src/lib.rs
+++ b/crates/sui-field-count-derive/src/lib.rs
@@ -19,9 +19,7 @@ pub fn field_count_derive(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         impl #impl_generics FieldCount for #name #ty_generics #where_clause {
-            fn field_count() -> usize {
-                #fields_count
-            }
+            const FIELD_COUNT: usize = #fields_count;
         }
     };
 

--- a/crates/sui-field-count/src/lib.rs
+++ b/crates/sui-field-count/src/lib.rs
@@ -4,7 +4,7 @@
 pub use sui_field_count_derive::*;
 
 pub trait FieldCount {
-    fn field_count() -> usize;
+    const FIELD_COUNT: usize;
 }
 
 #[cfg(test)]
@@ -22,8 +22,8 @@ mod tests {
             _field3: bool,
         }
 
-        assert_eq!(BasicStruct::field_count(), 3);
-        assert_eq!(EmptyStruct::field_count(), 0);
+        assert_eq!(BasicStruct::FIELD_COUNT, 3);
+        assert_eq!(EmptyStruct::FIELD_COUNT, 0);
     }
 
     #[test]
@@ -35,7 +35,7 @@ mod tests {
             _field3: &'a Vec<String>,
         }
 
-        assert_eq!(LifetimeStruct::field_count(), 3);
+        assert_eq!(LifetimeStruct::FIELD_COUNT, 3);
     }
 
     #[test]
@@ -47,8 +47,8 @@ mod tests {
             _field3: Option<T>,
         }
 
-        assert_eq!(GenericStruct::<String>::field_count(), 3);
-        assert_eq!(GenericStruct::<i32>::field_count(), 3);
+        assert_eq!(GenericStruct::<String>::FIELD_COUNT, 3);
+        assert_eq!(GenericStruct::<i32>::FIELD_COUNT, 3);
     }
 
     #[test]
@@ -62,7 +62,7 @@ mod tests {
             _field2: Vec<T>,
         }
 
-        assert_eq!(WhereStruct::<String>::field_count(), 2);
-        assert_eq!(WhereStruct::<i32>::field_count(), 2);
+        assert_eq!(WhereStruct::<String>::FIELD_COUNT, 2);
+        assert_eq!(WhereStruct::<i32>::FIELD_COUNT, 2);
     }
 }

--- a/crates/sui-indexer-alt/src/handlers/ev_emit_mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_emit_mod.rs
@@ -49,7 +49,6 @@ impl Processor for EvEmitMod {
 #[async_trait::async_trait]
 impl Handler for EvEmitMod {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
@@ -53,7 +53,6 @@ impl Processor for EvStructInst {
 #[async_trait::async_trait]
 impl Handler for EvStructInst {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/kv_feature_flags.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_feature_flags.rs
@@ -55,7 +55,6 @@ impl Processor for KvFeatureFlags {
 #[async_trait::async_trait]
 impl Handler for KvFeatureFlags {
     const MIN_EAGER_ROWS: usize = 1;
-    const MAX_CHUNK_ROWS: usize = i16::MAX as usize / 3;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/kv_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_objects.rs
@@ -56,7 +56,6 @@ impl Processor for KvObjects {
 #[async_trait::async_trait]
 impl Handler for KvObjects {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/kv_protocol_configs.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_protocol_configs.rs
@@ -55,7 +55,6 @@ impl Processor for KvProtocolConfigs {
 #[async_trait::async_trait]
 impl Handler for KvProtocolConfigs {
     const MIN_EAGER_ROWS: usize = 1;
-    const MAX_CHUNK_ROWS: usize = i16::MAX as usize / 3;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
@@ -59,7 +59,6 @@ impl Processor for KvTransactions {
 #[async_trait::async_trait]
 impl Handler for KvTransactions {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/obj_versions.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_versions.rs
@@ -49,7 +49,6 @@ impl Processor for ObjVersions {
 #[async_trait::async_trait]
 impl Handler for ObjVersions {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/sum_coin_balances.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_coin_balances.rs
@@ -151,7 +151,6 @@ impl Handler for SumCoinBalances {
                 deletes.push(update.object_id.to_vec());
             }
         }
-
         let update_chunks = updates.chunks(Self::INSERT_CHUNK_ROWS).map(Either::Left);
         let delete_chunks = deletes.chunks(Self::DELETE_CHUNK_ROWS).map(Either::Right);
 

--- a/crates/sui-indexer-alt/src/handlers/sum_coin_balances.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_coin_balances.rs
@@ -22,13 +22,6 @@ use crate::{
     schema::sum_coin_balances,
 };
 
-/// Each insert or update will include at most this many rows -- the size is chosen to maximize the
-/// rows without hitting the limit on bind parameters.
-const UPDATE_CHUNK_ROWS: usize = i16::MAX as usize / 5;
-
-/// Each deletion will include at most this many rows.
-const DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
-
 pub struct SumCoinBalances;
 
 impl Processor for SumCoinBalances {
@@ -159,8 +152,8 @@ impl Handler for SumCoinBalances {
             }
         }
 
-        let update_chunks = updates.chunks(UPDATE_CHUNK_ROWS).map(Either::Left);
-        let delete_chunks = deletes.chunks(DELETE_CHUNK_ROWS).map(Either::Right);
+        let update_chunks = updates.chunks(Self::INSERT_CHUNK_ROWS).map(Either::Left);
+        let delete_chunks = deletes.chunks(Self::DELETE_CHUNK_ROWS).map(Either::Right);
 
         let futures = update_chunks.chain(delete_chunks).map(|chunk| match chunk {
             Either::Left(update) => Either::Left(

--- a/crates/sui-indexer-alt/src/handlers/sum_displays.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_displays.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
 use futures::future::try_join_all;
+use sui_field_count::FieldCount;
 use sui_types::{display::DisplayVersionUpdatedEvent, full_checkpoint_content::CheckpointData};
 
 use crate::{
@@ -16,6 +17,7 @@ use crate::{
     schema::sum_displays,
 };
 
+const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / StoredDisplay::FIELD_COUNT;
 pub struct SumDisplays;
 
 impl Processor for SumDisplays {
@@ -69,22 +71,20 @@ impl Handler for SumDisplays {
 
     async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> Result<usize> {
         let values: Vec<_> = batch.values().cloned().collect();
-        let updates =
-            values
-                .chunks(Self::MAX_INSERT_CHUNK_ROWS)
-                .map(|chunk: &[StoredDisplay]| {
-                    diesel::insert_into(sum_displays::table)
-                        .values(chunk)
-                        .on_conflict(sum_displays::object_type)
-                        .do_update()
-                        .set((
-                            sum_displays::display_id.eq(excluded(sum_displays::display_id)),
-                            sum_displays::display_version
-                                .eq(excluded(sum_displays::display_version)),
-                            sum_displays::display.eq(excluded(sum_displays::display)),
-                        ))
-                        .execute(conn)
-                });
+        let updates = values
+            .chunks(MAX_INSERT_CHUNK_ROWS)
+            .map(|chunk: &[StoredDisplay]| {
+                diesel::insert_into(sum_displays::table)
+                    .values(chunk)
+                    .on_conflict(sum_displays::object_type)
+                    .do_update()
+                    .set((
+                        sum_displays::display_id.eq(excluded(sum_displays::display_id)),
+                        sum_displays::display_version.eq(excluded(sum_displays::display_version)),
+                        sum_displays::display.eq(excluded(sum_displays::display)),
+                    ))
+                    .execute(conn)
+            });
 
         Ok(try_join_all(updates).await?.into_iter().sum())
     }

--- a/crates/sui-indexer-alt/src/handlers/sum_obj_types.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_obj_types.rs
@@ -22,13 +22,6 @@ use crate::{
     schema::sum_obj_types,
 };
 
-/// Each insert or update will include at most this many rows -- the size is chosen to maximize the
-/// rows without hitting the limit on bind parameters.
-const UPDATE_CHUNK_ROWS: usize = i16::MAX as usize / 8;
-
-/// Each deletion will include at most this many rows.
-const DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
-
 pub struct SumObjTypes;
 
 impl Processor for SumObjTypes {
@@ -158,8 +151,8 @@ impl Handler for SumObjTypes {
             }
         }
 
-        let update_chunks = updates.chunks(UPDATE_CHUNK_ROWS).map(Either::Left);
-        let delete_chunks = deletes.chunks(DELETE_CHUNK_ROWS).map(Either::Right);
+        let update_chunks = updates.chunks(Self::INSERT_CHUNK_ROWS).map(Either::Left);
+        let delete_chunks = deletes.chunks(Self::DELETE_CHUNK_ROWS).map(Either::Right);
 
         let futures = update_chunks.chain(delete_chunks).map(|chunk| match chunk {
             Either::Left(update) => Either::Left(

--- a/crates/sui-indexer-alt/src/handlers/sum_obj_types.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_obj_types.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, ensure};
 use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
 use futures::future::{try_join_all, Either};
+use sui_field_count::FieldCount;
 use sui_types::{
     base_types::ObjectID, effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointData,
     object::Owner,
@@ -21,6 +22,9 @@ use crate::{
     pipeline::{sequential::Handler, Processor},
     schema::sum_obj_types,
 };
+
+const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / StoredSumObjType::FIELD_COUNT;
+const MAX_DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
 
 pub struct SumObjTypes;
 
@@ -151,8 +155,8 @@ impl Handler for SumObjTypes {
             }
         }
 
-        let update_chunks = updates.chunks(Self::INSERT_CHUNK_ROWS).map(Either::Left);
-        let delete_chunks = deletes.chunks(Self::DELETE_CHUNK_ROWS).map(Either::Right);
+        let update_chunks = updates.chunks(MAX_INSERT_CHUNK_ROWS).map(Either::Left);
+        let delete_chunks = deletes.chunks(MAX_DELETE_CHUNK_ROWS).map(Either::Right);
 
         let futures = update_chunks.chain(delete_chunks).map(|chunk| match chunk {
             Either::Left(update) => Either::Left(

--- a/crates/sui-indexer-alt/src/handlers/sum_packages.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_packages.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
 use futures::future::try_join_all;
+use sui_field_count::FieldCount;
 use sui_types::full_checkpoint_content::CheckpointData;
 
 use crate::{
@@ -15,6 +16,8 @@ use crate::{
     pipeline::{sequential::Handler, Processor},
     schema::sum_packages,
 };
+
+const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / StoredPackage::FIELD_COUNT;
 
 pub struct SumPackages;
 
@@ -65,7 +68,7 @@ impl Handler for SumPackages {
 
     async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> Result<usize> {
         let values: Vec<_> = batch.values().cloned().collect();
-        let updates = values.chunks(Self::MAX_INSERT_CHUNK_ROWS).map(|chunk| {
+        let updates = values.chunks(MAX_INSERT_CHUNK_ROWS).map(|chunk| {
             diesel::insert_into(sum_packages::table)
                 .values(chunk)
                 .on_conflict(sum_packages::package_id)

--- a/crates/sui-indexer-alt/src/handlers/sum_packages.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_packages.rs
@@ -16,8 +16,6 @@ use crate::{
     schema::sum_packages,
 };
 
-const CHUNK_ROWS: usize = i16::MAX as usize / 5;
-
 pub struct SumPackages;
 
 impl Processor for SumPackages {
@@ -67,7 +65,7 @@ impl Handler for SumPackages {
 
     async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> Result<usize> {
         let values: Vec<_> = batch.values().cloned().collect();
-        let updates = values.chunks(CHUNK_ROWS).map(|chunk| {
+        let updates = values.chunks(Self::MAX_INSERT_CHUNK_ROWS).map(|chunk| {
             diesel::insert_into(sum_packages::table)
                 .values(chunk)
                 .on_conflict(sum_packages::package_id)

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_addresses.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_addresses.rs
@@ -60,7 +60,6 @@ impl Processor for TxAffectedAddresses {
 #[async_trait::async_trait]
 impl Handler for TxAffectedAddresses {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
@@ -52,7 +52,6 @@ impl Processor for TxAffectedObjects {
 #[async_trait::async_trait]
 impl Handler for TxAffectedObjects {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
@@ -58,7 +58,6 @@ impl Processor for TxBalanceChanges {
 #[async_trait::async_trait]
 impl Handler for TxBalanceChanges {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/tx_calls.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_calls.rs
@@ -55,7 +55,6 @@ impl Processor for TxCalls {
 #[async_trait::async_trait]
 impl Handler for TxCalls {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/tx_digests.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_digests.rs
@@ -42,7 +42,6 @@ impl Processor for TxDigests {
 #[async_trait::async_trait]
 impl Handler for TxDigests {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/tx_kinds.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_kinds.rs
@@ -52,7 +52,6 @@ impl Processor for TxKinds {
 #[async_trait::async_trait]
 impl Handler for TxKinds {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/wal_coin_balances.rs
+++ b/crates/sui-indexer-alt/src/handlers/wal_coin_balances.rs
@@ -32,7 +32,6 @@ impl Processor for WalCoinBalances {
 #[async_trait::async_trait]
 impl Handler for WalCoinBalances {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/handlers/wal_obj_types.rs
+++ b/crates/sui-indexer-alt/src/handlers/wal_obj_types.rs
@@ -32,7 +32,6 @@ impl Processor for WalObjTypes {
 #[async_trait::async_trait]
 impl Handler for WalObjTypes {
     const MIN_EAGER_ROWS: usize = 100;
-    const MAX_CHUNK_ROWS: usize = 1000;
     const MAX_PENDING_ROWS: usize = 10000;
 
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>) -> Result<usize> {

--- a/crates/sui-indexer-alt/src/models/displays.rs
+++ b/crates/sui-indexer-alt/src/models/displays.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
+use sui_field_count::FieldCount;
 
 use crate::schema::sum_displays;
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = sum_displays, primary_key(object_type))]
 pub struct StoredDisplay {
     pub object_type: Vec<u8>,

--- a/crates/sui-indexer-alt/src/models/objects.rs
+++ b/crates/sui-indexer-alt/src/models/objects.rs
@@ -21,7 +21,7 @@ pub struct StoredObject {
     pub serialized_object: Option<Vec<u8>>,
 }
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = obj_versions, primary_key(object_id, object_version))]
 pub struct StoredObjVersion {
     pub object_id: Vec<u8>,
@@ -97,6 +97,11 @@ pub struct StoredWalObjType {
     pub name: Option<String>,
     pub instantiation: Option<Vec<u8>>,
     pub cp_sequence_number: i64,
+}
+
+/// StoredObjectUpdate is a wrapper type, we want to count the fields of the inner type.
+impl<T: FieldCount> FieldCount for StoredObjectUpdate<T> {
+    const FIELD_COUNT: usize = T::FIELD_COUNT;
 }
 
 impl<DB: Backend> serialize::ToSql<SmallInt, DB> for StoredOwnerKind

--- a/crates/sui-indexer-alt/src/models/packages.rs
+++ b/crates/sui-indexer-alt/src/models/packages.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
+use sui_field_count::FieldCount;
 
 use crate::schema::sum_packages;
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = sum_packages, primary_key(package_id))]
 pub struct StoredPackage {
     pub package_id: Vec<u8>,

--- a/crates/sui-indexer-alt/src/models/transactions.rs
+++ b/crates/sui-indexer-alt/src/models/transactions.rs
@@ -70,7 +70,7 @@ pub struct StoredTxBalanceChange {
     pub balance_changes: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = tx_calls)]
 pub struct StoredTxCalls {
     pub tx_sequence_number: i64,
@@ -80,7 +80,7 @@ pub struct StoredTxCalls {
     pub sender: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = tx_digests)]
 pub struct StoredTxDigest {
     pub tx_sequence_number: i64,
@@ -95,7 +95,7 @@ pub enum StoredKind {
     ProgrammableTransaction = 1,
 }
 
-#[derive(Insertable, Debug, Clone)]
+#[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = tx_kinds)]
 pub struct StoredTxKind {
     pub tx_sequence_number: i64,

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
@@ -4,7 +4,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use mysten_metrics::spawn_monitored_task;
-use sui_field_count::FieldCount;
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
@@ -39,7 +38,7 @@ impl<H: Handler> Pending<H> {
     /// Adds data from this indexed checkpoint to the `batch`, honoring the handler's bounds on
     /// chunk size.
     fn batch_into(&mut self, batch: &mut Batched<H>) {
-        let max_chunk_rows = i16::MAX as usize / H::Value::FIELD_COUNT;
+        let max_chunk_rows = super::max_chunk_rows::<H>();
         if batch.values.len() + self.values.len() > max_chunk_rows {
             let mut for_batch = self.values.split_off(max_chunk_rows - batch.values.len());
 

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
@@ -4,6 +4,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use mysten_metrics::spawn_monitored_task;
+use sui_field_count::FieldCount;
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
@@ -38,10 +39,9 @@ impl<H: Handler> Pending<H> {
     /// Adds data from this indexed checkpoint to the `batch`, honoring the handler's bounds on
     /// chunk size.
     fn batch_into(&mut self, batch: &mut Batched<H>) {
-        if batch.values.len() + self.values.len() > H::MAX_CHUNK_ROWS {
-            let mut for_batch = self
-                .values
-                .split_off(H::MAX_CHUNK_ROWS - batch.values.len());
+        let max_chunk_rows = i16::MAX as usize / H::Value::FIELD_COUNT;
+        if batch.values.len() + self.values.len() > max_chunk_rows {
+            let mut for_batch = self.values.split_off(max_chunk_rows - batch.values.len());
 
             std::mem::swap(&mut self.values, &mut for_batch);
             batch.watermark.push(self.watermark.take(for_batch.len()));

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
@@ -133,8 +133,7 @@ impl<H: Handler> Batched<H> {
     /// The batch is full if it has more than enough values to write to the database, or more than
     /// enough watermarks to update.
     fn is_full(&self) -> bool {
-        let max_chunk_rows = i16::MAX as usize / H::Value::FIELD_COUNT;
-        self.values.len() >= max_chunk_rows || self.watermark.len() >= MAX_WATERMARK_UPDATES
+        self.values.len() >= max_chunk_rows::<H>() || self.watermark.len() >= MAX_WATERMARK_UPDATES
     }
 }
 
@@ -247,4 +246,8 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         pruner_cancel.cancel();
         let _ = futures::join!(reader_watermark, pruner);
     })
+}
+
+const fn max_chunk_rows<H: Handler>() -> usize {
+    i16::MAX as usize / H::Value::FIELD_COUNT
 }

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
@@ -4,6 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use serde::{Deserialize, Serialize};
+use sui_field_count::FieldCount;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -57,8 +58,8 @@ pub trait Handler: Processor {
     const MIN_EAGER_ROWS: usize = 50;
 
     /// If there are more than this many rows pending, the committer will only commit this many in
-    /// one operation.
-    const MAX_CHUNK_ROWS: usize = 1000;
+    /// one operation. The size is chosen to maximize the rows without hitting the limit on bind parameters.
+    const MAX_CHUNK_ROWS: usize = i16::MAX as usize / Self::Value::FIELD_COUNT;
 
     /// If there are more than this many rows pending, the committer applies backpressure.
     const MAX_PENDING_ROWS: usize = 5000;

--- a/crates/sui-indexer-alt/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt/src/pipeline/processor.rs
@@ -26,13 +26,6 @@ pub trait Processor {
     /// How much concurrency to use when processing checkpoint data.
     const FANOUT: usize = 10;
 
-    /// Each insert or update will include at most this many rows -- the size is chosen to maximize the
-    /// rows without hitting the limit on bind parameters.
-    const INSERT_CHUNK_ROWS: usize = i16::MAX as usize / Self::Value::FIELD_COUNT;
-
-    /// Each deletion will include at most this many rows without hitting the limit on bind parameters.
-    const DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
-
     /// The type of value being inserted by the handler.
     type Value: Send + Sync + 'static + FieldCount;
 

--- a/crates/sui-indexer-alt/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt/src/pipeline/processor.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use mysten_metrics::spawn_monitored_task;
-use sui_field_count::FieldCount;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::wrappers::ReceiverStream;
@@ -27,7 +26,7 @@ pub trait Processor {
     const FANOUT: usize = 10;
 
     /// The type of value being inserted by the handler.
-    type Value: Send + Sync + 'static + FieldCount;
+    type Value: Send + Sync + 'static;
 
     /// The processing logic for turning a checkpoint into rows of the table.
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>>;

--- a/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use sui_field_count::FieldCount;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -42,13 +41,6 @@ mod committer;
 pub trait Handler: Processor {
     /// If at least this many rows are pending, the committer will commit them eagerly.
     const MIN_EAGER_ROWS: usize = 50;
-
-    /// If there are more than this many rows pending, the committer will only commit this many in
-    /// one operation. The size is chosen to maximize the rows without hitting the limit on bind parameters.
-    const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / Self::Value::FIELD_COUNT;
-
-    /// Each deletion will include at most this many rows without hitting the limit on bind parameters.
-    const MAX_DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
 
     /// Maximum number of checkpoints to try and write in a single batch. The larger this number
     /// is, the more chances the pipeline has to merge redundant writes, but the longer each write

--- a/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use sui_field_count::FieldCount;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -41,6 +42,13 @@ mod committer;
 pub trait Handler: Processor {
     /// If at least this many rows are pending, the committer will commit them eagerly.
     const MIN_EAGER_ROWS: usize = 50;
+
+    /// If there are more than this many rows pending, the committer will only commit this many in
+    /// one operation. The size is chosen to maximize the rows without hitting the limit on bind parameters.
+    const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / Self::Value::FIELD_COUNT;
+
+    /// Each deletion will include at most this many rows without hitting the limit on bind parameters.
+    const MAX_DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
 
     /// Maximum number of checkpoints to try and write in a single batch. The larger this number
     /// is, the more chances the pipeline has to merge redundant writes, but the longer each write


### PR DESCRIPTION
## Description 

- change field_count trait from fn to const as we want to use it as part of const def
- use it in sui-indexer-alt

## Test plan 

1. existing tests for sui-field-count
2. for replacements, I added temp tests to ensure the values before and after were the same, removed them afterwards to avoid unnecessary changes later on when we change struct definition

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
