### PR TITLE
[move-ide] Custom compiler edition notification

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
@@ -12,7 +12,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as commands from './commands';
 
-
 /**
  * An extension command that displays the version of the server that this extension
  * interfaces with.

--- a/external-crates/move/crates/move-analyzer/src/completions/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/mod.rs
@@ -10,7 +10,10 @@ use crate::{
         utils::{completion_item, PRIMITIVE_TYPE_COMPLETIONS},
     },
     context::Context,
-    symbols::{self, CursorContext, PrecomputedPkgDepsInfo, SymbolicatorRunner, Symbols},
+    symbols::{
+        get_symbols, CursorContext, PrecomputedPkgDepsInfo, SymbolicationResult,
+        SymbolicatorRunner, Symbols,
+    },
 };
 use lsp_server::Request;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, Position};
@@ -166,7 +169,7 @@ fn compute_completions_new_symbols(
     };
     let cursor_path = path.to_path_buf();
     let cursor_info = Some((&cursor_path, cursor_position));
-    let (symbols, _diags) = symbols::get_symbols(
+    let SymbolicationResult { symbols, .. } = get_symbols(
         pkg_dependencies,
         ide_files_root,
         &pkg_path,


### PR DESCRIPTION
## Description 

This PR implements support for passing custom notifications from LSP server to the IDE and an example of how this kind of notification can be handled on the IDE side (in this case on the VSCode side, and the handler simply logs the edition to the client log). In order to do it, I generalized the notification machinery between the symbolicator thread and the main `move-analyzer` thread a bit

## Test plan 

All existing tests must pass
