### PR TITLE
indexer-alt: merging file-based configs

### DIFF
--- a/crates/sui-indexer-alt/src/args.rs
+++ b/crates/sui-indexer-alt/src/args.rs
@@ -38,6 +38,14 @@ pub enum Command {
     /// Output the contents of the default configuration to STDOUT.
     GenerateConfig,
 
+    /// Combine the configuration held across multiple files into one and output it to STDOUT. When
+    /// two configurations set the same field, the last write wins.
+    MergeConfigs {
+        /// Path to a TOML file to be merged
+        #[arg(long, required = true, action = clap::ArgAction::Append)]
+        config: Vec<PathBuf>,
+    },
+
     /// Wipe the database of its contents
     ResetDatabase {
         /// If true, only drop all tables but do not run the migrations.

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -402,6 +402,7 @@ pub async fn start_indexer(
         ingestion,
         consistency,
         committer,
+        pruner,
         pipeline:
             PipelineLayer {
                 sum_coin_balances,
@@ -439,6 +440,7 @@ pub async fn start_indexer(
     } = consistency.finish(ConsistencyConfig::default());
 
     let committer = committer.finish(CommitterConfig::default());
+    let pruner = pruner.finish(PrunerConfig::default());
 
     // Pipelines that are split up into a summary table, and a write-ahead log prune their
     // write-ahead log so it contains just enough information to overlap with the summary table.
@@ -493,7 +495,7 @@ pub async fn start_indexer(
                         $handler,
                         layer.finish(ConcurrentConfig {
                             committer: committer.clone(),
-                            ..Default::default()
+                            pruner: Some(pruner.clone()),
                         }),
                     )
                     .await?

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::Path;
+
+use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
@@ -26,12 +29,7 @@ async fn main() -> Result<()> {
             indexer_args,
             config,
         } => {
-            let config_contents = fs::read_to_string(config)
-                .await
-                .context("failed to read configuration TOML file")?;
-
-            let indexer_config: IndexerConfig = toml::from_str(&config_contents)
-                .context("Failed to parse configuration TOML file.")?;
+            let indexer_config = read_config(&config).await?;
 
             start_indexer(
                 args.db_args,
@@ -48,7 +46,28 @@ async fn main() -> Result<()> {
             let config_toml = toml::to_string_pretty(&config)
                 .context("Failed to serialize default configuration to TOML.")?;
 
-            println!("{}", config_toml);
+            println!("{config_toml}");
+        }
+
+        Command::MergeConfigs { config } => {
+            let mut files = config.into_iter();
+
+            let Some(file) = files.next() else {
+                bail!("At least one configuration file must be provided.");
+            };
+
+            let mut indexer_config = read_config(&file).await?;
+            for file in files {
+                indexer_config =
+                    indexer_config.merge(read_config(&file).await.with_context(|| {
+                        format!("Failed to read configuration file: {}", file.display())
+                    })?);
+            }
+
+            let config_toml = toml::to_string_pretty(&indexer_config)
+                .context("Failed to serialize merged configuration to TOML.")?;
+
+            println!("{config_toml}");
         }
 
         Command::ResetDatabase { skip_migrations } => {
@@ -73,4 +92,12 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn read_config(path: &Path) -> Result<IndexerConfig> {
+    let config_contents = fs::read_to_string(path)
+        .await
+        .context("Failed to read configuration TOML file")?;
+
+    toml::from_str(&config_contents).context("Failed to parse configuration TOML file.")
 }

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/mod.rs
@@ -140,6 +140,17 @@ impl<H: Handler> Batched<H> {
     }
 }
 
+impl Default for PrunerConfig {
+    fn default() -> Self {
+        Self {
+            interval_ms: 300_000,
+            delay_ms: 120_000,
+            retention: 4_000_000,
+            max_chunk_size: 2_000,
+        }
+    }
+}
+
 /// Start a new concurrent (out-of-order) indexing pipeline served by the handler, `H`. Starting
 /// strictly after the `watermark` (or from the beginning if no watermark was provided).
 ///


### PR DESCRIPTION
## Description 

Add the ability to combine configs together using a `merge-configs` command on the indexer. This allows:

- Each pipeline to be configured in its own file, and then combined based on how we want to distribute pipelines between pods.
- Combining the configurations of multiple application-specific indexers into one configuration.

Generally, when multiple configs define the same field, the last write wins. An exception is made for pruning retention which we merge using the `max` operation to cater to the second use case above where two applications may want to index the same data, at different retentions. 

This change also lays a foundation to support parameterized indexing, where the indexer can be configured to filter out data based on predicates which will also need to be merged to handle the application-specific indexer case.

## Test plan 

New unit tests added for merging:

```
sui$ cargo nextest run -p sui-indexer-alt -- config::tests
```

And manual testing of the new command:

```
sui$ cargo run -p sui-indexer-alt -- merge-configs \
  --config tx.toml                                 \
  --config obj.toml                                \
  --config kv.toml

[ingestion]

[consistency]
consistent-range = 1000

[committer]
collect-interval-ms = 1000

[pipeline.sum_obj_types]

[pipeline.kv_objects]

[pipeline.kv_transactions]

[pipeline.tx_affected_objects]

[pipeline.tx_calls]

```

## Stack

- #20459
- #20460 
- #20461 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
