### PR TITLE
indexer-alt: reader watermark task

### DIFF
--- a/crates/sui-indexer-alt/migrations/2024-10-16-225607_watermarks/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-10-16-225607_watermarks/up.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS watermarks
     -- some data needs to be dropped. The pruner uses this column to determine
     -- whether to prune or wait long enough that all in-flight reads complete
     -- or timeout before it acts on an updated watermark.
-    pruner_timestamp_ms         BIGINT        NOT NULL,
+    pruner_timestamp            TIMESTAMP     NOT NULL,
     -- Column used by the pruner to track its true progress. Data below this
     -- watermark can be immediately pruned.
     pruner_hi                   BIGINT        NOT NULL

--- a/crates/sui-indexer-alt/src/args.rs
+++ b/crates/sui-indexer-alt/src/args.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use crate::db::DbConfig;
 use crate::IndexerConfig;
 use clap::Subcommand;
@@ -21,6 +23,16 @@ pub enum Command {
     Indexer {
         #[command(flatten)]
         indexer: IndexerConfig,
+
+        /// How often to check whether write-ahead logs related to the consistent range can be
+        /// pruned.
+        #[arg(
+            long,
+            default_value = "300",
+            value_name = "SECONDS",
+            value_parser = |s: &str| s.parse().map(Duration::from_secs),
+        )]
+        consistent_pruning_interval: Duration,
 
         /// Number of checkpoints to delay indexing summary tables for.
         #[clap(long)]

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -10,6 +10,7 @@ use sui_indexer_alt::handlers::kv_epoch_ends::KvEpochEnds;
 use sui_indexer_alt::handlers::kv_epoch_starts::KvEpochStarts;
 use sui_indexer_alt::handlers::kv_feature_flags::KvFeatureFlags;
 use sui_indexer_alt::handlers::kv_protocol_configs::KvProtocolConfigs;
