### PR TITLE
indexer restorer: init commit and restore object infos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14057,10 +14057,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-indexer-alt-restorer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "diesel",
+ "diesel-async",
+ "futures",
+ "indicatif",
+ "object_store",
+ "prometheus",
+ "sui-archival",
+ "sui-config",
+ "sui-core",
+ "sui-field-count",
+ "sui-indexer-alt",
+ "sui-indexer-alt-schema",
+ "sui-pg-db",
+ "sui-snapshot",
+ "sui-storage",
+ "sui-types",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "sui-indexer-alt-schema"
 version = "1.40.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "diesel",
  "diesel_migrations",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14073,6 +14073,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-field-count",
+ "sui-indexer-alt-framework",
  "sui-indexer-alt-schema",
  "sui-pg-db",
  "sui-snapshot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14081,7 +14081,6 @@ dependencies = [
  "sui-types",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14079,6 +14079,7 @@ dependencies = [
  "sui-snapshot",
  "sui-storage",
  "sui-types",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14073,7 +14073,6 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-field-count",
- "sui-indexer-alt",
  "sui-indexer-alt-schema",
  "sui-pg-db",
  "sui-snapshot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -645,7 +645,6 @@ sui-indexer = { path = "crates/sui-indexer" }
 sui-indexer-alt-framework = { path = "crates/sui-indexer-alt-framework" }
 sui-indexer-alt-jsonrpc = { path = "crates/sui-indexer-alt-jsonrpc" }
 sui-indexer-alt-schema = { path = "crates/sui-indexer-alt-schema" }
-sui-indexer-alt = { path = "crates/sui-indexer-alt" }
 sui-indexer-alt-restorer = { path = "crates/sui-indexer-restorer" }
 sui-indexer-builder = { path = "crates/sui-indexer-builder" }
 sui-json = { path = "crates/sui-json" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ members = [
     "crates/sui-indexer-alt-jsonrpc",
     "crates/sui-indexer-alt-schema",
     "crates/sui-indexer-builder",
+    "crates/sui-indexer-alt-restorer",
     "crates/sui-json",
     "crates/sui-json-rpc",
     "crates/sui-json-rpc-api",
@@ -644,6 +645,8 @@ sui-indexer = { path = "crates/sui-indexer" }
 sui-indexer-alt-framework = { path = "crates/sui-indexer-alt-framework" }
 sui-indexer-alt-jsonrpc = { path = "crates/sui-indexer-alt-jsonrpc" }
 sui-indexer-alt-schema = { path = "crates/sui-indexer-alt-schema" }
+sui-indexer-alt = { path = "crates/sui-indexer-alt" }
+sui-indexer-alt-restorer = { path = "crates/sui-indexer-restorer" }
 sui-indexer-builder = { path = "crates/sui-indexer-builder" }
 sui-json = { path = "crates/sui-json" }
 sui-json-rpc = { path = "crates/sui-json-rpc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,9 +119,9 @@ members = [
     "crates/sui-indexer-alt",
     "crates/sui-indexer-alt-framework",
     "crates/sui-indexer-alt-jsonrpc",
+    "crates/sui-indexer-alt-restorer",
     "crates/sui-indexer-alt-schema",
     "crates/sui-indexer-builder",
-    "crates/sui-indexer-alt-restorer",
     "crates/sui-json",
     "crates/sui-json-rpc",
     "crates/sui-json-rpc-api",
@@ -644,8 +644,8 @@ sui-genesis-builder = { path = "crates/sui-genesis-builder" }
 sui-indexer = { path = "crates/sui-indexer" }
 sui-indexer-alt-framework = { path = "crates/sui-indexer-alt-framework" }
 sui-indexer-alt-jsonrpc = { path = "crates/sui-indexer-alt-jsonrpc" }
+sui-indexer-alt-restorer = { path = "crates/sui-indexer-alt-restorer" }
 sui-indexer-alt-schema = { path = "crates/sui-indexer-alt-schema" }
-sui-indexer-alt-restorer = { path = "crates/sui-indexer-restorer" }
 sui-indexer-builder = { path = "crates/sui-indexer-builder" }
 sui-json = { path = "crates/sui-json" }
 sui-json-rpc = { path = "crates/sui-json-rpc" }

--- a/crates/sui-indexer-alt-restorer/Cargo.toml
+++ b/crates/sui-indexer-alt-restorer/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "sui-indexer-alt-restorer"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+anyhow = { version = "1.0.71", features = ["backtrace"] }
+async-trait = "0.1.68"
+clap = { version = "4.3.0", features = ["derive", "env"] }
+futures = "0.3.28"
+tracing = "0.1.37"
+
+diesel = { workspace = true, features = ["chrono"] }
+diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
+indicatif.workspace = true
+object_store.workspace = true
+prometheus.workspace = true
+sui-archival.workspace = true
+sui-config.workspace = true
+sui-core.workspace = true
+sui-field-count.workspace = true
+sui-indexer-alt.workspace = true
+sui-indexer-alt-schema.workspace = true
+sui-pg-db.workspace = true
+sui-snapshot.workspace = true
+sui-storage.workspace = true
+sui-types.workspace = true
+tokio = { workspace = true, features = ["full"] }
+url.workspace = true
+
+[[bin]]
+name = "sui-indexer-alt-restorer"
+path = "src/main.rs"

--- a/crates/sui-indexer-alt-restorer/Cargo.toml
+++ b/crates/sui-indexer-alt-restorer/Cargo.toml
@@ -23,6 +23,7 @@ sui-config.workspace = true
 sui-core.workspace = true
 sui-field-count.workspace = true
 sui-indexer-alt-schema.workspace = true
+sui-indexer-alt-framework.workspace = true
 sui-pg-db.workspace = true
 sui-snapshot.workspace = true
 sui-storage.workspace = true

--- a/crates/sui-indexer-alt-restorer/Cargo.toml
+++ b/crates/sui-indexer-alt-restorer/Cargo.toml
@@ -29,6 +29,7 @@ sui-snapshot.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 tokio = { workspace = true, features = ["full"] }
+telemetry-subscribers.workspace = true
 
 [[bin]]
 name = "sui-indexer-alt-restorer"

--- a/crates/sui-indexer-alt-restorer/Cargo.toml
+++ b/crates/sui-indexer-alt-restorer/Cargo.toml
@@ -22,7 +22,6 @@ sui-archival.workspace = true
 sui-config.workspace = true
 sui-core.workspace = true
 sui-field-count.workspace = true
-sui-indexer-alt.workspace = true
 sui-indexer-alt-schema.workspace = true
 sui-pg-db.workspace = true
 sui-snapshot.workspace = true

--- a/crates/sui-indexer-alt-restorer/Cargo.toml
+++ b/crates/sui-indexer-alt-restorer/Cargo.toml
@@ -29,7 +29,6 @@ sui-snapshot.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 tokio = { workspace = true, features = ["full"] }
-url.workspace = true
 
 [[bin]]
 name = "sui-indexer-alt-restorer"

--- a/crates/sui-indexer-alt-restorer/src/archives.rs
+++ b/crates/sui-indexer-alt-restorer/src/archives.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::num::NonZeroUsize;
+
+use prometheus::Registry;
+use sui_types::digests::CheckpointDigest;
+use tracing::info;
+
+use sui_archival::reader::{ArchiveReader, ArchiveReaderMetrics};
+use sui_config::node::ArchiveReaderConfig;
+use sui_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
+
+use crate::Args;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ArchivalCheckpointInfo {
+    pub next_checkpoint_after_epoch: u64,
+    #[allow(unused)]
+    pub chain_identifier: CheckpointDigest,
+}
+
+pub(crate) async fn read_archival_checkpoint_info(
+    args: &Args,
+) -> Result<ArchivalCheckpointInfo, anyhow::Error> {
+    let archive_store_config = ObjectStoreConfig {
+        object_store: Some(ObjectStoreType::GCS),
+        bucket: Some(args.archive_bucket.clone()),
+        object_store_connection_limit: args.concurrency,
+        no_sign_request: false,
+        ..Default::default()
+    };
+    let archive_reader_config = ArchiveReaderConfig {
+        remote_store_config: archive_store_config,
+        download_concurrency: NonZeroUsize::new(args.concurrency).unwrap(),
+        use_for_pruning_watermark: false,
+    };
+    let metrics = ArchiveReaderMetrics::new(&Registry::default());
+    let archive_reader = ArchiveReader::new(archive_reader_config, &metrics)?;
+    archive_reader.sync_manifest_once().await?;
+    let manifest = archive_reader.get_manifest().await?;
+    let next_checkpoint_after_epoch = manifest.next_checkpoint_after_epoch(args.start_epoch);
+    info!(
+        "Read from archives: next checkpoint sequence after epoch {} is: {}",
+        args.start_epoch, next_checkpoint_after_epoch
+    );
+    let cp_summaries = archive_reader
+        .get_summaries_for_list_no_verify(vec![0])
+        .await?;
+    let first_cp = cp_summaries
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No checkpoint found"))?;
+    let chain_identifier = *first_cp.digest();
+    Ok(ArchivalCheckpointInfo {
+        next_checkpoint_after_epoch,
+        chain_identifier,
+    })
+}

--- a/crates/sui-indexer-alt-restorer/src/archives.rs
+++ b/crates/sui-indexer-alt-restorer/src/archives.rs
@@ -16,44 +16,53 @@ use crate::Args;
 #[derive(Clone, Debug)]
 pub(crate) struct ArchivalCheckpointInfo {
     pub next_checkpoint_after_epoch: u64,
+    // TODO(gegaowp): unused for now, will be used for kv_genesis.
     #[allow(unused)]
     pub chain_identifier: CheckpointDigest,
 }
 
-pub(crate) async fn read_archival_checkpoint_info(
-    args: &Args,
-) -> Result<ArchivalCheckpointInfo, anyhow::Error> {
-    let archive_store_config = ObjectStoreConfig {
-        object_store: Some(ObjectStoreType::GCS),
-        bucket: Some(args.archive_bucket.clone()),
-        object_store_connection_limit: args.concurrency,
-        no_sign_request: false,
-        ..Default::default()
-    };
-    let archive_reader_config = ArchiveReaderConfig {
-        remote_store_config: archive_store_config,
-        download_concurrency: NonZeroUsize::new(args.concurrency).unwrap(),
-        use_for_pruning_watermark: false,
-    };
-    let metrics = ArchiveReaderMetrics::new(&Registry::default());
-    let archive_reader = ArchiveReader::new(archive_reader_config, &metrics)?;
-    archive_reader.sync_manifest_once().await?;
-    let manifest = archive_reader.get_manifest().await?;
-    let next_checkpoint_after_epoch = manifest.next_checkpoint_after_epoch(args.start_epoch);
-    info!(
-        epoch = args.start_epoch,
-        checkpoint = next_checkpoint_after_epoch,
-        "Next checkpoint after epoch",
-    );
-    let cp_summaries = archive_reader
-        .get_summaries_for_list_no_verify(vec![0])
-        .await?;
-    let first_cp = cp_summaries
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("No checkpoint found"))?;
-    let chain_identifier = *first_cp.digest();
-    Ok(ArchivalCheckpointInfo {
-        next_checkpoint_after_epoch,
-        chain_identifier,
-    })
+impl ArchivalCheckpointInfo {
+    /// Reads checkpoint information from archival storage to determine:
+    /// - The next checkpoint number after `start_epoch` for watermarking;
+    /// - The genesis checkpoint digest for kv_genesis.
+    pub async fn read_archival_checkpoint_info(args: &Args) -> anyhow::Result<Self> {
+        // Configure GCS object store and initialize archive reader with minimal concurrency.
+        let archive_store_config = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::GCS),
+            bucket: Some(args.archive_bucket.clone()),
+            object_store_connection_limit: 1, // 1 connection is sufficient
+            no_sign_request: false,
+            ..Default::default()
+        };
+        let archive_reader_config = ArchiveReaderConfig {
+            remote_store_config: archive_store_config,
+            download_concurrency: NonZeroUsize::new(1).unwrap(),
+            use_for_pruning_watermark: false,
+        };
+        let metrics = ArchiveReaderMetrics::new(&Registry::default());
+        let archive_reader = ArchiveReader::new(archive_reader_config, &metrics)?;
+
+        // Sync and read manifest to get next checkpoint after `start_epoch` for watermarking.
+        archive_reader.sync_manifest_once().await?;
+        let manifest = archive_reader.get_manifest().await?;
+        let next_checkpoint_after_epoch = manifest.next_checkpoint_after_epoch(args.start_epoch);
+        info!(
+            epoch = args.start_epoch,
+            checkpoint = next_checkpoint_after_epoch,
+            "Next checkpoint after epoch",
+        );
+
+        // Get genesis checkpoint (checkpoint 0) to determine chain identifier for kv_genesis.
+        let cp_summaries = archive_reader
+            .get_summaries_for_list_no_verify(vec![0])
+            .await?;
+        let first_cp = cp_summaries
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("No checkpoint found"))?;
+        let chain_identifier = *first_cp.digest();
+        Ok(Self {
+            next_checkpoint_after_epoch,
+            chain_identifier,
+        })
+    }
 }

--- a/crates/sui-indexer-alt-restorer/src/archives.rs
+++ b/crates/sui-indexer-alt-restorer/src/archives.rs
@@ -41,8 +41,9 @@ pub(crate) async fn read_archival_checkpoint_info(
     let manifest = archive_reader.get_manifest().await?;
     let next_checkpoint_after_epoch = manifest.next_checkpoint_after_epoch(args.start_epoch);
     info!(
-        "Read from archives: next checkpoint sequence after epoch {} is: {}",
-        args.start_epoch, next_checkpoint_after_epoch
+        epoch = args.start_epoch,
+        checkpoint = next_checkpoint_after_epoch,
+        "Next checkpoint after epoch",
     );
     let cp_summaries = archive_reader
         .get_summaries_for_list_no_verify(vec![0])

--- a/crates/sui-indexer-alt-restorer/src/lib.rs
+++ b/crates/sui-indexer-alt-restorer/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Args {
     pub start_epoch: u64,
 
     /// Url of the endpoint to fetch snapshot files from,
-    /// for example https://formal-snapshot.mainnet.sui.io
+    /// for example <https://formal-snapshot.mainnet.sui.io>
     #[clap(long, env = "ENDPOINT", required = true)]
     pub endpoint: String,
 

--- a/crates/sui-indexer-alt-restorer/src/lib.rs
+++ b/crates/sui-indexer-alt-restorer/src/lib.rs
@@ -4,7 +4,7 @@
 mod archives;
 mod snapshot;
 
-use archives::read_archival_checkpoint_info;
+use archives::ArchivalCheckpointInfo;
 use clap::Parser;
 use sui_pg_db::DbArgs;
 
@@ -17,7 +17,7 @@ pub struct Args {
     #[clap(long, env = "START_EPOCH", required = true)]
     pub start_epoch: u64,
 
-    /// Endpoint to fetch snapshot and archive files from.
+    /// Endpoint to fetch snapshot files from.
     #[clap(long, env = "ENDPOINT", required = true)]
     pub endpoint: String,
 
@@ -43,7 +43,8 @@ pub struct Args {
 }
 
 pub async fn restore(args: &Args) -> anyhow::Result<()> {
-    let archival_checkpoint_info = read_archival_checkpoint_info(args).await?;
+    let archival_checkpoint_info =
+        ArchivalCheckpointInfo::read_archival_checkpoint_info(args).await?;
     let mut snapshot_restorer =
         SnapshotRestorer::new(args, archival_checkpoint_info.next_checkpoint_after_epoch).await?;
     snapshot_restorer.restore().await?;

--- a/crates/sui-indexer-alt-restorer/src/lib.rs
+++ b/crates/sui-indexer-alt-restorer/src/lib.rs
@@ -13,24 +13,31 @@ use crate::snapshot::SnapshotRestorer;
 #[derive(Parser, Debug, Clone)]
 #[clap(name = "sui-indexer-restorer")]
 pub struct Args {
+    /// Restore from end of this epoch.
     #[clap(long, env = "START_EPOCH", required = true)]
     pub start_epoch: u64,
 
+    /// Endpoint to fetch snapshot and archive files from.
     #[clap(long, env = "ENDPOINT", required = true)]
     pub endpoint: String,
 
+    /// Bucket to fetch snapshot files from.
     #[clap(long, env = "SNAPSHOT_BUCKET", required = true)]
     pub snapshot_bucket: String,
 
+    /// Bucket to fetch archive files from.
     #[clap(long, env = "ARCHIVE_BUCKET", required = true)]
     pub archive_bucket: String,
 
+    /// Local directory to temporarily store snapshot files.
     #[clap(long, env = "SNAPSHOT_LOCAL_DIR", required = true)]
     pub snapshot_local_dir: String,
 
+    /// Number of concurrent restore tasks to run.
     #[clap(long, env = "CONCURRENCY", default_value_t = 50)]
     pub concurrency: usize,
 
+    /// Database connection arguments from `sui-pg-db`.
     #[clap(flatten)]
     pub db_args: DbArgs,
 }

--- a/crates/sui-indexer-alt-restorer/src/lib.rs
+++ b/crates/sui-indexer-alt-restorer/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod archives;
+mod snapshot;
+
+use archives::read_archival_checkpoint_info;
+use clap::Parser;
+use sui_pg_db::DbArgs;
+
+use crate::snapshot::SnapshotRestorer;
+
+#[derive(Parser, Debug, Clone)]
+#[clap(name = "sui-indexer-restorer")]
+pub struct Args {
+    #[clap(long, env = "START_EPOCH", required = true)]
+    pub start_epoch: u64,
+
+    #[clap(long, env = "ENDPOINT", required = true)]
+    pub endpoint: String,
+
+    #[clap(long, env = "SNAPSHOT_BUCKET", required = true)]
+    pub snapshot_bucket: String,
+
+    #[clap(long, env = "ARCHIVE_BUCKET", required = true)]
+    pub archive_bucket: String,
+
+    #[clap(long, env = "SNAPSHOT_LOCAL_DIR", required = true)]
+    pub snapshot_local_dir: String,
+
+    #[clap(long, env = "CONCURRENCY", default_value_t = 50)]
+    pub concurrency: usize,
+
+    #[clap(flatten)]
+    pub db_args: DbArgs,
+}
+
+pub async fn restore(args: &Args) -> anyhow::Result<()> {
+    let archival_checkpoint_info = read_archival_checkpoint_info(args).await?;
+    let mut snapshot_restorer =
+        SnapshotRestorer::new(args, archival_checkpoint_info.next_checkpoint_after_epoch).await?;
+    snapshot_restorer.restore().await?;
+    Ok(())
+}

--- a/crates/sui-indexer-alt-restorer/src/lib.rs
+++ b/crates/sui-indexer-alt-restorer/src/lib.rs
@@ -11,13 +11,14 @@ use sui_pg_db::DbArgs;
 use crate::snapshot::SnapshotRestorer;
 
 #[derive(Parser, Debug, Clone)]
-#[clap(name = "sui-indexer-restorer")]
+#[clap(name = "sui-indexer-alt-restorer")]
 pub struct Args {
     /// Restore from end of this epoch.
     #[clap(long, env = "START_EPOCH", required = true)]
     pub start_epoch: u64,
 
-    /// Endpoint to fetch snapshot files from.
+    /// Url of the endpoint to fetch snapshot files from,
+    /// for example https://formal-snapshot.mainnet.sui.io
     #[clap(long, env = "ENDPOINT", required = true)]
     pub endpoint: String,
 

--- a/crates/sui-indexer-alt-restorer/src/main.rs
+++ b/crates/sui-indexer-alt-restorer/src/main.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use tracing::info;
+
+use sui_indexer_alt_restorer::restore;
+use sui_indexer_alt_restorer::Args;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    info!("Starting indexer restorer from epoch {}", args.start_epoch);
+    restore(&args).await?;
+    info!("Finished indexer restorer!");
+    Ok(())
+}

--- a/crates/sui-indexer-alt-restorer/src/main.rs
+++ b/crates/sui-indexer-alt-restorer/src/main.rs
@@ -10,6 +10,10 @@ use sui_indexer_alt_restorer::Args;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // NOTE: this is to print out tracing like info, warn & error.
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
     let args = Args::parse();
     info!("Starting indexer restorer from epoch {}", args.start_epoch);
     restore(&args).await?;

--- a/crates/sui-indexer-alt-restorer/src/snapshot.rs
+++ b/crates/sui-indexer-alt-restorer/src/snapshot.rs
@@ -1,0 +1,207 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Error;
+use diesel_async::RunQueryDsl;
+use futures::future::{AbortHandle, AbortRegistration, Abortable};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use object_store::path::Path;
+use tokio::sync::{Mutex, Semaphore};
+use tokio::task;
+use tracing::info;
+
+use sui_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
+use sui_core::authority::authority_store_tables::LiveObject;
+use sui_field_count::FieldCount;
+use sui_indexer_alt_schema::objects::StoredObjInfo;
+use sui_indexer_alt_schema::schema::obj_info;
+use sui_pg_db::Db;
+use sui_snapshot::{
+    reader::{download_bytes, LiveObjectIter, StateSnapshotReaderV1},
+    FileMetadata,
+};
+use sui_storage::object_store::ObjectStoreGetExt;
+
+use crate::Args;
+
+pub type DigestByBucketAndPartition = BTreeMap<u32, BTreeMap<u32, [u8; 32]>>;
+
+pub struct SnapshotRestorer {
+    pub restore_args: Args,
+    pub next_checkpoint_after_epoch: u64,
+    pub snapshot_reader: StateSnapshotReaderV1,
+    pub db: Db,
+}
+
+impl SnapshotRestorer {
+    pub async fn new(args: &Args, next_checkpoint_after_epoch: u64) -> Result<Self, Error> {
+        let remote_store_config = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::S3),
+            aws_endpoint: Some(args.endpoint.clone()),
+            aws_virtual_hosted_style_request: true,
+            object_store_connection_limit: args.concurrency,
+            no_sign_request: true,
+            ..Default::default()
+        };
+
+        let local_path = PathBuf::from(&args.snapshot_local_dir);
+        let snapshot_dir = local_path.join("snapshot");
+        let local_store_config = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(snapshot_dir.clone().to_path_buf()),
+            ..Default::default()
+        };
+
+        let m = MultiProgress::new();
+        let snapshot_reader = StateSnapshotReaderV1::new(
+            args.start_epoch,
+            &remote_store_config,
+            &local_store_config,
+            usize::MAX,
+            NonZeroUsize::new(args.concurrency).unwrap(),
+            m,
+            true, // skip_reset_local_store
+        )
+        .await?;
+        let db = Db::new(args.db_args.clone()).await?;
+
+        Ok(Self {
+            restore_args: args.clone(),
+            snapshot_reader,
+            db,
+            next_checkpoint_after_epoch,
+        })
+    }
+
+    pub async fn restore(&mut self) -> Result<(), Error> {
+        info!(
+            "Starting snapshot restore from epoch {}",
+            self.restore_args.start_epoch
+        );
+        let (sha3_digests, num_part_files) = self.snapshot_reader.compute_checksum().await?;
+        let (_abort_handle, abort_registration) = AbortHandle::new_pair();
+        let (input_files, epoch_dir, remote_object_store, _concurrency) =
+            self.snapshot_reader.export_metadata().await?;
+        let owned_input_files: Vec<(u32, (u32, FileMetadata))> = input_files
+            .into_iter()
+            .map(|(bucket, (part_num, metadata))| (*bucket, (part_num, metadata.clone())))
+            .collect();
+
+        self.restore_object_infos(
+            abort_registration,
+            owned_input_files,
+            epoch_dir,
+            remote_object_store,
+            sha3_digests,
+            num_part_files,
+            self.restore_args.concurrency,
+        )
+        .await?;
+        info!(
+            "Finished snapshot restore from epoch {}",
+            self.restore_args.start_epoch
+        );
+        Ok(())
+    }
+
+    async fn restore_object_infos(
+        &self,
+        abort_registration: AbortRegistration,
+        input_files: Vec<(u32, (u32, FileMetadata))>,
+        epoch_dir: Path,
+        remote_object_store: Arc<dyn ObjectStoreGetExt>,
+        sha3_digests: Arc<Mutex<DigestByBucketAndPartition>>,
+        num_part_files: usize,
+        concurrency: usize,
+    ) -> std::result::Result<(), anyhow::Error> {
+        let move_object_progress_bar = Arc::new(self.snapshot_reader.get_multi_progress().add(
+            ProgressBar::new(num_part_files as u64).with_style(
+                ProgressStyle::with_template(
+                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} move object files restored ({msg})",
+                )
+                .unwrap(),
+            ),
+        ));
+
+        Abortable::new(
+            async move {
+                let sema_limit = Arc::new(Semaphore::new(concurrency));
+                let mut restore_tasks = vec![];
+
+                for (bucket, (part_num, file_metadata)) in input_files.into_iter() {
+                    let sema_limit_clone = sema_limit.clone();
+                    let epoch_dir_clone = epoch_dir.clone();
+                    let remote_object_store_clone = remote_object_store.clone();
+                    let sha3_digests_clone = sha3_digests.clone();
+                    let bar_clone = move_object_progress_bar.clone();
+                    let db = self.db.clone();
+                    let next_cp = self.next_checkpoint_after_epoch;
+
+                    let restore_task = task::spawn(async move {
+                        let mut conn = db.connect().await?;
+                        let _permit = sema_limit_clone.acquire().await.unwrap();
+                        let object_file_path = file_metadata.file_path(&epoch_dir_clone);
+                        let (bytes, _) = download_bytes(
+                            remote_object_store_clone,
+                            &file_metadata,
+                            epoch_dir_clone,
+                            sha3_digests_clone,
+                            &&bucket,
+                            &part_num,
+                            Some(512),
+                        )
+                        .await;
+                        info!(
+                            "Finished downloading move object file {:?}",
+                            object_file_path
+                        );
+                        let mut object_infos = vec![];
+                        let _result: Result<(), anyhow::Error> =
+                            LiveObjectIter::new(&file_metadata, bytes.clone()).map(|obj_iter| {
+                                for object in obj_iter {
+                                    match object {
+                                        LiveObject::Normal(obj) => {
+                                            let object_info =
+                                                StoredObjInfo::from_object(&obj, next_cp as i64);
+                                            object_infos.push(object_info);
+                                        }
+                                        LiveObject::Wrapped(_) => {}
+                                    }
+                                }
+                            });
+                        let object_infos =
+                            object_infos.into_iter().collect::<Result<Vec<_>, _>>()?;
+
+                        // NOTE: chunk to avoid hitting the PG limit
+                        let object_info_count = object_infos.len();
+                        let chunk_size: usize = i16::MAX as usize / StoredObjInfo::FIELD_COUNT;
+                        for chunk in object_infos.chunks(chunk_size) {
+                            diesel::insert_into(obj_info::table)
+                                .values(chunk)
+                                .on_conflict_do_nothing()
+                                .execute(&mut conn)
+                                .await?;
+                        }
+                        bar_clone.inc(1);
+                        info!("Restored {} move objects", object_info_count);
+                        Ok::<(), anyhow::Error>(())
+                    });
+                    restore_tasks.push(restore_task);
+                }
+
+                let restore_task_results = futures::future::join_all(restore_tasks).await;
+                for restore_task_result in restore_task_results {
+                    restore_task_result??;
+                }
+                Ok(())
+            },
+            abort_registration,
+        )
+        .await?
+    }
+}

--- a/crates/sui-indexer-alt-schema/Cargo.toml
+++ b/crates/sui-indexer-alt-schema/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 diesel = {workspace = true, features = ["postgres_backend", "chrono"]}
 diesel_migrations.workspace = true
 serde.workspace = true
+bcs.workspace = true
 
 sui-field-count.workspace = true
 sui-protocol-config.workspace = true

--- a/crates/sui-indexer-alt-schema/src/objects.rs
+++ b/crates/sui-indexer-alt-schema/src/objects.rs
@@ -6,6 +6,7 @@ use diesel::{
     sql_types::SmallInt, FromSqlRow,
 };
 use sui_field_count::FieldCount;
+use sui_types::object::{Object, Owner};
 
 use crate::schema::{coin_balance_buckets, kv_objects, obj_info, obj_versions};
 
@@ -66,6 +67,46 @@ pub struct StoredCoinBalanceBucket {
     pub owner_id: Option<Vec<u8>>,
     pub coin_type: Option<Vec<u8>>,
     pub coin_balance_bucket: Option<i16>,
+}
+
+impl StoredObjInfo {
+    pub fn from_object(
+        object: &Object,
+        cp_sequence_number: i64,
+    ) -> Result<Self, anyhow::Error> {
+        let type_ = object.type_();
+        Ok(Self {
+            object_id: object.id().to_vec(),
+            cp_sequence_number,
+            owner_kind: Some(match object.owner() {
+                Owner::AddressOwner(_) => StoredOwnerKind::Address,
+                Owner::ObjectOwner(_) => StoredOwnerKind::Object,
+                Owner::Shared { .. } => StoredOwnerKind::Shared,
+                Owner::Immutable => StoredOwnerKind::Immutable,
+                Owner::ConsensusV2 { .. } => todo!(),
+            }),
+    
+            owner_id: match object.owner() {
+                Owner::AddressOwner(a) => Some(a.to_vec()),
+                Owner::ObjectOwner(o) => Some(o.to_vec()),
+                Owner::Shared { .. } | Owner::Immutable { .. } => None,
+                Owner::ConsensusV2 { .. } => todo!(),
+            },
+    
+            package: type_.map(|t| t.address().to_vec()),
+            module: type_.map(|t| t.module().to_string()),
+            name: type_.map(|t| t.name().to_string()),
+            instantiation: type_
+                .map(|t| bcs::to_bytes(&t.type_params()))
+                .transpose()
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to serialize type parameters for {}: {e}",
+                        object.id().to_canonical_display(/* with_prefix */ true),
+                    )
+                })?,
+        })
+    }
 }
 
 impl<DB: Backend> serialize::ToSql<SmallInt, DB> for StoredOwnerKind

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -3,19 +3,19 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use diesel_async::RunQueryDsl;
 use sui_field_count::FieldCount;
 use sui_indexer_alt_framework::pipeline::{concurrent::Handler, Processor};
 use sui_indexer_alt_schema::{
-    objects::{StoredObjInfo, StoredOwnerKind},
+    objects::StoredObjInfo,
     schema::obj_info,
 };
 use sui_pg_db as db;
 use sui_types::{
     base_types::ObjectID,
     full_checkpoint_content::CheckpointData,
-    object::{Object, Owner},
+    object::Object,
 };
 
 pub(crate) struct ObjInfo;
