### PR TITLE
fix(sui): fix sui validator display-metadata for pending validators

### DIFF
--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -16,6 +16,7 @@ use url::{ParseError, Url};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
     crypto::{AuthorityPublicKey, NetworkPublicKey, Signable, DEFAULT_EPOCH_ID},
+    dynamic_field::Field,
     multiaddr::Multiaddr,
     object::Owner,
     sui_system_state::{
@@ -1090,15 +1091,15 @@ async fn get_pending_candidate_summary(
                 object_id
             )
         })?;
-        let val = bcs::from_bytes::<ValidatorV1>(bcs).map_err(|e| {
+        let field = bcs::from_bytes::<Field<u64, ValidatorV1>>(bcs).map_err(|e| {
             anyhow::anyhow!(
                 "Can't convert bcs bytes of object {} to ValidatorV1: {}",
                 object_id,
                 e,
             )
         })?;
-        if val.verified_metadata().sui_address == validator_address {
-            return Ok(Some(val));
+        if field.value.verified_metadata().sui_address == validator_address {
+            return Ok(Some(field.value));
         }
     }
     Ok(None)


### PR DESCRIPTION
## Description 

Fix the DisplayMetadata command when a validator is still pending
Without this change the ValidatorV1 can't be correctly decoded as the first bytes of the bcs are for the `Field` as the object is a dynamic field resulting in this error: `Can't convert bcs bytes of object 0x17792bdce1d0c032e64f5dff96a4e80eb453ab43f290ef6d091b1ebe50a511eb to ValidatorV1: malformed utf8`

Porting the fix from https://github.com/iotaledger/iota/pull/3611

## Test plan 

Running these commands
```
# increase faucet amount (just setting 30 million didn't work)
sed -i 's/200_000_000_000/4_000_000_000_000_000/g' crates/sui/src/sui_commands.rs
cargo run start --force-regenesis --with-faucet

# other terminal
cargo install --locked --bin sui --path crates/sui
sui client switch --env localnet
# get enough coins
sui client faucet --url http://127.0.0.1:9123/gas
sui client faucet --url http://127.0.0.1:9123/gas
sleep 2 
sui validator make-validator-info validator0 description https://sui.io https://github.com/MystenLabs/sui 127.0.0.1 1000
sui validator become-candidate validator.info
sleep 2
# stake enough coins
for run in {1..8};
do
    coinObjectId=$(sui client gas --json | jq '.[0].gasCoinId')
    validatorAddress=$(sui client active-address)
    sui client call --package 0x3 --module sui_system --function request_add_stake --args 0x5 $coinObjectId $validatorAddress --gas-budget 10000000
done
sleep 2
sui validator join-committee
sleep 2
sui validator display-metadata
```

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixed the `sui validator display-metadata` command bug for pending validators.
- [ ] Rust SDK:
- [ ] REST API:
