### PR TITLE
New Deepbook Indexer Endpoints

### DIFF
--- a/crates/sui-deepbook-indexer/src/models.rs
+++ b/crates/sui-deepbook-indexer/src/models.rs
@@ -67,7 +67,7 @@ pub struct OrderFillSummary {
     pub pool_id: String,
     pub maker_balance_manager_id: String,
     pub taker_balance_manager_id: String,
-    pub base_quantity: i64,
+    pub quantity: i64,
 }
 
 #[derive(QueryableByName, Debug, Serialize)]

--- a/crates/sui-deepbook-indexer/src/models.rs
+++ b/crates/sui-deepbook-indexer/src/models.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::data_types::PgTimestamp;
-use diesel::{Identifiable, Insertable, Queryable, QueryableByName, Selectable};
+use diesel::{Identifiable, Insertable, Queryable, Selectable};
 
 use serde::Serialize;
 use sui_indexer_builder::{Task, LIVE_TASK_TARGET_CHECKPOINT};
 
 use crate::schema::{
-    balances, balances_summary, flashloans, order_fills, order_updates, pool_prices, pools,
-    progress_store, proposals, rebates, stakes, sui_error_transactions, trade_params_update, votes,
+    balances, flashloans, order_fills, order_updates, pool_prices, pools, progress_store,
+    proposals, rebates, stakes, sui_error_transactions, trade_params_update, votes,
 };
 
 #[derive(Queryable, Selectable, Insertable, Identifiable, Debug)]

--- a/crates/sui-deepbook-indexer/src/models.rs
+++ b/crates/sui-deepbook-indexer/src/models.rs
@@ -70,14 +70,6 @@ pub struct OrderFillSummary {
     pub quantity: i64,
 }
 
