### PR TITLE
Add version 69 and move consensus voting round flag to 69

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1293,7 +1293,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "68",
+              "maxSupportedProtocolVersion": "69",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -18,7 +18,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 68;
+const MAX_PROTOCOL_VERSION: u64 = 69;
 
 // Record history of protocol version allocations here:
 //
@@ -195,6 +195,7 @@ const MAX_PROTOCOL_VERSION: u64 = 68;
 //             Enable gas based congestion control with overage.
 //             Further reduce minimum number of random beacon shares.
 //             Disallow adding new modules in `deps-only` packages.
+// Version 69: Sets number of rounds allowed for fastpath voting in consensus.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2939,7 +2940,8 @@ impl ProtocolConfig {
                     cfg.random_beacon_reduction_lower_bound = Some(500);
 
                     cfg.feature_flags.disallow_new_modules_in_deps_only_packages = true;
-
+                }
+                69 => {
                     // Sets number of rounds allowed for fastpath voting in consensus.
                     cfg.consensus_voting_rounds = Some(40);
                 }

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_68.snap
@@ -336,3 +336,4 @@ max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_69.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_69.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
+assertion_line: 3238
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 68
+version: 69
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -325,6 +326,7 @@ random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615
@@ -336,3 +338,4 @@ max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_68.snap
@@ -336,3 +336,4 @@ max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_68.snap
@@ -325,7 +325,6 @@ random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
-consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_69.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_69.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 68
+version: 69
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -325,6 +325,7 @@ random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615
@@ -336,3 +337,4 @@ max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_68.snap
@@ -336,7 +336,6 @@ random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
-consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_68.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_68.snap
@@ -347,3 +347,4 @@ max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_69.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_69.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 68
+version: 69
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -42,8 +42,10 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
+  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalGasBudgetWithCap
   consensus_choice: Mysticeti
@@ -53,17 +55,22 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
   validate_identifier_inputs: true
+  mysticeti_fastpath: true
   relocate_event_module: true
+  uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -244,6 +251,8 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 52
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 10
 group_ops_bls12381_decode_scalar_cost: 52
 group_ops_bls12381_decode_g1_cost: 52
 group_ops_bls12381_decode_g2_cost: 52
@@ -284,6 +293,8 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
 bcs_per_byte_serialized_cost: 2
 bcs_legacy_min_output_size_cost: 1
 bcs_failure_cost: 52
@@ -325,6 +336,7 @@ random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615
@@ -336,3 +348,4 @@ max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 68
+  protocol_version: 69
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 68
+protocol_version: 69
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x2f1c192f30b36b0d0a47520ff814ace58ce8a73580c9bf86c0fc729781351bcc"
+            id: "0x0ab85bf1aef18aad179ca34f4d95e34dd60dd1b2bda18d558e7b0bfe14ba8b77"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x0e83ac0a1c9938e12a692c734f8f38dfe5858076b17611402d46afcd5887ba8e"
+      operation_cap_id: "0x2fd0e88948443e54727efb6d1756d8c39735a421dac7bb92be690abe205b5bfa"
       gas_price: 1000
       staking_pool:
-        id: "0x222477b804c11404854c3c14cf29a2840472651c91d8870e07ae852a98c0a2e3"
+        id: "0xdcc39ac807721ee62f3fe0a6c697cbd93389f79b1a6717a95ccd28dca27821c8"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xf532945be4e9eb7ef597867c6dee34dc1d89f55f711d084bc6aa01c7c99ea179"
+          id: "0xaa706539eb8876b6c6a9b335c8d0ab1275d0a08a8ad29a6e6da68891e59298e4"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x4b5abcdcefc7404834889f2890b2b626ab85c15a20b19130b56cbee9bbe2b0af"
+            id: "0x651bc7aee334c01c02043e8caa326beaf7cf3fee5f099dda61cd39a971b1a0e6"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xeb9ab0c31391cb533e672f2aa1a919f474a988620c5eac625dab9e28e15a7661"
+          id: "0x3e9b72b2ab6660a2fd11af8d5f44925fccdb0fd793ec425f6438a1b149f8e3ea"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x1e0beb565adb7f908bce1bb65d14b5da4c6e4e0ff281e91e4c79fd7a20947d35"
+      id: "0xd93aaac7fc3ff26d6f2336ad8f11c15f2e51a0623715fce08742faa1caabdc65"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xabce5d04c1673e4e317e5c0f78bc346c4960d25473e095c9fb668ac32f5e216d"
+    id: "0xffabe0c370cf34f726bb6132f97dbc7bf7f77c4b5322797f786cbc73b0c0d125"
     size: 1
   inactive_validators:
-    id: "0x9069998be467d392b0a8ce1f598a353c415729af75bb2ebafbe66d26114ad52f"
+    id: "0x3d3953f69d3dcb19cbaad3c5372084f72a9290916c5faf5f8f241cb5d5e6c94b"
     size: 0
   validator_candidates:
-    id: "0x68667de51bea6086d3fd60059841df6da32a6fd475ad52ad10597797ec6a3ca9"
+    id: "0x66528ea16da7d7286671c3f187a1e68e0acd4fc13ffe45a0e5de12d2e2a825ec"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xfc98b9ca99540332ff24894fd810f83a85e726542c2119bc1325d350b0399434"
+      id: "0x1dff1b20ab0c400d5e48019f10ded46bdb08927f2e22fa4ced77ee6829b3c618"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x16212fe3db87d96453a048041166f3f491c06f00c45a4efe181bf7708c292d3f"
+      id: "0x3730cc216e9af079f9f8955b07b50366ee726b2d95dd102c4420e0e5102ce558"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x3110ada5ccc4394928c0116629587c1ad110099430f19ea183d799689eb5a8df"
+      id: "0xdf3d8018bba72f99aee8cfcb7af644e0edbbd86cb02732cf4bd2f3bbc8b45a25"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x34587a89960874da16d01bb778a02f7603278b0da8ec9258668982948f9b9535"
+    id: "0xbb67e32883f2542fb09119328da10c216ae19f663b64f024a724ca8c508502fa"
   size: 0
 


### PR DESCRIPTION
Fix for testnet compatibility test 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Sets number of rounds allowed for fastpath voting in consensus
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
