### PR TITLE
remove test-utils feature in various crates

### DIFF
--- a/crates/sui-archival/Cargo.toml
+++ b/crates/sui-archival/Cargo.toml
@@ -19,7 +19,7 @@ rand.workspace = true
 object_store.workspace = true
 prometheus.workspace = true
 sui-config.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
+sui-types.workspace = true
 sui-storage.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-bridge-indexer/Cargo.toml
+++ b/crates/sui-bridge-indexer/Cargo.toml
@@ -39,7 +39,6 @@ tempfile.workspace = true
 sui-indexer-builder.workspace = true
 
 [dev-dependencies]
-sui-types = { workspace = true, features = ["test-utils"] }
 sui-test-transaction-builder.workspace = true
 test-cluster.workspace = true
 hex-literal = "0.3.4"

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -53,8 +53,6 @@ hex-literal = { version = "0.3.4", optional = true }
 test-cluster = { workspace = true, optional = true }
 
 [dev-dependencies]
-sui-types = { workspace = true, features = ["test-utils"] }
-sui-json-rpc-types = { workspace = true, features = ["test-utils"] }
 sui-config.workspace = true
 sui-test-transaction-builder.workspace = true
 maplit = "1.0.2"

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -38,4 +38,3 @@ sui-rest-api.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -138,6 +138,3 @@ harness = false
 [[bench]]
 name = "batch_verification_bench"
 harness = false
-
-[features]
-test-utils = []

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -108,7 +108,6 @@ num-bigint = "0.4.4"
 move-symbol-pool.workspace = true
 
 sui-test-transaction-builder.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
 sui-move.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -199,7 +199,6 @@ mod batch_verification_tests;
 #[path = "unit_tests/coin_deny_list_tests.rs"]
 mod coin_deny_list_tests;
 
-#[cfg(any(test, feature = "test-utils"))]
 pub mod authority_test_utils;
 
 pub mod authority_per_epoch_store;
@@ -211,7 +210,6 @@ pub mod authority_store_types;
 pub mod epoch_start_configuration;
 pub mod shared_object_congestion_tracker;
 pub mod shared_object_version_manager;
