### PR TITLE
[sui-node] Add static assertion that it is not built with vm tracing enabled

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -47,6 +47,13 @@ fn main() {
     // TODO: re-enable after we figure out how to eliminate crashes in prod because of this.
     // ProtocolConfig::poison_get_for_min_version();
 
+    move_vm_profiler::static_assert_tracing_feature_disabled!(
+        "The sui-node binary cannot be built with the `tracing` feature enabled. Try rebuilding without the \
+        `tracing` feature or building the binary separately from all other binaries"
+    );
+
+    // Keep the runtime assertion as the last check before starting the node just on the off-chance
+    // that the static assertion didn't catch it.
     move_vm_profiler::tracing_feature_enabled! {
         panic!("Cannot run the sui-node binary with tracing feature enabled");
     }

--- a/external-crates/move/crates/move-vm-profiler/src/lib.rs
+++ b/external-crates/move/crates/move-vm-profiler/src/lib.rs
@@ -379,3 +379,20 @@ macro_rules! tracing_feature_disabled {
 macro_rules! tracing_feature_disabled {
     ( $( $tt:tt )* ) => {};
 }
+
+#[cfg(feature = "tracing")]
+#[macro_export]
+macro_rules! static_assert_tracing_feature_disabled {
+    ($err_msg:tt) => {
+        // Disable reporting an error in clippy mode as clippy will try to unify all features
+        // across all crates and will turn on this flag.
+        #[cfg(not(clippy))]
+        compile_error!($err_msg);
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+#[macro_export]
+macro_rules! static_assert_tracing_feature_disabled {
+    ($_err_msg:tt) => {};
+}


### PR DESCRIPTION
## Description 

Add a static assertion that the `sui-node` binary cannot be built with the `tracing` flag set. This is meant as a pure quality-of-life improvement to provide better locality of error messages. E.g., if someone tried to compile both the `sui-node` and `sui` binaries together with the `--features tracing` flag set this would provide a compilation error as opposed to a panic on startup.

The existing runtime check is also preserved for safety in depth, and to make absolutely certain a node cannot be started with this flag enabled (if it somehow managed to get through the static assertion). 

Note that the static check is turned off in clippy mode, as `cargo xclippy` unifies the feature flags and sets the `tracing` flag (although unsure why -- when I look at the `cargo tree -e feature` graph I don't see the feature flag anywhere and supposedly `clippy` doesn't turn on any additional features, but the feature flags don't lie...). Maybe `xclippy` is different? 

I also tested with a `cargo build` from the `sui` root, and that built fine. 

## Test plan 

Manually tested building both binaries together, both with and without setting the `tracing` feature flag and verified the error was as expected.

Also ran cargo xclippy and made sure it was happy.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
