### PR TITLE
[cargo-deny] fix security advisor errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5133,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -5150,9 +5150,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -5181,9 +5181,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.87",
  "quote 1.0.35",
@@ -5192,15 +5192,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -5214,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -9202,22 +9202,6 @@ dependencies = [
  "prost 0.13.3",
  "serde",
  "tonic 0.12.3",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
 ]
 
 [[package]]
@@ -15974,7 +15958,6 @@ dependencies = [
  "opentelemetry 0.25.0",
  "opentelemetry-otlp",
  "opentelemetry-proto",
- "opentelemetry_api",
  "opentelemetry_sdk",
  "prometheus",
  "prost 0.13.3",

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -18,7 +18,6 @@ tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 opentelemetry = { version = "0.25.0", optional = true }
-opentelemetry_api = { version = "0.20.0", optional = true }
 opentelemetry_sdk = { version = "0.25.0", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.25.0", features = ["grpc-tonic"], optional = true }
 tracing-opentelemetry = { version = "0.26.0", optional = true }
@@ -42,7 +41,6 @@ otlp = [
   "opentelemetry",
   "opentelemetry-otlp",
   "opentelemetry-proto",
-  "opentelemetry_api",
   "opentelemetry_sdk"
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,10 @@ ignore = [
 
     # Temporarily allow until arrow family of crates updates `lexical-core` to 1.0
     "RUSTSEC-2023-0086",
+    # allow derivative being unmaintained
+    "RUSTSEC-2024-0388",
+    # allow instant being unmaintained
+    "RUSTSEC-2024-0384",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## Description 

Running the following command from root folder:

```
cargo deny check --config deny.toml
```

gives some errors:

```
error[unmaintained]: `derivative` is unmaintained; consider using an alternative
    ┌─ /home/runner/work/sui/sui/Cargo.lock:298:1
    │
298 │ derivative 2.2.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0388
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0388
    ├ The [`derivative`](https://crates.io/crates/derivative) crate is no longer maintained.

.......................

error[unmaintained]: `instant` is unmaintained
    ┌─ /home/runner/work/sui/sui/Cargo.lock:512:1
    │
512 │ instant 0.1.12 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0384
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0384
    ├ This crate is no longer maintained, and the author recommends using the maintained [`web-time`] crate instead.
      
      [`web-time`]: https://crates.io/crates/web-time
    ├ Solution: No safe upgrade is available!
    ├ instant v0.1.12
      ├── backoff v0.4.0


..........................

error[unmaintained]: `opentelemetry_api` has been merged into the `opentelemetry` crate
    ┌─ /home/runner/work/sui/sui/Cargo.lock:734:1
    │
734 │ opentelemetry_api 0.20.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0387
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0387
    ├ Last release was on 2023-07-30.
      `opentelemetry_api` has been moved into the [`opentelemetry` crate](https://crates.io/crates/opentelemetry).
      
      Please use the `opentelemetry` crate going forward.
    ├ Announcement: https://github.com/open-telemetry/opentelemetry-rust/pull/1226
    ├ Solution: No safe upgrade is available!
    ├ opentelemetry_api v0.20.0


.........................

warning[yanked]: detected yanked crate (try `cargo update -p futures-util`)
    ┌─ /home/runner/work/sui/sui/Cargo.lock:426:1
    │
426 │ futures-util 0.3.30 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
    │
    ├ futures-util v0.3.30

```

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
