### PR TITLE
[move-compiler] Replace usage of global tvar counter

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -305,7 +305,7 @@ pub struct TParam {
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
-pub struct TVar(u64);
+pub struct TVar(pub u64);
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -717,12 +717,6 @@ impl BuiltinTypeName_ {
 impl TParamID {
     pub fn next() -> TParamID {
         TParamID(Counter::next())
-    }
-}
-
-impl TVar {
-    pub fn next() -> TVar {
-        TVar(Counter::next())
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -936,6 +936,7 @@ impl TVarCounter {
         TVarCounter { next: 0 }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> TVar {
         let id = self.next;
         self.next += 1;

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -93,6 +93,10 @@ pub(super) struct TypingDebugFlags {
     pub(super) type_elaboration: bool,
 }
 
+pub struct TVarCounter {
+    next: u64,
+}
+
 pub struct Context<'env> {
     pub modules: NamingProgramInfo,
     macros: UniqueMap<ModuleIdent, UniqueMap<FunctionName, N::Sequence>>,
@@ -115,6 +119,7 @@ pub struct Context<'env> {
     pub return_type: Option<Type>,
     locals: UniqueMap<Var, Type>,
 
+    pub tvar_counter: TVarCounter,
     pub subst: Subst,
     pub constraints: Constraints,
 
@@ -201,6 +206,7 @@ impl<'env> Context<'env> {
         let reporter = env.diagnostic_reporter_at_top_level();
         Context {
             use_funs: vec![global_use_funs],
+            tvar_counter: TVarCounter::new(),
             subst: Subst::empty(),
             current_package: None,
             current_module: None,
@@ -537,6 +543,7 @@ impl<'env> Context<'env> {
         self.return_type = None;
         self.locals = UniqueMap::new();
         self.subst = Subst::empty();
+        self.tvar_counter = TVarCounter::new();
         self.constraints = Constraints::new();
         self.current_function = None;
         self.in_macro_function = false;
@@ -924,6 +931,18 @@ impl MacroExpansion {
     }
 }
 
+impl TVarCounter {
+    pub fn new() -> Self {
+        TVarCounter { next: 0 }
+    }
+
+    pub fn next(&mut self) -> TVar {
+        let id = self.next;
+        self.next += 1;
+        TVar(id)
+    }
+}
+
 //**************************************************************************************************
 // Subst
 //**************************************************************************************************
@@ -950,8 +969,8 @@ impl Subst {
         self.tvars.get(&tvar)
     }
 
-    pub fn new_num_var(&mut self, loc: Loc) -> TVar {
-        let tvar = TVar::next();
+    pub fn new_num_var(&mut self, counter: &mut TVarCounter, loc: Loc) -> TVar {
+        let tvar = counter.next();
         assert!(self.num_vars.insert(tvar, loc).is_none());
         tvar
     }
@@ -1173,12 +1192,12 @@ fn debug_abilities_info(context: &mut Context, ty: &Type) -> (Option<Loc>, Abili
 }
 
 pub fn make_num_tvar(context: &mut Context, loc: Loc) -> Type {
-    let tvar = context.subst.new_num_var(loc);
+    let tvar = context.subst.new_num_var(&mut context.tvar_counter, loc);
     sp(loc, Type_::Var(tvar))
 }
 
-pub fn make_tvar(_context: &mut Context, loc: Loc) -> Type {
-    sp(loc, Type_::Var(TVar::next()))
+pub fn make_tvar(context: &mut Context, loc: Loc) -> Type {
+    sp(loc, Type_::Var(context.tvar_counter.next()))
 }
 
 //**************************************************************************************************
@@ -1833,7 +1852,9 @@ pub fn solve_constraints(context: &mut Context) {
         let tvar = sp(loc, Type_::Var(num_var));
         match unfold_type(&subst, tvar.clone()).value {
             Type_::UnresolvedError | Type_::Anything => {
-                let next_subst = join(subst, &Type_::u64(loc), &tvar).unwrap().0;
+                let next_subst = join(&mut context.tvar_counter, subst, &Type_::u64(loc), &tvar)
+                    .unwrap()
+                    .0;
                 subst = next_subst;
             }
             _ => (),
@@ -2372,7 +2393,9 @@ fn instantiate_type_args_impl(
         .zip(ty_args)
         .fold(subst, |subst, (tvar, ty_arg)| {
             // tvar is just a type variable, so shouldn't throw ever...
-            let (subst, t) = join(subst, &tvar, &ty_arg).ok().unwrap();
+            let (subst, t) = join(&mut context.tvar_counter, subst, &tvar, &ty_arg)
+                .ok()
+                .unwrap();
             res.push(t);
             subst
         });
@@ -2491,19 +2514,35 @@ enum TypingCase {
     Subtype,
 }
 
-pub fn subtype(subst: Subst, lhs: &Type, rhs: &Type) -> Result<(Subst, Type), TypingError> {
-    join_impl(subst, TypingCase::Subtype, lhs, rhs)
+pub fn subtype(
+    counter: &mut TVarCounter,
+    subst: Subst,
+    lhs: &Type,
+    rhs: &Type,
+) -> Result<(Subst, Type), TypingError> {
+    join_impl(counter, subst, TypingCase::Subtype, lhs, rhs)
 }
 
-pub fn join(subst: Subst, lhs: &Type, rhs: &Type) -> Result<(Subst, Type), TypingError> {
-    join_impl(subst, TypingCase::Join, lhs, rhs)
+pub fn join(
+    counter: &mut TVarCounter,
+    subst: Subst,
+    lhs: &Type,
+    rhs: &Type,
+) -> Result<(Subst, Type), TypingError> {
+    join_impl(counter, subst, TypingCase::Join, lhs, rhs)
 }
 
-pub fn invariant(subst: Subst, lhs: &Type, rhs: &Type) -> Result<(Subst, Type), TypingError> {
-    join_impl(subst, TypingCase::Invariant, lhs, rhs)
+pub fn invariant(
+    counter: &mut TVarCounter,
+    subst: Subst,
+    lhs: &Type,
+    rhs: &Type,
+) -> Result<(Subst, Type), TypingError> {
+    join_impl(counter, subst, TypingCase::Invariant, lhs, rhs)
 }
 
 fn join_impl(
+    counter: &mut TVarCounter,
     mut subst: Subst,
     case: TypingCase,
     lhs: &Type,
@@ -2544,7 +2583,7 @@ fn join_impl(
                     ))
                 }
             };
-            let (subst, t) = join_impl(subst, case, t1, t2)?;
+            let (subst, t) = join_impl(counter, subst, case, t1, t2)?;
             Ok((subst, sp(loc, Ref(mut_, Box::new(t)))))
         }
         (sp!(_, Param(TParam { id: id1, .. })), sp!(_, Param(TParam { id: id2, .. })))
@@ -2571,7 +2610,7 @@ fn join_impl(
                 k1,
                 k2
             );
-            let (subst, tys) = join_impl_types(subst, case, tys1, tys2)?;
+            let (subst, tys) = join_impl_types(counter, subst, case, tys1, tys2)?;
             Ok((subst, sp(*loc, Apply(k2.clone(), n2.clone(), tys))))
         }
         (sp!(_, Fun(a1, _)), sp!(_, Fun(a2, _))) if a1.len() != a2.len() => {
@@ -2586,17 +2625,17 @@ fn join_impl(
             // TODO this is going to likely lead to some strange error locations/messages
             // since the RHS in subtyping is currently assumed to be an annotation
             let (subst, args) = match case {
-                Join | Invariant => join_impl_types(subst, case, a1, a2)?,
-                Subtype => join_impl_types(subst, case, a2, a1)?,
+                Join | Invariant => join_impl_types(counter, subst, case, a1, a2)?,
+                Subtype => join_impl_types(counter, subst, case, a2, a1)?,
             };
-            let (subst, result) = join_impl(subst, case, r1, r2)?;
+            let (subst, result) = join_impl(counter, subst, case, r1, r2)?;
             Ok((subst, sp(*loc, Fun(args, Box::new(result)))))
         }
         (sp!(loc1, Var(id1)), sp!(loc2, Var(id2))) => {
             if *id1 == *id2 {
                 Ok((subst, sp(*loc2, Var(*id2))))
             } else {
-                join_tvar(subst, case, *loc1, *id1, *loc2, *id2)
+                join_tvar(counter, subst, case, *loc1, *id1, *loc2, *id2)
             }
         }
         (sp!(loc, Var(id)), other) if subst.get(*id).is_none() => {
@@ -2620,14 +2659,14 @@ fn join_impl(
             }
         }
         (sp!(loc, Var(id)), other) => {
-            let new_tvar = TVar::next();
+            let new_tvar = counter.next();
             subst.insert(new_tvar, other.clone());
-            join_tvar(subst, case, *loc, *id, other.loc, new_tvar)
+            join_tvar(counter, subst, case, *loc, *id, other.loc, new_tvar)
         }
         (other, sp!(loc, Var(id))) => {
-            let new_tvar = TVar::next();
+            let new_tvar = counter.next();
             subst.insert(new_tvar, other.clone());
-            join_tvar(subst, case, other.loc, new_tvar, *loc, *id)
+            join_tvar(counter, subst, case, other.loc, new_tvar, *loc, *id)
         }
 
         (sp!(_, UnresolvedError), other) | (other, sp!(_, UnresolvedError)) => {
@@ -2641,6 +2680,7 @@ fn join_impl(
 }
 
 fn join_impl_types(
+    counter: &mut TVarCounter,
     mut subst: Subst,
     case: TypingCase,
     tys1: &[Type],
@@ -2650,7 +2690,7 @@ fn join_impl_types(
     // as all types are instantiated as a sanity check
     let mut tys = vec![];
     for (ty1, ty2) in tys1.iter().zip(tys2) {
-        let (nsubst, t) = join_impl(subst, case, ty1, ty2)?;
+        let (nsubst, t) = join_impl(counter, subst, case, ty1, ty2)?;
         subst = nsubst;
         tys.push(t)
     }
@@ -2658,6 +2698,7 @@ fn join_impl_types(
 }
 
 fn join_tvar(
+    counter: &mut TVarCounter,
     mut subst: Subst,
     case: TypingCase,
     loc1: Loc,
@@ -2677,7 +2718,7 @@ fn join_tvar(
         Some(t) => t.clone(),
     };
 
-    let new_tvar = TVar::next();
+    let new_tvar = counter.next();
     let num_loc_1 = subst.num_vars.get(&last_id1);
     let num_loc_2 = subst.num_vars.get(&last_id2);
     match (num_loc_1, num_loc_2) {
@@ -2690,7 +2731,7 @@ fn join_tvar(
     subst.insert(last_id1, sp(loc1, Var(new_tvar)));
     subst.insert(last_id2, sp(loc2, Var(new_tvar)));
 
-    let (mut subst, new_ty) = join_impl(subst, case, &ty1, &ty2)?;
+    let (mut subst, new_ty) = join_impl(counter, subst, case, &ty1, &ty2)?;
     match subst.get(new_tvar) {
         Some(sp!(tloc, _)) => Err(TypingError::RecursiveType(*tloc)),
         None => {

--- a/external-crates/move/crates/move-compiler/src/typing/syntax_methods.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/syntax_methods.rs
@@ -185,9 +185,12 @@ fn validate_index_syntax_methods(
     // `&` param. We already ensured they were both references of the appropriate shape in naming,
     // so this is a bit redundant.
     if let Some((ndx, (subject_ref_type, subject_mut_ref_type))) = param_tys.next() {
-        if let Ok((subst_, _)) =
-            core::subtype(subst.clone(), subject_mut_ref_type, subject_ref_type)
-        {
+        if let Ok((subst_, _)) = core::subtype(
+            &mut context.tvar_counter,
+            subst.clone(),
+            subject_mut_ref_type,
+            subject_ref_type,
+        ) {
             subst = subst_;
         } else {
             let (_, _, index_type) = &index_finfo.signature.parameters[ndx];
@@ -237,7 +240,9 @@ fn validate_index_syntax_methods(
 
     // We ensure the rest of the parameters match exactly.
     for (ndx, (ptype, mut_ptype)) in param_tys {
-        if let Ok((subst_, _)) = core::invariant(subst.clone(), ptype, mut_ptype) {
+        if let Ok((subst_, _)) =
+            core::invariant(&mut context.tvar_counter, subst.clone(), ptype, mut_ptype)
+        {
             subst = subst_;
         } else {
             let (_, _, index_type) = &index_finfo.signature.parameters[ndx];
@@ -271,6 +276,7 @@ fn validate_index_syntax_methods(
     // that they are appropriately-shaped references, and now we ensure they refer to the same type
     // under the reference.
     if core::subtype(
+        &mut context.tvar_counter,
         subst.clone(),
         &mut_finfo.signature.return_type,
         &index_ty.return_,

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1215,7 +1215,7 @@ fn subtype_no_report(
     let subst = std::mem::replace(&mut context.subst, Subst::empty());
     let lhs = core::ready_tvars(&subst, pre_lhs);
     let rhs = core::ready_tvars(&subst, pre_rhs);
-    match core::subtype(subst.clone(), &lhs, &rhs) {
+    match core::subtype(&mut context.tvar_counter, subst.clone(), &lhs, &rhs) {
         Ok((next_subst, ty)) => {
             context.subst = next_subst;
             Ok(ty)
@@ -1237,7 +1237,7 @@ fn subtype_impl<T: ToString, F: FnOnce() -> T>(
     let subst = std::mem::replace(&mut context.subst, Subst::empty());
     let lhs = core::ready_tvars(&subst, pre_lhs);
     let rhs = core::ready_tvars(&subst, pre_rhs);
-    match core::subtype(subst.clone(), &lhs, &rhs) {
+    match core::subtype(&mut context.tvar_counter, subst.clone(), &lhs, &rhs) {
         Err(e) => {
             context.subst = subst;
             let diag = typing_error(context, /* from_subtype */ true, loc, msg, e);
@@ -1287,7 +1287,7 @@ fn join_opt<T: ToString, F: FnOnce() -> T>(
     let subst = std::mem::replace(&mut context.subst, Subst::empty());
     let t1 = core::ready_tvars(&subst, pre_t1);
     let t2 = core::ready_tvars(&subst, pre_t2);
-    match core::join(subst.clone(), &t1, &t2) {
+    match core::join(&mut context.tvar_counter, subst.clone(), &t1, &t2) {
         Err(e) => {
             context.subst = subst;
             let diag = typing_error(context, /* from_subtype */ false, loc, msg, e);
@@ -1322,7 +1322,7 @@ fn invariant_no_report(
     let subst = std::mem::replace(&mut context.subst, Subst::empty());
     let lhs = core::ready_tvars(&subst, pre_lhs);
     let rhs = core::ready_tvars(&subst, pre_rhs);
-    core::invariant(subst.clone(), &lhs, &rhs).map(|(next_subst, ty)| {
+    core::invariant(&mut context.tvar_counter, subst.clone(), &lhs, &rhs).map(|(next_subst, ty)| {
         context.subst = next_subst;
         ty
     })
@@ -1339,7 +1339,7 @@ fn invariant_impl<T: ToString, F: FnOnce() -> T>(
     let subst = std::mem::replace(&mut context.subst, Subst::empty());
     let lhs = core::ready_tvars(&subst, pre_lhs);
     let rhs = core::ready_tvars(&subst, pre_rhs);
-    match core::invariant(subst.clone(), &lhs, &rhs) {
+    match core::invariant(&mut context.tvar_counter, subst.clone(), &lhs, &rhs) {
         Err(e) => {
             context.subst = subst;
             let diag = typing_error(context, /* from_subtype */ false, loc, msg, e);


### PR DESCRIPTION
## Description 

- Type variable generation now uses a counter in the context, rather than a global one. 

## Test plan 

- non functional change 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
