### PR TITLE
[zksend SDK] fix getSentTransactions not respecting the passed in SuiClient URL

### DIFF
--- a/.changeset/shiny-cups-sniff.md
+++ b/.changeset/shiny-cups-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zksend': patch
+---
+
+Fix getSentTransactionsWithLinks defaulting to the public fullnode URL

--- a/sdk/zksend/src/links/get-sent-transactions.ts
+++ b/sdk/zksend/src/links/get-sent-transactions.ts
@@ -14,6 +14,7 @@ export async function getSentTransactionsWithLinks({
 	limit = 10,
 	network = 'mainnet',
 	contract = getContractIds(network),
+	client = new SuiClient({ url: getFullnodeUrl(network) }),
 	loadClaimedAssets = false,
 	...linkOptions
 }: {
@@ -30,10 +31,9 @@ export async function getSentTransactionsWithLinks({
 	claimApi?: string;
 	client?: SuiClient;
 }) {
-	const suiClient = linkOptions.client ?? new SuiClient({ url: getFullnodeUrl(network) });
 	const packageId = normalizeSuiAddress(contract.packageId);
 
-	const page = await suiClient.queryTransactionBlocks({
+	const page = await client.queryTransactionBlocks({
 		filter: {
 			FromAddress: address,
 		},
@@ -87,6 +87,7 @@ export async function getSentTransactionsWithLinks({
 							address,
 							contract,
 							isContractLink: true,
+							client,
 							...linkOptions,
 						});
 

--- a/sdk/zksend/src/links/get-sent-transactions.ts
+++ b/sdk/zksend/src/links/get-sent-transactions.ts
@@ -14,7 +14,6 @@ export async function getSentTransactionsWithLinks({
 	limit = 10,
 	network = 'mainnet',
 	contract = getContractIds(network),
-	client = new SuiClient({ url: getFullnodeUrl(network) }),
 	loadClaimedAssets = false,
 	...linkOptions
 }: {
@@ -31,9 +30,10 @@ export async function getSentTransactionsWithLinks({
 	claimApi?: string;
 	client?: SuiClient;
 }) {
+	const suiClient = linkOptions.client ?? new SuiClient({ url: getFullnodeUrl(network) });
 	const packageId = normalizeSuiAddress(contract.packageId);
 
-	const page = await client.queryTransactionBlocks({
+	const page = await suiClient.queryTransactionBlocks({
 		filter: {
 			FromAddress: address,
 		},


### PR DESCRIPTION
## Description 

Context: https://mysten-labs.slack.com/archives/C0701K5UHCP/p1732048923401389

We aren't passing through the Sui client instance to `loadAssets`, so it's defaulting to the public fullnode URL in Stashed which has heavier rate limits as opposed to our internal RPC.

<img width="1696" alt="image" src="https://github.com/user-attachments/assets/7d70fd2f-4532-406f-a591-1790f83ee108">


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
