### PR TITLE
[mvr] use mvr-mode on sui-mvr-graphql-rpc for in-crate tests

### DIFF
--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -467,6 +467,64 @@ impl From<IndexedDeletedObject> for StoredFullHistoryObject {
     }
 }
 
+impl TryFrom<StoredHistoryObject> for StoredObject {
+    type Error = IndexerError;
+
+    fn try_from(o: StoredHistoryObject) -> Result<Self, Self::Error> {
+        // Return early if any required fields are None
+        if o.object_digest.is_none() || o.owner_type.is_none() || o.serialized_object.is_none() {
+            return Err(IndexerError::PostgresReadError(
+                "Missing required fields in StoredHistoryObject".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            object_id: o.object_id,
+            object_version: o.object_version,
+            object_digest: o.object_digest.unwrap(),
+            owner_type: o.owner_type.unwrap(),
+            owner_id: o.owner_id,
+            object_type: o.object_type,
+            object_type_package: o.object_type_package,
+            object_type_module: o.object_type_module,
+            object_type_name: o.object_type_name,
+            serialized_object: o.serialized_object.unwrap(),
+            coin_type: o.coin_type,
+            coin_balance: o.coin_balance,
+            df_kind: o.df_kind,
+        })
+    }
+}
+
+impl TryFrom<StoredObjectSnapshot> for StoredObject {
+    type Error = IndexerError;
+
+    fn try_from(o: StoredObjectSnapshot) -> Result<Self, Self::Error> {
+        // Return early if any required fields are None
+        if o.object_digest.is_none() || o.owner_type.is_none() || o.serialized_object.is_none() {
+            return Err(IndexerError::PostgresReadError(
+                "Missing required fields in StoredObjectSnapshot".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            object_id: o.object_id,
+            object_version: o.object_version,
+            object_digest: o.object_digest.unwrap(),
+            owner_type: o.owner_type.unwrap(),
+            owner_id: o.owner_id,
+            object_type: o.object_type,
+            object_type_package: o.object_type_package,
+            object_type_module: o.object_type_module,
+            object_type_name: o.object_type_name,
+            serialized_object: o.serialized_object.unwrap(),
+            coin_type: o.coin_type,
+            coin_balance: o.coin_balance,
+            df_kind: o.df_kind,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use move_core_types::{account_address::AccountAddress, language_storage::StructTag};

--- a/crates/sui-mvr-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-mvr-graphql-rpc/src/test_infra/cluster.rs
@@ -18,7 +18,7 @@ pub use sui_indexer::config::RetentionConfig;
 pub use sui_indexer::config::SnapshotLagConfig;
 use sui_indexer::errors::IndexerError;
 use sui_indexer::store::PgIndexerStore;
-use sui_indexer::test_utils::start_indexer_writer_for_testing;
+use sui_indexer::test_utils::start_indexer_writer_for_testing_with_mvr_mode;
 use sui_pg_temp_db::{get_available_port, TempDb};
 use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_types::storage::RestStateReader;
@@ -125,7 +125,7 @@ pub async fn start_network_cluster() -> NetworkCluster {
     let val_fn = start_validator_with_fullnode(data_ingestion_path.path().to_path_buf()).await;
 
     // Starts indexer
-    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing(
+    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing_with_mvr_mode(
         db_url,
         None,
         None,
@@ -133,6 +133,7 @@ pub async fn start_network_cluster() -> NetworkCluster {
         Some(cancellation_token.clone()),
         None, /* start_checkpoint */
         None, /* end_checkpoint */
+        true,
     )
     .await;
 
@@ -182,7 +183,7 @@ pub async fn serve_executor(
 
     let snapshot_config = snapshot_config.unwrap_or_default();
 
-    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing(
+    let (pg_store, pg_handle, _) = start_indexer_writer_for_testing_with_mvr_mode(
         db_url,
         Some(snapshot_config.clone()),
         retention_config,
@@ -190,6 +191,7 @@ pub async fn serve_executor(
         Some(cancellation_token.clone()),
         None,
         None,
+        true,
     )
     .await;
 

--- a/crates/sui-mvr-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-mvr-graphql-rpc/tests/e2e_tests.rs
@@ -23,7 +23,6 @@ use sui_types::DEEPBOOK_ADDRESS;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use tempfile::tempdir;
-use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_simple_client_validator_cluster() {
@@ -676,10 +675,7 @@ async fn test_epoch_live_object_set_digest() {
         .await
         .unwrap();
 
-    println!("res: {:?}", res);
-
     let binding = res.response_body().data.clone().into_json().unwrap();
-    println!("binding: {:?}", binding);
 
     // Check that liveObjectSetDigest is not null
     assert!(!binding

--- a/crates/sui-mvr-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-mvr-graphql-rpc/tests/e2e_tests.rs
@@ -276,106 +276,6 @@ async fn test_graphql_client_variables() {
 }
 
 #[tokio::test]
-async fn test_transaction_execution() {
-    let cluster = start_cluster(ServiceConfig::test_defaults()).await;
-
-    let addresses = cluster
-        .network
-        .validator_fullnode_handle
-        .wallet
-        .get_addresses();
-
-    let sender = addresses[0];
-    let recipient = addresses[1];
-    let tx = cluster
-        .network
-        .validator_fullnode_handle
-        .test_transaction_builder()
-        .await
-        .transfer_sui(Some(1_000), recipient)
-        .build();
-    let signed_tx = cluster
-        .network
-        .validator_fullnode_handle
-        .wallet
-        .sign_transaction(&tx);
-    let original_digest = signed_tx.digest();
-    let (tx_bytes, sigs) = signed_tx.to_tx_bytes_and_signatures();
-    let tx_bytes = tx_bytes.encoded();
-    let sigs = sigs.iter().map(|sig| sig.encoded()).collect::<Vec<_>>();
-
-    let mutation = r#"{ executeTransactionBlock(txBytes: $tx,  signatures: $sigs) { effects { transactionBlock { digest } } errors}}"#;
-
-    let variables = vec![
-        GraphqlQueryVariable {
-            name: "tx".to_string(),
-            ty: "String!".to_string(),
-            value: json!(tx_bytes),
-        },
-        GraphqlQueryVariable {
-            name: "sigs".to_string(),
-            ty: "[String!]!".to_string(),
-            value: json!(sigs),
-        },
-    ];
-    let res = cluster
-        .graphql_client
-        .execute_mutation_to_graphql(mutation.to_string(), variables)
-        .await
-        .unwrap();
-    let binding = res.response_body().data.clone().into_json().unwrap();
-    let res = binding.get("executeTransactionBlock").unwrap();
-
-    let digest = res
-        .get("effects")
-        .unwrap()
-        .get("transactionBlock")
-        .unwrap()
-        .get("digest")
-        .unwrap()
-        .as_str()
-        .unwrap();
-    assert!(res.get("errors").unwrap().is_null());
-    assert_eq!(digest, original_digest.to_string());
-
-    // Wait for the transaction to be committed and indexed
-    sleep(Duration::from_secs(10)).await;
-    // Query the transaction
-    let query = r#"
-            {
-                transactionBlock(digest: $dig){
-                    sender {
-                        address
-                    }
-                }
-            }
-        "#;
-
-    let variables = vec![GraphqlQueryVariable {
-        name: "dig".to_string(),
-        ty: "String!".to_string(),
-        value: json!(digest),
-    }];
-    let res = cluster
-        .graphql_client
-        .execute_to_graphql(query.to_string(), true, variables, vec![])
-        .await
-        .unwrap();
-
-    let binding = res.response_body().data.clone().into_json().unwrap();
-    let sender_read = binding
-        .get("transactionBlock")
-        .unwrap()
-        .get("sender")
-        .unwrap()
-        .get("address")
-        .unwrap()
-        .as_str()
-        .unwrap();
-    assert_eq!(sender_read, sender.to_string());
-}
-
-#[tokio::test]
 async fn test_zklogin_sig_verify() {
     use shared_crypto::intent::Intent;
     use shared_crypto::intent::IntentMessage;
@@ -764,6 +664,7 @@ async fn test_epoch_live_object_set_digest() {
     let query = "
             {
                 epoch(id: 0){
+                    epochId
                     liveObjectSetDigest
                 }
             }
@@ -775,7 +676,10 @@ async fn test_epoch_live_object_set_digest() {
         .await
         .unwrap();
 
+    println!("res: {:?}", res);
+
     let binding = res.response_body().data.clone().into_json().unwrap();
+    println!("binding: {:?}", binding);
 
     // Check that liveObjectSetDigest is not null
     assert!(!binding


### PR DESCRIPTION
## Description 

Needed to adjust the `ConnectionAsObjectStore`, because `objects` will not be written to in `mvr-mode`. Querying `objects` and querying `objects_history` + `objects_snapshot` should both yield the live object set.



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
