### PR TITLE
[move-ide] Added tracing command

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/CONTRIBUTING.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/CONTRIBUTING.md
@@ -32,8 +32,6 @@ Running the extension's tests from the command-line is cumbersome because the te
 3. From the pull-down menu in the Run and Debug view, select "Launch with Extension" and click the green arrow button. This will launch a new VS Code window that has the `move-analyzer` extension installed. If you open a `.move` file, it will be highlighted according to the any changes you've made in your local checkout of this repository.
 4. Once you've launched the extension, in the original VS Code window you'll see a small box with pause, refresh, and stop buttons. Clicking these allows you to quickly refresh the extension window with your latest changes, or quit the window.
 
-To test the Move TextMate grammar, open a file with a `.move` file extension and use the command palette to run the "Developer: Inspect Editor Tokens and Scopes" command. This displays a large window that shows what token is detected below the typing cursor in the VS Code window.
-
 ## Running the tests from within VS Code
 
 You can run the extensions tests from within the "Run and Debug" view:
@@ -47,10 +45,10 @@ You can run the extensions tests from within the "Run and Debug" view:
 
 To add new versions of the move-analyzer Visual Studio Code extension, you will need to:
 
-1. Request to be added to the `move` publisher team.
+1. Request to be added to the `mysten` publisher team.
 2. Package and upload a new extension version.
 
-### 1: Become a member of the `move` publisher team
+### 1: Become a member of the `mysten` publisher team
 
 As [Visual Studio Code's documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) explains, the Visual Studio Marketplace  uses [Azure DevOps](https://azure.microsoft.com/services/devops/) to authenticate users who are allowed to manage extensions. To register with Azure DevOps, you need a Microsoft account.
 
@@ -76,7 +74,7 @@ To publish a new version of the extension, you'll need to:
 
 Follow the instructions in [the Visual Studio Code documentation on creating a personal access token](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token). To summarize:
 
-1. From the [`move` publisher page](https://marketplace.visualstudio.com/manage/publishers/move), click on your username in the upper-right of the page. This will load [your Azure DevOps page](https://aex.dev.azure.com/me).
+1. From the [`move` publisher page](https://marketplace.visualstudio.com/manage/publishers/mysten), click on your username in the upper-right of the page. This will load [your Azure DevOps page](https://aex.dev.azure.com/me).
 2. On that page, click on the `dev.azure.com/<name>` link below "Azure DevOps Organizations." If you have more than one organization listed there, choose the one you feel is best. This will load the `https://dev.azure.com/<name>` organization page.
 3. On that page, click on the "User Settings" icon in the upper-right, and select "Personal access tokens" from the drop-down menu. This will load the "Personal Access Tokens" page.
 4. On that page, click "New Token." Name it whatever you like but make sure to select an expiration of 30 days, select "All accessible organizations" under the "Organization" drop-down menu, and click the "Custom defined" button under "Scopes" followed by setting (only) "Marketplace" scope on the list of custom scopes to "Manage". Click "Create," and copy the token that is presented on the following page to your clipboard.

--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -29,8 +29,9 @@ Preferences > Settings*). Search for the `move.sui.path` user setting, set it to
 the `sui` binary, and restart VSCode.
 
 In order to trace Move code execution, the `sui` binary must be built with the `tracing` feature flag.
-If your version of the `sui` binary was not built with this feature flag, you may have to build it from
-source following these [instructions](https://docs.sui.io/guides/developer/getting-started/sui-install#install-sui-binaries-from-source).
+If your version of the `sui` binary was not built with this feature flag, an attempt to trace test
+execution will fail. In this case you may have to build the `sui` binary from source following these
+[instructions](https://docs.sui.io/guides/developer/getting-started/sui-install#install-sui-binaries-from-source).
 
 # Troubleshooting
 

--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -9,7 +9,7 @@ language [documentation](https://docs.sui.io/concepts/sui-move-concepts).
 2. Open the command palette (`⇧` + `⌘` + `P` on macOS, or use the menu item *View > Command Palette...*) and
    type **Extensions: Install Extensions**. This will open a panel named *Extensions* in the
    sidebar of your Visual Studio Code window.
-3. In the search bar labeled *Search Extensions in Marketplace*, type **Mysten**. The Move extension 
+3. In the search bar labeled *Search Extensions in Marketplace*, type **Mysten**. The Move extension
    should appear as one of the option in the list below the search bar. Click **Install**.
 4. Open any file that ends in `.move`.
 
@@ -21,12 +21,16 @@ definition, type on hover). Please see [Troubleshooting](#troubleshooting) for s
 the pre-built move-analyzer binary is not available for your platform or if you want to use move-analyzer
 binary stored in a different location.
 
-If you want to build and test Move code using the extension, you must install the `sui` binary on
+If you want to build, test, and trace Move code using the extension, you must install the `sui` binary on
 your machine - see [here](https://docs.sui.io/guides/developer/getting-started/sui-install) for
 instructions. The extension assumes that the `sui` binary is in your system path, but you can set
 its custom location location using VSCode's settings (`⌘` + `,` on macOS, or use the menu item *Code >
 Preferences > Settings*). Search for the `move.sui.path` user setting, set it to the new location of
 the `sui` binary, and restart VSCode.
+
+In order to trace Move code execution, the `sui` binary must be built with the `tracing` feature flag.
+If your version of the `sui` binary was not built with this feature flag, you may have to build it from
+source following these [instructions](https://docs.sui.io/guides/developer/getting-started/sui-install#install-sui-binaries-from-source).
 
 # Troubleshooting
 
@@ -98,4 +102,6 @@ Move source file (a file with a `.move` file extension) and:
     - parameter names at function calls
 - If the opened Move source file is located within a buildable project you can build and (locally)
   test this project using `Move: Build a Move package` and `Move: Test a Move package` commands from
-  VSCode's command palette
+  VSCode's command palette. You can also enable Move trace generation during test execution
+  using `Move: Trace Move package execution` command from VSCode's command palette (traces will
+  be available in the `traces` directory in JSON format).

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -49,7 +49,7 @@
       },
       {
         "command": "move.trace",
-        "title": "Trace Move package execution",
+        "title": "Trace Move test execution",
         "category": "Move"
       }
     ],

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -44,7 +44,12 @@
       },
       {
         "command": "move.test",
-        "title": "Test a Move package",
+        "title": "Run Move package test",
+        "category": "Move"
+      },
+      {
+        "command": "move.trace",
+        "title": "Trace Move package execution",
         "category": "Move"
       }
     ],
@@ -131,8 +136,11 @@
         },
         {
           "command": "move.test"
+        },
+        {
+          "command": "move.trace"
         }
-      ]
+        ]
     }
   },
   "scripts": {

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -59,7 +59,7 @@ export class Configuration {
     /** The path to the Sui binary. */
     get suiPath(): string {
         const suiBin = process.platform === 'win32' ? 'sui.exe' : 'sui';
-        const suiPath = this.configuration.get<string | null >(SUI_PATH_OPT) ?? suiBin;
+        const suiPath = this.configuration.get<string | null>(SUI_PATH_OPT) ?? suiBin;
 
         if (suiPath === suiBin) {
             return suiPath;


### PR DESCRIPTION
## Description 

This PR adds the ability to generate Move VM traces for tests from inside IDE. It also fixes a bug that would prevent IDE from picking up a custom Sui CLI path when building, running tests, and generating traces.

This PR also adds the ability to filter tests to be executed by test/trace commands

## Test plan 

Tested manually that the new functionality works correctly
