### PR TITLE
[mvr] Introduce mvr-mode on production indexer

### DIFF
--- a/crates/sui-indexer/src/benchmark.rs
+++ b/crates/sui-indexer/src/benchmark.rs
@@ -117,6 +117,7 @@ impl BenchmarkableIndexer for BenchmarkIndexer {
                 None,
                 cancel,
                 Some(committed_checkpoints_tx),
+                false, /* mvr_mode */
             )
             .await
         });

--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -199,6 +199,11 @@ pub enum Command {
         pruning_options: PruningOptions,
         #[command(flatten)]
         upload_options: UploadOptions,
+        /// If true, the indexer will run in MVR mode. It will only index data to
+        /// `objects_snapshot`, `objects_history`, `packages`, `checkpoints`, and `epochs` to
+        /// support MVR queries.
+        #[clap(long, default_value_t = false)]
+        mvr_mode: bool,
     },
     JsonRpcService(JsonRpcConfig),
     ResetDatabase {

--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -188,6 +188,7 @@ impl BackFillConfig {
     const DEFAULT_CHUNK_SIZE: usize = 1000;
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Clone, Debug)]
 pub enum Command {
     Indexer {

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -54,6 +54,7 @@ pub async fn new_handlers(
     committed_checkpoints_tx: Option<watch::Sender<Option<IndexerProgress>>>,
     start_checkpoint_opt: Option<CheckpointSequenceNumber>,
     end_checkpoint_opt: Option<CheckpointSequenceNumber>,
+    mvr_mode: bool,
 ) -> Result<(CheckpointHandler, u64), IndexerError> {
     let start_checkpoint = match start_checkpoint_opt {
         Some(start_checkpoint) => start_checkpoint,
@@ -87,6 +88,7 @@ pub async fn new_handlers(
         committed_checkpoints_tx,
         start_checkpoint,
         end_checkpoint_opt,
+        mvr_mode
     ));
     Ok((
         CheckpointHandler::new(state, metrics, indexed_checkpoint_sender),

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -205,12 +205,10 @@ async fn commit_checkpoints<S>(
     {
         let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
         let mut persist_tasks = Vec::new();
-
         // In MVR mode, persist only packages and object history
         persist_tasks.push(state.persist_packages(packages_batch));
         persist_tasks.push(state.persist_object_history(object_history_changes_batch.clone()));
         if !mvr_mode {
-            // In regular mode, persist all relevant data
             persist_tasks.push(state.persist_transactions(tx_batch));
             persist_tasks.push(state.persist_tx_indices(tx_indices_batch));
             persist_tasks.push(state.persist_events(events_batch));

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use prometheus::Registry;
 use tokio::sync::{oneshot, watch};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use async_trait::async_trait;
 use futures::future::try_join_all;
@@ -38,7 +38,7 @@ impl Indexer {
         store: PgIndexerStore,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
-        retention_config: Option<RetentionConfig>,
+        mut retention_config: Option<RetentionConfig>,
         cancel: CancellationToken,
         committed_checkpoints_tx: Option<watch::Sender<Option<IndexerProgress>>>,
         mvr_mode: bool,
@@ -67,6 +67,14 @@ impl Indexer {
             config.end_checkpoint,
         )
         .await?;
+
+        if mvr_mode {
+            warn!("Indexer in MVR mode is configured to prune `objects_history` to 2 epochs. The other tables have a 2000 epoch retention.");
+            retention_config = Some(RetentionConfig {
+                epochs_to_keep: 2000, // epochs, roughly 5+ years. We really just care about pruning `objects_history` per the default 2 epochs.
+                overrides: Default::default(),
+            });
+        }
 
         if let Some(retention_config) = retention_config {
             let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -41,6 +41,7 @@ impl Indexer {
         retention_config: Option<RetentionConfig>,
         cancel: CancellationToken,
         committed_checkpoints_tx: Option<watch::Sender<Option<IndexerProgress>>>,
+        mvr_mode: bool,
     ) -> Result<(), IndexerError> {
         info!(
             "Sui Indexer Writer (version {:?}) started...",
@@ -93,6 +94,7 @@ impl Indexer {
             committed_checkpoints_tx,
             config.start_checkpoint,
             config.end_checkpoint,
+            mvr_mode,
         )
         .await?;
         // Ingestion task watermarks are snapshotted once on indexer startup based on the

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 use sui_indexer::backfill::backfill_runner::BackfillRunner;
 use sui_indexer::benchmark::run_indexer_benchmark;
-use sui_indexer::config::{Command, UploadOptions};
+use sui_indexer::config::{Command, RetentionConfig, UploadOptions};
 use sui_indexer::database::ConnectionPool;
 use sui_indexer::db::setup_postgres::clear_database;
 use sui_indexer::db::{
@@ -46,12 +46,22 @@ async fn main() -> anyhow::Result<()> {
             snapshot_config,
             pruning_options,
             upload_options,
+            mvr_mode,
         } => {
             // Make sure to run all migrations on startup, and also serve as a compatibility check.
             run_migrations(pool.dedicated_connection().await?).await?;
-            let retention_config = pruning_options.load_from_file();
+            let mut retention_config = pruning_options.load_from_file();
             if retention_config.is_some() {
                 check_prunable_tables_valid(&mut pool.get().await?).await?;
+            } else {
+                if mvr_mode {
+                    warn!("No pruning options found in the config file, using default pruning options. Default epochs to keep is 2000 epochs, and `objects_history` will be pruned to 2 epochs.");
+                    // mvr-indexer override - enable `objects_history` pruning by default.
+                    retention_config = Some(RetentionConfig {
+                        epochs_to_keep: 2000, // epochs, roughly 4 years. We really just care about pruning `objects_history` per the default 2 epochs.
+                        overrides: Default::default(),
+                    });
+                }
             }
 
             let store = PgIndexerStore::new(pool, upload_options, indexer_metrics.clone());
@@ -64,6 +74,7 @@ async fn main() -> anyhow::Result<()> {
                 retention_config,
                 CancellationToken::new(),
                 None,
+                mvr_mode,
             )
             .await?;
         }

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -135,6 +135,7 @@ pub async fn start_indexer_writer_for_testing(
                 retention_config,
                 token_clone,
                 None,
+                false, /* mvr_mode */
             )
             .await
         })

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use std::sync::Arc;
+use std::time::Duration;
 
+use diesel::dsl::count_star;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
@@ -12,8 +14,13 @@ use sui_indexer::models::{
     checkpoints::StoredCheckpoint, objects::StoredObject, objects::StoredObjectSnapshot,
     transactions::StoredTransaction,
 };
+use sui_indexer::schema::epochs;
+use sui_indexer::schema::events;
+use sui_indexer::schema::full_objects_history;
+use sui_indexer::schema::objects_history;
 use sui_indexer::schema::{checkpoints, objects, objects_snapshot, transactions};
 use sui_indexer::store::indexer_store::IndexerStore;
+use sui_indexer::test_utils::set_up_on_mvr_mode;
 use sui_indexer::test_utils::{
     set_up, set_up_with_start_and_end_checkpoints, wait_for_checkpoint, wait_for_objects_snapshot,
 };
@@ -337,5 +344,101 @@ pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
         .expect("Failed reading checkpoint from PostgresDB");
     assert_eq!(db_checkpoint.sequence_number, 3);
     assert_eq!(db_checkpoint.epoch, 1);
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_mvr_mode() -> Result<(), IndexerError> {
+    let tempdir = tempdir().unwrap();
+    let mut sim = Simulacrum::new();
+    let data_ingestion_path = tempdir.path().to_path_buf();
+    sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+    // Create 3 checkpoints and epochs of sequence number 0 through 2 inclusive
+    for _ in 0..=2 {
+        let transfer_recipient = SuiAddress::random_for_testing_only();
+        let (transaction, _) = sim.transfer_txn(transfer_recipient);
+        let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();
+        assert!(err.is_none());
+
+        // creates checkpoint and advances epoch
+        sim.advance_epoch(true);
+    }
+
+    sim.create_checkpoint(); // advance to checkpoint 4 to stabilize indexer
+
+    let (_, pg_store, _, _database) = set_up_on_mvr_mode(Arc::new(sim), data_ingestion_path).await;
+    wait_for_checkpoint(&pg_store, 4).await?;
+    let mut connection = pg_store.pool().dedicated_connection().await.unwrap();
+    let db_checkpoint: StoredCheckpoint = checkpoints::table
+        .order(checkpoints::sequence_number.desc())
+        .first::<StoredCheckpoint>(&mut connection)
+        .await
+        .expect("Failed reading checkpoint from PostgresDB");
+    let db_epoch = epochs::table
+        .order(epochs::epoch.desc())
+        .select(epochs::epoch)
+        .first::<i64>(&mut connection)
+        .await
+        .expect("Failed reading epoch from PostgresDB");
+
+    assert_eq!(db_checkpoint.sequence_number, 4);
+    assert_eq!(db_checkpoint.epoch, db_epoch);
+
+    // Check that other tables have not been written to
+    assert_eq!(
+        0 as i64,
+        transactions::table
+            .select(count_star())
+            .first::<i64>(&mut connection)
+            .await
+            .expect("Failed to count * transactions")
+    );
+    assert_eq!(
+        0 as i64,
+        events::table
+            .select(count_star())
+            .first::<i64>(&mut connection)
+            .await
+            .expect("Failed to count * transactions")
+    );
+    assert_eq!(
+        0 as i64,
+        full_objects_history::table
+            .select(count_star())
+            .first::<i64>(&mut connection)
+            .await
+            .expect("Failed to count * transactions")
+    );
+
+    // Check that objects_history is being correctly pruned. At epoch 3, we should only have data
+    // between 2 and 3 inclusive.
+    loop {
+        let history_objects = objects_history::table
+            .select(objects_history::checkpoint_sequence_number)
+            .load::<i64>(&mut connection)
+            .await?;
+
+        let has_invalid_entries = history_objects.iter().any(|&elem| elem < 2);
+
+        if !has_invalid_entries {
+            // No more invalid entries found, exit the loop
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    // After the loop, verify all entries are within expected range
+    let final_check = objects_history::table
+        .select(objects_history::checkpoint_sequence_number)
+        .order_by(objects_history::checkpoint_sequence_number.asc())
+        .load::<i64>(&mut connection)
+        .await?;
+
+    for elem in final_check {
+        assert!(elem >= 2);
+    }
+
     Ok(())
 }

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -388,7 +388,7 @@ pub async fn test_mvr_mode() -> Result<(), IndexerError> {
 
     // Check that other tables have not been written to
     assert_eq!(
-        0 as i64,
+        0_i64,
         transactions::table
             .select(count_star())
             .first::<i64>(&mut connection)
@@ -396,7 +396,7 @@ pub async fn test_mvr_mode() -> Result<(), IndexerError> {
             .expect("Failed to count * transactions")
     );
     assert_eq!(
-        0 as i64,
+        0_i64,
         events::table
             .select(count_star())
             .first::<i64>(&mut connection)
@@ -404,7 +404,7 @@ pub async fn test_mvr_mode() -> Result<(), IndexerError> {
             .expect("Failed to count * transactions")
     );
     assert_eq!(
-        0 as i64,
+        0_i64,
         full_objects_history::table
             .select(count_star())
             .first::<i64>(&mut connection)

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -367,7 +367,8 @@ pub async fn test_mvr_mode() -> Result<(), IndexerError> {
 
     sim.create_checkpoint(); // advance to checkpoint 4 to stabilize indexer
 
-    let (_, pg_store, _, _database) = set_up_on_mvr_mode(Arc::new(sim), data_ingestion_path).await;
+    let (_, pg_store, _, _database) =
+        set_up_on_mvr_mode(Arc::new(sim), data_ingestion_path, true).await;
     wait_for_checkpoint(&pg_store, 4).await?;
     let mut connection = pg_store.pool().dedicated_connection().await.unwrap();
     let db_checkpoint: StoredCheckpoint = checkpoints::table


### PR DESCRIPTION
## Description 

introduce mvr-mode flag. If true, enables pruning objects_history, and toggles committer to write only a subset of tables to db. Compatible with the production indexer schema.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
