### PR TITLE
edition is changed for 2024.alpha

### DIFF
--- a/crates/sui-framework/packages/sui-framework/Move.toml
+++ b/crates/sui-framework/packages/sui-framework/Move.toml
@@ -2,7 +2,7 @@
 name = "Sui"
 version = "0.0.1"
 published-at = "0x2"
-edition = "2024.beta"
+edition = "2024.alpha"
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }


### PR DESCRIPTION
This PR includes only edition changes. Our development is not working in the old edition. Also, you have published your blog "You can change 2024.beta edition with 2024.alpha or old version"