### PR TITLE
[suiop][incidents][pro-236] show count before interactive selection

### DIFF
--- a/crates/suiop-cli/src/cli/incidents/selection.rs
+++ b/crates/suiop-cli/src/cli/incidents/selection.rs
@@ -66,6 +66,7 @@ pub async fn review_recent_incidents(incidents: Vec<Incident>) -> Result<()> {
         })
         .collect::<Vec<_>>();
     let filtered_incidents = filter_incidents_for_review(incidents, "P2");
+    println!("Reviewing {} recent incidents", filtered_incidents.len());
     let mut group_map = group_by_similar_title(filtered_incidents, 0.9);
     let mut to_review = vec![];
     let mut excluded = vec![];


### PR DESCRIPTION
## Description 

print the count so we know what's coming

## Test plan 

```
DEBUG=true cargo run -- i r -i  
    Blocking waiting for file lock on build directory
   Compiling suiop-cli v1.39.0 (/Users/jkjensen/mysten/sui/crates/suiop-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.54s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop i r -i`
2024-11-18T18:27:47.098537Z  INFO suiop: Debug mode enabled
2024-11-18T18:27:47.103333Z  INFO suioplib::cli::incidents: going back 7 days
Reviewing 4 recent incidents             
...                
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
