### PR TITLE
indexer-alt: try_for_each_spawned

### DIFF
--- a/crates/sui-indexer-alt/src/task.rs
+++ b/crates/sui-indexer-alt/src/task.rs
@@ -1,11 +1,132 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::iter;
+use std::{future::Future, iter, panic, pin::pin};
 
-use futures::future::{self, Either};
+use futures::{
+    future::{self, Either},
+    stream::{FuturesUnordered, Stream, StreamExt},
+};
 use tokio::{signal, sync::oneshot, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+
+/// Extension trait introducing `try_for_each_spawned` to all streams.
+pub trait TrySpawnStreamExt: Stream {
+    /// Attempts to run this stream to completion, executing the provided asynchronous closure on
+    /// each element from the stream as elements become available.
+    ///
+    /// This is similar to [StreamExt::for_each_concurrent], but it may take advantage of any
+    /// parallelism available in the underlying runtime, because each unit of work is spawned as
+    /// its own tokio task.
+    ///
+    /// The first argument is an optional limit on the number of tasks to spawn concurrently.
+    /// Values of `0` and `None` are interpreted as no limit, and any other value will result in no
+    /// more than that many tasks being spawned at one time.
+    ///
+    /// ## Safety
+    ///
+    /// This function will panic if any of its futures panics, will return early with success if
+    /// the runtime it is running on is cancelled, and will return early with an error propagated
+    /// from any worker that produces an error.
+    fn try_for_each_spawned<Fut, F, E>(
+        self,
+        limit: impl Into<Option<usize>>,
+        f: F,
+    ) -> impl Future<Output = Result<(), E>>
+    where
+        Fut: Future<Output = Result<(), E>> + Send + 'static,
+        F: FnMut(Self::Item) -> Fut,
+        E: Send + 'static;
+}
+
+impl<S: Stream + Sized + 'static> TrySpawnStreamExt for S {
+    fn try_for_each_spawned<Fut, F, E>(
+        self,
+        limit: impl Into<Option<usize>>,
+        mut f: F,
+    ) -> impl Future<Output = Result<(), E>>
+    where
+        Fut: Future<Output = Result<(), E>> + Send + 'static,
+        F: FnMut(Self::Item) -> Fut,
+        E: Send + 'static,
+    {
+        async move {
+            // Maximum number of tasks to spawn concurrently.
+            let limit = match limit.into() {
+                Some(0) | None => usize::MAX,
+                Some(n) => n,
+            };
+
+            // Number of permits to spawn tasks left.
+            let mut permits = limit;
+            // Futures for already spawned tasks.
+            let mut handles = FuturesUnordered::new();
+            // Whether the worker pool has stopped accepting new items and is draining.
+            let mut draining = false;
+            // Error that occurred in one of the workers, to be propagated to the called on exit.
+            let mut error = None;
+
+            let mut self_ = pin!(self);
+
+            loop {
+                tokio::select! {
+                    next = self_.next(), if !draining && permits > 0 => {
+                        if let Some(item) = next {
+                            permits -= 1;
+                            handles.push(tokio::spawn(f(item)));
+                        } else {
+                            // If the stream is empty, signal that the worker pool is going to
+                            // start draining now, so that once we get all our permits back, we
+                            // know we can wind down the pool.
+                            draining = true;
+                        }
+                    }
+
+                    Some(res) = handles.next() => {
+                        match res {
+                            Ok(Err(e)) if error.is_none() => {
+                                error = Some(e);
+                                permits += 1;
+                                draining = true;
+                            }
+
+                            Ok(_) => permits += 1,
+
+                            // Worker panicked, propagate the panic.
+                            Err(e) if e.is_panic() => {
+                                panic::resume_unwind(e.into_panic())
+                            }
+
+                            // Worker was cancelled -- this can only happen if its join handle was
+                            // cancelled (not possible because that was created in this function),
+                            // or the runtime it was running in was wound down, in which case,
+                            // prepare the worker pool to drain.
+                            Err(e) => {
+                                assert!(e.is_cancelled());
+                                permits += 1;
+                                draining = true;
+                            }
+                        }
+                    }
+
+                    else => {
+                        // Not accepting any more items from the stream, and all our workers are
+                        // idle, so we stop.
+                        if permits == limit && draining {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if let Some(e) = error {
+                Err(e)
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
 
 /// Manages cleanly exiting the process, either because one of its constituent services has stopped
 /// or because an interrupt signal was sent to the process.
@@ -29,7 +150,7 @@ pub async fn graceful_shutdown<T>(
         None
     };
 
-    tokio::pin!(interrupt);
+    let interrupt = pin!(interrupt);
     let futures: Vec<_> = services
         .into_iter()
         .map(|s| Either::Left(Box::pin(async move { s.await.ok() })))
@@ -45,4 +166,165 @@ pub async fn graceful_shutdown<T>(
     results.extend(first);
     results.extend(future::join_all(rest).await.into_iter().flatten());
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+        time::Duration,
+    };
+
+    use futures::stream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn explicit_sequential_iteration() {
+        let actual = Arc::new(Mutex::new(vec![]));
+        let result = stream::iter(0..100)
+            .try_for_each_spawned(1, |i| {
+                let actual = actual.clone();
+                async move {
+                    tokio::time::sleep(Duration::from_millis(100 - i)).await;
+                    actual.lock().unwrap().push(i);
+                    Ok::<(), ()>(())
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+
+        let actual = Arc::try_unwrap(actual).unwrap().into_inner().unwrap();
+        let expect: Vec<_> = (0..100).collect();
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn concurrent_iteration() {
+        let actual = Arc::new(AtomicUsize::new(0));
+        let result = stream::iter(0..100)
+            .try_for_each_spawned(16, |i| {
+                let actual = actual.clone();
+                async move {
+                    actual.fetch_add(i, Ordering::Relaxed);
+                    Ok::<(), ()>(())
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+
+        let actual = Arc::try_unwrap(actual).unwrap().into_inner();
+        let expect = 99 * 100 / 2;
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn implicit_unlimited_iteration() {
+        let actual = Arc::new(AtomicUsize::new(0));
+        let result = stream::iter(0..100)
+            .try_for_each_spawned(None, |i| {
+                let actual = actual.clone();
+                async move {
+                    actual.fetch_add(i, Ordering::Relaxed);
+                    Ok::<(), ()>(())
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+
+        let actual = Arc::try_unwrap(actual).unwrap().into_inner();
+        let expect = 99 * 100 / 2;
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn explicit_unlimited_iteration() {
+        let actual = Arc::new(AtomicUsize::new(0));
+        let result = stream::iter(0..100)
+            .try_for_each_spawned(0, |i| {
+                let actual = actual.clone();
+                async move {
+                    actual.fetch_add(i, Ordering::Relaxed);
+                    Ok::<(), ()>(())
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+
+        let actual = Arc::try_unwrap(actual).unwrap().into_inner();
+        let expect = 99 * 100 / 2;
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn max_concurrency() {
+        #[derive(Default, Debug)]
+        struct Jobs {
+            max: AtomicUsize,
+            curr: AtomicUsize,
+        }
+
+        let jobs = Arc::new(Jobs::default());
+
+        let result = stream::iter(0..32)
+            .try_for_each_spawned(4, |_| {
+                let jobs = jobs.clone();
+                async move {
+                    jobs.curr.fetch_add(1, Ordering::Relaxed);
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    let prev = jobs.curr.fetch_sub(1, Ordering::Relaxed);
+                    jobs.max.fetch_max(prev, Ordering::Relaxed);
+                    Ok::<(), ()>(())
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+
+        let Jobs { max, curr } = Arc::try_unwrap(jobs).unwrap();
+        assert_eq!(curr.into_inner(), 0);
+        assert!(max.into_inner() <= 4);
+    }
+
+    #[tokio::test]
+    async fn error_propagation() {
+        let actual = Arc::new(Mutex::new(vec![]));
+        let result = stream::iter(0..100)
+            .try_for_each_spawned(None, |i| {
+                let actual = actual.clone();
+                async move {
+                    if i < 42 {
+                        actual.lock().unwrap().push(i);
+                        Ok(())
+                    } else {
+                        Err(())
+                    }
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+
+        let actual = Arc::try_unwrap(actual).unwrap().into_inner().unwrap();
+        let expect: Vec<_> = (0..42).collect();
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn panic_propagation() {
+        let _ = stream::iter(0..100)
+            .try_for_each_spawned(None, |i| async move {
+                assert!(i < 42);
+                Ok::<(), ()>(())
+            })
+            .await;
+    }
 }


### PR DESCRIPTION
## Description

Create a `try_for_each_spawned` which works similarly to `try_for_each_concurrent` but spawns a new tokio task for each unit of work that it schedules based on values being pulled from the stream (but no more than the `limit` set on the max concurrency.

This does introduce some slight overhead if we run it with a limit of `1` (i.e. no concurrency) but otherwise will give the tokio runtime an opportunity to schedule each unit of work on a different thread (assuming the runtime is multi-threaded).

The interface is almost a drop-in replacement for
`try_for_each_concurrent` but with the following slight changes:

- The input stream does not need to be a `Result` itself.
- The future and returned error type must have `'static` lifetimes because they are being passed to the tokio runtime and we can't easily determine that they will not outlive the caller.

This addresses one of the main remaining differences between the existing indexer and `sui-indexer-alt` (`sui-data-ingestion-core`'s worker pool works roughly like this new abstraction, but without the support for streams etc).

## Test plan

New unit tests:

```
sui$ cargo nextest run -p sui-indexer-alt -- task::tests
```

Running the indexer locally also makes sure the system is still operable with the change.

Finally, I created some benchmarks in a repository to test that `try_for_each_concurrent` does not take advantage of parallelism and `try_for_each_spawned` does:

https://gist.github.com/amnn/6c6f198693d46d1f6d30bd7ef7be001d

Benchmarking results show that on a job counting the primes up to i for 2 <= i < 50,000, the concurrent and sequential implementations complete in 2.7s.

`try_for_each_spawned` without parallelism does the same work in 3.2s (slightly slower because of the overhead creating new tasks), and `try_for_each_spawned` with parallelism of `16` completes in about 400ms (an 8x improvement).

The most expensive individual task costs about 3ms to run on its own (counting the primes up to 50,000), which is roughly in line with the cost of processing.

The benchmarks also include an implementation that does the same thing as `try_for_each_spawned` but built out of existing stream extension libraries (`StreamExt::map`, and `StreamExt::buffered`) which have similar performance characteristics but don't have the same behaviour w.r.t. propagating panics and cancellations.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
