### PR TITLE
fix(graphql): loading Owner.dynamicObjectField.value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14629,7 +14629,7 @@ dependencies = [
  "tokio-util 0.7.10",
  "toml 0.7.4",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "uuid 1.2.2",
 ]

--- a/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.exp
@@ -33,14 +33,14 @@ created: object(5,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 6, lines 101-104:
+task 6, lines 100-103:
 //# run P0::M::connect --args object(2,0) object(3,0) object(4,0) object(5,0)
 created: object(6,0), object(6,1)
 mutated: object(0,1), object(2,0), object(4,0), object(5,0)
 wrapped: object(3,0)
 gas summary: computation_cost: 1000000, storage_cost: 9940800,  storage_rebate: 6041772, non_refundable_storage_fee: 61028
 
-task 7, lines 106-108:
+task 7, lines 105-107:
 //# view-object 2,0
 Owner: Account Address ( _ )
 Version: 7
@@ -65,27 +65,27 @@ Contents: P0::M::O {
     },
 }
 
-task 8, lines 110-111:
+task 8, lines 109-110:
 //# run P0::M::touch_root --args object(2,0)
 mutated: object(0,1), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2568800,  storage_rebate: 2543112, non_refundable_storage_fee: 25688
 
-task 9, lines 113-114:
+task 9, lines 112-113:
 //# run P0::M::touch_wrapped --args object(2,0)
 mutated: object(0,1), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2568800,  storage_rebate: 2543112, non_refundable_storage_fee: 25688
 
-task 10, lines 116-117:
+task 10, lines 115-116:
 //# run P0::M::touch_inner --args object(2,0)
 mutated: object(0,1), object(2,0), object(4,0)
 gas summary: computation_cost: 1000000, storage_cost: 3853200,  storage_rebate: 3814668, non_refundable_storage_fee: 38532
 
-task 11, lines 119-120:
+task 11, lines 118-119:
 //# run P0::M::touch_outer --args object(2,0)
 mutated: object(0,1), object(2,0), object(5,0)
 gas summary: computation_cost: 1000000, storage_cost: 3853200,  storage_rebate: 3814668, non_refundable_storage_fee: 38532
 
-task 12, line 122:
+task 12, line 121:
 //# view-object 2,0
 Owner: Account Address ( _ )
 Version: 11
@@ -110,11 +110,11 @@ Contents: P0::M::O {
     },
 }
 
-task 13, line 124:
+task 13, line 123:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 14, lines 126-141:
+task 14, lines 125-140:
 //# run-graphql
 Response: {
   "data": {
@@ -189,18 +189,18 @@ Response: {
   }
 }
 
-task 15, lines 143-171:
+task 15, lines 142-169:
 //# run-graphql
 Response: {
   "data": {
     "unversioned": {
       "dynamicObjectField": {
         "value": {
-          "version": 7,
+          "version": 10,
           "contents": {
             "json": {
               "id": "0xc6648a3386f34bd5b4757713a6d5f81852df299ef5a867de257b0c28a56f07e3",
-              "count": "0"
+              "count": "1"
             }
           }
         }
@@ -261,11 +261,24 @@ Response: {
   }
 }
 
-task 16, lines 173-194:
+task 16, lines 171-206:
 //# run-graphql
 Response: {
   "data": {
     "unversioned": {
+      "dynamicObjectField": {
+        "value": {
+          "version": 11,
+          "contents": {
+            "json": {
+              "id": "0x418dc1ff6ea1cdccbc2ab29974b3f233855dee9bedecfadaab0d4f906bef4295",
+              "count": "1"
+            }
+          }
+        }
+      }
+    },
+    "latestObject": {
       "dynamicObjectField": {
         "value": {
           "version": 7,

--- a/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/owner/root_version.move
@@ -95,8 +95,7 @@ module P0::M {
 // lamport version: 5 (inner)
 
 //# run P0::M::new_dof
-// lamprot version: 6 (outer)
-
+// lamport version: 6 (outer)
 
 //# run P0::M::connect --args object(2,0) object(3,0) object(4,0) object(5,0)
 // lamport version: 7 (o, w, inner, outer)
@@ -155,9 +154,8 @@ fragment DOF on Owner {
 { # Querying dynamic fields under the wrapped Move object
   # AA== is the base64 encoding of the boolean value `false` (0x00).
 
-  # The latest version konwn to the service for the wrapped object is
-  # the version it was wrapped at, so that will have no dynamic
-  # fields.
+  # Accessing an ID as an Owner imposes no version constraint, so we will end
+  # up fetching the latest versions of the dynamic object fields.
   unversioned: owner(address: "@{obj_3_0}") { ...DOF }
 
   # Specifying the latest version of the wrapping object has the
@@ -185,8 +183,22 @@ fragment DOF on Owner {
 { # Querying a nested dynamic field, where the version of the child
   # may be greater than the version of its immediate parent
 
-  # At its latest version, it doesn't see the latest change on its child.
+  # Accessing the outer ID as an owner imposes no version constraint, so we see
+  # the latest version of the inner object.
   unversioned: owner(address: "@{obj_4_0}") { ...DOF }
+
+  # At its latest version as an object, it doesn't see the latest change on its
+  # child.
+  latestObject: object(address: "@{obj_4_0}") {
+    dynamicObjectField(name: { type: "bool", bcs: "AA==" }) {
+      value {
+        ... on MoveObject {
+          version
+          contents { json }
+        }
+      }
+    }
+  }
 
   # But at its root's latest version, it does
   latest: owner(address: "@{obj_4_0}", rootVersion: 11) { ...DOF }


### PR DESCRIPTION
## Description

Today, when we fetch child objects, we can supply a root version, which is the version of the object in storage that eventually owns this object. We can't use the object's direct parent version because if we modify a child but not its parent in a transaction, then the parent's version will not be updated if that parent is itself a child object.

When we know that we are fetching a dynamic field off an object, O, if O was initialised with a root version, that is inherited by the dynamic field query, but if one was not supplied, then we use the object's version as the root version.

In the case of dynamic object fields, the dynamic field value is itself a child object of the `Field` that contains its name (which is itself a child object of some other object).

In the case of reading a dynamic object field off an owner address, these details all come together to form a bug: The owner does not supply a root version, so we use the version from the `Field`, the `Field` has not been modified since it was first assigned, so that means we're using the initial version of the field, and we end up fetching the initial version of the value as well.

The fix is to have a special carve out for dynamic fields' root versions: The dynamic field needs to remember the root version it was queried with and propagate that when querying its value (in the case of a dynamic object field).

## Test plan

Fixed E2E tests:

```
sui$ cargo nextest run -p sui-graphql-e2e-tests -- owner/root_version
```

And test the query that instigated this. The following query on testnet previously returned the first version of the dynamic field value, and now correctly returns the latest version:

```
{
  owner(
    address: "0x37c0e4d7b36a2f64d51bba262a1791f844cfd88f31379f1b7c04244061d43914"
  ) {
    dynamicObjectField(name: {type: "u64", bcs: "AAAAAAAAAAA="}) {
      value {
        ... on MoveObject {
          contents {
            json
          }
        }
      }
    }
  }
}
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [x] GraphQL: Fix a bug when reading a dynamic object field value from an `Owner`, where the value returned would not be the latest version when the `owner` was queried without a root/parent version supplied.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
