### PR TITLE
[Soft bundle] enable soft bundle byte size checks on API

### DIFF
--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -203,6 +203,11 @@ pub fn make_consensus_adapter_for_test(
                 .map(|txn| SequencedConsensusTransaction::new_test(txn.clone()))
                 .collect();
 
+            for t in transactions {
+                let size = bcs::serialized_size(t).unwrap();
+                println!("Transaction serialized size: {:?}", size);
+            }
+
             let checkpoint_service = Arc::new(CheckpointServiceNoop {});
             let mut transactions = Vec::new();
             let mut executed_via_checkpoint = 0;

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1781,7 +1781,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
     let mut senders = Vec::new();
     let mut gas_objects = Vec::new();
     let mut owned_objects = Vec::new();
-    for _i in 0..10 {
+    for _i in 0..20 {
         let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
         let mut objects = create_gas_objects(2, sender);
         senders.push((sender, keypair));
@@ -1793,6 +1793,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
     protocol_config.set_enable_soft_bundle_for_testing(true);
     protocol_config.set_max_soft_bundle_size_for_testing(3);
+    protocol_config.set_consensus_max_transactions_in_block_bytes_for_testing(10_000);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)
@@ -1863,6 +1864,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
     // Case 0: submit an empty soft bundle.
+    println!("Case 0: submit an empty soft bundle.");
     {
         let response = client
             .handle_soft_bundle_certificates_v3(
@@ -1886,6 +1888,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 1: submit a soft bundle with more txs than the limit.
     // The bundle should be rejected.
+    print!("Case 1: submit a soft bundle with more txs than the limit.");
     {
         let mut certificates: Vec<CertifiedTransaction> = vec![];
         for i in 0..5 {
@@ -1934,6 +1937,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 2: submit a soft bundle with tx containing no shared object.
     // The bundle should be rejected.
+    println!("Case 2: submit a soft bundle with tx containing no shared object.");
     {
         let owned_object_ref = authority
             .get_object(&owned_objects[5].id())
@@ -1978,6 +1982,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 3: submit a soft bundle with txs of different gas prices.
     // The bundle should be rejected.
+    println!("Case 3: submit a soft bundle with txs of different gas prices.");
     {
         let cert0 = {
             let gas_object_ref = authority
@@ -2061,6 +2066,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 4: submit a soft bundle with txs whose consensus message has been processed.
     // The bundle should be rejected.
+    println!("Case 4: submit a soft bundle with txs whose consensus message has been processed.");
     {
         let cert0 = {
             let gas_object_ref = authority
@@ -2140,6 +2146,75 @@ async fn test_handle_soft_bundle_certificates_errors() {
             response.unwrap_err(),
             SuiError::UserInputError {
                 error: UserInputError::CertificateAlreadyProcessed { .. },
+            }
+        );
+    }
+
+    // Case 5: submit a soft bundle with total tx size exceeding the block size limit.
+    // The bundle should be rejected.
+    println!("Case 5: submit a soft bundle with total tx size exceeding the block size limit.");
+    {
+        let mut certificates: Vec<CertifiedTransaction> = vec![];
+
+        for i in 11..14 {
+            let owned_object_ref = authority
+                .get_object(&owned_objects[i].id())
+                .await
+                .unwrap()
+                .compute_object_reference();
+            let gas_object_ref = authority
+                .get_object(&gas_objects[i].id())
+                .await
+                .unwrap()
+                .compute_object_reference();
+            let sender = &senders[i];
+            let recipient = &senders[i + 1].0;
+
+            // Construct an oversized txn.
+            let pt = {
+                let mut builder = ProgrammableTransactionBuilder::new();
+                // Put a lot of commands in the txn so it's large.
+                for _ in 0..1000 {
+                    builder
+                        .transfer_object(*recipient, owned_object_ref)
+                        .unwrap();
+                }
+                builder.finish()
+            };
+
+            let data = TransactionData::new_programmable(
+                sender.0,
+                vec![gas_object_ref],
+                pt,
+                rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+                rgp,
+            );
+
+            let signed = to_sender_signed_transaction(data, &sender.1);
+            certificates.push(signed_tx_into_certificate(signed).await.into());
+        }
+
+        let response = client
+            .handle_soft_bundle_certificates_v3(
+                HandleSoftBundleCertificatesRequestV3 {
+                    certificates,
+                    wait_for_effects: true,
+                    include_events: false,
+                    include_auxiliary_data: false,
+                    include_input_objects: false,
+                    include_output_objects: false,
+                },
+                None,
+            )
+            .await;
+        assert!(response.is_err());
+        assert_matches!(
+            response.unwrap_err(),
+            SuiError::UserInputError {
+                error: UserInputError::SoftBundleTooLarge {
+                    size: 25116,
+                    limit: 10000
+                },
             }
         );
     }

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -2213,7 +2213,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
             SuiError::UserInputError {
                 error: UserInputError::SoftBundleTooLarge {
                     size: 25116,
-                    limit: 10000
+                    limit: 5000
                 },
             }
         );

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -267,6 +267,11 @@ pub enum UserInputError {
         limit
     )]
     TooManyTransactionsInSoftBundle { limit: u64 },
+    #[error(
+        "Total transactions size ({:?})bytes exceeds the maximum allowed ({:?})bytes in a Soft Bundle",
+        size, limit
+    )]
+    SoftBundleTooLarge { size: u64, limit: u64 },
     #[error("Transaction {:?} in Soft Bundle contains no shared objects", digest)]
     NoSharedObjectError { digest: TransactionDigest },
     #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]


### PR DESCRIPTION
## Description 

Following the work on https://github.com/MystenLabs/sui/pull/20325 , this PR is essential to ensure that submitted soft bundle transactions will make it through consensus and won't be rejected due to excessive size (for the edge cases). Now the API will return a `SoftBundleTooLarge` error if the soft bundle in size bytes is ` > consensus_block_size/2` . 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
