### PR TITLE
[fix] Controlled collapsible component chevron not collapsing

### DIFF
--- a/apps/wallet/src/ui/app/components/accounts/AccountsList.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountsList.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ampli } from '_src/shared/analytics/ampli';
-import { Collapsible } from '_src/ui/app/shared/collapse';
 import { Filter16, Plus12 } from '@mysten/icons';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
+import { ampli } from '_src/shared/analytics/ampli';
+import { Collapsible } from '_src/ui/app/shared/collapse';
 import cn from 'clsx';
 import { useMemo, useState } from 'react';
 
@@ -59,14 +59,7 @@ export function AccountsList() {
 				onValueChange={handleSelectAccount}
 			>
 				<>
-					<Collapsible defaultOpen title="Current" shade="darker">
-						<ToggleGroup.Item asChild value={activeAccount.id}>
-							<div>
-								<AccountListItem account={activeAccount} editable showLock />
-							</div>
-						</ToggleGroup.Item>
-					</Collapsible>
-
+					<AccountListItem account={activeAccount} editable showLock />
 					{otherAccounts.length ? (
 						<Collapsible
 							isOpen={isSwitchToAccountOpen}

--- a/apps/wallet/src/ui/app/helpers/accounts.ts
+++ b/apps/wallet/src/ui/app/helpers/accounts.ts
@@ -22,9 +22,9 @@ export function getAccountBackgroundByType(account: SerializedUIAccount) {
 	if (!isZkLoginAccountSerializedUI(account)) return 'bg-gradients-graph-cards';
 	switch (account.provider) {
 		case 'google':
-			return 'bg-google bg-no-repeat bg-cover';
+			return 'bg-google bg-no-repeat bg-cover bg-center';
 		case 'twitch':
-			return 'bg-twitch-image bg-no-repeat bg-cover';
+			return 'bg-gradients-twitch bg-no-repeat bg-cover';
 		default:
 			return `bg-gradients-graph-cards`;
 	}

--- a/apps/wallet/src/ui/app/shared/collapse/index.tsx
+++ b/apps/wallet/src/ui/app/shared/collapse/index.tsx
@@ -1,39 +1,52 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChevronDown12, ChevronRight12 } from '@mysten/icons';
+import { ChevronRight12 } from '@mysten/icons';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 import cn from 'clsx';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
-interface CollapsibleProps {
-	title: string;
+type ControlledCollapsibleProps = {
+	isOpen: boolean;
+	onOpenChange: (isOpen: boolean) => void;
+	defaultOpen?: never;
+};
+
+type UncontrolledCollapsibleProps = {
 	defaultOpen?: boolean;
+	isOpen?: never;
+	onOpenChange?: never;
+};
+
+type CollapsibleProps = {
+	title: string;
 	children: ReactNode | ReactNode[];
 	shade?: 'lighter' | 'darker';
-	isOpen?: boolean;
-	onOpenChange?: (isOpen: boolean) => void;
-}
+} & (ControlledCollapsibleProps | UncontrolledCollapsibleProps);
 
 export function Collapsible({
 	title,
 	children,
-	defaultOpen,
+	defaultOpen = false,
 	isOpen,
 	onOpenChange,
 	shade = 'lighter',
 }: CollapsibleProps) {
-	const [open, setOpen] = useState(isOpen ?? defaultOpen ?? false);
+	const [open, setOpen] = useState(isOpen ?? defaultOpen);
 
 	const handleOpenChange = (isOpen: boolean) => {
 		setOpen(isOpen);
 		onOpenChange?.(isOpen);
 	};
 
+	useEffect(() => {
+		setOpen(Boolean(isOpen));
+	}, [isOpen]);
+
 	return (
 		<CollapsiblePrimitive.Root
 			className="flex flex-shrink-0 justify-start flex-col w-full gap-3"
-			open={isOpen ?? open}
+			open={open}
 			onOpenChange={handleOpenChange}
 		>
 			<CollapsiblePrimitive.Trigger className="flex items-center gap-2 w-full bg-transparent border-none p-0 cursor-pointer group">
@@ -52,12 +65,16 @@ export function Collapsible({
 					})}
 				/>
 				<div
-					className={cn('group-hover:text-hero inline-flex', {
-						'text-steel': shade === 'darker',
-						'text-gray-45': shade === 'lighter',
-					})}
+					className={cn(
+						'group-hover:text-hero inline-flex transition-transform',
+						{
+							'text-steel': shade === 'darker',
+							'text-gray-45': shade === 'lighter',
+						},
+						open ? 'transform rotate-90' : '',
+					)}
 				>
-					{open ? <ChevronDown12 /> : <ChevronRight12 />}
+					<ChevronRight12 />
 				</div>
 			</CollapsiblePrimitive.Trigger>
 

--- a/apps/wallet/tailwind.config.ts
+++ b/apps/wallet/tailwind.config.ts
@@ -71,7 +71,7 @@ export default {
 			},
 			backgroundImage: {
 				google: 'url(_assets/images/google-background.png)',
-				'twitch-image': 'linear-gradient(165deg, #ECE5FA 5.6%, #C8BAE2 89.58%);',
+				'gradients-twitch': 'linear-gradient(165deg, #ECE5FA 5.6%, #C8BAE2 89.58%);',
 			},
 		},
 	},


### PR DESCRIPTION
## Description 

Collapsing the switch accounts submenu after selecting a different account will not properly collapse the downward chevron (see video):

https://www.loom.com/share/eb2249e49d6148e08b1037b88b2baf8b

Changelog:
- The right chevron is replaced with the down chevron rotated 90 degrees, to reduce the number of image imports on this collapsible.
- A css transition animation was added to the rotation so that it moves between rotations
- The collapsible is removed from the active wallet display, because why would you ever want to collapse it?...
- Fixed the controlled component `Collapsible` to respond to changes to its `isOpen` prop by changing its internal state.
- Moved the google background image to center because there are compression artifacts near the edges of the image

## Test plan 

See video:

https://loom.com/share/2dd0e386877e47daa0c9ca020afba394

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
