### PR TITLE
snapshot restore: add option to reuse downloaded files

### DIFF
--- a/crates/sui-indexer/src/restorer/formal_snapshot.rs
+++ b/crates/sui-indexer/src/restorer/formal_snapshot.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
-use std::fs;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -55,17 +54,6 @@ impl IndexerFormalSnapshotRestorer {
 
         let base_path = PathBuf::from(restore_config.snapshot_download_dir.clone());
         let snapshot_dir = base_path.join("snapshot");
-        if snapshot_dir.exists() {
-            fs::remove_dir_all(snapshot_dir.clone()).unwrap();
-            info!(
-                "Deleted all files from snapshot directory: {:?}",
-                snapshot_dir
-            );
-        } else {
-            fs::create_dir(snapshot_dir.clone()).unwrap();
-            info!("Created snapshot directory: {:?}", snapshot_dir);
-        }
-
         let local_store_config = ObjectStoreConfig {
             object_store: Some(ObjectStoreType::File),
             directory: Some(snapshot_dir.clone().to_path_buf()),
@@ -80,6 +68,7 @@ impl IndexerFormalSnapshotRestorer {
             usize::MAX,
             NonZeroUsize::new(restore_config.object_store_concurrent_limit).unwrap(),
             m.clone(),
+            true, // skip_reset_local_store
         )
         .await
         .unwrap_or_else(|err| panic!("Failed to create reader: {}", err));

--- a/crates/sui-mvr-indexer/src/restorer/formal_snapshot.rs
+++ b/crates/sui-mvr-indexer/src/restorer/formal_snapshot.rs
@@ -80,6 +80,7 @@ impl IndexerFormalSnapshotRestorer {
             usize::MAX,
             NonZeroUsize::new(restore_config.object_store_concurrent_limit).unwrap(),
             m.clone(),
+            true, // skip_reset_local_store
         )
         .await
         .unwrap_or_else(|err| panic!("Failed to create reader: {}", err));

--- a/crates/sui-snapshot/src/tests.rs
+++ b/crates/sui-snapshot/src/tests.rs
@@ -112,6 +112,7 @@ async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
         usize::MAX,
         NonZeroUsize::new(1).unwrap(),
         MultiProgress::new(),
+        false, // skip_reset_local_store
     )
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&restored_db_path, None);
@@ -167,6 +168,7 @@ async fn test_snapshot_empty_db() -> Result<(), anyhow::Error> {
         usize::MAX,
         NonZeroUsize::new(1).unwrap(),
         MultiProgress::new(),
+        false, // skip_reset_local_store
     )
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&restored_db_path, None);

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -890,6 +890,7 @@ pub async fn download_formal_snapshot(
             usize::MAX,
             NonZeroUsize::new(num_parallel_downloads).unwrap(),
             m_clone,
+            false, // skip_reset_local_store
         )
         .await
         .unwrap_or_else(|err| panic!("Failed to create reader: {}", err));


### PR DESCRIPTION
## Description 

title, this can be problematic when a file is half-downloaded but useful when all file downloading is complete, which helps to speed up iteration over restore, as each time the .ref files download would take about 30min

## Test plan 

local run restorer and verify that it can reuse downloaded files
first run
```
104 out of 673 missing .ref files done
```
second run
```
8 out of 569 missing .ref files done
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
