### PR TITLE
indexer-alt: generate example config

### DIFF
--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -42,7 +42,6 @@ pub struct IndexerConfig {
     pub extra: toml::Table,
 }
 
-#[DefaultConfig]
 #[derive(Clone)]
 pub struct ConsistencyConfig {
     /// How often to check whether write-ahead logs related to the consistent range can be
@@ -177,6 +176,20 @@ macro_rules! merge_recursive {
 }
 
 impl IndexerConfig {
+    /// Generate an example configuration, suitable for demonstrating the fields available to
+    /// configure.
+    pub fn example() -> Self {
+        let mut example: Self = Default::default();
+
+        example.ingestion = IngestionConfig::default().into();
+        example.consistency = ConsistencyConfig::default().into();
+        example.committer = CommitterConfig::default().into();
+        example.pruner = PrunerConfig::default().into();
+        example.pipeline = PipelineLayer::example();
+
+        example
+    }
+
     pub fn merge(self, other: IndexerConfig) -> IndexerConfig {
         check_extra("top-level", self.extra);
         check_extra("top-level", other.extra);
@@ -354,6 +367,36 @@ impl PrunerLayer {
 }
 
 impl PipelineLayer {
+    /// Generate an example configuration, suitable for demonstrating the fields available to
+    /// configure.
+    pub fn example() -> Self {
+        PipelineLayer {
+            sum_coin_balances: Some(Default::default()),
+            wal_coin_balances: Some(Default::default()),
+            sum_obj_types: Some(Default::default()),
+            wal_obj_types: Some(Default::default()),
+            sum_displays: Some(Default::default()),
+            sum_packages: Some(Default::default()),
+            ev_emit_mod: Some(Default::default()),
+            ev_struct_inst: Some(Default::default()),
+            kv_checkpoints: Some(Default::default()),
+            kv_epoch_ends: Some(Default::default()),
+            kv_epoch_starts: Some(Default::default()),
+            kv_feature_flags: Some(Default::default()),
+            kv_objects: Some(Default::default()),
+            kv_protocol_configs: Some(Default::default()),
+            kv_transactions: Some(Default::default()),
+            obj_versions: Some(Default::default()),
+            tx_affected_addresses: Some(Default::default()),
+            tx_affected_objects: Some(Default::default()),
+            tx_balance_changes: Some(Default::default()),
+            tx_calls: Some(Default::default()),
+            tx_digests: Some(Default::default()),
+            tx_kinds: Some(Default::default()),
+            extra: Default::default(),
+        }
+    }
+
     pub fn merge(self, other: PipelineLayer) -> PipelineLayer {
         check_extra("pipeline", self.extra);
         check_extra("pipeline", other.extra);
@@ -405,6 +448,71 @@ impl Default for ConsistencyConfig {
             consistent_pruning_interval_ms: 300_000,
             pruner_delay_ms: 120_000,
             consistent_range: None,
+        }
+    }
+}
+
+impl From<IngestionConfig> for IngestionLayer {
+    fn from(config: IngestionConfig) -> Self {
+        Self {
+            checkpoint_buffer_size: Some(config.checkpoint_buffer_size),
+            ingest_concurrency: Some(config.ingest_concurrency),
+            retry_interval_ms: Some(config.retry_interval_ms),
+            extra: Default::default(),
+        }
+    }
+}
+
+impl From<ConsistencyConfig> for ConsistencyLayer {
+    fn from(config: ConsistencyConfig) -> Self {
+        Self {
+            consistent_pruning_interval_ms: Some(config.consistent_pruning_interval_ms),
+            pruner_delay_ms: Some(config.pruner_delay_ms),
+            consistent_range: config.consistent_range,
+            extra: Default::default(),
+        }
+    }
+}
+
+impl From<SequentialConfig> for SequentialLayer {
+    fn from(config: SequentialConfig) -> Self {
+        Self {
+            committer: Some(config.committer.into()),
+            checkpoint_lag: Some(config.checkpoint_lag),
+            extra: Default::default(),
+        }
+    }
+}
+
+impl From<ConcurrentConfig> for ConcurrentLayer {
+    fn from(config: ConcurrentConfig) -> Self {
+        Self {
+            committer: Some(config.committer.into()),
+            pruner: config.pruner.map(Into::into),
+            extra: Default::default(),
+        }
+    }
+}
+
+impl From<CommitterConfig> for CommitterLayer {
+    fn from(config: CommitterConfig) -> Self {
+        Self {
+            write_concurrency: Some(config.write_concurrency),
+            collect_interval_ms: Some(config.collect_interval_ms),
+            watermark_interval_ms: Some(config.watermark_interval_ms),
+            extra: Default::default(),
+        }
+    }
+}
+
+impl From<PrunerConfig> for PrunerLayer {
+    fn from(config: PrunerConfig) -> Self {
+        Self {
+            interval_ms: Some(config.interval_ms),
+            delay_ms: Some(config.delay_ms),
+            retention: Some(config.retention),
+            max_chunk_size: Some(config.max_chunk_size),
+            extra: Default::default(),
         }
     }
 }

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -581,7 +581,7 @@ mod tests {
                 consistent_pruning_interval_ms: Some(1000),
                 pruner_delay_ms: Some(2000),
                 consistent_range: Some(4000),
-                ..
+                extra: _,
             }
         );
 
@@ -591,7 +591,7 @@ mod tests {
                 consistent_pruning_interval_ms: Some(1000),
                 pruner_delay_ms: Some(2000),
                 consistent_range: Some(3000),
-                ..
+                extra: _,
             }
         );
     }
