### PR TITLE
[move-ide] Fixed auto-completion on the dot character

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
@@ -447,7 +447,7 @@ impl<'a> ParsingAnalysisContext<'a> {
             }
             E::Borrow(_, e) => self.exp_symbols(e),
             E::Dot(e, _, _) => self.exp_symbols(e),
-            E::DotCall(e, name, _, vo, v, _) => {
+            E::DotCall(e, _, name, _, vo, v) => {
                 self.exp_symbols(e);
                 if let Some(v) = vo {
                     v.iter().for_each(|t| self.type_symbols(t));

--- a/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
@@ -446,8 +446,8 @@ impl<'a> ParsingAnalysisContext<'a> {
                 self.exp_symbols(e2);
             }
             E::Borrow(_, e) => self.exp_symbols(e),
-            E::Dot(e, _) => self.exp_symbols(e),
-            E::DotCall(e, name, _, vo, v) => {
+            E::Dot(e, _, _) => self.exp_symbols(e),
+            E::DotCall(e, name, _, vo, v, _) => {
                 self.exp_symbols(e);
                 if let Some(v) = vo {
                     v.iter().for_each(|t| self.type_symbols(t));

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -336,7 +336,7 @@ pub type LambdaLValues = Spanned<LambdaLValues_>;
 #[allow(clippy::large_enum_variant)]
 pub enum ExpDotted_ {
     Exp(Box<Exp>),
-    Dot(Box<ExpDotted>, Name, Loc),
+    Dot(Box<ExpDotted>, /* dot location */ Loc, Name),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
     DotUnresolved(Loc, Box<ExpDotted>), // dot where Name could not be parsed
 }
@@ -389,11 +389,11 @@ pub enum Exp_ {
     ),
     MethodCall(
         Box<ExpDotted>,
+        Loc, // location of the dot
         Name,
         /* is_macro */ Option<Loc>,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
-        Loc, // location of the dot
     ),
     Pack(ModuleAccess, Option<Vec<Type>>, Fields<Exp>),
     Vector(Loc, Option<Vec<Type>>, Spanned<Vec<Exp>>),
@@ -1531,7 +1531,7 @@ impl AstDebug for Exp_ {
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            E::MethodCall(e, f, is_macro, tys_opt, sp!(_, rhs), _) => {
+            E::MethodCall(e, _, f, is_macro, tys_opt, sp!(_, rhs)) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", f));
                 if is_macro.is_some() {
@@ -1731,7 +1731,7 @@ impl AstDebug for ExpDotted_ {
         use ExpDotted_ as D;
         match self {
             D::Exp(e) => e.ast_debug(w),
-            D::Dot(e, n, _) => {
+            D::Dot(e, _, n) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n))
             }

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -336,7 +336,7 @@ pub type LambdaLValues = Spanned<LambdaLValues_>;
 #[allow(clippy::large_enum_variant)]
 pub enum ExpDotted_ {
     Exp(Box<Exp>),
-    Dot(Box<ExpDotted>, Name),
+    Dot(Box<ExpDotted>, Name, Loc),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
     DotUnresolved(Loc, Box<ExpDotted>), // dot where Name could not be parsed
 }
@@ -393,6 +393,7 @@ pub enum Exp_ {
         /* is_macro */ Option<Loc>,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
+        Loc, // location of the dot
     ),
     Pack(ModuleAccess, Option<Vec<Type>>, Fields<Exp>),
     Vector(Loc, Option<Vec<Type>>, Spanned<Vec<Exp>>),
@@ -1530,7 +1531,7 @@ impl AstDebug for Exp_ {
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            E::MethodCall(e, f, is_macro, tys_opt, sp!(_, rhs)) => {
+            E::MethodCall(e, f, is_macro, tys_opt, sp!(_, rhs), _) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", f));
                 if is_macro.is_some() {
@@ -1730,7 +1731,7 @@ impl AstDebug for ExpDotted_ {
         use ExpDotted_ as D;
         match self {
             D::Exp(e) => e.ast_debug(w),
-            D::Dot(e, n) => {
+            D::Dot(e, n, _) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n))
             }

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -2728,14 +2728,14 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
             }
         }
 
-        PE::DotCall(pdotted, n, is_macro, ptys_opt, sp!(rloc, prs), dot_loc) => {
+        PE::DotCall(pdotted, dot_loc, n, is_macro, ptys_opt, sp!(rloc, prs)) => {
             match exp_dotted(context, pdotted) {
                 Some(edotted) => {
                     let pkg = context.current_package();
                     context.check_feature(pkg, FeatureGate::DotCall, loc);
                     let tys_opt = optional_types(context, ptys_opt);
                     let ers = sp(rloc, exps(context, prs));
-                    EE::MethodCall(edotted, n, is_macro, tys_opt, ers, dot_loc)
+                    EE::MethodCall(edotted, dot_loc, n, is_macro, tys_opt, ers)
                 }
                 None => {
                     assert!(context.env().has_errors());
@@ -2922,9 +2922,9 @@ fn exp_dotted(context: &mut Context, pdotted: Box<P::Exp>) -> Option<Box<E::ExpD
     use P::Exp_ as PE;
     let sp!(loc, pdotted_) = *pdotted;
     let edotted_ = match pdotted_ {
-        PE::Dot(plhs, field, dot_loc) => {
+        PE::Dot(plhs, dot_loc, field) => {
             let lhs = exp_dotted(context, plhs)?;
-            EE::Dot(lhs, field, dot_loc)
+            EE::Dot(lhs, dot_loc, field)
         }
         PE::Index(plhs, sp!(argloc, args)) => {
             let cur_pkg = context.current_package();

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -358,7 +358,7 @@ pub type LambdaLValues = Spanned<LambdaLValues_>;
 #[derive(Debug, PartialEq, Clone)]
 pub enum ExpDotted_ {
     Exp(Box<Exp>),
-    Dot(Box<ExpDotted>, Field, Loc),
+    Dot(Box<ExpDotted>, /* dot loation */ Loc, Field),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
     DotAutocomplete(Loc, Box<ExpDotted>), // Dot (and its location) where Field could not be parsed
 }
@@ -1890,7 +1890,7 @@ impl AstDebug for ExpDotted_ {
         use ExpDotted_ as D;
         match self {
             D::Exp(e) => e.ast_debug(w),
-            D::Dot(e, n, _) => {
+            D::Dot(e, _, n) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n))
             }

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -417,11 +417,11 @@ pub enum Exp_ {
     ),
     MethodCall(
         ExpDotted,
+        Loc, // location of the dot
         Name,
         /* is_macro */ Option<Loc>,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
-        Loc, // location of the dot
     ),
     VarCall(Var, Spanned<Vec<Exp>>),
     Builtin(BuiltinFunction, Spanned<Vec<Exp>>),
@@ -1637,7 +1637,7 @@ impl AstDebug for Exp_ {
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            E::MethodCall(e, f, is_macro, tys_opt, sp!(_, rhs), _) => {
+            E::MethodCall(e, _, f, is_macro, tys_opt, sp!(_, rhs)) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", f));
                 if is_macro.is_some() {

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -358,7 +358,7 @@ pub type LambdaLValues = Spanned<LambdaLValues_>;
 #[derive(Debug, PartialEq, Clone)]
 pub enum ExpDotted_ {
     Exp(Box<Exp>),
-    Dot(Box<ExpDotted>, Field),
+    Dot(Box<ExpDotted>, Field, Loc),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
     DotAutocomplete(Loc, Box<ExpDotted>), // Dot (and its location) where Field could not be parsed
 }
@@ -421,6 +421,7 @@ pub enum Exp_ {
         /* is_macro */ Option<Loc>,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
+        Loc, // location of the dot
     ),
     VarCall(Var, Spanned<Vec<Exp>>),
     Builtin(BuiltinFunction, Spanned<Vec<Exp>>),
@@ -1636,7 +1637,7 @@ impl AstDebug for Exp_ {
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            E::MethodCall(e, f, is_macro, tys_opt, sp!(_, rhs)) => {
+            E::MethodCall(e, f, is_macro, tys_opt, sp!(_, rhs), _) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", f));
                 if is_macro.is_some() {
@@ -1889,7 +1890,7 @@ impl AstDebug for ExpDotted_ {
         use ExpDotted_ as D;
         match self {
             D::Exp(e) => e.ast_debug(w),
-            D::Dot(e, n) => {
+            D::Dot(e, n, _) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n))
             }

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -401,7 +401,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
                 exp(context, e)
             }
         }
-        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es), _) => {
+        N::Exp_::MethodCall(ed, _, _, _, _, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {
                 exp(context, e)

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -401,7 +401,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
                 exp(context, e)
             }
         }
-        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es)) => {
+        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es), _) => {
             exp_dotted(context, ed);
             for e in es {
                 exp(context, e)
@@ -416,7 +416,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
+        N::ExpDotted_::Dot(ed, _, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
             exp_dotted(context, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2912,7 +2912,7 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
                 if is_macro.is_some() {
                     context.check_feature(context.current_package, FeatureGate::MacroFuns, eloc);
                 }
-                NE::MethodCall(d, n, is_macro, ty_args, nes, dot_loc)
+                NE::MethodCall(d, dot_loc, n, is_macro, ty_args, nes)
             }
         },
         EE::Vector(vec_loc, tys_opt, rhs) => {
@@ -4330,7 +4330,7 @@ fn remove_unused_bindings_exp(
                 remove_unused_bindings_exp(context, used, e)
             }
         }
-        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es), _) => {
+        N::Exp_::MethodCall(ed, _, _, _, _, sp!(_, es)) => {
             remove_unused_bindings_exp_dotted(context, used, ed);
             for e in es {
                 remove_unused_bindings_exp(context, used, e)

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2901,7 +2901,7 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
         EE::Call(ma, is_macro, tys_opt, rhs) => {
             resolve_call(context, eloc, ma, is_macro, tys_opt, rhs)
         }
-        EE::MethodCall(edot, n, is_macro, tys_opt, rhs) => match dotted(context, *edot) {
+        EE::MethodCall(edot, n, is_macro, tys_opt, rhs, dot_loc) => match dotted(context, *edot) {
             None => {
                 assert!(context.env.has_errors());
                 NE::UnresolvedError
@@ -2912,7 +2912,7 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
                 if is_macro.is_some() {
                     context.check_feature(context.current_package, FeatureGate::MacroFuns, eloc);
                 }
-                NE::MethodCall(d, n, is_macro, ty_args, nes)
+                NE::MethodCall(d, n, is_macro, ty_args, nes, dot_loc)
             }
         },
         EE::Vector(vec_loc, tys_opt, rhs) => {
@@ -2978,7 +2978,9 @@ fn dotted(context: &mut Context, edot: E::ExpDotted) -> Option<N::ExpDotted> {
                 _ => N::ExpDotted_::Exp(ne),
             }
         }
-        E::ExpDotted_::Dot(d, f) => N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), Field(f)),
+        E::ExpDotted_::Dot(d, f, loc) => {
+            N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), Field(f), loc)
+        }
         E::ExpDotted_::DotUnresolved(loc, d) => {
             N::ExpDotted_::DotAutocomplete(loc, Box::new(dotted(context, *d)?))
         }
@@ -4328,7 +4330,7 @@ fn remove_unused_bindings_exp(
                 remove_unused_bindings_exp(context, used, e)
             }
         }
-        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es)) => {
+        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es), _) => {
             remove_unused_bindings_exp_dotted(context, used, ed);
             for e in es {
                 remove_unused_bindings_exp(context, used, e)
@@ -4346,7 +4348,7 @@ fn remove_unused_bindings_exp_dotted(
 ) {
     match ed_ {
         N::ExpDotted_::Exp(e) => remove_unused_bindings_exp(context, used, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
+        N::ExpDotted_::Dot(ed, _, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
             remove_unused_bindings_exp_dotted(context, used, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2901,7 +2901,7 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
         EE::Call(ma, is_macro, tys_opt, rhs) => {
             resolve_call(context, eloc, ma, is_macro, tys_opt, rhs)
         }
-        EE::MethodCall(edot, n, is_macro, tys_opt, rhs, dot_loc) => match dotted(context, *edot) {
+        EE::MethodCall(edot, dot_loc, n, is_macro, tys_opt, rhs) => match dotted(context, *edot) {
             None => {
                 assert!(context.env.has_errors());
                 NE::UnresolvedError
@@ -2978,8 +2978,8 @@ fn dotted(context: &mut Context, edot: E::ExpDotted) -> Option<N::ExpDotted> {
                 _ => N::ExpDotted_::Exp(ne),
             }
         }
-        E::ExpDotted_::Dot(d, f, loc) => {
-            N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), Field(f), loc)
+        E::ExpDotted_::Dot(d, loc, f) => {
+            N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), loc, Field(f))
         }
         E::ExpDotted_::DotUnresolved(loc, d) => {
             N::ExpDotted_::DotAutocomplete(loc, Box::new(dotted(context, *d)?))

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -629,15 +629,15 @@ pub enum Exp_ {
     Borrow(bool, Box<Exp>),
 
     // e.f (along with the location of the dot)
-    Dot(Box<Exp>, Name, Loc),
+    Dot(Box<Exp>, /* dot location */ Loc, Name),
     // e.f(earg,*)
     DotCall(
         Box<Exp>,
+        Loc, // location of the dot
         Name,
         /* is_macro */ Option<Loc>,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
-        Loc, // location of the dot
     ),
     // e[e']
     Index(Box<Exp>, Spanned<Vec<Exp>>), // spec only
@@ -2129,11 +2129,11 @@ impl AstDebug for Exp_ {
                 }
                 e.ast_debug(w);
             }
-            E::Dot(e, n, _) => {
+            E::Dot(e, _, n) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n));
             }
-            E::DotCall(e, n, is_macro, tyargs, sp!(_, rhs), _) => {
+            E::DotCall(e, _, n, is_macro, tyargs, sp!(_, rhs)) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n));
                 if is_macro.is_some() {

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -628,8 +628,8 @@ pub enum Exp_ {
     // &mut e
     Borrow(bool, Box<Exp>),
 
-    // e.f
-    Dot(Box<Exp>, Name),
+    // e.f (along with the location of the dot)
+    Dot(Box<Exp>, Name, Loc),
     // e.f(earg,*)
     DotCall(
         Box<Exp>,
@@ -637,6 +637,7 @@ pub enum Exp_ {
         /* is_macro */ Option<Loc>,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
+        Loc, // location of the dot
     ),
     // e[e']
     Index(Box<Exp>, Spanned<Vec<Exp>>), // spec only
@@ -2128,11 +2129,11 @@ impl AstDebug for Exp_ {
                 }
                 e.ast_debug(w);
             }
-            E::Dot(e, n) => {
+            E::Dot(e, n, _) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n));
             }
-            E::DotCall(e, n, is_macro, tyargs, sp!(_, rhs)) => {
+            E::DotCall(e, n, is_macro, tyargs, sp!(_, rhs), _) => {
                 e.ast_debug(w);
                 w.write(format!(".{}", n));
                 if is_macro.is_some() {

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2618,7 +2618,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                         match parse_u8(contents) {
                             Ok((parsed, NumberFormat::Decimal)) => {
                                 let field_access = Name::new(loc, format!("{parsed}").into());
-                                Exp_::Dot(Box::new(lhs), field_access)
+                                Exp_::Dot(Box::new(lhs), field_access, first_token_loc)
                             }
                             Ok((_, NumberFormat::Hex)) => {
                                 let msg = "Invalid field access. Expected a decimal number but was given a hexadecimal";
@@ -2627,7 +2627,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                                 context.add_diag(diag);
                                 // Continue on with the parsing
                                 let field_access = Name::new(loc, contents.into());
-                                Exp_::Dot(Box::new(lhs), field_access)
+                                Exp_::Dot(Box::new(lhs), field_access, first_token_loc)
                             }
                             Err(_) => {
                                 let msg = format!(
@@ -2639,7 +2639,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                                 context.add_diag(diag);
                                 // Continue on with the parsing
                                 let field_access = Name::new(loc, contents.into());
-                                Exp_::Dot(Box::new(lhs), field_access)
+                                Exp_::Dot(Box::new(lhs), field_access, first_token_loc)
                             }
                         }
                     }
@@ -2665,9 +2665,16 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                                     parse_macro_opt_and_tyargs_opt(context, false, n.loc);
                                 let tys = tys.map(|t| t.value);
                                 let args = parse_call_args(context);
-                                Exp_::DotCall(Box::new(lhs), n, is_macro, tys, args)
+                                Exp_::DotCall(
+                                    Box::new(lhs),
+                                    n,
+                                    is_macro,
+                                    tys,
+                                    args,
+                                    first_token_loc,
+                                )
                             } else {
-                                Exp_::Dot(Box::new(lhs), n)
+                                Exp_::Dot(Box::new(lhs), n, first_token_loc)
                             }
                         }
                     },

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2618,7 +2618,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                         match parse_u8(contents) {
                             Ok((parsed, NumberFormat::Decimal)) => {
                                 let field_access = Name::new(loc, format!("{parsed}").into());
-                                Exp_::Dot(Box::new(lhs), field_access, first_token_loc)
+                                Exp_::Dot(Box::new(lhs), first_token_loc, field_access)
                             }
                             Ok((_, NumberFormat::Hex)) => {
                                 let msg = "Invalid field access. Expected a decimal number but was given a hexadecimal";
@@ -2627,7 +2627,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                                 context.add_diag(diag);
                                 // Continue on with the parsing
                                 let field_access = Name::new(loc, contents.into());
-                                Exp_::Dot(Box::new(lhs), field_access, first_token_loc)
+                                Exp_::Dot(Box::new(lhs), first_token_loc, field_access)
                             }
                             Err(_) => {
                                 let msg = format!(
@@ -2639,7 +2639,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                                 context.add_diag(diag);
                                 // Continue on with the parsing
                                 let field_access = Name::new(loc, contents.into());
-                                Exp_::Dot(Box::new(lhs), field_access, first_token_loc)
+                                Exp_::Dot(Box::new(lhs), first_token_loc, field_access)
                             }
                         }
                     }
@@ -2667,14 +2667,14 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                                 let args = parse_call_args(context);
                                 Exp_::DotCall(
                                     Box::new(lhs),
+                                    first_token_loc,
                                     n,
                                     is_macro,
                                     tys,
                                     args,
-                                    first_token_loc,
                                 )
                             } else {
-                                Exp_::Dot(Box::new(lhs), n, first_token_loc)
+                                Exp_::Dot(Box::new(lhs), first_token_loc, n)
                             }
                         }
                     },

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -642,7 +642,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
                 recolor_exp(ctx, e)
             }
         }
-        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es), _) => {
+        N::Exp_::MethodCall(ed, _, _, _, _, sp!(_, es)) => {
             recolor_exp_dotted(ctx, ed);
             for e in es {
                 recolor_exp(ctx, e)
@@ -941,7 +941,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             }
             exps(context, es)
         }
-        N::Exp_::MethodCall(ed, _, _, tys_opt, sp!(_, es), _) => {
+        N::Exp_::MethodCall(ed, _, _, _, tys_opt, sp!(_, es)) => {
             if let Some(tys) = tys_opt {
                 types(context, tys)
             }

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -642,7 +642,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
                 recolor_exp(ctx, e)
             }
         }
-        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es)) => {
+        N::Exp_::MethodCall(ed, _, _, _, sp!(_, es), _) => {
             recolor_exp_dotted(ctx, ed);
             for e in es {
                 recolor_exp(ctx, e)
@@ -680,7 +680,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
 fn recolor_exp_dotted(ctx: &mut Recolor, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => recolor_exp(ctx, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
+        N::ExpDotted_::Dot(ed, _, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
             recolor_exp_dotted(ctx, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
@@ -941,7 +941,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             }
             exps(context, es)
         }
-        N::Exp_::MethodCall(ed, _, _, tys_opt, sp!(_, es)) => {
+        N::Exp_::MethodCall(ed, _, _, tys_opt, sp!(_, es), _) => {
             if let Some(tys) = tys_opt {
                 types(context, tys)
             }
@@ -1158,7 +1158,7 @@ fn builtin_function(context: &mut Context, sp!(_, bf_): &mut N::BuiltinFunction)
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
+        N::ExpDotted_::Dot(ed, _, _) | N::ExpDotted_::DotAutocomplete(_, ed) => {
             exp_dotted(context, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -3424,10 +3424,8 @@ fn resolve_exp_dotted(
         debug_print!(context.debug.autocomplete_resolution, ("computing unresolved dot autocomplete" => result; dbg));
         ide_report_autocomplete(context, &loc, &edotted_ty);
     }
-    if context.env.ide_mode() {
-        if let Some(mdot_loc) = method_dot_loc {
-            ide_report_autocomplete(context, &mdot_loc, &edotted_ty);
-        }
+    if let Some(mdot_loc) = method_dot_loc {
+        ide_report_autocomplete(context, &mdot_loc, &edotted_ty);
     }
     result
 }
@@ -3793,10 +3791,13 @@ fn method_call(
             ResolvedMethodCall::InvalidBaseType | ResolvedMethodCall::UnknownName => return None,
         };
     // report autocomplete information for the IDE
-    if context.env.ide_mode() {
+    let method_dot_loc = if context.env.ide_mode() {
         edotted.autocomplete_last = Some(method.loc);
-    }
-    let first_arg = *resolve_exp_dotted(context, usage, call_loc, edotted, Some(dot_loc));
+        Some(dot_loc)
+    } else {
+        None
+    };
+    let first_arg = *resolve_exp_dotted(context, usage, call_loc, edotted, method_dot_loc);
     args.insert(0, first_arg);
     let (mut call, ret_ty) = module_call_impl(context, call_loc, m, f, fty, argloc, args);
     call.method_name = Some(method);
@@ -4313,10 +4314,13 @@ fn macro_method_call(
         ResolvedMethodCall::InvalidBaseType | ResolvedMethodCall::UnknownName => return None,
     };
     // report autocomplete information for the IDE
-    if context.env.ide_mode() {
+    let method_dot_loc = if context.env.ide_mode() {
         edotted.autocomplete_last = Some(method.loc);
-    }
-    let first_arg = *resolve_exp_dotted(context, usage, loc, edotted, Some(dot_loc));
+        Some(dot_loc)
+    } else {
+        None
+    };
+    let first_arg = *resolve_exp_dotted(context, usage, loc, edotted, method_dot_loc);
     let mut args = vec![macro_expand::EvalStrategy::ByValue(first_arg)];
     args.extend(
         nargs

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1505,11 +1505,11 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
         }
         NE::MethodCall(
             ndotted,
+            dot_loc,
             f,
             /* is_macro */ None,
             ty_args_opt,
             sp!(argloc, nargs_),
-            dot_loc,
         ) => {
             let edotted = process_exp_dotted(context, None, ndotted);
             let args = exp_vec(context, nargs_);
@@ -1537,11 +1537,11 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
         }
         NE::MethodCall(
             ndotted,
+            dot_loc,
             f,
             Some(macro_call_loc),
             ty_args_opt,
             sp!(argloc, nargs_),
-            dot_loc,
         ) => {
             let edotted = process_exp_dotted(context, None, ndotted);
             let ty_call_opt = macro_method_call(

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/dot_incomplete.ide.exp
@@ -14,6 +14,12 @@ error[E01002]: unexpected token
    │                        Expected an identifier or a decimal number
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:15:23
+   │
+15 │         let _tmp2 = _s.a.;  // incomplete with `;` (next line should parse)
+   │                       ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/dot_incomplete.move:15:24
    │
 15 │         let _tmp2 = _s.a.;  // incomplete with `;` (next line should parse)
@@ -33,6 +39,12 @@ error[E01002]: unexpected token
    │                          │
    │                          Unexpected ';'
    │                          Expected an identifier or a decimal number
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/dot_incomplete.move:16:23
+   │
+16 │         let _tmp3 = _s.a.   // incomplete without `;` (unexpected `let`)
+   │                       ^ Possible dot names: 'a'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/dot_incomplete.move:16:24

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/method_and_field_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/method_and_field_autocomplete.ide.exp
@@ -7,10 +7,22 @@ warning[W09009]: unused struct field
   = This warning can be suppressed with '#[allow(unused_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:16:20
+   │
+16 │         let _ = &in.0.0;
+   │                    ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:16:21
    │
 16 │         let _ = &in.0.0;
    │                     ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:16:22
+   │
+16 │         let _ = &in.0.0;
+   │                      ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:16:23
@@ -19,10 +31,22 @@ note[I15001]: IDE dot autocomplete
    │                       ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:20:20
+   │
+20 │         let _ = &in.0.0.0 ;
+   │                    ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:20:21
    │
 20 │         let _ = &in.0.0.0 ;
    │                     ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:20:22
+   │
+20 │         let _ = &in.0.0.0 ;
+   │                      ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:20:23
@@ -31,10 +55,22 @@ note[I15001]: IDE dot autocomplete
    │                       ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:20:24
+   │
+20 │         let _ = &in.0.0.0 ;
+   │                        ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:20:25
    │
 20 │         let _ = &in.0.0.0 ;
    │                         ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:20
+   │
+24 │         let _ = &in.0.0.0.d ;
+   │                    ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:21
@@ -43,16 +79,34 @@ note[I15001]: IDE dot autocomplete
    │                     ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:22
+   │
+24 │         let _ = &in.0.0.0.d ;
+   │                      ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:23
    │
 24 │         let _ = &in.0.0.0.d ;
    │                       ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:24
+   │
+24 │         let _ = &in.0.0.0.d ;
+   │                        ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:25
    │
 24 │         let _ = &in.0.0.0.d ;
    │                         ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:26
+   │
+24 │         let _ = &in.0.0.0.d ;
+   │                          ^ Possible dot names: 'a::m::for_c_0', 'a::m::for_c_1', 'c', or 'd'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_and_field_autocomplete.move:24:27

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/method_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/method_autocomplete.ide.exp
@@ -15,10 +15,22 @@ warning[W09009]: unused struct field
   = This warning can be suppressed with '#[allow(unused_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:16:11
+   │
+16 │         in.for_b_0()
+   │           ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:16:12
    │
 16 │         in.for_b_0()
    │            ^^^^^^^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:20:11
+   │
+20 │         in.0.for_a_0();
+   │           ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:20:12
@@ -27,10 +39,22 @@ note[I15001]: IDE dot autocomplete
    │            ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:20:13
+   │
+20 │         in.0.for_a_0();
+   │             ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:20:14
    │
 20 │         in.0.for_a_0();
    │              ^^^^^^^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:11
+   │
+24 │         in.0.0.0.for_c_0();
+   │           ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:12
@@ -39,16 +63,34 @@ note[I15001]: IDE dot autocomplete
    │            ^ Possible dot names: 'a::m::for_b_0', 'a::m::for_b_1', 'a::m::test0', 'a::m::test1', 'a::m::test2', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:13
+   │
+24 │         in.0.0.0.for_c_0();
+   │             ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:14
    │
 24 │         in.0.0.0.for_c_0();
    │              ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:15
+   │
+24 │         in.0.0.0.for_c_0();
+   │               ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:16
    │
 24 │         in.0.0.0.for_c_0();
    │                ^ Possible dot names: 'a::m::for_a_0', 'a::m::for_a_1', or '0'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:17
+   │
+24 │         in.0.0.0.for_c_0();
+   │                 ^ Possible dot names: 'a::m::for_c_0', 'a::m::for_c_1', 'c', or 'd'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/method_autocomplete.move:24:18

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_autocomplete.ide.exp
@@ -14,6 +14,12 @@ error[E01002]: unexpected token
    │                        Expected an identifier or a decimal number
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:15:23
+   │
+15 │         let _tmp2 = _s.a.;
+   │                       ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/named_struct_autocomplete.move:15:24
    │
 15 │         let _tmp2 = _s.a.;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_middle_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/named_struct_middle_autocomplete.ide.exp
@@ -5,6 +5,12 @@ error[E03010]: unbound field
    │                     ^^^^ Unbound field 'b' in 'a::m::B'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/named_struct_middle_autocomplete.move:14:23
+   │
+14 │         let _tmp2 = _s.b.x;
+   │                       ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/named_struct_middle_autocomplete.move:14:24
    │
 14 │         let _tmp2 = _s.b.x;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/on_dot_autocomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/on_dot_autocomplete.exp
@@ -1,0 +1,15 @@
+warning[W10007]: issue with attribute value
+  ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:1:9
+  │
+1 │ #[allow(ide_path_autocomplete)]
+  │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'
+
+error[E04023]: invalid method call
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:9
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │         ^^^^^^^^^
+   │         │     │
+   │         │     No local 'use fun' alias was found for 'a::m::A.b', and no function 'b' was found in the defining module 'a::m'
+   │         Invalid method call. No known method 'b' on type 'a::m::A'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/on_dot_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/on_dot_autocomplete.ide.exp
@@ -1,0 +1,105 @@
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:21:10
+   │
+21 │         c.b.a;            // two dots that should trigger auto-completion
+   │          ^ Possible dot names: 'b'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:21:11
+   │
+21 │         c.b.a;            // two dots that should trigger auto-completion
+   │           ^ Possible dot names: 'b'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:21:12
+   │
+21 │         c.b.a;            // two dots that should trigger auto-completion
+   │            ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:21:13
+   │
+21 │         c.b.a;            // two dots that should trigger auto-completion
+   │             ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:22:10
+   │
+22 │         c.b.a.bar();      // resolved method name
+   │          ^ Possible dot names: 'b'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:22:11
+   │
+22 │         c.b.a.bar();      // resolved method name
+   │           ^ Possible dot names: 'b'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:22:12
+   │
+22 │         c.b.a.bar();      // resolved method name
+   │            ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:22:13
+   │
+22 │         c.b.a.bar();      // resolved method name
+   │             ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:22:14
+   │
+22 │         c.b.a.bar();      // resolved method name
+   │              ^ Possible dot names: 'a::m::bar' or 'x'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:22:15
+   │
+22 │         c.b.a.bar();      // resolved method name
+   │               ^^^ Possible dot names: 'a::m::bar' or 'x'
+
+error[E04023]: invalid method call
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:9
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │         ^^^^^^^^^
+   │         │     │
+   │         │     No local 'use fun' alias was found for 'a::m::A.b', and no function 'b' was found in the defining module 'a::m'
+   │         Invalid method call. No known method 'b' on type 'a::m::A'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:10
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │          ^ Possible dot names: 'b'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:11
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │           ^ Possible dot names: 'b'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:12
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │            ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:13
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │             ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:14
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │              ^ Possible dot names: 'a::m::bar' or 'x'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/on_dot_autocomplete.move:23:15
+   │
+23 │         c.b.a.b();        // unresolved method name
+   │               ^ Possible dot names: 'a::m::bar' or 'x'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/on_dot_autocomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/on_dot_autocomplete.move
@@ -1,0 +1,25 @@
+#[allow(ide_path_autocomplete)]
+module a::m {
+
+    public struct A has copy, drop {
+        x: u64
+    }
+
+    public struct B has copy, drop {
+        a: A
+    }
+
+    public struct C has copy, drop {
+        b: B
+    }
+
+    public fun bar(_a: A) {}
+
+    public fun foo() {
+        let b = B { a: A { x: 0 } };
+        let c = C { b: b };
+        c.b.a;            // two dots that should trigger auto-completion
+        c.b.a.bar();      // resolved method name
+        c.b.a.b();        // unresolved method name
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/positional_struct_autocomplete.ide.exp
@@ -14,6 +14,12 @@ error[E01002]: unexpected token
    │                        Expected an identifier or a decimal number
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:11:23
+   │
+11 │         let _tmp2 = _s.0.;
+   │                       ^ Possible dot names: '0'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/positional_struct_autocomplete.move:11:24
    │
 11 │         let _tmp2 = _s.0.;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_invalid_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/struct_method_invalid_autocomplete.ide.exp
@@ -8,6 +8,12 @@ error[E04023]: invalid method call
    │                     Invalid method call. No known method 't7' on type 'a::m::A'
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move:20:23
+   │
+20 │         let _tmp1 = _a.t7();
+   │                       ^ Possible dot names: 'a::m::t0', 'a::m::t1', or 'a::m::t2'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move:20:24
    │
 20 │         let _tmp1 = _a.t7();
@@ -21,6 +27,12 @@ error[E04023]: invalid method call
    │                     │  │
    │                     │  No local 'use fun' alias was found for 'a::m::B.t8', and no function 't8' was found in the defining module 'a::m'
    │                     Invalid method call. No known method 't8' on type 'a::m::B'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move:21:23
+   │
+21 │         let _tmp2 = _b.t8();
+   │                       ^ Possible dot names: 'a::m::t3', 'a::m::t4', or 'a::m::t5'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/struct_method_invalid_autocomplete.move:21:24

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_autocomplete.ide.exp
@@ -79,8 +79,31 @@ error[E04009]: expected specific type
   │          ^^^^^^^^^^^^^^^^ Unbound field 'bar'
 
 note[I15001]: IDE dot autocomplete
+  ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:16
+  │
+6 │     &mut action.inner.bar
+  │                ^ Possible dot names: '0x42::m::make_action_ref' or 'inner'
+
+note[I15001]: IDE dot autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:17
   │
 6 │     &mut action.inner.bar
   │                 ^^^^^ Possible dot names: '0x42::m::make_action_ref' or 'inner'
+
+error[E04023]: invalid method call
+  ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:22
+  │
+5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
+  │                                                   - Autocompletions are not supported on type parameters. Got an expression of type: 'T'
+6 │     &mut action.inner.bar
+  │                      ^ Invalid autocompletion
+
+error[E04023]: invalid method call
+  ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:23
+  │
+6 │     &mut action.inner.bar
+  │          -------------^^^
+  │          │            │
+  │          │            Invalid autocompletion
+  │          Autocompletions are not supported on type parameters. Got an expression of type: 'T'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_autocomplete.ide.exp
@@ -90,20 +90,3 @@ note[I15001]: IDE dot autocomplete
 6 │     &mut action.inner.bar
   │                 ^^^^^ Possible dot names: '0x42::m::make_action_ref' or 'inner'
 
-error[E04023]: invalid method call
-  ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:22
-  │
-5 │ public fun make_action_ref<T>(action: &mut Action<T>): &mut T {
-  │                                                   - Autocompletions are not supported on type parameters. Got an expression of type: 'T'
-6 │     &mut action.inner.bar
-  │                      ^ Invalid autocompletion
-
-error[E04023]: invalid method call
-  ┌─ tests/move_2024/ide_mode/type_param_autocomplete.move:6:23
-  │
-6 │     &mut action.inner.bar
-  │          -------------^^^
-  │          │            │
-  │          │            Invalid autocompletion
-  │          Autocompletions are not supported on type parameters. Got an expression of type: 'T'
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_no_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/type_param_no_autocomplete.ide.exp
@@ -71,6 +71,12 @@ note[I15006]: IDE path autocomplete
   = type params: 'T'
 
 note[I15001]: IDE dot autocomplete
+  ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:6:16
+  │
+6 │     &mut action.inner
+  │                ^ Possible dot names: '0x42::m::make_action_ref' or 'inner'
+
+note[I15001]: IDE dot autocomplete
   ┌─ tests/move_2024/ide_mode/type_param_no_autocomplete.move:6:17
   │
 6 │     &mut action.inner

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_fun_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/use_fun_autocomplete.ide.exp
@@ -1,8 +1,20 @@
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/use_fun_autocomplete.move:12:10
+   │
+12 │         s.bak(); // autocompletion to `bak` and `foo`
+   │          ^ Possible dot names: '0x42::m1::bak', '0x42::m1::foo', '0x42::m1::test1', or '0x42::m1::test2'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/use_fun_autocomplete.move:12:11
    │
 12 │         s.bak(); // autocompletion to `bak` and `foo`
    │           ^^^ Possible dot names: '0x42::m1::bak', '0x42::m1::foo', '0x42::m1::test1', or '0x42::m1::test2'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/use_fun_autocomplete.move:17:10
+   │
+17 │         s.bar(); // auto-completion to only one (shadowed) `bar`
+   │          ^ Possible dot names: '0x42::m1::bar', '0x42::m1::test1', or '0x42::m1::test2'
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/use_fun_autocomplete.move:17:11

--- a/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/named_struct_autocomplete.ide.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/ide_mode/named_struct_autocomplete.ide.exp
@@ -97,6 +97,12 @@ note[I15006]: IDE path autocomplete
    = type params: 
 
 note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:14:23
+   │
+14 │         let _tmp2 = _s.a.;
+   │                       ^ Possible dot names: 'a'
+
+note[I15001]: IDE dot autocomplete
    ┌─ tests/move_check/ide_mode/named_struct_autocomplete.move:14:24
    │
 14 │         let _tmp2 = _s.a.;


### PR DESCRIPTION
## Description 

This PR fixes a certain problem with auto-completion on the `.` character. Previously, once a part of the access chain after the `.` was parsed, auto-completion information for the `.` character location was no longer generated. This is particularly problematic if someone expects auto-completion in the middle of the function code, for example:
```move
public struct SomeStruct has drop {
    some_field: u64,
}

public fun foo(_param: SomeStruct) {}

public fun bar(): SomeStruct {
    let val = SomeStruct{some_field: 42};
    val.
    SomeStruct {some_field: 42}
}
```
It is expected that auto-completion would work correctly after `val.` but previously it did not because this expression was actually parsed as `val.SomeStruct`. This PR fixes this:
![image](https://github.com/user-attachments/assets/d7cb51d0-8faf-44a3-af16-fdb571459194)

Previously, auto-completion for the `.` location would also not work if what follows the `.` is a function call (whether the function being called was resolved correctly or not). It now works correctly in both cases:
![image](https://github.com/user-attachments/assets/11c5e07c-5f89-48ea-a3cd-a8b3829565c0)
![image](https://github.com/user-attachments/assets/57e7209c-1afe-4381-9a42-35279045fa45)



## Test plan 

All new and (updated) all tests must pass
