### PR TITLE
rpc benchmark init: directly read DB based on schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15328,15 +15328,20 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.41.0"
+version = "1.42.0"
 dependencies = [
  "anyhow",
  "bb8 0.9.0",
  "bb8-postgres",
  "clap",
+ "dashmap",
+ "futures",
  "rand 0.8.5",
+ "sui-indexer-alt-framework",
+ "telemetry-subscribers",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,6 +1733,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
+dependencies = [
+ "futures-util",
+ "parking_lot 0.12.1",
+ "tokio",
+]
+
+[[package]]
+name = "bb8-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e570e6557cd0f88d28d32afa76644873271a70dc22656df565b2021c4036aa9c"
+dependencies = [
+ "bb8 0.9.0",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "bcder"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,7 +3736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb799bb6f8ca6a794462125d7b8983b0c86e6c93a33a9c55934a4a5de4409d3"
 dependencies = [
  "async-trait",
- "bb8",
+ "bb8 0.8.5",
  "diesel",
  "futures-util",
  "scoped-futures",
@@ -12564,15 +12586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlparser"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14026,7 +14039,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "backoff",
- "bb8",
+ "bb8 0.8.5",
  "bcs",
  "bytes",
  "cached",
@@ -14171,7 +14184,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "backoff",
- "bb8",
+ "bb8 0.8.5",
  "chrono",
  "clap",
  "diesel",
@@ -15079,7 +15092,7 @@ name = "sui-pg-db"
 version = "1.44.0"
 dependencies = [
  "anyhow",
- "bb8",
+ "bb8 0.8.5",
  "clap",
  "diesel",
  "diesel-async",
@@ -15315,17 +15328,15 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.40.0"
+version = "1.41.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "bb8 0.9.0",
+ "bb8-postgres",
  "clap",
- "futures",
- "sqlparser",
- "sui-pg-db",
+ "rand 0.8.5",
  "tokio",
  "tokio-postgres",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12564,6 +12564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15336,6 +15336,7 @@ dependencies = [
  "clap",
  "dashmap",
  "futures",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "sui-indexer-alt-framework",
  "telemetry-subscribers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15342,6 +15342,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15314,6 +15314,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-rpc-benchmark"
+version = "1.40.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "futures",
+ "sqlparser",
+ "sui-pg-db",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
 name = "sui-rpc-loadgen"
 version = "1.44.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,23 +1733,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bb8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
-dependencies = [
- "futures-util",
- "parking_lot 0.12.1",
- "tokio",
-]
-
-[[package]]
 name = "bb8-postgres"
-version = "0.9.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e570e6557cd0f88d28d32afa76644873271a70dc22656df565b2021c4036aa9c"
+checksum = "56ac82c42eb30889b5c4ee4763a24b8c566518171ebea648cd7e3bc532c60680"
 dependencies = [
- "bb8 0.9.0",
+ "async-trait",
+ "bb8",
  "tokio",
  "tokio-postgres",
 ]
@@ -3736,7 +3726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb799bb6f8ca6a794462125d7b8983b0c86e6c93a33a9c55934a4a5de4409d3"
 dependencies = [
  "async-trait",
- "bb8 0.8.5",
+ "bb8",
  "diesel",
  "futures-util",
  "scoped-futures",
@@ -14039,7 +14029,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "backoff",
- "bb8 0.8.5",
+ "bb8",
  "bcs",
  "bytes",
  "cached",
@@ -14184,7 +14174,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "backoff",
- "bb8 0.8.5",
+ "bb8",
  "chrono",
  "clap",
  "diesel",
@@ -15092,7 +15082,7 @@ name = "sui-pg-db"
 version = "1.44.0"
 dependencies = [
  "anyhow",
- "bb8 0.8.5",
+ "bb8",
  "clap",
  "diesel",
  "diesel-async",
@@ -15328,15 +15318,15 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.42.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
- "bb8 0.9.0",
+ "bb8",
  "bb8-postgres",
  "clap",
  "dashmap",
  "futures",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "sui-indexer-alt-framework",
  "telemetry-subscribers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ members = [
     "crates/sui-replay",
     "crates/sui-rosetta",
     "crates/sui-rpc-api",
+    "crates/sui-rpc-benchmark",
     "crates/sui-rpc-loadgen",
     "crates/sui-sdk",
     "crates/sui-security-watchdog",

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sui-rpc-benchmark"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+clap = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+futures.workspace = true
+sqlparser = "0.52.0"
+tokio-postgres = "0.7.12"
+
+sui-pg-temp-db = { workspace = true }
+
+[[bin]]
+name = "sui-rpc-benchmark"
+path = "src/main.rs"

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -16,7 +16,7 @@ futures.workspace = true
 sqlparser = "0.52.0"
 tokio-postgres = "0.7.12"
 
-sui-pg-temp-db = { workspace = true }
+sui-pg-db = { workspace = true }
 
 [[bin]]
 name = "sui-rpc-benchmark"

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -8,15 +8,12 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
-tracing.workspace = true
-futures.workspace = true
-sqlparser = "0.52.0"
 tokio-postgres = "0.7.12"
-
-sui-pg-db = { workspace = true }
+bb8 = "0.9.0"
+bb8-postgres = "0.9.0"
+rand = "0.8.5"
 
 [[bin]]
 name = "sui-rpc-benchmark"

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -9,11 +9,16 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
+dashmap.workspace = true
+futures.workspace = true
+rand.workspace = true
+sui-indexer-alt-framework.workspace = true
+telemetry-subscribers.workspace = true
+tracing.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-postgres = "0.7.12"
 bb8 = "0.9.0"
 bb8-postgres = "0.9.0"
-rand = "0.8.5"
 
 [[bin]]
 name = "sui-rpc-benchmark"

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 dashmap.workspace = true
 futures.workspace = true
+parking_lot.workspace = true
 rand.workspace = true
 sui-indexer-alt-framework.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -16,6 +16,7 @@ sui-indexer-alt-framework.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["full"] }
+url.workspace = true
 tokio-postgres = "0.7.12"
 bb8 = "0.9.0"
 bb8-postgres = "0.9.0"

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -19,8 +19,8 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["full"] }
 url.workspace = true
 tokio-postgres = "0.7.12"
-bb8 = "0.9.0"
-bb8-postgres = "0.9.0"
+bb8 = "0.8.5"
+bb8-postgres = "0.8.0"
 
 [[bin]]
 name = "sui-rpc-benchmark"

--- a/crates/sui-rpc-benchmark/README.md
+++ b/crates/sui-rpc-benchmark/README.md
@@ -9,7 +9,7 @@
 Run benchmarks with:
 ```
 # Direct database queries:
-cargo run --bin sui-rpc-benchmark direct --db-url postgres://postgres:postgres@localhost:5432/sui
+cargo run --bin sui-rpc-benchmark direct --db-url postgres://postgres:postgres@localhost:5432/sui --concurrency 10  --duration-secs 10
 
 # JSON RPC endpoints:
 cargo run --bin sui-rpc-benchmark jsonrpc --endpoint http://127.0.0.1:9000

--- a/crates/sui-rpc-benchmark/README.md
+++ b/crates/sui-rpc-benchmark/README.md
@@ -1,0 +1,19 @@
+# sui-rpc-benchmark: Benchmarking Tool for SUI RPC Performance
+
+`sui-rpc-benchmark` is a benchmarking utility designed to measure performance across different RPC access methods in Sui:
+- Direct database reads
+- JSON RPC endpoints 
+- GraphQL queries
+
+## Usage Examples
+Run benchmarks with:
+```
+# Direct database queries:
+cargo run --bin sui-rpc-benchmark direct --db-url postgres://postgres:postgres@localhost:5432/sui
+
+# JSON RPC endpoints:
+cargo run --bin sui-rpc-benchmark jsonrpc --endpoint http://127.0.0.1:9000
+
+# GraphQL queries:
+cargo run --bin sui-rpc-benchmark graphql --endpoint http://127.0.0.1:9000/graphql
+```

--- a/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
+++ b/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+pub struct BenchmarkConfig {
+    // Number of concurrent clients
+    pub concurrency: usize,
+    // Duration to run the benchmark in seconds
+    pub duration: Duration,
+}
+
+impl Default for BenchmarkConfig {
+    fn default() -> Self {
+        Self {
+            concurrency: 50,
+            duration: Duration::from_secs(30),
+        }
+    }
+}

--- a/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
+++ b/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
@@ -4,9 +4,9 @@
 use std::time::Duration;
 
 pub struct BenchmarkConfig {
-    // Number of concurrent clients
+    /// Number of concurrent clients
     pub concurrency: usize,
-    // Duration to run the benchmark in seconds
+    /// Duration to run the benchmark in seconds
     pub duration: Duration,
 }
 

--- a/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
+++ b/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 pub struct BenchmarkConfig {
     /// Number of concurrent clients
     pub concurrency: usize,
-    /// Duration to run the benchmark in seconds
+    /// Duration to run the benchmark
     pub duration: Duration,
 }
 

--- a/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
+++ b/crates/sui-rpc-benchmark/src/direct/benchmark_config.rs
@@ -6,15 +6,16 @@ use std::time::Duration;
 pub struct BenchmarkConfig {
     /// Number of concurrent clients
     pub concurrency: usize,
-    /// Duration to run the benchmark
-    pub duration: Duration,
+    /// All queries will execute if they finish within the specified timeout.
+    /// Otherwise, the binary will stop at that time and report collected metrics.
+    pub timeout: Duration,
 }
 
 impl Default for BenchmarkConfig {
     fn default() -> Self {
         Self {
             concurrency: 50,
-            duration: Duration::from_secs(30),
+            timeout: Duration::from_secs(30),
         }
     }
 }

--- a/crates/sui-rpc-benchmark/src/direct/metrics.rs
+++ b/crates/sui-rpc-benchmark/src/direct/metrics.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Debug, Default)]
+pub struct QueryMetrics {
+    pub latency_ms: Vec<f64>,
+    pub errors: usize,
+    pub total_queries: usize,
+}
+
+#[derive(Debug)]
+pub struct BenchmarkResult {
+    pub total_queries: usize,
+    pub total_errors: usize,
+    pub avg_latency_ms: f64,
+    pub table_stats: Vec<TableStats>,
+}
+
+#[derive(Debug)]
+pub struct TableStats {
+    pub table_name: String,
+    pub queries: usize,
+    pub errors: usize,
+    pub avg_latency_ms: f64,
+}
+
+#[derive(Clone)]
+pub struct MetricsCollector {
+    metrics: Arc<Mutex<HashMap<String, QueryMetrics>>>,
+}
+
+impl Default for MetricsCollector {
+    fn default() -> Self {
+        Self {
+            metrics: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl MetricsCollector {
+    pub fn record_query(&self, query_type: &str, latency: Duration, is_error: bool) {
+        let mut metrics = self.metrics.lock().unwrap();
+        let metrics = metrics.entry(query_type.to_string()).or_default();
+
+        metrics.total_queries += 1;
+        if is_error {
+            metrics.errors += 1;
+        } else {
+            metrics.latency_ms.push(latency.as_secs_f64() * 1000.0);
+        }
+    }
+
+    pub fn generate_report(&self) -> BenchmarkResult {
+        let metrics = self.metrics.lock().unwrap();
+        let mut total_queries = 0;
+        let mut total_errors = 0;
+        let mut total_latency = 0.0;
+        let mut total_successful = 0;
+        let mut table_stats = Vec::new();
+
+        for (table_name, metrics) in metrics.iter() {
+            let successful = metrics.total_queries - metrics.errors;
+            let avg_latency = if successful > 0 {
+                metrics.latency_ms.iter().sum::<f64>() / successful as f64
+            } else {
+                0.0
+            };
+
+            table_stats.push(TableStats {
+                table_name: table_name.clone(),
+                queries: metrics.total_queries,
+                errors: metrics.errors,
+                avg_latency_ms: avg_latency,
+            });
+
+            total_queries += metrics.total_queries;
+            total_errors += metrics.errors;
+            total_latency += metrics.latency_ms.iter().sum::<f64>();
+            total_successful += successful;
+        }
+        table_stats.sort_by(|a, b| b.queries.cmp(&a.queries));
+
+        BenchmarkResult {
+            total_queries,
+            total_errors,
+            avg_latency_ms: if total_successful > 0 {
+                total_latency / total_successful as f64
+            } else {
+                0.0
+            },
+            table_stats,
+        }
+    }
+}

--- a/crates/sui-rpc-benchmark/src/direct/metrics.rs
+++ b/crates/sui-rpc-benchmark/src/direct/metrics.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// This module defines data structures and functions for collecting
-/// and summarizing performance metrics from benchmark queries. It
-/// supports tracking overall and per-table query latencies, error counts, total queries,
+/// and summarizing performance metrics from benchmark queries.
+/// It tracks both overall and per-table counts, errors and average latencies.
 use dashmap::DashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,6 +37,12 @@ pub struct MetricsCollector {
 }
 
 impl MetricsCollector {
+    /// Records a query execution with its latency and error status
+    /// 
+    /// # Arguments
+    /// * `query_type` - The type/name of the query being recorded
+    /// * `latency` - The duration taken to execute the query
+    /// * `is_error` - Whether the query resulted in an error
     pub fn record_query(&self, query_type: &str, latency: Duration, is_error: bool) {
         let mut entry = self.metrics.entry(query_type.to_string()).or_default();
 

--- a/crates/sui-rpc-benchmark/src/direct/mod.rs
+++ b/crates/sui-rpc-benchmark/src/direct/mod.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod benchmark_config;
+pub mod metrics;
 pub mod query_executor;
 pub mod query_generator;

--- a/crates/sui-rpc-benchmark/src/direct/mod.rs
+++ b/crates/sui-rpc-benchmark/src/direct/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod query_executor;
+pub mod query_generator;

--- a/crates/sui-rpc-benchmark/src/direct/mod.rs
+++ b/crates/sui-rpc-benchmark/src/direct/mod.rs
@@ -3,5 +3,6 @@
 
 pub mod benchmark_config;
 pub mod metrics;
+pub mod query_enricher;
 pub mod query_executor;
-pub mod query_generator;
+pub mod query_template_generator;

--- a/crates/sui-rpc-benchmark/src/direct/query_enricher.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_enricher.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module enriches query templates with real data from the database.
+/// This enrichment ensures that when we run the benchmark:
+/// - We use realistic data values that actually exist in the database:
+/// - We have a pool of valid values to randomly select from during execution.
+use anyhow::Result;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use tokio_postgres::{types::Type, NoTls, Row};
+use tracing::warn;
+use url::Url;
+
+use crate::direct::query_template_generator::QueryTemplate;
+
+#[derive(Clone, Debug)]
+pub enum SqlValue {
+    Text(Option<String>),
+    Int4(Option<i32>),
+    Int8(Option<i64>),
+    Float8(Option<f64>),
+    Bool(Option<bool>),
+    Int2(Option<i16>),
+    Bytea(Option<Vec<u8>>),
+}
+
+#[derive(Debug, Clone)]
+pub struct EnrichedBenchmarkQuery {
+    pub query: QueryTemplate,
+    pub rows: Vec<Vec<SqlValue>>,
+    pub types: Vec<Type>,
+}
+
+pub struct QueryEnricher {
+    pool: Pool<PostgresConnectionManager<NoTls>>,
+}
+
+impl QueryEnricher {
+    pub async fn new(db_url: &Url) -> Result<Self> {
+        let manager = PostgresConnectionManager::new_from_stringlike(db_url.as_str(), NoTls)?;
+        let pool = Pool::builder().build(manager).await?;
+        Ok(Self { pool })
+    }
+
+    fn row_to_values(row: &Row) -> Vec<SqlValue> {
+        (0..row.len())
+            .map(|i| match row.columns()[i].type_() {
+                &Type::TEXT | &Type::VARCHAR => SqlValue::Text(row.get(i)),
+                &Type::INT4 => SqlValue::Int4(row.get(i)),
+                &Type::INT8 => SqlValue::Int8(row.get(i)),
+                &Type::FLOAT8 => SqlValue::Float8(row.get(i)),
+                &Type::BOOL => SqlValue::Bool(row.get(i)),
+                &Type::INT2 => SqlValue::Int2(row.get(i)),
+                &Type::BYTEA => SqlValue::Bytea(row.get(i)),
+                ty => panic!("Unsupported type: {:?}", ty),
+            })
+            .collect()
+    }
+
+    async fn enrich_query(&self, query: &QueryTemplate) -> Result<EnrichedBenchmarkQuery> {
+        let client = self.pool.get().await?;
+        let sql = format!(
+            "SELECT {} FROM {} WHERE {} IS NOT NULL LIMIT 1000",
+            query.needed_columns.join(", "),
+            query.table_name,
+            query.needed_columns[0]
+        );
+
+        let rows = client.query(&sql, &[]).await?;
+        let Some(first_row) = rows.first() else {
+            warn!(
+                table = query.table_name,
+                "No sample data found for query on table, table is empty."
+            );
+            return Ok(EnrichedBenchmarkQuery {
+                query: query.clone(),
+                rows: Vec::new(),
+                types: query.needed_columns.iter().map(|_| Type::TEXT).collect(), // default type
+            });
+        };
+        let types = first_row
+            .columns()
+            .iter()
+            .map(|c| c.type_().clone())
+            .collect();
+        let raw_rows = rows.iter().map(Self::row_to_values).collect();
+
+        Ok(EnrichedBenchmarkQuery {
+            query: query.clone(),
+            rows: raw_rows,
+            types,
+        })
+    }
+
+    pub async fn enrich_queries(
+        &self,
+        queries: Vec<QueryTemplate>,
+    ) -> Result<Vec<EnrichedBenchmarkQuery>> {
+        let mut enriched_queries = Vec::new();
+        for query in queries {
+            let enriched = self.enrich_query(&query).await?;
+            enriched_queries.push(enriched);
+        }
+        Ok(enriched_queries)
+    }
+}

--- a/crates/sui-rpc-benchmark/src/direct/query_executor.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_executor.rs
@@ -1,0 +1,277 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use tokio_postgres::{types::ToSql, types::Type, Client, Row};
+
+use crate::direct::query_generator::BenchmarkQuery;
+
+pub struct QueryExecutor {
+    db_client: Client,
+    enriched_benchmark_queries: Vec<EnrichedBenchmarkQuery>,
+}
+
+#[derive(Debug)]
+pub struct EnrichedBenchmarkQuery {
+    pub query: BenchmarkQuery,
+    pub rows: Vec<Row>,
+}
+
+impl QueryExecutor {
+    pub async fn new(
+        db_url: &str,
+        benchmark_queries: Vec<BenchmarkQuery>,
+    ) -> Result<Self, anyhow::Error> {
+        let (client, connection) = tokio_postgres::connect(db_url, tokio_postgres::NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        let mut executor = Self {
+            db_client: client,
+            enriched_benchmark_queries: Vec::new(),
+        };
+        let mut enriched_queries = Vec::new();
+        for query in benchmark_queries {
+            let enriched = executor.enrich_query(&query).await?;
+            enriched_queries.push(enriched);
+        }
+        executor.enriched_benchmark_queries = enriched_queries;
+
+        Ok(executor)
+    }
+
+    pub async fn run(&self) -> Result<(), anyhow::Error> {
+        println!(
+            "Starting parallel execution of {} queries",
+            self.enriched_benchmark_queries.len()
+        );
+        let futures: Vec<_> = self
+            .enriched_benchmark_queries
+            .iter()
+            .map(|enriched| {
+                println!("Executing query: {}", enriched.query.query_template);
+                self.execute_query(enriched)
+            })
+            .collect();
+        let results = futures::future::join_all(futures).await;
+
+        for (i, result) in results.into_iter().enumerate() {
+            match result {
+                Ok(rows) => println!(
+                    "Query \n'{}'\n completed successfully with {} rows",
+                    self.enriched_benchmark_queries[i].query.query_template,
+                    rows.len()
+                ),
+                Err(e) => println!(
+                    "Query \n'{}'\n failed with error: {}",
+                    self.enriched_benchmark_queries[i].query.query_template, e
+                ),
+            }
+        }
+        println!("All benchmark queries completed");
+        Ok(())
+    }
+
+    async fn enrich_query(
+        &self,
+        bq: &BenchmarkQuery,
+    ) -> Result<EnrichedBenchmarkQuery, anyhow::Error> {
+        // TODO(gegaowp): only fetch one row for quick execution, will configure and fetch more.
+        let query = format!(
+            "SELECT {} FROM {} LIMIT 1",
+            bq.needed_columns.join(","),
+            bq.table_name
+        );
+        println!("Enriched query: {}", query);
+        let rows = self.db_client.query(&query, &[]).await?;
+
+        Ok(EnrichedBenchmarkQuery {
+            query: bq.clone(),
+            rows,
+        })
+    }
+
+    async fn execute_query(
+        &self,
+        query: &EnrichedBenchmarkQuery,
+    ) -> Result<Vec<tokio_postgres::Row>, tokio_postgres::Error> {
+        let mut all_results = Vec::new();
+        for row in &query.rows {
+            let params_vec = row_to_params(row);
+            let value_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+                params_vec.iter().map(|v| v.as_ref()).collect();
+
+            let results = self
+                .db_client
+                .query(&query.query.query_template, &value_refs)
+                .await?;
+            all_results.extend(results);
+        }
+        Ok(all_results)
+    }
+}
+
+fn row_to_params(row: &Row) -> Vec<Box<dyn ToSql + Sync>> {
+    let mut params: Vec<Box<dyn ToSql + Sync>> = Vec::new();
+
+    for i in 0..row.len() {
+        match row.columns()[i].type_() {
+            &Type::TEXT | &Type::VARCHAR => {
+                params.push(Box::new(row.get::<_, Option<String>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            &Type::INT4 => {
+                params.push(Box::new(row.get::<_, Option<i32>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            &Type::INT8 => {
+                params.push(Box::new(row.get::<_, Option<i64>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            &Type::FLOAT8 => {
+                params.push(Box::new(row.get::<_, Option<f64>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            &Type::BOOL => {
+                params.push(Box::new(row.get::<_, Option<bool>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            &Type::INT2 => {
+                params.push(Box::new(row.get::<_, Option<i16>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            &Type::BYTEA => {
+                params.push(Box::new(row.get::<_, Option<Vec<u8>>>(i)) as Box<dyn ToSql + Sync>)
+            }
+            _ => panic!("Unsupported type: {:?}", row.columns()[i].type_()),
+        }
+    }
+    params
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sui_pg_temp_db::TempDb;
+    use tokio_postgres::NoTls;
+
+    #[tokio::test]
+    async fn test_execute_enriched_query() -> Result<(), Box<dyn std::error::Error>> {
+        let db = TempDb::new().unwrap();
+        let url = db.database().url();
+        let (client, connection) = tokio_postgres::connect(url.as_str(), NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        // Create test table and insert test data
+        client
+            .execute(
+                "CREATE TABLE IF NOT EXISTS test_table (id INTEGER PRIMARY KEY, name TEXT)",
+                &[],
+            )
+            .await?;
+        client
+            .execute(
+                "INSERT INTO test_table (id, name) VALUES ($1, $2)",
+                &[
+                    &1i32 as &(dyn tokio_postgres::types::ToSql + Sync),
+                    &"test" as &(dyn tokio_postgres::types::ToSql + Sync),
+                ],
+            )
+            .await?;
+        // Create benchmark query
+        let benchmark_query = BenchmarkQuery {
+            query_template: "SELECT * FROM test_table WHERE id = $1 AND name = $2".to_string(),
+            table_name: "test_table".to_string(),
+            needed_columns: vec!["id".to_string(), "name".to_string()],
+        };
+
+        // Create executor and enrich query
+        let executor = QueryExecutor::new(url.as_str(), vec![benchmark_query]).await?;
+        let enriched_query = &executor.enriched_benchmark_queries[0];
+
+        // Assert enriched query details match what we expect
+        assert_eq!(
+            enriched_query.query.query_template,
+            "SELECT * FROM test_table WHERE id = $1 AND name = $2"
+        );
+        assert_eq!(enriched_query.query.table_name, "test_table");
+        assert_eq!(
+            enriched_query.query.needed_columns,
+            vec!["id".to_string(), "name".to_string()]
+        );
+        assert_eq!(enriched_query.rows.len(), 1);
+
+        // Execute enriched query
+        let result = executor.execute_query(enriched_query).await?;
+
+        // Verify result matches expected values
+        assert_eq!(result.len(), 1);
+        assert!(check_rows_consistency(&result[0], &enriched_query.rows[0])?);
+
+        Ok(())
+    }
+
+    fn check_rows_consistency(row1: &Row, row2: &Row) -> Result<bool, Box<dyn std::error::Error>> {
+        // Get column names for both rows
+        let cols1: Vec<&str> = row1.columns().iter().map(|c| c.name()).collect();
+        let cols2: Vec<&str> = row2.columns().iter().map(|c| c.name()).collect();
+
+        // Find overlapping columns
+        let common_cols: Vec<&str> = cols1
+            .iter()
+            .filter(|&col| cols2.contains(col))
+            .cloned()
+            .collect();
+
+        // Check each common column for value equality
+        for col in common_cols {
+            // assert the column types match
+            let col_type1 = row1
+                .columns()
+                .iter()
+                .find(|c| c.name() == col)
+                .map(|c| c.type_())
+                .unwrap();
+            let col_type2 = row2
+                .columns()
+                .iter()
+                .find(|c| c.name() == col)
+                .map(|c| c.type_())
+                .unwrap();
+            assert_eq!(
+                col_type1, col_type2,
+                "Column types should match for column {}",
+                col
+            );
+            let col_type = col_type1;
+
+            // assert the column values match
+            if !compare_row_values(row1, row2, col, col_type)? {
+                println!("Column '{}' has inconsistent values between rows", col);
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn compare_row_values(
+        row1: &Row,
+        row2: &Row,
+        col: &str,
+        col_type: &Type,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(match col_type {
+            &Type::TEXT | &Type::VARCHAR => {
+                row1.get::<_, String>(col) == row2.get::<_, String>(col)
+            }
+            &Type::INT4 => row1.get::<_, i32>(col) == row2.get::<_, i32>(col),
+            &Type::INT8 => row1.get::<_, i64>(col) == row2.get::<_, i64>(col),
+            &Type::FLOAT8 => row1.get::<_, f64>(col) == row2.get::<_, f64>(col),
+            &Type::BOOL => row1.get::<_, bool>(col) == row2.get::<_, bool>(col),
+            &Type::INT2 => row1.get::<_, i16>(col) == row2.get::<_, i16>(col),
+            &Type::BYTEA => row1.get::<_, Vec<u8>>(col) == row2.get::<_, Vec<u8>>(col),
+            _ => panic!("Unsupported type: {:?}", col_type),
+        })
+    }
+}

--- a/crates/sui-rpc-benchmark/src/direct/query_executor.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_executor.rs
@@ -1,277 +1,201 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use tokio_postgres::{types::ToSql, types::Type, Client, Row};
+use std::time::Instant;
 
+use anyhow::Result;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use rand::seq::SliceRandom;
+use tokio_postgres::{types::ToSql, types::Type, NoTls, Row};
+
+use crate::direct::benchmark_config::BenchmarkConfig;
+use crate::direct::metrics::{BenchmarkResult, MetricsCollector};
 use crate::direct::query_generator::BenchmarkQuery;
 
-pub struct QueryExecutor {
-    db_client: Client,
-    enriched_benchmark_queries: Vec<EnrichedBenchmarkQuery>,
+#[derive(Clone, Debug)]
+pub enum SqlValue {
+    Text(Option<String>),
+    Int4(Option<i32>),
+    Int8(Option<i64>),
+    Float8(Option<f64>),
+    Bool(Option<bool>),
+    Int2(Option<i16>),
+    Bytea(Option<Vec<u8>>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EnrichedBenchmarkQuery {
     pub query: BenchmarkQuery,
-    pub rows: Vec<Row>,
+    pub rows: Vec<Vec<SqlValue>>,
+    pub types: Vec<Type>,
+}
+
+pub struct QueryExecutor {
+    pool: Pool<PostgresConnectionManager<NoTls>>,
+    queries: Vec<BenchmarkQuery>,
+    enriched_queries: Vec<EnrichedBenchmarkQuery>,
+    config: BenchmarkConfig,
+    metrics: MetricsCollector,
 }
 
 impl QueryExecutor {
     pub async fn new(
         db_url: &str,
-        benchmark_queries: Vec<BenchmarkQuery>,
-    ) -> Result<Self, anyhow::Error> {
-        let (client, connection) = tokio_postgres::connect(db_url, tokio_postgres::NoTls).await?;
-        tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
-        });
+        queries: Vec<BenchmarkQuery>,
+        config: BenchmarkConfig,
+    ) -> Result<Self> {
+        let manager = PostgresConnectionManager::new_from_stringlike(db_url, NoTls)?;
+        let pool = Pool::builder().build(manager).await?;
 
-        let mut executor = Self {
-            db_client: client,
-            enriched_benchmark_queries: Vec::new(),
-        };
-        let mut enriched_queries = Vec::new();
-        for query in benchmark_queries {
-            let enriched = executor.enrich_query(&query).await?;
-            enriched_queries.push(enriched);
-        }
-        executor.enriched_benchmark_queries = enriched_queries;
-
-        Ok(executor)
+        Ok(Self {
+            pool,
+            queries,
+            enriched_queries: Vec::new(),
+            config,
+            metrics: MetricsCollector::default(),
+        })
     }
 
-    pub async fn run(&self) -> Result<(), anyhow::Error> {
-        println!(
-            "Starting parallel execution of {} queries",
-            self.enriched_benchmark_queries.len()
-        );
-        let futures: Vec<_> = self
-            .enriched_benchmark_queries
-            .iter()
-            .map(|enriched| {
-                println!("Executing query: {}", enriched.query.query_template);
-                self.execute_query(enriched)
+    fn row_to_values(row: &Row) -> Vec<SqlValue> {
+        (0..row.len())
+            .map(|i| match row.columns()[i].type_() {
+                &Type::TEXT | &Type::VARCHAR => SqlValue::Text(row.get(i)),
+                &Type::INT4 => SqlValue::Int4(row.get(i)),
+                &Type::INT8 => SqlValue::Int8(row.get(i)),
+                &Type::FLOAT8 => SqlValue::Float8(row.get(i)),
+                &Type::BOOL => SqlValue::Bool(row.get(i)),
+                &Type::INT2 => SqlValue::Int2(row.get(i)),
+                &Type::BYTEA => SqlValue::Bytea(row.get(i)),
+                ty => panic!("Unsupported type: {:?}", ty),
             })
-            .collect();
-        let results = futures::future::join_all(futures).await;
-
-        for (i, result) in results.into_iter().enumerate() {
-            match result {
-                Ok(rows) => println!(
-                    "Query \n'{}'\n completed successfully with {} rows",
-                    self.enriched_benchmark_queries[i].query.query_template,
-                    rows.len()
-                ),
-                Err(e) => println!(
-                    "Query \n'{}'\n failed with error: {}",
-                    self.enriched_benchmark_queries[i].query.query_template, e
-                ),
-            }
-        }
-        println!("All benchmark queries completed");
-        Ok(())
+            .collect()
     }
 
-    async fn enrich_query(
-        &self,
-        bq: &BenchmarkQuery,
-    ) -> Result<EnrichedBenchmarkQuery, anyhow::Error> {
-        // TODO(gegaowp): only fetch one row for quick execution, will configure and fetch more.
-        let query = format!(
-            "SELECT {} FROM {} LIMIT 1",
-            bq.needed_columns.join(","),
-            bq.table_name
+    async fn enrich_query(&self, query: &BenchmarkQuery) -> Result<EnrichedBenchmarkQuery> {
+        let client = self.pool.get().await?;
+        let sql = format!(
+            "SELECT DISTINCT {} FROM {} WHERE {} IS NOT NULL LIMIT 1000",
+            query.needed_columns.join(", "),
+            query.table_name,
+            query.needed_columns[0]
         );
-        println!("Enriched query: {}", query);
-        let rows = self.db_client.query(&query, &[]).await?;
+
+        let rows = client.query(&sql, &[]).await?;
+        if rows.is_empty() {
+            println!(
+                "Warning: No sample data found for query on table {}, table is empty",
+                query.table_name
+            );
+            return Ok(EnrichedBenchmarkQuery {
+                query: query.clone(),
+                rows: Vec::new(),
+                types: query.needed_columns.iter().map(|_| Type::TEXT).collect(), // default type
+            });
+        }
+
+        let types = rows[0]
+            .columns()
+            .iter()
+            .map(|c| c.type_().clone())
+            .collect();
+        let raw_rows = rows.iter().map(Self::row_to_values).collect();
 
         Ok(EnrichedBenchmarkQuery {
-            query: bq.clone(),
-            rows,
+            query: query.clone(),
+            rows: raw_rows,
+            types,
         })
     }
 
-    async fn execute_query(
-        &self,
-        query: &EnrichedBenchmarkQuery,
-    ) -> Result<Vec<tokio_postgres::Row>, tokio_postgres::Error> {
-        let mut all_results = Vec::new();
-        for row in &query.rows {
-            let params_vec = row_to_params(row);
-            let value_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
-                params_vec.iter().map(|v| v.as_ref()).collect();
-
-            let results = self
-                .db_client
-                .query(&query.query.query_template, &value_refs)
-                .await?;
-            all_results.extend(results);
+    pub async fn initialize_samples(&mut self) -> Result<()> {
+        for query in &self.queries.clone() {
+            let enriched = self.enrich_query(query).await?;
+            self.enriched_queries.push(enriched);
         }
-        Ok(all_results)
-    }
-}
-
-fn row_to_params(row: &Row) -> Vec<Box<dyn ToSql + Sync>> {
-    let mut params: Vec<Box<dyn ToSql + Sync>> = Vec::new();
-
-    for i in 0..row.len() {
-        match row.columns()[i].type_() {
-            &Type::TEXT | &Type::VARCHAR => {
-                params.push(Box::new(row.get::<_, Option<String>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            &Type::INT4 => {
-                params.push(Box::new(row.get::<_, Option<i32>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            &Type::INT8 => {
-                params.push(Box::new(row.get::<_, Option<i64>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            &Type::FLOAT8 => {
-                params.push(Box::new(row.get::<_, Option<f64>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            &Type::BOOL => {
-                params.push(Box::new(row.get::<_, Option<bool>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            &Type::INT2 => {
-                params.push(Box::new(row.get::<_, Option<i16>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            &Type::BYTEA => {
-                params.push(Box::new(row.get::<_, Option<Vec<u8>>>(i)) as Box<dyn ToSql + Sync>)
-            }
-            _ => panic!("Unsupported type: {:?}", row.columns()[i].type_()),
-        }
-    }
-    params
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use sui_pg_temp_db::TempDb;
-    use tokio_postgres::NoTls;
-
-    #[tokio::test]
-    async fn test_execute_enriched_query() -> Result<(), Box<dyn std::error::Error>> {
-        let db = TempDb::new().unwrap();
-        let url = db.database().url();
-        let (client, connection) = tokio_postgres::connect(url.as_str(), NoTls).await?;
-        tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
-        });
-
-        // Create test table and insert test data
-        client
-            .execute(
-                "CREATE TABLE IF NOT EXISTS test_table (id INTEGER PRIMARY KEY, name TEXT)",
-                &[],
-            )
-            .await?;
-        client
-            .execute(
-                "INSERT INTO test_table (id, name) VALUES ($1, $2)",
-                &[
-                    &1i32 as &(dyn tokio_postgres::types::ToSql + Sync),
-                    &"test" as &(dyn tokio_postgres::types::ToSql + Sync),
-                ],
-            )
-            .await?;
-        // Create benchmark query
-        let benchmark_query = BenchmarkQuery {
-            query_template: "SELECT * FROM test_table WHERE id = $1 AND name = $2".to_string(),
-            table_name: "test_table".to_string(),
-            needed_columns: vec!["id".to_string(), "name".to_string()],
-        };
-
-        // Create executor and enrich query
-        let executor = QueryExecutor::new(url.as_str(), vec![benchmark_query]).await?;
-        let enriched_query = &executor.enriched_benchmark_queries[0];
-
-        // Assert enriched query details match what we expect
-        assert_eq!(
-            enriched_query.query.query_template,
-            "SELECT * FROM test_table WHERE id = $1 AND name = $2"
-        );
-        assert_eq!(enriched_query.query.table_name, "test_table");
-        assert_eq!(
-            enriched_query.query.needed_columns,
-            vec!["id".to_string(), "name".to_string()]
-        );
-        assert_eq!(enriched_query.rows.len(), 1);
-
-        // Execute enriched query
-        let result = executor.execute_query(enriched_query).await?;
-
-        // Verify result matches expected values
-        assert_eq!(result.len(), 1);
-        assert!(check_rows_consistency(&result[0], &enriched_query.rows[0])?);
-
         Ok(())
     }
 
-    fn check_rows_consistency(row1: &Row, row2: &Row) -> Result<bool, Box<dyn std::error::Error>> {
-        // Get column names for both rows
-        let cols1: Vec<&str> = row1.columns().iter().map(|c| c.name()).collect();
-        let cols2: Vec<&str> = row2.columns().iter().map(|c| c.name()).collect();
+    async fn worker_task(
+        pool: Pool<PostgresConnectionManager<NoTls>>,
+        enriched_queries: Vec<EnrichedBenchmarkQuery>,
+        metrics: MetricsCollector,
+        deadline: Instant,
+    ) -> Result<()> {
+        let client = pool.get().await?;
+        while Instant::now() < deadline {
+            let enriched = enriched_queries
+                .choose(&mut rand::thread_rng())
+                .ok_or_else(|| anyhow::anyhow!("No queries available"))?;
 
-        // Find overlapping columns
-        let common_cols: Vec<&str> = cols1
-            .iter()
-            .filter(|&col| cols2.contains(col))
-            .cloned()
-            .collect();
+            let row = match enriched.rows.choose(&mut rand::thread_rng()) {
+                Some(row) => row,
+                None => {
+                    // skip when the table is empty and thus no values to sample.
+                    continue;
+                }
+            };
 
-        // Check each common column for value equality
-        for col in common_cols {
-            // assert the column types match
-            let col_type1 = row1
-                .columns()
+            let params: Vec<Box<dyn ToSql + Sync + Send>> = row
                 .iter()
-                .find(|c| c.name() == col)
-                .map(|c| c.type_())
-                .unwrap();
-            let col_type2 = row2
-                .columns()
+                .map(|val| match val {
+                    SqlValue::Text(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                    SqlValue::Int4(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                    SqlValue::Int8(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                    SqlValue::Float8(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                    SqlValue::Bool(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                    SqlValue::Int2(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                    SqlValue::Bytea(v) => Box::new(v) as Box<dyn ToSql + Sync + Send>,
+                })
+                .collect();
+            let param_refs: Vec<&(dyn ToSql + Sync)> = params
                 .iter()
-                .find(|c| c.name() == col)
-                .map(|c| c.type_())
-                .unwrap();
-            assert_eq!(
-                col_type1, col_type2,
-                "Column types should match for column {}",
-                col
-            );
-            let col_type = col_type1;
+                .map(|p| p.as_ref() as &(dyn ToSql + Sync))
+                .collect();
 
-            // assert the column values match
-            if !compare_row_values(row1, row2, col, col_type)? {
-                println!("Column '{}' has inconsistent values between rows", col);
-                return Ok(false);
-            }
+            let query_str = enriched.query.query_template.clone();
+
+            let start = Instant::now();
+            let result = client.query(&query_str, &param_refs[..]).await;
+
+            metrics.record_query(&enriched.query.table_name, start.elapsed(), result.is_err());
         }
-
-        Ok(true)
+        Ok(())
     }
 
-    fn compare_row_values(
-        row1: &Row,
-        row2: &Row,
-        col: &str,
-        col_type: &Type,
-    ) -> Result<bool, Box<dyn std::error::Error>> {
-        Ok(match col_type {
-            &Type::TEXT | &Type::VARCHAR => {
-                row1.get::<_, String>(col) == row2.get::<_, String>(col)
-            }
-            &Type::INT4 => row1.get::<_, i32>(col) == row2.get::<_, i32>(col),
-            &Type::INT8 => row1.get::<_, i64>(col) == row2.get::<_, i64>(col),
-            &Type::FLOAT8 => row1.get::<_, f64>(col) == row2.get::<_, f64>(col),
-            &Type::BOOL => row1.get::<_, bool>(col) == row2.get::<_, bool>(col),
-            &Type::INT2 => row1.get::<_, i16>(col) == row2.get::<_, i16>(col),
-            &Type::BYTEA => row1.get::<_, Vec<u8>>(col) == row2.get::<_, Vec<u8>>(col),
-            _ => panic!("Unsupported type: {:?}", col_type),
-        })
+    pub async fn run(&mut self) -> Result<BenchmarkResult> {
+        if self.enriched_queries.is_empty() {
+            self.initialize_samples().await?;
+        }
+
+        println!(
+            "Running benchmark with {} concurrent clients",
+            self.config.concurrency
+        );
+
+        let start = Instant::now();
+        let deadline = start + self.config.duration;
+
+        let queries_per_worker = self.enriched_queries.chunks(
+            (self.enriched_queries.len() + self.config.concurrency - 1) / self.config.concurrency,
+        );
+
+        let mut handles = Vec::new();
+        for worker_queries in queries_per_worker {
+            let pool = self.pool.clone();
+            let worker_queries = worker_queries.to_vec();
+            let metrics = self.metrics.clone();
+
+            let handle = tokio::spawn(async move {
+                QueryExecutor::worker_task(pool, worker_queries, metrics, deadline).await
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await??;
+        }
+
+        Ok(self.metrics.generate_report())
     }
 }

--- a/crates/sui-rpc-benchmark/src/direct/query_executor.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_executor.rs
@@ -51,13 +51,12 @@ impl QueryExecutor {
         deadline: Instant,
     ) -> Result<()> {
         let client = pool.get().await?;
-        let mut query_rng = rand::rngs::StdRng::from_entropy();
-        let mut row_rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = rand::rngs::StdRng::from_entropy();
         while Instant::now() < deadline {
             let enriched = enriched_queries
-                .choose(&mut query_rng)
+                .choose(&mut rng)
                 .ok_or_else(|| anyhow::anyhow!("No queries available"))?;
-            let Some(row) = enriched.rows.choose(&mut row_rng) else {
+            let Some(row) = enriched.rows.choose(&mut rng) else {
                 // skip when the table is empty and thus no values to sample.
                 continue;
             };

--- a/crates/sui-rpc-benchmark/src/direct/query_generator.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_generator.rs
@@ -1,7 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// This module generates SQL queries for benchmarking, including
+/// queries based on primary key columns and indexed columns.
+///
+/// The primary key queries ("pk queries") select a row by each PK,
+/// while the "index queries" filter by indexed columns. Instead
+/// of returning just a list of tables and indexes, this module
+/// returns a vector of BenchmarkQuery objects, each of which is
+/// ready to be executed. This approach streamlines the pipeline
+/// so we can directly run these queries as part of the benchmark.
 use tokio_postgres::NoTls;
+use tracing::info;
 
 pub struct QueryGenerator {
     pub db_url: String,
@@ -31,7 +41,7 @@ impl QueryGenerator {
             .iter()
             .map(|row| row.get::<_, String>(0))
             .collect();
-        println!(
+        info!(
             "Found {} active tables in database: {:?}",
             tables.len(),
             tables
@@ -94,9 +104,9 @@ impl QueryGenerator {
             queries.push(self.create_index_query(&table, &columns));
         }
 
-        println!("\nGenerated {} queries:", queries.len());
+        info!("\nGenerated {} queries:", queries.len());
         for (i, query) in queries.iter().enumerate() {
-            println!(
+            info!(
                 "  {}. Table: {}, Template: {}",
                 i + 1,
                 query.table_name,

--- a/crates/sui-rpc-benchmark/src/direct/query_generator.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_generator.rs
@@ -1,0 +1,308 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sqlparser::ast::{ColumnOption, CreateIndex, CreateTable, Statement, TableConstraint};
+use sqlparser::dialect::PostgreSqlDialect;
+use sqlparser::parser::Parser;
+
+pub struct QueryGenerator;
+
+#[derive(Debug, Clone)]
+pub struct BenchmarkQuery {
+    pub query_template: String,
+    pub table_name: String,
+    pub needed_columns: Vec<String>,
+}
+
+impl QueryGenerator {
+    fn read_sqls() -> Result<Vec<String>, anyhow::Error> {
+        let current_dir = std::env::current_dir()?;
+        let migration_path = current_dir
+            .parent() // up to crates/
+            .and_then(|p| p.parent()) // up to sui/
+            .map(|p| p.join("crates/sui-indexer-alt/migrations"))
+            .ok_or_else(|| anyhow::anyhow!("Could not find migrations directory"))?;
+        let migration_path = migration_path.to_str().unwrap();
+        let mut sqls = Vec::new();
+
+        Self::read_sql_impl(std::path::Path::new(migration_path), &mut sqls)?;
+        println!("Read {} up.sql files from migrations directory", sqls.len());
+        Ok(sqls)
+    }
+
+    fn read_sql_impl(dir: &std::path::Path, sqls: &mut Vec<String>) -> Result<(), anyhow::Error> {
+        if dir.is_dir() {
+            for entry in std::fs::read_dir(dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.is_dir() {
+                    Self::read_sql_impl(&path, sqls)?;
+                } else if path.is_file()
+                    && path
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .map(|s| s.ends_with("up.sql"))
+                        .unwrap_or(false)
+                {
+                    let sql = std::fs::read_to_string(&path)?;
+                    sqls.push(sql);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn generate_benchmark_queries() -> Result<Vec<BenchmarkQuery>, anyhow::Error> {
+        let sqls = Self::read_sqls()?;
+        let mut benchmark_queries = Vec::new();
+        for sql in sqls {
+            let queries = sql_to_benchmark_queries(&sql)?;
+            benchmark_queries.extend(queries);
+        }
+        Ok(benchmark_queries)
+    }
+}
+
+fn sql_to_benchmark_queries(sql: &str) -> Result<Vec<BenchmarkQuery>, anyhow::Error> {
+    let dialect = PostgreSqlDialect {};
+    let statements = Parser::parse_sql(&dialect, sql)?;
+
+    let mut tables = Vec::new();
+    let mut indexes = Vec::new();
+
+    for stmt in statements {
+        match stmt {
+            Statement::CreateTable(CreateTable {
+                name,
+                columns,
+                constraints,
+                ..
+            }) => {
+                let table_name = name.to_string();
+                let mut primary_keys = Vec::new();
+                // Extract primary keys from table PRIMARY KEY constraint, for example:
+                // CREATE TABLE test_table (
+                //     id BIGINT,
+                //     name VARCHAR(255),
+                //     value INTEGER,
+                //     PRIMARY KEY (id)
+                // );
+                for constraint in &constraints {
+                    if let TableConstraint::PrimaryKey { columns, .. } = constraint {
+                        primary_keys = columns.iter().map(|c| c.to_string()).collect();
+                    }
+                }
+                // If table PRIMARY KEY constraint is not defined, check column constraints for PRIMARY KEY option, for example:
+                // CREATE TABLE test_table (
+                //     id BIGINT PRIMARY KEY,
+                //     name VARCHAR(255),
+                //     value INTEGER
+                // );
+                if primary_keys.is_empty() {
+                    for column in &columns {
+                        for option in &column.options {
+                            if let ColumnOption::Unique { is_primary, .. } = &option.option {
+                                if *is_primary {
+                                    primary_keys.push(column.name.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+
+                tables.push((table_name, primary_keys));
+            }
+            Statement::CreateIndex(CreateIndex {
+                name: _,
+                table_name: idx_table,
+                columns,
+                ..
+            }) => {
+                indexes.push((
+                    idx_table.to_string(),
+                    columns.iter().map(|c| c.to_string()).collect::<Vec<_>>(),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let mut queries = Vec::new();
+    // 1. Primary key lookup queries
+    for (table_name, primary_keys) in tables {
+        if !primary_keys.is_empty() {
+            let pk_conditions = primary_keys
+                .iter()
+                .enumerate()
+                .map(|(i, pk)| format!("{} = ${}", pk, i + 1))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+
+            queries.push(BenchmarkQuery {
+                query_template: format!(
+                    "SELECT * FROM {} WHERE {} LIMIT 1",
+                    table_name, pk_conditions
+                ),
+                table_name: table_name.clone(),
+                needed_columns: primary_keys,
+            });
+        }
+    }
+    // 2. Index-based queries
+    for (table_name, idx_columns) in indexes {
+        let conditions = idx_columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| format!("{} = ${}", col, i + 1))
+            .collect::<Vec<_>>()
+            .join(" AND ");
+
+        queries.push(BenchmarkQuery {
+            query_template: format!("SELECT * FROM {} WHERE {} LIMIT 50", table_name, conditions),
+            table_name,
+            needed_columns: idx_columns,
+        });
+    }
+
+    Ok(queries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_queries() -> Result<(), Box<dyn std::error::Error>> {
+        let sql = r#"
+            CREATE TABLE test_table (
+                id BIGINT PRIMARY KEY,
+                name VARCHAR(255),
+                value INTEGER
+            );
+            
+            CREATE INDEX idx_name ON test_table(name);
+            CREATE INDEX idx_value ON test_table(value);
+        "#;
+
+        let queries = sql_to_benchmark_queries(sql)?;
+
+        // Should generate 3 queries - one for PK lookup and two for indexes
+        assert_eq!(queries.len(), 3);
+
+        // Verify PK query
+        assert_eq!(
+            queries[0].query_template,
+            "SELECT * FROM test_table WHERE id = $1 LIMIT 1"
+        );
+        assert_eq!(queries[0].table_name, "test_table");
+        assert_eq!(queries[0].needed_columns, vec!["id"]);
+
+        // Verify index queries
+        assert_eq!(
+            queries[1].query_template,
+            "SELECT * FROM test_table WHERE name = $1 LIMIT 50"
+        );
+        assert_eq!(queries[1].table_name, "test_table");
+        assert_eq!(queries[1].needed_columns, vec!["name"]);
+
+        assert_eq!(
+            queries[2].query_template,
+            "SELECT * FROM test_table WHERE value = $1 LIMIT 50"
+        );
+        assert_eq!(queries[2].table_name, "test_table");
+        assert_eq!(queries[2].needed_columns, vec!["value"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_queries_with_table_pk() -> Result<(), Box<dyn std::error::Error>> {
+        let sql = r#"
+            CREATE TABLE test_table2 (
+                id BIGINT,
+                name VARCHAR(255),
+                value INTEGER,
+                PRIMARY KEY (id)
+            );
+            
+            CREATE INDEX idx_name ON test_table2(name);
+            CREATE INDEX idx_value ON test_table2(value);
+        "#;
+
+        let queries = sql_to_benchmark_queries(sql)?;
+
+        // Should generate 3 queries - one for PK lookup and two for indexes
+        assert_eq!(queries.len(), 3);
+
+        // Verify PK query
+        assert_eq!(
+            queries[0].query_template,
+            "SELECT * FROM test_table2 WHERE id = $1 LIMIT 1"
+        );
+        assert_eq!(queries[0].table_name, "test_table2");
+        assert_eq!(queries[0].needed_columns, vec!["id"]);
+
+        // Verify index queries
+        assert_eq!(
+            queries[1].query_template,
+            "SELECT * FROM test_table2 WHERE name = $1 LIMIT 50"
+        );
+        assert_eq!(queries[1].table_name, "test_table2");
+        assert_eq!(queries[1].needed_columns, vec!["name"]);
+
+        assert_eq!(
+            queries[2].query_template,
+            "SELECT * FROM test_table2 WHERE value = $1 LIMIT 50"
+        );
+        assert_eq!(queries[2].table_name, "test_table2");
+        assert_eq!(queries[2].needed_columns, vec!["value"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_queries_with_multi_column_indexes() -> Result<(), Box<dyn std::error::Error>> {
+        let sql = r#"
+            CREATE TABLE test_table3 (
+                id BIGINT,
+                name VARCHAR(255),
+                value INTEGER,
+                category VARCHAR(50),
+                PRIMARY KEY (id)
+            );
+            
+            CREATE INDEX idx_name_value ON test_table3(name, value);
+            CREATE INDEX idx_category_value ON test_table3(category, value);
+        "#;
+
+        let queries = sql_to_benchmark_queries(sql)?;
+
+        // Should generate 3 queries - one for PK and two for composite indexes
+        assert_eq!(queries.len(), 3);
+
+        // Verify PK query
+        assert_eq!(
+            queries[0].query_template,
+            "SELECT * FROM test_table3 WHERE id = $1 LIMIT 1"
+        );
+        assert_eq!(queries[0].table_name, "test_table3");
+        assert_eq!(queries[0].needed_columns, vec!["id"]);
+
+        // Verify multi-column index queries
+        assert_eq!(
+            queries[1].query_template,
+            "SELECT * FROM test_table3 WHERE name = $1 AND value = $2 LIMIT 50"
+        );
+        assert_eq!(queries[1].table_name, "test_table3");
+        assert_eq!(queries[1].needed_columns, vec!["name", "value"]);
+
+        assert_eq!(
+            queries[2].query_template,
+            "SELECT * FROM test_table3 WHERE category = $1 AND value = $2 LIMIT 50"
+        );
+        assert_eq!(queries[2].table_name, "test_table3");
+        assert_eq!(queries[2].needed_columns, vec!["category", "value"]);
+
+        Ok(())
+    }
+}

--- a/crates/sui-rpc-benchmark/src/direct/query_generator.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_generator.rs
@@ -1,13 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sqlparser::ast::{ColumnOption, CreateIndex, CreateTable, Statement, TableConstraint};
-use sqlparser::dialect::PostgreSqlDialect;
-use sqlparser::parser::Parser;
-use std::path::PathBuf;
+use tokio_postgres::NoTls;
 
 pub struct QueryGenerator {
-    pub migration_path: PathBuf,
+    pub db_url: String,
 }
 
 #[derive(Debug, Clone)]
@@ -18,288 +15,130 @@ pub struct BenchmarkQuery {
 }
 
 impl QueryGenerator {
-    fn read_sqls(&self) -> Result<Vec<String>, anyhow::Error> {
-        let migration_path = self.migration_path.to_str().unwrap();
-        let sqls = Self::read_sql_impl(std::path::Path::new(migration_path))?;
-        println!("Read {} up.sql files from migrations directory", sqls.len());
-        Ok(sqls)
-    }
+    async fn get_tables_and_indexes(&self) -> Result<Vec<BenchmarkQuery>, anyhow::Error> {
+        let (client, connection) = tokio_postgres::connect(&self.db_url, NoTls).await?;
+        tokio::spawn(connection);
+        let tables_query = r#"
+            SELECT tablename 
+            FROM pg_tables 
+            WHERE schemaname = 'public' 
+            AND tablename != '__diesel_schema_migrations'
+            ORDER BY tablename;
+        "#;
+        let tables: Vec<String> = client
+            .query(tables_query, &[])
+            .await?
+            .iter()
+            .map(|row| row.get::<_, String>(0))
+            .collect();
+        println!(
+            "Found {} active tables in database: {:?}",
+            tables.len(),
+            tables
+        );
 
-    fn read_sql_impl(dir: &std::path::Path) -> Result<Vec<String>, anyhow::Error> {
-        let mut sqls: Vec<String> = Vec::new();
-        if dir.is_dir() {
-            for entry in std::fs::read_dir(dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if path.is_dir() {
-                    let inner_sqls = Self::read_sql_impl(&path)?;
-                    sqls.extend(inner_sqls);
-                } else if path.is_file()
-                    && path
-                        .file_name()
-                        .and_then(|f| f.to_str())
-                        .map(|s| s.ends_with("up.sql"))
-                        .unwrap_or(false)
-                {
-                    let sql = std::fs::read_to_string(&path)?;
-                    sqls.push(sql);
-                }
+        let pk_query = r#"
+            SELECT tc.table_name, kcu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu 
+                ON tc.constraint_name = kcu.constraint_name
+            WHERE tc.constraint_type = 'PRIMARY KEY'
+                AND tc.table_schema = 'public'
+                AND tc.table_name != '__diesel_schema_migrations'
+            ORDER BY tc.table_name, kcu.ordinal_position;
+        "#;
+
+        let mut queries = Vec::new();
+        let rows = client.query(pk_query, &[]).await?;
+        let mut current_table = String::new();
+        let mut pk_columns = Vec::new();
+
+        for row in rows {
+            let table: String = row.get("table_name");
+            let column: String = row.get("column_name");
+
+            if table != current_table && !current_table.is_empty() {
+                queries.push(self.create_pk_query(&current_table, &pk_columns));
+                pk_columns.clear();
             }
+
+            current_table = table;
+            pk_columns.push(column);
         }
-        Ok(sqls)
+        if !pk_columns.is_empty() {
+            queries.push(self.create_pk_query(&current_table, &pk_columns));
+        }
+
+        let idx_query = r#"
+            SELECT 
+                t.relname AS table_name,
+                i.relname AS index_name,
+                array_agg(a.attname ORDER BY k.i) AS column_names
+            FROM pg_class t
+            JOIN pg_index ix ON t.oid = ix.indrelid
+            JOIN pg_class i ON ix.indexrelid = i.oid
+            JOIN pg_attribute a ON t.oid = a.attrelid
+            JOIN generate_subscripts(ix.indkey, 1) k(i) ON a.attnum = ix.indkey[k.i]
+            WHERE t.relkind = 'r'
+                AND t.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+                AND NOT ix.indisprimary
+                AND t.relname != '__diesel_schema_migrations'
+            GROUP BY t.relname, i.relname
+            ORDER BY t.relname, i.relname;
+        "#;
+
+        let rows = client.query(idx_query, &[]).await?;
+        for row in rows {
+            let table: String = row.get("table_name");
+            let columns: Vec<String> = row.get("column_names");
+            queries.push(self.create_index_query(&table, &columns));
+        }
+
+        println!("\nGenerated {} queries:", queries.len());
+        for (i, query) in queries.iter().enumerate() {
+            println!(
+                "  {}. Table: {}, Template: {}",
+                i + 1,
+                query.table_name,
+                query.query_template
+            );
+        }
+
+        Ok(queries)
     }
 
-    pub fn generate_benchmark_queries(&self) -> Result<Vec<BenchmarkQuery>, anyhow::Error> {
-        let sqls = self.read_sqls()?;
-        let mut benchmark_queries = Vec::new();
-        for sql in sqls {
-            let queries = sql_to_benchmark_queries(&sql)?;
-            benchmark_queries.extend(queries);
-        }
-        Ok(benchmark_queries)
-    }
-}
-
-fn sql_to_benchmark_queries(sql: &str) -> Result<Vec<BenchmarkQuery>, anyhow::Error> {
-    let dialect = PostgreSqlDialect {};
-    let statements = Parser::parse_sql(&dialect, sql)?;
-
-    let mut tables = Vec::new();
-    let mut indexes = Vec::new();
-
-    for stmt in statements {
-        match stmt {
-            Statement::CreateTable(CreateTable {
-                name,
-                columns,
-                constraints,
-                ..
-            }) => {
-                let table_name = name.to_string();
-                let mut primary_keys = Vec::new();
-                // Extract primary keys from table PRIMARY KEY constraint, for example:
-                // CREATE TABLE test_table (
-                //     id BIGINT,
-                //     name VARCHAR(255),
-                //     value INTEGER,
-                //     PRIMARY KEY (id)
-                // );
-                for constraint in &constraints {
-                    if let TableConstraint::PrimaryKey { columns, .. } = constraint {
-                        primary_keys = columns.iter().map(|c| c.to_string()).collect();
-                    }
-                }
-                // If table PRIMARY KEY constraint is not defined, check column constraints for PRIMARY KEY option, for example:
-                // CREATE TABLE test_table (
-                //     id BIGINT PRIMARY KEY,
-                //     name VARCHAR(255),
-                //     value INTEGER
-                // );
-                if primary_keys.is_empty() {
-                    for column in &columns {
-                        for option in &column.options {
-                            if let ColumnOption::Unique { is_primary, .. } = &option.option {
-                                if *is_primary {
-                                    primary_keys.push(column.name.to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-
-                tables.push((table_name, primary_keys));
-            }
-            Statement::CreateIndex(CreateIndex {
-                name: _,
-                table_name: idx_table,
-                columns,
-                ..
-            }) => {
-                indexes.push((
-                    idx_table.to_string(),
-                    columns.iter().map(|c| c.to_string()).collect::<Vec<_>>(),
-                ));
-            }
-            _ => {}
-        }
-    }
-
-    let mut queries = Vec::new();
-    // 1. Primary key lookup queries
-    for (table_name, primary_keys) in tables {
-        if !primary_keys.is_empty() {
-            let pk_conditions = primary_keys
-                .iter()
-                .enumerate()
-                .map(|(i, pk)| format!("{} = ${}", pk, i + 1))
-                .collect::<Vec<_>>()
-                .join(" AND ");
-
-            queries.push(BenchmarkQuery {
-                query_template: format!(
-                    "SELECT * FROM {} WHERE {} LIMIT 1",
-                    table_name, pk_conditions
-                ),
-                table_name: table_name.clone(),
-                needed_columns: primary_keys,
-            });
-        }
-    }
-    // 2. Index-based queries
-    for (table_name, idx_columns) in indexes {
-        let conditions = idx_columns
+    fn create_pk_query(&self, table: &str, columns: &[String]) -> BenchmarkQuery {
+        let conditions = columns
             .iter()
             .enumerate()
             .map(|(i, col)| format!("{} = ${}", col, i + 1))
             .collect::<Vec<_>>()
             .join(" AND ");
 
-        queries.push(BenchmarkQuery {
-            query_template: format!("SELECT * FROM {} WHERE {} LIMIT 50", table_name, conditions),
-            table_name,
-            needed_columns: idx_columns,
-        });
+        BenchmarkQuery {
+            query_template: format!("SELECT * FROM {} WHERE {} LIMIT 1", table, conditions),
+            table_name: table.to_string(),
+            needed_columns: columns.to_vec(),
+        }
     }
 
-    Ok(queries)
-}
+    fn create_index_query(&self, table: &str, columns: &[String]) -> BenchmarkQuery {
+        let conditions = columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| format!("{} = ${}", col, i + 1))
+            .collect::<Vec<_>>()
+            .join(" AND ");
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_generate_queries() -> Result<(), Box<dyn std::error::Error>> {
-        let sql = r#"
-            CREATE TABLE test_table (
-                id BIGINT PRIMARY KEY,
-                name VARCHAR(255),
-                value INTEGER
-            );
-            
-            CREATE INDEX idx_name ON test_table(name);
-            CREATE INDEX idx_value ON test_table(value);
-        "#;
-
-        let queries = sql_to_benchmark_queries(sql)?;
-
-        // Should generate 3 queries - one for PK lookup and two for indexes
-        assert_eq!(queries.len(), 3);
-
-        // Verify PK query
-        assert_eq!(
-            queries[0].query_template,
-            "SELECT * FROM test_table WHERE id = $1 LIMIT 1"
-        );
-        assert_eq!(queries[0].table_name, "test_table");
-        assert_eq!(queries[0].needed_columns, vec!["id"]);
-
-        // Verify index queries
-        assert_eq!(
-            queries[1].query_template,
-            "SELECT * FROM test_table WHERE name = $1 LIMIT 50"
-        );
-        assert_eq!(queries[1].table_name, "test_table");
-        assert_eq!(queries[1].needed_columns, vec!["name"]);
-
-        assert_eq!(
-            queries[2].query_template,
-            "SELECT * FROM test_table WHERE value = $1 LIMIT 50"
-        );
-        assert_eq!(queries[2].table_name, "test_table");
-        assert_eq!(queries[2].needed_columns, vec!["value"]);
-
-        Ok(())
+        BenchmarkQuery {
+            query_template: format!("SELECT * FROM {} WHERE {} LIMIT 50", table, conditions),
+            table_name: table.to_string(),
+            needed_columns: columns.to_vec(),
+        }
     }
 
-    #[test]
-    fn test_generate_queries_with_table_pk() -> Result<(), Box<dyn std::error::Error>> {
-        let sql = r#"
-            CREATE TABLE test_table2 (
-                id BIGINT,
-                name VARCHAR(255),
-                value INTEGER,
-                PRIMARY KEY (id)
-            );
-            
-            CREATE INDEX idx_name ON test_table2(name);
-            CREATE INDEX idx_value ON test_table2(value);
-        "#;
-
-        let queries = sql_to_benchmark_queries(sql)?;
-
-        // Should generate 3 queries - one for PK lookup and two for indexes
-        assert_eq!(queries.len(), 3);
-
-        // Verify PK query
-        assert_eq!(
-            queries[0].query_template,
-            "SELECT * FROM test_table2 WHERE id = $1 LIMIT 1"
-        );
-        assert_eq!(queries[0].table_name, "test_table2");
-        assert_eq!(queries[0].needed_columns, vec!["id"]);
-
-        // Verify index queries
-        assert_eq!(
-            queries[1].query_template,
-            "SELECT * FROM test_table2 WHERE name = $1 LIMIT 50"
-        );
-        assert_eq!(queries[1].table_name, "test_table2");
-        assert_eq!(queries[1].needed_columns, vec!["name"]);
-
-        assert_eq!(
-            queries[2].query_template,
-            "SELECT * FROM test_table2 WHERE value = $1 LIMIT 50"
-        );
-        assert_eq!(queries[2].table_name, "test_table2");
-        assert_eq!(queries[2].needed_columns, vec!["value"]);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_generate_queries_with_multi_column_indexes() -> Result<(), Box<dyn std::error::Error>> {
-        let sql = r#"
-            CREATE TABLE test_table3 (
-                id BIGINT,
-                name VARCHAR(255),
-                value INTEGER,
-                category VARCHAR(50),
-                PRIMARY KEY (id)
-            );
-            
-            CREATE INDEX idx_name_value ON test_table3(name, value);
-            CREATE INDEX idx_category_value ON test_table3(category, value);
-        "#;
-
-        let queries = sql_to_benchmark_queries(sql)?;
-
-        // Should generate 3 queries - one for PK and two for composite indexes
-        assert_eq!(queries.len(), 3);
-
-        // Verify PK query
-        assert_eq!(
-            queries[0].query_template,
-            "SELECT * FROM test_table3 WHERE id = $1 LIMIT 1"
-        );
-        assert_eq!(queries[0].table_name, "test_table3");
-        assert_eq!(queries[0].needed_columns, vec!["id"]);
-
-        // Verify multi-column index queries
-        assert_eq!(
-            queries[1].query_template,
-            "SELECT * FROM test_table3 WHERE name = $1 AND value = $2 LIMIT 50"
-        );
-        assert_eq!(queries[1].table_name, "test_table3");
-        assert_eq!(queries[1].needed_columns, vec!["name", "value"]);
-
-        assert_eq!(
-            queries[2].query_template,
-            "SELECT * FROM test_table3 WHERE category = $1 AND value = $2 LIMIT 50"
-        );
-        assert_eq!(queries[2].table_name, "test_table3");
-        assert_eq!(queries[2].needed_columns, vec!["category", "value"]);
-
-        Ok(())
+    pub async fn generate_benchmark_queries(&self) -> Result<Vec<BenchmarkQuery>, anyhow::Error> {
+        let queries = self.get_tables_and_indexes().await?;
+        Ok(queries)
     }
 }

--- a/crates/sui-rpc-benchmark/src/lib.rs
+++ b/crates/sui-rpc-benchmark/src/lib.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod direct;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::direct::query_executor::QueryExecutor;
+use crate::direct::query_generator::QueryGenerator;
+
+#[derive(Parser)]
+#[clap(
+    name = "sui-rpc-benchmark",
+    about = "Benchmark tool for comparing Sui RPC access methods"
+)]
+pub struct Opts {
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Benchmark direct database queries
+    #[clap(name = "direct")]
+    DirectQuery {
+        #[clap(
+            long,
+            default_value = "postgres://postgres:postgres@localhost:5432/sui"
+        )]
+        db_url: String,
+    },
+    /// Benchmark JSON RPC endpoints
+    #[clap(name = "jsonrpc")]
+    JsonRpc {
+        #[clap(long, default_value = "http://127.0.0.1:9000")]
+        endpoint: String,
+    },
+    /// Benchmark GraphQL queries
+    #[clap(name = "graphql")]
+    GraphQL {
+        #[clap(long, default_value = "http://127.0.0.1:9000/graphql")]
+        endpoint: String,
+    },
+}
+
+pub async fn run_benchmarks() -> Result<(), anyhow::Error> {
+    let opts: Opts = Opts::parse();
+
+    match opts.command {
+        Command::DirectQuery { db_url } => {
+            println!("Running direct query benchmark against {}", db_url);
+            let benchmark_queries = QueryGenerator::generate_benchmark_queries()?;
+            println!("Generated {} benchmark queries", benchmark_queries.len());
+            let query_executor = QueryExecutor::new(db_url.as_str(), benchmark_queries).await?;
+            query_executor.run().await?;
+            Ok(())
+        }
+        Command::JsonRpc { endpoint } => {
+            println!("Running JSON RPC benchmark against {}", endpoint);
+            todo!()
+        }
+        Command::GraphQL { endpoint } => {
+            println!("Running GraphQL benchmark against {}", endpoint);
+            todo!()
+        }
+    }
+}

--- a/crates/sui-rpc-benchmark/src/lib.rs
+++ b/crates/sui-rpc-benchmark/src/lib.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use tracing::info;
 
 use crate::direct::benchmark_config::BenchmarkConfig;
 use crate::direct::query_executor::QueryExecutor;
@@ -60,12 +61,12 @@ pub async fn run_benchmarks() -> Result<(), anyhow::Error> {
             concurrency,
             duration_secs,
         } => {
-            println!("Running direct query benchmark against DB {}", db_url,);
+            info!("Running direct query benchmark against DB {}", db_url);
             let query_generator = QueryGenerator {
                 db_url: db_url.clone(),
             };
             let benchmark_queries = query_generator.generate_benchmark_queries().await?;
-            println!("Generated {} benchmark queries", benchmark_queries.len());
+            info!("Generated {} benchmark queries", benchmark_queries.len());
 
             let config = BenchmarkConfig {
                 concurrency,
@@ -74,12 +75,12 @@ pub async fn run_benchmarks() -> Result<(), anyhow::Error> {
 
             let mut query_executor = QueryExecutor::new(&db_url, benchmark_queries, config).await?;
             let result = query_executor.run().await?;
-            println!("\n\nTotal queries: {}", result.total_queries);
-            println!("Total errors: {}", result.total_errors);
-            println!("Average latency: {:.2}ms", result.avg_latency_ms);
-            println!("\nPer-table statistics:");
+            info!("Total queries: {}", result.total_queries);
+            info!("Total errors: {}", result.total_errors);
+            info!("Average latency: {:.2}ms", result.avg_latency_ms);
+            info!("Per-table statistics:");
             for stat in &result.table_stats {
-                println!(
+                info!(
                     "  {:<30} queries: {:<8} errors: {:<8} avg latency: {:.2}ms",
                     stat.table_name, stat.queries, stat.errors, stat.avg_latency_ms
                 );
@@ -87,11 +88,11 @@ pub async fn run_benchmarks() -> Result<(), anyhow::Error> {
             Ok(())
         }
         Command::JsonRpc { endpoint } => {
-            println!("Running JSON RPC benchmark against {}", endpoint);
+            info!("Running JSON RPC benchmark against {}", endpoint);
             todo!()
         }
         Command::GraphQL { endpoint } => {
-            println!("Running GraphQL benchmark against {}", endpoint);
+            info!("Running GraphQL benchmark against {}", endpoint);
             todo!()
         }
     }

--- a/crates/sui-rpc-benchmark/src/lib.rs
+++ b/crates/sui-rpc-benchmark/src/lib.rs
@@ -3,11 +3,12 @@
 
 pub mod direct;
 
-use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+use crate::direct::benchmark_config::BenchmarkConfig;
 use crate::direct::query_executor::QueryExecutor;
 use crate::direct::query_generator::QueryGenerator;
 
@@ -31,11 +32,10 @@ pub enum Command {
             default_value = "postgres://postgres:postgres@localhost:5432/sui"
         )]
         db_url: String,
-        #[clap(
-            long,
-            default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/../sui-indexer-alt/migrations")
-        )]
-        migration_path: PathBuf,
+        #[clap(long, default_value = "50")]
+        concurrency: usize,
+        #[clap(long, default_value = "30")]
+        duration_secs: u64,
     },
     /// Benchmark JSON RPC endpoints
     #[clap(name = "jsonrpc")]
@@ -57,18 +57,33 @@ pub async fn run_benchmarks() -> Result<(), anyhow::Error> {
     match opts.command {
         Command::DirectQuery {
             db_url,
-            migration_path,
+            concurrency,
+            duration_secs,
         } => {
-            println!(
-                "Running direct query benchmark against DB {} and migrations {}",
-                db_url,
-                migration_path.display()
-            );
-            let query_generator = QueryGenerator { migration_path };
-            let benchmark_queries = query_generator.generate_benchmark_queries()?;
+            println!("Running direct query benchmark against DB {}", db_url,);
+            let query_generator = QueryGenerator {
+                db_url: db_url.clone(),
+            };
+            let benchmark_queries = query_generator.generate_benchmark_queries().await?;
             println!("Generated {} benchmark queries", benchmark_queries.len());
-            let query_executor = QueryExecutor::new(db_url.as_str(), benchmark_queries).await?;
-            query_executor.run().await?;
+
+            let config = BenchmarkConfig {
+                concurrency,
+                duration: Duration::from_secs(duration_secs),
+            };
+
+            let mut query_executor = QueryExecutor::new(&db_url, benchmark_queries, config).await?;
+            let result = query_executor.run().await?;
+            println!("\n\nTotal queries: {}", result.total_queries);
+            println!("Total errors: {}", result.total_errors);
+            println!("Average latency: {:.2}ms", result.avg_latency_ms);
+            println!("\nPer-table statistics:");
+            for stat in &result.table_stats {
+                println!(
+                    "  {:<30} queries: {:<8} errors: {:<8} avg latency: {:.2}ms",
+                    stat.table_name, stat.queries, stat.errors, stat.avg_latency_ms
+                );
+            }
             Ok(())
         }
         Command::JsonRpc { endpoint } => {

--- a/crates/sui-rpc-benchmark/src/lib.rs
+++ b/crates/sui-rpc-benchmark/src/lib.rs
@@ -6,7 +6,7 @@ pub mod direct;
 use std::time::Duration;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{value_parser, Parser, Subcommand};
 use tracing::info;
 use url::Url;
 
@@ -32,9 +32,10 @@ pub enum Command {
     DirectQuery {
         #[clap(
             long,
-            default_value = "postgres://postgres:postgres@localhost:5432/sui"
+            default_value = "postgres://postgres:postgres@localhost:5432/sui",
+            value_parser = value_parser!(Url)
         )]
-        db_url: String,
+        db_url: Url,
         #[clap(long, default_value = "50")]
         concurrency: usize,
         #[clap(long, default_value = "30")]
@@ -63,7 +64,6 @@ pub async fn run_benchmarks() -> Result<(), anyhow::Error> {
             concurrency,
             duration_secs,
         } => {
-            let db_url = Url::parse(&db_url)?;
             info!("Running direct query benchmark against DB {}", db_url);
 
             let template_generator = QueryTemplateGenerator::new(db_url.clone());

--- a/crates/sui-rpc-benchmark/src/main.rs
+++ b/crates/sui-rpc-benchmark/src/main.rs
@@ -7,5 +7,8 @@ use sui_rpc_benchmark::run_benchmarks;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
     run_benchmarks().await
 }

--- a/crates/sui-rpc-benchmark/src/main.rs
+++ b/crates/sui-rpc-benchmark/src/main.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+use sui_rpc_benchmark::run_benchmarks;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    run_benchmarks().await
+}


### PR DESCRIPTION
## Description 
main things in this pr
- generate template queries based on tables in the DB, excluding `__diesel_schema_migrations`
- enrich the template with values read from DB and execute queries in parallel
- configs of concurrency and duration time
- metrics collection and reports

## Test plan 
- local run with a local DB populated with latest `sui-indexer-alt-schema`
```
cargo run --bin sui-rpc-benchmark -- direct \
    --db-url "postgres://postgres:postgres@localhost/gegao" \
    --concurrency 10 \
    --duration-secs 10
```

report with local DB
```

Total queries: 211772
Total errors: 0
Average latency: 0.46ms

Per-table statistics:
  obj_info                       queries: 33526    errors: 0        avg latency: 0.49ms
  ev_struct_inst                 queries: 31598    errors: 0        avg latency: 0.47ms
  tx_calls                       queries: 28752    errors: 0        avg latency: 0.45ms
  ev_emit_mod                    queries: 18321    errors: 0        avg latency: 0.44ms
  tx_affected_objects            queries: 11495    errors: 0        avg latency: 0.43ms
  tx_affected_addresses          queries: 11472    errors: 0        avg latency: 0.43ms
  sum_packages                   queries: 10759    errors: 0        avg latency: 0.55ms
  tx_kinds                       queries: 8140     errors: 0        avg latency: 0.43ms
  coin_balance_buckets           queries: 7542     errors: 0        avg latency: 0.45ms
  obj_versions                   queries: 7485     errors: 0        avg latency: 0.43ms
  kv_epoch_ends                  queries: 3750     errors: 0        avg latency: 0.45ms
  watermarks                     queries: 3742     errors: 0        avg latency: 0.44ms
  tx_digests                     queries: 3690     errors: 0        avg latency: 0.42ms
  tx_balance_changes             queries: 3662     errors: 0        avg latency: 0.42ms
  kv_checkpoints                 queries: 3619     errors: 0        avg latency: 0.43ms
  cp_sequence_numbers            queries: 3590     errors: 0        avg latency: 0.42ms
  kv_transactions                queries: 3463     errors: 0        avg latency: 0.43ms
  kv_protocol_configs            queries: 3451     errors: 0        avg latency: 0.44ms
  kv_epoch_starts                queries: 3448     errors: 0        avg latency: 0.71ms
  kv_genesis                     queries: 3424     errors: 0        avg latency: 0.42ms
  kv_objects                     queries: 3422     errors: 0        avg latency: 0.42ms
  kv_feature_flags               queries: 3421     errors: 0        avg latency: 0.42ms
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
