### PR TITLE
fix: remove high cardinality address label from safe_client_latency (…

### DIFF
--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -68,10 +68,11 @@ impl SafeClientMetricsBase {
                 registry,
             )
             .unwrap(),
+            // Address label is removed to reduce high cardinality, can be added back if needed
             latency: register_histogram_vec_with_registry!(
                 "safe_client_latency",
-                "RPC latency observed by safe client aggregator, group by address and method",
-                &["address", "method"],
+                "RPC latency observed by safe client aggregator, group by method",
+                &["method"],
                 mysten_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -113,16 +114,16 @@ impl SafeClientMetrics {
 
         let handle_transaction_latency = metrics_base
             .latency
-            .with_label_values(&[&validator_address, "handle_transaction"]);
+            .with_label_values(&["handle_transaction"]);
         let handle_certificate_latency = metrics_base
             .latency
-            .with_label_values(&[&validator_address, "handle_certificate"]);
+            .with_label_values(&["handle_certificate"]);
         let handle_obj_info_latency = metrics_base
             .latency
-            .with_label_values(&[&validator_address, "handle_object_info_request"]);
+            .with_label_values(&["handle_object_info_request"]);
         let handle_tx_info_latency = metrics_base
             .latency
-            .with_label_values(&[&validator_address, "handle_transaction_info_request"]);
+            .with_label_values(&["handle_transaction_info_request"]);
 
         Self {
             total_requests_handle_transaction_info_request,


### PR DESCRIPTION
…#20165)

## Description 

safe_client_latency is the highest cardinality metric across our observability system due to the `address` label + being a histogram:

```
root@sui-node-mysten-rpc-0:/sui# curl -s localhost:9184/metrics | grep safe_client_latency_bucket | wc -l
8512
```


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
