### PR TITLE
[json rpc] remove kv queries for checkpoint content by checkpoint contents digest

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5335,12 +5335,10 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         checkpoint_summaries: &[CheckpointSequenceNumber],
         checkpoint_contents: &[CheckpointSequenceNumber],
         checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
     ) -> SuiResult<(
         Vec<Option<CertifiedCheckpointSummary>>,
         Vec<Option<CheckpointContents>>,
         Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
     )> {
         // TODO: use multi-get methods if it ever becomes important (unlikely)
         let mut summaries = Vec::with_capacity(checkpoint_summaries.len());
@@ -5372,14 +5370,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
                 .map(|c| c.into_inner());
             summaries_by_digest.push(checkpoint);
         }
-
-        let mut contents_by_digest = Vec::with_capacity(checkpoint_contents_by_digest.len());
-        for digest in checkpoint_contents_by_digest {
-            let checkpoint = store.get_checkpoint_contents(digest)?;
-            contents_by_digest.push(checkpoint);
-        }
-
-        Ok((summaries, contents, summaries_by_digest, contents_by_digest))
+        Ok((summaries, contents, summaries_by_digest))
     }
 
     #[instrument(skip(self))]

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -17,8 +17,7 @@ use sui_json_rpc_types::{
     SuiObjectDataFilter, TransactionFilter,
 };
 use sui_storage::key_value_store::{
-    KVStoreCheckpointData, KVStoreTransactionData, TransactionKeyValueStore,
-    TransactionKeyValueStoreTrait,
+    KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
 };
 use sui_types::base_types::{
     MoveObjectType, ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress,
@@ -60,14 +59,6 @@ pub trait StateRead: Send + Sync {
         effects: &[TransactionDigest],
         events: &[TransactionEventsDigest],
     ) -> StateReadResult<KVStoreTransactionData>;
-
-    async fn multi_get_checkpoints(
-        &self,
-        checkpoint_summaries: &[CheckpointSequenceNumber],
-        checkpoint_contents: &[CheckpointSequenceNumber],
-        checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
-    ) -> StateReadResult<KVStoreCheckpointData>;
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
 
@@ -252,25 +243,6 @@ impl StateRead for AuthorityState {
                 transactions,
                 effects,
                 events,
-            )
-            .await?,
-        )
-    }
-
-    async fn multi_get_checkpoints(
-        &self,
-        checkpoint_summaries: &[CheckpointSequenceNumber],
-        checkpoint_contents: &[CheckpointSequenceNumber],
-        checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
-    ) -> StateReadResult<KVStoreCheckpointData> {
-        Ok(
-            <AuthorityState as TransactionKeyValueStoreTrait>::multi_get_checkpoints(
-                self,
-                checkpoint_summaries,
-                checkpoint_contents,
-                checkpoint_summaries_by_digest,
-                checkpoint_contents_by_digest,
             )
             .await?,
         )

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -440,9 +440,7 @@ mod tests {
     use sui_types::error::{SuiError, SuiResult};
     use sui_types::gas_coin::GAS;
     use sui_types::id::UID;
-    use sui_types::messages_checkpoint::{
-        CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
-    };
+    use sui_types::messages_checkpoint::{CheckpointDigest, CheckpointSequenceNumber};
     use sui_types::object::MoveObject;
     use sui_types::object::Object;
     use sui_types::object::Owner;
@@ -465,7 +463,6 @@ mod tests {
                 checkpoint_summaries: &[CheckpointSequenceNumber],
                 checkpoint_contents: &[CheckpointSequenceNumber],
                 checkpoint_summaries_by_digest: &[CheckpointDigest],
-                checkpoint_contents_by_digest: &[CheckpointContentsDigest],
             ) -> SuiResult<KVStoreCheckpointData>;
 
             async fn deprecated_get_transaction_checkpoint(

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -45,8 +45,7 @@ use sui_types::display::DisplayVersionUpdatedEvent;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::{SuiError, SuiObjectResponseError};
 use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
-    CheckpointTimestamp,
+    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp,
 };
 use sui_types::object::{Object, ObjectRead, PastObjectRead};
 use sui_types::sui_serde::BigInt;
@@ -122,7 +121,7 @@ impl ReadApi {
                     .await?;
                 let content = self
                     .transaction_kv_store
-                    .get_checkpoint_contents_by_digest(verified_summary.content_digest)
+                    .get_checkpoint_contents(verified_summary.sequence_number)
                     .await?;
                 let signature = verified_summary.auth_sig().signature.clone();
                 (verified_summary.into_data(), content, signature).into()
@@ -134,7 +133,7 @@ impl ReadApi {
                     .await?;
                 let content = self
                     .transaction_kv_store
-                    .get_checkpoint_contents_by_digest(verified_summary.content_digest)
+                    .get_checkpoint_contents(verified_summary.sequence_number)
                     .await?;
                 let signature = verified_summary.auth_sig().signature.clone();
                 (verified_summary.into_data(), content, signature).into()
@@ -172,13 +171,8 @@ impl ReadApi {
             })
             .collect();
 
-        let checkpoint_contents_digest: Vec<CheckpointContentsDigest> =
-            checkpoint_summaries_and_signatures
-                .iter()
-                .map(|summary| summary.0.content_digest)
-                .collect();
         let checkpoint_contents = transaction_kv_store
-            .multi_get_checkpoints_contents_by_digest(checkpoint_contents_digest.as_slice())
+            .multi_get_checkpoints_contents(&checkpoint_numbers)
             .await?;
         let contents: Vec<CheckpointContents> = checkpoint_contents.into_iter().flatten().collect();
 

--- a/crates/sui-storage/src/bin/http_kv_tool.rs
+++ b/crates/sui-storage/src/bin/http_kv_tool.rs
@@ -8,9 +8,7 @@ use sui_storage::http_key_value_store::*;
 use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
 use sui_types::base_types::ObjectID;
-use sui_types::digests::{
-    CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
-};
+use sui_types::digests::{CheckpointDigest, TransactionDigest, TransactionEventsDigest};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 #[derive(Parser)]
@@ -104,28 +102,12 @@ impl Command {
                     }
 
                     "ckpt_contents" => {
-                        let digests: Vec<_> = digest
-                            .into_iter()
-                            .map(|s| {
-                                CheckpointContentsDigest::from_str(&s)
-                                    .expect("invalid checkpoint digest")
-                            })
-                            .collect();
-
-                        let ckpts = kv
-                            .multi_get_checkpoints(&[], &seqs, &[], &digests)
-                            .await
-                            .unwrap();
+                        let ckpts = kv.multi_get_checkpoints(&[], &seqs, &[]).await.unwrap();
 
                         for (seq, ckpt) in seqs.iter().zip(ckpts.1.iter()) {
                             // populate digest before printing
                             ckpt.as_ref().map(|c| c.digest());
                             println!("fetched ckpt contents: {:?} {:?}", seq, ckpt);
-                        }
-                        for (digest, ckpt) in digests.iter().zip(ckpts.3.iter()) {
-                            // populate digest before printing
-                            ckpt.as_ref().map(|c| c.digest());
-                            println!("fetched ckpt contents: {:?} {:?}", digest, ckpt);
                         }
                     }
 
@@ -138,7 +120,7 @@ impl Command {
                             .collect();
 
                         let ckpts = kv
-                            .multi_get_checkpoints(&seqs, &[], &digests, &[])
+                            .multi_get_checkpoints(&seqs, &[], &digests)
                             .await
                             .unwrap();
 

--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -417,12 +417,10 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
         checkpoint_summaries: &[CheckpointSequenceNumber],
         checkpoint_contents: &[CheckpointSequenceNumber],
         checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
     ) -> SuiResult<(
         Vec<Option<CertifiedCheckpointSummary>>,
         Vec<Option<CheckpointContents>>,
         Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
     )> {
         let keys = checkpoint_summaries
             .iter()
@@ -437,26 +435,15 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
                     .iter()
                     .map(|cp| Key::CheckpointSummaryByDigest(*cp)),
             )
-            .chain(
-                checkpoint_contents_by_digest
-                    .iter()
-                    .map(|cp| Key::CheckpointContentsByDigest(*cp)),
-            )
             .collect::<Vec<_>>();
 
         let summaries_len = checkpoint_summaries.len();
         let contents_len = checkpoint_contents.len();
         let summaries_by_digest_len = checkpoint_summaries_by_digest.len();
-        let contents_by_digest_len = checkpoint_contents_by_digest.len();
 
         let fetches = self.multi_fetch(keys).await;
 
-        let input_slices = [
-            summaries_len,
-            contents_len,
-            summaries_by_digest_len,
-            contents_by_digest_len,
-        ];
+        let input_slices = [summaries_len, contents_len, summaries_by_digest_len];
 
         let result_slices = multi_split_slice(&fetches, &input_slices);
 
@@ -489,23 +476,10 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
                 })
             })
             .collect::<Vec<_>>();