+use sui_indexer_alt::pipeline::concurrent::PrunerConfig;
 use sui_indexer_alt::{
     args::Args,
     handlers::{
@@ -39,37 +40,63 @@ async fn main() -> Result<()> {
     match args.command {
         Command::Indexer {
             indexer,
+            consistent_pruning_interval,
             consistent_range: lag,
         } => {
             let retry_interval = indexer.ingestion_config.retry_interval;
             let mut indexer = Indexer::new(args.db_config, indexer, cancel.clone()).await?;
 
             let genesis = bootstrap(&indexer, retry_interval, cancel.clone()).await?;
-            let kv_feature_flags = KvFeatureFlags(genesis.clone());
-            let kv_protocol_configs = KvProtocolConfigs(genesis);
 
-            indexer.concurrent_pipeline(EvEmitMod).await?;
-            indexer.concurrent_pipeline(EvStructInst).await?;
-            indexer.concurrent_pipeline(KvCheckpoints).await?;
-            indexer.concurrent_pipeline(KvEpochEnds).await?;
-            indexer.concurrent_pipeline(KvEpochStarts).await?;
-            indexer.concurrent_pipeline(kv_feature_flags).await?;
-            indexer.concurrent_pipeline(KvObjects).await?;
-            indexer.concurrent_pipeline(kv_protocol_configs).await?;
-            indexer.concurrent_pipeline(KvTransactions).await?;
-            indexer.concurrent_pipeline(ObjVersions).await?;
-            indexer.concurrent_pipeline(TxAffectedAddress).await?;
-            indexer.concurrent_pipeline(TxAffectedObjects).await?;
-            indexer.concurrent_pipeline(TxBalanceChanges).await?;
-            indexer.concurrent_pipeline(TxCalls).await?;
-            indexer.concurrent_pipeline(TxDigests).await?;
-            indexer.concurrent_pipeline(TxKinds).await?;
-            indexer.concurrent_pipeline(WalCoinBalances).await?;
-            indexer.concurrent_pipeline(WalObjTypes).await?;
+            // Pipelines that rely on genesis information
+            indexer
+                .concurrent_pipeline(KvFeatureFlags(genesis.clone()), None)
+                .await?;
+
+            indexer
+                .concurrent_pipeline(KvProtocolConfigs(genesis.clone()), None)
+                .await?;
+
+            // Pipelines that are split up into a summary table, and a write-ahead log, where the
+            // write-ahead log needs to be pruned.
+            let pruner_config = lag.map(|l| PrunerConfig {
+                interval: consistent_pruning_interval,
+                // Retain at least twice as much data as the lag, to guarantee overlap between the
+                // summary table and the write-ahead log.
+                retention: l * 2,
+                // Prune roughly five minutes of data in one go.
+                max_chunk_size: 5 * 300,
+            });
+
             indexer.sequential_pipeline(SumCoinBalances, lag).await?;
-            indexer.sequential_pipeline(SumDisplays, None).await?;
+            indexer
+                .concurrent_pipeline(WalCoinBalances, pruner_config.clone())
+                .await?;
+
             indexer.sequential_pipeline(SumObjTypes, lag).await?;
+            indexer
+                .concurrent_pipeline(WalObjTypes, pruner_config)
+                .await?;
+
+            // Other summary tables (without write-ahead log)
+            indexer.sequential_pipeline(SumDisplays, None).await?;
             indexer.sequential_pipeline(SumPackages, None).await?;
+
+            // Unpruned concurrent pipelines
+            indexer.concurrent_pipeline(EvEmitMod, None).await?;
+            indexer.concurrent_pipeline(EvStructInst, None).await?;
+            indexer.concurrent_pipeline(KvCheckpoints, None).await?;
+            indexer.concurrent_pipeline(KvEpochEnds, None).await?;
+            indexer.concurrent_pipeline(KvEpochStarts, None).await?;
+            indexer.concurrent_pipeline(KvObjects, None).await?;
+            indexer.concurrent_pipeline(KvTransactions, None).await?;
+            indexer.concurrent_pipeline(ObjVersions, None).await?;
+            indexer.concurrent_pipeline(TxAffectedAddress, None).await?;
+            indexer.concurrent_pipeline(TxAffectedObjects, None).await?;
+            indexer.concurrent_pipeline(TxBalanceChanges, None).await?;
+            indexer.concurrent_pipeline(TxCalls, None).await?;
+            indexer.concurrent_pipeline(TxDigests, None).await?;
+            indexer.concurrent_pipeline(TxKinds, None).await?;
 
             let h_indexer = indexer.run().await.context("Failed to start indexer")?;
 

--- a/crates/sui-indexer-alt/src/metrics.rs
+++ b/crates/sui-indexer-alt/src/metrics.rs
@@ -100,11 +100,13 @@ pub struct IndexerMetrics {
     pub watermark_checkpoint: IntGaugeVec,
     pub watermark_transaction: IntGaugeVec,
     pub watermark_timestamp_ms: IntGaugeVec,
+    pub watermark_reader_lo: IntGaugeVec,
 
     pub watermark_epoch_in_db: IntGaugeVec,
     pub watermark_checkpoint_in_db: IntGaugeVec,
     pub watermark_transaction_in_db: IntGaugeVec,
     pub watermark_timestamp_in_db_ms: IntGaugeVec,
+    pub watermark_reader_lo_in_db: IntGaugeVec,
 }
 
 /// Collects information about the database connection pool.
@@ -385,6 +387,13 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            watermark_reader_lo: register_int_gauge_vec_with_registry!(
+                "indexer_watermark_reader_lo",
+                "Current reader low watermark for this pruner",
+                &["pipeline"],
+                registry,
+            )
+            .unwrap(),
             watermark_epoch_in_db: register_int_gauge_vec_with_registry!(
                 "indexer_watermark_epoch_in_db",
                 "Last epoch high watermark this committer wrote to the DB",
@@ -409,6 +418,13 @@ impl IndexerMetrics {
             watermark_timestamp_in_db_ms: register_int_gauge_vec_with_registry!(
                 "indexer_watermark_timestamp_ms_in_db",
                 "Last timestamp high watermark this committer wrote to the DB, in milliseconds",
+                &["pipeline"],
+                registry,
+            )
+            .unwrap(),
+            watermark_reader_lo_in_db: register_int_gauge_vec_with_registry!(
+                "indexer_watermark_reader_lo_in_db",
+                "Last reader low watermark this pruner wrote to the DB",
                 &["pipeline"],
                 registry,
             )

--- a/crates/sui-indexer-alt/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt/src/models/watermarks.rs
@@ -3,7 +3,7 @@
 
 use std::borrow::Cow;
 
-use chrono::{DateTime, Utc};
+use chrono::{naive::NaiveDateTime, DateTime, Utc};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use sui_field_count::FieldCount;
@@ -20,7 +20,7 @@ pub struct StoredWatermark {
     pub timestamp_ms_hi_inclusive: i64,
     pub epoch_lo: i64,
     pub reader_lo: i64,
-    pub pruner_timestamp_ms: i64,
+    pub pruner_timestamp: NaiveDateTime,
     pub pruner_hi: i64,
 }
 
@@ -95,7 +95,7 @@ impl<'p> From<CommitterWatermark<'p>> for StoredWatermark {
             timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive,
             epoch_lo: 0,
             reader_lo: 0,
-            pruner_timestamp_ms: 0,
+            pruner_timestamp: NaiveDateTime::UNIX_EPOCH,
             pruner_hi: 0,
         }
     }

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/reader_watermark.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use mysten_metrics::spawn_monitored_task;
+use tokio::{task::JoinHandle, time::interval};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    db::Db,
+    metrics::IndexerMetrics,
+    models::watermarks::{ReaderWatermark, StoredWatermark},
+};
+
+use super::{Handler, PrunerConfig};
+
+/// The reader watermark task is responsible for updating the `reader_lo` and `pruner_timestamp`
+/// values for a pipeline's row in the watermark table, based on the pruner configuration, and the
+/// committer's progress.
+///
+/// `reader_lo` is the lowest checkpoint that readers are allowed to read from with a guarantee of
+/// data availability for this pipeline, and `pruner_timestamp` is the timestamp at which this task
+/// last updated that watermark. The timestamp is always fetched from the database (not from the
+/// indexer or the reader), to avoid issues with drift between clocks.
+///
+/// If there is no pruner configuration, this task will immediately exit. Otherwise, the task exits
+/// when the provided cancellation token is triggered.
+pub(super) fn reader_watermark<H: Handler + 'static>(
+    config: Option<PrunerConfig>,
+    db: Db,
+    metrics: Arc<IndexerMetrics>,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    spawn_monitored_task!(async move {
+        let Some(config) = config else {
+            info!(pipeline = H::NAME, "Skipping reader watermark task");
+            return;
+        };
+
+        let mut poll = interval(config.interval);
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!(pipeline = H::NAME, "Shutdown received");
+                    break;
+                }
+
+                _ = poll.tick() => {
+                    let Ok(mut conn) = db.connect().await else {
+                        warn!(pipeline = H::NAME, "Reader watermark task failed to get connection for DB");
+                        continue;
+                    };
+
+                    let current = match StoredWatermark::get(&mut conn, H::NAME).await {
+                        Ok(Some(current)) => current,
+
+                        Ok(None) => {
+                            warn!(pipeline = H::NAME, "No watermark for pipeline, skipping");
+                            continue;
+                        }
+
+                        Err(e) => {
+                            warn!(pipeline = H::NAME, "Failed to get current watermark: {e}");
+                            continue;
+                        }
+                    };
+
+                    // Calculate the new reader watermark based on the current high watermark.
+                    let new_reader_lo = (current.checkpoint_hi_inclusive as u64 + 1)
+                        .saturating_sub(config.retention);
+
+                    if new_reader_lo <= current.reader_lo as u64 {
+                        debug!(
+                            pipeline = H::NAME,
+                            current = current.reader_lo,
+                            new = new_reader_lo,
+                            "No change to reader watermark",
+                        );
+                        continue;
+                    }
+
+                    metrics
+                        .watermark_reader_lo
+                        .with_label_values(&[H::NAME])
+                        .set(new_reader_lo as i64);
+
+                    let Ok(updated) = ReaderWatermark::new(H::NAME, new_reader_lo).update(&mut conn).await else {
+                        warn!(pipeline = H::NAME, "Failed to update reader watermark");
+                        continue;
+                    };
+
+                    if updated {
+                        info!(pipeline = H::NAME, new_reader_lo, "Watermark");
+
+                        metrics
+                            .watermark_reader_lo_in_db
+                            .with_label_values(&[H::NAME])
+                            .set(new_reader_lo as i64);
+                    }
+                }
+            }
+        }
+
+        info!(pipeline = H::NAME, "Stopping reader watermark task");
+    })
+}

--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -7,7 +7,7 @@ use crate::models::watermarks::CommitterWatermark;
 
 pub use processor::Processor;
 
-pub(crate) mod concurrent;
+pub mod concurrent;
 mod processor;
 pub(crate) mod sequential;
 

--- a/crates/sui-indexer-alt/src/schema.rs
+++ b/crates/sui-indexer-alt/src/schema.rs
@@ -235,7 +235,7 @@ diesel::table! {
         timestamp_ms_hi_inclusive -> Int8,
         epoch_lo -> Int8,
         reader_lo -> Int8,
-        pruner_timestamp_ms -> Int8,
+        pruner_timestamp -> Timestamp,
         pruner_hi -> Int8,
     }
 }


