### PR TITLE
[consensus] reduce parameter values for simtests

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -135,16 +135,28 @@ impl Parameters {
     }
 
     pub(crate) fn default_round_prober_interval_ms() -> u64 {
-        5000
+        if cfg!(msim) {
+            1000
+        } else {
+            5000
+        }
     }
 
     pub(crate) fn default_round_prober_request_timeout_ms() -> u64 {
-        2000
+        if cfg!(msim) {
+            800
+        } else {
+            2000
+        }
     }
 
     pub(crate) fn default_propagation_delay_stop_proposal_threshold() -> u32 {
         // Propagation delay is usually 0 round in production.
-        20
+        if cfg!(msim) {
+            2
+        } else {
+            10
+        }
     }
 
     pub(crate) fn default_dag_state_cached_rounds() -> u32 {

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -17,7 +17,7 @@ sync_last_known_own_block_timeout:
   nanos: 0
 round_prober_interval_ms: 5000
 round_prober_request_timeout_ms: 2000
-propagation_delay_stop_proposal_threshold: 20
+propagation_delay_stop_proposal_threshold: 10
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100


### PR DESCRIPTION
## Description 

This helps some edge cases exercised more in simtests.

Also reduce `propagation_delay_stop_proposal_threshold` to 10 by default, which is still more than enough.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
