### PR TITLE
[indexer-alt] Properly respect skip_watermark in sequential pipelines

### DIFF
--- a/crates/sui-indexer-alt/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/mod.rs
@@ -52,7 +52,9 @@ pub struct PipelineConfig {
     )]
     watermark_interval: Duration,
 
-    /// Avoid writing to the watermark table
+    /// Avoid writing to the watermark table. Note that when this is set, for sequential pipelines,
+    /// the data in the table will become inconsistent from the point of view of the watermark.
+    /// This is useful when we need to benchmark using checkpoints that are not continuous from the watarmerk.
     #[arg(long)]
     pub skip_watermark: bool,
 }

--- a/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/mod.rs
@@ -89,6 +89,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     handler: H,
     initial_watermark: Option<CommitterWatermark<'static>>,
     config: PipelineConfig,
+    first_checkpoint: Option<u64>,
     checkpoint_lag: Option<u64>,
     db: Db,
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
@@ -107,9 +108,10 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     );
 
     let committer = committer::<H>(
-        config.clone(),
+        config,
         checkpoint_lag,
         initial_watermark,
+        first_checkpoint,
         committer_rx,
         watermark_tx,
         db.clone(),


### PR DESCRIPTION
## Description 

This PR ensures that the sequential pipeline respects the skip_watermark flag.
It also relaxes the consistency rule and allows for arbitrary first checkpoint when skip_watermark is set in the sequential pipeline.

## Test plan 

We should test this when adding unit tests too.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
