### PR TITLE
[json-rpc] Add enums in `getNormalizedMoveModule`

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -5,8 +5,8 @@ use colored::Colorize;
 use itertools::Itertools;
 use move_binary_format::file_format::{Ability, AbilitySet, DatatypeTyParameter, Visibility};
 use move_binary_format::normalized::{
-    Field as NormalizedField, Function as SuiNormalizedFunction, Module as NormalizedModule,
-    Struct as NormalizedStruct, Type as NormalizedType,
+    Enum as NormalizedEnum, Field as NormalizedField, Function as SuiNormalizedFunction,
+    Module as NormalizedModule, Struct as NormalizedStruct, Type as NormalizedType,
 };
 use move_core_types::annotated_value::{MoveStruct, MoveValue, MoveVariant};
 use move_core_types::identifier::Identifier;
@@ -73,6 +73,14 @@ pub struct SuiMoveNormalizedStruct {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiMoveNormalizedEnum {
+    pub abilities: SuiMoveAbilitySet,
+    pub type_parameters: Vec<SuiMoveStructTypeParameter>,
+    pub variants: BTreeMap<String, Vec<SuiMoveNormalizedField>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub enum SuiMoveNormalizedType {
     Bool,
     U8,
@@ -120,6 +128,7 @@ pub struct SuiMoveNormalizedModule {
     pub name: String,
     pub friends: Vec<SuiMoveModuleId>,
     pub structs: BTreeMap<String, SuiMoveNormalizedStruct>,
+    pub enums: BTreeMap<String, SuiMoveNormalizedEnum>,
     pub exposed_functions: BTreeMap<String, SuiMoveNormalizedFunction>,
 }
 
@@ -150,6 +159,11 @@ impl From<NormalizedModule> for SuiMoveNormalizedModule {
                 .into_iter()
                 .map(|(name, struct_)| (name.to_string(), SuiMoveNormalizedStruct::from(struct_)))
                 .collect::<BTreeMap<String, SuiMoveNormalizedStruct>>(),
+            enums: module
+                .enums
+                .into_iter()
+                .map(|(name, enum_)| (name.to_string(), SuiMoveNormalizedEnum::from(enum_)))
+                .collect(),
             exposed_functions: module
                 .functions
                 .into_iter()
@@ -205,6 +219,33 @@ impl From<NormalizedStruct> for SuiMoveNormalizedStruct {
                 .into_iter()
                 .map(SuiMoveNormalizedField::from)
                 .collect::<Vec<SuiMoveNormalizedField>>(),
+        }
+    }
+}
+
+impl From<NormalizedEnum> for SuiMoveNormalizedEnum {
+    fn from(value: NormalizedEnum) -> Self {
+        Self {
+            abilities: value.abilities.into(),
+            type_parameters: value
+                .type_parameters
+                .into_iter()
+                .map(SuiMoveStructTypeParameter::from)
+                .collect::<Vec<SuiMoveStructTypeParameter>>(),
+            variants: value
+                .variants
+                .into_iter()
+                .map(|variant| {
+                    (
+                        variant.name.to_string(),
+                        variant
+                            .fields
+                            .into_iter()
+                            .map(SuiMoveNormalizedField::from)
+                            .collect::<Vec<SuiMoveNormalizedField>>(),
+                    )
+                })
+                .collect::<BTreeMap<String, Vec<SuiMoveNormalizedField>>>(),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -128,6 +128,7 @@ pub struct SuiMoveNormalizedModule {
     pub name: String,
     pub friends: Vec<SuiMoveModuleId>,
     pub structs: BTreeMap<String, SuiMoveNormalizedStruct>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub enums: BTreeMap<String, SuiMoveNormalizedEnum>,
     pub exposed_functions: BTreeMap<String, SuiMoveNormalizedFunction>,
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -8736,6 +8736,34 @@
           }
         }
       },
+      "SuiMoveNormalizedEnum": {
+        "type": "object",
+        "required": [
+          "abilities",
+          "typeParameters",
+          "variants"
+        ],
+        "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/SuiMoveAbilitySet"
+          },
+          "typeParameters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuiMoveStructTypeParameter"
+            }
+          },
+          "variants": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SuiMoveNormalizedField"
+              }
+            }
+          }
+        }
+      },
       "SuiMoveNormalizedField": {
         "type": "object",
         "required": [
@@ -8800,6 +8828,12 @@
         "properties": {
           "address": {
             "type": "string"
+          },
+          "enums": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SuiMoveNormalizedEnum"
+            }
           },
           "exposedFunctions": {
             "type": "object",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -1054,6 +1054,7 @@ impl RpcExampleProvider {
             friends: vec![],
             name: "module".to_string(),
             structs: BTreeMap::new(),
+            enums: BTreeMap::new(),
         };
 
         Examples::new(
@@ -1077,6 +1078,7 @@ impl RpcExampleProvider {
             friends: vec![],
             name: "module".to_string(),
             structs: BTreeMap::new(),
+            enums: BTreeMap::new(),
         };
 
         Examples::new(


### PR DESCRIPTION
## Description 

Adds enums to the `NormalizedMoveModule` for json-rpc.

This fixes #20205 

## Test plan 

Tested manually on the repro provided in the issue to make sure enums are included in the output. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [x] JSON-RPC: Fixes an issue where enum types were not included in the output of `getNormalizedMoveModule` and `getNormalizedMoveModuleForPackage`
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
