### PR TITLE
Coinmarketcap Deepbook Endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13594,6 +13594,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "serde",
+ "serde_json",
  "serde_yaml 0.8.26",
  "sui-config",
  "sui-data-ingestion-core",

--- a/crates/sui-deepbook-indexer/Cargo.toml
+++ b/crates/sui-deepbook-indexer/Cargo.toml
@@ -33,6 +33,7 @@ sui-indexer-builder.workspace = true
 tempfile.workspace = true
 axum.workspace = true
 bigdecimal = { version = "0.4.5" }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -484,7 +484,7 @@ async fn orderbook(
     let base_coin_type = parse_type_input(&base_asset_id)?;
     let quote_coin_type = parse_type_input(&quote_asset_id)?;
 
-    let package = ObjectID::from_hex_literal(&DEEPBOOK_PACKAGE_ID)
+    let package = ObjectID::from_hex_literal(DEEPBOOK_PACKAGE_ID)
         .map_err(|e| DeepBookError::InternalError(format!("Invalid pool ID: {}", e)))?;
     let module = "pool".to_string();
     let function = "get_level2_ticks_from_mid".to_string();
@@ -535,8 +535,8 @@ async fn orderbook(
         .zip(bid_parsed_quantities.into_iter())
         .take(ticks_from_mid as usize)
         .map(|(price, quantity)| {
-            let price_factor = 10u64.pow((9 - base_decimals + quote_decimals).try_into().unwrap());
-            let quantity_factor = 10u64.pow((base_decimals).try_into().unwrap());
+            let price_factor = 10u64.pow((9 - base_decimals + quote_decimals).into());
+            let quantity_factor = 10u64.pow((base_decimals).into());
             Value::Array(vec![
                 Value::from((price as f64 / price_factor as f64).to_string()),
                 Value::from((quantity as f64 / quantity_factor as f64).to_string()),
@@ -550,8 +550,8 @@ async fn orderbook(
         .zip(ask_parsed_quantities.into_iter())
         .take(ticks_from_mid as usize)
         .map(|(price, quantity)| {
-            let price_factor = 10u64.pow((9 - base_decimals + quote_decimals).try_into().unwrap());
-            let quantity_factor = 10u64.pow((base_decimals).try_into().unwrap());
+            let price_factor = 10u64.pow((9 - base_decimals + quote_decimals).into());
+            let quantity_factor = 10u64.pow((base_decimals).into());
             Value::Array(vec![
                 Value::from((price as f64 / price_factor as f64).to_string()),
                 Value::from((quantity as f64 / quantity_factor as f64).to_string()),

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -599,6 +599,14 @@ fn get_pool_name_mapping() -> HashMap<String, String> {
             "0xe8e56f377ab5a261449b92ac42c8ddaacd5671e9fec2179d7933dd1a91200eec",
             "TYPUS_SUI",
         ),
+        (
+            "0x183df694ebc852a5f90a959f0f563b82ac9691e42357e9a9fe961d71a1b809c8",
+            "SUI_AUSD",
+        ),
+        (
+            "0x5661fc7f88fbeb8cb881150a810758cf13700bb4e1f31274a244581b37c303c3",
+            "AUSD_USDC",
+        ),
     ]
     .iter()
     .map(|&(id, name)| (id.to_string(), name.to_string()))
@@ -662,6 +670,13 @@ fn get_asset_info_mapping() -> HashMap<String, (String, u64)> {
             (
                 "0xf82dc05634970553615eef6112a1ac4fb7bf10272bf6cbe0f80ef44a6c489385::typus::TYPUS",
                 9,
+            ),
+        ),
+        (
+            "AUSD",
+            (
+                "0x2053d08c1e2bd02791056171aab0fd12bd7cd7efad2ab8f6b9c8902f14df2ff2::ausd::AUSD",
+                6,
             ),
         ),
     ]

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -481,16 +481,15 @@ async fn get_level2_ticks_from_mid(
         .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
         .await?;
 
-    let binding = result.results.unwrap();
-
-    let bid_prices = &binding.get(0).unwrap().return_values.get(0).unwrap().0;
+    let mut binding = result.results.unwrap();
+    let bid_prices = &binding.first_mut().unwrap().return_values.get(0).unwrap().0;
     let bid_parsed_prices: Vec<u64> = bcs::from_bytes(bid_prices).unwrap();
-    let bid_quantities = &binding.get(0).unwrap().return_values.get(1).unwrap().0;
+    let bid_quantities = &binding.first_mut().unwrap().return_values.get(1).unwrap().0;
     let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(bid_quantities).unwrap();
 
-    let ask_prices = &binding.get(0).unwrap().return_values.get(2).unwrap().0;
+    let ask_prices = &binding.first_mut().unwrap().return_values.get(2).unwrap().0;
     let ask_parsed_prices: Vec<u64> = bcs::from_bytes(ask_prices).unwrap();
-    let ask_quantities = &binding.get(0).unwrap().return_values.get(3).unwrap().0;
+    let ask_quantities = &binding.first_mut().unwrap().return_values.get(3).unwrap().0;
     let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(ask_quantities).unwrap();
 
     let mut result = HashMap::new();

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -359,7 +359,7 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
 
 async fn get_level2_ticks_from_mid(
     Path(pool_id): Path<String>,
-) -> Result<Json<HashMap<String, Vec<u64>>>, DeepBookError> {
+) -> Result<Json<HashMap<String, Vec<f64>>>, DeepBookError> {
     let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;
     let mut ptb = ProgrammableTransactionBuilder::new();
 
@@ -476,32 +476,40 @@ async fn get_level2_ticks_from_mid(
         bid_parsed_prices
             .into_iter()
             .map(|quantity| {
-                quantity / 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap())
+                let factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
+                quantity as f64 / factor as f64
             })
-            .collect(),
+            .collect::<Vec<f64>>(),
     );
     result.insert(
         "bid_parsed_quantities".to_string(),
         bid_parsed_quantities
             .into_iter()
-            .map(|quantity| quantity / 10u64.pow((*base_decimals).try_into().unwrap()))
-            .collect(),
+            .map(|quantity| {
+                let factor = 10u64.pow((*base_decimals).try_into().unwrap());
+                quantity as f64 / factor as f64
+            })
+            .collect::<Vec<f64>>(),
     );
     result.insert(
         "ask_parsed_prices".to_string(),
         ask_parsed_prices
             .into_iter()
             .map(|quantity| {
-                quantity / 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap())
+                let factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
+                quantity as f64 / factor as f64
             })
-            .collect(),
+            .collect::<Vec<f64>>(),
     );
     result.insert(
         "ask_parsed_quantities".to_string(),
         ask_parsed_quantities
             .into_iter()
-            .map(|quantity| quantity / 10u64.pow((*base_decimals).try_into().unwrap()))
-            .collect(),
+            .map(|quantity| {
+                let factor = 10u64.pow((*base_decimals).try_into().unwrap());
+                quantity as f64 / factor as f64
+            })
+            .collect::<Vec<f64>>(),
     );
 
     Ok(Json(result))

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -482,7 +482,13 @@ async fn get_level2_ticks_from_mid(
         .await?;
 
     let mut binding = result.results.unwrap();
-    let bid_prices = &binding.first_mut().unwrap().return_values.get(0).unwrap().0;
+    let bid_prices = &binding
+        .first_mut()
+        .unwrap()
+        .return_values
+        .first_mut()
+        .unwrap()
+        .0;
     let bid_parsed_prices: Vec<u64> = bcs::from_bytes(bid_prices).unwrap();
     let bid_quantities = &binding.first_mut().unwrap().return_values.get(1).unwrap().0;
     let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(bid_quantities).unwrap();

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -394,10 +394,10 @@ async fn get_level2_ticks_from_mid(
 
     let ticks_from_mid = match (depth, level) {
         (Some(_), Some(1)) => 1u64, // Depth + Level 1 → Best bid and ask
-        (Some(depth), Some(2)) | (Some(depth), None) => (depth / 2) as u64, // Depth + Level 2 → Use depth
-        (None, Some(1)) => 1u64, // Only Level 1 → Best bid and ask
+        (Some(depth), Some(2)) | (Some(depth), None) => depth / 2, // Depth + Level 2 → Use depth
+        (None, Some(1)) => 1u64,    // Only Level 1 → Best bid and ask
         (None, Some(2)) | (None, None) => 100u64, // Level 2 or default → 100 ticks
-        _ => 100u64,             // Fallback to default
+        _ => 100u64,                // Fallback to default
     };
 
     let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;
@@ -420,11 +420,7 @@ async fn get_level2_ticks_from_mid(
         "Missing data in pool object response for '{}'",
         pool_name
     ))?;
-    let pool_object_ref: ObjectRef = (
-        pool_data.object_id.clone(),
-        SequenceNumber::from(pool_data.version),
-        ObjectDigest::from(pool_data.digest.clone()),
-    );
+    let pool_object_ref: ObjectRef = (pool_data.object_id, pool_data.version, pool_data.digest);
 
     let pool_input = CallArg::Object(ObjectArg::ImmOrOwnedObject(pool_object_ref));
     ptb.input(pool_input)?;
@@ -444,11 +440,8 @@ async fn get_level2_ticks_from_mid(
         .as_ref()
         .ok_or(anyhow!("Missing data in clock object response"))?;
 
-    let sui_clock_object_ref: ObjectRef = (
-        clock_data.object_id.clone(),
-        SequenceNumber::from(clock_data.version),
-        ObjectDigest::from(clock_data.digest.clone()),
-    );
+    let sui_clock_object_ref: ObjectRef =
+        (clock_data.object_id, clock_data.version, clock_data.digest);
 
     let clock_input = CallArg::Object(ObjectArg::ImmOrOwnedObject(sui_clock_object_ref));
     ptb.input(clock_input)?;
@@ -494,12 +487,12 @@ async fn get_level2_ticks_from_mid(
     let bid_prices = &binding.get(0).unwrap().return_values.get(0).unwrap().0;
     let bid_parsed_prices: Vec<u64> = bcs::from_bytes(&bid_prices).unwrap();
     let bid_quantities = &binding.get(0).unwrap().return_values.get(1).unwrap().0;
-    let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(&bid_quantities).unwrap();
+    let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(bid_quantities).unwrap();
 
     let ask_prices = &binding.get(0).unwrap().return_values.get(2).unwrap().0;
     let ask_parsed_prices: Vec<u64> = bcs::from_bytes(&ask_prices).unwrap();
     let ask_quantities = &binding.get(0).unwrap().return_values.get(3).unwrap().0;
-    let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(&ask_quantities).unwrap();
+    let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(ask_quantities).unwrap();
 
     let mut result = HashMap::new();
 

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -41,7 +41,7 @@ pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
     "/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id";
-pub const HISTORICAL_VOLUME_PATH: &str = "/historical_volume/:pool_ids";
+pub const HISTORICAL_VOLUME_PATH: &str = "/historical_volume/:pool_names";
 pub const ALL_HISTORICAL_VOLUME_PATH: &str = "/all_historical_volume";
 pub const LEVEL2_PATH: &str = "/orderbook/:pool_name";
 pub const DEEPBOOK_PACKAGE_ID: &str =

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -472,68 +472,43 @@ async fn get_level2_ticks_from_mid(
     let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(&ask_quantities).unwrap();
 
     let mut result = HashMap::new();
-    // Insert bid parsed prices
-    result.insert(
-        "bid_parsed_prices".to_string(),
-        Value::Array(
-            bid_parsed_prices
-                .into_iter()
-                .map(|quantity| {
-                    let factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
-                    Value::from(quantity as f64 / factor as f64)
-                })
-                .collect(),
-        ),
-    );
-
-    // Insert bid parsed quantities
-    result.insert(
-        "bid_parsed_quantities".to_string(),
-        Value::Array(
-            bid_parsed_quantities
-                .into_iter()
-                .map(|quantity| {
-                    let factor = 10u64.pow((*base_decimals).try_into().unwrap());
-                    Value::from(quantity as f64 / factor as f64)
-                })
-                .collect(),
-        ),
-    );
-
-    // Insert ask parsed prices
-    result.insert(
-        "ask_parsed_prices".to_string(),
-        Value::Array(
-            ask_parsed_prices
-                .into_iter()
-                .map(|quantity| {
-                    let factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
-                    Value::from(quantity as f64 / factor as f64)
-                })
-                .collect(),
-        ),
-    );
-
-    // Insert ask parsed quantities
-    result.insert(
-        "ask_parsed_quantities".to_string(),
-        Value::Array(
-            ask_parsed_quantities
-                .into_iter()
-                .map(|quantity| {
-                    let factor = 10u64.pow((*base_decimals).try_into().unwrap());
-                    Value::from(quantity as f64 / factor as f64)
-                })
-                .collect(),
-        ),
-    );
 
     // Insert timestamp
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis() as i64;
-    result.insert("timestamp".to_string(), Value::from(timestamp));
+    result.insert("timestamp".to_string(), Value::from(timestamp.to_string()));
+
+    // Generate bids
+    let bids: Vec<Value> = bid_parsed_prices
+        .into_iter()
+        .zip(bid_parsed_quantities.into_iter())
+        .map(|(price, quantity)| {
+            let price_factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
+            let quantity_factor = 10u64.pow((*base_decimals).try_into().unwrap());
+            Value::Array(vec![
+                Value::from((price as f64 / price_factor as f64).to_string()),
+                Value::from((quantity as f64 / quantity_factor as f64).to_string()),
+            ])
+        })
+        .collect();
+    result.insert("bids".to_string(), Value::Array(bids));
+
+    // Generate asks
+    let asks: Vec<Value> = ask_parsed_prices
+        .into_iter()
+        .zip(ask_parsed_quantities.into_iter())
+        .map(|(price, quantity)| {
+            let price_factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
+            let quantity_factor = 10u64.pow((*base_decimals).try_into().unwrap());
+            Value::Array(vec![
+                Value::from((price as f64 / price_factor as f64).to_string()),
+                Value::from((quantity as f64 / quantity_factor as f64).to_string()),
+            ])
+        })
+        .collect();
+    result.insert("asks".to_string(), Value::Array(asks));
 
     Ok(Json(result))
 }

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -378,7 +378,7 @@ async fn get_level2_ticks_from_mid(
 
     let ticks_from_mid = match depth {
         Some(depth) => (depth / 2) as u64,
-        None => 10u64,
+        None => 100u64,
     };
 
     let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -143,7 +143,7 @@ async fn get_historical_volume(
         *volume_by_pool.entry(pool_id).or_insert(0) += volume as u64;
     }
 
-    Ok(Json(volume_by_pool))
+    Ok(Json(normalize_pool_addresses(volume_by_pool)))
 }
 
 async fn get_all_historical_volume(
@@ -337,4 +337,32 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
     }
 
     Ok(Json(metrics_by_interval))
+}
+
+/// Helper function to normalize pool addresses
+fn normalize_pool_addresses(
+    raw_response: HashMap<String, u64>,
+) -> HashMap<String, u64> {
+    let pool_map = HashMap::from([
+        ("0xb663828d6217467c8a1838a03793da896cbe745b150ebd57d82f814ca579fc22", "DEEP_SUI"),
+        ("0xf948981b806057580f91622417534f491da5f61aeaf33d0ed8e69fd5691c95ce", "DEEP_USDC"),
+        ("0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407", "SUI_USDC"),
+        ("0x1109352b9112717bd2a7c3eb9a416fff1ba6951760f5bdd5424cf5e4e5b3e65c", "BWETH_USDC"),
+        ("0xa0b9ebefb38c963fd115f52d71fa64501b79d1adcb5270563f92ce0442376545", "WUSDC_USDC"),
+        ("0x4e2ca3988246e1d50b9bf209abb9c1cbfec65bd95afdacc620a36c67bdb8452f", "WUSDT_USDC"),
+        ("0x27c4fdb3b846aa3ae4a65ef5127a309aa3c1f466671471a806d8912a18b253e8", "NS_SUI"),
+        ("0x0c0fdd4008740d81a8a7d4281322aee71a1b62c449eb5b142656753d89ebc060", "NS_USDC"),
+        ("0xe8e56f377ab5a261449b92ac42c8ddaacd5671e9fec2179d7933dd1a91200eec", "TYPUS_SUI")
+    ]);
+
+    raw_response
+        .into_iter()
+        .map(|(address, volume)| {
+            let pool_name = pool_map
+                .get(address.as_str())
+                .unwrap_or(&"Unknown Pool")
+                .to_string();
+            (pool_name, volume)
+        })
+        .collect()
 }

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -201,7 +201,7 @@ async fn all_historical_volume(
         .collect::<Vec<String>>()
         .join(",");
 
-    get_historical_volume(Path(pool_ids), Query(params), State(state)).await
+    historical_volume(Path(pool_ids), Query(params), State(state)).await
 }
 
 async fn get_historical_volume_by_balance_manager_id(

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -28,8 +28,7 @@ use std::str::FromStr;
 use sui_json_rpc_types::{SuiObjectData, SuiObjectDataOptions, SuiObjectResponse};
 use sui_sdk::SuiClientBuilder;
 use sui_types::{
-    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress},
-    digests::ObjectDigest,
+    base_types::{ObjectID, ObjectRef, SuiAddress},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, TransactionKind},
     type_input::TypeInput,
@@ -485,12 +484,12 @@ async fn get_level2_ticks_from_mid(
     let binding = result.results.unwrap();
 
     let bid_prices = &binding.get(0).unwrap().return_values.get(0).unwrap().0;
-    let bid_parsed_prices: Vec<u64> = bcs::from_bytes(&bid_prices).unwrap();
+    let bid_parsed_prices: Vec<u64> = bcs::from_bytes(bid_prices).unwrap();
     let bid_quantities = &binding.get(0).unwrap().return_values.get(1).unwrap().0;
     let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(bid_quantities).unwrap();
 
     let ask_prices = &binding.get(0).unwrap().return_values.get(2).unwrap().0;
-    let ask_parsed_prices: Vec<u64> = bcs::from_bytes(&ask_prices).unwrap();
+    let ask_parsed_prices: Vec<u64> = bcs::from_bytes(ask_prices).unwrap();
     let ask_quantities = &binding.get(0).unwrap().return_values.get(3).unwrap().0;
     let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(ask_quantities).unwrap();
 

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -42,7 +42,7 @@ pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_PATH: &str = "/get_historical_volume/:pool_ids";
-pub const GET_ALL_HISTORICAL_VOLUME_PATH: &str = "/get_all_historical_volume";
+pub const ALL_HISTORICAL_VOLUME_PATH: &str = "/all_historical_volume";
 pub const LEVEL2_PATH: &str = "/orderbook/:pool_name";
 pub const DEEPBOOK_PACKAGE_ID: &str =
     "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809";
@@ -60,8 +60,8 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
         .route(GET_POOLS_PATH, get(get_pools))
         .route(GET_HISTORICAL_VOLUME_PATH, get(get_historical_volume))
         .route(
-            GET_ALL_HISTORICAL_VOLUME_PATH,
-            get(get_all_historical_volume),
+            ALL_HISTORICAL_VOLUME_PATH,
+            get(all_historical_volume),
         )
         .route(
             GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL,
@@ -167,7 +167,7 @@ async fn get_historical_volume(
 }
 
 /// Get all historical volume for all pools
-async fn get_all_historical_volume(
+async fn all_historical_volume(
     Query(params): Query<HashMap<String, String>>,
     State(state): State<PgDeepbookPersistent>,
 ) -> Result<Json<HashMap<String, u64>>, DeepBookError> {

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -30,6 +30,7 @@ use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress}, digests::ObjectDigest, programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, TransactionKind}, type_input::TypeInput, TypeTag
 };
 
+pub const SUI_MAINNET_URL: &str = "https://fullnode.mainnet.sui.io:443";
 pub const GET_POOLS_PATH: &str = "/get_pools";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
     "/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id";
@@ -351,7 +352,7 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
 async fn get_level2_ticks_from_mid(
     Path(pool_id): Path<String>,
 ) -> Result<Json<HashMap<String, Vec<u64>>>, DeepBookError> {
-    let sui_client = SuiClientBuilder::default().build_testnet().await?;
+    let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;
     let mut ptb = ProgrammableTransactionBuilder::new();
 
     let pool_address = ObjectID::from_hex_literal(
@@ -407,11 +408,11 @@ async fn get_level2_ticks_from_mid(
     ptb.input(clock_input)?;
 
     // Correctly use TypeTag for base_coin_type and quote_coin_type
-    let base_coin_type = parse_type_input("0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP")?;
+    let base_coin_type = parse_type_input("0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP")?;
     let quote_coin_type = parse_type_input("0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI")?;
 
     // Add the Move call to the PTB
-    let pkg_id = "0xc89b2bd6172c077aec6e8d7ba201e99c32f9770cdae7be6dac9d95132fff8e8e";
+    let pkg_id = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809"; // Mainnet package
     let package = ObjectID::from_hex_literal(pkg_id).map_err(|e| anyhow!(e))?;
     let module = "pool".to_string();
     let function = "get_level2_ticks_from_mid".to_string();

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -14,6 +14,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use anyhow::anyhow;
 use diesel::dsl::sql;
 use diesel::BoolExpressionMethods;
 use diesel::QueryDsl;
@@ -23,6 +24,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, net::SocketAddr};
 use tokio::{net::TcpListener, task::JoinHandle};
 
+use sui_json_rpc_types::{SuiObjectData, SuiObjectDataOptions, SuiObjectResponse};
+use sui_sdk::SuiClientBuilder;
+use std::str::FromStr;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress}, digests::ObjectDigest, programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, TransactionKind}, type_input::TypeInput, TypeTag
+};
+
 pub const GET_POOLS_PATH: &str = "/get_pools";
 pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID_WITH_INTERVAL: &str =
     "/get_historical_volume_by_balance_manager_id_with_interval/:pool_ids/:balance_manager_id";
@@ -30,6 +38,7 @@ pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
     "/get_historical_volume_by_balance_manager_id/:pool_ids/:balance_manager_id";
 pub const GET_HISTORICAL_VOLUME_PATH: &str = "/get_historical_volume/:pool_ids";
 pub const GET_ALL_HISTORICAL_VOLUME_PATH: &str = "/get_all_historical_volume";
+pub const TESTING_PATH: &str = "/testing";
 
 pub fn run_server(socket_address: SocketAddr, state: PgDeepbookPersistent) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -52,6 +61,7 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
             GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID,
             get(get_historical_volume_by_balance_manager_id),
         )
+        .route(TESTING_PATH, get(testing))
         .with_state(state)
 }
 
@@ -339,6 +349,115 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
     Ok(Json(metrics_by_interval))
 }
 
+async fn testing() -> Result<Json<HashMap<String, Vec<u64>>>, DeepBookError> {
+    let sui_client = SuiClientBuilder::default().build_testnet().await?;
+    let mut ptb = ProgrammableTransactionBuilder::new();
+
+    let pool_address = ObjectID::from_hex_literal(
+        "0x2decc59a6f05c5800e5c8a1135f9d133d1746f562bf56673e6e81ef4f7ccd3b7",
+    )?;
+    // get the latest pool object version
+    let pool_object: SuiObjectResponse = sui_client
+        .read_api()
+        .get_object_with_options(pool_address, SuiObjectDataOptions::full_content())
+        .await?;
+    let pool_data: &SuiObjectData = pool_object
+        .data
+        .as_ref()
+        .ok_or(anyhow!("Missing data in pool object response"))?;
+
+    let pool_object_ref: ObjectRef = (
+        pool_data.object_id.clone(),
+        SequenceNumber::from(pool_data.version),
+        ObjectDigest::from(pool_data.digest.clone()),
+    );
+
+    // mark pool_object_ref as the first input. Later used as Argument::Input(0)
+    let pool_input = CallArg::Object(ObjectArg::ImmOrOwnedObject(pool_object_ref));
+    ptb.input(pool_input)?;
+
+    // mark ticks_from_mid as the second input. Later used as Argument::Input(1)
+    let ticks_from_mid = 10u64;
+    let input_argument = CallArg::Pure(bcs::to_bytes(&ticks_from_mid).unwrap());
+    ptb.input(input_argument)?;
+
+    // Convert the sui_clock_object_id string to ObjectID
+    let sui_clock_object_id = ObjectID::from_hex_literal(
+        "0x0000000000000000000000000000000000000000000000000000000000000006",
+    )?;
+    // get the latest clock object version
+    let sui_clock_object: SuiObjectResponse = sui_client
+        .read_api()
+        .get_object_with_options(sui_clock_object_id, SuiObjectDataOptions::full_content())
+        .await?;
+    let clock_data: &SuiObjectData = sui_clock_object
+        .data
+        .as_ref()
+        .ok_or(anyhow!("Missing data in clock object response"))?;
+
+    let sui_clock_object_ref: ObjectRef = (
+        clock_data.object_id.clone(),
+        SequenceNumber::from(clock_data.version),
+        ObjectDigest::from(clock_data.digest.clone()),
+    );
+
+    // mark sui_clock_object_ref as the third input. Later used as Argument::Input(2)
+    let clock_input = CallArg::Object(ObjectArg::ImmOrOwnedObject(sui_clock_object_ref));
+    ptb.input(clock_input)?;
+
+    // Correctly use TypeTag for base_coin_type and quote_coin_type
+    let base_coin_type = parse_type_input("0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP")?;
+    let quote_coin_type = parse_type_input("0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI")?;
+
+    // Add the Move call to the PTB
+    let pkg_id = "0xc89b2bd6172c077aec6e8d7ba201e99c32f9770cdae7be6dac9d95132fff8e8e";
+    let package = ObjectID::from_hex_literal(pkg_id).map_err(|e| anyhow!(e))?;
+    let module = "pool".to_string();
+    let function = "get_level2_ticks_from_mid".to_string();
+
+    ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
+        package,
+        module,
+        function,
+        type_arguments: vec![base_coin_type, quote_coin_type],
+        arguments: vec![
+            Argument::Input(0), // pool.address
+            Argument::Input(1), // tickFromMid
+            Argument::Input(2), // SUI_CLOCK_OBJECT_ID
+        ],
+    })));
+
+    let builder = ptb.finish();
+    let tx = TransactionKind::ProgrammableTransaction(builder);
+    // use the read_api() to get the dev_inspect_transaction_block function.
+    // this does not require you to input any gas coins.
+    let result = sui_client
+        .read_api()
+        .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
+        .await?;
+
+    // parse the results.
+    let binding = result.results.unwrap();
+
+    let bid_prices = &binding.get(0).unwrap().return_values.get(0).unwrap().0;
+    let bid_parsed_prices: Vec<u64> = bcs::from_bytes(&bid_prices).unwrap();
+    let bid_quantities = &binding.get(0).unwrap().return_values.get(1).unwrap().0;
+    let bid_parsed_quantities: Vec<u64> = bcs::from_bytes(&bid_quantities).unwrap();
+
+    let ask_prices = &binding.get(0).unwrap().return_values.get(2).unwrap().0;
+    let ask_parsed_prices: Vec<u64> = bcs::from_bytes(&ask_prices).unwrap();
+    let ask_quantities = &binding.get(0).unwrap().return_values.get(3).unwrap().0;
+    let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(&ask_quantities).unwrap();
+
+    let mut result = HashMap::new();
+    result.insert("bid_parsed_prices".to_string(), bid_parsed_prices);
+    result.insert("bid_parsed_quantities".to_string(), bid_parsed_quantities);
+    result.insert("ask_parsed_prices".to_string(), ask_parsed_prices);
+    result.insert("ask_parsed_quantities".to_string(), ask_parsed_quantities);
+
+    Ok(Json(result))
+}
+
 /// Helper function to normalize pool addresses
 fn normalize_pool_addresses(
     raw_response: HashMap<String, u64>,
@@ -365,4 +484,9 @@ fn normalize_pool_addresses(
             (pool_name, volume)
         })
         .collect()
+}
+
+fn parse_type_input(type_str: &str) -> Result<TypeInput, DeepBookError> {
+    let type_tag = TypeTag::from_str(type_str)?;
+    Ok(TypeInput::from(type_tag))
 }

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -45,6 +45,8 @@ pub const GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID: &str =
 pub const GET_HISTORICAL_VOLUME_PATH: &str = "/get_historical_volume/:pool_ids";
 pub const GET_ALL_HISTORICAL_VOLUME_PATH: &str = "/get_all_historical_volume";
 pub const LEVEL2_PATH: &str = "/get_level2_ticks_from_mid/:pool_id";
+pub const DEEPBOOK_PACKAGE_ID: &str =
+    "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809";
 
 pub fn run_server(socket_address: SocketAddr, state: PgDeepbookPersistent) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -431,8 +433,7 @@ async fn get_level2_ticks_from_mid(
     let base_coin_type = parse_type_input(base_coin_type)?;
     let quote_coin_type = parse_type_input(quote_coin_type)?;
 
-    let pkg_id = "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809";
-    let package = ObjectID::from_hex_literal(pkg_id).map_err(|e| anyhow!(e))?;
+    let package = ObjectID::from_hex_literal(DEEPBOOK_PACKAGE_ID).map_err(|e| anyhow!(e))?;
     let module = "pool".to_string();
     let function = "get_level2_ticks_from_mid".to_string();
 

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -472,6 +472,20 @@ async fn get_level2_ticks_from_mid(
     let ask_parsed_quantities: Vec<u64> = bcs::from_bytes(&ask_quantities).unwrap();
 
     let mut result = HashMap::new();
+    // Insert bid parsed prices
+    result.insert(
+        "bid_parsed_prices".to_string(),
+        Value::Array(
+            bid_parsed_prices
+                .into_iter()
+                .map(|quantity| {
+                    let factor = 10u64.pow((9 - *base_decimals + *quote_decimals).try_into().unwrap());
+                    Value::from(quantity as f64 / factor as f64)
+                })
+                .collect(),
+        ),
+    );
+
     // Insert bid parsed quantities
     result.insert(
         "bid_parsed_quantities".to_string(),

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -366,7 +366,7 @@ async fn get_level2_ticks_from_mid(
 ) -> Result<Json<HashMap<String, Value>>, DeepBookError> {
     let depth = params
         .get("depth")
-        .map(|v| v.parse::<i64>())
+        .map(|v| v.parse::<u64>())
         .transpose()
         .map_err(|_| anyhow!("Depth must be a non-negative integer"))?;
 
@@ -380,6 +380,12 @@ async fn get_level2_ticks_from_mid(
         Some(depth) => (depth / 2) as u64,
         None => 100u64,
     };
+
+    let level = params
+        .get("level")
+        .map(|v| v.parse::<u64>())
+        .transpose()
+        .map_err(|_| anyhow!("Level must be between 1 and 3"))?;
 
     let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;
     let mut ptb = ProgrammableTransactionBuilder::new();

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -68,7 +68,7 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
             GET_HISTORICAL_VOLUME_BY_BALANCE_MANAGER_ID,
             get(get_historical_volume_by_balance_manager_id),
         )
-        .route(LEVEL2_PATH, get(get_level2_ticks_from_mid))
+        .route(LEVEL2_PATH, get(orderbook))
         .with_state(state)
 }
 
@@ -369,7 +369,9 @@ async fn get_historical_volume_by_balance_manager_id_with_interval(
 
     Ok(Json(metrics_by_interval))
 }
-async fn get_level2_ticks_from_mid(
+
+/// Level2 data for all pools
+async fn orderbook(
     Path(pool_name): Path<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<PgDeepbookPersistent>,


### PR DESCRIPTION
## Description 

**Modified Endpoint 1:** 
/get_historical_volume/:pool_id -> /historical_volume/pool_name
Response will display pool as pool_name

Example call:
`/historical_volume/SUI_USDC,DEEP_USDC?start_time=1733152516&end_time=1733238917`

Example response:
`{"DEEP_USDC":24033500000000,"SUI_USDC":2647584300000000}`

**New Endpoint 1: /all_historical_volume**
Retrieves the pools stored in db and return volume for all pools within time range

Example Call:
`/all_historical_volume?start_time=1733152516&end_time=1733238917`

Example Response:
`{"DEEP_USDC":23658150000000,"DEEP_SUI":5311220000000,"TYPUS_SUI":662314300000000,"SUI_USDC":3365051200000000,"WUSDC_USDC":7960304900000,"NS_USDC":783869300000,"NS_SUI":379958200000}`

**New Endpoint 2: /orderbook/:pool_name**
More information: [https://docs.google.com/document/d/1S4urpzUnO2t7DmS_1dc4EL4tgnnbTObPYXvDeBnukCg/edit?tab=t.0#bookmark=kix.ojdax1m5sg58](url)

Required path:
`pool_name`: "LTC_BTC" 

Optional params: 
`level` (1 or 2): Level 1 – Only the best bid and ask. Level 2 – Arranged by best bids and asks.
`depth`: Not defined or 0 = full order book Depth = 100 means 50 for each bid/ask side. Cannot be 1.
All bids and asks returned are sorted by best to worst

Example call:
`/orderbook/SUI_USDC?depth=4`

Example output:
`{"timestamp":"1733252111939","bids":[["3.796","958.5"],["3.795","5000"]],"asks":[["3.799","1000"],["3.801","7238"]]}`

## Test plan 

How did you test the new or updated feature?

Tested locally

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Deepbook Indexer
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
