### PR TITLE
Ignore chain id when using `--dump-bytecode-as-base64` in `sui move build`

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -22,6 +22,11 @@ pub struct Build {
     /// Whether we are printing in base64.
     #[clap(long, global = true)]
     pub dump_bytecode_as_base64: bool,
+    #[clap(long, global = true, requires = "dump_bytecode_as_base64")]
+    /// Ignore the chain ID when dumping bytecode as base64. This is mostly used to automate `sui
+    /// move build` such that it does not require a `client.yaml` file. Do not use in normal
+    /// production workflows as it will break automated address management feature!
+    pub ignore_chain: bool,
     /// If true, generate struct layout schemas for
     /// all struct types passed into `entry` functions declared by modules in this package
     /// These layout schemas can be consumed by clients (e.g.,

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -22,10 +22,10 @@ pub struct Build {
     /// Whether we are printing in base64.
     #[clap(long, global = true)]
     pub dump_bytecode_as_base64: bool,
+    /// Don't specialize the package to the active chain when dumping bytecode as Base64. This
+    /// allows building to proceed without a network connection or active environment, but it
+    /// will not be able to automatically determine the addresses of its dependencies.
     #[clap(long, global = true, requires = "dump_bytecode_as_base64")]
-    /// Ignore the chain ID when dumping bytecode as base64. This is mostly used to automate `sui
-    /// move build` such that it does not require a `client.yaml` file. Do not use in normal
-    /// production workflows as it will break automated address management feature!
     pub ignore_chain: bool,
     /// If true, generate struct layout schemas for
     /// all struct types passed into `entry` functions declared by modules in this package

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -477,20 +477,24 @@ impl SuiCommand {
             } => {
                 match &mut cmd {
                     sui_move::Command::Build(build) if build.dump_bytecode_as_base64 => {
-                        // `sui move build` does not ordinarily require a network connection.
-                        // The exception is when --dump-bytecode-as-base64 is specified: In this
-                        // case, we should resolve the correct addresses for the respective chain
-                        // (e.g., testnet, mainnet) from the Move.lock under automated address management.
-                        let config =
-                            client_config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
-                        prompt_if_no_config(&config, false).await?;
-                        let context = WalletContext::new(&config, None, None)?;
-                        if let Err(e) = context.get_client().await?.check_api_version() {
-                            eprintln!("{}", format!("[warning] {e}").yellow().bold());
+                        if build.ignore_chain {
+                            build.chain_id = None;
+                        } else {
+                            // `sui move build` does not ordinarily require a network connection.
+                            // The exception is when --dump-bytecode-as-base64 is specified: In this
+                            // case, we should resolve the correct addresses for the respective chain
+                            // (e.g., testnet, mainnet) from the Move.lock under automated address management.
+                            let config =
+                                client_config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
+                            prompt_if_no_config(&config, false).await?;
+                            let context = WalletContext::new(&config, None, None)?;
+                            if let Err(e) = context.get_client().await?.check_api_version() {
+                                eprintln!("{}", format!("[warning] {e}").yellow().bold());
+                            }
+                            let client = context.get_client().await?;
+                            let chain_id = client.read_api().get_chain_identifier().await.ok();
+                            build.chain_id = chain_id.clone();
                         }
-                        let client = context.get_client().await?;
-                        let chain_id = client.read_api().get_chain_identifier().await.ok();
-                        build.chain_id = chain_id.clone();
                     }
                     _ => (),
                 };


### PR DESCRIPTION
## Description 

Allow `sui move build --dump-bytecode-as-base64` to not need to read the chain from `client.yaml` by adding a flag `--ignore-chain`. This allows building to proceed without a network connection or active environment, but it will not be able to automatically determine the addresses of its dependencies.
NB: `--ignore-chain` depends on `dump-bytecode-as-base64`, so it cannot be used on its own.

Should close #20458.

## Test plan 

Local test.
```
➜  first_package git:(main) ✗ sui move build --dump-bytecode-as-base64 --ignore-chain
INCLUDING DEPENDENCY Sui
INCLUDING DEPENDENCY MoveStdlib
BUILDING my_first_package
JSON_OUTPUT_HERE - replaced for brevity.
➜  first_package git:(main) ✗ sui move build --dump-bytecode-as-base64
Config file ["/Users/user/.sui/sui_config/client.yaml"] doesn't exist, do you want to connect to a Sui Full node server [y/N]?
```
---
## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI:  Added the flag `--ignore-chain` that works together with `sui move build --dump-bytecode-as-base64` to bypass the need for a `client.yaml` file. This allows building to proceed without a network connection or active environment, but it will not be able to automatically determine the addresses of its dependencies. NB: `--ignore-chain` depends on `--dump-bytecode-as-base64`, so it cannot be used on its own.
- [ ] Rust SDK:
- [ ] REST API:
