### PR TITLE
[move-compiler] Improve interactions with Sui mode and interface files

### DIFF
--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -96,7 +96,7 @@ pub mod utils;
 macro_rules! built_in_ids {
     ($($addr:ident / $id:ident = $init:expr);* $(;)?) => {
         $(
-            pub const $addr: AccountAddress = builtin_address($init);
+            pub const $addr: AccountAddress = AccountAddress::from_suffix($init);
             pub const $id: ObjectID = ObjectID::from_address($addr);
         )*
     }
@@ -132,14 +132,6 @@ built_in_ids! {
 pub const SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 pub const SUI_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
-
-const fn builtin_address(suffix: u16) -> AccountAddress {
-    let mut addr = [0u8; AccountAddress::LENGTH];
-    let [hi, lo] = suffix.to_be_bytes();
-    addr[AccountAddress::LENGTH - 2] = hi;
-    addr[AccountAddress::LENGTH - 1] = lo;
-    AccountAddress::new(addr)
-}
 
 pub fn sui_framework_address_concat_string(suffix: &str) -> String {
     format!("{}{suffix}", SUI_FRAMEWORK_ADDRESS.to_hex_literal())

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -17,6 +17,7 @@ use crate::{
     parser::ast::{ConstantName, DatatypeName, FunctionName},
     shared::CompilationEnv,
 };
+use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 
@@ -846,19 +847,25 @@ where
     exp_satisfies_(e, &mut p)
 }
 
-pub fn calls_special_function(special: &[(&str, &str, &str)], cfg: &ImmForwardCFG) -> bool {
+pub fn calls_special_function(
+    special: &[(AccountAddress, &str, &str)],
+    cfg: &ImmForwardCFG,
+) -> bool {
     cfg_satisfies(cfg, |_| true, |e| is_special_function(special, e))
 }
 
-pub fn calls_special_function_command(special: &[(&str, &str, &str)], cmd: &Command) -> bool {
+pub fn calls_special_function_command(
+    special: &[(AccountAddress, &str, &str)],
+    cmd: &Command,
+) -> bool {
     command_satisfies(cmd, |_| true, |e| is_special_function(special, e))
 }
 
-pub fn calls_special_function_exp(special: &[(&str, &str, &str)], e: &Exp) -> bool {
+pub fn calls_special_function_exp(special: &[(AccountAddress, &str, &str)], e: &Exp) -> bool {
     exp_satisfies(e, |e| is_special_function(special, e))
 }
 
-fn is_special_function(special: &[(&str, &str, &str)], e: &Exp) -> bool {
+fn is_special_function(special: &[(AccountAddress, &str, &str)], e: &Exp) -> bool {
     use H::UnannotatedExp_ as E;
     matches!(
         &e.exp.value,

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -655,12 +655,10 @@ impl Address {
         }
     }
 
-    pub fn is(&self, address: impl AsRef<str>) -> bool {
+    pub fn numerical_value(&self) -> Option<&Spanned<NumericalAddress>> {
         match self {
-            Self::Numerical { name: Some(n), .. } | Self::NamedUnassigned(n) => {
-                n.value.as_str() == address.as_ref()
-            }
-            Self::Numerical { name: None, .. } => false,
+            Self::Numerical { value, .. } => Some(value),
+            Self::NamedUnassigned(_) => None,
         }
     }
 }
@@ -670,12 +668,15 @@ impl ModuleIdent_ {
         Self { address, module }
     }
 
-    pub fn is(&self, address: impl AsRef<str>, module: impl AsRef<str>) -> bool {
+    pub fn is<Addr>(&self, address: &Addr, module: impl AsRef<str>) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         let Self {
             address: a,
             module: m,
         } = self;
-        a.is(address) && m == module.as_ref()
+        a.numerical_value().is_some_and(|sp!(_, v)| v == address) && m == module.as_ref()
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -655,6 +655,13 @@ impl Address {
         }
     }
 
+    pub fn is<Addr>(&self, address: &Addr) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
+        self.numerical_value().is_some_and(|sp!(_, v)| v == address)
+    }
+
     pub fn numerical_value(&self) -> Option<&Spanned<NumericalAddress>> {
         match self {
             Self::Numerical { value, .. } => Some(value),
@@ -676,7 +683,7 @@ impl ModuleIdent_ {
             address: a,
             module: m,
         } = self;
-        a.numerical_value().is_some_and(|sp!(_, v)| v == address) && m == module.as_ref()
+        a.is(address) && m == module.as_ref()
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -580,12 +580,10 @@ impl UnannotatedExp_ {
 }
 
 impl TypeName_ {
-    pub fn is(
-        &self,
-        address: impl AsRef<str>,
-        module: impl AsRef<str>,
-        name: impl AsRef<str>,
-    ) -> bool {
+    pub fn is<Addr>(&self, address: &Addr, module: impl AsRef<str>, name: impl AsRef<str>) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         match self {
             TypeName_::Builtin(_) => false,
             TypeName_::ModuleType(mident, n) => {
@@ -675,12 +673,15 @@ impl BaseType_ {
         }
     }
 
-    pub fn is_apply(
+    pub fn is_apply<Addr>(
         &self,
-        address: impl AsRef<str>,
+        address: &Addr,
         module: impl AsRef<str>,
         name: impl AsRef<str>,
-    ) -> Option<(&AbilitySet, &TypeName, &[BaseType])> {
+    ) -> Option<(&AbilitySet, &TypeName, &[BaseType])>
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         match self {
             Self::Apply(abs, n, tys) if n.value.is(address, module, name) => Some((abs, n, tys)),
             _ => None,
@@ -732,12 +733,15 @@ impl SingleType_ {
         }
     }
 
-    pub fn is_apply(
+    pub fn is_apply<Addr>(
         &self,
-        address: impl AsRef<str>,
+        address: &Addr,
         module: impl AsRef<str>,
         name: impl AsRef<str>,
-    ) -> Option<(&AbilitySet, &TypeName, &[BaseType])> {
+    ) -> Option<(&AbilitySet, &TypeName, &[BaseType])>
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         match self {
             Self::Ref(_, b) | Self::Base(b) => b.value.is_apply(address, module, name),
         }
@@ -808,12 +812,15 @@ impl Type_ {
         sp(loc, t_)
     }
 
-    pub fn is_apply(
+    pub fn is_apply<Addr>(
         &self,
-        address: impl AsRef<str>,
+        address: &Addr,
         module: impl AsRef<str>,
         name: impl AsRef<str>,
-    ) -> Option<(&AbilitySet, &TypeName, &[BaseType])> {
+    ) -> Option<(&AbilitySet, &TypeName, &[BaseType])>
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         match self {
             Type_::Unit => None,
             Type_::Single(t) => t.value.is_apply(address, module, name),
@@ -857,12 +864,15 @@ impl TName for BlockLabel {
 }
 
 impl ModuleCall {
-    pub fn is(
+    pub fn is<Addr>(
         &self,
-        address: impl AsRef<str>,
+        address: &Addr,
         module: impl AsRef<str>,
         function: impl AsRef<str>,
-    ) -> bool {
+    ) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         let Self {
             module: sp!(_, mident),
             name: f,

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -755,12 +755,10 @@ impl BuiltinFunction_ {
 }
 
 impl TypeName_ {
-    pub fn is(
-        &self,
-        address: impl AsRef<str>,
-        module: impl AsRef<str>,
-        name: impl AsRef<str>,
-    ) -> bool {
+    pub fn is<Addr>(&self, address: &Addr, module: impl AsRef<str>, name: impl AsRef<str>) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         match self {
             TypeName_::Builtin(_) | TypeName_::Multiple(_) => false,
             TypeName_::ModuleType(mident, n) => {
@@ -892,12 +890,10 @@ impl Type_ {
         }
     }
 
-    pub fn is(
-        &self,
-        address: impl AsRef<str>,
-        module: impl AsRef<str>,
-        name: impl AsRef<str>,
-    ) -> bool {
+    pub fn is<Addr>(&self, address: &Addr, module: impl AsRef<str>, name: impl AsRef<str>) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         self.type_name()
             .is_some_and(|tn| tn.value.is(address, module, name))
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/info.rs
@@ -19,7 +19,7 @@ use crate::{
         unique_map::UniqueMap,
     },
     sui_mode::{
-        OBJECT_MODULE_NAME, SUI_ADDR_NAME, TRANSFER_FUNCTION_NAME, TRANSFER_MODULE_NAME,
+        OBJECT_MODULE_NAME, SUI_ADDR_VALUE, TRANSFER_FUNCTION_NAME, TRANSFER_MODULE_NAME,
         UID_TYPE_NAME,
     },
     typing::{ast as T, visitor::TypingVisitorContext},
@@ -131,7 +131,7 @@ fn all_uid_holders(info: &TypingProgramInfo) -> BTreeMap<(ModuleIdent, DatatypeN
             N::Type_::Ref(_, inner) => visit_ty(info, visited, uid_holders, inner),
 
             N::Type_::Apply(_, sp!(_, tn_), _)
-                if tn_.is(SUI_ADDR_NAME, OBJECT_MODULE_NAME, UID_TYPE_NAME) =>
+                if tn_.is(&SUI_ADDR_VALUE, OBJECT_MODULE_NAME, UID_TYPE_NAME) =>
             {
                 Some(UIDHolder::IsUID)
             }
@@ -285,7 +285,11 @@ fn add_private_transfers(
             let E::ModuleCall(call) = &e.exp.value else {
                 return false;
             };
-            if !call.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME, TRANSFER_FUNCTION_NAME) {
+            if !call.is(
+                &SUI_ADDR_VALUE,
+                TRANSFER_MODULE_NAME,
+                TRANSFER_FUNCTION_NAME,
+            ) {
                 return false;
             }
             let [sp!(_, ty)] = call.type_arguments.as_slice() else {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -10,12 +10,13 @@ use crate::{
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::DatatypeName,
+    sui_mode::SUI_ADDR_VALUE,
     typing::{ast as T, visitor::simple_visitor},
 };
 
 use super::{
     LinterDiagnosticCategory, LinterDiagnosticCode, COIN_MOD_NAME, COIN_STRUCT_NAME,
-    LINT_WARNING_PREFIX, SUI_PKG_NAME,
+    LINT_WARNING_PREFIX,
 };
 
 const COIN_FIELD_DIAG: DiagnosticInfo = custom(
@@ -62,7 +63,7 @@ fn is_field_coin_type(sp!(_, t): &N::Type) -> bool {
         T::Ref(_, inner_t) => is_field_coin_type(inner_t),
         T::Apply(_, tname, _) => {
             let sp!(_, tname) = tname;
-            tname.is(SUI_PKG_NAME, COIN_MOD_NAME, COIN_STRUCT_NAME)
+            tname.is(&SUI_ADDR_VALUE, COIN_MOD_NAME, COIN_STRUCT_NAME)
         }
         T::Unit | T::Param(_) | T::Var(_) | T::Anything | T::UnresolvedError | T::Fun(_, _) => {
             false

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -5,20 +5,23 @@
 //! or sui::bag::Bag are being compared for (in)equality at this type of comparison is not very
 //! useful and DOES NOT take into consideration structural (in)equality.
 
+use move_core_types::account_address::AccountAddress;
+
 use crate::{
     diag,
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
     naming::ast as N,
     parser::ast as P,
     shared::Identifier,
+    sui_mode::SUI_ADDR_VALUE,
     typing::{ast as T, visitor::simple_visitor},
 };
 
 use super::{
     base_type, LinterDiagnosticCategory, LinterDiagnosticCode, BAG_MOD_NAME, BAG_STRUCT_NAME,
     LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME, LINT_WARNING_PREFIX, OBJECT_BAG_MOD_NAME,
-    OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, SUI_PKG_NAME,
-    TABLE_MOD_NAME, TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
+    OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME,
+    TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
     VEC_MAP_STRUCT_NAME, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
 };
 
@@ -30,23 +33,23 @@ const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
     "possibly useless collections compare",
 );
 
-const COLLECTION_TYPES: &[(&str, &str, &str)] = &[
-    (SUI_PKG_NAME, BAG_MOD_NAME, BAG_STRUCT_NAME),
-    (SUI_PKG_NAME, OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME),
-    (SUI_PKG_NAME, TABLE_MOD_NAME, TABLE_STRUCT_NAME),
+const COLLECTION_TYPES: &[(AccountAddress, &str, &str)] = &[
+    (SUI_ADDR_VALUE, BAG_MOD_NAME, BAG_STRUCT_NAME),
+    (SUI_ADDR_VALUE, OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME),
+    (SUI_ADDR_VALUE, TABLE_MOD_NAME, TABLE_STRUCT_NAME),
     (
-        SUI_PKG_NAME,
+        SUI_ADDR_VALUE,
         OBJECT_TABLE_MOD_NAME,
         OBJECT_TABLE_STRUCT_NAME,
     ),
     (
-        SUI_PKG_NAME,
+        SUI_ADDR_VALUE,
         LINKED_TABLE_MOD_NAME,
         LINKED_TABLE_STRUCT_NAME,
     ),
-    (SUI_PKG_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME),
-    (SUI_PKG_NAME, VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME),
-    (SUI_PKG_NAME, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME),
+    (SUI_ADDR_VALUE, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME),
+    (SUI_ADDR_VALUE, VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME),
+    (SUI_ADDR_VALUE, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME),
 ];
 
 simple_visitor!(
@@ -70,7 +73,7 @@ simple_visitor!(
 
             if let Some((caddr, cmodule, cname)) =
                 COLLECTION_TYPES.iter().find(|(caddr, cmodule, cname)| {
-                    mident.value.is(*caddr, *cmodule) && sname.value().as_str() == *cname
+                    mident.value.is(caddr, *cmodule) && sname.value().as_str() == *cname
                 })
             {
                 let msg = format!(

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -6,19 +6,18 @@
 //! useful and DOES NOT take into consideration structural (in)equality.
 
 use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
-    naming::ast as N,
     parser::ast as P,
-    shared::Identifier,
-    sui_mode::SUI_ADDR_VALUE,
+    sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE},
     typing::{ast as T, visitor::simple_visitor},
 };
 
 use super::{
-    base_type, LinterDiagnosticCategory, LinterDiagnosticCode, BAG_MOD_NAME, BAG_STRUCT_NAME,
+    LinterDiagnosticCategory, LinterDiagnosticCode, BAG_MOD_NAME, BAG_STRUCT_NAME,
     LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME, LINT_WARNING_PREFIX, OBJECT_BAG_MOD_NAME,
     OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME,
     TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
@@ -33,23 +32,50 @@ const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
     "possibly useless collections compare",
 );
 
-const COLLECTION_TYPES: &[(AccountAddress, &str, &str)] = &[
-    (SUI_ADDR_VALUE, BAG_MOD_NAME, BAG_STRUCT_NAME),
-    (SUI_ADDR_VALUE, OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME),
-    (SUI_ADDR_VALUE, TABLE_MOD_NAME, TABLE_STRUCT_NAME),
+const COLLECTION_TYPES: &[(Symbol, AccountAddress, &str, &str)] = &[
+    (SUI_ADDR_NAME, SUI_ADDR_VALUE, BAG_MOD_NAME, BAG_STRUCT_NAME),
     (
+        SUI_ADDR_NAME,
+        SUI_ADDR_VALUE,
+        OBJECT_BAG_MOD_NAME,
+        OBJECT_BAG_STRUCT_NAME,
+    ),
+    (
+        SUI_ADDR_NAME,
+        SUI_ADDR_VALUE,
+        TABLE_MOD_NAME,
+        TABLE_STRUCT_NAME,
+    ),
+    (
+        SUI_ADDR_NAME,
         SUI_ADDR_VALUE,
         OBJECT_TABLE_MOD_NAME,
         OBJECT_TABLE_STRUCT_NAME,
     ),
     (
+        SUI_ADDR_NAME,
         SUI_ADDR_VALUE,
         LINKED_TABLE_MOD_NAME,
         LINKED_TABLE_STRUCT_NAME,
     ),
-    (SUI_ADDR_VALUE, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME),
-    (SUI_ADDR_VALUE, VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME),
-    (SUI_ADDR_VALUE, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME),
+    (
+        SUI_ADDR_NAME,
+        SUI_ADDR_VALUE,
+        TABLE_VEC_MOD_NAME,
+        TABLE_VEC_STRUCT_NAME,
+    ),
+    (
+        SUI_ADDR_NAME,
+        SUI_ADDR_VALUE,
+        VEC_MAP_MOD_NAME,
+        VEC_MAP_STRUCT_NAME,
+    ),
+    (
+        SUI_ADDR_NAME,
+        SUI_ADDR_VALUE,
+        VEC_SET_MOD_NAME,
+        VEC_SET_STRUCT_NAME,
+    ),
 ];
 
 simple_visitor!(
@@ -61,26 +87,22 @@ simple_visitor!(
                 // not a comparison
                 return false;
             }
-            let Some(bt) = base_type(t) else {
+            let Some(sp!(_, tn_)) = t.value.unfold_to_type_name() else {
+                // no type name
                 return false;
             };
-            let N::Type_::Apply(_, tname, _) = &bt.value else {
-                return false;
-            };
-            let N::TypeName_::ModuleType(mident, sname) = tname.value else {
-                return false;
-            };
-
-            if let Some((caddr, cmodule, cname)) =
-                COLLECTION_TYPES.iter().find(|(caddr, cmodule, cname)| {
-                    mident.value.is(caddr, *cmodule) && sname.value().as_str() == *cname
-                })
+            if let Some((caddr_name, _, cmodule, cname)) = COLLECTION_TYPES
+                .iter()
+                .find(|(_, caddr_value, cmodule, cname)| tn_.is(caddr_value, *cmodule, *cname))
             {
                 let msg = format!(
-                    "Comparing collections of type '{caddr}::{cmodule}::{cname}' may yield unexpected result."
+                    "Comparing collections of type '{caddr_name}::{cmodule}::{cname}' \
+                    may yield unexpected result."
                 );
-                let note_msg =
-                    format!("Equality for collections of type '{caddr}::{cmodule}::{cname}' IS NOT a structural check based on content");
+                let note_msg = format!(
+                    "Equality for collections of type '{caddr_name}::{cmodule}::{cname}' \
+                    IS NOT a structural check based on content"
+                );
                 let mut d = diag!(COLLECTIONS_EQUALITY_DIAG, (op.loc, msg),);
                 d.add_note(note_msg);
                 self.add_diag(d);

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -8,6 +8,7 @@
 //! parameter an instance of a struct type defined in a given module with a store ability and passes
 //! it as an argument to a "private" transfer/share/freeze call.
 
+use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::*;
 
 use crate::{
@@ -30,19 +31,20 @@ use crate::{
     },
     parser::ast::Ability_,
     shared::Identifier,
+    sui_mode::SUI_ADDR_VALUE,
 };
 use std::collections::BTreeMap;
 
 use super::{
     LinterDiagnosticCategory, LinterDiagnosticCode, FREEZE_FUN, INVALID_LOC, LINT_WARNING_PREFIX,
-    RECEIVE_FUN, SHARE_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    RECEIVE_FUN, SHARE_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
-const PRIVATE_OBJ_FUNCTIONS: &[(&str, &str, &str)] = &[
-    (SUI_PKG_NAME, TRANSFER_MOD_NAME, TRANSFER_FUN),
-    (SUI_PKG_NAME, TRANSFER_MOD_NAME, SHARE_FUN),
-    (SUI_PKG_NAME, TRANSFER_MOD_NAME, FREEZE_FUN),
-    (SUI_PKG_NAME, TRANSFER_MOD_NAME, RECEIVE_FUN),
+const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
+    (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, TRANSFER_FUN),
+    (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, SHARE_FUN),
+    (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, FREEZE_FUN),
+    (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, RECEIVE_FUN),
 ];
 
 const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo = custom(

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -207,10 +207,7 @@ impl<'a> Context<'a> {
         mident: &E::ModuleIdent,
         sname: &P::DatatypeName,
     ) -> Option<WrappingFieldInfo> {
-        let memoized_info = self
-            .wrapping_fields
-            .get(&mident)
-            .and_then(|m| m.get(&sname));
+        let memoized_info = self.wrapping_fields.get(mident).and_then(|m| m.get(sname));
         if memoized_info.is_none() {
             let info = self.find_wrapping_field_loc_impl(mident, sname);
             self.wrapping_fields
@@ -220,8 +217,8 @@ impl<'a> Context<'a> {
         }
         *self
             .wrapping_fields
-            .get(&mident)
-            .and_then(|m| m.get(&sname))
+            .get(mident)
+            .and_then(|m| m.get(sname))
             .unwrap()
     }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
@@ -11,6 +11,7 @@ use crate::{
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
     naming::ast::{StructDefinition, StructFields},
     parser::ast::Ability_,
+    sui_mode::{ID_FIELD_NAME, OBJECT_MODULE_NAME, SUI_ADDR_VALUE, UID_TYPE_NAME},
     typing::visitor::simple_visitor,
 };
 
@@ -43,7 +44,11 @@ simple_visitor!(
 fn first_field_has_id_field_of_type_uid(sdef: &StructDefinition) -> bool {
     match &sdef.fields {
         StructFields::Defined(_, fields) => fields.iter().any(|(_, symbol, (idx, ty))| {
-            *idx == 0 && symbol == &symbol!("id") && ty.value.is("sui", "object", "UID")
+            *idx == 0
+                && symbol == &ID_FIELD_NAME
+                && ty
+                    .value
+                    .is(&SUI_ADDR_VALUE, OBJECT_MODULE_NAME, UID_TYPE_NAME)
         }),
         StructFields::Native(_) => false,
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
     linters::{LintLevel, LinterDiagnosticCategory, ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX},
-    naming::ast as N,
     typing::visitor::TypingVisitor,
 };
 use move_ir_types::location::Loc;
@@ -182,15 +181,6 @@ pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {
             ]);
             visitors
         }
-    }
-}
-
-pub fn base_type(t: &N::Type) -> Option<&N::Type> {
-    use N::Type_ as T;
-    match &t.value {
-        T::Ref(_, inner_t) => base_type(inner_t),
-        T::Apply(_, _, _) | T::Param(_) => Some(t),
-        T::Unit | T::Var(_) | T::Anything | T::UnresolvedError | T::Fun(_, _) => None,
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -25,8 +25,6 @@ pub mod public_random;
 pub mod self_transfer;
 pub mod share_owned;
 
-pub const SUI_PKG_NAME: &str = "sui";
-
 pub const TRANSFER_MOD_NAME: &str = "transfer";
 pub const TRANSFER_FUN: &str = "transfer";
 pub const PUBLIC_TRANSFER_FUN: &str = "public_transfer";

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
@@ -12,7 +12,7 @@ use crate::{
     expansion::ast::{ModuleIdent, Visibility},
     naming::ast::Type_,
     parser::ast::FunctionName,
-    sui_mode::{SUI_ADDR_NAME, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME},
+    sui_mode::{SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME},
     typing::{ast as T, visitor::simple_visitor},
 };
 use move_ir_types::location::Loc;
@@ -29,7 +29,7 @@ simple_visitor!(
     PreferMutableTxContext,
     fn visit_module_custom(&mut self, ident: ModuleIdent, _mdef: &T::ModuleDefinition) -> bool {
         // skip if in 'sui::tx_context'
-        ident.value.is(SUI_ADDR_NAME, TX_CONTEXT_MODULE_NAME)
+        ident.value.is(&SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME)
     },
     fn visit_function_custom(
         &mut self,
@@ -44,7 +44,7 @@ simple_visitor!(
         for (_, _, sp!(loc, param_ty_)) in &fdef.signature.parameters {
             if matches!(
                 param_ty_,
-                Type_::Ref(false, t) if t.value.is(SUI_ADDR_NAME, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME),
+                Type_::Ref(false, t) if t.value.is(&SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME),
             ) {
                 report_non_mutable_tx_context(self, *loc);
             }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
@@ -5,7 +5,7 @@
 
 use crate::expansion::ast::ModuleIdent;
 use crate::parser::ast::FunctionName;
-use crate::sui_mode::SUI_ADDR_NAME;
+use crate::sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE};
 use crate::typing::visitor::simple_visitor;
 use crate::{
     diag,
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{
     LinterDiagnosticCategory, LinterDiagnosticCode, LINT_WARNING_PREFIX,
-    RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME, SUI_PKG_NAME,
+    RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME,
 };
 
 const PUBLIC_RANDOM_DIAG: DiagnosticInfo = custom(
@@ -32,7 +32,7 @@ simple_visitor!(
     PublicRandomVisitor,
     fn visit_module_custom(&mut self, ident: ModuleIdent, mdef: &T::ModuleDefinition) -> bool {
         // skips if true
-        mdef.attributes.is_test_or_test_only() || ident.value.address.is(SUI_ADDR_NAME)
+        mdef.attributes.is_test_or_test_only() || ident.value.address.is(&SUI_ADDR_VALUE)
     },
     fn visit_function_custom(
         &mut self,
@@ -52,7 +52,7 @@ simple_visitor!(
                     format!("'public' function '{fname}' accepts '{struct_name}' as a parameter");
                 let mut d = diag!(PUBLIC_RANDOM_DIAG, (tloc, msg));
                 let note = format!("Functions that accept '{}::{}::{}' as a parameter might be abused by attackers by inspecting the results of randomness",
-                                   SUI_PKG_NAME, RANDOM_MOD_NAME, struct_name);
+                                   SUI_ADDR_NAME, RANDOM_MOD_NAME, struct_name);
                 d.add_note(note);
                 d.add_note("Non-public functions are preferred");
                 self.add_diag(d);
@@ -67,9 +67,13 @@ fn is_random_or_random_generator(sp!(_, t): &N::Type) -> Option<&str> {
     match t {
         T::Ref(_, inner_t) => is_random_or_random_generator(inner_t),
         T::Apply(_, sp!(_, tname), _) => {
-            if tname.is(SUI_PKG_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME) {
+            if tname.is(&SUI_ADDR_VALUE, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME) {
                 Some(RANDOM_STRUCT_NAME)
-            } else if tname.is(SUI_PKG_NAME, RANDOM_MOD_NAME, RANDOM_GENERATOR_STRUCT_NAME) {
+            } else if tname.is(
+                &SUI_ADDR_VALUE,
+                RANDOM_MOD_NAME,
+                RANDOM_GENERATOR_STRUCT_NAME,
+            ) {
                 Some(RANDOM_GENERATOR_STRUCT_NAME)
             } else {
                 None

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -4,6 +4,7 @@
 //! This analysis flags transfers of an object to tx_context::sender(). Such objects should be
 //! returned from the function instead
 
+use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::*;
 
 use crate::{
@@ -23,17 +24,18 @@ use crate::{
     },
     hlir::ast::{Label, ModuleCall, Type, Type_, Var},
     parser::ast::Ability_,
+    sui_mode::{SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME},
 };
 use std::collections::BTreeMap;
 
 use super::{
     type_abilities, LinterDiagnosticCategory, LinterDiagnosticCode, INVALID_LOC,
-    LINT_WARNING_PREFIX, PUBLIC_TRANSFER_FUN, SUI_PKG_NAME, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    LINT_WARNING_PREFIX, PUBLIC_TRANSFER_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
-const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
-    (SUI_PKG_NAME, TRANSFER_MOD_NAME, PUBLIC_TRANSFER_FUN),
-    (SUI_PKG_NAME, TRANSFER_MOD_NAME, TRANSFER_FUN),
+const TRANSFER_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
+    (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_TRANSFER_FUN),
+    (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, TRANSFER_FUN),
 ];
 
 const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
@@ -166,7 +168,7 @@ impl SimpleAbsInt for SelfTransferVerifierAI {
             }
             return Some(vec![]);
         }
-        if f.is("sui", "tx_context", "sender") {
+        if f.is(&SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, "sender") {
             return Some(vec![Value::SenderAddress(*loc)]);
         }
         Some(match &return_ty.value {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 
 use crate::diagnostics::codes::{custom, DiagnosticInfo, Severity};
@@ -9,6 +10,13 @@ pub mod id_leak;
 pub mod info;
 pub mod linters;
 pub mod typing;
+
+// DEEPBOOK_ADDRESS / DEEPBOOK_PACKAGE_ID = 0xdee9;
+
+pub const STD_ADDR_VALUE: AccountAddress = AccountAddress::from_suffix(0x1);
+pub const SUI_ADDR_VALUE: AccountAddress = AccountAddress::from_suffix(0x2);
+pub const SUI_SYSTEM_ADDR_VALUE: AccountAddress = AccountAddress::from_suffix(0x3);
+pub const BRIDGE_ADDR_VALUE: AccountAddress = AccountAddress::from_suffix(0xb);
 
 pub const INIT_FUNCTION_NAME: Symbol = symbol!("init");
 pub const ID_FIELD_NAME: Symbol = symbol!("id");

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -58,7 +58,7 @@ impl<'a> Context<'a> {
         let sui_module_ident = info
             .modules
             .key_cloned_iter()
-            .find(|(m, _)| m.value.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME))
+            .find(|(m, _)| m.value.is(&SUI_ADDR_VALUE, TRANSFER_MODULE_NAME))
             .map(|(m, _)| m);
         let reporter = env.diagnostic_reporter_at_top_level();
         Context {
@@ -225,7 +225,7 @@ fn struct_def(context: &mut Context, name: DatatypeName, sdef: &N::StructDefinit
     let id_field_loc = fields.get_loc_(&ID_FIELD_NAME).unwrap();
     if !id_field_type
         .value
-        .is(SUI_ADDR_NAME, OBJECT_MODULE_NAME, UID_TYPE_NAME)
+        .is(&SUI_ADDR_VALUE, OBJECT_MODULE_NAME, UID_TYPE_NAME)
     {
         let actual = format!(
             "But found type: {}",
@@ -618,7 +618,11 @@ fn tx_context_kind(sp!(_, last_param_ty_): &Type) -> TxContextKind {
         // not a user defined type
         return TxContextKind::None;
     };
-    if inner_name.is(SUI_ADDR_NAME, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME) {
+    if inner_name.is(
+        &SUI_ADDR_VALUE,
+        TX_CONTEXT_MODULE_NAME,
+        TX_CONTEXT_TYPE_NAME,
+    ) {
         if *is_mut {
             TxContextKind::Mutable
         } else {
@@ -713,7 +717,9 @@ fn is_mut_clock(param_ty: &Type) -> bool {
     match &param_ty.value {
         Type_::Ref(/* mut */ false, _) => false,
         Type_::Ref(/* mut */ true, t) => is_mut_clock(t),
-        Type_::Apply(_, sp!(_, n_), _) => n_.is(SUI_ADDR_NAME, CLOCK_MODULE_NAME, CLOCK_TYPE_NAME),
+        Type_::Apply(_, sp!(_, n_), _) => {
+            n_.is(&SUI_ADDR_VALUE, CLOCK_MODULE_NAME, CLOCK_TYPE_NAME)
+        }
         Type_::Unit
         | Type_::Param(_)
         | Type_::Var(_)
@@ -728,7 +734,7 @@ fn is_mut_random(param_ty: &Type) -> bool {
         Type_::Ref(/* mut */ false, _) => false,
         Type_::Ref(/* mut */ true, t) => is_mut_random(t),
         Type_::Apply(_, sp!(_, n_), _) => n_.is(
-            SUI_ADDR_NAME,
+            &SUI_ADDR_VALUE,
             RANDOMNESS_MODULE_NAME,
             RANDOMNESS_STATE_TYPE_NAME,
         ),
@@ -745,7 +751,7 @@ fn is_entry_receiving_ty(param_ty: &Type) -> bool {
     match &param_ty.value {
         Type_::Ref(_, t) => is_entry_receiving_ty(t),
         Type_::Apply(_, sp!(_, n), targs)
-            if n.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME, RECEIVING_TYPE_NAME) =>
+            if n.is(&SUI_ADDR_VALUE, TRANSFER_MODULE_NAME, RECEIVING_TYPE_NAME) =>
         {
             debug_assert!(targs.len() == 1);
             // Don't care about the type parameter, just that it's a receiving type -- since it has
@@ -775,15 +781,15 @@ fn is_entry_primitive_ty(param_ty: &Type) -> bool {
 
         // custom "primitives"
         Type_::Apply(_, sp!(_, n), targs)
-            if n.is(STD_ADDR_NAME, ASCII_MODULE_NAME, ASCII_TYPE_NAME)
-                || n.is(STD_ADDR_NAME, UTF_MODULE_NAME, UTF_TYPE_NAME)
-                || n.is(SUI_ADDR_NAME, OBJECT_MODULE_NAME, ID_TYPE_NAME) =>
+            if n.is(&STD_ADDR_VALUE, ASCII_MODULE_NAME, ASCII_TYPE_NAME)
+                || n.is(&STD_ADDR_VALUE, UTF_MODULE_NAME, UTF_TYPE_NAME)
+                || n.is(&STD_ADDR_VALUE, OBJECT_MODULE_NAME, ID_TYPE_NAME) =>
         {
             debug_assert!(targs.is_empty());
             true
         }
         Type_::Apply(_, sp!(_, n), targs)
-            if n.is(STD_ADDR_NAME, OPTION_MODULE_NAME, OPTION_TYPE_NAME) =>
+            if n.is(&STD_ADDR_VALUE, OPTION_MODULE_NAME, OPTION_TYPE_NAME) =>
         {
             debug_assert!(targs.len() == 1);
             is_entry_primitive_ty(&targs[0])
@@ -952,12 +958,12 @@ fn exp(context: &mut Context, e: &T::Exp) {
                 );
                 context.add_diag(diag)
             }
-            if module.value.is(SUI_ADDR_NAME, EVENT_MODULE_NAME)
+            if module.value.is(&SUI_ADDR_VALUE, EVENT_MODULE_NAME)
                 && name.value() == EVENT_FUNCTION_NAME
             {
                 check_event_emit(context, e.exp.loc, mcall)
             }
-            let is_transfer_module = module.value.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME);
+            let is_transfer_module = module.value.is(&SUI_ADDR_VALUE, TRANSFER_MODULE_NAME);
             if is_transfer_module && PRIVATE_TRANSFER_FUNCTIONS.contains(&name.value()) {
                 check_private_transfer(context, e.exp.loc, mcall)
             }
@@ -984,11 +990,11 @@ fn exp(context: &mut Context, e: &T::Exp) {
 fn otw_special_cases(context: &Context) -> bool {
     BRIDGE_SUPPORTED_ASSET
         .iter()
-        .any(|token| context.current_module().value.is(BRIDGE_ADDR_NAME, token))
+        .any(|token| context.current_module().value.is(&BRIDGE_ADDR_VALUE, token))
         || context
             .current_module()
             .value
-            .is(SUI_ADDR_NAME, SUI_MODULE_NAME)
+            .is(&SUI_ADDR_VALUE, SUI_MODULE_NAME)
 }
 
 fn check_event_emit(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
@@ -1032,7 +1038,7 @@ fn check_private_transfer(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
     let current_module = context.current_module();
     if current_module
         .value
-        .is(SUI_ADDR_NAME, TRANSFER_FUNCTION_NAME)
+        .is(&SUI_ADDR_VALUE, TRANSFER_FUNCTION_NAME)
     {
         // inside the transfer module, so no private transfer rules
         return;

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -783,7 +783,7 @@ fn is_entry_primitive_ty(param_ty: &Type) -> bool {
         Type_::Apply(_, sp!(_, n), targs)
             if n.is(&STD_ADDR_VALUE, ASCII_MODULE_NAME, ASCII_TYPE_NAME)
                 || n.is(&STD_ADDR_VALUE, UTF_MODULE_NAME, UTF_TYPE_NAME)
-                || n.is(&STD_ADDR_VALUE, OBJECT_MODULE_NAME, ID_TYPE_NAME) =>
+                || n.is(&SUI_ADDR_VALUE, OBJECT_MODULE_NAME, ID_TYPE_NAME) =>
         {
             debug_assert!(targs.is_empty());
             true

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     shared::{ast_debug::*, program_info::TypingProgramInfo, unique_map::UniqueMap, Name},
 };
+use move_core_types::parsing::address::NumericalAddress;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{
@@ -362,12 +363,15 @@ pub fn pat(ty: Type, pat: UnannotatedPat) -> MatchPattern {
 }
 
 impl ModuleCall {
-    pub fn is(
+    pub fn is<Addr>(
         &self,
-        address: impl AsRef<str>,
+        address: &Addr,
         module: impl AsRef<str>,
         function: impl AsRef<str>,
-    ) -> bool {
+    ) -> bool
+    where
+        NumericalAddress: PartialEq<Addr>,
+    {
         let Self {
             module: sp!(_, mident),
             name: f,

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
@@ -9,12 +9,12 @@ error[Sui E02007]: invalid object declaration
   │         Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 
 error[Sui E02007]: invalid object declaration
-   ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move:13:9
+   ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move:12:9
    │
-12 │     struct S has key {
+11 │     struct S has key {
    │                  --- The 'key' ability is used to declare objects in Sui
-13 │         id: UID
-   │         ^^  --- But found type: '0x2::object::UID'
+12 │         id: UID
+   │         ^^  --- But found type: '0x3::object::UID'
    │         │    
    │         Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move
@@ -6,8 +6,7 @@ module a::object {
     }
 }
 
-// TODO we might want to support this
-module 0x2::object {
+module 0x3::object {
     struct UID has store { flag: bool }
     struct S has key {
         id: UID

--- a/external-crates/move/crates/move-core-types/src/account_address.rs
+++ b/external-crates/move/crates/move-core-types/src/account_address.rs
@@ -32,6 +32,14 @@ impl AccountAddress {
     /// Hex address: 0x2
     pub const TWO: Self = Self::get_hex_address_two();
 
+    pub const fn from_suffix(suffix: u16) -> AccountAddress {
+        let mut addr = [0u8; AccountAddress::LENGTH];
+        let [hi, lo] = suffix.to_be_bytes();
+        addr[AccountAddress::LENGTH - 2] = hi;
+        addr[AccountAddress::LENGTH - 1] = lo;
+        AccountAddress::new(addr)
+    }
+
     const fn get_hex_address_one() -> Self {
         let mut addr = [0u8; AccountAddress::LENGTH];
         addr[AccountAddress::LENGTH - 1] = 1u8;

--- a/external-crates/move/crates/move-core-types/src/parsing/address.rs
+++ b/external-crates/move/crates/move-core-types/src/parsing/address.rs
@@ -176,6 +176,16 @@ impl PartialEq for NumericalAddress {
 }
 impl Eq for NumericalAddress {}
 
+impl PartialEq<AccountAddress> for NumericalAddress {
+    fn eq(&self, other: &AccountAddress) -> bool {
+        let Self {
+            bytes: self_bytes,
+            format: _,
+        } = self;
+        self_bytes == other
+    }
+}
+
 impl Hash for NumericalAddress {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let Self {


### PR DESCRIPTION
## Description 

- Sui mode used only named addresses for type comparison. This is not sufficient for interface files that might be using only the numerical address.
- Switched `is` to use only the numerical address. We might want to evaluate differently if we start using it more outside of Sui mode

## Test plan 

- Ran tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
