### PR TITLE
indexer-alt: generalize GraphQLConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13608,6 +13608,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-default-config"
+version = "1.39.0"
+dependencies = [
+ "quote 1.0.35",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "sui-e2e-tests"
 version = "1.39.0"
 dependencies = [
@@ -13866,14 +13874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-graphql-config"
-version = "1.39.0"
-dependencies = [
- "quote 1.0.35",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "sui-graphql-e2e-tests"
 version = "0.1.0"
 dependencies = [
@@ -13935,8 +13935,8 @@ dependencies = [
  "shared-crypto",
  "similar",
  "simulacrum",
+ "sui-default-config",
  "sui-framework",
- "sui-graphql-config",
  "sui-graphql-rpc-client",
  "sui-graphql-rpc-headers",
  "sui-indexer",
@@ -14590,8 +14590,8 @@ dependencies = [
  "shared-crypto",
  "similar",
  "simulacrum",
+ "sui-default-config",
  "sui-framework",
- "sui-graphql-config",
  "sui-graphql-rpc-client",
  "sui-graphql-rpc-headers",
  "sui-indexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ members = [
     "crates/sui-data-ingestion",
     "crates/sui-data-ingestion-core",
     "crates/sui-deepbook-indexer",
+    "crates/sui-default-config",
     "crates/sui-e2e-tests",
     "crates/sui-enum-compat-util",
     "crates/sui-faucet",
@@ -109,7 +110,6 @@ members = [
     "crates/sui-framework-snapshot",
     "crates/sui-framework-tests",
     "crates/sui-genesis-builder",
-    "crates/sui-graphql-config",
     "crates/sui-graphql-e2e-tests",
     "crates/sui-graphql-rpc",
     "crates/sui-graphql-rpc-client",
@@ -631,6 +631,7 @@ sui-core = { path = "crates/sui-core" }
 sui-cost = { path = "crates/sui-cost" }
 sui-data-ingestion = { path = "crates/sui-data-ingestion" }
 sui-data-ingestion-core = { path = "crates/sui-data-ingestion-core" }
+sui-default-config = { path = "crates/sui-default-config" }
 sui-e2e-tests = { path = "crates/sui-e2e-tests" }
 sui-enum-compat-util = { path = "crates/sui-enum-compat-util" }
 sui-faucet = { path = "crates/sui-faucet" }
@@ -639,7 +640,6 @@ sui-field-count-derive = { path = "crates/sui-field-count-derive" }
 sui-framework = { path = "crates/sui-framework" }
 sui-framework-snapshot = { path = "crates/sui-framework-snapshot" }
 sui-framework-tests = { path = "crates/sui-framework-tests" }
-sui-graphql-config = { path = "crates/sui-graphql-config" }
 sui-graphql-rpc = { path = "crates/sui-graphql-rpc" }
 sui-graphql-rpc-client = { path = "crates/sui-graphql-rpc-client" }
 sui-graphql-rpc-headers = { path = "crates/sui-graphql-rpc-headers" }

--- a/crates/sui-default-config/Cargo.toml
+++ b/crates/sui-default-config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sui-graphql-config"
+name = "sui-default-config"
 version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com"]
 license = "Apache-2.0"

--- a/crates/sui-default-config/src/lib.rs
+++ b/crates/sui-default-config/src/lib.rs
@@ -17,7 +17,7 @@ use syn::{
 /// the config struct.
 #[allow(non_snake_case)]
 #[proc_macro_attribute]
-pub fn GraphQLConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn DefaultConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let DeriveInput {
         attrs,
         vis,
@@ -32,7 +32,7 @@ pub fn GraphQLConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
         semi_token,
     }) = data
     else {
-        panic!("GraphQL configs must be structs.");
+        panic!("Default configs must be structs.");
     };
 
     let Fields::Named(FieldsNamed {
@@ -40,7 +40,7 @@ pub fn GraphQLConfig(_attr: TokenStream, input: TokenStream) -> TokenStream {
         named,
     }) = fields
     else {
-        panic!("GraphQL configs must have named fields.");
+        panic!("Default configs must have named fields.");
     };
 
     // Figure out which derives need to be added to meet the criteria of a config struct.

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -64,7 +64,7 @@ uuid.workspace = true
 im.workspace = true
 downcast = "0.11.0"
 
-sui-graphql-config.workspace = true
+sui-default-config.workspace = true
 sui-graphql-rpc-headers.workspace = true
 sui-graphql-rpc-client.workspace = true
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -9,7 +9,7 @@ use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt::Display, time::Duration};
-use sui_graphql_config::GraphQLConfig;
+use sui_default_config::DefaultConfig;
 use sui_json_rpc::name_service::NameServiceConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};
 
@@ -28,7 +28,7 @@ const MOVE_REGISTRY_TABLE_ID: &str =
 const DEFAULT_PAGE_LIMIT: u16 = 50;
 
 /// The combination of all configurations for the GraphQL service.
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct ServerConfig {
     pub service: ServiceConfig,
@@ -41,7 +41,7 @@ pub struct ServerConfig {
 /// Configuration for connections for the RPC, passed in as command-line arguments. This configures
 /// specific connections between this service and other services, and might differ from instance to
 /// instance of the GraphQL service.
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(clap::Args, Clone, Eq, PartialEq)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
@@ -71,7 +71,7 @@ pub struct ConnectionConfig {
 /// Configuration on features supported by the GraphQL service, passed in a TOML-based file. These
 /// configurations are shared across fleets of the service, i.e. all testnet services will have the
 /// same `ServiceConfig`.
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct ServiceConfig {
     pub limits: Limits,
@@ -83,7 +83,7 @@ pub struct ServiceConfig {
     pub move_registry: MoveRegistryConfig,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 pub struct Limits {
     /// Maximum depth of nodes in the requests.
     pub max_query_depth: u32,
@@ -127,7 +127,7 @@ pub struct Limits {
     pub max_scan_limit: u32,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Copy)]
 pub struct BackgroundTasksConfig {
     /// How often the watermark task checks the indexer database to update the checkpoint and epoch
@@ -135,7 +135,7 @@ pub struct BackgroundTasksConfig {
     pub watermark_update_ms: u64,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Clone)]
 pub struct MoveRegistryConfig {
     pub(crate) external_api_url: Option<String>,
@@ -185,7 +185,7 @@ impl Version {
     }
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(clap::Args)]
 pub struct Ide {
     /// The title to display at the top of the web-based GraphiQL IDE.
@@ -193,7 +193,7 @@ pub struct Ide {
     pub ide_title: String,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct Experiments {
     // Add experimental flags here, to provide access to them through-out the GraphQL
@@ -202,7 +202,7 @@ pub struct Experiments {
     test_flag: bool,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 pub struct InternalFeatureConfig {
     pub(crate) query_limits_checker: bool,
     pub(crate) directive_checker: bool,
@@ -215,7 +215,7 @@ pub struct InternalFeatureConfig {
     pub(crate) open_telemetry: bool,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(clap::Args, Default)]
 pub struct TxExecFullNodeConfig {
     /// RPC URL for the fullnode to send transactions to execute and dry-run.
@@ -223,7 +223,7 @@ pub struct TxExecFullNodeConfig {
     pub(crate) node_rpc_url: Option<String>,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct ZkLoginConfig {
     pub env: ZkLoginEnv,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -29,7 +29,7 @@ const DEFAULT_PAGE_LIMIT: u16 = 50;
 
 /// The combination of all configurations for the GraphQL service.
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ServerConfig {
     pub service: ServiceConfig,
     pub connection: ConnectionConfig,
@@ -42,7 +42,7 @@ pub struct ServerConfig {
 /// specific connections between this service and other services, and might differ from instance to
 /// instance of the GraphQL service.
 #[DefaultConfig]
-#[derive(clap::Args, Clone, Eq, PartialEq)]
+#[derive(clap::Args, Clone, Eq, PartialEq, Debug)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
     #[clap(short, long, default_value_t = ConnectionConfig::default().port)]
@@ -72,7 +72,7 @@ pub struct ConnectionConfig {
 /// configurations are shared across fleets of the service, i.e. all testnet services will have the
 /// same `ServiceConfig`.
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Eq, PartialEq, Debug)]
 pub struct ServiceConfig {
     pub limits: Limits,
     pub disabled_features: BTreeSet<FunctionalGroup>,
@@ -84,6 +84,7 @@ pub struct ServiceConfig {
 }
 
 #[DefaultConfig]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Limits {
     /// Maximum depth of nodes in the requests.
     pub max_query_depth: u32,
@@ -128,7 +129,7 @@ pub struct Limits {
 }
 
 #[DefaultConfig]
-#[derive(Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct BackgroundTasksConfig {
     /// How often the watermark task checks the indexer database to update the checkpoint and epoch
     /// watermarks.
@@ -136,7 +137,7 @@ pub struct BackgroundTasksConfig {
 }
 
 #[DefaultConfig]
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct MoveRegistryConfig {
     pub(crate) external_api_url: Option<String>,
     pub(crate) resolution_type: ResolutionType,
@@ -186,7 +187,7 @@ impl Version {
 }
 
 #[DefaultConfig]
-#[derive(clap::Args)]
+#[derive(clap::Args, Clone, Debug)]
 pub struct Ide {
     /// The title to display at the top of the web-based GraphiQL IDE.
     #[clap(short, long, default_value_t = Ide::default().ide_title)]
@@ -194,7 +195,7 @@ pub struct Ide {
 }
 
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Eq, PartialEq, Debug)]
 pub struct Experiments {
     // Add experimental flags here, to provide access to them through-out the GraphQL
     // implementation.
@@ -203,6 +204,7 @@ pub struct Experiments {
 }
 
 #[DefaultConfig]
+#[derive(Clone, Debug)]
 pub struct InternalFeatureConfig {
     pub(crate) query_limits_checker: bool,
     pub(crate) directive_checker: bool,
@@ -216,7 +218,7 @@ pub struct InternalFeatureConfig {
 }
 
 #[DefaultConfig]
-#[derive(clap::Args, Default)]
+#[derive(clap::Args, Clone, Default, Debug)]
 pub struct TxExecFullNodeConfig {
     /// RPC URL for the fullnode to send transactions to execute and dry-run.
     #[clap(long)]
@@ -224,7 +226,7 @@ pub struct TxExecFullNodeConfig {
 }
 
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Eq, PartialEq, Debug)]
 pub struct ZkLoginConfig {
     pub env: ZkLoginEnv,
 }

--- a/crates/sui-mvr-graphql-rpc/Cargo.toml
+++ b/crates/sui-mvr-graphql-rpc/Cargo.toml
@@ -64,7 +64,7 @@ uuid.workspace = true
 im.workspace = true
 downcast = "0.11.0"
 
-sui-graphql-config.workspace = true
+sui-default-config.workspace = true
 sui-graphql-rpc-headers.workspace = true
 sui-graphql-rpc-client.workspace = true
 

--- a/crates/sui-mvr-graphql-rpc/src/config.rs
+++ b/crates/sui-mvr-graphql-rpc/src/config.rs
@@ -9,7 +9,7 @@ use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt::Display, time::Duration};
-use sui_graphql_config::GraphQLConfig;
+use sui_default_config::DefaultConfig;
 use sui_json_rpc::name_service::NameServiceConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};
 
@@ -28,7 +28,7 @@ const MOVE_REGISTRY_TABLE_ID: &str =
 const DEFAULT_PAGE_LIMIT: u16 = 50;
 
 /// The combination of all configurations for the GraphQL service.
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct ServerConfig {
     pub service: ServiceConfig,
@@ -41,7 +41,7 @@ pub struct ServerConfig {
 /// Configuration for connections for the RPC, passed in as command-line arguments. This configures
 /// specific connections between this service and other services, and might differ from instance to
 /// instance of the GraphQL service.
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(clap::Args, Clone, Eq, PartialEq)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
@@ -71,7 +71,7 @@ pub struct ConnectionConfig {
 /// Configuration on features supported by the GraphQL service, passed in a TOML-based file. These
 /// configurations are shared across fleets of the service, i.e. all testnet services will have the
 /// same `ServiceConfig`.
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct ServiceConfig {
     pub limits: Limits,
@@ -83,7 +83,7 @@ pub struct ServiceConfig {
     pub move_registry: MoveRegistryConfig,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 pub struct Limits {
     /// Maximum depth of nodes in the requests.
     pub max_query_depth: u32,
@@ -127,7 +127,7 @@ pub struct Limits {
     pub max_scan_limit: u32,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Copy)]
 pub struct BackgroundTasksConfig {
     /// How often the watermark task checks the indexer database to update the checkpoint and epoch
@@ -135,7 +135,7 @@ pub struct BackgroundTasksConfig {
     pub watermark_update_ms: u64,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Clone)]
 pub struct MoveRegistryConfig {
     pub(crate) external_api_url: Option<String>,
@@ -185,7 +185,7 @@ impl Version {
     }
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(clap::Args)]
 pub struct Ide {
     /// The title to display at the top of the web-based GraphiQL IDE.
@@ -193,7 +193,7 @@ pub struct Ide {
     pub ide_title: String,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct Experiments {
     // Add experimental flags here, to provide access to them through-out the GraphQL
@@ -202,7 +202,7 @@ pub struct Experiments {
     test_flag: bool,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 pub struct InternalFeatureConfig {
     pub(crate) query_limits_checker: bool,
     pub(crate) directive_checker: bool,
@@ -215,7 +215,7 @@ pub struct InternalFeatureConfig {
     pub(crate) open_telemetry: bool,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(clap::Args, Default)]
 pub struct TxExecFullNodeConfig {
     /// RPC URL for the fullnode to send transactions to execute and dry-run.
@@ -223,7 +223,7 @@ pub struct TxExecFullNodeConfig {
     pub(crate) node_rpc_url: Option<String>,
 }
 
-#[GraphQLConfig]
+#[DefaultConfig]
 #[derive(Default)]
 pub struct ZkLoginConfig {
     pub env: ZkLoginEnv,

--- a/crates/sui-mvr-graphql-rpc/src/config.rs
+++ b/crates/sui-mvr-graphql-rpc/src/config.rs
@@ -29,7 +29,7 @@ const DEFAULT_PAGE_LIMIT: u16 = 50;
 
 /// The combination of all configurations for the GraphQL service.
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ServerConfig {
     pub service: ServiceConfig,
     pub connection: ConnectionConfig,
@@ -42,7 +42,7 @@ pub struct ServerConfig {
 /// specific connections between this service and other services, and might differ from instance to
 /// instance of the GraphQL service.
 #[DefaultConfig]
-#[derive(clap::Args, Clone, Eq, PartialEq)]
+#[derive(clap::Args, Clone, Eq, PartialEq, Debug)]
 pub struct ConnectionConfig {
     /// Port to bind the server to
     #[clap(short, long, default_value_t = ConnectionConfig::default().port)]
@@ -72,7 +72,7 @@ pub struct ConnectionConfig {
 /// configurations are shared across fleets of the service, i.e. all testnet services will have the
 /// same `ServiceConfig`.
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Eq, PartialEq, Debug)]
 pub struct ServiceConfig {
     pub limits: Limits,
     pub disabled_features: BTreeSet<FunctionalGroup>,
@@ -84,6 +84,7 @@ pub struct ServiceConfig {
 }
 
 #[DefaultConfig]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Limits {
     /// Maximum depth of nodes in the requests.
     pub max_query_depth: u32,
@@ -128,7 +129,7 @@ pub struct Limits {
 }
 
 #[DefaultConfig]
-#[derive(Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct BackgroundTasksConfig {
     /// How often the watermark task checks the indexer database to update the checkpoint and epoch
     /// watermarks.
@@ -136,7 +137,7 @@ pub struct BackgroundTasksConfig {
 }
 
 #[DefaultConfig]
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct MoveRegistryConfig {
     pub(crate) external_api_url: Option<String>,
     pub(crate) resolution_type: ResolutionType,
@@ -186,7 +187,7 @@ impl Version {
 }
 
 #[DefaultConfig]
-#[derive(clap::Args)]
+#[derive(clap::Args, Clone, Debug)]
 pub struct Ide {
     /// The title to display at the top of the web-based GraphiQL IDE.
     #[clap(short, long, default_value_t = Ide::default().ide_title)]
@@ -194,7 +195,7 @@ pub struct Ide {
 }
 
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Eq, PartialEq, Debug)]
 pub struct Experiments {
     // Add experimental flags here, to provide access to them through-out the GraphQL
     // implementation.
@@ -203,6 +204,7 @@ pub struct Experiments {
 }
 
 #[DefaultConfig]
+#[derive(Clone, Debug)]
 pub struct InternalFeatureConfig {
     pub(crate) query_limits_checker: bool,
     pub(crate) directive_checker: bool,
@@ -216,7 +218,7 @@ pub struct InternalFeatureConfig {
 }
 
 #[DefaultConfig]
-#[derive(clap::Args, Default)]
+#[derive(clap::Args, Clone, Default, Debug)]
 pub struct TxExecFullNodeConfig {
     /// RPC URL for the fullnode to send transactions to execute and dry-run.
     #[clap(long)]
@@ -224,7 +226,7 @@ pub struct TxExecFullNodeConfig {
 }
 
 #[DefaultConfig]
-#[derive(Default)]
+#[derive(Clone, Default, Eq, PartialEq, Debug)]
 pub struct ZkLoginConfig {
     pub env: ZkLoginEnv,
 }


### PR DESCRIPTION
## Description 

Take the `GraphQLConfig` procedural macro used by GraphQL and generalize it for use in other crates, as `DefaultConfig`. This macro simplifies defining a configuration to be read from a file, using serde's Serialze/Deserialize, and automatically using the type's `Default` to supply the default values while deserializing as well.

As part of generalizing, we dropped support for some features that don't work well in the more general setting:

- We no longer derive a number of other traits (like `Clone`, `Eq`, etc) -- these can be added manually if needed.
- We no longer force field names to be `rename_all = "kebab-case"`, because for the Indexer's config, we will want some of them to be renamed as `"snake_case"`. A check was added to see whether a `rename_all` attribute has been supplied, and in that case, the macro does not add its own.

## Test plan 

Build and test existing uses of the crate:

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests
sui$ cargo nextest run -p sui-mvr-graphql-rpc
```

## Stack

- #20459 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
