### PR TITLE
Add move 2024 Conventions as comments to the new package example

### DIFF
--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -36,76 +36,9 @@ impl New {
 module {name}::{name};
 */
 
-// The following recommendations are based on 2024 Move.
+// For Move coding conventions, see
+// https://docs.sui.io/concepts/sui-move-concepts/conventions
 
-// === Imports ===
-
-// === Errors ===
-// Use PascalCase for errors, start with an E and be descriptive.
-// ex: const ENameHasMaxLengthOf64Chars: u64 = 0;
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#errors
-
-// === Constants ===
-
-// === Structs ===
-// * Describe the properties of your structs.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#struct-property-comments
-//
-// * Do not use 'potato' in the name of structs. The lack of abilities define it as a potato pattern.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#potato-structs
-
-// === Method Aliases ===
-
-// === Public-Mutative Functions ===
-// * Name the functions that create data structures as `public fun empty`.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#empty-function
-//
-// * Name the functions that create objects as `pub fun new`.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#new-function
-//
-// * Library modules that share objects should provide two functions:
-// one to create the object `public fun new(ctx:&mut TxContext): Object`
-// and another to share it `public fun share(profile: Profile)`.
-// It allows the caller to access its UID and run custom functionality before sharing it.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#new-function
-//
-// * Name the functions that return a reference as `<PROPERTY-NAME>_mut`, replacing with
-// <PROPERTY-NAME\> the actual name of the property.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#reference-functions
-//
-// * Provide functions to delete objects. Destroy empty objects with the `public fun destroy_empty`
-// Use the `public fun drop` for objects that have types that can be dropped.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#destroy-functions
-//
-// * CRUD functions names
-// `add`, `new`, `drop`, `empty`, `remove`, `destroy_empty`, `to_object_name`, `from_object_name`, `property_name_mut`
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#crud-functions-names
-
-// === Public-View Functions ===
-// * Name the functions that return a reference as <<PROPERTY-NAME>, replacing with
-// <PROPERTY-NAME\> the actual name of the property.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#reference-functions
-//
-// * Keep your functions pure to maintain composability. Do not use `transfer::transfer` or
-// `transfer::public_transfer` inside core functions.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#pure-functions
-//
-// * CRUD functions names
-// `exists_`, `contains`, `property_name`
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#crud-functions-names
-
-// === Admin Functions ===
-// * In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#admin-capability
-//
-// * To maintain composability, use capabilities instead of addresses for access control.
-// https://docs.sui.io/concepts/sui-move-concepts/conventions#access-control
-
-// === Public-Package Functions ===
-
-// === Private Functions ===
-
-// === Test Functions ===
 "#,
             name = name
         )?;

--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -34,7 +34,79 @@ impl New {
             r#"/*
 /// Module: {name}
 module {name}::{name};
-*/"#,
+*/
+
+// The following recommendations are based on 2024 Move.
+
+// === Imports ===
+
+// === Errors ===
+// Use PascalCase for errors, start with an E and be descriptive.
+// ex: const ENameHasMaxLengthOf64Chars: u64 = 0;
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#errors
+
+// === Constants ===
+
+// === Structs ===
+// * Describe the properties of your structs.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#struct-property-comments
+//
+// * Do not use 'potato' in the name of structs. The lack of abilities define it as a potato pattern.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#potato-structs
+
+// === Method Aliases ===
+
+// === Public-Mutative Functions ===
+// * Name the functions that create data structures as `public fun empty`.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#empty-function
+//
+// * Name the functions that create objects as `pub fun new`.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#new-function
+//
+// * Library modules that share objects should provide two functions:
+// one to create the object `public fun new(ctx:&mut TxContext): Object`
+// and another to share it `public fun share(profile: Profile)`.
+// It allows the caller to access its UID and run custom functionality before sharing it.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#new-function
+//
+// * Name the functions that return a reference as `<PROPERTY-NAME>_mut`, replacing with
+// <PROPERTY-NAME\> the actual name of the property.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#reference-functions
+//
+// * Provide functions to delete objects. Destroy empty objects with the `public fun destroy_empty`
+// Use the `public fun drop` for objects that have types that can be dropped.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#destroy-functions
+//
+// * CRUD functions names
+// `add`, `new`, `drop`, `empty`, `remove`, `destroy_empty`, `to_object_name`, `from_object_name`, `property_name_mut`
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#crud-functions-names
+
+// === Public-View Functions ===
+// * Name the functions that return a reference as <<PROPERTY-NAME>, replacing with
+// <PROPERTY-NAME\> the actual name of the property.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#reference-functions
+//
+// * Keep your functions pure to maintain composability. Do not use `transfer::transfer` or
+// `transfer::public_transfer` inside core functions.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#pure-functions
+//
+// * CRUD functions names
+// `exists_`, `contains`, `property_name`
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#crud-functions-names
+
+// === Admin Functions ===
+// * In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#admin-capability
+//
+// * To maintain composability, use capabilities instead of addresses for access control.
+// https://docs.sui.io/concepts/sui-move-concepts/conventions#access-control
+
+// === Public-Package Functions ===
+
+// === Private Functions ===
+
+// === Test Functions ===
+"#,
             name = name
         )?;
 

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -78,7 +78,7 @@ module conventions::profile {
     }
 
     // ✅ Right
-    public fun age(self: &Profile):    u64 {
+    public fun age(self: &Profile): u64 {
         self.age
     }
 


### PR DESCRIPTION
## Description 
* Fix typo in 2024 Conventions
* ~Add Conventions as comments to a new package when `sui move new`~
* Add Conventions link to a new package when `sui move new`

## Test plan 
* no extra tests needed

## Release notes
- [X] CLI: Add Conventions as comments to a new package when `sui move new`