### PR TITLE
refactor(indexer-alt): a variety of refactors

### DIFF
--- a/crates/sui-indexer-alt/migrations/2024-10-19-113135_ev_indices/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-19-113135_ev_indices/up.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS ev_emit_mod
 (
-    package                     BYTEA,
-    module                      TEXT,
-    tx_sequence_number          BIGINT,
+    package                     BYTEA         NOT NULL,
+    module                      TEXT          NOT NULL,
+    tx_sequence_number          BIGINT        NOT NULL,
     sender                      BYTEA         NOT NULL,
     PRIMARY KEY(package, module, tx_sequence_number)
 );
@@ -21,12 +21,12 @@ ON ev_emit_mod (sender, package, tx_sequence_number);
 
 CREATE TABLE IF NOT EXISTS ev_struct_inst
 (
-    package                     BYTEA,
-    module                      TEXT,
-    name                        TEXT,
+    package                     BYTEA         NOT NULL,
+    module                      TEXT          NOT NULL,
+    name                        TEXT          NOT NULL,
     -- BCS encoded array of TypeTags for type parameters.
-    instantiation               BYTEA,
-    tx_sequence_number          BIGINT,
+    instantiation               BYTEA         NOT NULL,
+    tx_sequence_number          BIGINT        NOT NULL,
     sender                      BYTEA         NOT NULL,
     PRIMARY KEY(package, module, name, instantiation, tx_sequence_number)
 );

--- a/crates/sui-indexer-alt/migrations/2024-10-31-174742_sum_displays/down.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-31-174742_sum_displays/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sum_displays;

--- a/crates/sui-indexer-alt/migrations/2024-10-31-174742_sum_displays/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-31-174742_sum_displays/up.sql
@@ -1,0 +1,13 @@
+-- This table tracks the latest versions of `Display`, keyed by Object type.
+CREATE TABLE IF NOT EXISTS sum_displays
+(
+    -- BCS-encoded StructTag of the object that this Display belongs to.
+    object_type                 BYTEA         PRIMARY KEY,
+    -- Object ID of the Display object
+    display_id                  BYTEA         NOT NULL,
+    -- Version of the Display object (In the VersionUpdate event this is stored as a u16)
+    display_version             SMALLINT      NOT NULL,
+    -- BCS-encoded content of DisplayVersionUpdatedEvent that was indexed into
+    -- this record.
+    display                     BYTEA         NOT NULL
+);

--- a/crates/sui-indexer-alt/src/handlers/mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod kv_objects;
 pub mod kv_transactions;
 pub mod obj_versions;
 pub mod sum_coin_balances;
+pub mod sum_displays;
 pub mod sum_obj_types;
 pub mod sum_packages;
 pub mod tx_affected_addresses;

