### PR TITLE
indexer: fix and more tests for pruning enabling

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.exp
@@ -76,7 +76,9 @@ task 12, lines 57-67:
 Response: {
   "data": {
     "availableRange": {
-      "first": null,
+      "first": {
+        "sequenceNumber": 5
+      },
       "last": {
         "sequenceNumber": 6
       }

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.exp
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.exp
@@ -1,4 +1,4 @@
-processed 12 tasks
+processed 15 tasks
 
 task 1, lines 6-25:
 //# publish
@@ -67,6 +67,58 @@ Response: {
           "sequenceNumber": 6
         }
       ]
+    }
+  }
+}
+
+task 12, lines 57-67:
+//# run-graphql
+Response: {
+  "data": {
+    "availableRange": {
+      "first": null,
+      "last": {
+        "sequenceNumber": 6
+      }
+    }
+  }
+}
+
+task 13, lines 69-72:
+//# run-graphql
+Response: {
+  "data": {
+    "chainIdentifier": "084d40f2"
+  }
+}
+
+task 14, lines 74-103:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "validatorSet": {
+        "totalStake": "0",
+        "activeValidators": {
+          "nodes": [
+            {
+              "name": "validator-0"
+            }
+          ]
+        },
+        "validatorCandidatesSize": 0,
+        "inactivePoolsId": "0x514509ad914ad681508af65f278bea302598aa33653436d497faaa0dbd756f61"
+      },
+      "totalGasFees": "2000000",
+      "totalStakeRewards": "2000000",
+      "totalStakeSubsidies": "0",
+      "fundSize": "0",
+      "fundInflow": "7873600",
+      "fundOutflow": "978120",
+      "netInflow": "6895480",
+      "transactionBlocks": {
+        "nodes": []
+      }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.move
@@ -53,3 +53,51 @@ module Test::M1 {
     }
   }
 }
+
+//# run-graphql
+{
+  availableRange {
+    first {
+      sequenceNumber
+    }
+    last {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+    chainIdentifier
+}
+
+//# run-graphql
+{
+  epoch(id: 0) {
+    validatorSet {
+      totalStake
+      activeValidators {
+        nodes {
+          name
+        }
+      }
+      validatorCandidatesSize
+      inactivePoolsId
+    }
+    totalGasFees
+    totalStakeRewards
+    totalStakeSubsidies
+    fundSize
+    fundInflow
+    fundOutflow
+    netInflow
+    transactionBlocks {
+      nodes {
+        kind {
+          __typename
+        }
+        digest
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 51 --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 2
+//# init --protocol-version 51 --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 2 --objects-snapshot-min-checkpoint-lag 1
 
 //# publish
 module Test::M1 {


### PR DESCRIPTION
## Description 

- a fix for pruning wait-for, `checkpoints` should be pruned last so that wait-for in test_infra can use that as a watermark table
- add more tests for pruning enabling

## Test plan 

cargo nextest run sui-graphql-e2e-tests::tests run_test::stable/prune  

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
