### PR TITLE
[move][move-compiler] Revise block comment parsing to be more-resilient

### DIFF
--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/block_comments_inline.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/block_comments_inline.exp
@@ -1,0 +1,18 @@
+warning[W01004]: invalid documentation comment
+   ┌─ tests/move_check/parser/block_comments_inline.move:11:61
+   │
+11 │         let /*comment*/s = S { /***/w, /**/x, /*comment*/y, /** doc */z };
+   │                                                             ^^^^^^^^ Documentation comment cannot be matched to a language item
+
+warning[W01004]: invalid documentation comment
+   ┌─ tests/move_check/parser/block_comments_inline.move:12:17
+   │
+12 │         let S { /****/w, /**/x, /*comment*/y, /** doc */z } = /*comment*/s;
+   │                 ^^^^ Documentation comment cannot be matched to a language item
+
+warning[W01004]: invalid documentation comment
+   ┌─ tests/move_check/parser/block_comments_inline.move:12:47
+   │
+12 │         let S { /****/w, /**/x, /*comment*/y, /** doc */z } = /*comment*/s;
+   │                                               ^^^^^^^^ Documentation comment cannot be matched to a language item
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/block_comments_inline.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/block_comments_inline.move
@@ -1,0 +1,15 @@
+module 0x42::m {
+
+    struct S {
+        /*comment*/ w: u64,
+        /*comment*/ x: u64,
+        /**/ y: u64,
+        /** doc */ z: u64,
+    }
+
+    fun t(w: u64, x: u64, /*ignore*/y: u64, z:u64/**/): (u64, u64, u64, u64) {
+        let /*comment*/s = S { /***/w, /**/x, /*comment*/y, /** doc */z };
+        let S { /****/w, /**/x, /*comment*/y, /** doc */z } = /*comment*/s;
+        (w, x, y, z)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/comments_nested_unbalanced.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/comments_nested_unbalanced.exp
@@ -2,5 +2,5 @@ warning[W01004]: invalid documentation comment
   ┌─ tests/move_check/parser/comments_nested_unbalanced.move:1:4
   │
 1 │ /* /** /** * / */ /** */
-  │    ^^ Unclosed block comment
+  │    ^^^ Unclosed block comment
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/empty_doc_comment.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/empty_doc_comment.move
@@ -1,0 +1,16 @@
+module 0x42::m {
+    /* */
+    struct A { }
+    /** **/
+    struct B { }
+    /** */
+    struct C { }
+    /*** */
+    struct D { }
+    /****/
+    struct E { }
+    /***/
+    struct F { }
+    /**/
+    struct G { }
+}


### PR DESCRIPTION
## Description 

Partially revise block comment parsing, plus fix issues around parsing `/**/`

## Test plan 

New tests that work now

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
