### PR TITLE
[indexer-alt] Add indexer_latest_ingested_checkpoint metric

### DIFF
--- a/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
@@ -1,10 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use futures::{future::try_join_all, TryStreamExt};
 use mysten_metrics::spawn_monitored_task;
+use std::sync::Arc;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};

--- a/crates/sui-indexer-alt/src/ingestion/local_client.rs
+++ b/crates/sui-indexer-alt/src/ingestion/local_client.rs
@@ -5,6 +5,8 @@ use crate::ingestion::client::{FetchError, FetchResult, IngestionClientTrait};
 use axum::body::Bytes;
 use std::path::PathBuf;
 
+// FIXME: To productionize this, we need to add garbage collection to remove old checkpoint files.
+
 pub struct LocalIngestionClient {
     path: PathBuf,
 }

--- a/crates/sui-indexer-alt/src/metrics.rs
+++ b/crates/sui-indexer-alt/src/metrics.rs
@@ -11,8 +11,8 @@ use prometheus::{
     proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType, Summary},
     register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_vec_with_registry, Histogram, HistogramVec, IntCounter, IntCounterVec,
-    IntGaugeVec, Registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Histogram,
+    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
 use tokio::{net::TcpListener, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -60,6 +60,8 @@ pub struct IndexerMetrics {
     pub total_ingested_bytes: IntCounter,
     pub total_ingested_transient_retries: IntCounterVec,
     pub total_ingested_not_found_retries: IntCounter,
+
+    pub latest_ingested_checkpoint: IntGauge,
 
     pub ingested_checkpoint_latency: Histogram,
 
@@ -197,6 +199,12 @@ impl IndexerMetrics {
                 "indexer_total_ingested_not_found_retries",
                 "Total number of retries due to the not found errors while fetching data from the \
                  remote store",
+                registry,
+            )
+            .unwrap(),
+            latest_ingested_checkpoint: register_int_gauge_with_registry!(
+                "indexer_latest_ingested_checkpoint",
+                "Latest checkpoint sequence number fetched from the remote store",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

This metric will allow us to observe latest ingested checkpoint seq number. We could track its progress relative to other parts of the indexer.
## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
