### PR TITLE
Historical volume by balance manager

### DIFF
--- a/crates/sui-deepbook-indexer/src/models.rs
+++ b/crates/sui-deepbook-indexer/src/models.rs
@@ -64,6 +64,7 @@ pub struct OrderFill {
 
 #[derive(Queryable)]
 pub struct OrderFillSummary {
+    pub pool_id: String,
     pub maker_balance_manager_id: String,
     pub taker_balance_manager_id: String,
     pub base_quantity: i64,

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -201,7 +201,13 @@ async fn get_24hr_volume_by_balance_manager_id(
 }
 
 async fn get_historical_volume_by_balance_manager_id_with_interval(
-    Path((pool_ids, balance_manager_id, start_time, end_time, interval)): Path<(String, String, i64, i64, i64)>,
+    Path((pool_ids, balance_manager_id, start_time, end_time, interval)): Path<(
+        String,
+        String,
+        i64,
+        i64,
+        i64,
+    )>,
     State(state): State<PgDeepbookPersistent>,
 ) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
     let connection = &mut state.pool.get().await?;
@@ -238,7 +244,9 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
 
         let mut volume_by_pool: HashMap<String, Vec<i64>> = HashMap::new();
         for order_fill in results {
-            let entry = volume_by_pool.entry(order_fill.pool_id.clone()).or_insert(vec![0, 0]);
+            let entry = volume_by_pool
+                .entry(order_fill.pool_id.clone())
+                .or_insert(vec![0, 0]);
             if order_fill.maker_balance_manager_id == balance_manager_id {
                 entry[0] += order_fill.base_quantity;
             }
@@ -247,8 +255,7 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
             }
         }
 
-        metrics_by_interval
-            .insert(current_start.to_string(), volume_by_pool);
+        metrics_by_interval.insert(current_start.to_string(), volume_by_pool);
 
         current_start = current_end;
     }
@@ -282,7 +289,9 @@ async fn get_historical_volume_by_balance_manager_id(
 
     let mut volume_by_pool: HashMap<String, Vec<i64>> = HashMap::new();
     for order_fill in results {
-        let entry = volume_by_pool.entry(order_fill.pool_id.clone()).or_insert(vec![0, 0]);
+        let entry = volume_by_pool
+            .entry(order_fill.pool_id.clone())
+            .or_insert(vec![0, 0]);
         if order_fill.maker_balance_manager_id == balance_manager_id {
             entry[0] += order_fill.base_quantity;
         }
@@ -291,7 +300,10 @@ async fn get_historical_volume_by_balance_manager_id(
         }
     }
 
-    Ok(Json(HashMap::from([(String::from("total"), volume_by_pool)])))
+    Ok(Json(HashMap::from([(
+        String::from("total"),
+        volume_by_pool,
+    )])))
 }
 
 #[debug_handler]

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -26,8 +26,10 @@ pub const GET_POOLS_PATH: &str = "/get_pools";
 pub const GET_24HR_VOLUME_PATH: &str = "/get_24hr_volume/:pool_ids";
 pub const GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_24hr_volume_by_balance_manager_id/:pool_id/:balance_manager_id";
+pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
+    "/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id/:start_time/:end_time/:interval";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
-    "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id/:start_time/:end_time"; // this is being added, start_time and end_time are in unix ts, look at get_24hr_volume_by_balance_manager_id as example. Output of get_24hr_volume_by_balance_manager_id is [maker_vol, taker_vol]. I want this format to be {pool_id1: [maker_vol, taker_vol], pool_id2: [maker_vol, taker_vol], ...}
+    "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id/:start_time/:end_time";
 pub const GET_HISTORICAL_VOLUME_PATH: &str =
     "/get_historical_volume/:pool_ids/:start_time/:end_time";
 pub const GET_NET_DEPOSITS: &str = "/get_net_deposits/:asset_ids/:timestamp";
