### PR TITLE
Fix: fullnode template ipv4 docs

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -1,7 +1,7 @@
 # Update this value to the location you want Sui to store its database
 db-path: "suidb"
 
-# For ipv4, update this to "/ipv4/X.X.X.X/tcp/8080/http"
+# For ipv4, update this to "/ip4/X.X.X.X/tcp/8080/http"
 network-address: "/dns/localhost/tcp/8080/http"
 metrics-address: "0.0.0.0:9184"
 # this address is also used for web socket connections

--- a/crates/sui-config/data/fullnode-template.yaml
+++ b/crates/sui-config/data/fullnode-template.yaml
@@ -1,7 +1,7 @@
 # Update this value to the location you want Sui to store its database
 db-path: "/opt/sui/db"
 
-# For ipv4, update this to "/ipv4/X.X.X.X/tcp/8080/http"
+# For ipv4, update this to "/ip4/X.X.X.X/tcp/8080/http"
 network-address: "/dns/localhost/tcp/8080/http"
 metrics-address: "0.0.0.0:9184"
 # this address is also used for web socket connections


### PR DESCRIPTION
## Description 

Fixes the fullnode template: incorrect documentation on how to set ipv4 address.

See reference: [sui/creates/sui-config/src/node.rs:478](https://github.com/MystenLabs/sui/blob/8bd53998f88c4619f39dcf298f699199a0071e7c/crates/sui-config/src/node.rs#L478)

## Test plan 

How did you test the new or updated feature?

Set the configuration value on a locally running node. Setting to `/ipv4/...` crashes on boot. Setting to `/ip4/...` continues to boot.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
