### PR TITLE
indexer-alt: separate updates for consistent sequential pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "diesel-update-from"
-version = "1.39.0"
+version = "1.40.0"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -13948,6 +13948,7 @@ dependencies = [
  "clap",
  "diesel",
  "diesel-async",
+ "diesel-update-from",
  "diesel_migrations",
  "futures",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,6 +3768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-update-from"
+version = "1.39.0"
+dependencies = [
+ "diesel",
+ "diesel-async",
+ "insta",
+ "sui-pg-db",
+ "tokio",
+]
+
+[[package]]
 name = "diesel_derives"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "consensus/core",
     "crates/anemo-benchmark",
     "crates/bin-version",
+    "crates/diesel-update-from",
     "crates/mysten-common",
     "crates/mysten-metrics",
     "crates/mysten-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -603,6 +603,7 @@ sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }
 bin-version = { path = "crates/bin-version" }
+diesel-update-from = { path = "crates/diesel-update-from" }
 mysten-common = { path = "crates/mysten-common" }
 mysten-metrics = { path = "crates/mysten-metrics" }
 mysten-network = { path = "crates/mysten-network" }

--- a/crates/diesel-update-from/Cargo.toml
+++ b/crates/diesel-update-from/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "diesel-update-from"
+edition = "2021"
+version.workspace = true
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+# Opting in to breaking changes to gain access to types and traits related to
+# insertion statements: BatchInsert, ValuesClause. Diesel's codegen builds
+# conversions from collections of model types into these types.
+diesel = { workspace = true, features = ["postgres_backend", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
+
+[dev-dependencies]
+diesel-async = { workspace = true, features = ["postgres"] }
+insta.workspace = true
+sui-pg-db.workspace = true
+tokio.workspace = true

--- a/crates/diesel-update-from/src/lib.rs
+++ b/crates/diesel-update-from/src/lib.rs
@@ -1,0 +1,177 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::{
+    insertable::InsertValues,
+    pg::Pg,
+    query_builder::{AstPass, BatchInsert, QueryFragment, QueryId, ValuesClause},
+    AsChangeset, Insertable, QueryResult, RunQueryDsl, Table,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Diesel bindings for the postgres specific Bulk-`UPDATE` statement, of the form:
+///
+/// ```sql
+/// UPDATE
+///     $table
+/// SET
+///     $set, ...
+/// FROM
+///     (VALUES $values, ...) AS excluded ($columns, ...)
+/// WHERE
+///     $where_clause;
+/// ```
+#[derive(Debug)]
+pub struct UpdateFromStatement<T: Table, S = SetNotCalled, V = ValuesNotCalled, W = WhereNotCalled>
+{
+    table: T::FromClause,
+    set_clause: S,
+    values: V,
+    where_clause: W,
+}
+
+pub struct SetNotCalled;
+pub struct ValuesNotCalled;
+pub struct WhereNotCalled;
+
+impl<T: Table, V, W> UpdateFromStatement<T, SetNotCalled, V, W> {
+    /// Provides the `SET` clause of the `UPDATE` statement.
+    ///
+    /// This clause decides which fields in the table are updated with the values from the `VALUES`
+    /// clause.
+    pub fn set<S>(self, set_clause: S) -> UpdateFromStatement<T, S::Changeset, V, W>
+    where
+        S: AsChangeset<Target = T>,
+    {
+        UpdateFromStatement {
+            table: self.table,
+            set_clause: set_clause.as_changeset(),
+            values: self.values,
+            where_clause: self.where_clause,
+        }
+    }
+}
+
+impl<T: Table, S, W> UpdateFromStatement<T, S, ValuesNotCalled, W> {
+    /// Provides the `VALUES` clause of the `UPDATE` statement.
+    ///
+    /// This clause provides potentially multiple values to write into the table. `values` must be
+    /// `Insertable` into the `table` being updated, and can contain values that are not actually
+    /// written to the table (including, for example, the key columns used to identify which rows
+    /// to associate each value with for the update).
+    pub fn values<V>(self, values: V) -> UpdateFromStatement<T, S, V::Values, W>
+    where
+        V: Insertable<T>,
+    {
+        UpdateFromStatement {
+            table: self.table,
+            set_clause: self.set_clause,
+            values: values.values(),
+            where_clause: self.where_clause,
+        }
+    }
+}
+
+impl<T: Table, S, V> UpdateFromStatement<T, S, V, WhereNotCalled> {
+    /// Restrict the rows that are updated by the `UPDATE` statement.
+    ///
+    /// This kind of query must have a filter supplied, to join the values being updated from with
+    /// the rows they are updating. Without a filter, all rows in the table will be updated using
+    /// values from the first value in the `VALUES` clause.
+    pub fn filter<W>(self, where_clause: W) -> UpdateFromStatement<T, S, V, W> {
+        UpdateFromStatement {
+            table: self.table,
+            set_clause: self.set_clause,
+            values: self.values,
+            where_clause,
+        }
+    }
+}
+
+/// `QueryId` is used to support prepared statement cachine. The `values` clause causes complicates
+/// for the `UPDATE ... FROM` statement, because it will generate a different prepared statement
+/// based on the number of values being inserted.
+impl<T: Table, S, V, W> QueryId for UpdateFromStatement<T, S, V, W> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<T: Table, S, V, W, Conn> RunQueryDsl<Conn> for UpdateFromStatement<T, S, V, W> {}
+
+impl<T: Table, S, V, W, QId, const HAS_STATIC_QUERY_ID: bool> QueryFragment<Pg>
+    for UpdateFromStatement<
+        T,
+        S,
+        BatchInsert<Vec<ValuesClause<V, T>>, T, QId, HAS_STATIC_QUERY_ID>,
+        W,
+    >
+where
+    T::FromClause: QueryFragment<Pg>,
+    S: QueryFragment<Pg>,
+    V: InsertValues<Pg, T>,
+    W: QueryFragment<Pg>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        out.push_sql("UPDATE ");
+        self.table.walk_ast(out.reborrow())?;
+        out.push_sql(" SET ");
+        self.set_clause.walk_ast(out.reborrow())?;
+
+        let mut values = self.values.values.iter();
+        let Some(first) = values.next() else {
+            out.push_sql(" WHERE 1=0");
+            return Ok(());
+        };
+
+        out.push_sql(" FROM (VALUES (");
+        first.values.walk_ast(out.reborrow())?;
+        out.push_sql(")");
+
+        for value in values {
+            out.push_sql(", (");
+            value.values.walk_ast(out.reborrow())?;
+            out.push_sql(")");
+        }
+
+        out.push_sql(") AS excluded (");
+        first.values.column_names(out.reborrow())?;
+        out.push_sql(") WHERE ");
+        self.where_clause.walk_ast(out.reborrow())?;
+        Ok(())
+    }
+}
+
+/// Creates an `UPDATE` statement where the values to update are provided by a `VALUES` clause
+/// (i.e. a bulk update). A Postgres-specific extension, which Diesel does not support natively.
+///
+/// The `values` being updated must be `Insertable` into the `table` being updated.
+///
+/// The fields that are updated are determined by the `set` clause, and the `filter` clause must be
+/// used to join the values being updated from with the rows in the table they are updating. The
+/// set of values being updated from can be referred to as the `excluded` table (similar to how the
+/// regular [diesel::update] works) in both the `set` and `filter` clauses.
+///
+/// NOTE: By default, diesel treats `None` fields being inserted as equivalent to `DEFAULT`, (for
+/// `INSERT` statements), but this syntax is not compatible with the `UPDATE ... FROM` statement,
+/// where `None` fields must be treated as `NULL`. To work around this, for types that are only
+/// used for bulk updates, you can set:
+///
+///  #[diesel(treat_none_as_default_value = false)]
+///
+/// Which will cause `None` to be interpreted as `NULL`, or, if `DEFAULT` is useful in some cases,
+/// use `Option<Option<T>>`: `None` will be interpreted as `DEFAULT`, and `Some(None)` will be
+/// interpreted as `NULL`.
+pub fn update_from<T>(table: T) -> UpdateFromStatement<T>
+where
+    T: Table,
+{
+    UpdateFromStatement {
+        table: table.from_clause(),
+        set_clause: SetNotCalled,
+        values: ValuesNotCalled,
+        where_clause: WhereNotCalled,
+    }
+}

--- a/crates/diesel-update-from/src/tests.rs
+++ b/crates/diesel-update-from/src/tests.rs
@@ -1,0 +1,405 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::{
+    debug_query, upsert::excluded, BoolExpressionMethods, ExpressionMethods, QueryDsl, Queryable,
+};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use insta::assert_display_snapshot;
+use sui_pg_db::temp::TempDb;
+
+use super::*;
+
+diesel::table! {
+    objects (object_id) {
+        object_id -> Bytea,
+        version -> Int8,
+        kind -> Int2,
+        owner -> Nullable<Bytea>,
+        type_ -> Nullable<Text>,
+    }
+}
+
+#[derive(Insertable, Queryable, Debug, Clone, Eq, PartialEq)]
+#[diesel(table_name = objects, primary_key(object_id))]
+#[diesel(treat_none_as_default_value = false)]
+struct StoredObject {
+    object_id: Vec<u8>,
+    version: i64,
+    kind: i16,
+    owner: Option<Vec<u8>>,
+    type_: Option<String>,
+}
+
+#[test]
+fn test_update_from() {
+    let query = update_from(objects::table)
+        .set((
+            objects::version.eq(excluded(objects::version)),
+            objects::kind.eq(excluded(objects::kind)),
+            objects::owner.eq(excluded(objects::owner)),
+            objects::type_.eq(excluded(objects::type_)),
+        ))
+        .filter(objects::object_id.eq(excluded(objects::object_id)))
+        .values(vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 1,
+                kind: 2,
+                owner: None,
+                type_: Some("type".to_string()),
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 2,
+                kind: 3,
+                owner: Some(vec![7, 8, 9]),
+                type_: None,
+            },
+        ]);
+
+    assert_display_snapshot!(debug_query::<Pg, _>(&query), @r###"UPDATE "objects" SET "version" = excluded."version", "kind" = excluded."kind", "owner" = excluded."owner", "type_" = excluded."type_" FROM (VALUES ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10)) AS excluded ("object_id", "version", "kind", "owner", "type_") WHERE ("objects"."object_id" = excluded."object_id") -- binds: [[1, 2, 3], 1, 2, None, Some("type"), [4, 5, 6], 2, 3, Some([7, 8, 9]), None]"###);
+}
+
+#[test]
+fn test_update_from_empty() {
+    let query = update_from(objects::table)
+        .set((
+            objects::version.eq(excluded(objects::version)),
+            objects::kind.eq(excluded(objects::kind)),
+            objects::owner.eq(excluded(objects::owner)),
+            objects::type_.eq(excluded(objects::type_)),
+        ))
+        .filter(objects::object_id.eq(excluded(objects::object_id)))
+        .values::<Vec<StoredObject>>(vec![]);
+
+    assert_display_snapshot!(debug_query::<Pg, _>(&query), @r###"UPDATE "objects" SET "version" = excluded."version", "kind" = excluded."kind", "owner" = excluded."owner", "type_" = excluded."type_" WHERE 1=0 -- binds: []"###);
+}
+
+/// Update all the columns from the model type.
+#[tokio::test]
+async fn test_bulk_update() {
+    let temp_db = TempDb::new().unwrap();
+    setup_objects_table(&temp_db).await;
+
+    update_from(objects::table)
+        .set((
+            objects::version.eq(excluded(objects::version)),
+            objects::kind.eq(excluded(objects::kind)),
+            objects::owner.eq(excluded(objects::owner)),
+            objects::type_.eq(excluded(objects::type_)),
+        ))
+        .filter(objects::object_id.eq(excluded(objects::object_id)))
+        .values(vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 200,
+                kind: 300,
+                owner: Some(vec![4, 5, 6]),
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 300,
+                kind: 200,
+                owner: None,
+                type_: Some("qux".to_string()),
+            },
+        ])
+        .execute(&mut conn(&temp_db).await)
+        .await
+        .unwrap();
+
+    let objects: Vec<StoredObject> = objects::table
+        .order_by(objects::dsl::object_id)
+        .load(&mut conn(&temp_db).await)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        objects,
+        vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 200,
+                kind: 300,
+                owner: Some(vec![4, 5, 6]),
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 300,
+                kind: 200,
+                owner: None,
+                type_: Some("qux".to_string()),
+            },
+            StoredObject {
+                object_id: vec![10, 11, 12],
+                version: 3,
+                kind: 0,
+                owner: Some(vec![13, 14, 15]),
+                type_: Some("bar".to_string()),
+            },
+            StoredObject {
+                object_id: vec![16, 17, 18],
+                version: 4,
+                kind: 3,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![19, 20, 21],
+                version: 5,
+                kind: 2,
+                owner: Some(vec![22, 23, 24]),
+                type_: Some("baz".to_string()),
+            },
+        ]
+    );
+}
+
+/// Only update certain columns from the model type.
+#[tokio::test]
+async fn test_bulk_update_partial_rows() {
+    let temp_db = TempDb::new().unwrap();
+    setup_objects_table(&temp_db).await;
+
+    update_from(objects::table)
+        .set((
+            objects::version.eq(excluded(objects::version)),
+            objects::type_.eq(excluded(objects::type_)),
+        ))
+        .filter(objects::object_id.eq(excluded(objects::object_id)))
+        .values(vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 200,
+                kind: 300,
+                owner: Some(vec![4, 5, 6]),
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 300,
+                kind: 200,
+                owner: None,
+                type_: Some("qux".to_string()),
+            },
+        ])
+        .execute(&mut conn(&temp_db).await)
+        .await
+        .unwrap();
+
+    let objects: Vec<StoredObject> = objects::table
+        .order_by(objects::dsl::object_id)
+        .load(&mut conn(&temp_db).await)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        objects,
+        vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 200,
+                kind: 2,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 300,
+                kind: 1,
+                owner: Some(vec![7, 8, 9]),
+                type_: Some("qux".to_string()),
+            },
+            StoredObject {
+                object_id: vec![10, 11, 12],
+                version: 3,
+                kind: 0,
+                owner: Some(vec![13, 14, 15]),
+                type_: Some("bar".to_string()),
+            },
+            StoredObject {
+                object_id: vec![16, 17, 18],
+                version: 4,
+                kind: 3,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![19, 20, 21],
+                version: 5,
+                kind: 2,
+                owner: Some(vec![22, 23, 24]),
+                type_: Some("baz".to_string()),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_bulk_update_filtered() {
+    let temp_db = TempDb::new().unwrap();
+    setup_objects_table(&temp_db).await;
+
+    update_from(objects::table)
+        .set((
+            objects::version.eq(excluded(objects::version)),
+            objects::kind.eq(excluded(objects::kind)),
+            objects::owner.eq(excluded(objects::owner)),
+            objects::type_.eq(excluded(objects::type_)),
+        ))
+        .filter(
+            objects::object_id
+                .eq(excluded(objects::object_id))
+                .and(objects::version.ge(3)),
+        )
+        .values(vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 200,
+                kind: 300,
+                owner: Some(vec![4, 5, 6]),
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 300,
+                kind: 200,
+                owner: None,
+                type_: Some("qux".to_string()),
+            },
+            StoredObject {
+                object_id: vec![10, 11, 12],
+                version: 400,
+                kind: 300,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![19, 20, 21],
+                version: 500,
+                kind: 200,
+                owner: Some(vec![24, 23, 22]),
+                type_: Some("quy".to_string()),
+            },
+        ])
+        .execute(&mut conn(&temp_db).await)
+        .await
+        .unwrap();
+
+    let objects: Vec<StoredObject> = objects::table
+        .order_by(objects::dsl::object_id)
+        .load(&mut conn(&temp_db).await)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        objects,
+        vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 1,
+                kind: 2,
+                owner: None,
+                type_: Some("foo".to_string()),
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 2,
+                kind: 1,
+                owner: Some(vec![7, 8, 9]),
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![10, 11, 12],
+                version: 400,
+                kind: 300,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![16, 17, 18],
+                version: 4,
+                kind: 3,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![19, 20, 21],
+                version: 500,
+                kind: 200,
+                owner: Some(vec![24, 23, 22]),
+                type_: Some("quy".to_string()),
+            },
+        ]
+    );
+}
+
+async fn conn(temp_db: &TempDb) -> AsyncPgConnection {
+    AsyncPgConnection::establish(temp_db.database().url().as_str())
+        .await
+        .expect("Failed to establish connection")
+}
+
+async fn setup_objects_table(temp_db: &TempDb) {
+    let mut conn = conn(temp_db).await;
+
+    diesel::sql_query(
+        r#"
+        CREATE TABLE objects (
+            object_id       BYTEA           PRIMARY KEY,
+            version         BIGINT          NOT NULL,
+            kind            SMALLINT        NOT NULL,
+            owner           BYTEA,
+            type_           TEXT
+        )
+        "#,
+    )
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    diesel::insert_into(objects::table)
+        .values(vec![
+            StoredObject {
+                object_id: vec![1, 2, 3],
+                version: 1,
+                kind: 2,
+                owner: None,
+                type_: Some("foo".to_string()),
+            },
+            StoredObject {
+                object_id: vec![4, 5, 6],
+                version: 2,
+                kind: 1,
+                owner: Some(vec![7, 8, 9]),
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![10, 11, 12],
+                version: 3,
+                kind: 0,
+                owner: Some(vec![13, 14, 15]),
+                type_: Some("bar".to_string()),
+            },
+            StoredObject {
+                object_id: vec![16, 17, 18],
+                version: 4,
+                kind: 3,
+                owner: None,
+                type_: None,
+            },
+            StoredObject {
+                object_id: vec![19, 20, 21],
+                version: 5,
+                kind: 2,
+                owner: Some(vec![22, 23, 24]),
+                type_: Some("baz".to_string()),
+            },
+        ])
+        .execute(&mut conn)
+        .await
+        .unwrap();
+}

