### PR TITLE
[move][move-2024] Fix match bug, rework work queue from match for sanity

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -24,61 +24,34 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 //**************************************************************************************************
 // This mostly follows the classical Maranget (2008) implementation toward optimal decision trees.
 
-type Fringe = VecDeque<FringeEntry>;
-
 #[derive(Clone)]
 enum StructUnpack<T> {
     Default(T),
     Unpack(Vec<(Field, Var, Type)>, T),
 }
 
-enum MatchStep {
-    Leaf(Vec<ArmResult>),
-    Failure,
-    LiteralSwitch {
-        subject: FringeEntry,
-        subject_binders: Vec<(Mutability, Var)>,
-        fringe: Fringe,
-        arms: BTreeMap<Value, PatternMatrix>,
-        default: PatternMatrix,
-    },
-    StructUnpack {
-        subject: FringeEntry,
-        subject_binders: Vec<(Mutability, Var)>,
-        tyargs: Vec<Type>,
-        unpack: StructUnpack<(Fringe, PatternMatrix)>,
-    },
-    VariantSwitch {
-        subject: FringeEntry,
-        subject_binders: Vec<(Mutability, Var)>,
-        tyargs: Vec<Type>,
-        arms: BTreeMap<VariantName, (Vec<(Field, Var, Type)>, Fringe, PatternMatrix)>,
-        default: (Fringe, PatternMatrix),
-    },
-}
-
 #[derive(Clone)]
