### PR TITLE
[easy][indexer] Remove last mentions of tx_recipients and tx_senders tables

### DIFF
--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -288,8 +288,6 @@ pub enum CommitterTables {
     TxDigests,
     TxInputObjects,
     TxKinds,
-    TxRecipients,
-    TxSenders,
 
     Checkpoints,
     PrunerCpWatermark,

--- a/crates/sui-indexer/src/handlers/pruner.rs
+++ b/crates/sui-indexer/src/handlers/pruner.rs
@@ -65,8 +65,6 @@ pub enum PrunableTable {
     TxDigests,
     TxInputObjects,
     TxKinds,
-    TxRecipients,
-    TxSenders,
 
     Checkpoints,
     PrunerCpWatermark,
@@ -96,8 +94,6 @@ impl PrunableTable {
             PrunableTable::TxDigests => tx,
             PrunableTable::TxInputObjects => tx,
             PrunableTable::TxKinds => tx,
-            PrunableTable::TxRecipients => tx,
-            PrunableTable::TxSenders => tx,
 
             PrunableTable::Checkpoints => cp,
             PrunableTable::PrunerCpWatermark => cp,


### PR DESCRIPTION
## Description 

These tables no longer exist in the indexer schema

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
