### PR TITLE
[consensus] Enable smart ancestor selection in testnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -198,7 +198,8 @@ const MAX_PROTOCOL_VERSION: u64 = 70;
 // Version 69: Sets number of rounds allowed for fastpath voting in consensus.
 //             Enable smart ancestor selection in devnet.
 //             Enable G1Uncompressed group in testnet.
-// Version 70: Enable probing for accepted rounds in round prober.
+// Version 70: Enable smart ancestor selection in testnet.
+//             Enable probing for accepted rounds in round prober in testnet
 //             Add new gas model version to update charging of native functions.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -2990,8 +2991,10 @@ impl ProtocolConfig {
                     }
                 }
                 70 => {
-                    if chain != Chain::Mainnet && chain != Chain::Testnet {
-                        // Enable probing for accepted rounds in round prober.
+                    if chain != Chain::Mainnet {
+                        // Enable smart ancestor selection for testnet
+                        cfg.feature_flags.consensus_smart_ancestor_selection = true;
+                        // Enable probing for accepted rounds in round prober for testnet
                         cfg.feature_flags
                             .consensus_round_prober_probe_accepted_rounds = true;
                     }

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_70.snap
@@ -66,6 +66,8 @@ feature_flags:
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
Additionally will enable probing for accepted rounds which is used only by ancestor selection.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Enable smart ancestor selection in testnet for v70
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
