### PR TITLE
adding back Client-Request-Method to sdk reqs

### DIFF
--- a/.changeset/shy-coats-exist.md
+++ b/.changeset/shy-coats-exist.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Adding back 'Client-Request-Method' header

--- a/sdk/typescript/src/client/http-transport.ts
+++ b/sdk/typescript/src/client/http-transport.ts
@@ -95,6 +95,7 @@ export class SuiHTTPTransport implements SuiTransport {
 				'Client-Sdk-Type': 'typescript',
 				'Client-Sdk-Version': PACKAGE_VERSION,
 				'Client-Target-Api-Version': TARGETED_RPC_VERSION,
+				'Client-Request-Method': input.method,
 				...this.#options.rpc?.headers,
 			},
 			body: JSON.stringify({

--- a/sdk/typescript/test/unit/client/http-transport.test.ts
+++ b/sdk/typescript/test/unit/client/http-transport.test.ts
@@ -62,7 +62,7 @@ describe('SuiHTTPTransport', () => {
 					'Client-Sdk-Type': 'typescript',
 					'Client-Sdk-Version': PACKAGE_VERSION,
 					'Client-Target-Api-Version': TARGETED_RPC_VERSION,
-					// 'Client-Request-Method': 'getAllBalances',
+					'Client-Request-Method': 'getAllBalances',
 				},
 				method: 'POST',
 			});


### PR DESCRIPTION
## Description 

Re-merging https://github.com/MystenLabs/sui/pull/20071, as an optimization to skip parsing jsonrpc request bodies when `Client-Request-Method` is set

This shouldn't cause any issues now that https://github.com/MystenLabs/sui/pull/20160 is merged and is running on testnet and mainnet (via https://github.com/MystenLabs/sui/tree/releases/sui-v1.38.0-release & https://github.com/MystenLabs/sui/tree/releases/sui-v1.37.0-release branches)


## Test plan 

Tested via `pnpm create @mysten/dapp --template react-client-dapp` (ref https://github.com/MystenLabs/sui/issues/20158) and:
```
curl -v 'https://fullnode.testnet.sui.io/' -X OPTIONS
* Host fullnode.testnet.sui.io:443 was resolved.
[...]
* Request completely sent off
< HTTP/2 200
< access-control-allow-origin: *
< vary: origin, access-control-request-method, access-control-request-headers
< access-control-allow-methods: POST
< access-control-allow-headers: content-type,client-sdk-type,client-sdk-version,client-target-api-version,app-name,client-request-method
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
