### PR TITLE
[move-ide] Track all files requiring analysis

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1408,7 +1408,7 @@ impl SymbolicatorRunner {
                     if let Some(all_starting_paths) = all_starting_paths_opt {
                         let mut pkgs_to_analyze = BTreeMap::new();
                         for starting_path in &all_starting_paths {
-                            let root_dir = Self::root_dir(&starting_path);
+                            let root_dir = Self::root_dir(starting_path);
                             if root_dir.is_none() {
                                 if !missing_manifests.contains(starting_path) {
                                     eprintln!("reporting missing manifest");

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -663,7 +663,7 @@ pub struct Symbols {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 enum RunnerState {
-    Run(PathBuf),
+    Run(BTreeSet<PathBuf>),
     Wait,
     Quit,
 }
@@ -1381,7 +1381,7 @@ impl SymbolicatorRunner {
                 // infinite loop to wait for symbolication requests
                 eprintln!("starting symbolicator runner loop");
                 loop {
-                    let starting_path_opt = {
+                    let all_starting_paths_opt = {
                         // hold the lock only as long as it takes to get the data, rather than through
                         // the whole symbolication process (hence a separate scope here)
                         let mut symbolicate = mtx.lock().unwrap();
@@ -1405,54 +1405,64 @@ impl SymbolicatorRunner {
                             }
                         }
                     };
-                    if let Some(starting_path) = starting_path_opt {
-                        let root_dir = Self::root_dir(&starting_path);
-                        if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
-                            eprintln!("reporting missing manifest");
+                    if let Some(all_starting_paths) = all_starting_paths_opt {
+                        let mut pkgs_to_analyze = BTreeMap::new();
+                        for starting_path in &all_starting_paths {
+                            let root_dir = Self::root_dir(&starting_path);
+                            if root_dir.is_none() {
+                                if !missing_manifests.contains(starting_path) {
+                                    eprintln!("reporting missing manifest");
 
-                            // report missing manifest file only once to avoid cluttering IDE's UI in
-                            // cases when developer indeed intended to open a standalone file that was
-                            // not meant to compile
-                            missing_manifests.insert(starting_path);
-                            if let Err(err) = sender.send(Err(anyhow!(
-                                "Unable to find package manifest. Make sure that
-                            the source files are located in a sub-directory of a package containing
-                            a Move.toml file. "
-                            ))) {
-                                eprintln!("could not pass missing manifest error: {:?}", err);
+                                    // report missing manifest file only once to avoid cluttering IDE's UI in
+                                    // cases when developer indeed intended to open a standalone file that was
+                                    // not meant to compile
+                                    missing_manifests.insert(starting_path.clone());
+                                    if let Err(err) = sender.send(Err(anyhow!(
+                                        "Unable to find package manifest. Make sure that
+                                        the source files are located in a sub-directory of a package containing
+                                        a Move.toml file. "
+                                    ))) {
+                                        eprintln!("could not pass missing manifest error: {:?}", err);
+                                    }
+                                }
+                                continue;
                             }
-                            continue;
+                            pkgs_to_analyze
+                                .entry(root_dir.unwrap())
+                                .or_insert_with(BTreeSet::new)
+                                .insert(starting_path.clone());
                         }
-                        eprintln!("symbolication started");
-                        let pkg_path = root_dir.unwrap();
-                        match get_symbols(
-                            pkg_deps.clone(),
-                            ide_files_root.clone(),
-                            pkg_path.as_path(),
-                            lint,
-                            None,
-                        ) {
-                            Ok((symbols_opt, lsp_diagnostics)) => {
-                                eprintln!("symbolication finished");
-                                if let Some(new_symbols) = symbols_opt {
-                                    // replace symbolication info for a given package
-                                    //
-                                    // TODO: we may consider "unloading" symbolication information when
-                                    // files/directories are being closed but as with other performance
-                                    // optimizations (e.g. incrementalizatino of the vfs), let's wait
-                                    // until we know we actually need it
-                                    let mut old_symbols_map = symbols_map.lock().unwrap();
-                                    old_symbols_map.insert(pkg_path, new_symbols);
+                        for pkg_path in pkgs_to_analyze.keys() {
+                            eprintln!("symbolication started");
+                            match get_symbols(
+                                pkg_deps.clone(),
+                                ide_files_root.clone(),
+                                pkg_path.as_path(),
+                                lint,
+                                None,
+                            ) {
+                                Ok((symbols_opt, lsp_diagnostics)) => {
+                                    eprintln!("symbolication finished");
+                                    if let Some(new_symbols) = symbols_opt {
+                                        // replace symbolication info for a given package
+                                        //
+                                        // TODO: we may consider "unloading" symbolication information when
+                                        // files/directories are being closed but as with other performance
+                                        // optimizations (e.g. incrementalizatino of the vfs), let's wait
+                                        // until we know we actually need it
+                                        let mut old_symbols_map = symbols_map.lock().unwrap();
+                                        old_symbols_map.insert(pkg_path.clone(), new_symbols);
+                                    }
+                                    // set/reset (previous) diagnostics
+                                    if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
+                                        eprintln!("could not pass diagnostics: {:?}", err);
+                                    }
                                 }
-                                // set/reset (previous) diagnostics
-                                if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
-                                    eprintln!("could not pass diagnostics: {:?}", err);
-                                }
-                            }
-                            Err(err) => {
-                                eprintln!("symbolication failed: {:?}", err);
-                                if let Err(err) = sender.send(Err(err)) {
-                                    eprintln!("could not pass compiler error: {:?}", err);
+                                Err(err) => {
+                                    eprintln!("symbolication failed: {:?}", err);
+                                    if let Err(err) = sender.send(Err(err)) {
+                                        eprintln!("could not pass compiler error: {:?}", err);
+                                    }
                                 }
                             }
                         }
@@ -1468,7 +1478,18 @@ impl SymbolicatorRunner {
         eprintln!("scheduling run for {:?}", starting_path);
         let (mtx, cvar) = &*self.mtx_cvar;
         let mut symbolicate = mtx.lock().unwrap();
-        *symbolicate = RunnerState::Run(starting_path);
+        match symbolicate.clone() {
+            RunnerState::Quit => (), // do nothing as we are quitting
+            RunnerState::Run(mut all_starting_paths) => {
+                all_starting_paths.insert(starting_path);
+                *symbolicate = RunnerState::Run(all_starting_paths);
+            }
+            RunnerState::Wait => {
+                let mut all_starting_paths = BTreeSet::new();
+                all_starting_paths.insert(starting_path);
+                *symbolicate = RunnerState::Run(all_starting_paths);
+            }
+        }
         cvar.notify_one();
         eprintln!("scheduled run");
     }


### PR DESCRIPTION
## Description 

Currently move-analyzer does not fully track all files requiring analysis but rather only the last one sent to the symbolicator. It should not be a huge deal from the user's point of view as they spend significant amount of time (at least compared to analysis time) editing a single file before switching to the next, but precise tracking will be needed if we only want to re-analyze specific files (as part of an upcoming optimization). This PR implements tracking of all files requiring analysis.

## Test plan 

All tests must pass
