### PR TITLE
[CLI] Only put on chain the transitive dependencies that are actually referenced.

### DIFF
--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -481,7 +481,7 @@ pub fn build_test_modules_with_dep_addr(
             .additional_named_addresses
             .insert(addr_name.to_string(), AccountAddress::from(obj_id));
     }
-    let mut package = build_config.build(path).unwrap();
+    let mut package = build_config.build(path, false).unwrap();
 
     let dep_id_mapping: BTreeMap<_, _> = dep_ids
         .into_iter()
@@ -527,7 +527,11 @@ pub async fn publish_package_on_single_authority(
             .additional_named_addresses
             .insert(addr_name.to_string(), AccountAddress::from(obj_id));
     }
-    let modules = build_config.build(path).unwrap().get_package_bytes(false);
+    let with_unpublished_deps = false;
+    let modules = build_config
+        .build(path, with_unpublished_deps)
+        .unwrap()
+        .get_package_bytes(with_unpublished_deps);
 
     let mut builder = ProgrammableTransactionBuilder::new();
     let cap = builder.publish_upgradeable(modules, dep_ids);

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -203,7 +203,7 @@ pub fn compile_example_package(relative_path: &str) -> CompiledPackage {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(relative_path);
 
-    BuildConfig::new_for_testing().build(&path).unwrap()
+    BuildConfig::new_for_testing().build(&path, false).unwrap()
 }
 
 async fn init_genesis(

--- a/crates/sui-move-build/src/unit_tests/build_tests.rs
+++ b/crates/sui-move-build/src/unit_tests/build_tests.rs
@@ -17,7 +17,9 @@ fn generate_struct_layouts() {
         .join("sui-framework")
         .join("packages")
         .join("sui-framework");
-    let pkg = BuildConfig::new_for_testing().build(&path).unwrap();
+    let pkg = BuildConfig::new_for_testing()
+        .build(&path, false /*with_unpublished_dependencies*/)
+        .unwrap();
     let registry = pkg.generate_struct_layouts();
     // check for a couple of types that aren't likely to go away
     assert!(registry.contains_key(
@@ -40,7 +42,7 @@ fn development_mode_not_allowed() {
         .join("data")
         .join("no_development_mode");
     let err = BuildConfig::new_for_testing()
-        .build(&path)
+        .build(&path, false /*with_unpublished_dependencies*/)
         .expect_err("Should have failed due to unsupported edition");
     assert!(err
         .to_string()

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -68,7 +68,7 @@ impl Build {
             print_diags_to_stderr: true,
             chain_id,
         }
-        .build(rerooted_path)?;
+        .build(rerooted_path, with_unpublished_deps)?;
         if dump_bytecode_as_base64 {
             check_invalid_dependencies(&pkg.dependency_ids.invalid)?;
             if !with_unpublished_deps {

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -328,7 +328,9 @@ impl TestTransactionBuilder {
             TestTransactionData::Publish(data) => {
                 let (all_module_bytes, dependencies) = match data {
                     PublishData::Source(path, with_unpublished_deps) => {
-                        let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+                        let compiled_package = BuildConfig::new_for_testing()
+                            .build(&path, with_unpublished_deps)
+                            .unwrap();
                         let all_module_bytes =
                             compiled_package.get_package_bytes(with_unpublished_deps);
                         let dependencies = compiled_package.get_dependency_storage_package_ids();

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -965,8 +965,10 @@ impl<'a> PTBBuilder<'a> {
                     )
                     .map_err(|e| err!(pkg_loc, "{e}"))?;
                 }
-                let (dependencies, compiled_modules, _, _) =
-                    compile_result.map_err(|e| err!(pkg_loc, "{e}"))?;
+                let compiled_package = compile_result.map_err(|e| err!(pkg_loc, "{e}"))?;
+                let compiled_modules = compiled_package
+                    .get_package_bytes(false /* with_unpublished_dependencies */);
+                let dependencies = compiled_package.dependency_ids;
 
                 let res = self.ptb.publish_upgradeable(
                     compiled_modules,


### PR DESCRIPTION
## Description 

When a package is added as a dependency in the Move.toml manifest file, it will become part of the linkage table regardless if any code in that package is actually referenced in the code or not. This PR fixes that by making sure that a package's linkage table contains only the dependencies that are actually referenced in the code by computing the list of dependencies from the modules' dependencies after all modules and their transitive dependencies are compiled rather than the manifest files.

## Test plan 

👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
