### PR TITLE
effects: fix modified_at_versions in V1 to have parity with V2 semantics

### DIFF
--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -133,7 +133,19 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     }
 
     fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
-        self.modified_at_versions.clone()
+        self.modified_at_versions
+            .iter()
+            // V1 transaction effects "modified_at_versions" includes unwrapped_then_deleted
+            // objects, so in order to have parity with the V2 transaction effects semantics of
+            // "modified_at_versions", filter out any objects that are unwrapped_then_deleted'ed
+            .filter(|(object_id, _)| {
+                !self
+                    .unwrapped_then_deleted
+                    .iter()
+                    .any(|(deleted_id, _, _)| deleted_id == object_id)
+            })
+            .cloned()
+            .collect()
     }
 
     fn lamport_version(&self) -> SequenceNumber {


### PR DESCRIPTION
Fix a bug introduced in 874da38e39 (CheckpointData: fix bug when loading input objects with deleted shared objects, 2024-06-10) whereby CheckpointData began to be constructed by only leveraging the `TransactionEffectsAPI::modified_at_versions` method instead of the hand-rolled version which explicitly filtered out
`unwrapped_then_deleted` objects from calling the set of `modified_at_versions` list of objects. The impact of this, was that when processing transactions which have V1 format effects, the process which constructs CheckpointData tries to load an unwrapped_then_deleted object, which does not exist, leading to a crash. This behavior was never observed because at the time 874da38e39 was committed, the network only produced V2 formatted effects who's `modified_at_versions` properly does not contain `unwrapped_then_deleted` objects.

To fix the bug, change the implementation of the
`TransactionEffectsAPI::modified_at_versions` method for TransactionEffectsV1 to explicitly filter out unwrapped_then_deleted objects.

This is intended to fix #20487.