### PR TITLE
[move] Add Move 2024 (non-beta) edition and make it the default edition

### DIFF
--- a/crates/sui-core/src/unit_tests/move_package_management_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_management_tests.rs
@@ -56,7 +56,7 @@ async fn test_manage_package_update() {
 
         [move.toolchain-version]
         compiler-version = "0.0.1"
-        edition = "2024.beta"
+        edition = "2024"
         flavor = "sui"
 
         [env]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
@@ -2,4 +2,4 @@ Command `build`:
 Error: Error parsing '[package]' section of manifest
 
 Caused by:
-    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"
+    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_multiline/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_multiline/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_multiline/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_multiline/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "migration"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.beta
+1) 2024
 2) legacy
 
 Selection (default=1): 

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -96,11 +96,19 @@ pub fn feature_edition_error_msg(edition: Edition, feature: FeatureGate) -> Opti
                     feature.error_prefix()
                 )
             } else {
-                format!(
-                    "{} not supported by current edition '{edition}', \
-                    only {} support this feature",
-                    feature.error_prefix(),
-                    format_oxford_list!("and", "'{}'", valid_editions)
+                valid_editions.last().map_or(
+                    format!(
+                        "{} not supported by current edition '{edition}', \
+                        no other editions support this feature",
+                        feature.error_prefix()
+                    ),
+                    |supporting_edition| {
+                        format!(
+                            "{} not supported by current edition '{edition}', \
+                             the '{supporting_edition}' edition supports this feature",
+                            feature.error_prefix(),
+                        )
+                    },
                 )
             };
         Some(message)
@@ -136,7 +144,13 @@ static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
 
 const E2024_ALPHA_FEATURES: &[FeatureGate] = &[];
 
-const E2024_BETA_FEATURES: &[FeatureGate] = &[
+const E2024_BETA_FEATURES: &[FeatureGate] = &[];
+
+const DEVELOPMENT_FEATURES: &[FeatureGate] = &[];
+
+const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
+
+const E2024_FEATURES: &[FeatureGate] = &[
     FeatureGate::NestedUse,
     FeatureGate::PublicPackage,
     FeatureGate::PostFixAbilities,
@@ -159,10 +173,6 @@ const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::Enums,
 ];
 
-const DEVELOPMENT_FEATURES: &[FeatureGate] = &[];
-
-const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
-
 impl Edition {
     pub const LEGACY: Self = Self {
         edition: symbol!("legacy"),
@@ -184,6 +194,10 @@ impl Edition {
         edition: symbol!("development"),
         release: None,
     };
+    pub const E2024: Self = Self {
+        edition: symbol!("2024"),
+        release: None,
+    };
 
     const SEP: &'static str = ".";
 
@@ -193,8 +207,16 @@ impl Edition {
         Self::E2024_BETA,
         Self::E2024_MIGRATION,
         Self::DEVELOPMENT,
+        Self::E2024,
     ];
-    pub const VALID: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_BETA];
+    // NB: This is the list of editions that are considered "valid" for the purposes of the Move.
+    // This list should be kept in order from oldest edition to newest.
+    pub const VALID: &'static [Self] = &[
+        Self::LEGACY,
+        Self::E2024_ALPHA,
+        Self::E2024_BETA,
+        Self::E2024,
+    ];
 
     pub fn supports(&self, feature: FeatureGate) -> bool {
         SUPPORTED_FEATURES.get(self).unwrap().contains(&feature)
@@ -205,8 +227,9 @@ impl Edition {
         match *self {
             Self::LEGACY => None,
             Self::E2024_ALPHA => Some(Self::E2024_BETA),
-            Self::E2024_BETA => Some(Self::LEGACY),
-            Self::E2024_MIGRATION => Some(Self::E2024_BETA),
+            Self::E2024_BETA => Some(Self::E2024),
+            Self::E2024 => Some(Self::LEGACY),
+            Self::E2024_MIGRATION => Some(Self::E2024),
             Self::DEVELOPMENT => Some(Self::E2024_ALPHA),
             _ => self.unknown_edition_panic(),
         }
@@ -225,6 +248,11 @@ impl Edition {
             Self::E2024_BETA => {
                 let mut features = self.prev().unwrap().features();
                 features.extend(E2024_BETA_FEATURES);
+                features
+            }
+            Self::E2024 => {
+                let mut features = self.prev().unwrap().features();
+                features.extend(E2024_FEATURES);
                 features
             }
             Self::E2024_MIGRATION => {
@@ -397,6 +425,6 @@ impl Serialize for Flavor {
 
 impl Default for Edition {
     fn default() -> Self {
-        Edition::E2024_BETA
+        Edition::E2024
     }
 }

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -98,13 +98,13 @@ pub fn feature_edition_error_msg(edition: Edition, feature: FeatureGate) -> Opti
             } else {
                 valid_editions.last().map_or(
                     format!(
-                        "{} not supported by current edition '{edition}', \
-                        no other editions support this feature",
+                        "{} not supported by any current edition '{edition}', \
+                         the feature is still in development",
                         feature.error_prefix()
                     ),
                     |supporting_edition| {
                         format!(
-                            "{} not supported by current edition '{edition}', \
+                            "{} not supported by current edition '{edition}'; \
                              the '{supporting_edition}' edition supports this feature",
                             feature.error_prefix(),
                         )

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
@@ -17,7 +17,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.move:5:9
   │
 5 │         foo() = 0;
-  │         ^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
@@ -17,7 +17,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.move:5:9
   │
 5 │         foo() = 0;
-  │         ^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
@@ -14,7 +14,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.move:4:9
   │
 4 │         Self::f() = 0;
-  │         ^^^^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
@@ -14,7 +14,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.move:4:9
   │
 4 │         Self::f() = 0;
-  │         ^^^^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/mdot_with_non_address_exp.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/mdot_with_non_address_exp.exp
@@ -20,7 +20,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/expansion/mdot_with_non_address_exp.move:17:9
    │
 17 │         foo().bar().X::bar()
-   │         ^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/mdot_with_non_address_exp.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/mdot_with_non_address_exp.exp
@@ -20,7 +20,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/expansion/mdot_with_non_address_exp.move:17:9
    │
 17 │         foo().bar().X::bar()
-   │         ^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
@@ -45,7 +45,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/pack_no_fields_single_block_other_expr.move:8:18
   │
 8 │         let _g = G ();
-  │                  ^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                  ^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
@@ -45,7 +45,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/pack_no_fields_single_block_other_expr.move:8:18
   │
 8 │         let _g = G ();
-  │                  ^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                  ^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/type_arguments_on_field_access.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/type_arguments_on_field_access.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/type_arguments_on_field_access.move:6:9
   │
 6 │         x.f<u64>;
-  │         ^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/type_arguments_on_field_access.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/type_arguments_on_field_access.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/type_arguments_on_field_access.move:6:9
   │
 6 │         x.f<u64>;
-  │         ^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_other_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_other_expr.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/unpack_assign_other_expr.move:6:9
   │
 6 │         S ( f ) = S { f: 0 };
-  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -65,7 +65,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/expansion/unpack_assign_other_expr.move:11:9
    │
 11 │         G () = G {};
-   │         ^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_other_expr.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/unpack_assign_other_expr.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/unpack_assign_other_expr.move:6:9
   │
 6 │         S ( f ) = S { f: 0 };
-  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -65,7 +65,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/expansion/unpack_assign_other_expr.move:11:9
    │
 11 │         G () = G {};
-   │         ^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/dot_call.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/dot_call.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/dot_call.move:4:5
   │
 4 │     public use fun imm as S.f;
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:13:9
    │
 13 │         use fun mut as S.g;
-   │         ^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:14:9
    │
 14 │         s.imm();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -26,7 +26,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:15:9
    │
 15 │         s.f();
-   │         ^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -34,7 +34,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:16:9
    │
 16 │         s.mut();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -42,7 +42,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:17:9
    │
 17 │         s.g();
-   │         ^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -50,7 +50,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:18:9
    │
 18 │         s.val();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/dot_call.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/dot_call.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/dot_call.move:4:5
   │
 4 │     public use fun imm as S.f;
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:13:9
    │
 13 │         use fun mut as S.g;
-   │         ^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:14:9
    │
 14 │         s.imm();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -26,7 +26,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:15:9
    │
 15 │         s.f();
-   │         ^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -34,7 +34,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:16:9
    │
 16 │         s.mut();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -42,7 +42,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:17:9
    │
 17 │         s.g();
-   │         ^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -50,7 +50,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:18:9
    │
 18 │         s.val();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_call.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_call.exp
@@ -14,7 +14,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_call.move:4:12
   │
 4 │         foo!(|| ())
-  │            ^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │            ^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_call.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_call.exp
@@ -14,7 +14,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_call.move:4:12
   │
 4 │         foo!(|| ())
-  │            ^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │            ^ 'macro' functions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition.move:2:12
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition.move:2:38
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition.move:2:12
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition.move:2:38
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:2:12
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:2:38
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:4:24
   │
 4 │     public fun t() { do!(|| q() ) }
-  │                        ^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                        ^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_definition_with_usage.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:2:12
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │            ^^^^^ 'macro' functions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:2:38
   │
 2 │     public macro fun do($f: || ()) { $f() }
-  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                                      ^^^^ lambda expressions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_definition_with_usage.move:4:24
   │
 4 │     public fun t() { do!(|| q() ) }
-  │                        ^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                        ^ 'macro' functions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:2:17
   │
 2 │     fun tfun(_: |u64| u64) {}
-  │                 ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                 ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:4:17
   │
 4 │         let _ = |x| x;
-  │                 ^^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                 ^^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/macro_lambda.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:2:17
   │
 2 │     fun tfun(_: |u64| u64) {}
-  │                 ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                 ^^^^^^^^^ 'macro' functions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/macro_lambda.move:4:17
   │
 4 │         let _ = |x| x;
-  │                 ^^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                 ^^^^^ lambda expressions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/public_package.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/public_package.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/public_package.move:2:5
   │
 2 │     public(package) fun foo(): u64 { 0 }
-  │     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
+  │     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/public_package.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/public_package.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/public_package.move:2:5
   │
 2 │     public(package) fun foo(): u64 { 0 }
-  │     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/assert_one_arg.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/assert_one_arg.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/assert_one_arg.move:3:9
   │
 3 │         assert!(false);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/assert_one_arg.move:4:9
   │
 4 │         assert!(0 != 1);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/assert_one_arg.move:5:9
   │
 5 │         assert!(x != y);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/assert_one_arg.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/assert_one_arg.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/assert_one_arg.move:3:9
   │
 3 │         assert!(false);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/assert_one_arg.move:4:9
   │
 4 │         assert!(0 != 1);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/assert_one_arg.move:5:9
   │
 5 │         assert!(x != y);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/named_blocks_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/named_blocks_invalid.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/named_blocks_invalid.move:3:9
   │
 3 │         'name: {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -22,7 +22,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:11:14
    │
 11 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -36,7 +36,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:17:14
    │
 17 │         loop 'outer: {
-   │              ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -44,7 +44,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:18:18
    │
 18 │             loop 'inner: {
-   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -64,7 +64,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:26:22
    │
 26 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -72,7 +72,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:27:26
    │
 27 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -92,7 +92,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:35:22
    │
 35 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -100,7 +100,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:36:22
    │
 36 │             let _x = 'inner: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -120,7 +120,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:45:14
    │
 45 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -128,7 +128,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:46:18
    │
 46 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -142,7 +142,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:53:9
    │
 53 │         'name: {
-   │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -156,7 +156,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:60:14
    │
 60 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -176,7 +176,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:67:14
    │
 67 │         loop 'outer2: {
-   │              ^^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -184,7 +184,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:68:18
    │
 68 │             loop 'inner2: {
-   │                  ^^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                  ^^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -204,7 +204,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:76:22
    │
 76 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -212,7 +212,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:77:26
    │
 77 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -232,7 +232,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:85:14
    │
 85 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -240,7 +240,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:86:18
    │
 86 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/named_blocks_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/named_blocks_invalid.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/named_blocks_invalid.move:3:9
   │
 3 │         'name: {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -22,7 +22,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:11:14
    │
 11 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -36,7 +36,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:17:14
    │
 17 │         loop 'outer: {
-   │              ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -44,7 +44,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:18:18
    │
 18 │             loop 'inner: {
-   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                  ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -64,7 +64,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:26:22
    │
 26 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -72,7 +72,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:27:26
    │
 27 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -92,7 +92,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:35:22
    │
 35 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -100,7 +100,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:36:22
    │
 36 │             let _x = 'inner: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -120,7 +120,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:45:14
    │
 45 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -128,7 +128,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:46:18
    │
 46 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -142,7 +142,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:53:9
    │
 53 │         'name: {
-   │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -156,7 +156,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:60:14
    │
 60 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -176,7 +176,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:67:14
    │
 67 │         loop 'outer2: {
-   │              ^^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -184,7 +184,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:68:18
    │
 68 │             loop 'inner2: {
-   │                  ^^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                  ^^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -204,7 +204,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:76:22
    │
 76 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -212,7 +212,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:77:26
    │
 77 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -232,7 +232,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:85:14
    │
 85 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -240,7 +240,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:86:18
    │
 86 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/other_builtins_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/other_builtins_invalid.exp
@@ -29,7 +29,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/other_builtins_invalid.move:6:9
   │
 6 │         assert!(false);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -37,7 +37,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/other_builtins_invalid.move:7:9
   │
 7 │         assert!(0 != 1);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/other_builtins_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/other_builtins_invalid.exp
@@ -29,7 +29,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/other_builtins_invalid.move:6:9
   │
 6 │         assert!(false);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -37,7 +37,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/other_builtins_invalid.move:7:9
   │
 7 │         assert!(0 != 1);
-  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/syntax_annotations_unsupported.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/syntax_annotations_unsupported.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:6:7
   │
 6 │     #[syntax(index)]
-  │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:10:7
    │
 10 │     #[syntax(index)]
-   │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -27,7 +27,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:21:7
    │
 21 │     #[syntax(for)]
-   │       ^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │       ^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -35,7 +35,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:25:7
    │
 25 │     #[syntax(assign)]
-   │       ^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │       ^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -43,7 +43,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:29:7
    │
 29 │     #[syntax(nonsense)]
-   │       ^^^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │       ^^^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/syntax_annotations_unsupported.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/syntax_annotations_unsupported.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:6:7
   │
 6 │     #[syntax(index)]
-  │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:10:7
    │
 10 │     #[syntax(index)]
-   │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -27,7 +27,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:21:7
    │
 21 │     #[syntax(for)]
-   │       ^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │       ^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -35,7 +35,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:25:7
    │
 25 │     #[syntax(assign)]
-   │       ^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │       ^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -43,7 +43,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:29:7
    │
 29 │     #[syntax(nonsense)]
-   │       ^^^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │       ^^^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_invalid_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_invalid_usage.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_invalid_usage.move:2:22
   │
 2 │     struct S<T> { f: _ }
-  │                      ^ '_' placeholders for type inference are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                      ^ '_' placeholders for type inference are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -24,7 +24,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_invalid_usage.move:3:16
   │
 3 │     fun foo(_: _) {}
-  │                ^ '_' placeholders for type inference are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                ^ '_' placeholders for type inference are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_invalid_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_invalid_usage.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_invalid_usage.move:2:22
   │
 2 │     struct S<T> { f: _ }
-  │                      ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                      ^ '_' placeholders for type inference are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -24,7 +24,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_invalid_usage.move:3:16
   │
 3 │     fun foo(_: _) {}
-  │                ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                ^ '_' placeholders for type inference are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_valid_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_valid_usage.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_valid_usage.move:3:23
   │
 3 │         let v: vector<_> = vector[0];
-  │                       ^ '_' placeholders for type inference are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                       ^ '_' placeholders for type inference are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_valid_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/type_hole_gated_valid_usage.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/type_hole_gated_valid_usage.move:3:23
   │
 3 │         let v: vector<_> = vector[0];
-  │                       ^ '_' placeholders for type inference are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                       ^ '_' placeholders for type inference are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/unknown_assertion_annotation.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/unknown_assertion_annotation.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/unknown_assertion_annotation.move:2:7
   │
 2 │     #[error] 
-  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/unknown_assertion_annotation.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/unknown_assertion_annotation.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/unknown_assertion_annotation.move:2:7
   │
 2 │     #[error] 
-  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/var_as_fun_invalid.move:4:9
   │
 4 │         var();
-  │         ^^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^ lambda expressions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/var_as_fun_invalid.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/var_as_fun_invalid.move:4:9
   │
 4 │         var();
-  │         ^^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_infix_and_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_infix_and_postfix.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_infix_and_postfix.move:5:34
   │
 5 │     struct Foo has copy, drop {} has store;
-  │                                  ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                                  ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_infix_and_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_infix_and_postfix.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_infix_and_postfix.move:5:34
   │
 5 │     struct Foo has copy, drop {} has store;
-  │                                  ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                                  ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_invalid_infix_with_valid_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_invalid_infix_with_valid_postfix.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_invalid_infix_with_valid_postfix.move:4:23
   │
 4 │     struct Foo has {} has copy;
-  │                       ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                       ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_invalid_infix_with_valid_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_invalid_infix_with_valid_postfix.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_invalid_infix_with_valid_postfix.move:4:23
   │
 4 │     struct Foo has {} has copy;
-  │                       ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                       ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_commas.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_commas.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_missing_commas.move:5:19
   │
 5 │     struct Foo {} has store copy;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_commas.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_commas.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_missing_commas.move:5:19
   │
 5 │     struct Foo {} has store copy;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.move:5:19
   │
 5 │     struct Foo {} has store
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.move:5:19
   │
 5 │     struct Foo {} has store
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.move:5:19
   │
 5 │     struct Foo {} has
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.move:5:19
   │
 5 │     struct Foo {} has
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.move:5:19
   │
 5 │     struct Foo {} has;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.move:5:19
   │
 5 │     struct Foo {} has;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_semi.move:5:19
   │
 5 │     struct Foo {} has store
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_semi.move:5:19
   │
 5 │     struct Foo {} has store
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_with_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_with_semi.move:4:19
   │
 4 │     struct Foo {} has store;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_with_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_with_semi.move:4:19
   │
 4 │     struct Foo {} has store;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.move:4:28
   │
 4 │     struct Foo has copy {} has;
-  │                            ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                            ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.move:4:28
   │
 4 │     struct Foo has copy {} has;
-  │                            ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                            ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_no_abilities_infix_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_no_abilities_infix_postfix.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifies_no_abilities_infix_postfix.move:4:23
   │
 4 │     struct Foo has {} has;
-  │                       ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                       ^^^ Postfix abilities are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_no_abilities_infix_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_no_abilities_infix_postfix.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifies_no_abilities_infix_postfix.move:4:23
   │
 4 │     struct Foo has {} has;
-  │                       ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                       ^^^ Postfix abilities are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/copy_move_path.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/copy_move_path.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/copy_move_path.move:12:9
    │
 12 │         copy x.y.z;
-   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/copy_move_path.move:13:9
    │
 13 │         move x.y.z;
-   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/copy_move_path.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/copy_move_path.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/copy_move_path.move:12:9
    │
 12 │         copy x.y.z;
-   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/copy_move_path.move:13:9
    │
 13 │         move x.y.z;
-   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/expr_abort_missing_value.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/expr_abort_missing_value.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/expr_abort_missing_value.move:4:22
   │
 4 │         if (v > 100) abort
-  │                      ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                      ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/expr_abort_missing_value.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/expr_abort_missing_value.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/expr_abort_missing_value.move:4:22
   │
 4 │         if (v > 100) abort
-  │                      ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                      ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_conflicting_visibility.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_conflicting_visibility.exp
@@ -19,7 +19,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/function_conflicting_visibility.move:2:20
   │
 2 │     public(friend) public(package) fun t0() {}
-  │                    ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                    ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -60,7 +60,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/function_conflicting_visibility.move:4:12
   │
 4 │     public public(package) fun t2() {}
-  │            ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │            ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -125,7 +125,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/function_conflicting_visibility.move:10:21
    │
 10 │     public(package) public(package) fun s1() {}
-   │                     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_conflicting_visibility.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_conflicting_visibility.exp
@@ -19,7 +19,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/function_conflicting_visibility.move:2:20
   │
 2 │     public(friend) public(package) fun t0() {}
-  │                    ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                    ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -60,7 +60,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/function_conflicting_visibility.move:4:12
   │
 4 │     public public(package) fun t2() {}
-  │            ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
+  │            ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -125,7 +125,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/function_conflicting_visibility.move:10:21
    │
 10 │     public(package) public(package) fun s1() {}
-   │                     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.move:9:9
   │
 9 │         X::S () = 0;
-  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.move:9:9
   │
 9 │         X::S () = 0;
-  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_2.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/named_blocks_invalid_2.move:4:9
   │
 4 │         'name {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_2.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/named_blocks_invalid_2.move:4:9
   │
 4 │         'name {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_3.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_3.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/named_blocks_invalid_3.move:4:9
   │
 4 │         'name: {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -16,7 +16,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:11:14
    │
 11 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -30,7 +30,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:17:14
    │
 17 │         loop 'outer: {
-   │              ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -38,7 +38,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:18:18
    │
 18 │             loop 'inner: {
-   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -58,7 +58,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:26:22
    │
 26 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -66,7 +66,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:27:26
    │
 27 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -86,7 +86,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:35:22
    │
 35 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -94,7 +94,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:36:22
    │
 36 │             let _x = 'inner: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -114,7 +114,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:45:14
    │
 45 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │              ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -122,7 +122,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:46:18
    │
 46 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_3.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_3.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/named_blocks_invalid_3.move:4:9
   │
 4 │         'name: {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -16,7 +16,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:11:14
    │
 11 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -30,7 +30,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:17:14
    │
 17 │         loop 'outer: {
-   │              ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -38,7 +38,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:18:18
    │
 18 │             loop 'inner: {
-   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                  ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -58,7 +58,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:26:22
    │
 26 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -66,7 +66,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:27:26
    │
 27 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -86,7 +86,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:35:22
    │
 35 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -94,7 +94,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:36:22
    │
 36 │             let _x = 'inner: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -114,7 +114,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:45:14
    │
 45 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │              ^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -122,7 +122,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:46:18
    │
 46 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_declaration.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_declaration.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_declaration.move:4:15
   │
 4 │     struct Foo(u64)
-  │               ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │               ^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_declaration.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_declaration.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_declaration.move:4:15
   │
 4 │     struct Foo(u64)
-  │               ^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │               ^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:5
   │
 4 │     public struct Foo(fun)
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:22
   │
 4 │     public struct Foo(fun)
-  │                      ^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                      ^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:5
   │
 4 │     public struct Foo(fun)
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:22
   │
 4 │     public struct Foo(fun)
-  │                      ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                      ^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_pack.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_pack.move:7:17
   │
 7 │         let _ = Foo(0);
-  │                 ^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │                 ^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_pack.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_pack.move:7:17
   │
 7 │         let _ = Foo(0);
-  │                 ^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │                 ^^^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_unpack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_unpack.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_unpack.move:7:9
   │
 7 │         Foo(_) = x;
-  │         ^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^ Positional fields are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_unpack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_unpack.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_unpack.move:7:9
   │
 7 │         Foo(_) = x;
-  │         ^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^ Positional fields are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
@@ -12,6 +12,6 @@ error[E00002]: DEPRECATED. unexpected spec item
 3 │       let _ = x[1];
   │               ^^^^ Specification blocks are deprecated and are no longer used
   │
-  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024.beta'
+  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024.beta, 2024'
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
   │
 3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │               ^^^^^^^^^ lambda expressions are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
   │
 3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ lambda expressions are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │               ^^^^^^^^^ lambda expressions are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_public.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_public.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/struct_public.move:3:5
   │
 3 │     public struct Foo {}
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_public.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_public.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/struct_public.move:3:5
   │
 3 │     public struct Foo {}
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/top_level_module.move:1:11
   │
 1 │ module a::m;
-  │           ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │           ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/top_level_module.move:1:11
   │
 1 │ module a::m;
-  │           ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │           ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module_address_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module_address_invalid.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/top_level_module_address_invalid.move:2:12
   │
 2 │     module m;
-  │            ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │            ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module_address_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/top_level_module_address_invalid.exp
@@ -8,7 +8,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/top_level_module_address_invalid.move:2:12
   │
 2 │     module m;
-  │            ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │            ^ 'module' label forms (ending with ';') are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_with_modifiers_exp.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_with_modifiers_exp.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/use_with_modifiers_exp.move:3:9
   │
 3 │         public use fun bar as X.baz;
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_with_modifiers_exp.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_with_modifiers_exp.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/use_with_modifiers_exp.move:3:9
   │
 3 │         public use fun bar as X.baz;
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/cast_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/cast_invalid.exp
@@ -95,7 +95,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:23:9
    │
 23 │         false as u8;
-   │         ^^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -112,7 +112,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:24:9
    │
 24 │         true as u128;
-   │         ^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -129,7 +129,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:26:9
    │
 26 │         () as u64;
-   │         ^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -146,7 +146,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:27:9
    │
 27 │         (0, 1) as u8;
-   │         ^^^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -163,7 +163,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:29:9
    │
 29 │         0 as bool;
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -179,7 +179,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:30:9
    │
 30 │         0 as address;
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -195,7 +195,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:31:15
    │
 31 │         R{} = 0 as R;
-   │               ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │               ^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -211,7 +211,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:32:9
    │
 32 │         0 as Cup<u8>;
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -227,7 +227,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:33:9
    │
 33 │         0 as ();
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -243,7 +243,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:34:9
    │
 34 │         0 as (u64, u8);
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -259,7 +259,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:36:9
    │
 36 │         x"1234" as u64;
-   │         ^^^^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^^ 'as' without parentheses is not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/cast_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/cast_invalid.exp
@@ -95,7 +95,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:23:9
    │
 23 │         false as u8;
-   │         ^^^^^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -112,7 +112,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:24:9
    │
 24 │         true as u128;
-   │         ^^^^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -129,7 +129,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:26:9
    │
 26 │         () as u64;
-   │         ^^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -146,7 +146,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:27:9
    │
 27 │         (0, 1) as u8;
-   │         ^^^^^^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -163,7 +163,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:29:9
    │
 29 │         0 as bool;
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -179,7 +179,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:30:9
    │
 30 │         0 as address;
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -195,7 +195,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:31:15
    │
 31 │         R{} = 0 as R;
-   │               ^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │               ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -211,7 +211,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:32:9
    │
 32 │         0 as Cup<u8>;
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -227,7 +227,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:33:9
    │
 33 │         0 as ();
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -243,7 +243,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:34:9
    │
 34 │         0 as (u64, u8);
-   │         ^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -259,7 +259,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/cast_invalid.move:36:9
    │
 36 │         x"1234" as u64;
-   │         ^^^^^^^ 'as' without parentheses is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^^ 'as' without parentheses is not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/clever_assertions.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/clever_assertions.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/typing/clever_assertions.move:4:7
   │
 4 │     #[error]
-  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/typing/clever_assertions.move:7:7
   │
 7 │     #[error]
-  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/clever_assertions.move:23:9
    │
 23 │         assert!(false);
-   │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
+   │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy'; the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/clever_assertions.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/clever_assertions.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/typing/clever_assertions.move:4:7
   │
 4 │     #[error]
-  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/typing/clever_assertions.move:7:7
   │
 7 │     #[error]
-  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+  │       ^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/typing/clever_assertions.move:23:9
    │
 23 │         assert!(false);
-   │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
+   │         ^^^^^^ Clever `assert!`, `abort`, and `#[error]` are not supported by current edition 'legacy', the '2024' edition supports this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-package/src/migration/mod.rs
+++ b/external-crates/move/crates/move-package/src/migration/mod.rs
@@ -20,7 +20,7 @@ pub const EDITION_SELECT_PROMPT: &str = "Please select one of the following edit
 
 pub static EDITION_OPTIONS: Lazy<BTreeMap<String, Edition>> = Lazy::new(|| {
     let mut map = BTreeMap::new();
-    map.insert("1".to_string(), Edition::E2024_BETA);
+    map.insert("1".to_string(), Edition::E2024);
     map.insert("2".to_string(), Edition::LEGACY);
     map
 });
@@ -95,7 +95,7 @@ impl<'a, W: Write, R: BufRead> MigrationContext<'a, W, R> {
                 self.terminal.writeln(EDITION_RECORDED_MSG)?;
                 self.terminal.newline()?;
             }
-            Edition::E2024_BETA => {
+            Edition::E2024 => {
                 self.terminal.newline()?;
                 self.terminal.newline()?;
                 self.perform_upgrade()?;

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move.resolved
@@ -1,1 +1,73 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"
+ResolvedGraph {
+    graph: DependencyGraph {
+        root_path: "tests/test_sources/parsing_edition_2024",
+        root_package_id: "name",
+        root_package_name: "name",
+        package_graph: {
+            "name": [],
+        },
+        package_table: {},
+        always_deps: {
+            "name",
+        },
+        manifest_digest: "9CA39D4DF2F4A9804A698BA06940004E030B6C5611DAC594177C63B68F6440D5",
+        deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+    },
+    build_options: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        json_errors: false,
+        additional_named_addresses: {},
+        lint_flag: LintFlag {
+            no_lint: false,
+            lint: false,
+        },
+    },
+    package_table: {
+        "name": Package {
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "name",
+                    authors: [
+                        "some author",
+                    ],
+                    license: Some(
+                        "\"license\"",
+                    ),
+                    edition: Some(
+                        Edition {
+                            edition: "2024",
+                            release: None,
+                        },
+                    ),
+                    flavor: None,
+                    custom_properties: {},
+                },
+                addresses: None,
+                dev_address_assignments: None,
+                build: None,
+                dependencies: {},
+                dev_dependencies: {},
+            },
+            package_path: "ELIDED_FOR_TEST",
+            renaming: {},
+            resolved_table: {},
+            source_digest: "ELIDED_FOR_TEST",
+        },
+    },
+}

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"


### PR DESCRIPTION
## Description 

Add Move `2024` edition and make it the default edition. 

## Test plan 

Updated existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Added the Move `2024` edition, and set it as the default Move edition both when creating a new Move package and when migrating from an existing package. Existing `2024.beta` and `2024.alpha` editions remain supported.  
- [ ] Rust SDK:
- [ ] REST API:
