### PR TITLE
[suiop] add service logs command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,9 +2254,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -2800,7 +2800,7 @@ dependencies = [
  "tonic-build",
  "tonic-rustls",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "typed-store",
 ]
@@ -5924,6 +5924,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5964,6 +5984,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
+ "log",
  "rustls 0.23.12",
  "rustls-native-certs 0.7.1",
  "rustls-pki-types",
@@ -6000,9 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -6013,7 +6034,6 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -6463,6 +6483,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+dependencies = [
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonpath_lib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6651,6 +6686,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-openapi"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6677,6 +6725,71 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kube"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf471ece8ff8d24735ce78dac4d091e9fcb8d74811aeb6b75de4d1c3f5de0f1"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.2",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem 3.0.4",
+ "rustls 0.23.12",
+ "rustls-pemfile 2.1.2",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.21",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.10",
+ "tower 0.5.1",
+ "tower-http 0.6.1",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http 1.1.0",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -8220,7 +8333,7 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-health",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
 ]
 
@@ -11740,6 +11853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11845,6 +11967,16 @@ dependencies = [
  "once_cell",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -12769,7 +12901,7 @@ dependencies = [
  "tokio",
  "toml 0.7.4",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "unescape",
  "url",
@@ -13641,7 +13773,7 @@ dependencies = [
  "tokio",
  "tonic 0.12.3",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "ttl_cache",
  "typed-store",
@@ -13842,7 +13974,7 @@ dependencies = [
  "tokio-util 0.7.10",
  "toml 0.7.4",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "uuid 1.2.2",
 ]
@@ -14074,7 +14206,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.10",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "typed-store-error",
 ]
@@ -14801,7 +14933,7 @@ dependencies = [
  "telemetry-subscribers",
  "tokio",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "url",
 ]
@@ -15194,7 +15326,7 @@ dependencies = [
  "tokio",
  "toml 0.7.4",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "url",
 ]
@@ -15742,6 +15874,8 @@ dependencies = [
  "include_dir",
  "inquire",
  "itertools 0.13.0",
+ "k8s-openapi",
+ "kube",
  "once_cell",
  "open",
  "prettytable-rs",
@@ -16720,7 +16854,7 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tokio-stream",
  "tonic 0.12.3",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -16762,9 +16896,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b837f86b25d7c0d7988f00a54e74739be6477f2aac6201b8f429a7569991b7"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -16811,6 +16945,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.4.1",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "mime",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16818,9 +16970,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -57,6 +57,8 @@ thiserror.workspace = true
 strsim = "0.11.1"
 futures-timer = "3.0.3"
 tempfile.workspace = true
+kube = { version = "0.96.0", features = ["client"] }
+k8s-openapi = { version = "0.23.0", features = ["latest"] }
 
 
 [dev-dependencies]

--- a/crates/suiop-cli/src/cli/lib/cache.rs
+++ b/crates/suiop-cli/src/cli/lib/cache.rs
@@ -1,4 +1,7 @@
-use std::{fs::Metadata, path::Path};
+use std::{
+    fs::{create_dir_all, Metadata},
+    path::Path,
+};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -30,6 +33,7 @@ pub fn cache<T: Serialize + for<'a> Deserialize<'a>>(
 }
 
 pub fn cache_local<T: Serialize + for<'a> Deserialize<'a>>(key: &str, value: T) -> Result<T> {
+    create_dir_all(Path::new(LOCAL_CACHE_DIR))?;
     cache(key, value, Path::new(LOCAL_CACHE_DIR))
 }
 

--- a/crates/suiop-cli/src/cli/lib/cache.rs
+++ b/crates/suiop-cli/src/cli/lib/cache.rs
@@ -22,6 +22,16 @@ impl<T> CacheResult<T> {
     pub fn new(value: T, metadata: Metadata) -> Self {
         Self { value, metadata }
     }
+
+    pub fn is_expired(&self) -> bool {
+        self.metadata
+            .modified()
+            .unwrap()
+            .elapsed()
+            .unwrap()
+            .as_secs()
+            > 86400
+    }
 }
 
 pub fn cache<T: Serialize + for<'a> Deserialize<'a>>(

--- a/crates/suiop-cli/src/cli/lib/cache.rs
+++ b/crates/suiop-cli/src/cli/lib/cache.rs
@@ -1,0 +1,50 @@
+use std::{fs::Metadata, path::Path};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::LOCAL_CACHE_DIR;
+
+/// A generic cache for values that take time to compute.
+pub struct CacheResult<T> {
+    pub value: T,
+    pub metadata: Metadata,
+}
+
+impl<T> CacheResult<T> {
+    pub fn new(value: T, metadata: Metadata) -> Self {
+        Self { value, metadata }
+    }
+}
+
+pub fn cache<T: Serialize + for<'a> Deserialize<'a>>(
+    key: &str,
+    value: T,
+    cache_dir: &Path,
+) -> Result<T> {
+    let cache_file = cache_dir.join(key);
+    std::fs::write(cache_file, serde_json::to_string(&value)?)?;
+    debug!("Cached value for key: {}", key);
+    Ok(value)
+}
+
+pub fn cache_local<T: Serialize + for<'a> Deserialize<'a>>(key: &str, value: T) -> Result<T> {
+    cache(key, value, Path::new(LOCAL_CACHE_DIR))
+}
+
+pub fn get_cached<T: for<'a> Deserialize<'a>>(
+    key: &str,
+    cache_dir: &Path,
+) -> Result<CacheResult<T>> {
+    let cache_file = cache_dir.join(key);
+    let value = std::fs::read_to_string(&cache_file)?;
+    debug!("Retrieved cached value for key: {}", key);
+    Ok(CacheResult::new(
+        serde_json::from_str(&value)?,
+        std::fs::metadata(&cache_file)?,
+    ))
+}
+pub fn get_cached_local<T: for<'a> Deserialize<'a>>(key: &str) -> Result<CacheResult<T>> {
+    get_cached(key, Path::new(LOCAL_CACHE_DIR))
+}

--- a/crates/suiop-cli/src/cli/lib/cache.rs
+++ b/crates/suiop-cli/src/cli/lib/cache.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{
     fs::{create_dir_all, Metadata},
     path::Path,

--- a/crates/suiop-cli/src/cli/lib/mod.rs
+++ b/crates/suiop-cli/src/cli/lib/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod autocomplete;
+pub mod cache;
 mod oauth;
 
 pub use autocomplete::FilePathCompleter;

--- a/crates/suiop-cli/src/cli/service/logs.rs
+++ b/crates/suiop-cli/src/cli/service/logs.rs
@@ -16,11 +16,13 @@ pub async fn get_kubeconfig() -> Result<Client> {
     let kubeconfig_yaml =
         if let Ok(cached_kubeconfig) = get_cached_local::<String>(KUBECONFIG_CACHE_KEY) {
             debug!("Using cached kubeconfig");
-            cached_kubeconfig
+            cached_kubeconfig.value
         } else {
             let cmd_output = run_cmd(vec!["pulumi", "config", "get", "kubeconfig"], None)?;
             let kubeconfig_yaml = String::from_utf8(cmd_output.stdout)?;
-            cache_local(KUBECONFIG_CACHE_KEY, kubeconfig_yaml)?
+            cache_local(KUBECONFIG_CACHE_KEY, kubeconfig_yaml.clone())?;
+
+            kubeconfig_yaml
         };
     // create a new client
     let kubeconfig = Kubeconfig::from_yaml(&kubeconfig_yaml)?;

--- a/crates/suiop-cli/src/cli/service/logs.rs
+++ b/crates/suiop-cli/src/cli/service/logs.rs
@@ -1,0 +1,71 @@
+use anyhow::{Context, Result};
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{Api, LogParams},
+    config::Kubeconfig,
+    Client, Config,
+};
+use tracing::debug;
+
+use crate::{cache_local, get_cached_local, run_cmd};
+
+const KUBECONFIG_CACHE_KEY: &str = "kubeconfig.yaml";
+
+pub async fn get_kubeconfig() -> Result<Client> {
+    // run pulumi config get config kubeconfig
+    let kubeconfig_yaml =
+        if let Ok(cached_kubeconfig) = get_cached_local::<String>(KUBECONFIG_CACHE_KEY) {
+            debug!("Using cached kubeconfig");
+            cached_kubeconfig
+        } else {
+            let cmd_output = run_cmd(vec!["pulumi", "config", "get", "kubeconfig"], None)?;
+            let kubeconfig_yaml = String::from_utf8(cmd_output.stdout)?;
+            cache_local(KUBECONFIG_CACHE_KEY, kubeconfig_yaml)?
+        };
+    // create a new client
+    let kubeconfig = Kubeconfig::from_yaml(&kubeconfig_yaml)?;
+    let config = Config::from_custom_kubeconfig(kubeconfig, &Default::default())
+        .await
+        .context("Failed to create kubernetes client")?;
+    let client = Client::try_from(config)?;
+    Ok(client)
+}
+
+pub async fn get_logs(namespace: &str) -> Result<()> {
+    // Create kubernetes client
+    // TODO: Use kubeconfig from pulumi env
+    let client = get_kubeconfig().await?;
+
+    // Get deployments API in the specified namespace
+    let pods: Api<Pod> = Api::namespaced(client, namespace);
+    // Get list of pods
+    let pod_list = pods
+        .list(&Default::default())
+        .await
+        .context("Failed to get pods")?;
+
+    // Extract pod names
+    let pod_names: Vec<String> = pod_list
+        .iter()
+        .map(|pod| pod.metadata.name.clone().unwrap_or_default())
+        .collect();
+
+    if pod_names.is_empty() {
+        println!("No pods found in namespace '{}'", namespace);
+        return Ok(());
+    }
+
+    // Ask user to select a pod
+    let pod_name = inquire::Select::new("Select pod to view logs from:", pod_names)
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("Failed to get pod selection: {}", e))?;
+
+    // Get logs from the deployment named "deploy"
+    let logs = pods
+        .logs(&pod_name, &LogParams::default())
+        .await
+        .context("Failed to get logs")?;
+
+    println!("{}", logs);
+    Ok(())
+}

--- a/crates/suiop-cli/src/cli/service/logs.rs
+++ b/crates/suiop-cli/src/cli/service/logs.rs
@@ -35,7 +35,6 @@ pub async fn get_kubeconfig() -> Result<Client> {
 
 pub async fn get_logs(namespace: &str) -> Result<()> {
     // Create kubernetes client
-    // TODO: Use kubeconfig from pulumi env
     let client = get_kubeconfig().await?;
 
     // Get deployments API in the specified namespace

--- a/crates/suiop-cli/src/cli/service/logs.rs
+++ b/crates/suiop-cli/src/cli/service/logs.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -5,15 +5,14 @@ pub mod init;
 mod logs;
 
 use anyhow::Result;
-use clap::{builder::OsStr, Parser};
+use clap::Parser;
 use colored::Colorize;
 pub use init::bootstrap_service;
 use init::ServiceLanguage;
 use logs::get_logs;
 use std::path::PathBuf;
-use tracing::info;
 
-use crate::{cache_local, command::CommandOptions, get_cached_local, run_cmd};
+use crate::{cache_local, get_cached_local, run_cmd};
 
 const PULUMI_NAMESPACE_CACHE_KEY: &str = "pulumi_namespace";
 
@@ -62,7 +61,7 @@ fn get_pulumi_namespace_from_cmd() -> String {
 fn get_pulumi_namespace() -> String {
     let cached_ns = get_cached_local::<String>(PULUMI_NAMESPACE_CACHE_KEY);
 
-    let ns = cached_ns
+    cached_ns
         .map(|ca| {
             // check if the cached entry is older than 1 day, if so, refresh it
             if ca.metadata.modified().unwrap().elapsed().unwrap().as_secs() > 86400 {
@@ -71,9 +70,7 @@ fn get_pulumi_namespace() -> String {
                 ca.value
             }
         })
-        .unwrap_or_else(|_| get_pulumi_namespace_from_cmd());
-
-    ns
+        .unwrap_or_else(|_| get_pulumi_namespace_from_cmd())
 }
 
 pub async fn service_cmd(args: &ServiceArgs) -> Result<()> {

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -21,9 +21,12 @@ use crate::{cache_local, get_cached_local, run_cmd};
 const PULUMI_WORKSPACE_FILE_CACHE_KEY: &str = "pulumi_workspace_file";
 
 #[derive(Parser, Debug, Clone)]
+pub struct LogsArgs {}
+
+#[derive(Parser, Debug, Clone)]
 pub struct ServiceArgs {
     #[command(subcommand)]
-    action: ServiceAction,
+    pub action: ServiceAction,
 }
 
 #[derive(clap::Subcommand, Debug, Clone)]

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -10,11 +10,12 @@ use colored::Colorize;
 pub use init::bootstrap_service;
 use init::ServiceLanguage;
 use logs::get_logs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use tracing::debug;
 
 use crate::{cache_local, get_cached_local, run_cmd};
 
-const PULUMI_NAMESPACE_CACHE_KEY: &str = "pulumi_namespace";
+const PULUMI_WORKSPACE_FILE_CACHE_KEY: &str = "pulumi_workspace_file";
 
 #[derive(Parser, Debug, Clone)]
 pub struct ServiceArgs {
@@ -44,14 +45,18 @@ pub enum ServiceAction {
     },
 }
 
-fn get_pulumi_namespace_from_cmd() -> String {
+fn get_ns_cache_key(stack: &str) -> String {
+    format!("pulumi_namespace.{}", stack)
+}
+
+fn get_pulumi_namespace_from_cmd(stack: &str) -> String {
     run_cmd(vec!["pulumi", "stack", "output", "namespace"], None)
         .map(|cmd_output| {
             let ns = String::from_utf8(cmd_output.stdout)
                 .unwrap()
                 .trim()
                 .to_string();
-            cache_local(PULUMI_NAMESPACE_CACHE_KEY, ns.clone())
+            cache_local(&get_ns_cache_key(stack), ns.clone())
                 .expect("Failed to cache pulumi namespace");
             ns
         })
@@ -59,18 +64,72 @@ fn get_pulumi_namespace_from_cmd() -> String {
 }
 
 fn get_pulumi_namespace() -> String {
-    let cached_ns = get_cached_local::<String>(PULUMI_NAMESPACE_CACHE_KEY);
+    let stack = get_pulumi_stack();
+    let cached_ns = get_cached_local::<String>(&get_ns_cache_key(&stack));
 
     cached_ns
         .map(|ca| {
             // check if the cached entry is older than 1 day, if so, refresh it
-            if ca.metadata.modified().unwrap().elapsed().unwrap().as_secs() > 86400 {
-                get_pulumi_namespace_from_cmd()
+            if ca.is_expired() {
+                get_pulumi_namespace_from_cmd(&stack)
             } else {
                 ca.value
             }
         })
-        .unwrap_or_else(|_| get_pulumi_namespace_from_cmd())
+        .unwrap_or_else(|_| get_pulumi_namespace_from_cmd(&stack))
+}
+
+fn find_workspace_file(project_name: &str) -> PathBuf {
+    // Try to find the workspace file in ~/.pulumi/workspaces
+    let home = std::env::var("HOME").expect("HOME environment variable not set");
+    let workspace_path = Path::new(&home).join(".pulumi").join("workspaces");
+    let dir_entries =
+        std::fs::read_dir(&workspace_path).expect("Failed to read workspace directory");
+    let dir_entries2 =
+        std::fs::read_dir(workspace_path).expect("Failed to read workspace directory");
+    for dir in dir_entries2 {
+        debug!("entries: {:?}", dir.unwrap().path());
+    }
+    let workspace_file = dir_entries.flatten().find(|entry| {
+        let filename = entry.file_name();
+        let captures = regex::Regex::new(r"^(.*?)-[0-9a-fA-F-]+-workspace\.json$")
+            .unwrap()
+            .captures_iter(filename.to_str().unwrap())
+            .next()
+            .expect("No captures found");
+        captures.get(1).expect("No stack name found").as_str() == project_name
+    });
+    // read the workspace file and extract the stack name
+    let workspace_file = workspace_file.expect("No workspace file found");
+    cache_local(
+        PULUMI_WORKSPACE_FILE_CACHE_KEY,
+        workspace_file.path().to_str().unwrap().to_string(),
+    )
+    .expect("Failed to cache workspace file");
+    workspace_file.path()
+}
+
+fn get_pulumi_stack() -> String {
+    let project_name = "enoki-api"; // TODO: make an arg
+
+    let workspace_file = get_cached_local::<String>(PULUMI_WORKSPACE_FILE_CACHE_KEY)
+        .map(|cached_workspace_file| {
+            if cached_workspace_file.is_expired() {
+                find_workspace_file(project_name)
+            } else {
+                PathBuf::from(cached_workspace_file.value)
+            }
+        })
+        .unwrap_or_else(|_| find_workspace_file(project_name));
+    let contents = std::fs::read_to_string(workspace_file).expect("Failed to read workspace file");
+    let json: serde_json::Value =
+        serde_json::from_str(&contents).expect("Failed to parse workspace file as JSON");
+    let stack = json["stack"]
+        .as_str()
+        .expect("Stack name should be a string");
+
+    debug!("stack: {}", stack);
+    stack.to_string()
 }
 
 pub async fn service_cmd(args: &ServiceArgs) -> Result<()> {
@@ -79,7 +138,8 @@ pub async fn service_cmd(args: &ServiceArgs) -> Result<()> {
         ServiceAction::ViewLogs { namespace } => {
             println!("namespace: {}", namespace.bright_purple());
             println!("View logs for the entire namespace at {}", format!("https://metrics.sui.io/explore?schemaVersion=1&panes=%7B%22yo7%22:%7B%22datasource%22:%22CU1v-k2Vk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22{}%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22CU1v-k2Vk%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1", namespace).bold());
-            get_logs(namespace).await
+            let stack = get_pulumi_stack();
+            get_logs(&stack, namespace).await
         }
     }
 }

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod init;
+mod logs;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{builder::OsStr, Parser};
 pub use init::bootstrap_service;
 use init::ServiceLanguage;
+use logs::get_logs;
 use std::path::PathBuf;
+
+use crate::{command::CommandOptions, get_cached_local, run_cmd};
 
 #[derive(Parser, Debug, Clone)]
 pub struct ServiceArgs {
@@ -28,10 +32,50 @@ pub enum ServiceAction {
         #[arg(short, long)]
         path: PathBuf,
     },
+    /// View service logs
+    #[command(name = "logs", aliases=["l"])]
+    ViewLogs {
+        /// service namespace to view logs for
+        #[arg(short, long, default_value_t=get_pulumi_namespace())]
+        namespace: String,
+    },
+}
+
+fn get_pulumi_namespace() -> String {
+    let cached_ns = get_cached_local::<String>("pulumi_namespace");
+
+    ns = cached_ns.map(|ca|{
+       // check if the cached entry is older than 1 day, if so, refresh it
+    }).unwrap_or_else(|_| {
+        run_cmd(vec!["pulumi", "stack", "output", "namespace"], None).map(|cmd_output| 
+        String::from_utf8(cmd_output.stdout)
+            .unwrap()
+            .trim()
+            .to_string())
+            .unwrap_or_else(|_| "default".to_string())
+    });
+
+
+    if let Ok(cached_namespace) = cached_ns
+        && cached_namespace
+            .metadata
+            .modified()
+            .unwrap()
+            .elapsed()
+            .unwrap()
+            .as_secs()
+            < 60
+    {
+        cached_namespace.value
+    } else if let Ok(cmd_output) = 
 }
 
 pub async fn service_cmd(args: &ServiceArgs) -> Result<()> {
     match &args.action {
         ServiceAction::InitService { lang, path } => bootstrap_service(lang, path),
+        ServiceAction::ViewLogs { namespace } => {
+            println!("namespace: {}", namespace);
+            get_logs(namespace).await
+        }
     }
 }

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -6,10 +6,12 @@ mod logs;
 
 use anyhow::Result;
 use clap::{builder::OsStr, Parser};
+use colored::Colorize;
 pub use init::bootstrap_service;
 use init::ServiceLanguage;
 use logs::get_logs;
 use std::path::PathBuf;
+use tracing::info;
 
 use crate::{cache_local, command::CommandOptions, get_cached_local, run_cmd};
 
@@ -78,7 +80,8 @@ pub async fn service_cmd(args: &ServiceArgs) -> Result<()> {
     match &args.action {
         ServiceAction::InitService { lang, path } => bootstrap_service(lang, path),
         ServiceAction::ViewLogs { namespace } => {
-            println!("namespace: {}", namespace);
+            println!("namespace: {}", namespace.bright_purple());
+            println!("View logs for the entire namespace at {}", format!("https://metrics.sui.io/explore?schemaVersion=1&panes=%7B%22yo7%22:%7B%22datasource%22:%22CU1v-k2Vk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22{}%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22CU1v-k2Vk%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1", namespace).bold());
             get_logs(namespace).await
         }
     }

--- a/crates/suiop-cli/src/cli/slack/mod.rs
+++ b/crates/suiop-cli/src/cli/slack/mod.rs
@@ -15,6 +15,8 @@ use tracing::debug;
 /// Reexport for convenience
 pub use slack_api::*;
 
+use crate::LOCAL_CACHE_DIR;
+
 #[derive(Debug, Default)]
 pub struct Slack {
     client: Client,
@@ -25,7 +27,7 @@ pub struct Slack {
 fn get_serialize_filepath(subname: &str) -> PathBuf {
     dirs::home_dir()
         .expect("HOME env var not set")
-        .join(".suiop")
+        .join(LOCAL_CACHE_DIR)
         .join(subname)
 }
 

--- a/crates/suiop-cli/src/lib.rs
+++ b/crates/suiop-cli/src/lib.rs
@@ -3,7 +3,10 @@
 
 pub mod cli;
 pub mod command;
+pub use cli::lib::cache::*;
 pub use command::run_cmd;
 use once_cell::sync::Lazy;
 
 pub static DEBUG_MODE: Lazy<bool> = Lazy::new(|| std::env::var("DEBUG").is_ok());
+
+const LOCAL_CACHE_DIR: &str = ".suiop";

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -6,9 +6,8 @@ use clap::Parser;
 use suioplib::{
     cli::{
         ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_cmd, pulumi_cmd,
-        service::{LogsArgs, ServiceAction},
-        service_cmd, CIArgs, DockerArgs, IAMArgs, IncidentsArgs, LoadEnvironmentArgs, PulumiArgs,
-        ServiceArgs,
+        service::ServiceAction, service_cmd, CIArgs, DockerArgs, IAMArgs, IncidentsArgs,
+        LoadEnvironmentArgs, PulumiArgs, ServiceArgs,
     },
     DEBUG_MODE,
 };

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -5,8 +5,10 @@ use anyhow::Result;
 use clap::Parser;
 use suioplib::{
     cli::{
-        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_cmd, pulumi_cmd, service_cmd,
-        CIArgs, DockerArgs, IAMArgs, IncidentsArgs, LoadEnvironmentArgs, PulumiArgs, ServiceArgs,
+        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_cmd, pulumi_cmd,
+        service::{LogsArgs, ServiceAction},
+        service_cmd, CIArgs, DockerArgs, IAMArgs, IncidentsArgs, LoadEnvironmentArgs, PulumiArgs,
+        ServiceArgs,
     },
     DEBUG_MODE,
 };
@@ -40,6 +42,8 @@ pub(crate) enum Resource {
     CI(CIArgs),
     #[clap(name="load-env", aliases = ["e", "env"])]
     LoadEnvironment(LoadEnvironmentArgs),
+    #[clap(name = "logs", aliases = ["l"])]
+    Logs,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -98,6 +102,12 @@ async fn main() -> Result<()> {
         }
         Resource::LoadEnvironment(args) => {
             load_environment_cmd(&args)?;
+        }
+        Resource::Logs => {
+            service_cmd(&ServiceArgs {
+                action: ServiceAction::ViewLogs,
+            })
+            .await?;
         }
     }
 


### PR DESCRIPTION
## Description 

allow log fetching via the k8s api.
- use pulumi esc for the kubeconfig
- use the local pulumi cwd + stack to determine the ns to query
- present the user with a list of pods to choose from, and also offer a quick link to namespace logs
- besides that, a bunch of extra this and that to make it all work, including caching the kubeconfig, stack-namespace mapping, and pulumi workspace file (indicates current stack). All cache usage expires after 1 day and uses a slower method (usually shelling out to pulumi) to refresh the cache on a miss.

## Test plan 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
