### PR TITLE
[indexer-alt] Sort cp_sequence_number DESC in obj_info indexes

### DIFF
--- a/crates/sui-indexer-alt/migrations/2024-11-25-211949_obj_info/up.sql
+++ b/crates/sui-indexer-alt/migrations/2024-11-25-211949_obj_info/up.sql
@@ -40,28 +40,28 @@ CREATE TABLE IF NOT EXISTS obj_info
 );
 
 CREATE INDEX IF NOT EXISTS obj_info_owner
-ON obj_info (owner_kind, owner_id, cp_sequence_number, object_id);
+ON obj_info (owner_kind, owner_id, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_pkg
-ON obj_info (package, cp_sequence_number, object_id);
+ON obj_info (package, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_mod
-ON obj_info (package, module, cp_sequence_number, object_id);
+ON obj_info (package, module, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_name
-ON obj_info (package, module, name, cp_sequence_number, object_id);
+ON obj_info (package, module, name, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_inst
-ON obj_info (package, module, name, instantiation, cp_sequence_number, object_id);
+ON obj_info (package, module, name, instantiation, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_owner_pkg
-ON obj_info (owner_kind, owner_id, package, cp_sequence_number, object_id);
+ON obj_info (owner_kind, owner_id, package, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_owner_mod
-ON obj_info (owner_kind, owner_id, package, module, cp_sequence_number, object_id);
+ON obj_info (owner_kind, owner_id, package, module, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_owner_name
-ON obj_info (owner_kind, owner_id, package, module, name, cp_sequence_number, object_id);
+ON obj_info (owner_kind, owner_id, package, module, name, cp_sequence_number DESC, object_id);
 
 CREATE INDEX IF NOT EXISTS obj_info_owner_inst
-ON obj_info (owner_kind, owner_id, package, module, name, instantiation, cp_sequence_number, object_id);
+ON obj_info (owner_kind, owner_id, package, module, name, instantiation, cp_sequence_number DESC, object_id);


### PR DESCRIPTION
## Description 

We always query cp_sequence_number in DESC order.
I will manually update the DB.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
