### PR TITLE
Update index.module.css

### DIFF
--- a/docs/site/src/pages/index.module.css
+++ b/docs/site/src/pages/index.module.css
@@ -175,7 +175,7 @@
 .TwoColItem p {
   flex: 8;
   color: var(--sui-gray);
-  font-family: Inter;
+  font-family: 'Inter', sans-serif;
   font-size: 1.125rem;
   font-weight: 500;
   line-height: 1.6875rem;


### PR DESCRIPTION
## Description 

**Missing Font-Family Quotes.**

For the `font-family` property, values with spaces should be enclosed in quotes.

## Test plan 

Tested on local web server, no errors. This is correct and valid value.