### PR TITLE
need to add object_status=0 to use partial indexes

### DIFF
--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -270,7 +270,7 @@ fn balance_query(
 /// Applies the filtering criteria for balances to the input `RawQuery` and returns a new
 /// `RawQuery`.
 fn filter(mut query: RawQuery, owner: SuiAddress, coin_type: Option<TypeTag>) -> RawQuery {
-    query = filter!(query, "coin_type IS NOT NULL");
+    query = filter!(query, "coin_type IS NOT NULL AND object_status = 0");
 
     query = filter!(
         query,

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -435,7 +435,7 @@ fn apply_filter(mut query: RawQuery, coin_type: &TypeTag, owner: Option<SuiAddre
 
     query = filter!(
         query,
-        "coin_type IS NOT NULL AND coin_type = {}",
+        "coin_type IS NOT NULL AND coin_type = {} AND object_status = 0",
         coin_type.to_canonical_display(/* with_prefix */ true)
     );
 


### PR DESCRIPTION
## Description 

objects_snapshot no longer indexes wrapped or deleted objects. we added `object_status` to objects history, and modified all indexes to partial indexes. Coins and balances weren't picked up since they don't go through the same raw objects query path, so it was causing elevated query latencies.

## Test plan 

Manually reran same graphql queries that were timing out. Also, estimated cost went from 3.5k down to 200.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
