### PR TITLE
[Consensus] fix transaction size checks & metrics

### DIFF
--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -988,6 +988,10 @@ mod tests {
             Ok(())
         }
 
+        fn check_transactions(&self, _transactions: &[&[u8]]) -> ConsensusResult<()> {
+            Ok(())
+        }
+
         fn check_ancestors(
             &self,
             block: &VerifiedBlock,

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -988,10 +988,6 @@ mod tests {
             Ok(())
         }
 
-        fn check_transactions(&self, _transactions: &[&[u8]]) -> ConsensusResult<()> {
-            Ok(())
-        }
-
         fn check_ancestors(
             &self,
             block: &VerifiedBlock,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -471,7 +471,7 @@ impl Core {
 
         // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge
         // the inclusion of transactions. Just let this be done in the end of the method.
-        let (transactions, ack_transactions) = self.transaction_consumer.next();
+        let (_limit_reached, transactions, ack_transactions) = self.transaction_consumer.next();
         self.context
             .metrics
             .node_metrics

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -471,7 +471,7 @@ impl Core {
 
         // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge
         // the inclusion of transactions. Just let this be done in the end of the method.
-        let (_limit_reached, transactions, ack_transactions) = self.transaction_consumer.next();
+        let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
         self.context
             .metrics
             .node_metrics

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -59,8 +59,8 @@ pub enum LimitReached {
     MaxNumOfTransactions,
     // The maximum number of bytes have been included
     MaxBytes,
-    // There are no more transactions available to include
-    NoMoreTransactions,
+    // All available transactions have been included
+    AllTransactionsIncluded,
 }
 
 impl TransactionConsumer {
@@ -85,7 +85,7 @@ impl TransactionConsumer {
         let mut transactions = Vec::new();
         let mut acks = Vec::new();
         let mut total_bytes = 0;
-        let mut limit_reached = LimitReached::NoMoreTransactions;
+        let mut limit_reached = LimitReached::AllTransactionsIncluded;
 
         // Handle one batch of incoming transactions from TransactionGuard.
         // The method will return `None` if all the transactions can be included in the block. Otherwise none of the transactions will be

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -185,6 +185,7 @@ pub struct ValidatorServiceMetrics {
     pub handle_certificate_consensus_latency: Histogram,
     pub handle_certificate_non_consensus_latency: Histogram,
     pub handle_soft_bundle_certificates_consensus_latency: Histogram,
+    pub handle_soft_bundle_certificates_count: Histogram,
     pub handle_transaction_consensus_latency: Histogram,
 
     num_rejected_tx_in_epoch_boundary: IntCounter,
@@ -267,6 +268,13 @@ impl ValidatorServiceMetrics {
                 "validator_service_handle_soft_bundle_certificates_consensus_latency",
                 "Latency of handling a consensus soft bundle",
                 mysten_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            handle_soft_bundle_certificates_count: register_histogram_with_registry!(
+                "handle_soft_bundle_certificates_count",
+                "The number of certificates included in a soft bundle",
+                mysten_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -638,6 +646,7 @@ impl ValidatorService {
             }
         } else {
             // `soft_bundle_validity_check` ensured that all certificates contain shared objects.
+            sefl.metrics.handle_soft_bundle_certificates_count.observe(certificates.len() as f64);
             &self
                 .metrics
                 .handle_soft_bundle_certificates_consensus_latency

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -186,6 +186,7 @@ pub struct ValidatorServiceMetrics {
     pub handle_certificate_non_consensus_latency: Histogram,
     pub handle_soft_bundle_certificates_consensus_latency: Histogram,
     pub handle_soft_bundle_certificates_count: Histogram,
+    pub handle_soft_bundle_certificates_size_bytes: Histogram,
     pub handle_transaction_consensus_latency: Histogram,
 
     num_rejected_tx_in_epoch_boundary: IntCounter,
@@ -275,6 +276,13 @@ impl ValidatorServiceMetrics {
                 "handle_soft_bundle_certificates_count",
                 "The number of certificates included in a soft bundle",
                 mysten_metrics::COUNT_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
+                "handle_soft_bundle_certificates_size_bytes",
+                "The size of soft bundle in bytes",
+                mysten_metrics::BYTES_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -646,7 +654,6 @@ impl ValidatorService {
             }
         } else {
             // `soft_bundle_validity_check` ensured that all certificates contain shared objects.
-            sefl.metrics.handle_soft_bundle_certificates_count.observe(certificates.len() as f64);
             &self
                 .metrics
                 .handle_soft_bundle_certificates_consensus_latency
@@ -1089,10 +1096,20 @@ impl ValidatorService {
 
         let certificates = NonEmpty::from_vec(request.certificates)
             .ok_or_else(|| SuiError::NoCertificateProvidedError)?;
+        let mut total_size_bytes = 0;
         for certificate in &certificates {
             // We need to check this first because we haven't verified the cert signature.
-            certificate.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+            total_size_bytes +=
+                certificate.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
         }
+
+        self.metrics
+            .handle_soft_bundle_certificates_count
+            .observe(certificates.len() as f64);
+
+        self.metrics
+            .handle_soft_bundle_certificates_size_bytes
+            .observe(total_size_bytes as f64);
 
         // Now that individual certificates are valid, we check if the bundle is valid.
         self.soft_bundle_validity_check(&certificates, &epoch_store)
@@ -1110,6 +1127,7 @@ impl ValidatorService {
                 .collect::<Vec<_>>()
                 .join(", ")
         );
+
         let span = error_span!("handle_soft_bundle_certificates_v3");
         self.handle_certificates(
             certificates,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2360,7 +2360,8 @@ impl SenderSignedData {
     }
 
     /// Validate untrusted user transaction, including its size, input count, command count, etc.
-    pub fn validity_check(&self, config: &ProtocolConfig, epoch: EpochId) -> SuiResult {
+    /// Returns the certificate serialised bytes size.
+    pub fn validity_check(&self, config: &ProtocolConfig, epoch: EpochId) -> Result<usize, SuiError> {
         // Check that the features used by the user signatures are enabled on the network.
         self.check_user_signature_protocol_compatibility(config)?;
 
@@ -2403,7 +2404,7 @@ impl SenderSignedData {
             .validity_check(config)
             .map_err(Into::<SuiError>::into)?;
 
-        Ok(())
+        Ok(tx_size)
     }
 }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2361,7 +2361,11 @@ impl SenderSignedData {
 
     /// Validate untrusted user transaction, including its size, input count, command count, etc.
     /// Returns the certificate serialised bytes size.
-    pub fn validity_check(&self, config: &ProtocolConfig, epoch: EpochId) -> Result<usize, SuiError> {
+    pub fn validity_check(
+        &self,
+        config: &ProtocolConfig,
+        epoch: EpochId,
+    ) -> Result<usize, SuiError> {
         // Check that the features used by the user signatures are enabled on the network.
         self.check_user_signature_protocol_compatibility(config)?;
 


### PR DESCRIPTION
## Description 

Fixes a bug when checking the total number of transactions included in a block via the transactions consumer in consensus. It would be possible to go over the max limit and effectively produce invalid blocks when it would verify on the block verifier side.

Also took this as opportunity to have an integration test that checks both the construction of block sizes and the block verifier so makes sure we are always aligned.

Added a couple of more soft bundle related metrics

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
