### PR TITLE
[Consensus] Linearizer to use commit up to gc_round

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -488,7 +488,7 @@ mod tests {
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
 
         if gc_depth == 0 {
-            protocol_config.set_consensus_linearizer_collect_subdag_v2_for_testing(false);
+            protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
         }
 
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
@@ -698,7 +698,7 @@ mod tests {
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
 
         if gc_depth == 0 {
-            protocol_config.set_consensus_linearizer_collect_subdag_v2_for_testing(false);
+            protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
         }
 
         for (index, _authority_info) in committee.authorities() {

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -487,6 +487,10 @@ mod tests {
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
 
+        if gc_depth == 0 {
+            protocol_config.set_consensus_linearizer_collect_subdag_v2_for_testing(false);
+        }
+
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())
             .collect::<Vec<_>>();
@@ -692,6 +696,10 @@ mod tests {
 
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
+
+        if gc_depth == 0 {
+            protocol_config.set_consensus_linearizer_collect_subdag_v2_for_testing(false);
+        }
 
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -54,9 +54,9 @@ impl CommitObserver {
     ) -> Self {
         let mut observer = Self {
             commit_interpreter: Linearizer::new(
+                context.clone(),
                 dag_state.clone(),
                 leader_schedule.clone(),
-                context.clone(),
             ),
             context,
             sender: commit_consumer.commit_sender,

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -53,8 +53,12 @@ impl CommitObserver {
         leader_schedule: Arc<LeaderSchedule>,
     ) -> Self {
         let mut observer = Self {
+            commit_interpreter: Linearizer::new(
+                dag_state.clone(),
+                leader_schedule.clone(),
+                context.clone(),
+            ),
             context,
-            commit_interpreter: Linearizer::new(dag_state.clone(), leader_schedule.clone()),
             sender: commit_consumer.commit_sender,
             store,
             leader_schedule,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -425,7 +425,6 @@ impl DagState {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn is_committed(&self, block_ref: &BlockRef) -> bool {
         self.recent_blocks
             .get(block_ref)

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -245,7 +245,9 @@ impl DagState {
                         .scan_commits((index..=index).into())
                         .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
                     let Some(commit) = commits.first() else {
-                        info!("Recovering finished, no more commits to recover");
+                        info!(
+                            "Recovering finished up to index {index}, no more commits to recover"
+                        );
                         break;
                     };
 
@@ -268,8 +270,11 @@ impl DagState {
                         assert!(state.set_committed(block_ref), "Attempted to set again a block {:?} as committed when recovering commit {:?}", block_ref, commit);
                     });
 
-                    // When reaching zero will exist anyways as all commits are indexed starting from 1.
+                    // All commits are indexed starting from 1, so one reach zero exit.
                     index = index.saturating_sub(1);
+                    if index == 0 {
+                        break;
+                    }
                 }
             }
         }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1857,7 +1857,7 @@ mod test {
             .set_consensus_gc_depth_for_testing(GC_DEPTH);
         context
             .protocol_config
-            .set_consensus_linearizer_collect_subdag_v2_for_testing(true);
+            .set_consensus_linearize_subdag_v2_for_testing(true);
 
         let context = Arc::new(context);
 

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -57,16 +57,16 @@ impl BlockStoreAPI
 #[derive(Clone)]
 pub(crate) struct Linearizer {
     /// In memory block store representing the dag state
+    context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     leader_schedule: Arc<LeaderSchedule>,
-    context: Arc<Context>,
 }
 
 impl Linearizer {
     pub(crate) fn new(
+        context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
         leader_schedule: Arc<LeaderSchedule>,
-        context: Arc<Context>,
     ) -> Self {
         Self {
             dag_state,
@@ -325,7 +325,7 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule, context.clone());
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
@@ -376,7 +376,7 @@ mod tests {
                 .with_num_commits_per_schedule(NUM_OF_COMMITS_PER_SCHEDULE),
         );
         let mut linearizer =
-            Linearizer::new(dag_state.clone(), leader_schedule.clone(), context.clone());
+            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
 
         // Populate fully connected test blocks for round 0 ~ 20, authorities 0 ~ 3.
         let num_rounds: u32 = 20;
@@ -446,7 +446,7 @@ mod tests {
                 .with_num_commits_per_schedule(NUM_OF_COMMITS_PER_SCHEDULE),
         );
         let mut linearizer =
-            Linearizer::new(dag_state.clone(), leader_schedule.clone(), context.clone());
+            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
 
         // Populate fully connected test blocks for round 0 ~ 20, authorities 0 ~ 3.
         let num_rounds: u32 = 20;
@@ -514,7 +514,7 @@ mod tests {
             LeaderSwapTable::default(),
         ));
         let mut linearizer =
-            Linearizer::new(dag_state.clone(), leader_schedule.clone(), context.clone());
+            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
         let wave_length = DEFAULT_WAVE_LENGTH;
 
         let leader_round_wave_1 = 3;
@@ -633,7 +633,7 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule, context.clone());
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
         // Authorities of index 0->2 will always creates blocks that see each other, but until round 5 they won't see the blocks of authority 3.
         // For authority 3 we create blocks that connect to all the other authorities.
@@ -747,7 +747,7 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule, context.clone());
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
         // Authority D will create an "orphaned" block on round 1 as it won't reference to it on the block of round 2. Similar, no other authority will reference to it on round 2.
         // Then on round 3 the authorities A, B & C will link to block D1. Once the DAG gets committed we should see the block D1 getting committed as well. Normally ,as block D2 would

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -727,7 +727,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_handle_commit_with_gc_orphaned_blocks(#[values(3)] gc_depth: u32) {
+    async fn test_handle_commit_below_highest_committed_round(#[values(3)] gc_depth: u32) {
         telemetry_subscribers::init_for_testing();
 
         let num_authorities = 4;

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -153,10 +153,7 @@ impl Linearizer {
 
         // The new logic will perform the recursion without stopping at the highest round round that has been committed per authority. Instead it will
         // allow to commit blocks that are lower than the highest committed round for an authority but higher than gc_round.
-        if context
-            .protocol_config
-            .consensus_linearize_subdag_v2()
-        {
+        if context.protocol_config.consensus_linearize_subdag_v2() {
             assert!(
                 dag_state.set_committed(&leader_block_ref),
                 "Leader block with reference {:?} attempted to be committed twice",

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -106,6 +106,8 @@ impl Linearizer {
             &mut dag_state,
         );
 
+        drop(dag_state);
+
         // Create the Commit.
         let commit = Commit::new(
             last_commit_index + 1,

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -155,7 +155,7 @@ impl Linearizer {
         // allow to commit blocks that are lower than the highest committed round for an authority but higher than gc_round.
         if context
             .protocol_config
-            .consensus_linearizer_collect_subdag_v2()
+            .consensus_linearize_subdag_v2()
         {
             assert!(
                 dag_state.set_committed(&leader_block_ref),
@@ -622,7 +622,7 @@ mod tests {
         if gc_depth > 0 {
             context
                 .protocol_config
-                .set_consensus_linearizer_collect_subdag_v2_for_testing(true);
+                .set_consensus_linearize_subdag_v2_for_testing(true);
         }
 
         let context = Arc::new(context);
@@ -737,7 +737,7 @@ mod tests {
             .set_consensus_gc_depth_for_testing(gc_depth);
         context
             .protocol_config
-            .set_consensus_linearizer_collect_subdag_v2_for_testing(true);
+            .set_consensus_linearize_subdag_v2_for_testing(true);
 
         let context = Arc::new(context);
         let dag_state = Arc::new(RwLock::new(DagState::new(

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -177,13 +177,21 @@ impl DagBuilder {
             }
 
             fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
-                if let Some((block, committed)) = self.blocks.get_mut(block_ref) {
-                    if !*committed {
-                        *committed = true;
-                        return true;
-                    }
+                let Some((block, committed)) = self.blocks.get_mut(block_ref) else {
+                    panic!("Block {:?} should be found in store", block_ref);
+                };
+                if !*committed {
+                    *committed = true;
+                    return true;
                 }
                 false
+            }
+
+            fn is_committed(&self, block_ref: &BlockRef) -> bool {
+                self.blocks
+                    .get(block_ref)
+                    .map(|(_, committed)| *committed)
+                    .expect("Block should be found in store")
             }
         }
         let mut storage = BlockStorage {

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -181,8 +181,12 @@ impl DagBuilder {
                 fn gc_enabled(&self) -> bool {
                     self.context.protocol_config.gc_depth() > 0
                 }
+
+                fn set_committed(&mut self, block_ref: &BlockRef) {
+                    // Do nothing
+                }
             }
-            let storage = FooStorage {
+            let mut storage = FooStorage {
                 context: self.context.clone(),
                 blocks: self.blocks.clone(),
                 gc_round: leader_block
@@ -194,7 +198,7 @@ impl DagBuilder {
             let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
                 leader_block,
                 self.last_committed_rounds.clone(),
-                storage,
+                &mut storage,
             );
 
             // Update the last committed rounds

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -152,49 +152,66 @@ impl DagBuilder {
                 (0, 0, 0)
             };
 
+        struct BlockStorage {
+            gc_round: Round,
+            context: Arc<Context>,
+            blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>, // the tuple represends the block and whether it is committed
+        }
+        impl BlockStoreAPI for BlockStorage {
+            fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
+                refs.iter()
+                    .map(|block_ref| {
+                        self.blocks
+                            .get(block_ref)
+                            .map(|(block, _committed)| block.clone())
+                    })
+                    .collect()
+            }
+
+            fn gc_round(&self) -> Round {
+                self.gc_round
+            }
+
+            fn gc_enabled(&self) -> bool {
+                self.context.protocol_config.gc_depth() > 0
+            }
+
+            fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
+                if let Some((block, committed)) = self.blocks.get_mut(block_ref) {
+                    if !*committed {
+                        *committed = true;
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+        let mut storage = BlockStorage {
+            context: self.context.clone(),
+            blocks: self
+                .blocks
+                .clone()
+                .into_iter()
+                .map(|(k, v)| (k, (v, false)))
+                .collect(),
+            gc_round: 0,
+        };
+
         // Create any remaining committed sub dags
         for leader_block in self
             .leader_blocks(last_leader_round + 1..=*leader_rounds.end())
             .into_iter()
             .flatten()
         {
+            // set the gc round to the round of the leader block
+            storage.gc_round = leader_block
+                .round()
+                .saturating_sub(1)
+                .saturating_sub(self.context.protocol_config.gc_depth());
+
             let leader_block_ref = leader_block.reference();
             last_commit_index += 1;
             last_timestamp_ms = leader_block.timestamp_ms().max(last_timestamp_ms);
-
-            struct FooStorage {
-                gc_round: Round,
-                context: Arc<Context>,
-                blocks: BTreeMap<BlockRef, VerifiedBlock>,
-            }
-            impl BlockStoreAPI for FooStorage {
-                fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-                    refs.iter()
-                        .map(|block_ref| self.blocks.get(block_ref).cloned())
-                        .collect()
-                }
-
-                fn gc_round(&self) -> Round {
-                    self.gc_round
-                }
-
-                fn gc_enabled(&self) -> bool {
-                    self.context.protocol_config.gc_depth() > 0
-                }
-
-                fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
-                    // Do nothing
-                    true
-                }
-            }
-            let mut storage = FooStorage {
-                context: self.context.clone(),
-                blocks: self.blocks.clone(),
-                gc_round: leader_block
-                    .round()
-                    .saturating_sub(1)
-                    .saturating_sub(self.context.protocol_config.gc_depth()),
-            };
 
             let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
                 &self.context.clone(),

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -182,8 +182,9 @@ impl DagBuilder {
                     self.context.protocol_config.gc_depth() > 0
                 }
 
-                fn set_committed(&mut self, block_ref: &BlockRef) {
+                fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
                     // Do nothing
+                    true
                 }
             }
             let mut storage = FooStorage {
@@ -196,6 +197,7 @@ impl DagBuilder {
             };
 
             let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
+                &self.context.clone(),
                 leader_block,
                 self.last_committed_rounds.clone(),
                 &mut storage,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1306,6 +1306,7 @@
                 "bridge": false,
                 "commit_root_state_digest": false,
                 "consensus_distributed_vote_scoring_strategy": false,
+                "consensus_linearize_subdag_v2": false,
                 "consensus_order_end_of_epoch_last": true,
                 "consensus_round_prober": false,
                 "consensus_round_prober_probe_accepted_rounds": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -589,7 +589,7 @@ struct FeatureFlags {
     // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic does not stop the recursion at the highest
     // committed round for each authority, but allows to commit uncommitted blocks up to gc round (excluded) for that authority.
     #[serde(skip_serializing_if = "is_false")]
-    consensus_linearizer_collect_subdag_v2: bool,
+    consensus_linearize_subdag_v2: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1730,11 +1730,11 @@ impl ProtocolConfig {
         self.feature_flags.native_charging_v2
     }
 
-    pub fn consensus_linearizer_collect_subdag_v2(&self) -> bool {
-        let res = self.feature_flags.consensus_linearizer_collect_subdag_v2;
+    pub fn consensus_linearize_subdag_v2(&self) -> bool {
+        let res = self.feature_flags.consensus_linearize_subdag_v2;
         assert!(
             !res || self.gc_depth() > 0,
-            "The consensus linearizer collect sub dag V2 requires GC to be enabled"
+            "The consensus linearize sub dag V2 requires GC to be enabled"
         );
         res
     }
@@ -3280,8 +3280,8 @@ impl ProtocolConfig {
             .consensus_round_prober_probe_accepted_rounds = val;
     }
 
-    pub fn set_consensus_linearizer_collect_subdag_v2_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_linearizer_collect_subdag_v2 = val;
+    pub fn set_consensus_linearize_subdag_v2_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_linearize_subdag_v2 = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -586,8 +586,8 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     native_charging_v2: bool,
 
-    // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic
-    // does not stop the recursion when comes across a committed block, but it keeps looking for the committed history until gc_round.
+    // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic does not stop the recursion at the highest 
+    // committed round for each authority, but allows to commit uncommitted blocks up to gc round (excluded) for that authority.
     #[serde(skip_serializing_if = "is_false")]
     consensus_linearizer_collect_subdag_v2: bool,
 }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -585,6 +585,11 @@ struct FeatureFlags {
     // Enable v2 native charging for natives.
     #[serde(skip_serializing_if = "is_false")]
     native_charging_v2: bool,
+
+    // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic
+    // does not stop the recursion when comes across a committed block, but it keeps looking for the committed history until gc_round.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_linearizer_collect_subdag_v2: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1723,6 +1728,15 @@ impl ProtocolConfig {
 
     pub fn native_charging_v2(&self) -> bool {
         self.feature_flags.native_charging_v2
+    }
+
+    pub fn consensus_linearizer_collect_subdag_v2(&self) -> bool {
+        let res = self.feature_flags.consensus_linearizer_collect_subdag_v2;
+        assert!(
+            !res || self.gc_depth() > 0,
+            "The consensus linearizer collect sub dag V2 requires GC to be enabled"
+        );
+        res
     }
 }
 
@@ -3264,6 +3278,10 @@ impl ProtocolConfig {
     pub fn set_consensus_round_prober_probe_accepted_rounds(&mut self, val: bool) {
         self.feature_flags
             .consensus_round_prober_probe_accepted_rounds = val;
+    }
+
+    pub fn set_consensus_linearizer_collect_subdag_v2_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_linearizer_collect_subdag_v2 = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -586,7 +586,7 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     native_charging_v2: bool,
 
-    // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic does not stop the recursion at the highest 
+    // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic does not stop the recursion at the highest
     // committed round for each authority, but allows to commit uncommitted blocks up to gc round (excluded) for that authority.
     #[serde(skip_serializing_if = "is_false")]
     consensus_linearizer_collect_subdag_v2: bool,


### PR DESCRIPTION
## Description 

Currently when committing/collecting the sub dag we always stop the recursion when we come across the highest committed round for an authority. This works well, but with the upcoming Fast Path changes it can lead to uncommitted FP certificates in the presence of blocks that don't form a proper hash chain. 

This could be done if for example an authority `A` produces blocks `A100, A101, A102` , but block `A102` uses as ancestor block `A100` and never references `A101`. `A101` gets broadcasted and participate in the form of an FP certificate and referenced by others. With the current logic in Linearizer, if `A102` gets committed first, then `A101` will never get committed as part of subsequent DAG sequencing as we always stop our recursion to the highest committed round. With the new logic we ensure that `A101` will get committed as well if it's `> gc_round`. Having `Garbage Collection` allows us to limit the recursion depth making the process efficient enough and knowing that we'll not attempt to keep committing blocks too far in the past. Using a reasonable depth (ex 50 - 60) for production shouldn't cause performance troubles.

To achieve the above `DagState` has been refactored to keep a global commit state of blocks. When we linearise the DAG across commits we do not re-commit previously committed blocks.

The new changes are guarded behind a feature flag and can only be enabled if GC is enabled.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
