### PR TITLE
Update local-network.mdx

### DIFF
--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -21,7 +21,7 @@ This command:
 * Instructs Rust to set specific logging through the `RUST_LOG`=`off,sui_node=info` flags, which turns off logging for all components except `sui-node`. If you want to see more detailed logs, you can remove `RUST_LOG` from the command.
 
 :::info
-Each time you start the network by passing `--force-regenesis`, the local network starts from a random genesis with no previous data, and the local network is not persisted. If you'd like to persist data, skip passing the `--force-regenesis` flag. For more details, see the [Persist local network state](#persist-local-network-state) section. Please note that a temporary directory is created in `/tmp`, which might not work if the `/tmp` folder is mounted to `/tmpfs`.
+Each time you start the network by passing `--force-regenesis`, the local network starts from a random genesis with no previous data, and the local network is not persisted. If you'd like to persist data, skip passing the `--force-regenesis` flag. For more details, see the [Persist local network state](#persist-local-network-state) section. Please note that a temporary directory is created in `/tmp`, which might not work if the `/tmp` folder is mounted to `/tmpfs`. If this is the case, set `TMPDIR=./some_folder`.
 :::
 
 To customize your local Sui network, such as starting other services or changing default ports and hosts, include additional flags or options in the `sui start` command.

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -21,7 +21,7 @@ This command:
 * Instructs Rust to set specific logging through the `RUST_LOG`=`off,sui_node=info` flags, which turns off logging for all components except `sui-node`. If you want to see more detailed logs, you can remove `RUST_LOG` from the command.
 
 :::info
-Each time you start the network by passing `--force-regenesis`, the local network starts from a random genesis with no previous data, and the local network is not persisted. If you'd like to persist data, skip passing the `--force-regenesis` flag. For more details, see the [Persist local network state](#persist-local-network-state) section.
+Each time you start the network by passing `--force-regenesis`, the local network starts from a random genesis with no previous data, and the local network is not persisted. If you'd like to persist data, skip passing the `--force-regenesis` flag. For more details, see the [Persist local network state](#persist-local-network-state) section. Please note that a temporary directory is created in `/tmp`, which might not work if the `/tmp` folder is mounted to `/tmpfs`.
 :::
 
 To customize your local Sui network, such as starting other services or changing default ports and hosts, include additional flags or options in the `sui start` command.
@@ -173,7 +173,8 @@ The response resembles the following, but with different IDs:
 
 ## Generate example data
 
-Use the TypeScript SDK to add example data to your network. Run the following command from the `sui` root folder:
+Use the TypeScript SDK to add example data to your network. This requires to start a local network with an indexer and GraphQL: `sui start --force-regenesis --with-faucet --with-indexer --with-graphql`. 
+Then run the following command from the `sui` root folder:
 
 ```bash
 pnpm --filter @mysten/sui test:e2e


### PR DESCRIPTION
## Description 

Got some report that the tests only work if an indexer & graphql are started. Also when using --force-regenesis, if the tmp folder is mounted to `tmpfs`, it will likely fail to properly start.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