--- a/crates/sui-indexer-alt-schema/src/epochs.rs
+++ b/crates/sui-indexer-alt-schema/src/epochs.rs
@@ -8,6 +8,7 @@ use crate::schema::{kv_epoch_ends, kv_epoch_starts, kv_feature_flags, kv_protoco
 
 #[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = kv_epoch_ends)]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredEpochEnd {
     pub epoch: i64,
     pub cp_hi: i64,
@@ -47,6 +48,7 @@ pub struct StoredFeatureFlag {
 
 #[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = kv_protocol_configs)]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredProtocolConfig {
     pub protocol_version: i64,
     pub config_name: String,

--- a/crates/sui-indexer-alt-schema/src/objects.rs
+++ b/crates/sui-indexer-alt-schema/src/objects.rs
@@ -15,6 +15,7 @@ use crate::schema::{
 
 #[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = kv_objects, primary_key(object_id, object_version))]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredObject {
     pub object_id: Vec<u8>,
     pub object_version: i64,
@@ -70,7 +71,6 @@ pub enum StoredCoinOwnerKind {
 
 #[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = sum_coin_balances, primary_key(object_id))]
-#[diesel(treat_none_as_default_value = false)]
 pub struct StoredSumCoinBalance {
     pub object_id: Vec<u8>,
     pub object_version: i64,
@@ -95,6 +95,7 @@ pub struct StoredSumObjType {
 
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = wal_coin_balances, primary_key(object_id, object_version))]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredWalCoinBalance {
     pub object_id: Vec<u8>,
     pub object_version: i64,
@@ -106,6 +107,7 @@ pub struct StoredWalCoinBalance {
 
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = wal_obj_types, primary_key(object_id, object_version))]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredWalObjType {
     pub object_id: Vec<u8>,
     pub object_version: i64,

--- a/crates/sui-indexer-alt-schema/src/objects.rs
+++ b/crates/sui-indexer-alt-schema/src/objects.rs
@@ -30,15 +30,24 @@ pub struct StoredObjVersion {
     pub cp_sequence_number: i64,
 }
 
-/// An insert/update or deletion of an object record, keyed on a particular Object ID and version.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// An insert, update or deletion of an object record, keyed on a particular Object ID and version.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StoredObjectUpdate<T> {
+    pub kind: UpdateKind,
     pub object_id: ObjectID,
     pub object_version: u64,
     pub cp_sequence_number: u64,
-    /// `None` means the object was deleted or wrapped at this version, `Some(x)` means it was
-    /// changed to `x`.
-    pub update: Option<T>,
+    pub value: Option<T>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UpdateKind {
+    /// Object was created or unwrapped at this version.
+    Insert,
+    /// Object existed before but was modified at this version.
+    Update,
+    /// Object was deleted or wrapped at this version.
+    Delete,
 }
 
 #[derive(AsExpression, FromSqlRow, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -61,6 +70,7 @@ pub enum StoredCoinOwnerKind {
 
 #[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = sum_coin_balances, primary_key(object_id))]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredSumCoinBalance {
     pub object_id: Vec<u8>,
     pub object_version: i64,
@@ -71,6 +81,7 @@ pub struct StoredSumCoinBalance {
 
 #[derive(Insertable, Debug, Clone, FieldCount)]
 #[diesel(table_name = sum_obj_types, primary_key(object_id))]
+#[diesel(treat_none_as_default_value = false)]
 pub struct StoredSumObjType {
     pub object_id: Vec<u8>,
     pub object_version: i64,

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -28,6 +28,7 @@ tokio-util.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
+diesel-update-from.workspace = true
 sui-default-config.workspace = true
 sui-field-count.workspace = true
 sui-indexer-alt-framework.workspace = true

--- a/crates/sui-indexer-alt/src/handlers/sum_coin_balances.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_coin_balances.rs
@@ -9,11 +9,12 @@ use std::{
 use anyhow::{anyhow, bail, ensure};
 use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
+use diesel_update_from::update_from;
 use futures::future::{try_join_all, Either};
 use sui_field_count::FieldCount;
 use sui_indexer_alt_framework::pipeline::{sequential::Handler, Processor};
 use sui_indexer_alt_schema::{
-    objects::{StoredObjectUpdate, StoredSumCoinBalance},
+    objects::{StoredObjectUpdate, StoredSumCoinBalance, UpdateKind},
     schema::sum_coin_balances,
 };
 use sui_pg_db as db;
@@ -22,7 +23,7 @@ use sui_types::{
     object::Owner,
 };
 
-const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / StoredSumCoinBalance::FIELD_COUNT;
+const MAX_UPDATE_CHUNK_ROWS: usize = i16::MAX as usize / StoredSumCoinBalance::FIELD_COUNT;
 const MAX_DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
 
 pub(crate) struct SumCoinBalances;
@@ -55,38 +56,49 @@ impl Processor for SumCoinBalances {
                 }
             }
 
-            // Deleted and wrapped coins
+            // Do a fist pass to add updates without their associated contents into the `values`
+            // mapping, based on the transaction's object changes.
             for change in tx.effects.object_changes() {
-                // The object is not deleted/wrapped, or if it is it was unwrapped in the same
-                // transaction.
-                if change.output_digest.is_some() || change.input_version.is_none() {
-                    continue;
-                }
-
-                // Object is not a coin
-                if !coin_types.contains_key(&change.id) {
-                    continue;
-                }
-
                 let object_id = change.id;
-                let object_version = tx.effects.lamport_version().value();
-                match values.entry(object_id) {
+                let lamport_version = tx.effects.lamport_version().value();
+
+                // Object is not a coin, so not relevant for this processor.
+                if !coin_types.contains_key(&object_id) {
+                    continue;
+                }
+
+                let (kind, object_version) = match (change.input_version, change.output_version) {
+                    // Unwrapped and deleted
+                    (None, None) => continue,
+
+                    // Unwrapped or created
+                    (None, Some(object_version)) => (UpdateKind::Insert, object_version.value()),
+
+                    // Wrapped or deleted
+                    (Some(_), None) => (UpdateKind::Delete, lamport_version),
+
+                    // Mutated
+                    (Some(_), Some(object_version)) => (UpdateKind::Update, object_version.value()),
+                };
+
+                let entry = match values.entry(object_id) {
+                    Entry::Vacant(entry) => entry,
                     Entry::Occupied(entry) => {
                         ensure!(entry.get().object_version > object_version);
+                        continue;
                     }
+                };
 
-                    Entry::Vacant(entry) => {
-                        entry.insert(StoredObjectUpdate {
-                            object_id,
-                            object_version,
-                            cp_sequence_number,
-                            update: None,
-                        });
-                    }
-                }
+                entry.insert(StoredObjectUpdate {
+                    kind,
+                    object_id,
+                    object_version,
+                    cp_sequence_number,
+                    value: None,
+                });
             }
 
-            // Modified and created coins.
+            // Then, do a second pass to fill out contents for created and updated objects.
             for object in &tx.output_objects {
                 let object_id = object.id();
                 let object_version = object.version().value();
@@ -95,34 +107,42 @@ impl Processor for SumCoinBalances {
                     continue;
                 };
 
-                // Coin balance only tracks address-owned objects
-                let Owner::AddressOwner(owner_id) = object.owner() else {
+                let Some(update) = values.get_mut(&object_id) else {
+                    bail!(
+                        "Missing update for output object {}, in transaction {}",
+                        object_id.to_canonical_display(/* with_prefix */ true),
+                        tx.transaction.digest(),
+                    );
+                };
+
+                // Update from a later transaction, no need to fill its contents.
+                if update.object_version > object_version {
                     continue;
-                };
+                }
 
-                let Some(coin) = object.as_coin_maybe() else {
-                    bail!("Failed to deserialize Coin for {object_id}");
-                };
+                ensure!(
+                    update.kind != UpdateKind::Delete,
+                    "Deleted coin {} appears in outputs for transaction {}",
+                    object_id.to_canonical_display(/* with_prefix */ true),
+                    tx.transaction.digest(),
+                );
 
-                match values.entry(object_id) {
-                    Entry::Occupied(entry) => {
-                        ensure!(entry.get().object_version > object_version);
-                    }
+                if let Owner::AddressOwner(owner_id) = object.owner() {
+                    let Some(coin) = object.as_coin_maybe() else {
+                        bail!("Failed to deserialize Coin for {object_id}");
+                    };
 
-                    Entry::Vacant(entry) => {
-                        entry.insert(StoredObjectUpdate {
-                            object_id,
-                            object_version,
-                            cp_sequence_number,
-                            update: Some(StoredSumCoinBalance {
-                                object_id: object_id.to_vec(),
-                                object_version: object_version as i64,
-                                owner_id: owner_id.to_vec(),
-                                coin_type: coin_type.clone(),
-                                coin_balance: coin.balance.value() as i64,
-                            }),
-                        });
-                    }
+                    update.value = Some(StoredSumCoinBalance {
+                        object_id: object_id.to_vec(),
+                        object_version: object_version as i64,
+                        owner_id: owner_id.to_vec(),
+                        coin_type: coin_type.clone(),
+                        coin_balance: coin.balance.value() as i64,
+                    });
+                } else {
+                    // The coin exists but is no longer address owned, so get rid of it from this
+                    // table.
+                    update.kind = UpdateKind::Delete;
                 }
             }
         }
@@ -136,49 +156,107 @@ impl Handler for SumCoinBalances {
     type Batch = BTreeMap<ObjectID, Self::Value>;
 
     fn batch(batch: &mut Self::Batch, updates: Vec<Self::Value>) {
-        // `updates` are guaranteed to be provided in checkpoint order, so blindly inserting them
-        // will result in the batch containing the most up-to-date update for each object.
-        for update in updates {
-            batch.insert(update.object_id, update);
+        // `updates` are guaranteed to be provided in checkpoint order, so overwriting them in the
+        // batch will result in it containing the most up-to-date update for each object, but when
+        // overwriting, we need to handle the `kind` field carefully, to not miss an insert or a
+        // delete.
+        for mut update in updates {
+            match batch.entry(update.object_id) {
+                Entry::Vacant(entry) => {
+                    entry.insert(update);
+                }
+
+                Entry::Occupied(mut entry) => {
+                    use UpdateKind as K;
+                    match (entry.get().kind, update.kind) {
+                        (K::Insert, K::Delete) => {
+                            entry.remove();
+                        }
+
+                        (K::Insert, K::Insert | K::Update) => {
+                            update.kind = K::Insert;
+                            entry.insert(update);
+                        }
+
+                        (K::Update | K::Delete, K::Delete) => {
+                            update.kind = K::Delete;
+                            entry.insert(update);
+                        }
+
+                        (K::Update | K::Delete, K::Insert | K::Update) => {
+                            update.kind = K::Update;
+                            entry.insert(update);
+                        }
+                    }
+                }
+            }
         }
     }
 
     async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> anyhow::Result<usize> {
+        let mut inserts = vec![];
         let mut updates = vec![];
         let mut deletes = vec![];
 
         for update in batch.values() {
-            if let Some(update) = &update.update {
-                updates.push(update.clone());
-            } else {
-                deletes.push(update.object_id.to_vec());
+            let object_id = update.object_id;
+            let object_version = update.object_version;
+            match (&update.kind, &update.value) {
+                (UpdateKind::Insert, Some(value)) => inserts.push(value.clone()),
+                (UpdateKind::Update, Some(value)) => updates.push(value.clone()),
+                (UpdateKind::Delete, _) => deletes.push(object_id.to_vec()),
+
+                (UpdateKind::Insert | UpdateKind::Update, None) => {
+                    bail!(
+                        "Missing contents for coin {} version {}",
+                        object_id.to_canonical_display(/* with_prefix */ true),
+                        object_version,
+                    );
+                }
             }
         }
-        let update_chunks = updates.chunks(MAX_INSERT_CHUNK_ROWS).map(Either::Left);
+
+        let insert_chunks = inserts
+            .chunks(MAX_UPDATE_CHUNK_ROWS)
+            .map(|i| Either::Left(Either::Left(i)));
+
+        let update_chunks = updates
+            .chunks(MAX_UPDATE_CHUNK_ROWS)
+            .map(|u| Either::Left(Either::Right(u)));
+
         let delete_chunks = deletes.chunks(MAX_DELETE_CHUNK_ROWS).map(Either::Right);
 
-        let futures = update_chunks.chain(delete_chunks).map(|chunk| match chunk {
-            Either::Left(update) => Either::Left(
-                diesel::insert_into(sum_coin_balances::table)
-                    .values(update)
-                    .on_conflict(sum_coin_balances::object_id)
-                    .do_update()
-                    .set((
-                        sum_coin_balances::object_version
-                            .eq(excluded(sum_coin_balances::object_version)),
-                        sum_coin_balances::owner_id.eq(excluded(sum_coin_balances::owner_id)),
-                        sum_coin_balances::coin_balance
-                            .eq(excluded(sum_coin_balances::coin_balance)),
-                    ))
-                    .execute(conn),
-            ),
+        let futures = insert_chunks
+            .chain(update_chunks)
+            .chain(delete_chunks)
+            .map(|chunk| match chunk {
+                Either::Left(Either::Left(insert)) => Either::Left(Either::Left(
+                    diesel::insert_into(sum_coin_balances::table)
+                        .values(insert)
+                        .execute(conn),
+                )),
+                Either::Left(Either::Right(update)) => Either::Left(Either::Right(
+                    update_from(sum_coin_balances::table)
+                        .values(update)
+                        .set((
+                            sum_coin_balances::object_version
+                                .eq(excluded(sum_coin_balances::object_version)),
+                            sum_coin_balances::owner_id.eq(excluded(sum_coin_balances::owner_id)),
+                            sum_coin_balances::coin_balance
+                                .eq(excluded(sum_coin_balances::coin_balance)),
+                        ))
+                        .filter(
+                            sum_coin_balances::object_id.eq(excluded(sum_coin_balances::object_id)),
+                        )
+                        .execute(conn),
+                )),
 
-            Either::Right(delete) => Either::Right(
-                diesel::delete(sum_coin_balances::table)
-                    .filter(sum_coin_balances::object_id.eq_any(delete.iter().cloned()))
-                    .execute(conn),
-            ),
-        });
+                Either::Right(delete) => Either::Right(
+                    diesel::delete(sum_coin_balances::table)
+                        .filter(sum_coin_balances::object_id.eq_any(delete.iter().cloned()))
+                        .execute(conn),
+                ),
+            });
 
         Ok(try_join_all(futures).await?.into_iter().sum())
     }

--- a/crates/sui-indexer-alt/src/handlers/sum_obj_types.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_obj_types.rs
@@ -6,14 +6,15 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, ensure};
+use anyhow::{anyhow, bail, ensure};
 use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
+use diesel_update_from::update_from;
 use futures::future::{try_join_all, Either};
 use sui_field_count::FieldCount;
 use sui_indexer_alt_framework::pipeline::{sequential::Handler, Processor};
 use sui_indexer_alt_schema::{
-    objects::{StoredObjectUpdate, StoredOwnerKind, StoredSumObjType},
+    objects::{StoredObjectUpdate, StoredOwnerKind, StoredSumObjType, UpdateKind},
     schema::sum_obj_types,
 };
 use sui_pg_db as db;
@@ -22,7 +23,7 @@ use sui_types::{
     object::Owner,
 };
 
-const MAX_INSERT_CHUNK_ROWS: usize = i16::MAX as usize / StoredSumObjType::FIELD_COUNT;
+const MAX_UPDATE_CHUNK_ROWS: usize = i16::MAX as usize / StoredSumObjType::FIELD_COUNT;
 const MAX_DELETE_CHUNK_ROWS: usize = i16::MAX as usize;
 
 pub(crate) struct SumObjTypes;
@@ -44,85 +45,100 @@ impl Processor for SumObjTypes {
 
         // Iterate over transactions in reverse so we see the latest version of each object first.
         for tx in transactions.iter().rev() {
-            // Deleted and wrapped objects -- objects that show up without a digest in
-            // `object_changes` are either deleted or wrapped. Objects without an input version
-            // must have been unwrapped and deleted, meaning they do not need to be deleted from
-            // our records.
+            // Do a first pass to add updates without their associated contents into the `values`
+            // mapping, based on the transaction's object changes.
             for change in tx.effects.object_changes() {
-                if change.output_digest.is_some() || change.input_version.is_none() {
-                    continue;
-                }
-
                 let object_id = change.id;
-                let object_version = tx.effects.lamport_version().value();
-                match values.entry(object_id) {
+                let lamport_version = tx.effects.lamport_version().value();
+
+                let (kind, object_version) = match (change.input_version, change.output_version) {
+                    // Unwrapped and deleted
+                    (None, None) => continue,
+
+                    // Unwrapped or created
+                    (None, Some(object_version)) => (UpdateKind::Insert, object_version.value()),
+
+                    // Wrapped or deleted
+                    (Some(_), None) => (UpdateKind::Delete, lamport_version),
+
+                    // Mutated
+                    (Some(_), Some(object_version)) => (UpdateKind::Update, object_version.value()),
+                };
+
+                let entry = match values.entry(object_id) {
+                    Entry::Vacant(entry) => entry,
                     Entry::Occupied(entry) => {
                         ensure!(entry.get().object_version > object_version);
+                        continue;
                     }
+                };
 
-                    Entry::Vacant(entry) => {
-                        entry.insert(StoredObjectUpdate {
-                            object_id,
-                            object_version,
-                            cp_sequence_number,
-                            update: None,
-                        });
-                    }
-                }
+                entry.insert(StoredObjectUpdate {
+                    kind,
+                    object_id,
+                    object_version,
+                    cp_sequence_number,
+                    value: None,
+                });
             }
 
-            // Modified and created objects.
+            // Then, do a second pass to fill out the contents for created and updated objects.
             for object in &tx.output_objects {
                 let object_id = object.id();
                 let object_version = object.version().value();
-                match values.entry(object_id) {
-                    Entry::Occupied(entry) => {
-                        ensure!(entry.get().object_version > object_version);
-                    }
+                let Some(update) = values.get_mut(&object_id) else {
+                    bail!(
+                        "Missing object change for output object {}, in transaction {}",
+                        object_id.to_canonical_display(/* with_prefix */ true),
+                        tx.transaction.digest(),
+                    );
+                };
 
-                    Entry::Vacant(entry) => {
-                        let type_ = object.type_();
-                        entry.insert(StoredObjectUpdate {
-                            object_id,
-                            object_version,
-                            cp_sequence_number,
-                            update: Some(StoredSumObjType {
-                                object_id: object_id.to_vec(),
-                                object_version: object_version as i64,
-
-                                owner_kind: match object.owner() {
-                                    Owner::AddressOwner(_) => StoredOwnerKind::Address,
-                                    Owner::ObjectOwner(_) => StoredOwnerKind::Object,
-                                    Owner::Shared { .. } => StoredOwnerKind::Shared,
-                                    Owner::Immutable => StoredOwnerKind::Immutable,
-                                    // TODO: Implement support for ConsensusV2 objects.
-                                    Owner::ConsensusV2 { .. } => todo!(),
-                                },
-
-                                owner_id: match object.owner() {
-                                    Owner::AddressOwner(a) => Some(a.to_vec()),
-                                    Owner::ObjectOwner(o) => Some(o.to_vec()),
-                                    _ => None,
-                                },
-
-                                package: type_.map(|t| t.address().to_vec()),
-                                module: type_.map(|t| t.module().to_string()),
-                                name: type_.map(|t| t.name().to_string()),
-                                instantiation: type_
-                                    .map(|t| bcs::to_bytes(&t.type_params()))
-                                    .transpose()
-                                    .map_err(|e| {
-                                        anyhow!(
-                                            "Failed to serialize type parameters for {}: {e}",
-                                            object
-                                                .id()
-                                                .to_canonical_display(/* with_prefix */ true),
-                                        )
-                                    })?,
-                            }),
-                        });
-                    }
+                // Update from a later transaction, no need to fill its contents.
+                if update.object_version > object_version {
+                    continue;
                 }
+
+                ensure!(
+                    update.kind != UpdateKind::Delete,
+                    "Deleted object {} appears in outputs for transaction {}",
+                    object_id.to_canonical_display(/* with_prefix */ true),
+                    tx.transaction.digest(),
+                );
+
+                let type_ = object.type_();
+                update.value = Some(StoredSumObjType {
+                    object_id: object_id.to_vec(),
+                    object_version: object_version as i64,
+
+                    owner_kind: match object.owner() {
+                        Owner::AddressOwner(_) => StoredOwnerKind::Address,
+                        Owner::ObjectOwner(_) => StoredOwnerKind::Object,
+                        Owner::Shared { .. } => StoredOwnerKind::Shared,
+                        Owner::Immutable => StoredOwnerKind::Immutable,
+                        // TODO: Implement support for ConsensusV2 objects.
+                        Owner::ConsensusV2 { .. } => todo!(),
+                    },
+
+                    owner_id: match object.owner() {
+                        Owner::AddressOwner(a) => Some(a.to_vec()),
+                        Owner::ObjectOwner(o) => Some(o.to_vec()),
+                        _ => None,
+                    },
+
+                    package: type_.map(|t| t.address().to_vec()),
+                    module: type_.map(|t| t.module().to_string()),
+                    name: type_.map(|t| t.name().to_string()),
+                    instantiation: type_
+                        .map(|t| bcs::to_bytes(&t.type_params()))
+                        .transpose()
+                        .map_err(|e| {
+                            anyhow!(
+                                "Failed to serialize type parameters for {}: {e}",
+                                object.id().to_canonical_display(/* with_prefix */ true),
+                            )
+                        })?,
+                });
             }
         }
 
@@ -135,48 +151,113 @@ impl Handler for SumObjTypes {
     type Batch = BTreeMap<ObjectID, Self::Value>;
 
     fn batch(batch: &mut Self::Batch, updates: Vec<Self::Value>) {
-        // `updates` are guaranteed to be provided in checkpoint order, so blindly inserting them
-        // will result in the batch containing the most up-to-date update for each object.
-        for update in updates {
-            batch.insert(update.object_id, update);
+        // `updates` are guaranteed to be provided in checkpoint order, so overwriting them in the
+        // batch will result in it containing the most up-to-date update for each object, but when
+        // overwriting, we need to handle the `kind` field carefully, to not miss an insert or a
+        // delete.
+        for mut update in updates {
+            match batch.entry(update.object_id) {
+                Entry::Vacant(entry) => {
+                    entry.insert(update);
+                }
+
+                Entry::Occupied(mut entry) => {
+                    use UpdateKind as K;
+                    match (entry.get().kind, update.kind) {
+                        (K::Insert, K::Delete) => {
+                            entry.remove();
+                        }
+
+                        (K::Insert, K::Insert | K::Update) => {
+                            update.kind = K::Insert;
+                            entry.insert(update);
+                        }
+
+                        (K::Update | K::Delete, K::Delete) => {
+                            update.kind = K::Delete;
+                            entry.insert(update);
+                        }
+
+                        (K::Update | K::Delete, K::Insert | K::Update) => {
+                            update.kind = K::Update;
+                            entry.insert(update);
+                        }
+                    }
+                }
+            }
         }
     }
 
     async fn commit(values: &Self::Batch, conn: &mut db::Connection<'_>) -> anyhow::Result<usize> {
+        let mut inserts = vec![];
         let mut updates = vec![];
         let mut deletes = vec![];
 
         for update in values.values() {
-            if let Some(update) = &update.update {
-                updates.push(update.clone());
-            } else {
-                deletes.push(update.object_id.to_vec());
+            let object_id = update.object_id;
+            let object_version = update.object_version;
+
+            match (&update.kind, &update.value) {
+                (UpdateKind::Insert, Some(value)) => inserts.push(value.clone()),
+                (UpdateKind::Update, Some(value)) => updates.push(value.clone()),
+                (UpdateKind::Delete, None) => deletes.push(update.object_id.to_vec()),
+
+                (UpdateKind::Insert | UpdateKind::Update, None) => {
+                    bail!(
+                        "Missing contents for object {} version {}",
+                        object_id.to_canonical_display(/* with_prefix */ true),
+                        object_version,
+                    );
+                }
+
+                (UpdateKind::Delete, Some(_)) => {
+                    bail!(
+                        "Unexpected contents for deleted object {} version {}",
+                        object_id.to_canonical_display(/* with_prefix */ true),
+                        object_version,
+                    );
+                }
             }
         }
 
-        let update_chunks = updates.chunks(MAX_INSERT_CHUNK_ROWS).map(Either::Left);
+        let insert_chunks = inserts
+            .chunks(MAX_UPDATE_CHUNK_ROWS)
+            .map(|i| Either::Left(Either::Left(i)));
+
+        let update_chunks = updates
+            .chunks(MAX_UPDATE_CHUNK_ROWS)
+            .map(|u| Either::Left(Either::Right(u)));
+
         let delete_chunks = deletes.chunks(MAX_DELETE_CHUNK_ROWS).map(Either::Right);
 
-        let futures = update_chunks.chain(delete_chunks).map(|chunk| match chunk {
-            Either::Left(update) => Either::Left(
-                diesel::insert_into(sum_obj_types::table)
-                    .values(update)
-                    .on_conflict(sum_obj_types::object_id)
-                    .do_update()
-                    .set((
-                        sum_obj_types::object_version.eq(excluded(sum_obj_types::object_version)),
-                        sum_obj_types::owner_kind.eq(excluded(sum_obj_types::owner_kind)),
-                        sum_obj_types::owner_id.eq(excluded(sum_obj_types::owner_id)),
-                    ))
-                    .execute(conn),
-            ),
+        let futures = insert_chunks
+            .chain(update_chunks)
+            .chain(delete_chunks)
+            .map(|chunk| match chunk {
+                Either::Left(Either::Left(insert)) => Either::Left(Either::Left(
+                    diesel::insert_into(sum_obj_types::table)
+                        .values(insert)
+                        .execute(conn),
+                )),
+                Either::Left(Either::Right(update)) => Either::Left(Either::Right(
+                    update_from(sum_obj_types::table)
+                        .values(update)
+                        .set((
+                            sum_obj_types::object_version
+                                .eq(excluded(sum_obj_types::object_version)),
+                            sum_obj_types::owner_kind.eq(excluded(sum_obj_types::owner_kind)),
+                            sum_obj_types::owner_id.eq(excluded(sum_obj_types::owner_id)),
+                        ))
+                        .filter(sum_obj_types::object_id.eq(excluded(sum_obj_types::object_id)))
+                        .execute(conn),
+                )),
 
-            Either::Right(delete) => Either::Right(
-                diesel::delete(sum_obj_types::table)
-                    .filter(sum_obj_types::object_id.eq_any(delete.iter().cloned()))
-                    .execute(conn),
-            ),
-        });
+                Either::Right(delete) => Either::Right(
+                    diesel::delete(sum_obj_types::table)
+                        .filter(sum_obj_types::object_id.eq_any(delete.iter().cloned()))
+                        .execute(conn),
+                ),
+            });
 
         Ok(try_join_all(futures).await?.into_iter().sum())
     }

--- a/crates/sui-indexer-alt/src/handlers/wal_coin_balances.rs
+++ b/crates/sui-indexer-alt/src/handlers/wal_coin_balances.rs
@@ -40,10 +40,10 @@ impl Handler for WalCoinBalances {
                 object_id: value.object_id.to_vec(),
                 object_version: value.object_version as i64,
 
-                owner_id: value.update.as_ref().map(|o| o.owner_id.clone()),
+                owner_id: value.value.as_ref().map(|o| o.owner_id.clone()),
 
-                coin_type: value.update.as_ref().map(|o| o.coin_type.clone()),
-                coin_balance: value.update.as_ref().map(|o| o.coin_balance),
+                coin_type: value.value.as_ref().map(|o| o.coin_type.clone()),
+                coin_balance: value.value.as_ref().map(|o| o.coin_balance),
 
                 cp_sequence_number: value.cp_sequence_number as i64,
             })

--- a/crates/sui-indexer-alt/src/handlers/wal_obj_types.rs
+++ b/crates/sui-indexer-alt/src/handlers/wal_obj_types.rs
@@ -40,13 +40,13 @@ impl Handler for WalObjTypes {
                 object_id: value.object_id.to_vec(),
                 object_version: value.object_version as i64,
 
-                owner_kind: value.update.as_ref().map(|o| o.owner_kind),
-                owner_id: value.update.as_ref().and_then(|o| o.owner_id.clone()),
+                owner_kind: value.value.as_ref().map(|o| o.owner_kind),
+                owner_id: value.value.as_ref().and_then(|o| o.owner_id.clone()),
 
-                package: value.update.as_ref().and_then(|o| o.package.clone()),
-                module: value.update.as_ref().and_then(|o| o.module.clone()),
-                name: value.update.as_ref().and_then(|o| o.name.clone()),
-                instantiation: value.update.as_ref().and_then(|o| o.instantiation.clone()),
+                package: value.value.as_ref().and_then(|o| o.package.clone()),
+                module: value.value.as_ref().and_then(|o| o.module.clone()),
+                name: value.value.as_ref().and_then(|o| o.name.clone()),
+                instantiation: value.value.as_ref().and_then(|o| o.instantiation.clone()),
 
                 cp_sequence_number: value.cp_sequence_number as i64,
             })


### PR DESCRIPTION
## Description

Use object changes from transaction effects to figure out which changes to consistent tables correspond to new rows and which changes correspond to updates. This means we can avoid using `INSERT ... ON CONFLICT DO UPDATE` which requires postgres to try an insert, detect constraints, and then go for the update, which should hopefully improve performance. On the other hand, it means that these pipelines will not work at all if they are started at an arbitrary point in time (because the `UPDATE`-s will fail).

The largest part of this change was adding support for bulk-updates to diesel (see https://github.com/diesel-rs/diesel/discussions/2879). This requires opting in to breaking changes by exposing diesel's internals. To limit the fall out of that, this support has been added in its own crate.

Finally, as part of this change, I ran into a flag that can be set on model types: `#[diesel(treat_none_as_default_value = ...)]` which defaults to `true`. Setting this to `false` on models that contain optional values should improve statistics collection and may improve performance through prepared statement caching.

## Test plan

Unit tests for `update_from` query generation, and E2E tests for running updates on a DB with the new DSL:

```
sui$ cargo nextest run -p diesel-update-from
```

Run the indexer before and after the change, dump the resulting tables and make sure the results are the same:

```
sui$ cargo run -p sui-indexer-alt -- generate-config > /tmp/indexer.toml
sui$ cargo run -p sui-indexer-alt -- indexer            \
  --remote-store-url https://checkpoints.mainnet.sui.io/ \
  --last-checkpoint 50000 --config /tmp/indexer.toml    \
  --pipeline sum_obj_types --pipeline sum_coin_balances

sui$ psql postgres://postgres:postgrespw@localhost:5432/sui_indexer_alt
sui_indexer_alt=# COPY
    (SELECT object_id, object_version, owner_kind, owner_id FROM sum_obj_types ORDER BY object_id)
TO
    '/tmp/objs.csv'
WITH
    DELIMITER ',' CSV HEADER;
sui_indexer_alt=# COPY
    (SELECT object_id, object_version, owner_id, coin_balance FROM sum_coin_balances ORDER BY object_id)
TO
    '/tmp/coins.csv'
WITH
    DELIMITER ',' CSV HEADER;
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
