### PR TITLE
fix(sui-indexer): Fix StructTag conversion for suix_queryEvents Indexer-RPC method

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1030,7 +1030,8 @@ impl IndexerReader {
                     )
                 }
                 EventFilter::MoveEventType(struct_tag) => {
-                    format!("event_type = '{}'", struct_tag)
+                    let formatted_struct_tag = struct_tag.to_canonical_string(true);
+                    format!("event_type = '{formatted_struct_tag}'")
                 }
                 EventFilter::MoveEventModule { package, module } => {
                     let package_module_prefix = format!("{}::{}", package.to_hex_literal(), module);

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1030,8 +1030,10 @@ impl IndexerReader {
                     )
                 }
                 EventFilter::MoveEventType(struct_tag) => {
-                    let formatted_struct_tag = struct_tag.to_canonical_string(true);
-                    format!("event_type = '{formatted_struct_tag}'")
+                    format!(
+                        "event_type = '{}'",
+                        struct_tag.to_canonical_display(/* with_prefix */ true),
+                    )
                 }
                 EventFilter::MoveEventModule { package, module } => {
                     let package_module_prefix = format!("{}::{}", package.to_hex_literal(), module);

--- a/crates/sui-indexer/tests/json_rpc_tests.rs
+++ b/crates/sui-indexer/tests/json_rpc_tests.rs
@@ -241,3 +241,61 @@ async fn test_events() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_event_type_filter() {
+    let cluster = TestClusterBuilder::new()
+        .with_indexer_backed_rpc()
+        .build()
+        .await;
+
+    let client = cluster.rpc_client();
+
+    cluster.trigger_reconfiguration().await;
+
+    let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV2".parse().unwrap()), None, None, None).await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().data.is_empty());
+    let result = client
+        .query_events(
+            EventFilter::MoveEventType(
+                "0x3::validator_set::ValidatorEpochInfoEventV2"
+                    .parse()
+                    .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().data.is_empty());
+    let result = client
+        .query_events(
+            EventFilter::MoveEventType(
+                "0x0003::validator_set::ValidatorEpochInfoEventV2"
+                    .parse()
+                    .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().data.is_empty());
+    let result = client
+        .query_events(
+            EventFilter::MoveEventType(
+                "0x1::validator_set::ValidatorEpochInfoEventV2"
+                    .parse()
+                    .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().data.is_empty());
+}


### PR DESCRIPTION
## Description 

Currently, there is a bug in the `suix_queryEvents` implementation when processing `EventFilter::MoveEventType(struct_tag)`. Even if the user provides a `struct_tag` in its full canonical hex representation (including the necessary prefix), it is not converted correctly to the format expected by the database. Instead, the struct_tag is transformed into a simplified representation that does not align with the structure stored in the indexer database.

This mismatch causes the SQL query to fail in finding the relevant records, effectively preventing the retrieval of the desired event data, despite the user supplying the correct input.

While `suix_queryEvents` makes use of following string:

https://github.com/MystenLabs/sui/blob/8bd53998f88c4619f39dcf298f699199a0071e7c/crates/sui-indexer/src/indexer_reader.rs#L1032-L1034

The indexed event is stored makes use of the full canonical string (including the prefix):

https://github.com/MystenLabs/sui/blob/8bd53998f88c4619f39dcf298f699199a0071e7c/crates/sui-indexer/src/types.rs#L134

You can reproduce the issue by calling the `suix_queryEvents` RPC endpoint on a indexer instance as follows:

```
curl 'http://INDEXER_IP:INDEXER_PORT' \
  -H 'content-type: application/json' \
  --data-raw '{"jsonrpc":"2.0","id":4,"method":"suix_queryEvents","params":[{"MoveEventType":"0x00000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV2"},null,8,true]}'
```

**Inspired from this PR: https://github.com/iotaledger/iota/pull/4289**

## Test plan 

Please see the provided test.

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [X] Indexer: Fix `StructTag` conversion for `suix_queryEvents` Indexer-RPC method
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