@@ -48,6 +50,10 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
         .route(
             GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID,
             get(get_24hr_volume_by_balance_manager_id),
+        )
+        .route(
+            GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL,
+            get(get_historical_volume_by_balance_manager_id_with_interval),
         )
         .route(
             GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID,
@@ -194,10 +200,66 @@ async fn get_24hr_volume_by_balance_manager_id(
     Ok(Json(vec![maker_vol, taker_vol]))
 }
 
+async fn get_historical_volume_by_balance_manager_id_with_interval(
+    Path((pool_ids, balance_manager_id, start_time, end_time, interval)): Path<(String, String, i64, i64, i64)>,
+    State(state): State<PgDeepbookPersistent>,
+) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
+    let connection = &mut state.pool.get().await?;
+    let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
+
+    if interval <= 0 {
+        return Err(DeepBookError::InternalError(
+            "Interval must be greater than 0".to_string(),
+        ));
+    }
+
+    let mut metrics_by_interval: HashMap<String, HashMap<String, Vec<i64>>> = HashMap::new();
+    let mut current_start = start_time * 1000;
+    let interval_ms = interval * 1000;
+    while current_start + interval_ms <= end_time * 1000 {
+        let current_end = current_start + interval_ms;
+
+        let results: Vec<OrderFillSummary> = schema::order_fills::table
+            .select((
+                schema::order_fills::pool_id,
+                schema::order_fills::maker_balance_manager_id,
+                schema::order_fills::taker_balance_manager_id,
+                schema::order_fills::base_quantity,
+            ))
+            .filter(schema::order_fills::pool_id.eq_any(&pool_ids_list))
+            .filter(schema::order_fills::onchain_timestamp.between(current_start, current_end))
+            .filter(
+                schema::order_fills::maker_balance_manager_id
+                    .eq(&balance_manager_id)
+                    .or(schema::order_fills::taker_balance_manager_id.eq(&balance_manager_id)),
+            )
+            .load(connection)
+            .await?;
+
+        let mut volume_by_pool: HashMap<String, Vec<i64>> = HashMap::new();
+        for order_fill in results {
+            let entry = volume_by_pool.entry(order_fill.pool_id.clone()).or_insert(vec![0, 0]);
+            if order_fill.maker_balance_manager_id == balance_manager_id {
+                entry[0] += order_fill.base_quantity;
+            }
+            if order_fill.taker_balance_manager_id == balance_manager_id {
+                entry[1] += order_fill.base_quantity;
+            }
+        }
+
+        metrics_by_interval
+            .insert(current_start.to_string(), volume_by_pool);
+
+        current_start = current_end;
+    }
+
+    Ok(Json(metrics_by_interval))
+}
+
 async fn get_historical_volume_by_balance_manager_id(
     Path((pool_ids, balance_manager_id, start_time, end_time)): Path<(String, String, i64, i64)>,
     State(state): State<PgDeepbookPersistent>,
-) -> Result<Json<HashMap<String, Vec<i64>>>, DeepBookError> {
+) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
     let connection = &mut state.pool.get().await?;
     let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
 
@@ -208,11 +270,8 @@ async fn get_historical_volume_by_balance_manager_id(
             schema::order_fills::taker_balance_manager_id,
             schema::order_fills::base_quantity,
         ))
-        .filter(schema::order_fills::pool_id.eq_any(pool_ids_list))
-        .filter(schema::order_fills::onchain_timestamp.between(
-            start_time * 1000,
-            end_time * 1000,
-        ))
+        .filter(schema::order_fills::pool_id.eq_any(&pool_ids_list))
+        .filter(schema::order_fills::onchain_timestamp.between(start_time * 1000, end_time * 1000))
         .filter(
             schema::order_fills::maker_balance_manager_id
                 .eq(&balance_manager_id)
@@ -232,7 +291,7 @@ async fn get_historical_volume_by_balance_manager_id(
         }
     }
 
-    Ok(Json(volume_by_pool))
+    Ok(Json(HashMap::from([(String::from("total"), volume_by_pool)])))
 }
 
 #[debug_handler]

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -266,7 +266,7 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
 async fn get_historical_volume_by_balance_manager_id(
     Path((pool_ids, balance_manager_id, start_time, end_time)): Path<(String, String, i64, i64)>,
     State(state): State<PgDeepbookPersistent>,
-) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
+) -> Result<Json<HashMap<String, Vec<i64>>>, DeepBookError> {
     let connection = &mut state.pool.get().await?;
     let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
 
@@ -300,10 +300,7 @@ async fn get_historical_volume_by_balance_manager_id(
         }
     }
 
-    Ok(Json(HashMap::from([(
-        String::from("total"),
-        volume_by_pool,
-    )])))
+    Ok(Json(volume_by_pool))
 }
 
 #[debug_handler]


### PR DESCRIPTION
## Description 

Historical volume by balance manager

**Endpoint 1:** `/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id/:start_time/:end_time`

pool_ids delimited by ",", start_time and end_time in unix ts seconds

Response format:
`{pool_id_1: [maker_volume, taker_volume], pool_id_2: ...}
`

Example: `/get_historical_volume_by_balance_manager_id/0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22,0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407/0x344c2734b1d211bd15212bfb7847c66a3b18803f3f5ab00f5ff6f87b6fe6d27d/1731260703/1731692703`

Response example:
`{"0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407":[2036945300000000,17349400000000],"0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22":[14206210000000,3690000000]}`

**Endpoint 2:** `/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id/:start_time/:end_time/:interval`

pool_ids delimited by ",", start_time, end_time, and interval in unix ts seconds. If start time is 5, end time is 10, and interval is 2, response will include volume from 5-7 and 7-9 with the start time of the periods as keys.

Response format:
`{time_1: {pool_id_1: [maker_volume, taker_volume], pool_id_2: ...}, time_2: {pool_id_1: [maker_volume, taker_volume], pool_id_2: ...}
`

Example: 
`/get_historical_volume_by_balance_manager_id_with_interval/0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22,0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407/0x344c2734b1d211bd15212bfb7847c66a3b18803f3f5ab00f5ff6f87b6fe6d27d/1731460703/1731692703/86400`

Response example:
`{"1731460703000":{"0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407":[505887400000000,2051300000000],"0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22":[703740000000,0]},"1731547103000":{"0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407":[336777500000000,470600000000],"0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22":[2665470000000,0]}}`

## Test plan 

How did you test the new or updated feature?

Tested locally

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Deepbook indexer
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