### PR DESCRIPTION
## Description

The reader watermark task is one half of the pruning implementation. It applies only to concurrent pipelines, and tracks the lowest checkpoint sequence number the reader is guaranteed to get data for, and the timestamp (from the DB), that this threshold was set at.

This task does not do any actual pruning, but it sets the limit that the pruner can go to, and a time at which it can start pruning to that point. A later PR will introduce the actual pruning task.

Unlike the existing pruner implementation, this system does not support pruning by epoch, only by checkpoint. This was for two reasons:

- Pruning no longer works by dropping partitions, so we can keep the implementation simple by only supporting the form of pruning we need (by checkpoint sequence number).
- Pruning is part of the indexing framework, rather than a specific part of our indexer implementation, so pruning by epoch would require that the indexing framework kept track of a mapping from epoch to checkpoint sequence number.

Along with the reader watermark, the following changes were made:

- The existing watermark task was renamed to the `committer_watermark` to distinguish it.
- The interface between pipelines and the indexing framework has been simplified to return just one `JoinHandle`. This was because clippy complained that returning 6 handles was too complex, and additionally, because the reader watermark task is not connected to the rest of the tasks for a pipeline, it needs a more complicated tear down logic, where firstly the committer tasks are wound down, and then the pruner is explicitly cancelled, before its tasks are awaited as well.
- (In its own commit) `watermarks.pruner_timestamp_ms: BIGINT` was turned into `watermarks.pruner_timestamp: TIMESTAMP` because we always read/write it from the database's `NOW(): TIMESTAMP` function.

