### PR TITLE
[move] Update debugging flags in compiler to stop warnings during builds

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -119,17 +119,24 @@ pub fn display_var(s: Symbol) -> DisplayVar {
 //**************************************************************************************************
 
 pub(super) struct HLIRDebugFlags {
+    #[allow(dead_code)]
     pub(super) match_variant_translation: bool,
+    #[allow(dead_code)]
     pub(super) match_translation: bool,
+    #[allow(dead_code)]
     pub(super) match_specialization: bool,
+    #[allow(dead_code)]
     pub(super) match_work_queue: bool,
+    #[allow(dead_code)]
     pub(super) function_translation: bool,
+    #[allow(dead_code)]
     pub(super) eval_order: bool,
 }
 
 pub(super) struct Context<'env> {
     pub env: &'env CompilationEnv,
     pub info: Arc<TypingProgramInfo>,
+    #[allow(dead_code)]
     pub debug: HLIRDebugFlags,
     pub reporter: DiagnosticReporter<'env>,
     current_package: Option<Symbol>,

--- a/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/string_utils.rs
@@ -96,11 +96,14 @@ pub(crate) use format_oxford_list;
 /// - `fmt`: calls `println!("{}", val)`
 /// - `dbg`: calls `println!("{:?}", val)`
 /// - `sdbg`: calls `println!("{:#?}", val)`
+#[allow(unused_macros)]
 macro_rules! debug_print_format {
     ($val:expr) => {{
+        use crate::shared::ast_debug::AstDebug;
         $val.print();
     }};
     ($val:expr ; verbose) => {{
+        use crate::shared::ast_debug::AstDebug;
         $val.print_verbose();
     }};
     ($val:expr ; fmt) => {{
@@ -114,6 +117,7 @@ macro_rules! debug_print_format {
     }};
 }
 
+#[allow(unused_imports)]
 pub(crate) use debug_print_format;
 
 /// Print formatter for debugging. Allows a few different forms:
@@ -124,6 +128,7 @@ pub(crate) use debug_print_format;
 /// `(lines name => val [; fmt]) ` as "name: " + for n in val { debug_print_format!(n; fmt) }
 ///
 /// See `debug_print_format` for different `fmt` options.
+#[allow(unused_macros)]
 macro_rules! debug_print_internal {
     () => {};
     ((msg $msg:expr)) => {
@@ -165,6 +170,7 @@ macro_rules! debug_print_internal {
     };
 }
 
+#[allow(unused_imports)]
 pub(crate) use debug_print_internal;
 
 /// Macro for a small DSL for compactling printing debug information based on the provided flag.
@@ -181,6 +187,7 @@ pub(crate) use debug_print_internal;
 /// See `debug_print_internal` for the available syntax.
 ///
 /// Feature gates the print and check against the `debug_assertions` feature.
+#[allow(unused_macros)]
 macro_rules! debug_print {
     ($flag:expr, $($arg:tt),+) => {
         #[cfg(debug_assertions)]

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -83,9 +83,13 @@ pub enum MacroExpansion {
 }
 
 pub(super) struct TypingDebugFlags {
+    #[allow(dead_code)]
     pub(super) match_counterexample: bool,
+    #[allow(dead_code)]
     pub(super) autocomplete_resolution: bool,
+    #[allow(dead_code)]
     pub(super) function_translation: bool,
+    #[allow(dead_code)]
     pub(super) type_elaboration: bool,
 }
 
@@ -94,6 +98,7 @@ pub struct Context<'env> {
     macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
     pub env: &'env CompilationEnv,
     pub reporter: DiagnosticReporter<'env>,
+    #[allow(dead_code)]
     pub(super) debug: TypingDebugFlags,
 
     deprecations: Deprecations,

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -9,7 +9,7 @@ use crate::{
     ice,
     naming::ast::{BuiltinTypeName_, FunctionSignature, Type, TypeName_, Type_},
     parser::ast::Ability_,
-    shared::{ide::IDEAnnotation, string_utils::debug_print, AstDebug},
+    shared::{ide::IDEAnnotation, string_utils::debug_print},
     typing::{
         ast::{self as T},
         core::{self, Context},

--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -9,7 +9,6 @@ use crate::{
     naming::ast::BuiltinTypeName_,
     parser::ast::{DatatypeName, VariantName},
     shared::{
-        ast_debug::AstDebug,
         ide::{IDEAnnotation, MissingMatchArmsInfo, PatternSuggestion},
         matching::{MatchContext, PatternMatrix},
         string_utils::{debug_print, format_oxford_list},


### PR DESCRIPTION
## Description 

This updates the debug flags to quiet down warnings during builds.

## Test plan 

Local testing no longer emits warnings

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
