### PR TITLE
fix(sui_indexer): get object packages

### DIFF
--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -307,10 +307,7 @@ impl StoredObject {
         let oref = self.get_object_ref()?;
         let object: sui_types::object::Object = self.try_into()?;
         let Some(move_object) = object.data.try_as_move().cloned() else {
-            return Err(IndexerError::PostgresReadError(format!(
-                "Object {:?} is not a Move object",
-                oref,
-            )));
+            return Ok(ObjectRead::Exists(oref, object, None));
         };
 
         let move_type_layout = package_resolver


### PR DESCRIPTION
## Description 
When requesting a package object

```sh
curl --location 'localhost:9124' \
--header 'content-type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "id": 3,
    "method": "sui_getObject",
    "params": [
        "0x2",
        {
            "showType": true,
            "showContent": true,
            "showOwner": true,
            "showPreviousTransaction": true,
            "showStorageRebate": true,
            "showDisplay": true
        }
    ]
}'
   
```

this error is returned

```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32000,
        "message": "Indexer failed to read PostgresDB with error: `Object (0x0000000000000000000000000000000000000000000000000000000000000002, SequenceNumber(1), o#8MAXVsbUti4fZvSmk8xvKLYsaKSWyv8nNomCkGpLaj1T) is not a Move object`"
    },
    "id": 3
}
```
Before this [commit](https://github.com/MystenLabs/sui/commit/6c07b18b3b6da79ffaad9936b583008aff6a0f25#diff-c8d8604b043d015485da632c0a3122cdb0fb8def722494a2ccdbaac915f340feR193) the indexer was able to fetch the package objects, this PR fixes the ability to get package objects in the indexer's `ReadApi` `get_object` RPC function.

Inspired from this PR: https://github.com/iotaledger/iota/pull/3610

## Test plan 

Start Postgres

```sh
docker run --rm --name sui_indexer -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_USER=postgres -e POSTGRES_DB=sui_indexer -d -p 5432:5432 postgres
```
start the local network

```sh
RUST_LOG=info cargo run --bin sui start --force-regenesis  --with-indexer
```

<details>

<summary>REQUEST & RESPONSE</summary>

```sh
   curl --location 'localhost:9124' \
--header 'content-type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "id": 3,
    "method": "sui_getObject",
    "params": [
        "0x2",
        {
            "showType": true,
            "showContent": true,
            "showOwner": true,
            "showPreviousTransaction": true,
            "showStorageRebate": true,
            "showDisplay": true
        }
    ]
}'
```

```json
{
    "jsonrpc": "2.0",
    "result": {
        "data": {
            "objectId": "0x0000000000000000000000000000000000000000000000000000000000000002",
            "version": "1",
            "digest": "FwHb3FcUrPqMuzdvTK9jsp6xuwM4HzTTAc5dz9AsBwVZ",
            "type": "package",
            "owner": "Immutable",
            "previousTransaction": "2oLipcFA1DRyVfV2C8xzXJmG8scXDLKyQfFCQD6kLXpz",
            "storageRebate": "0",
            "display": {
                "data": null,
                "error": null
            },
            "content": {
                "dataType": "package",
                "disassembled": {..}
            }
        }
    },
    "id": 3
}
```

</details>

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