-enum WorkResult {
+enum MatchTree {
     Leaf(Vec<ArmResult>),
     Failure,
     LiteralSwitch {
         subject: FringeEntry,
         subject_binders: Vec<(Mutability, Var)>,
-        arms: BTreeMap<Value, usize>,
-        default: usize, // default
+        arms: BTreeMap<Value, Box<MatchTree>>,
+        default: Box<MatchTree>, // default
     },
     StructUnpack {
         subject: FringeEntry,
         subject_binders: Vec<(Mutability, Var)>,
         tyargs: Vec<Type>,
-        unpack: StructUnpack<usize>,
+        unpack: StructUnpack<Box<MatchTree>>,
     },
     VariantSwitch {
         subject: FringeEntry,
         subject_binders: Vec<(Mutability, Var)>,
         tyargs: Vec<Type>,
-        arms: BTreeMap<VariantName, (Vec<(Field, Var, Type)>, usize)>,
-        default: usize,
+        arms: BTreeMap<VariantName, (Vec<(Field, Var, Type)>, Box<MatchTree>)>,
+        default: Box<MatchTree>,
     },
 }
 
@@ -92,169 +65,17 @@ pub(super) fn compile_match(
     // NB: `from` also flattens `or` and converts constants into guards.
     let (pattern_matrix, arms) = PatternMatrix::from(context, loc, subject.ty.clone(), arms.value);
 
-    let mut compilation_results: BTreeMap<usize, WorkResult> = BTreeMap::new();
+    let (mut initial_binders, init_subject, match_subject) =
+        make_initial_fringe(context, subject, loc);
 
-    let (mut initial_binders, init_subject, match_subject) = {
-        let subject_var = context.new_match_var("unpack_subject".to_string(), loc);
-        let subject_loc = subject.exp.loc;
-        let match_var = context.new_match_var("match_subject".to_string(), loc);
-
-        let subject_entry = FringeEntry {
-            var: subject_var,
-            ty: subject.ty.clone(),
-        };
-        let subject_borrow_rhs = make_var_ref(subject_entry.clone());
-
-        let match_entry = FringeEntry {
-            var: match_var,
-            ty: subject_borrow_rhs.ty.clone(),
-        };
-
-        let subject_binder = {
-            let lhs_loc = subject_loc;
-            let lhs_lvalue = make_lvalue(subject_var, Mutability::Imm, subject.ty.clone());
-            let binder = T::SequenceItem_::Bind(
-                sp(lhs_loc, vec![lhs_lvalue]),
-                vec![Some(subject.ty.clone())],
-                Box::new(subject),
-            );
-            sp(lhs_loc, binder)
-        };
-
-        let subject_borrow = {
-            let lhs_loc = loc;
-            let lhs_lvalue = make_lvalue(match_var, Mutability::Imm, subject_borrow_rhs.ty.clone());
-            let binder = T::SequenceItem_::Bind(
-                sp(lhs_loc, vec![lhs_lvalue]),
-                vec![Some(subject_borrow_rhs.ty.clone())],
-                subject_borrow_rhs,
-            );
-            sp(lhs_loc, binder)
-        };
-
-        (
-            VecDeque::from([subject_binder, subject_borrow]),
-            subject_entry,
-            match_entry,
-        )
-    };
-
-    let mut work_queue: Vec<(usize, Fringe, PatternMatrix)> =
-        vec![(0, VecDeque::from([match_subject]), pattern_matrix)];
-
-    let mut work_id = 0;
-
-    let mut next_id = || {
-        work_id += 1;
-        work_id
-    };
-
-    while let Some((cur_id, init_fringe, matrix)) = work_queue.pop() {
-        debug_print!(
-            context.debug.match_work_queue,
-            ("work queue entry" => cur_id; fmt),
-            (lines "fringe" => &init_fringe; sdbg),
-            ("matrix" => matrix; verbose)
-        );
-        let redefined: Option<WorkResult> =
-            match compile_match_head(context, init_fringe.clone(), matrix) {
-                MatchStep::Leaf(leaf) => compilation_results.insert(cur_id, WorkResult::Leaf(leaf)),
-                MatchStep::Failure => compilation_results.insert(cur_id, WorkResult::Failure),
-                MatchStep::LiteralSwitch {
-                    subject,
-                    subject_binders,
-                    fringe,
-                    arms,
-                    default,
-                } => {
-                    let mut answer_map = BTreeMap::new();
-                    for (value, matrix) in arms {
-                        let work_id = next_id();
-                        answer_map.insert(value, work_id);
-                        work_queue.push((work_id, fringe.clone(), matrix));
-                    }
-                    let default_work_id = next_id();
-                    work_queue.push((default_work_id, fringe, default));
-                    let result = WorkResult::LiteralSwitch {
-                        subject,
-                        subject_binders,
-                        arms: answer_map,
-                        default: default_work_id,
-                    };
-                    compilation_results.insert(cur_id, result)
-                }
-                MatchStep::StructUnpack {
-                    subject,
-                    subject_binders,
-                    tyargs,
-                    unpack,
-                } => {
-                    let unpack_work_id = next_id();
-                    let unpack = match unpack {
-                        StructUnpack::Default((fringe, matrix)) => {
-                            work_queue.push((unpack_work_id, fringe, matrix));
-                            StructUnpack::Default(unpack_work_id)
-                        }
-                        StructUnpack::Unpack(dtor_fields, (fringe, matrix)) => {
-                            work_queue.push((unpack_work_id, fringe, matrix));
-                            StructUnpack::Unpack(dtor_fields, unpack_work_id)
-                        }
-                    };
-                    compilation_results.insert(
-                        cur_id,
-                        WorkResult::StructUnpack {
-                            subject,
-                            subject_binders,
-                            tyargs,
-                            unpack,
-                        },
-                    )
-                }
-
-                MatchStep::VariantSwitch {
-                    subject,
-                    subject_binders,
-                    tyargs,
-                    arms,
-                    default: (dfringe, dmatrix),
-                } => {
-                    let mut answer_map = BTreeMap::new();
-                    for (name, (dtor_fields, fringe, matrix)) in arms {
-                        let work_id = next_id();
-                        answer_map.insert(name, (dtor_fields, work_id));
-                        work_queue.push((work_id, fringe, matrix));
-                    }
-                    let default_work_id = next_id();
-                    work_queue.push((default_work_id, dfringe, dmatrix));
-                    compilation_results.insert(
-                        cur_id,
-                        WorkResult::VariantSwitch {
-                            subject,
-                            subject_binders,
-                            tyargs,
-                            arms: answer_map,
-                            default: default_work_id,
-                        },
-                    )
-                }
-            };
-        ice_assert!(
-            context.reporter,
-            redefined.is_none(),
-            loc,
-            "Match work queue went awry"
-        );
-    }
-
-    let match_start = compilation_results.remove(&0).unwrap();
+    let match_tree = build_match_tree(context, VecDeque::from([match_subject]), pattern_matrix);
     let mut resolution_context = ResolutionContext {
         hlir_context: context,
         output_type: result_type,
         arms: &arms,
         arms_loc: loc,
-        results: &mut compilation_results,
     };
-    let match_exp = resolve_result(&mut resolution_context, &init_subject, match_start);
+    let match_exp = match_tree_to_exp(&mut resolution_context, &init_subject, match_tree);
 
     let eloc = match_exp.exp.loc;
     let mut seq = VecDeque::new();
@@ -264,64 +85,88 @@ pub(super) fn compile_match(
     T::exp(result_type.clone(), exp_value)
 }
 
-fn compile_match_head(
+/// Makes the initial fringe, including the bindings, subject, and imm-ref version of the subject
+/// for use in the actual decision tree.
+fn make_initial_fringe(
+    context: &mut Context,
+    subject: T::Exp,
+    loc: Loc,
+) -> (VecDeque<T::SequenceItem>, FringeEntry, FringeEntry) {
+    let subject_var = context.new_match_var("unpack_subject".to_string(), loc);
+    let subject_loc = subject.exp.loc;
+    let match_var = context.new_match_var("match_subject".to_string(), loc);
+
+    let subject_entry = FringeEntry {
+        var: subject_var,
+        ty: subject.ty.clone(),
+    };
+    let subject_borrow_rhs = make_var_ref(subject_entry.clone());
+
+    let match_entry = FringeEntry {
+        var: match_var,
+        ty: subject_borrow_rhs.ty.clone(),
+    };
+
+    let subject_binder = {
+        let lhs_loc = subject_loc;
+        let lhs_lvalue = make_lvalue(subject_var, Mutability::Imm, subject.ty.clone());
+        let binder = T::SequenceItem_::Bind(
+            sp(lhs_loc, vec![lhs_lvalue]),
+            vec![Some(subject.ty.clone())],
+            Box::new(subject),
+        );
+        sp(lhs_loc, binder)
+    };
+
+    let subject_borrow = {
+        let lhs_loc = loc;
+        let lhs_lvalue = make_lvalue(match_var, Mutability::Imm, subject_borrow_rhs.ty.clone());
+        let binder = T::SequenceItem_::Bind(
+            sp(lhs_loc, vec![lhs_lvalue]),
+            vec![Some(subject_borrow_rhs.ty.clone())],
+            subject_borrow_rhs,
+        );
+        sp(lhs_loc, binder)
+    };
+
+    (
+        VecDeque::from([subject_binder, subject_borrow]),
+        subject_entry,
+        match_entry,
+    )
+}
+
+#[growing_stack]
+fn build_match_tree(
     context: &mut Context,
     mut fringe: VecDeque<FringeEntry>,
     mut matrix: PatternMatrix,
-) -> MatchStep {
+) -> MatchTree {
     debug_print!(
         context.debug.match_specialization,
         ("-----\ncompiling with fringe queue entry" => fringe; sdbg)
     );
+
     if matrix.is_empty() {
-        MatchStep::Failure
-    } else if let Some(leaf) = matrix.wild_arm_opt(&fringe) {
-        MatchStep::Leaf(leaf)
-    } else if fringe[0].ty.value.unfold_to_builtin_type_name().is_some() {
-        let subject = fringe
-            .pop_front()
-            .expect("ICE empty fringe in match compilation");
-        let mut subject_binders = vec![];
-        // treat column as a literal
-        let lits = matrix.first_lits();
-        let mut arms = BTreeMap::new();
-        for lit in lits {
-            let lit_loc = lit.loc;
-            debug_print!(context.debug.match_specialization, ("lit specializing" => lit ; fmt));
-            let (mut new_binders, inner_matrix) = matrix.specialize_literal(&lit);
-            debug_print!(
-                context.debug.match_specialization,
-                ("binders" => &new_binders; dbg), ("specialized" => inner_matrix)
-            );
-            subject_binders.append(&mut new_binders);
-            ice_assert!(
-                context.reporter,
-                arms.insert(lit, inner_matrix).is_none(),
-                lit_loc,
-                "Specialization failed"
-            );
-        }
-        let (mut new_binders, default) = matrix.specialize_default();
-        debug_print!(context.debug.match_specialization, ("default binders" => &new_binders; dbg));
-        subject_binders.append(&mut new_binders);
-        MatchStep::LiteralSwitch {
-            subject,
-            subject_binders,
-            fringe,
-            arms,
-            default,
-        }
+        debug_print!(context.debug.match_specialization, (msg "empty matrix"));
+        return MatchTree::Failure;
+    }
+
+    if let Some(leaf) = matrix.wild_arm_opt(&fringe) {
+        debug_print!(context.debug.match_specialization, (msg "wild leaf"), ("matrix" => matrix));
+        return MatchTree::Leaf(leaf);
+    }
+
+    let Some(subject) = fringe.pop_front() else {
+        debug_print!(context.debug.match_specialization, (msg "empty fringe"));
+        return MatchTree::Failure;
+    };
+
+    if subject.ty.value.unfold_to_builtin_type_name().is_some() {
+        compile_match_literal(context, subject, fringe, matrix)
     } else {
-        let subject = fringe
-            .pop_front()
-            .expect("ICE empty fringe in match compilation");
         let tyargs = subject.ty.value.type_arguments().unwrap().clone();
-        let mut subject_binders = vec![];
-        debug_print!(
-            context.debug.match_specialization,
-            ("subject" => subject),
-            ("matrix" => matrix)
-        );
+
         let (mident, datatype_name) = subject
             .ty
             .value
@@ -330,98 +175,174 @@ fn compile_match_head(
             .expect("ICE non-datatype type in head constructor fringe position");
 
         if context.info.is_struct(&mident, &datatype_name) {
-            // If we have an actual destructuring anywhere, we do that and take the specialized
-            // matrix (which holds the default matrix and bindings, for our purpose). If we don't,
-            // we just take the default matrix.
-            let decl_fields = context.info.struct_fields(&mident, &datatype_name).unwrap();
-            let unpack = if let Some((ploc, arg_types)) = matrix.first_struct_ctors() {
-                let fringe_binders =
-                    context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
-                let fringe_exps = make_fringe_entries(&fringe_binders);
-                let mut inner_fringe = fringe.clone();
-                for fringe_exp in fringe_exps.into_iter().rev() {
-                    inner_fringe.push_front(fringe_exp);
-                }
-                let bind_tys = fringe_binders
-                    .iter()
-                    .map(|(_, _, ty)| ty)
-                    .collect::<Vec<_>>();
-                debug_print!(
-                    context.debug.match_specialization, ("struct specialized" => datatype_name; dbg)
-                );
-                let (mut new_binders, inner_matrix) = matrix.specialize_struct(context, bind_tys);
-                debug_print!(context.debug.match_specialization,
-                             ("binders" => new_binders; dbg),
-                             ("specialized" => inner_matrix));
-                subject_binders.append(&mut new_binders);
-                StructUnpack::Unpack(fringe_binders, (inner_fringe, inner_matrix))
-            } else {
-                let (mut new_binders, default_matrix) = matrix.specialize_default();
-                subject_binders.append(&mut new_binders);
-                StructUnpack::Default((fringe, default_matrix))
-            };
-            MatchStep::StructUnpack {
+            compile_match_struct(
+                context,
                 subject,
-                subject_binders,
                 tyargs,
-                unpack,
-            }
+                fringe,
+                matrix,
+                mident,
+                datatype_name,
+            )
         } else {
-            let mut unmatched_variants = context
-                .info
-                .enum_variants(&mident, &datatype_name)
-                .into_iter()
-                .collect::<BTreeSet<_>>();
-
-            let ctors = matrix.first_variant_ctors();
-
-            let mut arms = BTreeMap::new();
-            for (ctor, (ploc, arg_types)) in ctors {
-                unmatched_variants.remove(&ctor);
-                let decl_fields = context
-                    .info
-                    .enum_variant_fields(&mident, &datatype_name, &ctor)
-                    .unwrap();
-                let fringe_binders =
-                    context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
-                let fringe_exps = make_fringe_entries(&fringe_binders);
-                let mut inner_fringe = fringe.clone();
-                for fringe_exp in fringe_exps.into_iter().rev() {
-                    inner_fringe.push_front(fringe_exp);
-                }
-                let bind_tys = fringe_binders
-                    .iter()
-                    .map(|(_, _, ty)| ty)
-                    .collect::<Vec<_>>();
-                debug_print!(
-                    context.debug.match_specialization, ("enum specialized" => datatype_name; dbg)
-                );
-                let (mut new_binders, inner_matrix) =
-                    matrix.specialize_variant(context, &ctor, bind_tys);
-                debug_print!(context.debug.match_specialization,
-                             ("binders" => new_binders; dbg),
-                             ("specialized" => inner_matrix));
-                subject_binders.append(&mut new_binders);
-                ice_assert!(
-                    context.reporter,
-                    arms.insert(ctor, (fringe_binders, inner_fringe, inner_matrix))
-                        .is_none(),
-                    ploc,
-                    "Inserted duplicate ctor"
-                );
-            }
-
-            let (mut new_binders, default_matrix) = matrix.specialize_default();
-            subject_binders.append(&mut new_binders);
-
-            MatchStep::VariantSwitch {
+            compile_variant_switch(
+                context,
                 subject,
-                subject_binders,
                 tyargs,
-                arms,
-                default: (fringe, default_matrix),
-            }
+                fringe,
+                matrix,
+                mident,
+                datatype_name,
+            )
         }
+    }
+}
+
+#[growing_stack]
+fn compile_match_literal(
+    context: &mut Context,
+    subject: FringeEntry,
+    fringe: VecDeque<FringeEntry>,
+    matrix: PatternMatrix,
+) -> MatchTree {
+    let mut subject_binders = vec![];
+    let lits = matrix.first_lits();
+    let mut arms = BTreeMap::new();
+
+    for lit in lits {
+        debug_print!(context.debug.match_specialization, ("lit specializing" => lit ; fmt));
+        let (mut new_binders, inner_matrix) = matrix.specialize_literal(&lit);
+        subject_binders.append(&mut new_binders);
+        arms.insert(
+            lit,
+            Box::new(build_match_tree(context, fringe.clone(), inner_matrix)),
+        );
+    }
+
+    let (mut new_binders, default) = matrix.specialize_default();
+    subject_binders.append(&mut new_binders);
+    let default_result = Box::new(build_match_tree(context, fringe, default));
+
+    MatchTree::LiteralSwitch {
+        subject,
+        subject_binders,
+        arms,
+        default: default_result,
+    }
+}
+
+#[growing_stack]
+fn compile_match_struct(
+    context: &mut Context,
+    subject: FringeEntry,
+    tyargs: Vec<Type>,
+    fringe: VecDeque<FringeEntry>,
+    matrix: PatternMatrix,
+    mident: ModuleIdent,
+    datatype_name: DatatypeName,
+) -> MatchTree {
+    let mut subject_binders = vec![];
+    let decl_fields = context.info.struct_fields(&mident, &datatype_name).unwrap();
+    let unpack = if let Some((ploc, arg_types)) = matrix.first_struct_ctors() {
+        let fringe_binders = context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
+        let fringe_exps = make_fringe_entries(&fringe_binders);
+        let mut inner_fringe = fringe.clone();
+        for fringe_exp in fringe_exps.into_iter().rev() {
+            inner_fringe.push_front(fringe_exp);
+        }
+
+        let bind_tys = fringe_binders
+            .iter()
+            .map(|(_, _, ty)| ty)
+            .collect::<Vec<_>>();
+        let (mut new_binders, inner_matrix) = matrix.specialize_struct(context, bind_tys);
+        subject_binders.append(&mut new_binders);
+
+        StructUnpack::Unpack(
+            fringe_binders,
+            Box::new(build_match_tree(context, inner_fringe, inner_matrix)),
+        )
+    } else {
+        let (mut new_binders, default_matrix) = matrix.specialize_default();
+        subject_binders.append(&mut new_binders);
+        StructUnpack::Default(Box::new(build_match_tree(context, fringe, default_matrix)))
+    };
+
+    MatchTree::StructUnpack {
+        subject,
+        subject_binders,
+        tyargs,
+        unpack,
+    }
+}
+
+#[growing_stack]
+fn compile_variant_switch(
+    context: &mut Context,
+    subject: FringeEntry,
+    tyargs: Vec<Type>,
+    fringe: VecDeque<FringeEntry>,
+    matrix: PatternMatrix,
+    mident: ModuleIdent,
+    datatype_name: DatatypeName,
+) -> MatchTree {
+    let mut subject_binders = vec![];
+    let mut unmatched_variants = context
+        .info
+        .enum_variants(&mident, &datatype_name)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    let ctors = matrix.first_variant_ctors();
+    let mut arms = BTreeMap::new();
+
+    for (ctor, (ploc, arg_types)) in ctors {
+        unmatched_variants.remove(&ctor);
+        let decl_fields = context
+            .info
+            .enum_variant_fields(&mident, &datatype_name, &ctor)
+            .unwrap();
+        let fringe_binders = context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
+        let fringe_exps = make_fringe_entries(&fringe_binders);
+        let mut inner_fringe = fringe.clone();
+        for fringe_exp in fringe_exps.into_iter().rev() {
+            inner_fringe.push_front(fringe_exp);
+        }
+
+        let bind_tys = fringe_binders
+            .iter()
+            .map(|(_, _, ty)| ty)
+            .collect::<Vec<_>>();
+        let (mut new_binders, inner_matrix) = matrix.specialize_variant(context, &ctor, bind_tys);
+        subject_binders.append(&mut new_binders);
+
+        arms.insert(
+            ctor,
+            (
+                fringe_binders,
+                Box::new(build_match_tree(context, inner_fringe, inner_matrix)),
+            ),
+        );
+    }
+
+    let (mut new_binders, default_matrix) = if unmatched_variants.is_empty() {
+        let empty_pattern = PatternMatrix {
+            tys: vec![],
+            loc: matrix.loc,
+            patterns: vec![],
+        };
+        (vec![], empty_pattern)
+    } else {
+        matrix.specialize_default()
+    };
+    subject_binders.append(&mut new_binders);
+
+    MatchTree::VariantSwitch {
+        subject,
+        subject_binders,
+        tyargs,
+        arms,
+        default: Box::new(build_match_tree(context, fringe, default_matrix)),
     }
 }
 
@@ -444,7 +365,6 @@ struct ResolutionContext<'ctxt, 'call> {
     output_type: &'call Type,
     arms: &'call Vec<T::Exp>,
     arms_loc: Loc,
-    results: &'call mut BTreeMap<usize, WorkResult>,
 }
 
 impl<'ctxt, 'call> ResolutionContext<'ctxt, 'call> {
@@ -456,37 +376,32 @@ impl<'ctxt, 'call> ResolutionContext<'ctxt, 'call> {
         self.arms_loc
     }
 
-    fn work_result(&mut self, work_id: usize) -> WorkResult {
-        self.results.remove(&work_id).unwrap()
-    }
-
-    fn copy_work_result(&mut self, work_id: usize) -> WorkResult {
-        self.results.get(&work_id).unwrap().clone()
-    }
-
     fn output_type(&self) -> Type {
         self.output_type.clone()
     }
 }
 
 #[growing_stack]
-fn resolve_result(
+fn match_tree_to_exp(
     context: &mut ResolutionContext,
     init_subject: &FringeEntry,
-    result: WorkResult,
+    result: MatchTree,
 ) -> T::Exp {
     match result {
-        WorkResult::Leaf(leaf) => make_leaf(context, init_subject, leaf),
-        WorkResult::Failure => T::exp(
-            context.output_type(),
-            sp(context.arms_loc, T::UnannotatedExp_::UnresolvedError),
-        ),
-        WorkResult::VariantSwitch {
+        MatchTree::Leaf(leaf) => make_leaf(context, init_subject, leaf),
+        MatchTree::Failure => {
+            context.hlir_context.add_diag(ice!((context.arms_loc, "Generated a failure expression, which should not be allowed under match exhaustion.")));
+            T::exp(
+                context.output_type(),
+                sp(context.arms_loc, T::UnannotatedExp_::UnresolvedError),
+            )
+        }
+        MatchTree::VariantSwitch {
             subject,
             subject_binders,
             tyargs,
             mut arms,
-            default: default_ndx,
+            default,
         } => {
             let (m, e) = subject
                 .ty
@@ -503,9 +418,8 @@ fn resolve_result(
             let sorted_variants: Vec<VariantName> = context.hlir_context.info.enum_variants(&m, &e);
             let mut blocks = vec![];
             for v in sorted_variants {
-                if let Some((unpack_fields, result_ndx)) = arms.remove(&v) {
-                    let work_result = context.work_result(result_ndx);
-                    let rest_result = resolve_result(context, init_subject, work_result);
+                if let Some((unpack_fields, next)) = arms.remove(&v) {
+                    let rest_result = match_tree_to_exp(context, init_subject, *next);
                     let unpack_block = make_match_variant_unpack(
                         m,
                         e,
@@ -517,8 +431,8 @@ fn resolve_result(
                     );
                     blocks.push((v, unpack_block));
                 } else {
-                    let work_result = context.copy_work_result(default_ndx);
-                    let rest_result = resolve_result(context, init_subject, work_result);
+                    let default_tree = (*default).clone();
+                    let rest_result = match_tree_to_exp(context, init_subject, default_tree);
                     blocks.push((v, rest_result));
                 }
             }
@@ -526,7 +440,7 @@ fn resolve_result(
             let body_exp = T::exp(context.output_type(), sp(context.arms_loc(), out_exp));
             make_copy_bindings(bindings, body_exp)
         }
-        WorkResult::StructUnpack {
+        MatchTree::StructUnpack {
             subject,
             subject_binders,
             tyargs,
@@ -544,13 +458,9 @@ fn resolve_result(
                 .map(|(_mut, binder)| (binder, (Mutability::Imm, subject.clone())))
                 .collect();
             let unpack_exp = match unpack {
-                StructUnpack::Default(result_ndx) => {
-                    let work_result = context.work_result(result_ndx);
-                    resolve_result(context, init_subject, work_result)
-                }
-                StructUnpack::Unpack(unpack_fields, result_ndx) => {
-                    let work_result = context.work_result(result_ndx);
-                    let rest_result = resolve_result(context, init_subject, work_result);
+                StructUnpack::Default(next) => match_tree_to_exp(context, init_subject, *next),
+                StructUnpack::Unpack(unpack_fields, next) => {
+                    let rest_result = match_tree_to_exp(context, init_subject, *next);
                     make_match_struct_unpack(
                         m,
                         s,
@@ -563,7 +473,7 @@ fn resolve_result(
             };
             make_copy_bindings(bindings, unpack_exp)
         }
-        WorkResult::LiteralSwitch {
+        MatchTree::LiteralSwitch {
             subject,
             subject_binders,
             mut arms,
@@ -580,18 +490,15 @@ fn resolve_result(
                 .collect();
             // If the literal switch for a boolean is saturated, no default case.
             let lit_subject = make_match_lit(subject.clone());
-            let true_arm_ndx = arms
+            let true_arm = arms
                 .remove(&sp(Loc::invalid(), Value_::Bool(true)))
                 .unwrap();
-            let false_arm_ndx = arms
+            let false_arm = arms
                 .remove(&sp(Loc::invalid(), Value_::Bool(false)))
                 .unwrap();
 
-            let true_arm_result = context.work_result(true_arm_ndx);
-            let false_arm_result = context.work_result(false_arm_ndx);
-
-            let true_arm = resolve_result(context, init_subject, true_arm_result);
-            let false_arm = resolve_result(context, init_subject, false_arm_result);
+            let true_arm = match_tree_to_exp(context, init_subject, *true_arm);
+            let false_arm = match_tree_to_exp(context, init_subject, *false_arm);
             let result_ty = context.output_type().clone();
 
             make_copy_bindings(
@@ -599,7 +506,7 @@ fn resolve_result(
                 make_if_else(lit_subject, true_arm, false_arm, result_ty),
             )
         }
-        WorkResult::LiteralSwitch {
+        MatchTree::LiteralSwitch {
             subject,
             subject_binders,
             arms: map,
@@ -615,12 +522,11 @@ fn resolve_result(
             let mut entries = map.into_iter().collect::<Vec<_>>();
             entries.sort_by(|(key1, _), (key2, _)| key1.cmp(key2));
 
-            let else_work_result = context.work_result(default);
-            let mut out_exp = resolve_result(context, init_subject, else_work_result);
+            let else_work_result = (*default).clone();
+            let mut out_exp = match_tree_to_exp(context, init_subject, else_work_result);
 
-            for (key, result_ndx) in entries.into_iter().rev() {
-                let work_result = context.work_result(result_ndx);
-                let match_arm = resolve_result(context, init_subject, work_result);
+            for (key, next_tree) in entries.into_iter().rev() {
+                let match_arm = match_tree_to_exp(context, init_subject, *next_tree);
                 let test_exp = make_lit_test(lit_subject.clone(), key);
                 let result_ty = context.output_type().clone();
                 out_exp = make_if_else(test_exp, match_arm, out_exp, result_ty);

--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -24,13 +24,13 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 //**************************************************************************************************
 // This mostly follows the classical Maranget (2008) implementation toward optimal decision trees.
 
-#[derive(Clone)]
+#[derive(Debug,Clone)]
 enum StructUnpack<T> {
     Default(T),
     Unpack(Vec<(Field, Var, Type)>, T),
 }
 
-#[derive(Clone)]
+#[derive(Debug,Clone)]
 enum MatchTree {
     Leaf(Vec<ArmResult>),
     Failure,
@@ -69,6 +69,10 @@ pub(super) fn compile_match(
         make_initial_fringe(context, subject, loc);
 
     let match_tree = build_match_tree(context, VecDeque::from([match_subject]), pattern_matrix);
+    debug_print!(
+        context.debug.match_translation,
+        ("match tree" => match_tree; sdbg)
+    );
     let mut resolution_context = ResolutionContext {
         hlir_context: context,
         output_type: result_type,
@@ -152,7 +156,7 @@ fn build_match_tree(
         return MatchTree::Failure;
     }
 
-    if let Some(leaf) = matrix.wild_arm_opt(&fringe) {
+    if let Some(leaf) = matrix.wild_tree_opt(&fringe) {
         debug_print!(context.debug.match_specialization, (msg "wild leaf"), ("matrix" => matrix));
         return MatchTree::Leaf(leaf);
     }

--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -24,13 +24,13 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 //**************************************************************************************************
 // This mostly follows the classical Maranget (2008) implementation toward optimal decision trees.
 
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 enum StructUnpack<T> {
     Default(T),
     Unpack(Vec<(Field, Var, Type)>, T),
 }
 
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 enum MatchTree {
     Leaf(Vec<ArmResult>),
     Failure,

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -534,6 +534,7 @@ impl PatternMatrix {
                     }
                 }
             }
+            // FIXME: This is wrong in a number of situations.
             Some(result)
         } else {
             None

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -517,9 +517,10 @@ impl PatternMatrix {
             .any(|pat| pat.is_wild_arm() && pat.guard.is_none())
     }
 
-    pub fn wild_arm_opt(&mut self, fringe: &VecDeque<FringeEntry>) -> Option<Vec<ArmResult>> {
+    pub fn wild_tree_opt(&mut self, fringe: &VecDeque<FringeEntry>) -> Option<Vec<ArmResult>> {
         // NB: If the first row is all wild, we need to collect _all_ wild rows that have guards
-        // until we find one that does not.
+        // until we find one that does not. If we do not find one without a guard, then this isn't
+        // a wild tree.
         if let Some(arm) = self.patterns[0].all_wild_arm(fringe) {
             if arm.guard.is_none() {
                 return Some(vec![arm]);
@@ -534,8 +535,7 @@ impl PatternMatrix {
                     }
                 }
             }
-            // FIXME: This is wrong in a number of situations.
-            Some(result)
+            None
         } else {
             None
         }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/generated_0.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/generated_0.move
@@ -1,0 +1,418 @@
+module 0x42::m;
+
+public enum Option<T> has drop {
+    None,
+    Some(T)
+}
+
+fun t1(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::None  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t2(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val) if (_value) => val,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t3(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        _  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        _ if (true) => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t4(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        _  => 0u64,
+        Option::Some(val) if (val == 0) => val,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t5(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        _  => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        _ if (_value) => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t6(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::Some(val) if (_value) => val,
+        Option::Some(val)  => val,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _ if (_value) => 0u64,
+        _ if (_value) => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t7(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        _  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        _  => 0u64,
+        _ if (_value) => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t8(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val) if (true) => val,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val > 50) => val,
+        Option::Some(val) if (val == 0) => val,
+        Option::Some(val) if (_value) => val,
+        _ if (true) => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t9(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        _ if (true) => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t10(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _ if (true) => 0u64,
+        _  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t11(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val) if (_value) => val,
+        _ if (true) => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t12(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::None  => 0u64,
+        _  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val) if (*val > 50) => val,
+        Option::Some(val) if (*val > 50) => val,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val)  => val,
+        _  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t13(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        Option::Some(val)  => val,
+        _  => 0u64,
+        _ if (true) => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        _  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t14(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val) if (val == 0) => val,
+        Option::Some(val) if (*val > 50) => val,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        _  => 0u64,
+        Option::Some(val) if (*val > 50) => val,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        _ if (true) => 0u64,
+        _  => 0u64,
+        Option::Some(val) if (val == 0) => val,
+        Option::Some(val) if (*val > 50) => val,
+        Option::Some(val) if (*val > 50) => val,
+        _  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t15(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val > 50) => val,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t16(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val) if (val == 0) => val,
+        _  => 0u64,
+        _ if (_value) => 0u64,
+        _ if (true) => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _  => 0u64,
+        _ if (_value) => 0u64,
+        Option::Some(val) if (val == 0) => val,
+        Option::Some(val) if (_value) => val,
+        _  => 0u64,
+        _  => 0u64,
+        _  => 0u64,
+        Option::Some(val)  => val,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t17(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::None  => 0u64,
+        Option::Some(val) if (_value) => val,
+        _ if (true) => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _  => 0u64,
+        Option::Some(val) if (_value) => val,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::Some(val) if (_value) => val,
+        Option::Some(val) if (*val > 50) => val,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t18(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val > 50) => val,
+        Option::Some(val) if (val == 0) => val,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val) if (true) => val,
+        _  => 0u64,
+        _  => 0u64,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::Some(val)  => val,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t19(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _ if (true) => 0u64,
+        Option::Some(val)  => val,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _  => 0u64,
+        Option::Some(val) if (val == 0) => val,
+        Option::Some(val) if (*val > 50) => val,
+        Option::Some(val) if (_value) => val,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val)  => val,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        _ if (true) => 0u64,
+        Option::None  => 0u64,
+        _  => 0u64,
+        Option::Some(val) if (val == 0) => val,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+fun t20(): u64 {
+    let _value = false;
+    let o: Option<u64> = Option::None;
+    match (o) {
+        _ if (true) => 0u64,
+        _ if (_value) => 0u64,
+        Option::Some(val)  => val,
+        Option::Some(val) if (val == 0) => val,
+        Option::None  => 0u64,
+        _ if (_value) => 0u64,
+        _  => 0u64,
+        Option::Some(val)  => val,
+        Option::Some(val) if (_value) => val,
+        Option::None  => 0u64,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::Some(val) if (*val < 100 && val != 42) => val,
+        Option::Some(val)  => val,
+        _ if (true) => 0u64,
+        Option::Some(val) if (val == 0) => val,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::None  => 0u64,
+        Option::Some(val) if (_value) => val,
+        _  => 0u64,
+        Option::None  => 0u64,
+        Option::None => 2,
+        Option::Some(_) => 3,
+    }
+}
+
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_invalid_copy.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_invalid_copy.exp
@@ -1,18 +1,18 @@
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/matching/guard_invalid_copy.move:17:32
+   ┌─ tests/move_2024/matching/guard_invalid_copy.move:17:28
    │
-17 │             Option::Some(n) if check_s(n) => n,
-   │                                ^^^^^^^
-   │                                │
-   │                                Unexpected 'check_s'
-   │                                Expected '('
+17 │         Option::Some(n) if check_s(n) => n,
+   │                            ^^^^^^^
+   │                            │
+   │                            Unexpected 'check_s'
+   │                            Expected '('
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/matching/guard_invalid_copy.move:26:32
+   ┌─ tests/move_2024/matching/guard_invalid_copy.move:26:28
    │
-26 │             Option::Some(n) if check_s(copy n) => n,
-   │                                ^^^^^^^
-   │                                │
-   │                                Unexpected 'check_s'
-   │                                Expected '('
+26 │         Option::Some(n) if check_s(copy n) => n,
+   │                            ^^^^^^^
+   │                            │
+   │                            Unexpected 'check_s'
+   │                            Expected '('
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_invalid_copy.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_invalid_copy.move
@@ -1,32 +1,30 @@
-module 0x42::m {
+module 0x42::m;
 
-    public enum Option<T> has drop {
-        None,
-        Some(T)
+public enum Option<T> has drop {
+    None,
+    Some(T)
+}
+
+public struct S has drop {}
+
+fun check_s(_s: S): bool {
+    false
+}
+
+fun t0(): S {
+    let o: Option<S> = Option::None;
+    match (o) {
+        Option::Some(n) if check_s(n) => n,
+        Option::Some(y) => y,
+        Option::None => S {},
     }
+}
 
-    public struct S has drop {}
-
-    fun check_s(_s: S): bool {
-        false
+fun t1(): S {
+    let o: Option<S> = Option::None;
+    match (o) {
+        Option::Some(n) if check_s(copy n) => n,
+        Option::Some(y) => y,
+        Option::None => S {},
     }
-
-    fun t0(): S {
-        let o: Option<S> = Option::None;
-        match (o) {
-            Option::Some(n) if check_s(n) => n,
-            Option::Some(y) => y,
-            Option::None => S {},
-        }
-    }
-
-    fun t1(): S {
-        let o: Option<S> = Option::None;
-        match (o) {
-            Option::Some(n) if check_s(copy n) => n,
-            Option::Some(y) => y,
-            Option::None => S {},
-        }
-    }
-
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild.move
@@ -1,0 +1,13 @@
+module 0x0::repro;
+
+public enum Tile has store, drop {
+    Empty,
+    Unwalkable,
+}
+
+public fun failure(tile: &Tile, value: bool): u64 {
+    match (tile) {
+        _ if (value) => 0,
+        _ => 1,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild_inexhaustive.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild_inexhaustive.exp
@@ -1,0 +1,8 @@
+error[E04036]: non-exhaustive pattern
+  ┌─ tests/move_2024/matching/guard_wild_inexhaustive.move:9:12
+  │
+9 │     match (tile) {
+  │            ^^^^ Pattern 'Tile::Unwalkable' not covered
+  │
+  = Match arms with guards are not considered for coverage.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild_inexhaustive.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild_inexhaustive.move
@@ -1,0 +1,13 @@
+module 0x0::repro;
+
+public enum Tile has store, drop {
+    Empty,
+    Unwalkable,
+}
+
+public fun failure(tile: &Tile, value: bool): u64 {
+    match (tile) {
+        _ if (value) => 0,
+        Tile::Empty => 1,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild_initial.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/guard_wild_initial.move
@@ -1,0 +1,14 @@
+module 0x0::repro;
+
+public enum Tile has store, drop {
+    Empty,
+    Unwalkable,
+}
+
+public fun failure(tile: &Tile, value: bool): u64 {
+    match (tile) {
+        _ if (value) => 0,
+        Tile::Empty => 1,
+        Tile::Unwalkable => 2,
+    }
+}


### PR DESCRIPTION
## Description 

Fix a bug, plus a bit of yak shaving: this removes the work queue from match compilation in favor of `growing_stack`, for the purpose of sanity. This refactor was actually sufficient (along with one small change) to eliminate the bug.

## Test plan 

All tests still pass, plus the new ones.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
