### PR TITLE
[consensus] Get highest accepted rounds from RoundProber and use in ancestor selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,8 +841,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.0",
- "zstd-safe 7.0.0",
+ "zstd 0.13.2",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -2254,9 +2254,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -6758,7 +6758,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.10",
  "tower 0.5.1",
- "tower-http 0.6.2",
+ "tower-http 0.6.1",
  "tracing",
 ]
 
@@ -9634,7 +9634,7 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
- "zstd 0.13.0",
+ "zstd 0.13.2",
  "zstd-sys",
 ]
 
@@ -17044,9 +17044,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.4.1",
@@ -18472,11 +18472,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 7.0.0",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -18501,20 +18501,19 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,8 +841,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.2",
- "zstd-safe 7.2.1",
+ "zstd 0.13.0",
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -2254,9 +2254,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
@@ -6758,7 +6758,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.10",
  "tower 0.5.1",
- "tower-http 0.6.1",
+ "tower-http 0.6.2",
  "tracing",
 ]
 
@@ -9634,7 +9634,7 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
- "zstd 0.13.2",
+ "zstd 0.13.0",
  "zstd-sys",
 ]
 
@@ -17044,9 +17044,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.4.1",
@@ -18472,11 +18472,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 7.2.1",
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -18501,19 +18501,20 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
 ]

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -68,11 +68,6 @@ impl Committee {
         self.total_stake
     }
 
-    pub fn n_percent_stake_threshold(&self, n: u64) -> Stake {
-        assert!(n <= 100, "n must be between 0 and 100");
-        self.total_stake * n / 100
-    }
-
     pub fn quorum_threshold(&self) -> Stake {
         self.quorum_threshold
     }

--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -84,15 +84,6 @@ fn build_tonic_services(out_dir: &Path) {
                 .codec_path(codec_path)
                 .build(),
         )
-        .method(
-            tonic_build::manual::Method::builder()
-                .name("get_latest_rounds_v2")
-                .route_name("GetLatestRoundsV2")
-                .input_type("crate::network::tonic_network::GetLatestRoundsRequest")
-                .output_type("crate::network::tonic_network::GetLatestRoundsResponseV2")
-                .codec_path(codec_path)
-                .build(),
-        )
         .build();
 
     tonic_build::manual::Builder::new()
