### PR TITLE
[trace-view] Un-ignore Move icon file

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-debug/.vscodeignore
+++ b/external-crates/move/crates/move-analyzer/trace-debug/.vscodeignore
@@ -9,3 +9,4 @@
 !package.json
 !LICENSE
 !README.md
+!images/move.png

--- a/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "move-trace-debug",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@vscode/debugadapter": "^1.56.0",
         "@vscode/debugadapter-testsupport": "^1.56.0",


### PR DESCRIPTION
## Description 

What the title says (so that the Move icon file can be included in the published extension)

