### PR TITLE
fix(indexer-alt): connection timeout default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,20 @@ name = "const-str"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca749d3d3f5b87a0d6100509879f9cf486ab510803a4a4e1001da1ff61c2bd6"
+dependencies = [
+ "const-str-proc-macro",
+]
+
+[[package]]
+name = "const-str-proc-macro"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3007177ccd2435eef6de9e7471365c36bc35c0b31773e27b4fe797f39f84bf"
+dependencies = [
+ "proc-macro2 1.0.87",
+ "quote 1.0.35",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -13936,6 +13950,7 @@ dependencies = [
  "bcs",
  "chrono",
  "clap",
+ "const-str",
  "diesel",
  "diesel-async",
  "diesel_migrations",

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -19,6 +19,7 @@ bb8 = "0.8.5"
 bcs.workspace = true
 chrono.workspace = true
 clap.workspace = true
+const-str = { workspace = true, features = ["proc"] }
 diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true

--- a/crates/sui-indexer-alt/src/db.rs
+++ b/crates/sui-indexer-alt/src/db.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use const_str::format as const_format;
 use diesel::migration::MigrationVersion;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use diesel_async::{
@@ -38,7 +39,7 @@ pub struct DbConfig {
     /// Time spent waiting for a connection from the pool to become available.
     #[arg(
         long,
-        default_value = stringify!(DEFAULT_CONNECTION_TIMEOUT_SECS),
+        default_value = const_format!("{DEFAULT_CONNECTION_TIMEOUT_SECS}"),
         value_name = "SECONDS",
         value_parser = |s: &str| s.parse().map(Duration::from_secs)
     )]


### PR DESCRIPTION
## Description

Using `stringify!(DEFAULT...)` doesn't work, because it stringifies the constant name, not its contents. This change uses `const_str::format` to achieve what was originally intended.

## Test plan

Run the indexer without supplying a connection timeout. Before this change it would fail with a parse int error, because it tried to interpret the string `DEFAULT_CONNECTION_TIMEOUT_SECS` as an integer.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
