### PR TITLE
change prettier-extension vscode setting name, tabSize to  tabWidth

### DIFF
--- a/external-crates/move/tooling/prettier-extension/package.json
+++ b/external-crates/move/tooling/prettier-extension/package.json
@@ -36,10 +36,10 @@
 					"default": 100,
 					"description": "Set `printWidth` in prettier"
 				},
-				"prettierMove.tabSize": {
+				"prettierMove.tabWidth": {
 					"type": "number",
 					"default": 4,
-					"description": "Set `tabSize` in prettier"
+					"description": "Set `tabWidth` in prettier"
 				},
 				"prettierMove.useModuleLabel": {
 					"type": "boolean",


### PR DESCRIPTION
## Description 

the prettier-move in vscode setting, `tabWidth` label name is error, it show the `tabSize`. So when I set the `tabSize`, format not work

in the source, the extension only read the `tabWidth` value, so need change `tabWidth` to `tabWidth`

https://github.com/MystenLabs/sui/blob/main/external-crates/move/tooling/prettier-extension/src/extension.js#L110

## Test plan 

How did you test the new or updated feature?
yes

open the vscode settings, then find the menu that name is  `prettierMove`
you can see the `Tab Size`, set it to 2,
![image](https://github.com/user-attachments/assets/d6876f79-5f9c-4cb7-9f29-f64aa2cb5c70)
 then format the move file, it not work
![image](https://github.com/user-attachments/assets/382a6b60-7e16-438e-8257-b0c0d6ad29a9)

but direct set the tabWidth, it work
![image](https://github.com/user-attachments/assets/a4579118-3f14-490c-aeb2-7d156a696550)

![image](https://github.com/user-attachments/assets/93166d25-dc0f-4cd6-b219-c4aee77bd376)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