@@ -650,23 +650,23 @@ mod tests {
                     write_concurrency: Some(10),
                     collect_interval_ms: None,
                     watermark_interval_ms: Some(1000),
-                    ..
+                    extra: _,
                 }),
                 sum_obj_types: Some(CommitterLayer {
                     write_concurrency: Some(5),
                     collect_interval_ms: Some(500),
                     watermark_interval_ms: None,
-                    ..
+                    extra: _,
                 }),
                 sum_displays: Some(SequentialLayer {
                     committer: Some(CommitterLayer {
                         write_concurrency: Some(5),
                         collect_interval_ms: Some(1000),
                         watermark_interval_ms: Some(500),
-                        ..
+                        extra: _,
                     }),
                     checkpoint_lag: Some(200),
-                    ..
+                    extra: _,
                 }),
                 ..
             },
@@ -679,23 +679,23 @@ mod tests {
                     write_concurrency: Some(10),
                     collect_interval_ms: None,
                     watermark_interval_ms: Some(1000),
-                    ..
+                    extra: _,
                 }),
                 sum_obj_types: Some(CommitterLayer {
                     write_concurrency: Some(5),
                     collect_interval_ms: Some(500),
                     watermark_interval_ms: None,
-                    ..
+                    extra: _,
                 }),
                 sum_displays: Some(SequentialLayer {
                     committer: Some(CommitterLayer {
                         write_concurrency: Some(10),
                         collect_interval_ms: Some(1000),
                         watermark_interval_ms: Some(500),
-                        ..
+                        extra: _,
                     }),
                     checkpoint_lag: Some(100),
-                    ..
+                    extra: _,
                 }),
                 ..
             },
@@ -730,7 +730,7 @@ mod tests {
                 delay_ms: Some(100),
                 retention: Some(500),
                 max_chunk_size: Some(600),
-                ..
+                extra: _,
             },
         );
 
@@ -741,7 +741,7 @@ mod tests {
                 delay_ms: Some(100),
                 retention: Some(500),
                 max_chunk_size: Some(300),
-                ..
+                extra: _,
             },
         );
     }

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -404,7 +404,7 @@ pub async fn start_indexer(
         committer,
         pruner,
         pipeline,
-        ..
+        extra: _,
     } = indexer_config.finish();
 
     let PipelineLayer {
@@ -430,7 +430,7 @@ pub async fn start_indexer(
         tx_calls,
         tx_digests,
         tx_kinds,
-        ..
+        extra: _,
     } = pipeline.finish();
 
     let ingestion = ingestion.finish(IngestionConfig::default());

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use sui_indexer_alt::args::Args;
 use sui_indexer_alt::args::Command;
 use sui_indexer_alt::config::IndexerConfig;
+use sui_indexer_alt::config::Merge;
 use sui_indexer_alt::db::reset_database;
 use sui_indexer_alt::start_indexer;
 use tokio::fs;

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         }
 
         Command::GenerateConfig => {
-            let config = IndexerConfig::default();
+            let config = IndexerConfig::example();
             let config_toml = toml::to_string_pretty(&config)
                 .context("Failed to serialize default configuration to TOML.")?;
 


### PR DESCRIPTION
## Description

Using the default impl for `IndexerConfig` to generate the output for `generate-config` lead to sub-par results because most of its fields are optional, and so will not show up.

This change introduces an explicit `example` function that is responsible for generating a non-default output that does a better job of documenting what fields and pipelines are available to configure.

## Test plan

Generate a config:

```
sui$ cargo run -p sui-indexer-alt -- generate-config

[ingestion]
checkpoint-buffer-size = 5000
ingest-concurrency = 200
retry-interval-ms = 200

[consistency]
consistent-pruning-interval-ms = 300000
pruner-delay-ms = 120000

[committer]
write-concurrency = 5
collect-interval-ms = 500
watermark-interval-ms = 500

[pruner]
interval-ms = 300000
delay-ms = 120000
retention = 4000000
max-chunk-size = 2000

[pipeline.sum_coin_balances]

[pipeline.wal_coin_balances]

[pipeline.sum_obj_types]

[pipeline.wal_obj_types]

[pipeline.sum_displays]

[pipeline.sum_packages]

[pipeline.ev_emit_mod]

[pipeline.ev_struct_inst]

[pipeline.kv_checkpoints]

[pipeline.kv_epoch_ends]

[pipeline.kv_epoch_starts]

[pipeline.kv_feature_flags]

[pipeline.kv_objects]

[pipeline.kv_protocol_configs]

[pipeline.kv_transactions]

[pipeline.obj_versions]

[pipeline.tx_affected_addresses]

[pipeline.tx_affected_objects]

[pipeline.tx_balance_changes]

[pipeline.tx_calls]

[pipeline.tx_digests]

[pipeline.tx_kinds]

```

## Stack

- #20459 
- #20460 
- #20461 
- #20462 
- #20463 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
