### PR TITLE
Fix a small syntax error in Sui Documentation, on TS SDK

### DIFF
--- a/sdk/docs/pages/typescript/transaction-building/basics.mdx
+++ b/sdk/docs/pages/typescript/transaction-building/basics.mdx
@@ -140,7 +140,7 @@ tx.transferObjects([coin], tx.pure.address('0xSomeSuiAddress'));
 tx.transferObjects([coin], tx.pure(bcs.Address.serialize('0xSomeSuiAddress')));
 ```
 
-To pass `vector` or `option` types, you you can pass use the corresponding methods on `tx.pure`, use
+To pass `vector` or `option` types, you can pass use the corresponding methods on `tx.pure`, use
 tx.pure as a function with a type argument, or serialize the value before passing it to tx.pure
 using the bcs sdk:
 


### PR DESCRIPTION
correct minor errors on TS SDK page: Transaction Building/ Sui Programmable Transaction Basics/ Pure values 
fix " you you can ..." -> "you can ..."

## Description 
There seems to be a small mistake on the description in TS SDK/ Transaction Building/ Sui Programmable Transaction Basics/ Pure values:
<img width="1122" alt="截屏2024-11-05 14 16 57" src="https://github.com/user-attachments/assets/7aa5b12d-d947-4950-8f8f-f598a18caeb4">

Thus I created this PR to fix this error.