--- a/crates/sui-indexer-alt/src/handlers/sum_displays.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_displays.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use anyhow::{anyhow, Result};
+use diesel::{upsert::excluded, ExpressionMethods};
+use diesel_async::RunQueryDsl;
+use futures::future::try_join_all;
+use sui_types::{display::DisplayVersionUpdatedEvent, full_checkpoint_content::CheckpointData};
+
+use crate::{
+    db,
+    models::displays::StoredDisplay,
+    pipeline::{sequential::Handler, Processor},
+    schema::sum_displays,
+};
+
+const CHUNK_ROWS: usize = i16::MAX as usize / 4;
+
+pub struct SumDisplays;
+
+impl Processor for SumDisplays {
+    const NAME: &'static str = "sum_displays";
+
+    type Value = StoredDisplay;
+
+    fn process(checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
+        let CheckpointData { transactions, .. } = checkpoint.as_ref();
+
+        let mut values = vec![];
+        for tx in transactions {
+            let Some(events) = &tx.events else {
+                continue;
+            };
+
+            for event in &events.data {
+                let Some((object_type, update)) = DisplayVersionUpdatedEvent::try_from_event(event)
+                else {
+                    continue;
+                };
+
+                values.push(StoredDisplay {
+                    object_type: bcs::to_bytes(&object_type).map_err(|e| {
+                        anyhow!(
+                            "Error serializing object type {}: {e}",
+                            object_type.to_canonical_display(/* with_prefix */ true)
+                        )
+                    })?,
+
+                    display_id: update.id.bytes.to_vec(),
+                    display_version: update.version as i16,
+                    display: event.contents.clone(),
+                })
+            }
+        }
+
+        Ok(values)
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for SumDisplays {
+    type Batch = BTreeMap<Vec<u8>, Self::Value>;
+
+    fn batch(batch: &mut Self::Batch, values: Vec<Self::Value>) {
+        for value in values {
+            batch.insert(value.object_type.clone(), value);
+        }
+    }
+
+    async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> Result<usize> {
+        let values: Vec<_> = batch.values().cloned().collect();
+        let updates = values.chunks(CHUNK_ROWS).map(|chunk| {
+            diesel::insert_into(sum_displays::table)
+                .values(chunk)
+                .on_conflict(sum_displays::object_type)
+                .do_update()
+                .set((
+                    sum_displays::display_id.eq(excluded(sum_displays::display_id)),
+                    sum_displays::display_version.eq(excluded(sum_displays::display_version)),
+                    sum_displays::display.eq(excluded(sum_displays::display)),
+                ))
+                .execute(conn)
+        });
+
+        Ok(try_join_all(updates).await?.into_iter().sum())
+    }
+}

--- a/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
@@ -3,16 +3,15 @@
 
 use std::sync::Arc;
 
-use backoff::backoff::Constant;
 use futures::{future::try_join_all, TryStreamExt};
 use mysten_metrics::spawn_monitored_task;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
-use crate::{ingestion::error::Error, metrics::IndexerMetrics};
+use crate::ingestion::error::Error;
 
 use super::{client::IngestionClient, IngestionConfig};
 
@@ -25,7 +24,6 @@ use super::{client::IngestionClient, IngestionConfig};
 pub(super) fn broadcaster(
     config: IngestionConfig,
     client: IngestionClient,
-    metrics: Arc<IndexerMetrics>,
     checkpoint_rx: mpsc::Receiver<u64>,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointData>>>,
     cancel: CancellationToken,
@@ -37,7 +35,6 @@ pub(super) fn broadcaster(
             .map(Ok)
             .try_for_each_concurrent(/* limit */ config.ingest_concurrency, |cp| {
                 let client = client.clone();
-                let metrics = metrics.clone();
                 let subscribers = subscribers.clone();
 
                 // One clone is for the supervisor to signal a cancel if it detects a
@@ -46,33 +43,10 @@ pub(super) fn broadcaster(
                 let supervisor_cancel = cancel.clone();
                 let cancel = cancel.clone();
 
-                // Repeatedly retry if the checkpoint is not found, assuming that we are at the
-                // tip of the network and it will become available soon.
-                let backoff = Constant::new(config.retry_interval);
-                let fetch = move || {
-                    let client = client.clone();
-                    let metrics = metrics.clone();
-                    let cancel = cancel.clone();
-
-                    async move {
-                        use backoff::Error as BE;
-                        if cancel.is_cancelled() {
-                            return Err(BE::permanent(Error::Cancelled));
-                        }
-
-                        client.fetch(cp, &cancel).await.map_err(|e| match e {
-                            Error::NotFound(checkpoint) => {
-                                debug!(checkpoint, "Checkpoint not found, retrying...");
-                                metrics.total_ingested_not_found_retries.inc();
-                                BE::transient(e)
-                            }
-                            e => BE::permanent(e),
-                        })
-                    }
-                };
-
                 async move {
-                    let checkpoint = backoff::future::retry(backoff, fetch).await?;
+                    // Repeatedly retry if the checkpoint is not found, assuming that we are at the
+                    // tip of the network and it will become available soon.
+                    let checkpoint = client.wait_for(cp, config.retry_interval, &cancel).await?;
                     let futures = subscribers.iter().map(|s| s.send(checkpoint.clone()));
 
                     if try_join_all(futures).await.is_err() {

--- a/crates/sui-indexer-alt/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt/src/ingestion/client.rs
@@ -43,7 +43,7 @@ pub enum FetchError {
 pub type FetchResult = Result<Bytes, FetchError>;
 
 #[derive(Clone)]
-pub(crate) struct IngestionClient {
+pub struct IngestionClient {
     client: Arc<dyn IngestionClientTrait>,
     /// Wrap the metrics in an `Arc` to keep copies of the client cheap.
     metrics: Arc<IndexerMetrics>,

--- a/crates/sui-indexer-alt/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt/src/ingestion/mod.rs
@@ -20,7 +20,7 @@ use crate::ingestion::regulator::regulator;
 use crate::metrics::IndexerMetrics;
 
 mod broadcaster;
-mod client;
+pub mod client;
 pub mod error;
 mod local_client;
 mod regulator;
@@ -92,6 +92,11 @@ impl IngestionService {
             subscribers,
             cancel,
         })
+    }
+
+    /// The client this service uses to fetch checkpoints.
+    pub fn client(&self) -> &IngestionClient {
+        &self.client
     }
 
     /// Add a new subscription to the ingestion service. Note that the service is susceptible to

--- a/crates/sui-indexer-alt/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt/src/ingestion/mod.rs
@@ -31,7 +31,6 @@ mod test_utils;
 pub struct IngestionService {
     config: IngestionConfig,
     client: IngestionClient,
-    metrics: Arc<IndexerMetrics>,
     ingest_hi_tx: mpsc::UnboundedSender<(&'static str, u64)>,
     ingest_hi_rx: mpsc::UnboundedReceiver<(&'static str, u64)>,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointData>>>,
@@ -86,7 +85,6 @@ impl IngestionService {
         Ok(Self {
             config,
             client,
-            metrics,
             ingest_hi_tx,
             ingest_hi_rx,
             subscribers,
@@ -141,7 +139,6 @@ impl IngestionService {
         let IngestionService {
             config,
             client,
-            metrics,
             ingest_hi_tx: _,
             ingest_hi_rx,
             subscribers,
@@ -162,14 +159,7 @@ impl IngestionService {
             cancel.clone(),
         );
 
-        let broadcaster = broadcaster(
-            config,
-            client,
-            metrics,
-            checkpoint_rx,
-            subscribers,
-            cancel.clone(),
-        );
+        let broadcaster = broadcaster(config, client, checkpoint_rx, subscribers, cancel.clone());
 
         Ok((regulator, broadcaster))
     }

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -134,6 +134,11 @@ impl Indexer {
         })
     }
 
+    /// The database connection pool used by the indexer.
+    pub fn db(&self) -> &Db {
+        &self.db
+    }
+
     /// The ingestion client used by the indexer to fetch checkpoints.
     pub fn ingestion_client(&self) -> &IngestionClient {
         self.ingestion_service.client()

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 
 use anyhow::{ensure, Context, Result};
 use db::{Db, DbConfig};
-use ingestion::{IngestionConfig, IngestionService};
+use ingestion::{client::IngestionClient, IngestionConfig, IngestionService};
 use metrics::{IndexerMetrics, MetricsService};
 use models::watermarks::CommitterWatermark;
 use pipeline::{concurrent, sequential, PipelineConfig, Processor};
@@ -132,6 +132,11 @@ impl Indexer {
             first_checkpoint_from_watermark: u64::MAX,
             handles: vec![],
         })
+    }
+
+    /// The ingestion client used by the indexer to fetch checkpoints.
+    pub fn ingestion_client(&self) -> &IngestionClient {
+        self.ingestion_service.client()
     }
 
     /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -10,10 +10,11 @@ use sui_indexer_alt::{
     handlers::{
         ev_emit_mod::EvEmitMod, ev_struct_inst::EvStructInst, kv_checkpoints::KvCheckpoints,
         kv_objects::KvObjects, kv_transactions::KvTransactions, obj_versions::ObjVersions,
-        sum_coin_balances::SumCoinBalances, sum_obj_types::SumObjTypes, sum_packages::SumPackages,
-        tx_affected_addresses::TxAffectedAddress, tx_affected_objects::TxAffectedObjects,
-        tx_balance_changes::TxBalanceChanges, tx_calls_fun::TxCallsFun, tx_digests::TxDigests,
-        tx_kinds::TxKinds, wal_coin_balances::WalCoinBalances, wal_obj_types::WalObjTypes,
+        sum_coin_balances::SumCoinBalances, sum_displays::SumDisplays, sum_obj_types::SumObjTypes,
+        sum_packages::SumPackages, tx_affected_addresses::TxAffectedAddress,
+        tx_affected_objects::TxAffectedObjects, tx_balance_changes::TxBalanceChanges,
+        tx_calls_fun::TxCallsFun, tx_digests::TxDigests, tx_kinds::TxKinds,
+        wal_coin_balances::WalCoinBalances, wal_obj_types::WalObjTypes,
     },
     Indexer,
 };
@@ -53,6 +54,7 @@ async fn main() -> Result<()> {
             indexer.concurrent_pipeline::<WalCoinBalances>().await?;
             indexer.concurrent_pipeline::<WalObjTypes>().await?;
             indexer.sequential_pipeline::<SumCoinBalances>(lag).await?;
+            indexer.sequential_pipeline::<SumDisplays>(None).await?;
             indexer.sequential_pipeline::<SumObjTypes>(lag).await?;
             indexer.sequential_pipeline::<SumPackages>(None).await?;
 

--- a/crates/sui-indexer-alt/src/models/displays.rs
+++ b/crates/sui-indexer-alt/src/models/displays.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::prelude::*;
+
+use crate::schema::sum_displays;
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = sum_displays, primary_key(object_type))]
+pub struct StoredDisplay {
+    pub object_type: Vec<u8>,
+    pub display_id: Vec<u8>,
+    pub display_version: i16,
+    pub display: Vec<u8>,
+}

--- a/crates/sui-indexer-alt/src/models/mod.rs
+++ b/crates/sui-indexer-alt/src/models/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod checkpoints;
+pub mod displays;
 pub mod events;
 pub mod objects;
 pub mod packages;

--- a/crates/sui-indexer-alt/src/schema.rs
+++ b/crates/sui-indexer-alt/src/schema.rs
@@ -69,6 +69,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    sum_displays (object_type) {
+        object_type -> Bytea,
+        display_id -> Bytea,
+        display_version -> Int2,
+        display -> Bytea,
+    }
+}
+
+diesel::table! {
     sum_obj_types (object_id) {
         object_id -> Bytea,
         object_version -> Int8,
@@ -185,6 +194,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     kv_transactions,
     obj_versions,
     sum_coin_balances,
+    sum_displays,
     sum_obj_types,
     sum_packages,
     tx_affected_addresses,

--- a/crates/sui-indexer-alt/src/task.rs
+++ b/crates/sui-indexer-alt/src/task.rs
@@ -9,10 +9,12 @@ use tokio_util::sync::CancellationToken;
 
 /// Manages cleanly exiting the process, either because one of its constituent services has stopped
 /// or because an interrupt signal was sent to the process.
-pub async fn graceful_shutdown(
-    services: impl IntoIterator<Item = JoinHandle<()>>,
+///
+/// Returns the exit values from all services that exited successfully.
+pub async fn graceful_shutdown<T>(
+    services: impl IntoIterator<Item = JoinHandle<T>>,
     cancel: CancellationToken,
-) {
+) -> Vec<T> {
     // If the service is naturalling winding down, we don't need to wait for an interrupt signal.
     // This channel is used to short-circuit the await in that case.
     let (cancel_ctrl_c_tx, cancel_ctrl_c_rx) = oneshot::channel();
@@ -24,20 +26,23 @@ pub async fn graceful_shutdown(
             _ = signal::ctrl_c() => cancel.cancel(),
         }
 
-        Ok(())
+        None
     };
 
     tokio::pin!(interrupt);
     let futures: Vec<_> = services
         .into_iter()
-        .map(Either::Left)
+        .map(|s| Either::Left(Box::pin(async move { s.await.ok() })))
         .chain(iter::once(Either::Right(interrupt)))
         .collect();
 
     // Wait for the first service to finish, or for an interrupt signal.
-    let (_, _, rest) = future::select_all(futures).await;
+    let (first, _, rest) = future::select_all(futures).await;
     let _ = cancel_ctrl_c_tx.send(());
 
     // Wait for the remaining services to finish.
-    let _ = future::join_all(rest).await;
+    let mut results = vec![];
+    results.extend(first);
+    results.extend(future::join_all(rest).await.into_iter().flatten());
+    results
 }


### PR DESCRIPTION
## Description 

A batch of clean-ups and refactorings that will help when implementing further pipelines (see stacked PRs):

- Expose the indexer's ingestion client and move the logic to repeatedly refetch a not found checkpoint into the client (from the ingestion service).
- Expose the indexer's DB connection pool.
- Allow the `graceful_shutdown` helper to return values (don't always expect the tasks will return `()`).

These changes are all in preparation for adding a "bootstrap" process to the indexer, where it waits until it can fetch the very first checkpoint in order to write out the chain identifier and initial protocol version, which will then be used to configure other pipelines.

- Make the `NOT NULL` constraints on event index columns explicit (as per an earlier PR comment).

## Test plan 

CI

## Stack

- #20118 
- #20132 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