@@ -152,15 +143,6 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetLatestRounds")
                 .request_type("crate::network::anemo_network::GetLatestRoundsRequest")
                 .response_type("crate::network::anemo_network::GetLatestRoundsResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
-                .name("get_latest_rounds_v2")
-                .route_name("GetLatestRoundsV2")
-                .request_type("crate::network::anemo_network::GetLatestRoundsRequest")
-                .response_type("crate::network::anemo_network::GetLatestRoundsResponseV2")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -84,6 +84,15 @@ fn build_tonic_services(out_dir: &Path) {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_latest_rounds_v2")
+                .route_name("GetLatestRoundsV2")
+                .input_type("crate::network::tonic_network::GetLatestRoundsRequest")
+                .output_type("crate::network::tonic_network::GetLatestRoundsResponseV2")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     tonic_build::manual::Builder::new()
@@ -143,6 +152,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("GetLatestRounds")
                 .request_type("crate::network::anemo_network::GetLatestRoundsRequest")
                 .response_type("crate::network::anemo_network::GetLatestRoundsResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_latest_rounds_v2")
+                .route_name("GetLatestRoundsV2")
+                .request_type("crate::network::anemo_network::GetLatestRoundsRequest")
+                .response_type("crate::network::anemo_network::GetLatestRoundsResponseV2")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/consensus/core/src/ancestor.rs
+++ b/consensus/core/src/ancestor.rs
@@ -52,7 +52,8 @@ pub(crate) struct AncestorStateManager {
     state_map: Vec<AncestorInfo>,
     propagation_score_update_count: u32,
     quorum_round_update_count: u32,
-    pub(crate) quorum_round_per_authority: Vec<QuorumRound>,
+    pub(crate) received_quorum_round_per_authority: Vec<QuorumRound>,
+    pub(crate) accepted_quorum_round_per_authority: Vec<QuorumRound>,
     // This is the reputation scores that we use for leader election but we are
     // using it here as a signal for high quality block propagation as well.
     pub(crate) propagation_scores: ReputationScores,
@@ -84,19 +85,26 @@ impl AncestorStateManager {
     pub(crate) fn new(context: Arc<Context>) -> Self {
         let state_map = vec![AncestorInfo::new(); context.committee.size()];
 
-        let quorum_round_per_authority = vec![(0, 0); context.committee.size()];
+        let received_quorum_round_per_authority = vec![(0, 0); context.committee.size()];
+        let accepted_quorum_round_per_authority = vec![(0, 0); context.committee.size()];
         Self {
             context,
             state_map,
             propagation_score_update_count: 0,
             quorum_round_update_count: 0,
             propagation_scores: ReputationScores::default(),
-            quorum_round_per_authority,
+            received_quorum_round_per_authority,
+            accepted_quorum_round_per_authority,
         }
     }
 
-    pub(crate) fn set_quorum_round_per_authority(&mut self, quorum_rounds: Vec<QuorumRound>) {
-        self.quorum_round_per_authority = quorum_rounds;
+    pub(crate) fn set_quorum_rounds_per_authority(
+        &mut self,
+        received_quorum_rounds: Vec<QuorumRound>,
+        accepted_quorum_rounds: Vec<QuorumRound>,
+    ) {
+        self.received_quorum_round_per_authority = received_quorum_rounds;
+        self.accepted_quorum_round_per_authority = accepted_quorum_rounds;
         self.quorum_round_update_count += 1;
     }
 
@@ -137,7 +145,15 @@ impl AncestorStateManager {
         // happened, this is okay as we will only start excluding ancestors after that
         // point in time.
         for (authority_id, score) in propagation_scores_by_authority {
-            let (authority_low_quorum_round, _high) = self.quorum_round_per_authority[authority_id];
+            let (authority_low_quorum_round, _high) = if self
+                .context
+                .protocol_config
+                .consensus_round_prober_probe_accepted_rounds()
+            {
+                self.accepted_quorum_round_per_authority[authority_id]
+            } else {
+                self.received_quorum_round_per_authority[authority_id]
+            };
 
             self.update_state(
                 authority_id,
@@ -172,6 +188,7 @@ impl AncestorStateManager {
 
         match ancestor_info.state {
             // Check conditions to switch to EXCLUDE state
+            // TODO: Consider using received round gaps for exclusion.
             AncestorState::Include => {
                 if propagation_score <= low_score_threshold {
                     ancestor_info.state = AncestorState::Exclude(propagation_score);
@@ -219,19 +236,65 @@ impl AncestorStateManager {
         self.state_map[authority_id] = ancestor_info;
     }
 
-    /// Calculate the network's quorum round from authorities by inclusion stake
-    /// threshold, where quorum round is the highest round a block has been seen
-    /// by a percentage (inclusion threshold) of authorities.
+    /// Calculate the network's quorum round based on what information is available
+    /// via RoundProber.
+    /// When consensus_round_prober_probe_accepted_rounds is true, uses accepted rounds.
+    /// Otherwise falls back to received rounds.
     /// TODO: experiment with using high quorum round
     fn calculate_network_low_quorum_round(&self) -> u32 {
+        if self
+            .context
+            .protocol_config
+            .consensus_round_prober_probe_accepted_rounds()
+        {
+            self.calculate_network_low_accepted_quorum_round()
+        } else {
+            self.calculate_network_low_received_quorum_round()
+        }
+    }
+
+    fn calculate_network_low_accepted_quorum_round(&self) -> u32 {
         let committee = &self.context.committee;
         let inclusion_stake_threshold = self.get_inclusion_stake_threshold();
-        let mut low_quorum_rounds_with_stake = self
-            .quorum_round_per_authority
+
+        let low_quorum_rounds_with_stake = self
+            .accepted_quorum_round_per_authority
             .iter()
             .zip(committee.authorities())
             .map(|((low, _high), (_, authority))| (*low, authority.stake))
             .collect::<Vec<_>>();
+
+        self.calculate_network_low_quorum_round_internal(
+            low_quorum_rounds_with_stake,
+            inclusion_stake_threshold,
+        )
+    }
+
+    fn calculate_network_low_received_quorum_round(&self) -> u32 {
+        let committee = &self.context.committee;
+        let inclusion_stake_threshold = self.get_inclusion_stake_threshold();
+
+        let low_quorum_rounds_with_stake = self
+            .received_quorum_round_per_authority
+            .iter()
+            .zip(committee.authorities())
+            .map(|((low, _high), (_, authority))| (*low, authority.stake))
+            .collect::<Vec<_>>();
+
+        self.calculate_network_low_quorum_round_internal(
+            low_quorum_rounds_with_stake,
+            inclusion_stake_threshold,
+        )
+    }
+
+    /// Calculate the network's quorum round from authorities by inclusion stake
+    /// threshold, where quorum round is the highest round a block has been accepted
+    /// or received by a percentage (inclusion threshold) of authorities.
+    fn calculate_network_low_quorum_round_internal(
+        &self,
+        mut low_quorum_rounds_with_stake: Vec<(u32, u64)>,
+        inclusion_stake_threshold: u64,
+    ) -> u32 {
         low_quorum_rounds_with_stake.sort();
 
         let mut total_stake = 0;
@@ -261,43 +324,90 @@ mod test {
     use crate::leader_scoring::ReputationScores;
 
     #[tokio::test]
-    async fn test_calculate_network_low_quorum_round() {
+    async fn test_calculate_network_low_accepted_quorum_round() {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(false);
+        let context = Arc::new(context);
 
         let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
-        let mut ancestor_state_manager = AncestorStateManager::new(context);
+        let mut ancestor_state_manager = AncestorStateManager::new(context.clone());
         ancestor_state_manager.set_propagation_scores(scores);
 
-        // Quorum rounds are not set yet, so we should calculate a network quorum
-        // round of 0 to start.
+        // Quorum rounds are not set yet, so we should calculate a network
+        // quorum round of 0 to start.
         let network_low_quorum_round = ancestor_state_manager.calculate_network_low_quorum_round();
         assert_eq!(network_low_quorum_round, 0);
 
-        let quorum_rounds = vec![(100, 229), (225, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(100, 229), (225, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(50, 229), (175, 300), (179, 300), (179, 300)];
+        ancestor_state_manager.set_quorum_rounds_per_authority(
+            received_quorum_rounds.clone(),
+            accepted_quorum_rounds.clone(),
+        );
 
+        // When probe_accepted_rounds is false, should use received rounds
         let network_low_quorum_round = ancestor_state_manager.calculate_network_low_quorum_round();
         assert_eq!(network_low_quorum_round, 225);
     }
 
-    // Test all state transitions
+    #[tokio::test]
+    async fn test_calculate_network_low_received_quorum_round() {
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(true);
+        let context = Arc::new(context);
+
+        let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
+        let mut ancestor_state_manager = AncestorStateManager::new(context.clone());
+        ancestor_state_manager.set_propagation_scores(scores);
+
+        // Quorum rounds are not set yet, so we should calculate a network
+        // quorum round of 0 to start.
+        let network_low_quorum_round = ancestor_state_manager.calculate_network_low_quorum_round();
+        assert_eq!(network_low_quorum_round, 0);
+
+        let received_quorum_rounds = vec![(100, 229), (225, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(50, 229), (175, 300), (179, 300), (179, 300)];
+        ancestor_state_manager.set_quorum_rounds_per_authority(
+            received_quorum_rounds.clone(),
+            accepted_quorum_rounds.clone(),
+        );
+
+        // When probe_accepted_rounds is true, should use accepted rounds
+        let network_low_quorum_round = ancestor_state_manager.calculate_network_low_quorum_round();
+        assert_eq!(network_low_quorum_round, 175);
+    }
+
+    // Test all state transitions with probe_accepted_rounds = true
     // Default all INCLUDE -> EXCLUDE
     // EXCLUDE -> INCLUDE (Blocked due to lock)
     // EXCLUDE -> INCLUDE (Pass due to lock expired)
     // INCLUDE -> EXCLUDE (Blocked due to lock)
     // INCLUDE -> EXCLUDE (Pass due to lock expired)
     #[tokio::test]
-    async fn test_update_all_ancestor_state() {
+    async fn test_update_all_ancestor_state_using_accepted_rounds() {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(true);
+        let context = Arc::new(context);
 
         let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
         let mut ancestor_state_manager = AncestorStateManager::new(context);
         ancestor_state_manager.set_propagation_scores(scores);
 
-        let quorum_rounds = vec![(225, 229), (225, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(300, 400), (300, 400), (300, 400), (300, 400)];
+        let accepted_quorum_rounds = vec![(225, 229), (225, 300), (229, 300), (229, 300)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
         // Score threshold for exclude is (4 * 10) / 100 = 0
@@ -337,8 +447,10 @@ mod test {
 
         // Updating the quorum rounds will expire the lock as we only need 1
         // quorum round update for tests.
-        let quorum_rounds = vec![(229, 300), (225, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(400, 500), (400, 500), (400, 500), (400, 500)];
+        let accepted_quorum_rounds = vec![(229, 300), (225, 300), (229, 300), (229, 300)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
         // Authority 0 should now be included again because low quorum round is
@@ -353,8 +465,122 @@ mod test {
             }
         }
 
-        let quorum_rounds = vec![(229, 300), (229, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(500, 600), (500, 600), (500, 600), (500, 600)];
+        let accepted_quorum_rounds = vec![(229, 300), (229, 300), (229, 300), (229, 300)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Ancestor 1 can transtion to the INCLUDE state. Ancestor 0 is still locked
+        // in the INCLUDE state until a score update is performed which is why
+        // even though the scores are still low it has not moved to the EXCLUDE
+        // state.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for state in state_map.iter() {
+            assert_eq!(*state, AncestorState::Include);
+        }
+
+        // Updating the scores will expire the lock as we only need 1 update for tests.
+        let scores = ReputationScores::new((1..=300).into(), vec![100, 10, 100, 100]);
+        ancestor_state_manager.set_propagation_scores(scores);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Ancestor 1 can transition to EXCLUDE state now that the lock expired
+        // and its scores are below the threshold.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if authority == 1 {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+    }
+
+    // Test all state transitions with probe_accepted_rounds = false
+    // Default all INCLUDE -> EXCLUDE
+    // EXCLUDE -> INCLUDE (Blocked due to lock)
+    // EXCLUDE -> INCLUDE (Pass due to lock expired)
+    // INCLUDE -> EXCLUDE (Blocked due to lock)
+    // INCLUDE -> EXCLUDE (Pass due to lock expired)
+    #[tokio::test]
+    async fn test_update_all_ancestor_state_using_received_rounds() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(false);
+        let context = Arc::new(context);
+
+        let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
+        let mut ancestor_state_manager = AncestorStateManager::new(context);
+        ancestor_state_manager.set_propagation_scores(scores);
+
+        let received_quorum_rounds = vec![(225, 229), (225, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(100, 150), (100, 150), (100, 150), (100, 150)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Score threshold for exclude is (4 * 10) / 100 = 0
+        // No ancestors should be excluded in with this threshold
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for state in state_map.iter() {
+            assert_eq!(*state, AncestorState::Include);
+        }
+
+        let scores = ReputationScores::new((1..=300).into(), vec![10, 10, 100, 100]);
+        ancestor_state_manager.set_propagation_scores(scores);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Score threshold for exclude is (100 * 10) / 100 = 10
+        // 2 authorities should be excluded in with this threshold
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if (0..=1).contains(&authority) {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // 2 authorities should still be excluded with these scores and no new
+        // quorum round updates have been set to expire the locks.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if (0..=1).contains(&authority) {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+
+        // Updating the quorum rounds will expire the lock as we only need 1
+        // quorum round update for tests.
+        let received_quorum_rounds = vec![(229, 300), (225, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(100, 150), (100, 150), (100, 150), (100, 150)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Authority 0 should now be included again because low quorum round is
+        // at the network low quorum round of 229. Authority 1's quorum round is
+        // too low and will remain excluded.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if authority == 1 {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+
+        let received_quorum_rounds = vec![(229, 300), (229, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(100, 150), (100, 150), (100, 150), (100, 150)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
         // Ancestor 1 can transtion to the INCLUDE state. Ancestor 0 is still locked

--- a/consensus/core/src/ancestor.rs
+++ b/consensus/core/src/ancestor.rs
@@ -307,7 +307,7 @@ mod test {
     use crate::leader_scoring::ReputationScores;
 
     #[tokio::test]
-    async fn test_calculate_network_high_accepted_quorum_round() {
+    async fn test_calculate_network_high_received_quorum_round() {
         telemetry_subscribers::init_for_testing();
 
         let (mut context, _key_pairs) = Context::new_for_test(4);
@@ -340,7 +340,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_calculate_network_high_received_quorum_round() {
+    async fn test_calculate_network_high_accepted_quorum_round() {
         telemetry_subscribers::init_for_testing();
 
         let (mut context, _key_pairs) = Context::new_for_test(4);

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -409,21 +409,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(result)
     }
 
-    async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
-        fail_point_async!("consensus-rpc-response");
-
-        let mut highest_received_rounds = self.core_dispatcher.highest_received_rounds();
-        // Own blocks do not go through the core dispatcher, so they need to be set separately.
-        highest_received_rounds[self.context.own_index] = self
-            .dag_state
-            .read()
-            .get_last_block_for_authority(self.context.own_index)
-            .round();
-
-        Ok(highest_received_rounds)
-    }
-
-    async fn handle_get_latest_rounds_v2(
+    async fn handle_get_latest_rounds(
         &self,
         _peer: AuthorityIndex,
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
@@ -763,14 +749,6 @@ mod tests {
         }
 
         async fn get_latest_rounds(
-            &self,
-            _peer: AuthorityIndex,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn get_latest_rounds_v2(
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -279,14 +279,6 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn get_latest_rounds_v2(
-            &self,
-            _peer: AuthorityIndex,
-            _timeout: Duration,
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -282,6 +282,14 @@ mod test {
         ) -> ConsensusResult<Vec<Round>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds_v2(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -809,14 +809,6 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn get_latest_rounds_v2(
-            &self,
-            _peer: AuthorityIndex,
-            _timeout: Duration,
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -812,6 +812,14 @@ mod tests {
         ) -> ConsensusResult<Vec<Round>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds_v2(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -247,12 +247,12 @@ impl Core {
 
     /// Processes the provided blocks and accepts them if possible when their causal history exists.
     /// The method returns:
-    /// - The references of accepted blocks in a BTreeSet for efficient lookup
-    /// - The references of parents that are unknown and need to be fetched
+    /// - The references of accepted blocks
+    /// - The references of ancestors missing their block
     pub(crate) fn add_blocks(
         &mut self,
         blocks: Vec<VerifiedBlock>,
-    ) -> ConsensusResult<(BTreeSet<BlockRef>, BTreeSet<BlockRef>)> {
+    ) -> ConsensusResult<BTreeSet<BlockRef>> {
         let _scope = monitored_scope("Core::add_blocks");
         let _s = self
             .context
@@ -270,7 +270,7 @@ impl Core {
         // Try to accept them via the block manager
         let (accepted_blocks, missing_block_refs) = self.block_manager.try_accept_blocks(blocks);
 
-        let accepted_block_refs = if !accepted_blocks.is_empty() {
+        if !accepted_blocks.is_empty() {
             debug!(
                 "Accepted blocks: {}",
                 accepted_blocks
@@ -279,11 +279,6 @@ impl Core {
                     .join(",")
             );
 
-            let refs: BTreeSet<BlockRef> = accepted_blocks
-                .iter()
-                .map(|block| block.reference())
-                .collect();
-
             // Now add accepted blocks to the threshold clock and pending ancestors list.
             self.add_accepted_blocks(accepted_blocks);
 
@@ -291,17 +286,13 @@ impl Core {
 
             // Try to propose now since there are new blocks accepted.
             self.try_propose(false)?;
-
-            refs
-        } else {
-            BTreeSet::new()
         };
 
         if !missing_block_refs.is_empty() {
             debug!("Missing block refs: {:?}", missing_block_refs);
         }
 
-        Ok((accepted_block_refs, missing_block_refs))
+        Ok(missing_block_refs)
     }
 
     /// Adds/processed all the newly `accepted_blocks`. We basically try to move the threshold clock and add them to the
@@ -1840,7 +1831,7 @@ mod test {
         let blocks = builder.blocks.values().cloned().collect::<Vec<_>>();
 
         // Process all the blocks
-        assert!(core.add_blocks(blocks).unwrap().1.is_empty());
+        assert!(core.add_blocks(blocks).unwrap().is_empty());
 
         // Try to propose - no block should be produced.
         assert!(core.try_propose(true).unwrap().is_none());
@@ -2142,7 +2133,7 @@ mod test {
             .build();
         let blocks = builder.blocks(1..=12);
         // Process all the blocks
-        assert!(core.add_blocks(blocks).unwrap().1.is_empty());
+        assert!(core.add_blocks(blocks).unwrap().is_empty());
         core.set_last_known_proposed_round(12);
 
         let block = core.try_propose(true).expect("No error").unwrap();
@@ -2156,7 +2147,7 @@ mod test {
             .skip_block()
             .build();
         let blocks = builder.blocks(13..=14);
-        assert!(core.add_blocks(blocks).unwrap().1.is_empty());
+        assert!(core.add_blocks(blocks).unwrap().is_empty());
 
         // We now have triggered a leader schedule change so we should have
         // one EXCLUDE ancestor when we go to select ancestors for the next proposal
@@ -2179,7 +2170,7 @@ mod test {
         // Wait for min round delay to allow blocks to be proposed.
         sleep(context.parameters.min_round_delay).await;
         // Smart select should be triggered and no block should be proposed.
-        assert!(core.add_blocks(blocks).unwrap().1.is_empty());
+        assert!(core.add_blocks(blocks).unwrap().is_empty());
         assert_eq!(core.last_proposed_block().round(), 15);
 
         builder
@@ -2195,7 +2186,7 @@ mod test {
             .build();
         let blocks = builder.blocks(15..=15);
         // Have enough ancestor blocks to propose now.
-        assert!(core.add_blocks(blocks).unwrap().1.is_empty());
+        assert!(core.add_blocks(blocks).unwrap().is_empty());
         assert_eq!(core.last_proposed_block().round(), 16);
 
         // Build blocks for a quorum of the network including the EXCLUDE ancestor
@@ -2215,7 +2206,7 @@ mod test {
         // Wait for leader timeout to force blocks to be proposed.
         sleep(context.parameters.min_round_delay).await;
         // Smart select should be triggered and no block should be proposed.
-        assert!(core.add_blocks(blocks).unwrap().1.is_empty());
+        assert!(core.add_blocks(blocks).unwrap().is_empty());
         assert_eq!(core.last_proposed_block().round(), 16);
 
         // Simulate a leader timeout and a force proposal where we will include

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -691,16 +691,18 @@ impl Core {
         self.subscriber_exists = exists;
     }
 
-    /// Sets the delay by round for propagating blocks to a quorum and the
-    /// quorum round per authority for ancestor state manager.
+    /// Sets the delay by round for propagating blocks to a quorum and the received
+    /// & accepted quorum rounds per authority for ancestor state manager.
     pub(crate) fn set_propagation_delay_and_quorum_rounds(
         &mut self,
         delay: Round,
-        quorum_rounds: Vec<QuorumRound>,
+        received_quorum_rounds: Vec<QuorumRound>,
+        accepted_quorum_rounds: Vec<QuorumRound>,
     ) {
-        info!("Quorum round per authority in ancestor state manager set to: {quorum_rounds:?}");
+        info!("Received quorum round per authority in ancestor state manager set to: {received_quorum_rounds:?}");
+        info!("Accepted quorum round per authority in ancestor state manager set to: {accepted_quorum_rounds:?}");
         self.ancestor_state_manager
-            .set_quorum_round_per_authority(quorum_rounds);
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         info!("Propagation round delay set to: {delay}");
         self.propagation_delay = delay;
     }
@@ -2332,7 +2334,7 @@ mod test {
         );
 
         // Use a large propagation delay to disable proposing.
-        core.set_propagation_delay_and_quorum_rounds(1000, vec![]);
+        core.set_propagation_delay_and_quorum_rounds(1000, vec![], vec![]);
 
         // Make propagation delay the only reason for not proposing.
         core.set_subscriber_exists(true);
@@ -2341,7 +2343,7 @@ mod test {
         assert!(core.try_propose(true).unwrap().is_none());
 
         // Let Core know there is no propagation delay.
-        core.set_propagation_delay_and_quorum_rounds(0, vec![]);
+        core.set_propagation_delay_and_quorum_rounds(0, vec![], vec![]);
 
         // Proposing now would succeed.
         assert!(core.try_propose(true).unwrap().is_some());

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -188,10 +188,6 @@ mod tests {
         fn highest_received_rounds(&self) -> Vec<Round> {
             todo!()
         }
-
-        fn highest_accepted_rounds(&self) -> Vec<Round> {
-            todo!()
-        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -175,7 +175,8 @@ mod tests {
         fn set_propagation_delay_and_quorum_rounds(
             &self,
             _delay: Round,
-            _quorum_rounds: Vec<QuorumRound>,
+            _received_quorum_rounds: Vec<QuorumRound>,
+            _accepted_quorum_rounds: Vec<QuorumRound>,
         ) -> Result<(), CoreError> {
             todo!()
         }
@@ -185,6 +186,10 @@ mod tests {
         }
 
         fn highest_received_rounds(&self) -> Vec<Round> {
+            todo!()
+        }
+
+        fn highest_accepted_rounds(&self) -> Vec<Round> {
             todo!()
         }
     }

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -179,9 +179,12 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: Histogram,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
-    pub(crate) round_prober_quorum_round_gaps: IntGaugeVec,
-    pub(crate) round_prober_low_quorum_round: IntGaugeVec,
-    pub(crate) round_prober_current_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_received_quorum_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_accepted_quorum_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_low_received_quorum_round: IntGaugeVec,
+    pub(crate) round_prober_low_accepted_quorum_round: IntGaugeVec,
+    pub(crate) round_prober_current_received_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_current_accepted_round_gaps: IntGaugeVec,
     pub(crate) round_prober_propagation_delays: Histogram,
     pub(crate) round_prober_last_propagation_delay: IntGauge,
     pub(crate) round_prober_request_errors: IntCounter,
@@ -654,21 +657,39 @@ impl NodeMetrics {
                 &["authority", "error"],
                 registry
             ).unwrap(),
-            round_prober_quorum_round_gaps: register_int_gauge_vec_with_registry!(
-                "round_prober_quorum_round_gaps",
+            round_prober_received_quorum_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_received_quorum_round_gaps",
                 "Round gaps among peers for blocks proposed from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
-            round_prober_low_quorum_round: register_int_gauge_vec_with_registry!(
-                "round_prober_low_quorum_round",
+            round_prober_accepted_quorum_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_accepted_quorum_round_gaps",
+                "Round gaps among peers for blocks  & accepted from each authority",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_low_received_quorum_round: register_int_gauge_vec_with_registry!(
+                "round_prober_low_received_quorum_round",
                 "Low quorum round among peers for blocks proposed from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
-            round_prober_current_round_gaps: register_int_gauge_vec_with_registry!(
-                "round_prober_current_round_gaps",
-                "Round gaps from local last proposed round to the low quorum round of each peer. Can be negative.",
+            round_prober_low_accepted_quorum_round: register_int_gauge_vec_with_registry!(
+                "round_prober_low_accepted_quorum_round",
+                "Low quorum round among peers for blocks proposed & accepted from each authority",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_current_received_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_current_received_round_gaps",
+                "Round gaps from local last proposed round to the low received quorum round of each peer. Can be negative.",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_current_accepted_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_current_accepted_round_gaps",
+                "Round gaps from local last proposed & accepted round to the low accepted quorum round of each peer. Can be negative.",
                 &["authority"],
                 registry
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -665,7 +665,7 @@ impl NodeMetrics {
             ).unwrap(),
             round_prober_accepted_quorum_round_gaps: register_int_gauge_vec_with_registry!(
                 "round_prober_accepted_quorum_round_gaps",
-                "Round gaps among peers for blocks  & accepted from each authority",
+                "Round gaps among peers for blocks proposed & accepted from each authority",
                 &["authority"],
                 registry
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -659,13 +659,13 @@ impl NodeMetrics {
             ).unwrap(),
             round_prober_received_quorum_round_gaps: register_int_gauge_vec_with_registry!(
                 "round_prober_received_quorum_round_gaps",
-                "Round gaps among peers for blocks proposed from each authority",
+                "Received round gaps among peers for blocks proposed from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
             round_prober_accepted_quorum_round_gaps: register_int_gauge_vec_with_registry!(
                 "round_prober_accepted_quorum_round_gaps",
-                "Round gaps among peers for blocks proposed & accepted from each authority",
+                "Accepted round gaps among peers for blocks proposed & accepted from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
@@ -683,13 +683,13 @@ impl NodeMetrics {
             ).unwrap(),
             round_prober_current_received_round_gaps: register_int_gauge_vec_with_registry!(
                 "round_prober_current_received_round_gaps",
-                "Round gaps from local last proposed round to the low received quorum round of each peer. Can be negative.",
+                "Received round gaps from local last proposed round to the low received quorum round of each peer. Can be negative.",
                 &["authority"],
                 registry
             ).unwrap(),
             round_prober_current_accepted_round_gaps: register_int_gauge_vec_with_registry!(
                 "round_prober_current_accepted_round_gaps",
-                "Round gaps from local last proposed & accepted round to the low accepted quorum round of each peer. Can be negative.",
+                "Accepted round gaps from local last proposed & accepted round to the low accepted quorum round of each peer. Can be negative.",
                 &["authority"],
                 registry
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -187,7 +187,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) round_prober_current_accepted_round_gaps: IntGaugeVec,
     pub(crate) round_prober_propagation_delays: Histogram,
     pub(crate) round_prober_last_propagation_delay: IntGauge,
-    pub(crate) round_prober_request_errors: IntCounter,
+    pub(crate) round_prober_request_errors: IntCounterVec,
     pub(crate) uptime: Histogram,
 }
 
@@ -704,9 +704,10 @@ impl NodeMetrics {
                 "Most recent propagation delay observed by RoundProber",
                 registry
             ).unwrap(),
-            round_prober_request_errors: register_int_counter_with_registry!(
+            round_prober_request_errors: register_int_counter_vec_with_registry!(
                 "round_prober_request_errors",
-                "Number of timeouts when probing against peers",
+                "Number of errors when probing against peers per error type",
+                &["error_type"],
                 registry
             ).unwrap(),
             uptime: register_histogram_with_registry!(

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -238,37 +238,14 @@ impl NetworkClient for AnemoClient {
         &self,
         peer: AuthorityIndex,
         timeout: Duration,
-    ) -> ConsensusResult<Vec<Round>> {
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
         let mut client = self.get_client(peer, timeout).await?;
         let request = GetLatestRoundsRequest {};
         let response = client
             .get_latest_rounds(anemo::Request::new(request).with_timeout(timeout))
             .await
-            .map_err(|e: Status| {
-                if e.status() == StatusCode::RequestTimeout {
-                    ConsensusError::NetworkRequestTimeout(format!(
-                        "get_latest_rounds timeout: {e:?}"
-                    ))
-                } else {
-                    ConsensusError::NetworkRequest(format!("get_latest_rounds failed: {e:?}"))
-                }
-            })?;
-        let body = response.into_body();
-        Ok(body.highest_received)
-    }
-
-    async fn get_latest_rounds_v2(
-        &self,
-        peer: AuthorityIndex,
-        timeout: Duration,
-    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
-        let mut client = self.get_client(peer, timeout).await?;
-        let request = GetLatestRoundsRequest {};
-        let response = client
-            .get_latest_rounds_v2(anemo::Request::new(request).with_timeout(timeout))
-            .await
             .map_err(|e| {
-                ConsensusError::NetworkRequest(format!("get_latest_rounds_v2 failed: {e:?}"))
+                ConsensusError::NetworkRequest(format!("get_latest_rounds failed: {e:?}"))
             })?;
         let body = response.into_body();
         Ok((body.highest_received, body.highest_accepted))
@@ -457,7 +434,7 @@ impl<S: NetworkService> ConsensusRpc for AnemoServiceProxy<S> {
                 "peer not found",
             )
         })?;
-        let highest_received = self
+        let (highest_received, highest_accepted) = self
             .service
             .handle_get_latest_rounds(index)
             .await
@@ -467,36 +444,7 @@ impl<S: NetworkService> ConsensusRpc for AnemoServiceProxy<S> {
                     format!("{e}"),
                 )
             })?;
-        Ok(Response::new(GetLatestRoundsResponse { highest_received }))
-    }
-
-    async fn get_latest_rounds_v2(
-        &self,
-        request: anemo::Request<GetLatestRoundsRequest>,
-    ) -> Result<anemo::Response<GetLatestRoundsResponseV2>, anemo::rpc::Status> {
-        let Some(peer_id) = request.peer_id() else {
-            return Err(anemo::rpc::Status::new_with_message(
-                anemo::types::response::StatusCode::BadRequest,
-                "peer_id not found",
-            ));
-        };
-        let index = *self.peer_map.get(peer_id).ok_or_else(|| {
-            anemo::rpc::Status::new_with_message(
-                anemo::types::response::StatusCode::BadRequest,
-                "peer not found",
-            )
-        })?;
-        let (highest_received, highest_accepted) = self
-            .service
-            .handle_get_latest_rounds_v2(index)
-            .await
-            .map_err(|e| {
-                anemo::rpc::Status::new_with_message(
-                    anemo::types::response::StatusCode::InternalServerError,
-                    format!("{e}"),
-                )
-            })?;
-        Ok(Response::new(GetLatestRoundsResponseV2 {
+        Ok(Response::new(GetLatestRoundsResponse {
             highest_received,
             highest_accepted,
         }))
@@ -832,12 +780,6 @@ pub(crate) struct GetLatestRoundsRequest {}
 
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct GetLatestRoundsResponse {
-    // Highest received round per authority.
-    highest_received: Vec<u32>,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub(crate) struct GetLatestRoundsResponseV2 {
     // Highest received round per authority.
     highest_received: Vec<u32>,
     // Highest accepted round per authority.

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -787,7 +787,7 @@ pub(crate) struct GetLatestRoundsRequest {}
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct GetLatestRoundsResponse {
     // Highest received round per authority.
-    highest_received: Vec<u32>,
+    highest_received: Vec<Round>,
     // Highest accepted round per authority.
-    highest_accepted: Vec<u32>,
+    highest_accepted: Vec<Round>,
 }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -116,15 +116,8 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Gets the latest received rounds of all authorities from the peer.
-    async fn get_latest_rounds(
-        &self,
-        peer: AuthorityIndex,
-        timeout: Duration,
-    ) -> ConsensusResult<Vec<Round>>;
-
     /// Gets the latest received & accepted rounds of all authorities from the peer.
-    async fn get_latest_rounds_v2(
+    async fn get_latest_rounds(
         &self,
         peer: AuthorityIndex,
         timeout: Duration,
@@ -173,11 +166,8 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         authorities: Vec<AuthorityIndex>,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Handles the request to get the latest received rounds of all authorities.
-    async fn handle_get_latest_rounds(&self, peer: AuthorityIndex) -> ConsensusResult<Vec<Round>>;
-
     /// Handles the request to get the latest received & accepted rounds of all authorities.
-    async fn handle_get_latest_rounds_v2(
+    async fn handle_get_latest_rounds(
         &self,
         peer: AuthorityIndex,
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -122,6 +122,13 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         peer: AuthorityIndex,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Round>>;
+
+    /// Gets the latest received & accepted rounds of all authorities from the peer.
+    async fn get_latest_rounds_v2(
+        &self,
+        peer: AuthorityIndex,
+        timeout: Duration,
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 }
 
 /// Network service for handling requests from peers.
@@ -168,6 +175,12 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
 
     /// Handles the request to get the latest received rounds of all authorities.
     async fn handle_get_latest_rounds(&self, peer: AuthorityIndex) -> ConsensusResult<Vec<Round>>;
+
+    /// Handles the request to get the latest received & accepted rounds of all authorities.
+    async fn handle_get_latest_rounds_v2(
+        &self,
+        peer: AuthorityIndex,
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 }
 
 /// An `AuthorityNode` holds a `NetworkManager` until shutdown.

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -92,11 +92,7 @@ impl NetworkService for Mutex<TestService> {
         unimplemented!("Unimplemented")
     }
 
-    async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
-        unimplemented!("Unimplemented")
-    }
-
-    async fn handle_get_latest_rounds_v2(
+    async fn handle_get_latest_rounds(
         &self,
         _peer: AuthorityIndex,
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -95,4 +95,11 @@ impl NetworkService for Mutex<TestService> {
     async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
         unimplemented!("Unimplemented")
     }
+
+    async fn handle_get_latest_rounds_v2(
+        &self,
+        _peer: AuthorityIndex,
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+        unimplemented!("Unimplemented")
+    }
 }

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -373,9 +373,8 @@ fn compute_quorum_round(
     let mut total_stake = 0;
     let mut low = 0;
     for (round, stake) in rounds_with_stake.iter().rev() {
-        let reached_quorum_before = total_stake >= committee.quorum_threshold();
         total_stake += stake;
-        if !reached_quorum_before && total_stake >= committee.quorum_threshold() {
+        if total_stake >= committee.quorum_threshold() {
             low = *round;
             break;
         }
@@ -384,9 +383,8 @@ fn compute_quorum_round(
     let mut total_stake = 0;
     let mut high = 0;
     for (round, stake) in rounds_with_stake.iter() {
-        let reached_quorum_before = total_stake >= committee.quorum_threshold();
         total_stake += stake;
-        if !reached_quorum_before && total_stake >= committee.quorum_threshold() {
+        if total_stake >= committee.quorum_threshold() {
             high = *round;
             break;
         }

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -176,7 +176,7 @@ impl<C: NetworkClient> RoundProber<C> {
                             {
                                 highest_received_rounds[peer] = received;
                             } else {
-                                node_metrics.round_prober_request_errors.inc();
+                                node_metrics.round_prober_request_errors.with_label_values(&["invalid_received_rounds"]).inc();
                                 tracing::warn!("Received invalid number of received rounds from peer {}", peer);
                             }
 
@@ -187,7 +187,7 @@ impl<C: NetworkClient> RoundProber<C> {
                                     if accepted.len() == self.context.committee.size() {
                                         highest_accepted_rounds[peer] = accepted;
                                     } else {
-                                        node_metrics.round_prober_request_errors.inc();
+                                        node_metrics.round_prober_request_errors.with_label_values(&["invalid_accepted_rounds"]).inc();
                                         tracing::warn!("Received invalid number of accepted rounds from peer {}", peer);
                                     }
                                 }
@@ -204,11 +204,11 @@ impl<C: NetworkClient> RoundProber<C> {
                         // (peer A cannot propagate its blocks well). It can be difficult to distinguish between
                         // own probing failures and actual propagation issues.
                         Ok(Err(err)) => {
-                            node_metrics.round_prober_request_errors.inc();
+                            node_metrics.round_prober_request_errors.with_label_values(&["failed_fetch"]).inc();
                             tracing::warn!("Failed to get latest rounds from peer {}: {:?}", peer, err);
                         },
                         Err(_) => {
-                            node_metrics.round_prober_request_errors.inc();
+                            node_metrics.round_prober_request_errors.with_label_values(&["timeout"]).inc();
                             tracing::warn!("Timeout while getting latest rounds from peer {}", peer);
                         },
                     }

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -311,14 +311,6 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn get_latest_rounds_v2(
-            &self,
-            _peer: AuthorityIndex,
-            _timeout: Duration,
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -314,6 +314,14 @@ mod test {
         ) -> ConsensusResult<Vec<Round>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds_v2(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1223,6 +1223,14 @@ mod tests {
         ) -> ConsensusResult<Vec<Round>> {
             unimplemented!("Unimplemented")
         }
+
+        async fn get_latest_rounds_v2(
+            &self,
+            _peer: AuthorityIndex,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[test]

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1220,14 +1220,6 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn get_latest_rounds_v2(
-            &self,
-            _peer: AuthorityIndex,
-            _timeout: Duration,
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1293,7 +1293,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "69",
+              "maxSupportedProtocolVersion": "70",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,
@@ -1307,6 +1307,7 @@
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_order_end_of_epoch_last": true,
                 "consensus_round_prober": false,
+                "consensus_round_prober_probe_accepted_rounds": false,
                 "consensus_smart_ancestor_selection": false,
                 "disable_invariant_violation_check_in_swap_loc": false,
                 "disallow_adding_abilities_on_upgrade": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -198,6 +198,7 @@ const MAX_PROTOCOL_VERSION: u64 = 69;
 // Version 69: Sets number of rounds allowed for fastpath voting in consensus.
 //             Enable smart ancestor selection in devnet.
 //             Enable G1Uncompressed group in testnet.
+//             Enable probing for accepted rounds in round prober.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -571,6 +572,10 @@ struct FeatureFlags {
     // Use smart ancestor selection in consensus.
     #[serde(skip_serializing_if = "is_false")]
     consensus_smart_ancestor_selection: bool,
+
+    // Probe accepted rounds in round prober.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_round_prober_probe_accepted_rounds: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1690,6 +1695,11 @@ impl ProtocolConfig {
 
     pub fn consensus_smart_ancestor_selection(&self) -> bool {
         self.feature_flags.consensus_smart_ancestor_selection
+    }
+
+    pub fn consensus_round_prober_probe_accepted_rounds(&self) -> bool {
+        self.feature_flags
+            .consensus_round_prober_probe_accepted_rounds
     }
 }
 
@@ -2969,6 +2979,12 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.uncompressed_g1_group_elements = true;
                     }
+
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        // Enable probing for accepted rounds in round prober.
+                        cfg.feature_flags
+                            .consensus_round_prober_probe_accepted_rounds = true;
+                    }
                 }
                 // Use this template when making changes:
                 //
@@ -3135,6 +3151,11 @@ impl ProtocolConfig {
     pub fn set_disallow_new_modules_in_deps_only_packages_for_testing(&mut self, val: bool) {
         self.feature_flags
             .disallow_new_modules_in_deps_only_packages = val;
+    }
+
+    pub fn set_consensus_round_prober_probe_accepted_rounds(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_round_prober_probe_accepted_rounds = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -18,7 +18,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 69;
+const MAX_PROTOCOL_VERSION: u64 = 70;
 
 // Record history of protocol version allocations here:
 //
@@ -198,7 +198,7 @@ const MAX_PROTOCOL_VERSION: u64 = 69;
 // Version 69: Sets number of rounds allowed for fastpath voting in consensus.
 //             Enable smart ancestor selection in devnet.
 //             Enable G1Uncompressed group in testnet.
-//             Enable probing for accepted rounds in round prober.
+// Version 70: Enable probing for accepted rounds in round prober.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2979,7 +2979,8 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.uncompressed_g1_group_elements = true;
                     }
-
+                }
+                70 => {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         // Enable probing for accepted rounds in round prober.
                         cfg.feature_flags

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_70.snap
@@ -1,0 +1,340 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 70
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode: TotalGasBudgetWithCap
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  relocate_event_module: true
+  disallow_new_modules_in_deps_only_packages: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 26
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 52
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 26
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 13
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 2000
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_70.snap
@@ -1,0 +1,341 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 70
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode: TotalGasBudgetWithCap
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 26
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 52
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 26
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 13
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 2000
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_70.snap
@@ -1,0 +1,353 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 70
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode: TotalGasBudgetWithCap
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  mysticeti_fastpath: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 10
+group_ops_bls12381_decode_scalar_cost: 52
+group_ops_bls12381_decode_g1_cost: 52
+group_ops_bls12381_decode_g2_cost: 52
+group_ops_bls12381_decode_gt_cost: 52
+group_ops_bls12381_scalar_add_cost: 52
+group_ops_bls12381_g1_add_cost: 52
+group_ops_bls12381_g2_add_cost: 52
+group_ops_bls12381_gt_add_cost: 52
+group_ops_bls12381_scalar_sub_cost: 52
+group_ops_bls12381_g1_sub_cost: 52
+group_ops_bls12381_g2_sub_cost: 52
+group_ops_bls12381_gt_sub_cost: 52
+group_ops_bls12381_scalar_mul_cost: 52
+group_ops_bls12381_g1_mul_cost: 52
+group_ops_bls12381_g2_mul_cost: 52
+group_ops_bls12381_gt_mul_cost: 52
+group_ops_bls12381_scalar_div_cost: 52
+group_ops_bls12381_g1_div_cost: 52
+group_ops_bls12381_g2_div_cost: 52
+group_ops_bls12381_gt_div_cost: 52
+group_ops_bls12381_g1_hash_to_base_cost: 52
+group_ops_bls12381_g2_hash_to_base_cost: 52
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 52
+group_ops_bls12381_g2_msm_base_cost: 52
+group_ops_bls12381_g1_msm_base_cost_per_input: 52
+group_ops_bls12381_g2_msm_base_cost_per_input: 52
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 52
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 26
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 52
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 26
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 13
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 2000
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 3
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 18500000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 3700000
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 69
+  protocol_version: 70
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 69
+protocol_version: 70
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x0ab85bf1aef18aad179ca34f4d95e34dd60dd1b2bda18d558e7b0bfe14ba8b77"
+            id: "0xd95aeec428abb407baf6185f83090de23f0fbe3ab5ec5ac455dfb09b01a86823"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x2fd0e88948443e54727efb6d1756d8c39735a421dac7bb92be690abe205b5bfa"
+      operation_cap_id: "0x3a9f6bbd0b886a6e35dd50bdb54bb9a1dca35b24b6ae826add15a5e9ea45c1fb"
       gas_price: 1000
       staking_pool:
-        id: "0xdcc39ac807721ee62f3fe0a6c697cbd93389f79b1a6717a95ccd28dca27821c8"
+        id: "0x5d5d4c125492ab2dcf2068aeb8f3c1361b4d30912023aac14313ddbbb77e7d71"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xaa706539eb8876b6c6a9b335c8d0ab1275d0a08a8ad29a6e6da68891e59298e4"
+          id: "0x0383c9a5226e6811ada38b22bf838c2617f89770394bd74560a9a0fdfd94c95d"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x651bc7aee334c01c02043e8caa326beaf7cf3fee5f099dda61cd39a971b1a0e6"
+            id: "0xc883911bbcf25665e4336f1e024c68535cfb34177b558d84a3e7870741bfb1b2"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x3e9b72b2ab6660a2fd11af8d5f44925fccdb0fd793ec425f6438a1b149f8e3ea"
+          id: "0x24724d158dc6771c67b1dfce287faaac19570abbc4636bd0a9c3ca84cbc386f9"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xd93aaac7fc3ff26d6f2336ad8f11c15f2e51a0623715fce08742faa1caabdc65"
+      id: "0x07d40f289f98cf6f567ff9faaf07a266fba60765fa14389b4b956bba44c1a95a"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xffabe0c370cf34f726bb6132f97dbc7bf7f77c4b5322797f786cbc73b0c0d125"
+    id: "0xd4fe1d15e9895507c5018cf0319d87dc43802ca4b86c1506fd643b83809cf731"
     size: 1
   inactive_validators:
-    id: "0x3d3953f69d3dcb19cbaad3c5372084f72a9290916c5faf5f8f241cb5d5e6c94b"
+    id: "0xeedec924bd8bbb8b71a3533270c6c59d834268f82c55941140fd0b0a5473cbed"
     size: 0
   validator_candidates:
-    id: "0x66528ea16da7d7286671c3f187a1e68e0acd4fc13ffe45a0e5de12d2e2a825ec"
+    id: "0x2b0f871fb557f02fa03767da3ed958431a6d368924716f3f40e442a19f50d93a"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x1dff1b20ab0c400d5e48019f10ded46bdb08927f2e22fa4ced77ee6829b3c618"
+      id: "0x1f240b3a58741356c667ae3f8afc9b555951caff229481a42ae7ba2d83e020c6"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x3730cc216e9af079f9f8955b07b50366ee726b2d95dd102c4420e0e5102ce558"
+      id: "0x210b2c39cb45252263779891213f744bc7e9f41bb36f909312981339e7cdc407"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xdf3d8018bba72f99aee8cfcb7af644e0edbbd86cb02732cf4bd2f3bbc8b45a25"
+      id: "0x7e868a08d450d1b4efb59ae47d11b7653bfcfb4951aa8df560c2dc91cd96af81"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xbb67e32883f2542fb09119328da10c216ae19f663b64f024a724ca8c508502fa"
+    id: "0x255200b4f3d4163d381d794c0915bdd635ff52661dfc9810d07285738fef908d"
   size: 0
 


### PR DESCRIPTION
## Description 

For ancestor selection we want to ensure the highest quality ancestors are included in the proposal, therefore if an authority is excluded we should start including them once they have caught up to the network with their accepted blocks not just received as its possible for blocks to be received but suspended on many hosts which can cause performance degradation

Additionally switched to using high quorum round of the high quorum round of accepted rounds for inclusion metric.

Also bumped protocol version to 70 to include the new feature.

## Test plan 

How did you test the new or updated feature?

Injected Latency Test - https://metrics.sui.io/goto/Jowh4F7Hg?orgId=1
Hoarded Block Test - Pending

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: v70 Enable probing for accepted rounds in round prober in consensus.
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
