### PR TITLE
refactor(indexer-alt): remove dependency on mysten-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14106,7 +14106,6 @@ dependencies = [
  "diesel_migrations",
  "futures",
  "itertools 0.13.0",
- "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.5",

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -36,7 +36,6 @@ toml.workspace = true
 tracing.workspace = true
 url.workspace = true
 
-mysten-metrics.workspace = true
 sui-default-config.workspace = true
 sui-field-count.workspace = true
 sui-pg-temp-db.workspace = true

--- a/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt/src/ingestion/broadcaster.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::future::try_join_all;
-use mysten_metrics::spawn_monitored_task;
 use std::sync::Arc;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -27,7 +26,7 @@ pub(super) fn broadcaster(
     subscribers: Vec<mpsc::Sender<Arc<CheckpointData>>>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         info!("Starting ingestion broadcaster");
         let retry_interval = config.retry_interval();
 

--- a/crates/sui-indexer-alt/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt/src/ingestion/mod.rs
@@ -183,7 +183,6 @@ impl Default for IngestionConfig {
 mod tests {
     use std::sync::Mutex;
 
-    use mysten_metrics::spawn_monitored_task;
     use reqwest::StatusCode;
     use wiremock::{MockServer, Request};
 
@@ -220,7 +219,7 @@ mod tests {
         mut rx: mpsc::Receiver<Arc<CheckpointData>>,
         cancel: CancellationToken,
     ) -> JoinHandle<Vec<u64>> {
-        spawn_monitored_task!(async move {
+        tokio::spawn(async move {
             let mut seqs = vec![];
             for _ in 0..stop_after {
                 tokio::select! {

--- a/crates/sui-indexer-alt/src/ingestion/regulator.rs
+++ b/crates/sui-indexer-alt/src/ingestion/regulator.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 
-use mysten_metrics::spawn_monitored_task;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -38,7 +37,7 @@ where
     I: IntoIterator<Item = u64> + Send + Sync + 'static,
     I::IntoIter: Send + Sync + 'static,
 {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         let mut ingest_hi = None;
         let mut subscribers_hi = HashMap::new();
         let mut checkpoints = checkpoints.into_iter().peekable();

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/collector.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use mysten_metrics::spawn_monitored_task;
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
@@ -87,7 +86,7 @@ pub(super) fn collector<H: Handler + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         // The `poll` interval controls the maximum time to wait between collecting batches,
         // regardless of number of rows pending.
         let mut poll = interval(config.collect_interval());

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/commit_watermark.rs
@@ -7,7 +7,6 @@ use std::{
     sync::Arc,
 };
 
-use mysten_metrics::spawn_monitored_task;
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
@@ -56,7 +55,7 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         if skip_watermark {
             info!(pipeline = H::NAME, "Skipping commit watermark task");
             return;

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/committer.rs
@@ -4,7 +4,6 @@
 use std::{sync::Arc, time::Duration};
 
 use backoff::ExponentialBackoff;
-use mysten_metrics::spawn_monitored_task;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -44,7 +43,7 @@ pub(super) fn committer<H: Handler + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         info!(pipeline = H::NAME, "Starting committer");
 
         match ReceiverStream::new(rx)

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/pruner.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use mysten_metrics::spawn_monitored_task;
 use tokio::{
     task::JoinHandle,
     time::{interval, MissedTickBehavior},
@@ -38,7 +37,7 @@ pub(super) fn pruner<H: Handler + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         let Some(config) = config else {
             info!(pipeline = H::NAME, "Skipping pruner task");
             return;

--- a/crates/sui-indexer-alt/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt/src/pipeline/concurrent/reader_watermark.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use mysten_metrics::spawn_monitored_task;
 use tokio::{task::JoinHandle, time::interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -33,7 +32,7 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         let Some(config) = config else {
             info!(pipeline = H::NAME, "Skipping reader watermark task");
             return;

--- a/crates/sui-indexer-alt/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt/src/pipeline/processor.rs
@@ -4,7 +4,6 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-use mysten_metrics::spawn_monitored_task;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::wrappers::ReceiverStream;
@@ -48,7 +47,7 @@ pub(super) fn processor<P: Processor + Send + Sync + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         info!(pipeline = P::NAME, "Starting processor");
         let latest_processed_checkpoint = Arc::new(AtomicU64::new(0));
         let processor = Arc::new(processor);

--- a/crates/sui-indexer-alt/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt/src/pipeline/sequential/committer.rs
@@ -4,7 +4,6 @@
 use std::{cmp::Ordering, collections::BTreeMap, sync::Arc};
 
 use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
-use mysten_metrics::spawn_monitored_task;
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
@@ -49,7 +48,7 @@ pub(super) fn committer<H: Handler + 'static>(
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
-    spawn_monitored_task!(async move {
+    tokio::spawn(async move {
         // The `poll` interval controls the maximum time to wait between commits, regardless of the
         // amount of data available.
         let mut poll = interval(config.committer.collect_interval());


### PR DESCRIPTION
## Description
Part of the preparation for factoring out the indexer framework and schema. Removing a dependency on `mysten-metrics` because this is probably not something we want people outside of Mysten to depend on, and it is used in code that would be factored into the indexer framework.

This means we lose some metrics related to thread stalls, and number of tracked tasks, but as far as I'm aware, we don't rely on these metrics anywhere.

## Test plan
CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
