### PR TITLE
Make sui-tools a multiplatform build

### DIFF
--- a/docker/sui-tools/build.sh
+++ b/docker/sui-tools/build.sh
@@ -19,7 +19,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker buildx build --platform linux/amd64,linux/arm64 -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	"$@"


### PR DESCRIPTION
## Description 

This updates the build process for the `sui-tools` docker image to use a multiplatform build, which should improve the compatibility of the image on Macs.

## Test plan 

Ran `./docker/sui-tools/build.sh` locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
