### PR TITLE
feat(crates/sui): add --with-data-ingestion to 'sui start'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ cached = "0.43.0"
 camino = "1.1.1"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.26", features = ["clock", "serde"] }
-clap = { version = "4.4", features = ["derive", "wrap_help"] }
+clap = { version = "4.4", features = ["derive", "string", "wrap_help"] }
 codespan-reporting = "0.11.1"
 collectable = "0.0.2"
 colored = "2.0.0"
@@ -604,7 +604,11 @@ anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "e609f769
 
 # core-types with json format for REST api
 # sui-sdk-types = { version = "0.0.1", features = ["hash", "serde", "schemars"] }
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "31bd9da32a8057edc45da8f5e6a8f25b83919b93", features = ["hash", "serde", "schemars"] }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "31bd9da32a8057edc45da8f5e6a8f25b83919b93", features = [
+    "hash",
+    "serde",
+    "schemars",
+] }
 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }
@@ -652,7 +656,7 @@ sui-json-rpc = { path = "crates/sui-json-rpc" }
 sui-json-rpc-api = { path = "crates/sui-json-rpc-api" }
 sui-json-rpc-types = { path = "crates/sui-json-rpc-types" }
 sui-keys = { path = "crates/sui-keys" }
-sui-kvstore = {path = "crates/sui-kvstore"}
+sui-kvstore = { path = "crates/sui-kvstore" }
 sui-macros = { path = "crates/sui-macros" }
 sui-metric-checker = { path = "crates/sui-metric-checker" }
 sui-move = { path = "crates/sui-move" }


### PR DESCRIPTION
## Description 

Adds the `--with-data-ingestion` option to `sui start` that allows users to set a custom data ingestion directory where checkpoint files will be written to.

This is useful, among other things, for testing a custom [local reader](https://docs.sui.io/guides/developer/advanced/custom-indexer#local-reader) indexing setup with low overhead.

It is worth noting that this is a breaking change, as previously `sui start --with-indexer` would work, but now it requires at least `sui start --with-data-ingestion --with-indexer` to achieve the same results.

The `string` feature was added to `clap` in the root `Cargo.toml` so that a dynamic default value for `--with-data-ingestion` could be configured. I can try to move that feature requirement to `crates/sui/Cargo.toml`.

P.s.: every time I ran `sui start --with-data-ingestion=<path>` (no other arguments), the network started producing checkpoints from 0. Is this intended or was the network supposed to pick up from where it left off? Perhaps it's the full node syncing.

## Test plan 

I tested it locally to verify that the checkpoints are indeed written to the configured directory. See the screenshot below. `sui start --with-data-ingestion --with-indexer` seems to run like the previous `sui start --with-indexer` without problems and I verified that checkpoints were committed to the DB.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
