### PR TITLE
feat(analytics): Add package filter to object handler

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/mod.rs
+++ b/crates/sui-analytics-indexer/src/handlers/mod.rs
@@ -29,7 +29,6 @@ pub mod package_handler;
 pub mod transaction_handler;
 pub mod transaction_objects_handler;
 pub mod wrapped_object_handler;
-
 const WRAPPED_INDEXING_DISALLOW_LIST: [&str; 4] = [
     "0x1::string::String",
     "0x1::ascii::String",

--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 use sui_json_rpc_types::SuiMoveStruct;
 use sui_package_resolver::Resolver;
 use sui_rest_api::{CheckpointData, CheckpointTransaction};
+use sui_types::base_types::ObjectID;
 use sui_types::effects::TransactionEffects;
 use sui_types::object::Object;
 
@@ -25,6 +26,7 @@ use crate::FileType;
 
 pub struct ObjectHandler {
     state: Mutex<State>,
+    package_filter: Option<ObjectID>,
 }
 
 struct State {
@@ -87,7 +89,7 @@ impl AnalyticsHandler<ObjectEntry> for ObjectHandler {
 }
 
 impl ObjectHandler {
-    pub fn new(store_path: &Path, rest_uri: &str) -> Self {
+    pub fn new(store_path: &Path, rest_uri: &str, package_filter: &Option<String>) -> Self {
         let package_store = LocalDBPackageStore::new(&store_path.join("object"), rest_uri);
         let state = State {
             objects: vec![],
@@ -96,6 +98,9 @@ impl ObjectHandler {
         };
         Self {
             state: Mutex::new(state),
+            package_filter: package_filter
+                .clone()
+                .map(|x| ObjectID::from_hex_literal(&x).unwrap()),
         }
     }
     async fn process_transaction(
@@ -179,13 +184,30 @@ impl ObjectHandler {
         } else {
             (None, None)
         };
-        let object_type = move_obj_opt.map(|o| o.type_().to_string());
+
+        let object_type = move_obj_opt.map(|o| o.type_());
+
+        let is_match = if let Some(package_id) = self.package_filter {
+            if let Some(move_object_type) = object_type {
+                let object_package_id: ObjectID = move_object_type.address().into();
+                object_package_id == package_id
+            } else {
+                false
+            }
+        } else {
+            true
+        };
+
+        if !is_match {
+            return Ok(());
+        }
+
         let object_id = object.id();
         let entry = ObjectEntry {
             object_id: object_id.to_string(),
             digest: object.digest().to_string(),
             version: object.version().value(),
-            type_: object_type,
+            type_: object_type.map(|t| t.to_string()),
             checkpoint,
             epoch,
             timestamp_ms,

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -158,6 +158,8 @@ pub struct AnalyticsIndexerConfig {
     pub sf_checkpoint_col_id: Option<String>,
     #[clap(long, global = true)]
     pub report_sf_max_table_checkpoint: bool,
+    #[clap(long, default_value = None, global = true)]
+    pub package_id_filter: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -690,6 +692,7 @@ pub async fn make_object_processor(
     let handler: Box<dyn AnalyticsHandler<ObjectEntry>> = Box::new(ObjectHandler::new(
         &config.package_cache_path,
         &config.rest_url,
+        &config.package_id_filter,
     ));
     let starting_checkpoint_seq_num =
         get_starting_checkpoint_seq_num(config.clone(), FileType::Object).await?;


### PR DESCRIPTION
## Description 

This PR adds a package filter for object handler in analytics for being able to generate an object table specifically for walrus in testnet.

## Test
Invoking with `--package-id-filter 0x9f992cc2430a1f442ca7a5ca7638169f5d5c00e0ebc3977a65e9ac6e497fe5ef --starting-checkpoint-seq-num 120132840` to filter for walrus specific objects. Here is the walrus package object:
https://testnet.suivision.xyz/package/0x9f992cc2430a1f442ca7a5ca7638169f5d5c00e0ebc3977a65e9ac6e497fe5ef