-#[cfg(any(test, feature = "test-utils"))]
 pub mod test_authority_builder;
 pub mod transaction_deferral;
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3037,7 +3037,6 @@ impl AuthorityPerEpochStore {
         consensus_commit_info: &ConsensusCommitInfo,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
     ) -> SuiResult<Option<TransactionKey>> {
-        #[cfg(any(test, feature = "test-utils"))]
         {
             if consensus_commit_info.skip_consensus_commit_prologue_in_test() {
                 return Ok(None);
@@ -3119,7 +3118,6 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
     pub fn get_highest_pending_checkpoint_height(&self) -> CheckpointHeight {
         self.tables()
             .expect("test should not cross epoch boundary")
@@ -3135,7 +3133,6 @@ impl AuthorityPerEpochStore {
     // VerifiedSequencedConsensusTransaction.
     // Also, ConsensusStats and hash will not be updated in the db with this function, unlike in
     // process_consensus_transactions_and_commit_boundary().
-    #[cfg(any(test, feature = "test-utils"))]
     pub async fn process_consensus_transactions_for_tests<C: CheckpointServiceNotify>(
         self: &Arc<Self>,
         transactions: Vec<SequencedConsensusTransaction>,
@@ -3163,7 +3160,6 @@ impl AuthorityPerEpochStore {
         .await
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
     pub async fn assign_shared_object_versions_for_tests(
         self: &Arc<Self>,
         cache_reader: &dyn ObjectCacheRead,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -768,7 +768,6 @@ pub struct ConsensusCommitInfo {
     pub timestamp: u64,
     pub consensus_commit_digest: ConsensusCommitDigest,
 
-    #[cfg(any(test, feature = "test-utils"))]
     skip_consensus_commit_prologue_in_test: bool,
 }
 
@@ -779,12 +778,10 @@ impl ConsensusCommitInfo {
             timestamp: consensus_commit.commit_timestamp_ms(),
             consensus_commit_digest: consensus_commit.consensus_digest(protocol_config),
 
-            #[cfg(any(test, feature = "test-utils"))]
             skip_consensus_commit_prologue_in_test: false,
         }
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
     pub fn new_for_test(
         commit_round: u64,
         commit_timestamp: u64,
@@ -798,7 +795,6 @@ impl ConsensusCommitInfo {
         }
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
     pub fn skip_consensus_commit_prologue_in_test(&self) -> bool {
         self.skip_consensus_commit_prologue_in_test
     }

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -21,7 +21,6 @@ pub mod execution_cache;
 mod execution_driver;
 pub mod jsonrpc_index;
 pub mod metrics;
-#[cfg(any(test, feature = "test-utils"))]
 pub mod mock_consensus;
 pub mod module_cache_metrics;
 pub mod mysticeti_adapter;
@@ -37,7 +36,6 @@ pub mod state_accumulator;
 pub mod storage;
 pub mod streamer;
 pub mod subscription_handler;
-#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 pub mod traffic_controller;
 mod transaction_input_loader;
@@ -68,7 +66,6 @@ mod pay_sui_tests;
 #[cfg(test)]
 #[path = "unit_tests/shared_object_deletion_tests.rs"]
 mod shared_object_deletion_tests;
-#[cfg(any(test, feature = "test-utils"))]
 pub mod test_authority_clients;
 #[cfg(test)]
 #[path = "unit_tests/transfer_to_object_tests.rs"]

--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -32,4 +32,3 @@ sui-rest-api.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-data-ingestion/Cargo.toml
+++ b/crates/sui-data-ingestion/Cargo.toml
@@ -39,4 +39,3 @@ url.workspace = true
 [dev-dependencies]
 rand.workspace = true
 tempfile.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-deepbook-indexer/Cargo.toml
+++ b/crates/sui-deepbook-indexer/Cargo.toml
@@ -35,7 +35,6 @@ axum.workspace = true
 bigdecimal = { version = "0.4.5" }
 
 [dev-dependencies]
-sui-types = { workspace = true, features = ["test-utils"] }
 hex-literal = "0.3.4"
 
 [[bin]]

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -37,4 +37,3 @@ sui-simulator.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -47,5 +47,3 @@ sui-types.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 wiremock.workspace = true
-
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -32,9 +32,3 @@ mysten-metrics.workspace = true
 sui-types.workspace = true
 sui-json.workspace = true
 sui-package-resolver.workspace = true
-
-[dev-dependencies]
-sui-types = { workspace = true, features = ["test-utils"] }
-
-[features]
-test-utils = []

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -23,7 +23,6 @@ use tabled::settings::Style as TableStyle;
 use crate::{type_and_fields_from_move_event_data, Page};
 use sui_types::sui_serde::SuiStructTag;
 
-#[cfg(any(feature = "test-utils", test))]
 use std::str::FromStr;
 
 pub type EventPage = Page<SuiEvent, EventID>;
@@ -154,7 +153,6 @@ impl Display for SuiEvent {
     }
 }
 
-#[cfg(any(feature = "test-utils", test))]
 impl SuiEvent {
     pub fn random_for_testing() -> Self {
         Self {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -915,7 +915,6 @@ impl SuiTransactionBlockEffectsAPI for SuiTransactionBlockEffectsV1 {
 }
 
 impl SuiTransactionBlockEffects {
-    #[cfg(any(feature = "test-utils", test))]
     pub fn new_for_testing(
         transaction_digest: TransactionDigest,
         status: SuiExecutionStatus,

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -61,5 +61,4 @@ cached.workspace = true
 [dev-dependencies]
 mockall.workspace = true
 expect-test.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
 telemetry-subscribers.workspace = true

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -22,6 +22,5 @@ fastcrypto.workspace = true
 
 [dev-dependencies]
 test-fuzz.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
 sui-move-build.workspace = true
 sui-framework.workspace = true

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -26,7 +26,7 @@ sui-json-rpc.workspace = true
 sui-json-rpc-api.workspace = true
 sui-json-rpc-types.workspace = true
 sui-json.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
+sui-types.workspace = true
 sui-protocol-config.workspace = true
 rand.workspace = true
 

--- a/crates/sui-proxy/Cargo.toml
+++ b/crates/sui-proxy/Cargo.toml
@@ -52,7 +52,6 @@ mime.workspace = true
 serde_json.workspace = true
 tower.workspace = true
 axum-server.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
 
 [build-dependencies]
 prost-build.workspace = true

--- a/crates/sui-rpc-loadgen/Cargo.toml
+++ b/crates/sui-rpc-loadgen/Cargo.toml
@@ -21,7 +21,7 @@ itertools.workspace = true
 
 shellexpand.workspace = true
 
-sui-types = { workspace = true, features = ["test-utils"]}
+sui-types.workspace = true
 sui-keys.workspace = true
 sui-sdk.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -12,7 +12,7 @@ move-core-types.workspace = true
 move-package.workspace = true
 move-symbol-pool.workspace = true
 sui-config.workspace = true
-sui-core = { workspace = true, features = ["test-utils"] }
+sui-core.workspace = true
 sui-move-build.workspace = true
 sui-test-transaction-builder.workspace = true
 sui-transaction-checks.workspace = true

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -16,7 +16,7 @@ sui-core = { workspace = true, features = ["test-utils"] }
 sui-move-build.workspace = true
 sui-test-transaction-builder.workspace = true
 sui-transaction-checks.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
+sui-types.workspace = true
 sui-storage.workspace = true
 
 async-trait.workspace = true

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -65,6 +65,5 @@ num_cpus.workspace = true
 pretty_assertions.workspace = true
 once_cell.workspace = true
 sui-test-transaction-builder.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
 sui-macros.workspace = true
 sui-simulator.workspace = true

--- a/crates/sui-synthetic-ingestion/Cargo.toml
+++ b/crates/sui-synthetic-ingestion/Cargo.toml
@@ -11,7 +11,7 @@ async-trait.workspace = true
 clap.workspace = true
 simulacrum.workspace = true
 sui-test-transaction-builder.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
+sui-types.workspace = true
 telemetry-subscribers.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -44,7 +44,7 @@ sui-graphql-rpc.workspace = true
 sui-rest-api.workspace = true
 sui-swarm-config.workspace = true
 sui-config.workspace = true
-sui-core = { workspace = true, features = ["test-utils"] }
+sui-core.workspace = true
 sui-framework.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -47,7 +47,7 @@ sui-config.workspace = true
 sui-core = { workspace = true, features = ["test-utils"] }
 sui-framework.workspace = true
 sui-protocol-config.workspace = true
-sui-types = { workspace = true, features = ["test-utils"]}
+sui-types.workspace = true
 sui-json-rpc-types.workspace = true
 sui-json-rpc.workspace = true
 sui-json-rpc-api.workspace = true

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -99,7 +99,6 @@ harness = false
 
 [features]
 default = []
-test-utils = []
 tracing = [
     "move-vm-profiler/tracing",
     "move-vm-test-utils/tracing",

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -70,7 +70,6 @@ use std::fmt;
 use std::str::FromStr;
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 #[path = "unit_tests/base_types_tests.rs"]
 mod base_types_tests;
 
@@ -148,7 +147,6 @@ pub fn random_object_ref() -> ObjectRef {
     )
 }
 
-#[cfg(any(feature = "test-utils", test))]
 pub fn update_object_ref_for_testing(object_ref: ObjectRef) -> ObjectRef {
     (
         object_ref.0,
@@ -587,7 +585,6 @@ impl SuiAddress {
         self.0.to_vec()
     }
 
-    #[cfg(any(feature = "test-utils", test))]
     /// Return a random SuiAddress.
     pub fn random_for_testing_only() -> Self {
         AccountAddress::random().into()
@@ -790,7 +787,6 @@ impl fmt::Debug for SuiAddress {
     }
 }
 
-#[cfg(any(test, feature = "test-utils"))]
 /// Generate a fake SuiAddress with repeated one byte.
 pub fn dbg_addr(name: u8) -> SuiAddress {
     let addr = [name; SUI_ADDRESS_LENGTH];
@@ -1049,7 +1045,6 @@ impl TxContext {
         Ok(())
     }
 
-    #[cfg(feature = "test-utils")]
     // Generate a random TxContext for testing.
     pub fn random_for_testing_only() -> Self {
         Self::new(
@@ -1059,7 +1054,6 @@ impl TxContext {
         )
     }
 
-    #[cfg(feature = "test-utils")]
     /// Generate a TxContext for testing with a specific sender.
     pub fn with_sender_for_testing_only(sender: &SuiAddress) -> Self {
         Self::new(sender, &TransactionDigest::random(), &EpochData::new_test())
@@ -1378,7 +1372,6 @@ impl std::ops::Deref for ObjectID {
     }
 }
 
-#[cfg(feature = "test-utils")]
 /// Generate a fake ObjectID with repeated one byte.
 pub fn dbg_object_id(name: u8) -> ObjectID {
     ObjectID::new([name; ObjectID::LENGTH])

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -58,7 +58,6 @@ use tracing::{instrument, warn};
 mod crypto_tests;
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 

--- a/crates/sui-types/src/gas_coin.rs
+++ b/crates/sui-types/src/gas_coin.rs
@@ -112,12 +112,10 @@ mod checked {
             Coin::layout(TypeTag::Struct(Box::new(GAS::type_())))
         }
 
-        #[cfg(any(feature = "test-utils", test))]
         pub fn new_for_testing(value: u64) -> Self {
             Self::new(ObjectID::random(), value)
         }
 
-        #[cfg(any(feature = "test-utils", test))]
         pub fn new_for_testing_with_id(id: ObjectID, value: u64) -> Self {
             Self::new(id, value)
         }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -89,7 +89,6 @@ pub mod versioned;
 pub mod zk_login_authenticator;
 pub mod zk_login_util;
 
-#[cfg(any(test, feature = "test-utils"))]
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -465,7 +465,6 @@ impl CheckpointContents {
         })
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
     pub fn new_with_digests_only_for_tests<T>(contents: T) -> Self
     where
         T: IntoIterator<Item = ExecutionDigests>,
@@ -773,7 +772,6 @@ pub struct CheckpointVersionSpecificDataV1 {
 }
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 mod tests {
     use crate::digests::{ConsensusCommitDigest, TransactionDigest, TransactionEffectsDigest};
     use crate::transaction::VerifiedTransaction;

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -73,7 +73,6 @@ pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = 1000;
 const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 0] = [];
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 #[path = "unit_tests/messages_tests.rs"]
 mod messages_tests;
 

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -90,15 +90,12 @@ impl ZkLoginAuthenticator {
         self.max_epoch
     }
 
-    #[cfg(feature = "test-utils")]
     pub fn user_signature_mut_for_testing(&mut self) -> &mut Signature {
         &mut self.user_signature
     }
-    #[cfg(feature = "test-utils")]
     pub fn max_epoch_mut_for_testing(&mut self) -> &mut EpochId {
         &mut self.max_epoch
     }
-    #[cfg(feature = "test-utils")]
     pub fn zk_login_inputs_mut_for_testing(&mut self) -> &mut ZkLoginInputs {
         &mut self.inputs
     }

--- a/crates/suins-indexer/Cargo.toml
+++ b/crates/suins-indexer/Cargo.toml
@@ -43,4 +43,3 @@ futures-util = "0.3.30"
 [dev-dependencies]
 rand.workspace = true
 tempfile.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -21,7 +21,7 @@ tokio-util.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 sui-config.workspace = true
-sui-core = { workspace = true, features = ["test-utils"] }
+sui-core.workspace = true
 sui-framework.workspace = true
 sui-swarm-config.workspace = true
 sui-indexer.workspace = true

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -32,7 +32,7 @@ sui-node.workspace = true
 sui-pg-temp-db.workspace = true
 sui-protocol-config.workspace = true
 sui-swarm.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }
+sui-types.workspace = true
 prometheus.workspace = true
 sui-keys.workspace = true
 sui-sdk.workspace = true

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -28,4 +28,3 @@ sui-move-build.workspace = true
 [dev-dependencies]
 sui-core = { workspace = true, features = ["test-utils"] }
 sui-protocol-config.workspace = true
-sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -26,5 +26,4 @@ sui-move-build.workspace = true
 
 
 [dev-dependencies]
-sui-core = { workspace = true, features = ["test-utils"] }
 sui-protocol-config.workspace = true


### PR DESCRIPTION
## Description 

Remove the test-utils feature from various crates. This feature was error prone and caused a number of tests to not be run under normal circumstances.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
