### PR TITLE
[move] Update source coverage gathering so we don't include any duplicate source spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7519,6 +7519,7 @@ dependencies = [
  "clap",
  "codespan",
  "colored",
+ "indexmap 2.2.6",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "clap 4.5.17",
  "codespan",
  "colored",
+ "indexmap 2.5.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",

--- a/external-crates/move/crates/move-coverage/Cargo.toml
+++ b/external-crates/move/crates/move-coverage/Cargo.toml
@@ -25,6 +25,7 @@ move-ir-types.workspace = true
 move-binary-format.workspace = true
 move-bytecode-source-map.workspace = true
 move-abstract-interpreter.workspace = true
+indexmap.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
## Description 

Hardens source coverage gathering to be resilient to duplicate source spans from the compiler. (e.g., from macros and the like). 

Fixes issue #20075

## Test plan 

Manually tested on a failing test case. 