@@ -105,36 +105,7 @@ impl TryInto<StoredObjInfo> for &ProcessedObjInfo {
     fn try_into(self) -> Result<StoredObjInfo> {
         match &self.update {
             ProcessedObjInfoUpdate::Insert(object) => {
-                let type_ = object.type_();
-                let (owner_kind, owner_id) = match object.owner() {
-                    Owner::AddressOwner(a) => (StoredOwnerKind::Address, Some(a.to_vec())),
-                    Owner::ObjectOwner(o) => (StoredOwnerKind::Object, Some(o.to_vec())),
-                    Owner::Shared { .. } | Owner::Immutable { .. } => {
-                        (StoredOwnerKind::Shared, None)
-                    }
-                    Owner::ConsensusV2 { authenticator, .. } => (
-                        StoredOwnerKind::Address,
-                        Some(authenticator.as_single_owner().to_vec()),
-                    ),
-                };
-                Ok(StoredObjInfo {
-                    object_id: object.id().to_vec(),
-                    cp_sequence_number: self.cp_sequence_number as i64,
-                    owner_kind: Some(owner_kind),
-                    owner_id,
-                    package: type_.map(|t| t.address().to_vec()),
-                    module: type_.map(|t| t.module().to_string()),
-                    name: type_.map(|t| t.name().to_string()),
-                    instantiation: type_
-                        .map(|t| bcs::to_bytes(&t.type_params()))
-                        .transpose()
-                        .map_err(|e| {
-                            anyhow!(
-                                "Failed to serialize type parameters for {}: {e}",
-                                object.id().to_canonical_display(/* with_prefix */ true),
-                            )
-                        })?,
-                })
+                StoredObjInfo::from_object(object, self.cp_sequence_number as i64)
             }
             ProcessedObjInfoUpdate::Delete(object_id) => Ok(StoredObjInfo {
                 object_id: object_id.to_vec(),

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -7,16 +7,9 @@ use anyhow::Result;
 use diesel_async::RunQueryDsl;
 use sui_field_count::FieldCount;
 use sui_indexer_alt_framework::pipeline::{concurrent::Handler, Processor};
-use sui_indexer_alt_schema::{
-    objects::StoredObjInfo,
-    schema::obj_info,
-};
+use sui_indexer_alt_schema::{objects::StoredObjInfo, schema::obj_info};
 use sui_pg_db as db;
-use sui_types::{
-    base_types::ObjectID,
-    full_checkpoint_content::CheckpointData,
-    object::Object,
-};
+use sui_types::{base_types::ObjectID, full_checkpoint_content::CheckpointData, object::Object};
 
 pub(crate) struct ObjInfo;
 


### PR DESCRIPTION
## Description 

title, the main parts are:
- read archival storage for checkpoint info of seq number and chain identifier
- read snapshot files and restore obj_info table

## Test plan 

local run
```
cargo run --bin sui-indexer-alt-restorer -- --start-epoch 600 --endpoint "https://formal-snapshot.mainnet.sui.io" --snapshot-bucket "mysten-mainnet-formal" --archive-bucket "mysten-mainnet-archives" --snapshot-local-dir "/Users/gegao/Desktop/formal" --database-url "postgres://postgres:postgres@localhost/gegao"
```
it's worth doing some data integrity check eventually and not done yet. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
