### PR TITLE
indexer-alt: metric for affected row histogram

### DIFF
--- a/crates/sui-indexer-alt/src/metrics.rs
+++ b/crates/sui-indexer-alt/src/metrics.rs
@@ -100,6 +100,7 @@ pub struct IndexerMetrics {
     pub collector_gather_latency: HistogramVec,
     pub collector_batch_size: HistogramVec,
     pub committer_commit_latency: HistogramVec,
+    pub committer_tx_rows: HistogramVec,
     pub watermark_gather_latency: HistogramVec,
     pub watermark_commit_latency: HistogramVec,
     pub watermark_pruner_read_latency: HistogramVec,
@@ -397,6 +398,14 @@ impl IndexerMetrics {
                 "Time taken to write a batch of rows to the database by this committer",
                 &["pipeline"],
                 DB_UPDATE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            committer_tx_rows: register_histogram_vec_with_registry!(
+                "indexer_committer_tx_rows",
+                "Number of rows written to the database in a single database transaction by this committer",
+                &["pipeline"],
+                BATCH_SIZE_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
@@ -138,6 +138,11 @@ pub(super) fn committer<H: Handler + 'static>(
                             .with_label_values(&[H::NAME])
                             .inc_by(affected as u64);
 
+                        metrics
+                            .committer_tx_rows
+                            .with_label_values(&[H::NAME])
+                            .observe(affected as f64);
+
                         Ok(())
                     }
                 };

--- a/crates/sui-indexer-alt/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/committer.rs
@@ -286,6 +286,11 @@ pub(super) fn committer<H: Handler + 'static>(
                         .inc_by(affected as u64);
 
                     metrics
+                        .committer_tx_rows
+                        .with_label_values(&[H::NAME])
+                        .observe(affected as f64);
+
+                    metrics
                         .watermark_epoch_in_db
                         .with_label_values(&[H::NAME])
                         .set(watermark.epoch_hi_inclusive);


### PR DESCRIPTION
## Description

Add a metric to track the distribution of affected rows per database transaction from the committer. This will help measure how many rows the `sum_obj_types` pipeline is touching per write.

## Test plan

Local run, and test on deployment.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
