### PR TITLE
update transaction_outputs

### DIFF
--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -632,7 +632,7 @@ impl TransactionOrchestratorMetrics {
             )
             .unwrap(),
             wait_for_finality_finished: register_int_counter_with_registry!(
-                "tx_orchestrator_wait_for_finality_fnished",
+                "tx_orchestrator_wait_for_finality_finished",
                 "Total number of txns Transaction Orchestrator gets responses from Quorum Driver before timeout, either success or failure",
                 registry,
             )

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -632,7 +632,7 @@ impl TransactionOrchestratorMetrics {
             )
             .unwrap(),
             wait_for_finality_finished: register_int_counter_with_registry!(
-                "tx_orchestrator_wait_for_finality_finished",
+                "tx_orchestrator_wait_for_finality_fnished",
                 "Total number of txns Transaction Orchestrator gets responses from Quorum Driver before timeout, either success or failure",
                 registry,
             )

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -93,7 +93,7 @@ impl TransactionOutputs {
             .filter_map(|(id, ((version, digest), owner))| {
                 owner.is_address_owned().then_some((id, version, digest))
             })
-            .chain(received_objects.into_iter())
+            .chain(received_objects)
             .collect();
 
         let new_locks_to_init: Vec<_> = written

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -50,8 +50,7 @@ impl TransactionOutputs {
         let modified_at: HashSet<_> = effects.modified_at_versions().into_iter().collect();
         let possible_to_receive = transaction.transaction_data().receiving_objects();
         let received_objects = possible_to_receive
-            .iter()
-            .cloned()
+            .into_iter()
             .filter(|obj_ref| modified_at.contains(&(obj_ref.0, obj_ref.1)));
 
         // We record any received or deleted objects since they could be pruned, and smear shared
@@ -94,7 +93,7 @@ impl TransactionOutputs {
             .filter_map(|(id, ((version, digest), owner))| {
                 owner.is_address_owned().then_some((id, version, digest))
             })
-            .chain(received_objects)
+            .chain(received_objects.into_iter())
             .collect();
 
         let new_locks_to_init: Vec<_> = written


### PR DESCRIPTION
## Description 

1. **`possible_to_receive.iter().clone()` -> `possible_to_receive.into_iter()`**:

This modification is generally appropriate and improves performance by avoiding unnecessary cloning of the `possible_to_receive` collection. Instead of cloning, it consumes the iterator, which is more efficient.

2. **` .chain(received_objects)` -> ` .chain(received_objects.into_iter())`**:

By calling `into_iter()` on `received_objects` when adding them to `locks_to_delete`, the objects are directly used in the collection and the original reference to `received_objects` is no longer necessary.

3. ** Correct the spelling error in `transaction_orchestrator`**:

`fnished` -> `finished`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: