### PR TITLE
[move-compiler] public init for unittesting in dubug build

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1727,9 +1727,9 @@ fn check_function_visibility(
 pub enum PublicForTesting {
     /// The function is entry, so it can be called in unit tests
     Entry(Loc),
-    // TODO we should allow calling init in unit tests, but this would need Sui bytecode verifier
-    // support. Or we would need to name dodge init in unit tests
-    // SuiInit(Loc),
+    // We allow calling init in unit tests in debug build
+    #[cfg(debug_assertions)]
+    SuiInit,
 }
 
 pub fn public_testing_visibility(
@@ -1743,9 +1743,10 @@ pub fn public_testing_visibility(
         return None;
     }
 
-    // TODO support sui init functions
-    // let flavor = env.package_config(package).flavor;
-    // flavor == Flavor::Sui && callee_name.value() == INIT_FUNCTION_NAME
+    #[cfg(debug_assertions)]
+    if _callee_name.value() == crate::sui_mode::INIT_FUNCTION_NAME {
+        return Some(PublicForTesting::SuiInit)
+    }
     callee_entry.map(PublicForTesting::Entry)
 }
 
@@ -1780,7 +1781,18 @@ fn report_visibility_error_(
                         TestingAttribute::TEST_ONLY,
                     );
                     (entry_loc, entry_msg)
-                }
+                },
+                #[cfg(debug_assertions)]
+                PublicForTesting::SuiInit => {
+                    let entry_msg = format!(
+                        "'{}' functions can be called in tests, \
+                    but only from testing contexts, e.g. '#[{}]' or '#[{}]'",
+                        crate::sui_mode::INIT_FUNCTION_NAME,
+                        TestingAttribute::TEST,
+                        TestingAttribute::TEST_ONLY,
+                    );
+                    (Loc::invalid(), entry_msg)
+                },
             };
             diag.add_secondary_label((test_loc, test_msg))
         }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -303,6 +303,8 @@ fn function(context: &mut Context, name: FunctionName, f: N::Function) -> T::Fun
     let compiled_visibility =
         match public_testing_visibility(context.env, context.current_package, &name, entry) {
             Some(PublicForTesting::Entry(loc)) => Visibility::Public(loc),
+            #[cfg(debug_assertions)]
+            Some(PublicForTesting::SuiInit) => Visibility::Public(Loc::invalid()),
             None => visibility,
         };
     function_signature(context, macro_, &signature);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_init_function.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_init_function.move
@@ -1,0 +1,12 @@
+// check that fun `init` can not be used cross module
+module 0x1::M {
+    fun init() { }
+}
+
+module 0x1::Tests {
+    #[test]
+    fun tester() {
+        use 0x1::M;
+        M::init();
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_init_function.unit_test.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_init_function.unit_test.exp
@@ -1,0 +1,9 @@
+error[E04001]: restricted visibility
+   ┌─ tests/move_2024/unit_test/cross_module_init_function.move:10:9
+   │
+ 3 │     fun init() { }
+   │         ---- This function is internal to its module. Only 'public' and 'public(package)' functions can be called outside of their module
+   ·
+10 │         M::init();
+   │         ^^^^^^^^^ Invalid call to internal function '0x1::M::init'
+


### PR DESCRIPTION
## Description 
Provide `init` for unit test in debug build, please reference #20389.

## Test plan 
`cross_module_init_function.move` is added for make sure there is no change on the release baseline.

---

## Release notes
The release did no change any production level code.
- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
