### PR TITLE
[Consensus] soft bundle to be included in a block atomically

### DIFF
--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -77,41 +77,27 @@ impl TransactionConsumer {
     pub(crate) fn next(&mut self) -> (Vec<Transaction>, Box<dyn FnOnce(BlockRef)>) {
         let mut transactions = Vec::new();
         let mut acks = Vec::new();
-        let mut total_size: usize = 0;
+        let mut total_size = 0;
 
         // Handle one batch of incoming transactions from TransactionGuard.
-        // Returns the remaining txs as a new TransactionGuard, if the batch breaks any limit.
+        // The method will return `None` if all the transactions can be included in the block. Otherwise none of the transactions will be
+        // included in the block and the method will return the TransactionGuard.
         let mut handle_txs = |t: TransactionsGuard| -> Option<TransactionsGuard> {
-            let remaining_txs: Vec<_> = t
-                .transactions
-                .into_iter()
-                .filter_map(|tx| {
-                    if (total_size + tx.data().len()) as u64 > self.max_consumed_bytes_per_request
-                        || transactions.len() as u64 >= self.max_consumed_transactions_per_request
-                    {
-                        // Adding this tx would exceed the size limit or the number of txs limit, cache it for the next pull.
-                        Some(tx)
-                    } else {
-                        total_size += tx.data().len();
-                        transactions.push(tx);
-                        None
-                    }
-                })
-                .collect();
+            let transactions_size: u64 =
+                t.transactions.iter().map(|t| t.data().len()).sum::<usize>() as u64;
 
-            if remaining_txs.is_empty() {
-                // The batch has been fully consumed, register its ack.
-                // In case a batch gets split, ack shall only be sent when the last transaction is included in the block.
-                acks.push(t.included_in_block_ack);
-                None
-            } else {
-                // If we went over the any limit while processing the batch, return the remainings.
-                // It is the caller's responsibility to cache it for the next pull.
-                Some(TransactionsGuard {
-                    transactions: remaining_txs,
-                    included_in_block_ack: t.included_in_block_ack,
-                })
+            if total_size + transactions_size > self.max_consumed_bytes_per_request
+                || transactions.len() as u64 >= self.max_consumed_transactions_per_request
+            {
+                return Some(t);
             }
+
+            total_size += transactions_size;
+
+            // The transactions can be consumed, register its ack.
+            acks.push(t.included_in_block_ack);
+            transactions.extend(t.transactions);
+            None
         };
 
         if let Some(t) = self.pending_transactions.take() {
@@ -217,6 +203,8 @@ impl TransactionConsumer {
 pub struct TransactionClient {
     sender: Sender<TransactionsGuard>,
     max_transaction_size: u64,
+    max_transactions_in_block_bytes: u64,
+    max_transactions_in_block_size: u64,
 }
 
 #[derive(Debug, Error)]
@@ -226,6 +214,12 @@ pub enum ClientError {
 
     #[error("Transaction size ({0}B) is over limit ({1}B)")]
     OversizedTransaction(u64, u64),
+
+    #[error("Transaction bundle size ({0}B) is over limit ({1}B)")]
+    OversizedTransactionBundleBytes(u64, u64),
+
+    #[error("Transaction bundle size ({0}) is over limit ({1})")]
+    OversizedTransactionBundleSize(u64, u64),
 }
 
 impl TransactionClient {
@@ -236,6 +230,12 @@ impl TransactionClient {
             Self {
                 sender,
                 max_transaction_size: context.protocol_config.max_transaction_size_bytes(),
+                max_transactions_in_block_bytes: context
+                    .protocol_config
+                    .max_transactions_in_block_bytes(),
+                max_transactions_in_block_size: context
+                    .protocol_config
+                    .max_num_transactions_in_block(),
             },
             receiver,
         )
@@ -261,17 +261,37 @@ impl TransactionClient {
     /// a receiver to wait on until the transactions has been included in the next block to get proposed. The consumer should
     /// wait on it to consider as inclusion acknowledgement. If the receiver errors then consensus is shutting down and transaction
     /// has not been included to any block.
-    /// If multiple transactions are submitted, the receiver will be signalled when the last transaction is included in the block.
+    /// If multiple transactions are submitted, the method will attempt to bundle them together in a single block. If the total size of
+    /// the transactions exceeds `max_transactions_in_block_bytes`, no transaction will be submitted and an error will be returned instead.
+    /// Similar if transactions exceed `max_transactions_in_block_size` an error will be returned.
     pub(crate) async fn submit_no_wait(
         &self,
         transactions: Vec<Vec<u8>>,
     ) -> Result<oneshot::Receiver<(BlockRef, oneshot::Receiver<BlockStatus>)>, ClientError> {
         let (included_in_block_ack_send, included_in_block_ack_receive) = oneshot::channel();
+
+        let mut bundle_size = 0;
+
+        if transactions.len() as u64 > self.max_transactions_in_block_size {
+            return Err(ClientError::OversizedTransactionBundleSize(
+                transactions.len() as u64,
+                self.max_transactions_in_block_size,
+            ));
+        }
+
         for transaction in &transactions {
             if transaction.len() as u64 > self.max_transaction_size {
                 return Err(ClientError::OversizedTransaction(
                     transaction.len() as u64,
                     self.max_transaction_size,
+                ));
+            }
+            bundle_size += transaction.len() as u64;
+
+            if bundle_size > self.max_transactions_in_block_bytes {
+                return Err(ClientError::OversizedTransactionBundleBytes(
+                    bundle_size,
+                    self.max_transactions_in_block_bytes,
                 ));
             }
         }
@@ -583,8 +603,8 @@ mod tests {
     #[tokio::test]
     async fn submit_large_batch_and_ack() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_consensus_max_transaction_size_bytes_for_testing(100);
-            config.set_consensus_max_transactions_in_block_bytes_for_testing(100);
+            config.set_consensus_max_transaction_size_bytes_for_testing(15);
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(200);
             config
         });
 
@@ -599,13 +619,13 @@ mod tests {
             let w = client
                 .submit_no_wait(vec![transaction])
                 .await
-                .expect("Shouldn't submit successfully transaction");
+                .expect("Should submit successfully transaction");
             all_receivers.push(w);
         }
 
-        // construct a over-size-limit batch and submit, which should get broken into smaller ones.
+        // construct an acceptable batch and submit, it should be accepted
         {
-            let transactions: Vec<_> = (10..32)
+            let transactions: Vec<_> = (10..15)
                 .map(|i| {
                     bcs::to_bytes(&format!("transaction {i}"))
                         .expect("Serialization should not fail.")
@@ -614,13 +634,13 @@ mod tests {
             let w = client
                 .submit_no_wait(transactions)
                 .await
-                .expect("Shouldn't submit successfully transaction");
+                .expect("Should submit successfully transaction");
             all_receivers.push(w);
         }
 
         // submit another individual transaction.
         {
-            let i = 32;
+            let i = 15;
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
             let w = client
@@ -630,12 +650,34 @@ mod tests {
             all_receivers.push(w);
         }
 
+        // construct a over-size-limit batch and submit, it should not be accepted
+        {
+            let transactions: Vec<_> = (16..32)
+                .map(|i| {
+                    bcs::to_bytes(&format!("transaction {i}"))
+                        .expect("Serialization should not fail.")
+                })
+                .collect();
+            let result = client.submit_no_wait(transactions).await.unwrap_err();
+            assert_eq!(
+                result.to_string(),
+                "Transaction bundle size (210B) is over limit (200B)"
+            );
+        }
+
         // now pull the transactions from the consumer.
         // we expect all transactions are fetched in order, not missing any, and not exceeding the size limit.
-        let mut all_transactions = Vec::new();
         let mut all_acks: Vec<Box<dyn FnOnce(BlockRef)>> = Vec::new();
+        let mut batch_index = 0;
         while !consumer.is_empty() {
             let (transactions, ack_transactions) = consumer.next();
+
+            assert!(
+                transactions.len() as u64
+                    <= context.protocol_config.max_num_transactions_in_block(),
+                "Should have fetched transactions up to {}",
+                context.protocol_config.max_num_transactions_in_block()
+            );
 
             let total_size: u64 = transactions.iter().map(|t| t.data().len() as u64).sum();
             assert!(
@@ -644,15 +686,27 @@ mod tests {
                 context.protocol_config.max_transactions_in_block_bytes()
             );
 
-            all_transactions.extend(transactions);
-            all_acks.push(ack_transactions);
-        }
+            // first batch should contain all transactions from 0..10. The softbundle it is to big to fit as well, so it's parked.
+            if batch_index == 0 {
+                assert_eq!(transactions.len(), 10);
+                for (i, transaction) in transactions.iter().enumerate() {
+                    let t: String = bcs::from_bytes(transaction.data()).unwrap();
+                    assert_eq!(format!("transaction {}", i).to_string(), t);
+                }
+            // second batch will contain the soft bundle and the additional last transaction.
+            } else if batch_index == 1 {
+                assert_eq!(transactions.len(), 6);
+                for (i, transaction) in transactions.iter().enumerate() {
+                    let t: String = bcs::from_bytes(transaction.data()).unwrap();
+                    assert_eq!(format!("transaction {}", i + 10).to_string(), t);
+                }
+            } else {
+                panic!("Unexpected batch index");
+            }
 
-        // verify the number of transactions as well as the content.
-        assert_eq!(all_transactions.len(), 33);
-        for (i, t) in all_transactions.iter().enumerate() {
-            let t: String = bcs::from_bytes(t.data()).unwrap();
-            assert_eq!(format!("transaction {i}").to_string(), t);
+            batch_index += 1;
+
+            all_acks.push(ack_transactions);
         }
 
         // now acknowledge the inclusion of all transactions.

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -101,7 +101,9 @@ impl ConsensusClient for LazyMysticetiClient {
                     ClientError::ConsensusShuttingDown(_) => {
                         info!("{}", msg);
                     }
-                    ClientError::OversizedTransaction(_, _) => {
+                    ClientError::OversizedTransaction(_, _)
+                    | ClientError::OversizedTransactionBundleBytes(_, _)
+                    | ClientError::OversizedTransactionBundleSize(_, _) => {
                         if cfg!(debug_assertions) {
                             panic!("{}", msg);
                         } else {

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -103,7 +103,7 @@ impl ConsensusClient for LazyMysticetiClient {
                     }
                     ClientError::OversizedTransaction(_, _)
                     | ClientError::OversizedTransactionBundleBytes(_, _)
-                    | ClientError::OversizedTransactionBundleSize(_, _) => {
+                    | ClientError::OversizedTransactionBundleCount(_, _) => {
                         if cfg!(debug_assertions) {
                             panic!("{}", msg);
                         } else {


### PR DESCRIPTION
## Description 

Following the work of https://github.com/MystenLabs/sui/pull/19572 , this PR is ensuring that a soft bundle will atomically be included in a consensus block. That:
1. Strengthens the guarantees around the soft bundle sequencing to allow them processed in exact sequence and not break in multiple blocks.
2. allow us to simply retry transactions of GC'ed blocks as we just retry all the transactions of softbundle

Kept the solution simple for now and if a soft bundle doesn't fit to a block then it's cached and is added to the next block.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