-
-        let contents_by_digest_results = result_slices[3]
-            .iter()
-            .zip(checkpoint_contents_by_digest.iter())
-            .map(map_fetch)
-            .map(|maybe_bytes| {
-                maybe_bytes.and_then(|(bytes, digest)| {
-                    deser_check_digest(digest, bytes, |c: &CheckpointContents| *c.digest())
-                })
-            })
-            .collect::<Vec<_>>();
-
         Ok((
             summaries_results,
             contents_results,
             summaries_by_digest_results,
-            contents_by_digest_results,
         ))
     }
 

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -190,12 +190,10 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         checkpoint_summaries: &[CheckpointSequenceNumber],
         checkpoint_contents: &[CheckpointSequenceNumber],
         checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
     ) -> SuiResult<(
         Vec<Option<CertifiedCheckpointSummary>>,
         Vec<Option<CheckpointContents>>,
         Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
     )> {
         let mut summaries = Vec::new();
         for digest in checkpoint_summaries {
@@ -212,12 +210,7 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
             summaries_by_digest.push(self.checkpoint_summaries_by_digest.get(digest).cloned());
         }
 
-        let mut contents_by_digest = Vec::new();
-        for digest in checkpoint_contents_by_digest {
-            contents_by_digest.push(self.checkpoint_contents_by_digest.get(digest).cloned());
-        }
-
-        Ok((summaries, contents, summaries_by_digest, contents_by_digest))
+        Ok((summaries, contents, summaries_by_digest))
     }
 
     async fn deprecated_get_transaction_checkpoint(
@@ -357,7 +350,6 @@ async fn test_checkpoints() {
             &[s1.sequence_number, s2.sequence_number],
             &[s1.sequence_number, s2.sequence_number],
             &[*s1.digest(), *s2.digest()],
-            &[s1.content_digest, s2.content_digest],
         )
         .now_or_never()
         .unwrap()
@@ -366,12 +358,10 @@ async fn test_checkpoints() {
     let summaries_by_seq = result.0;
     let contents_by_seq = result.1;
     let summaries_by_digest = result.2;
-    let contents_by_digest = result.3;
 
     assert_eq!(summaries_by_seq[0].as_ref().unwrap().data(), s1.data());
     assert_eq!(contents_by_seq[1].as_ref().unwrap(), &c2);
     assert_eq!(summaries_by_digest[0].as_ref().unwrap().data(), s1.data());
-    assert_eq!(contents_by_digest[1].as_ref().unwrap(), &c2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description 

Allows not to maintain extra table in Bigtable (i.e. checkpoint contents digest => checkpoint_sequence_number)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
