### PR TITLE
[kv store] add watermark table to bigtable

### DIFF
--- a/crates/sui-data-ingestion/src/lib.rs
+++ b/crates/sui-data-ingestion/src/lib.rs
@@ -4,7 +4,7 @@
 mod progress_store;
 mod workers;
 
-pub use progress_store::DynamoDBProgressStore;
+pub use progress_store::IngestionWorkflowsProgressStore;
 pub use workers::{
     ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig,
     KVStoreWorker,

--- a/crates/sui-data-ingestion/src/main.rs
+++ b/crates/sui-data-ingestion/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use sui_data_ingestion::{
     ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker,
-    DynamoDBProgressStore, KVStoreTaskConfig, KVStoreWorker,
+    IngestionWorkflowsProgressStore, KVStoreTaskConfig, KVStoreWorker,
 };
 use sui_data_ingestion_core::{DataIngestionMetrics, ReaderOptions};
 use sui_data_ingestion_core::{IndexerExecutor, WorkerPool};
@@ -119,12 +119,27 @@ async fn main() -> Result<()> {
     mysten_metrics::init_metrics(&registry);
     let metrics = DataIngestionMetrics::new(&registry);
 
-    let progress_store = DynamoDBProgressStore::new(
+    let mut bigtable_client = None;
+    for task in &config.tasks {
+        if let Task::BigTableKV(kv_config) = &task.task {
+            bigtable_client = Some(
+                BigTableClient::new_remote(
+                    kv_config.instance_id.clone(),
+                    false,
+                    Some(Duration::from_secs(kv_config.timeout_secs as u64)),
+                )
+                .await?,
+            );
+        }
+    }
+
+    let progress_store = IngestionWorkflowsProgressStore::new(
         &config.progress_store.aws_access_key_id,
         &config.progress_store.aws_secret_access_key,
         config.progress_store.aws_region,
         config.progress_store.table_name,
         config.is_backfill,
+        bigtable_client,
     )
     .await;
     let mut executor = IndexerExecutor::new(progress_store, config.tasks.len(), metrics);

--- a/crates/sui-data-ingestion/src/progress_store.rs
+++ b/crates/sui-data-ingestion/src/progress_store.rs
@@ -11,21 +11,24 @@ use aws_sdk_s3::config::{Credentials, Region};
 use std::str::FromStr;
 use std::time::Duration;
 use sui_data_ingestion_core::ProgressStore;
+use sui_kvstore::{BigTableClient, KeyValueStoreWriter};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
-pub struct DynamoDBProgressStore {
+pub struct IngestionWorkflowsProgressStore {
     client: Client,
     table_name: String,
     is_backfill: bool,
+    bigtable_client: Option<BigTableClient>,
 }
 
-impl DynamoDBProgressStore {
+impl IngestionWorkflowsProgressStore {
     pub async fn new(
         aws_access_key_id: &str,
         aws_secret_access_key: &str,
         aws_region: String,
         table_name: String,
         is_backfill: bool,
+        bigtable_client: Option<BigTableClient>,
     ) -> Self {
         let credentials = Credentials::new(
             aws_access_key_id,
@@ -50,12 +53,13 @@ impl DynamoDBProgressStore {
             client,
             table_name,
             is_backfill,
+            bigtable_client,
         }
     }
 }
 
 #[async_trait]
-impl ProgressStore for DynamoDBProgressStore {
+impl ProgressStore for IngestionWorkflowsProgressStore {
     async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber> {
         let item = self
             .client
@@ -78,6 +82,11 @@ impl ProgressStore for DynamoDBProgressStore {
     ) -> Result<()> {
         if self.is_backfill && checkpoint_number % 1000 != 0 {
             return Ok(());
+        }
+        if let Some(ref mut bigtable_client) = self.bigtable_client {
+            bigtable_client
+                .save_watermark(&task_name, checkpoint_number)
+                .await?;
         }
         let backoff = backoff::ExponentialBackoff::default();
         backoff::future::retry(backoff, || async {

--- a/crates/sui-kvstore/src/bigtable/init.sh
+++ b/crates/sui-kvstore/src/bigtable/init.sh
@@ -10,7 +10,7 @@ if [[ -n $BIGTABLE_EMULATOR_HOST ]]; then
   command+=(-project emulator)
 fi
 
-for table in objects transactions checkpoints checkpoints_by_digest; do
+for table in objects transactions checkpoints checkpoints_by_digest watermark; do
   (
     set -x
     "${command[@]}" createtable $table

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -34,6 +34,7 @@ pub trait KeyValueStoreReader {
     ) -> Result<Option<Checkpoint>>;
     async fn get_latest_checkpoint(&mut self) -> Result<CheckpointSequenceNumber>;
     async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>>;
+    async fn get_watermark(&mut self, task_name: &str) -> Result<u64>;
 }
 
 #[async_trait]
@@ -41,6 +42,11 @@ pub trait KeyValueStoreWriter {
     async fn save_objects(&mut self, objects: &[&Object]) -> Result<()>;
     async fn save_transactions(&mut self, transactions: &[TransactionData]) -> Result<()>;
     async fn save_checkpoint(&mut self, checkpoint: &CheckpointData) -> Result<()>;
+    async fn save_watermark(
+        &mut self,
+        name: &str,
+        watermark: CheckpointSequenceNumber,
+    ) -> Result<()>;
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Description 

The PR adds a watermark table to BigTable. The internal workflow progress store now writes watermarks to both DynamoDB and BigTable. In the future, the DynamoDB progress store will be deprecated

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
