### PR TITLE
[CLI] Add a warning if the CLI falls behind more than 2 protocol versions

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -873,6 +873,8 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let chain_id = client.read_api().get_chain_identifier().await.ok();
 
+                check_protocol_version_and_warn(&client).await?;
+
                 let package_path =
                     package_path
                         .canonicalize()
@@ -980,6 +982,8 @@ impl SuiClientCommands {
                 let sender = sender.unwrap_or(context.active_address()?);
                 let client = context.get_client().await?;
                 let chain_id = client.read_api().get_chain_identifier().await.ok();
+
+                check_protocol_version_and_warn(&client).await?;
 
                 let package_path =
                     package_path
@@ -2991,4 +2995,25 @@ pub(crate) async fn prerender_clever_errors(
             *error = rendered;
         }
     }
+}
+
+/// Warn the user if the CLI falls behind more than 2 protocol versions.
+async fn check_protocol_version_and_warn(client: &SuiClient) -> Result<(), anyhow::Error> {
+    let protocol_cfg = client.read_api().get_protocol_config(None).await?;
+    let on_chain_protocol_version = protocol_cfg.protocol_version.as_u64();
+    let cli_protocol_version = ProtocolVersion::MAX.as_u64();
+    if (cli_protocol_version + 2) < on_chain_protocol_version {
+        eprintln!(
+            "{}",
+            format!(
+                "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
+                network's protocol version is {on_chain_protocol_version}.\nPlease consider \
+                updating the CLI: https://docs.sui.io/guides/developer/getting-started/sui-install"
+            )
+            .yellow()
+            .bold()
+        );
+    }
+
+    Ok(())
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -3006,9 +3006,12 @@ async fn check_protocol_version_and_warn(client: &SuiClient) -> Result<(), anyho
         eprintln!(
             "{}",
             format!(
-                "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
-                network's protocol version is {on_chain_protocol_version}.\nPlease consider \
-                updating the CLI: https://docs.sui.io/guides/developer/getting-started/sui-install"
+                "[warning] CLI's protocol version is {cli_protocol_version}, but the active \
+                network's protocol version is {on_chain_protocol_version}. \
+                \n Consider installing the latest version of the CLI - \
+                https://docs.sui.io/guides/developer/getting-started/sui-install \n\n \
+                If publishing/upgrading returns a dependency verification error, then install the \
+                latest CLI version."
             )
             .yellow()
             .bold()

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1253,12 +1253,9 @@ async fn check_protocol_version_and_warn(context: &mut WalletContext) -> Result<
 
     if (cli_protocol_version + 2) < on_chain_protocol_version {
         eprintln!(
-            "{}",
-            format!(
-                "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
+            "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
                 network's protocol version is {on_chain_protocol_version}.\nPlease consider \
                 updating the CLI: https://docs.sui.io/guides/developer/getting-started/sui-install"
-            )
         );
     }
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -47,7 +47,6 @@ use sui_keys::keypair_file::read_key;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_move::{self, execute_move_command};
 use sui_move_build::SuiPackageHooks;
-use sui_protocol_config::ProtocolConfig;
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use sui_sdk::wallet_context::WalletContext;
 use sui_swarm::memory::Swarm;
@@ -439,7 +438,6 @@ impl SuiCommand {
                     if let Err(e) = context.get_client().await?.check_api_version() {
                         eprintln!("{}", format!("[warning] {e}").yellow().bold());
                     }
-                    check_protocol_version_and_warn(&mut context).await?;
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
                     // Print help
@@ -1240,29 +1238,4 @@ pub fn parse_host_port(
     } else {
         format!("{default_host}:{default_port_if_missing}").parse::<SocketAddr>()
     }
-}
-
-/// Warn the user if the CLI falls behind more than 2 protocol versions.
-async fn check_protocol_version_and_warn(context: &mut WalletContext) -> Result<(), anyhow::Error> {
-    let client = context.get_client().await?;
-    let protocol_cfg = client.read_api().get_protocol_config(None).await?;
-    let on_chain_protocol_version = protocol_cfg.protocol_version.as_u64();
-    let cli_protocol_version = ProtocolConfig::get_for_max_version_UNSAFE()
-        .version
-        .as_u64();
-
-    if (cli_protocol_version + 2) < on_chain_protocol_version {
-        eprintln!(
-            "{}",
-            format!(
-                "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
-                network's protocol version is {on_chain_protocol_version}.\nPlease consider \
-                updating the CLI: https://docs.sui.io/guides/developer/getting-started/sui-install"
-            )
-            .yellow()
-            .bold()
-        );
-    }
-
-    Ok(())
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1253,9 +1253,14 @@ async fn check_protocol_version_and_warn(context: &mut WalletContext) -> Result<
 
     if (cli_protocol_version + 2) < on_chain_protocol_version {
         eprintln!(
-            "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
+            "{}",
+            format!(
+                "[warning] CLI is aware protocol version {cli_protocol_version}, but the active \
                 network's protocol version is {on_chain_protocol_version}.\nPlease consider \
                 updating the CLI: https://docs.sui.io/guides/developer/getting-started/sui-install"
+            )
+            .yellow()
+            .bold()
         );
     }
 


### PR DESCRIPTION
## Description 

This change adds a warning when the CLI falls behind more than 2 protocol versions against the current active network on which the command will be executing against.

## Test plan 

Locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Added a warn when trying to publish/upgrade a package, if the CLI fell behind more than two protocol versions than the network on which the package is about to be published/upgraded.
- [ ] Rust SDK:
- [ ] REST API:
