### PR TITLE
[simtests] adding nodes with unpruned history

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -554,7 +554,12 @@ mod test {
             config
         });
 
-        let test_cluster = build_test_cluster(4, 5000).await;
+        let test_cluster = Arc::new(
+            init_test_cluster_builder(4, 5000)
+                .with_num_unpruned_validators(2)
+                .build()
+                .await,
+        );
         let mut simulated_load_config = SimulatedLoadConfig::default();
         {
             let mut rng = thread_rng();


### PR DESCRIPTION
## Description 

Simtest `test_simulated_load_shared_object_congestion_control` seems to have been occasionally failing the assertion `assertion failed: results.num_successful_transactions > 0` , ex:
https://github.com/MystenLabs/sui/actions/runs/11949884838/job/33310255818
https://github.com/MystenLabs/sui/actions/runs/11082671210/job/30796002007

Investigating the issue this looks to be related to the Full Node falling behind on state sync from the rest of the network (due to connectivity issues etc) and when coming back effectively rest of the network has advanced and also pruned checkpoint history that would be necessary for the FN in order to advance. Any transactions at this point can not successfully execute as local state is missing dependencies which can never be fetched.

This PR is making two of the validators having unpruned history so if that happens FN can still sync state when falls behind.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