The change also sets up pruning configs for write-ahead log tables, so that we can test reader watermark behaviour.

## Test plan

Run the indexer with just one of the consistent read summary and write-ahead logs, and then query the watermarks table:

```
cargo run -p sui-indexer-alt --release --                                        \
  --database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_alt" \
  indexer --remote-store-url https://checkpoints.mainnet.sui.io/                 \
  --last-checkpoint 10000                                                        \
  --consistent-range 100 --consistent-pruning-interval 10                        \
  --pipeline sum_obj_types --pipeline wal_obj_types
```

```
sui_indexer_alt=# SELECT * FROM watermarks;
   pipeline    | epoch_hi_inclusive | checkpoint_hi_inclusive | tx_hi | timestamp_ms_hi_inclusive | epoch_lo | reader_lo |      pruner_timestamp      | pruner_hi
---------------+--------------------+-------------------------+-------+---------------------------+----------+-----------+----------------------------+-----------
 sum_obj_types |                  1 |                    9900 |  9902 |             1681405380769 |        0 |         0 | 1970-01-01 00:00:00        |         0
 wal_obj_types |                  1 |                   10000 | 10002 |             1681405504878 |        0 |      6321 | 2024-11-10 17:33:11.459593 |         0
(2 rows)
```

Note that `reader_lo` is not guaranteed to be as advanced as it could be, because this task checks in relatively infrequently, and the indexer as a whole might shut down efore it has a chance to catch up. However, on restart, the indexer should fast-forward the watermark (i.e. if the steps above are repeated, `reader_lo` will be updated):

```
sui_indexer_alt=# SELECT * FROM watermarks;
   pipeline    | epoch_hi_inclusive | checkpoint_hi_inclusive | tx_hi | timestamp_ms_hi_inclusive | epoch_lo | reader_lo |      pruner_timestamp      | pruner_hi
---------------+--------------------+-------------------------+-------+---------------------------+----------+-----------+----------------------------+-----------
 sum_obj_types |                  1 |                    9900 |  9902 |             1681405380769 |        0 |         0 | 1970-01-01 00:00:00        |         0
 wal_obj_types |                  1 |                   10000 | 10002 |             1681405504878 |        0 |      9801 | 2024-11-10 17:33:49.913129 |         0
(2 rows)
```

## Stack

- #20149 
- #20150 
- #20166

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
