### PR TITLE
 Fix integer overflow and underflow in DeferralKey methods and add corresponding tests

### DIFF
--- a/crates/sui-core/src/authority/transaction_deferral.rs
+++ b/crates/sui-core/src/authority/transaction_deferral.rs
@@ -54,7 +54,7 @@ impl DeferralKey {
                 deferred_from_round: 0,
             },
             Self::ConsensusRound {
-                future_round: consensus_round.checked_add(1).unwrap(),
+                future_round: consensus_round.saturating_add(1),
                 deferred_from_round: 0,
             },
         )
@@ -90,11 +90,15 @@ pub fn transaction_deferral_within_limit(
         deferred_from_round,
     } = deferral_key
     {
-        return (future_round - deferred_from_round) <= max_deferral_rounds_for_congestion_control;
+        if let Some(diff) = future_round.checked_sub(*deferred_from_round) {
+            return diff <= max_deferral_rounds_for_congestion_control;
+        } else {
+            // future_round < deferred_from_round
+            return false;
+        }
     }
-
     // TODO: drop transactions at the end of the queue if the queue is too long.
-
+    
     true
 }
 
@@ -208,5 +212,36 @@ mod object_cost_tests {
             }
         }
         assert!(result_count > 0);
+    }
+    #[test]
+    fn test_range_for_up_to_consensus_round_no_overflow() {
+        let consensus_round = u64::MAX;
+        let (_, max_key) = DeferralKey::range_for_up_to_consensus_round(consensus_round);
+    
+        match max_key {
+            DeferralKey::ConsensusRound { future_round, .. } => {
+                assert_eq!(future_round, u64::MAX);
+            }
+            _ => panic!("Expected ConsensusRound variant"),
+        }
+    }
+    #[test]
+    fn test_transaction_deferral_within_limit_underflow() {
+        let future_round = 100;
+        let deferred_from_round = 200;
+        let max_deferral_rounds_for_congestion_control = 10;
+    
+        let deferral_key = DeferralKey::new_for_consensus_round(future_round, deferred_from_round);
+        let result = transaction_deferral_within_limit(
+            &deferral_key,
+            max_deferral_rounds_for_congestion_control,
+        );
+    
+        // Expected result is false due to future_round < deferred_from_round
+        assert_eq!(
+            result,
+            false,
+            "Expected false because future_round < deferred_from_round"
+        );
     }
 }


### PR DESCRIPTION

## Description 

This PR addresses two critical issues in the `DeferralKey` implementation that could lead to integer overflow and underflow, potentially causing panics or incorrect behavior. It also includes new test cases to verify the correctness of the fixes.

**Issues Fixed:**

1. **Prevent Integer Overflow in `range_for_up_to_consensus_round`**

   - **Issue:** When `consensus_round` equals `u64::MAX`, using `checked_add(1).unwrap()` in `DeferralKey::range_for_up_to_consensus_round` causes a panic due to overflow.
   - **Solution:** Replace `checked_add(1).unwrap()` with `saturating_add(1)` to safely handle the maximum value without causing a panic.

2. **Prevent Integer Underflow in `transaction_deferral_within_limit`**

   - **Issue:** In `transaction_deferral_within_limit`, when `future_round` is less than `deferred_from_round`, subtracting them causes an underflow, resulting in incorrect behavior.
   - **Solution:** Use `checked_sub` to safely perform the subtraction, and handle the `None` case by returning `false`.

## Test plan 

1. **Test Name:** `test_range_for_up_to_consensus_round_no_overflow`

   **Description:** Verifies that `DeferralKey::range_for_up_to_consensus_round` does not overflow when `consensus_round` is `u64::MAX`, and that it correctly returns `future_round` equal to `u64::MAX`.

2. **Test Name:** `test_transaction_deferral_within_limit_underflow`

   **Description:** Ensures that `transaction_deferral_within_limit` correctly handles cases where `future_round` is less than `deferred_from_round`, preventing integer underflow and returning `false`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [X] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