-#[derive(QueryableByName, Debug, Serialize)]
-#[diesel(table_name = balances_summary)]
-pub struct BalancesSummary {
-    pub asset: String,
-    pub amount: i64,
-    pub deposit: bool,
-}
-
 #[derive(Queryable, Selectable, Insertable, Identifiable, Debug)]
 #[diesel(table_name = flashloans, primary_key(event_digest))]
 pub struct Flashloan {

--- a/crates/sui-deepbook-indexer/src/schema.rs
+++ b/crates/sui-deepbook-indexer/src/schema.rs
@@ -240,11 +240,3 @@ diesel::allow_tables_to_appear_in_same_query!(
     trade_params_update,
     votes,
 );
-
-diesel::table! {
-    balances_summary (asset) {
-        asset -> Text,
-        amount -> Int8,
-        deposit -> Bool,
-    }
-}

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -24,10 +24,8 @@ use std::{collections::HashMap, net::SocketAddr};
 use tokio::{net::TcpListener, task::JoinHandle};
 
 pub const GET_POOLS_PATH: &str = "/get_pools";
-pub const GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID: &str =
-    "/get_24hr_volume_by_balance_manager_id/:pool_id/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
-    "/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id/:start_time/:end_time/:interval";
+    "/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_PATH: &str =
@@ -45,10 +43,6 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
         .route("/", get(health_check))
         .route(GET_POOLS_PATH, get(get_pools))
         .route(GET_HISTORICAL_VOLUME_PATH, get(get_historical_volume))
-        .route(
-            GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID,
-            get(get_24hr_volume_by_balance_manager_id),
-        )
         .route(
             GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL,
             get(get_historical_volume_by_balance_manager_id_with_interval),
@@ -147,56 +141,6 @@ async fn get_historical_volume(
     Ok(Json(volume_by_pool))
 }
 
-async fn get_24hr_volume_by_balance_manager_id(
-    Path((pool_id, balance_manager_id)): Path<(String, String)>,
-    Query(params): Query<HashMap<String, String>>,
-    State(state): State<PgDeepbookPersistent>,
-) -> Result<Json<Vec<i64>>, DeepBookError> {
-    let connection = &mut state.pool.get().await?;
-    let unix_ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as i64;
-    let day_ago = unix_ts - 24 * 60 * 60 * 1000;
-
-    let volume_in_base = params.get("volume_in_base").map(|v| v == "true").unwrap_or(true);
-    let column_to_query = if volume_in_base {
-        sql::<diesel::sql_types::BigInt>("base_quantity")
-    } else {
-        sql::<diesel::sql_types::BigInt>("quote_quantity")
-    };
-
-    let results: Vec<OrderFillSummary> = schema::order_fills::table
-        .select((
-            schema::order_fills::pool_id,
-            schema::order_fills::maker_balance_manager_id,
-            schema::order_fills::taker_balance_manager_id,
-            column_to_query,
-        ))
-        .filter(schema::order_fills::pool_id.eq(pool_id))
-        .filter(schema::order_fills::onchain_timestamp.gt(day_ago))
-        .filter(
-            schema::order_fills::maker_balance_manager_id
-                .eq(&balance_manager_id)
-                .or(schema::order_fills::taker_balance_manager_id.eq(&balance_manager_id)),
-        )
-        .load(connection)
-        .await?;
-
-    let mut maker_vol = 0;
-    let mut taker_vol = 0;
-    for order_fill in results {
-        if order_fill.maker_balance_manager_id == balance_manager_id {
-            maker_vol += order_fill.quantity;
-        };
-        if order_fill.taker_balance_manager_id == balance_manager_id {
-            taker_vol += order_fill.quantity;
-        };
-    }
-
-    Ok(Json(vec![maker_vol, taker_vol]))
-}
-
 async fn get_historical_volume_by_balance_manager_id(
     Path((pool_ids, balance_manager_id)): Path<(String, String)>,
     Query(params): Query<HashMap<String, String>>,
@@ -259,18 +203,18 @@ async fn get_historical_volume_by_balance_manager_id(
 }
 
 async fn get_historical_volume_by_balance_manager_id_with_interval(
-    Path((pool_ids, balance_manager_id, start_time, end_time, interval)): Path<(
-        String,
-        String,
-        i64,
-        i64,
-        i64,
-    )>,
+    Path((pool_ids, balance_manager_id)): Path<(String, String)>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<PgDeepbookPersistent>,
 ) -> Result<Json<HashMap<String, HashMap<String, Vec<i64>>>>, DeepBookError> {
     let connection = &mut state.pool.get().await?;
     let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
+
+    // Parse interval from query parameters (in seconds), default to 1 hour (3600 seconds)
+    let interval = params
+        .get("interval")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(3600); // Default interval: 1 hour
 
     if interval <= 0 {
         return Err(DeepBookError::InternalError(
@@ -278,10 +222,25 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
         ));
     }
 
-    let mut metrics_by_interval: HashMap<String, HashMap<String, Vec<i64>>> = HashMap::new();
-    let mut current_start = start_time * 1000;
     let interval_ms = interval * 1000;
-    while current_start + interval_ms <= end_time * 1000 {
+
+    // Parse start_time and end_time (in seconds) and convert to milliseconds
+    let end_time = params
+        .get("end_time")
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(|t| t * 1000) // Convert to milliseconds
+        .unwrap_or_else(|| SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64);
+
+    let start_time = params
+        .get("start_time")
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(|t| t * 1000) // Convert to milliseconds
+        .unwrap_or_else(|| end_time - 24 * 60 * 60 * 1000);
+
+    let mut metrics_by_interval: HashMap<String, HashMap<String, Vec<i64>>> = HashMap::new();
+
+    let mut current_start = start_time;
+    while current_start + interval_ms <= end_time {
         let current_end = current_start + interval_ms;
 
         let volume_in_base = params.get("volume_in_base").map(|v| v == "true").unwrap_or(true);

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -24,7 +24,6 @@ use std::{collections::HashMap, net::SocketAddr};
 use tokio::{net::TcpListener, task::JoinHandle};
 
 pub const GET_POOLS_PATH: &str = "/get_pools";
-pub const GET_24HR_VOLUME_PATH: &str = "/get_24hr_volume/:pool_ids";
 pub const GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_24hr_volume_by_balance_manager_id/:pool_id/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
@@ -32,8 +31,7 @@ pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id/:start_time/:end_time";
 pub const GET_HISTORICAL_VOLUME_PATH: &str =
-    "/get_historical_volume/:pool_ids/:start_time/:end_time";
-pub const GET_NET_DEPOSITS: &str = "/get_net_deposits/:asset_ids/:timestamp";
+    "/get_historical_volume/:pool_ids";
 
 pub fn run_server(socket_address: SocketAddr, state: PgDeepbookPersistent) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -46,7 +44,6 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
     Router::new()
         .route("/", get(health_check))
         .route(GET_POOLS_PATH, get(get_pools))
-        .route(GET_24HR_VOLUME_PATH, get(get_24hr_volume))
         .route(GET_HISTORICAL_VOLUME_PATH, get(get_historical_volume))
         .route(
             GET_24HR_VOLUME_BY_BALANCE_MANAGER_ID,
@@ -60,7 +57,6 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
             GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID,
             get(get_historical_volume_by_balance_manager_id),
         )
-        .route(GET_NET_DEPOSITS, get(get_net_deposits))
         .with_state(state)
 }
 
@@ -102,45 +98,29 @@ async fn get_pools(
     Ok(Json(results))
 }
 
-async fn get_24hr_volume(
-    Path(pool_ids): Path<String>,
-    State(state): State<PgDeepbookPersistent>,
-) -> Result<Json<HashMap<String, u64>>, DeepBookError> {
-    let connection = &mut state.pool.get().await?;
-    let unix_ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as i64;
-    let day_ago = unix_ts - 24 * 60 * 60 * 1000;
-
-    let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
-
-    let results: Vec<(String, i64)> = schema::order_fills::table
-        .select((
-            schema::order_fills::pool_id,
-            schema::order_fills::base_quantity,
-        ))
-        .filter(schema::order_fills::pool_id.eq_any(pool_ids_list))
-        .filter(schema::order_fills::onchain_timestamp.gt(day_ago))
-        .load(connection)
-        .await?;
-
-    let mut volume_by_pool = HashMap::new();
-    for (pool_id, volume) in results {
-        *volume_by_pool.entry(pool_id).or_insert(0) += volume as u64;
-    }
-
-    Ok(Json(volume_by_pool))
-}
-
 async fn get_historical_volume(
-    Path((pool_ids, start_time, end_time)): Path<(String, i64, i64)>,
+    Path(pool_ids): Path<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<PgDeepbookPersistent>,
 ) -> Result<Json<HashMap<String, u64>>, DeepBookError> {
     let connection = &mut state.pool.get().await?;
 
     let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
+
+    // Get start_time and end_time from query parameters (in seconds)
+    let end_time = params
+        .get("end_time")
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(|t| t * 1000) // Convert to milliseconds
+        .unwrap_or_else(|| SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64);
+
+    let start_time = params
+        .get("start_time")
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(|t| t * 1000) // Convert to milliseconds
+        .unwrap_or_else(|| end_time - 24 * 60 * 60 * 1000);
+
+    // Determine whether to query volume in base or quote
     let volume_in_base = params.get("volume_in_base").map(|v| v == "true").unwrap_or(true);
     let column_to_query = if volume_in_base {
         sql::<diesel::sql_types::BigInt>("base_quantity")
@@ -217,6 +197,54 @@ async fn get_24hr_volume_by_balance_manager_id(
     Ok(Json(vec![maker_vol, taker_vol]))
 }
 
+async fn get_historical_volume_by_balance_manager_id(
+    Path((pool_ids, balance_manager_id, start_time, end_time)): Path<(String, String, i64, i64)>,
+    Query(params): Query<HashMap<String, String>>,
+    State(state): State<PgDeepbookPersistent>,
+) -> Result<Json<HashMap<String, Vec<i64>>>, DeepBookError> {
+    let connection = &mut state.pool.get().await?;
+    let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
+
+    let volume_in_base = params.get("volume_in_base").map(|v| v == "true").unwrap_or(true);
+    let column_to_query = if volume_in_base {
+        sql::<diesel::sql_types::BigInt>("base_quantity")
+    } else {
+        sql::<diesel::sql_types::BigInt>("quote_quantity")
+    };
+
+    let results: Vec<OrderFillSummary> = schema::order_fills::table
+        .select((
+            schema::order_fills::pool_id,
+            schema::order_fills::maker_balance_manager_id,
+            schema::order_fills::taker_balance_manager_id,
+            column_to_query,
+        ))
+        .filter(schema::order_fills::pool_id.eq_any(&pool_ids_list))
+        .filter(schema::order_fills::onchain_timestamp.between(start_time * 1000, end_time * 1000))
+        .filter(
+            schema::order_fills::maker_balance_manager_id
+                .eq(&balance_manager_id)
+                .or(schema::order_fills::taker_balance_manager_id.eq(&balance_manager_id)),
+        )
+        .load(connection)
+        .await?;
+
+    let mut volume_by_pool: HashMap<String, Vec<i64>> = HashMap::new();
+    for order_fill in results {
+        let entry = volume_by_pool
+            .entry(order_fill.pool_id.clone())
+            .or_insert(vec![0, 0]);
+        if order_fill.maker_balance_manager_id == balance_manager_id {
+            entry[0] += order_fill.quantity;
+        }
+        if order_fill.taker_balance_manager_id == balance_manager_id {
+            entry[1] += order_fill.quantity;
+        }
+    }
+
+    Ok(Json(volume_by_pool))
+}
+
 async fn get_historical_volume_by_balance_manager_id_with_interval(
     Path((pool_ids, balance_manager_id, start_time, end_time, interval)): Path<(
         String,
@@ -286,92 +314,4 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
     }
 
     Ok(Json(metrics_by_interval))
-}
-
-async fn get_historical_volume_by_balance_manager_id(
-    Path((pool_ids, balance_manager_id, start_time, end_time)): Path<(String, String, i64, i64)>,
-    Query(params): Query<HashMap<String, String>>,
-    State(state): State<PgDeepbookPersistent>,
-) -> Result<Json<HashMap<String, Vec<i64>>>, DeepBookError> {
-    let connection = &mut state.pool.get().await?;
-    let pool_ids_list: Vec<String> = pool_ids.split(',').map(|s| s.to_string()).collect();
-
-    let volume_in_base = params.get("volume_in_base").map(|v| v == "true").unwrap_or(true);
-    let column_to_query = if volume_in_base {
-        sql::<diesel::sql_types::BigInt>("base_quantity")
-    } else {
-        sql::<diesel::sql_types::BigInt>("quote_quantity")
-    };
-
-    let results: Vec<OrderFillSummary> = schema::order_fills::table
-        .select((
-            schema::order_fills::pool_id,
-            schema::order_fills::maker_balance_manager_id,
-            schema::order_fills::taker_balance_manager_id,
-            column_to_query,
-        ))
-        .filter(schema::order_fills::pool_id.eq_any(&pool_ids_list))
-        .filter(schema::order_fills::onchain_timestamp.between(start_time * 1000, end_time * 1000))
-        .filter(
-            schema::order_fills::maker_balance_manager_id
-                .eq(&balance_manager_id)
-                .or(schema::order_fills::taker_balance_manager_id.eq(&balance_manager_id)),
-        )
-        .load(connection)
-        .await?;
-
-    let mut volume_by_pool: HashMap<String, Vec<i64>> = HashMap::new();
-    for order_fill in results {
-        let entry = volume_by_pool
-            .entry(order_fill.pool_id.clone())
-            .or_insert(vec![0, 0]);
-        if order_fill.maker_balance_manager_id == balance_manager_id {
-            entry[0] += order_fill.quantity;
-        }
-        if order_fill.taker_balance_manager_id == balance_manager_id {
-            entry[1] += order_fill.quantity;
-        }
-    }
-
-    Ok(Json(volume_by_pool))
-}
-
-#[debug_handler]
-async fn get_net_deposits(
-    Path((asset_ids, timestamp)): Path<(String, String)>,
-    State(state): State<PgDeepbookPersistent>,
-) -> Result<Json<HashMap<String, i64>>, DeepBookError> {
-    let connection = &mut state.pool.get().await?;
-    let mut query =
-        "SELECT asset, SUM(amount)::bigint AS amount, deposit FROM balances WHERE checkpoint_timestamp_ms < "
-            .to_string();
-    query.push_str(&timestamp);
-    query.push_str("000 AND asset in (");
-    for asset in asset_ids.split(",") {
-        if asset.starts_with("0x") {
-            let len = asset.len();
-            query.push_str(&format!("'{}',", &asset[2..len]));
-        } else {
-            query.push_str(&format!("'{}',", asset));
-        }
-    }
-    query.pop();
-    query.push_str(") GROUP BY asset, deposit");
-
-    let results: Vec<BalancesSummary> = diesel::sql_query(query).load(connection).await?;
-    let mut net_deposits = HashMap::new();
-    for result in results {
-        let mut asset = result.asset;
-        if !asset.starts_with("0x") {
-            asset.insert_str(0, "0x");
-        }
-        let amount = result.amount;
-        if result.deposit {
-            *net_deposits.entry(asset).or_insert(0) += amount;
-        } else {
-            *net_deposits.entry(asset).or_insert(0) -= amount;
-        }
-    }
-
-    Ok(Json(net_deposits))
 }

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -280,7 +280,10 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
             }
         }
 
-        metrics_by_interval.insert(current_start.to_string(), volume_by_pool);
+        metrics_by_interval.insert(
+            format!("[{}, {}]", current_start / 1000, current_end / 1000),
+            volume_by_pool,
+        );
 
         current_start = current_end;
     }


### PR DESCRIPTION
## Description 

1. Allow for querying for quote asset
2. Removed 24 hour endpoints, historical endpoints will return 24 hour volume using base asset by default if query params not given
3. Interval default is 1 hour for interval endpoint

**Endpoint call examples:**
Public endpoint: https://deepbook-indexer.mainnet.mystenlabs.com/
```
/get_historical_volume/:pool_ids?start_time=1731260703&end_time=1731692703&volume_in_base=true
/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id?start_time=1731260703&end_time=1731692703&volume_in_base=true
/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id?start_time=1731260703&end_time=1731462703&interval=86400&volume_in_base=true
```

## Test plan 

How did you test the new or updated feature?

Tested locally, updated docs

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
