### PR TITLE
[indexer-alt] Add support for lagged concurrent pipeline

### DIFF
--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -85,6 +85,7 @@ pub(crate) struct IndexerMetrics {
     pub handler_checkpoint_latency: HistogramVec,
 
     // Statistics related to individual ingestion pipelines.
+    pub total_collector_checkpoints_received: IntCounterVec,
     pub total_collector_rows_received: IntCounterVec,
     pub total_collector_batches_created: IntCounterVec,
     pub total_committer_batches_attempted: IntCounterVec,
@@ -302,6 +303,13 @@ impl IndexerMetrics {
                 "Time taken to process a checkpoint by this handler",
                 &["pipeline"],
                 PROCESSING_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            total_collector_checkpoints_received: register_int_counter_vec_with_registry!(
+                "indexer_total_collector_checkpoints_received",
+                "Total number of checkpoints received by this collector",
+                &["pipeline"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -18,6 +18,12 @@ use crate::{
 
 use super::{Batched, Handler};
 
+/// When there is a checkpoint lag specified, the collector will keep a buffer of checkpoints to
+/// account for the lag. This multiplier controls how much buffer to keep.
+/// We need to make the range wide enough to account for both the lag and the time it takes to
+/// actually commit the checkpoint.
+const CHECKPOINT_LAG_BUFFER_MULTIPLIER: usize = 2;
+
 /// Processed values that are waiting to be written to the database. This is an internal type used
 /// by the concurrent collector to hold data it is waiting to send to the committer.
 struct Pending<H: Handler> {
@@ -80,6 +86,7 @@ impl<H: Handler> From<Indexed<H>> for Pending<H> {
 /// closed.
 pub(super) fn collector<H: Handler + 'static>(
     config: CommitterConfig,
+    checkpoint_lag: Option<u64>,
     mut rx: mpsc::Receiver<Indexed<H>>,
     tx: mpsc::Sender<Batched<H>>,
     metrics: Arc<IndexerMetrics>,
@@ -91,7 +98,15 @@ pub(super) fn collector<H: Handler + 'static>(
         let mut poll = interval(config.collect_interval());
         poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        // Data for checkpoints that haven't been written yet.
+        // Data for checkpoints that have been received but not yet ready to be sent to committer due to lag constraint.
+        let mut received: BTreeMap<u64, Indexed<H>> = BTreeMap::new();
+        // In the case when checkpoint_lag is 0, max_allowed_received will be 0 as well.
+        // This is OK because we will always move all checkpoints from `received` to `pending` right away,
+        // and hence `received` will always be empty.
+        let checkpoint_lag = checkpoint_lag.unwrap_or_default();
+        let max_allowed_received = checkpoint_lag as usize * CHECKPOINT_LAG_BUFFER_MULTIPLIER;
+
+        // Data for checkpoints that are ready to be sent but haven't been written yet.
         let mut pending: BTreeMap<u64, Pending<H>> = BTreeMap::new();
         let mut pending_rows = 0;
 
@@ -160,14 +175,18 @@ pub(super) fn collector<H: Handler + 'static>(
                     }
                 }
 
-                Some(indexed) = rx.recv(), if pending_rows < H::MAX_PENDING_ROWS => {
+                Some(indexed) = rx.recv(), if pending_rows < H::MAX_PENDING_ROWS && received.len() <= max_allowed_received => {
                     metrics
                         .total_collector_rows_received
                         .with_label_values(&[H::NAME])
                         .inc_by(indexed.len() as u64);
+                    metrics
+                        .total_collector_checkpoints_received
+                        .with_label_values(&[H::NAME])
+                        .inc();
 
-                    pending_rows += indexed.len();
-                    pending.insert(indexed.checkpoint(), indexed.into());
+                    received.insert(indexed.checkpoint(), indexed);
+                    pending_rows += move_ready_checkpoints(&mut received, &mut pending, checkpoint_lag);
 
                     if pending_rows >= H::MIN_EAGER_ROWS {
                         poll.reset_immediately()
@@ -176,4 +195,135 @@ pub(super) fn collector<H: Handler + 'static>(
             }
         }
     })
+}
+
+/// Move all checkpoints from `received` that are within the lag range into `pending`.
+/// Returns the number of rows moved.
+fn move_ready_checkpoints<H: Handler>(
+    received: &mut BTreeMap<u64, Indexed<H>>,
+    pending: &mut BTreeMap<u64, Pending<H>>,
+    checkpoint_lag: u64,
+) -> usize {
+    let tip = match (received.last_key_value(), pending.last_key_value()) {
+        (Some((cp, _)), None) | (None, Some((cp, _))) => *cp,
+        (Some((cp1, _)), Some((cp2, _))) => std::cmp::max(*cp1, *cp2),
+        (None, None) => return 0,
+    };
+
+    let mut moved_rows = 0;
+    while let Some(entry) = received.first_entry() {
+        let cp = *entry.key();
+        if cp + checkpoint_lag > tip {
+            break;
+        }
+
+        let indexed = entry.remove();
+        moved_rows += indexed.len();
+        pending.insert(cp, indexed.into());
+    }
+
+    moved_rows
+}
+
+#[cfg(test)]
+mod tests {
+    use sui_field_count::FieldCount;
+    use sui_types::full_checkpoint_content::CheckpointData;
+
+    use crate::{db, pipeline::Processor};
+
+    use super::*;
+
+    #[derive(FieldCount)]
+    struct Entry;
+
+    struct TestHandler;
+    impl Processor for TestHandler {
+        type Value = Entry;
+        const NAME: &'static str = "test";
+
+        fn process(&self, _: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Handler for TestHandler {
+        const MAX_PENDING_ROWS: usize = 1000;
+        const MIN_EAGER_ROWS: usize = 100;
+
+        async fn commit(_: &[Self::Value], _: &mut db::Connection<'_>) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    #[test]
+    fn test_move_ready_checkpoints_empty() {
+        let mut received = BTreeMap::new();
+        let mut pending = BTreeMap::new();
+        let moved = move_ready_checkpoints::<TestHandler>(&mut received, &mut pending, 10);
+        assert_eq!(moved, 0);
+        assert!(received.is_empty());
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn test_move_ready_checkpoints_within_lag() {
+        let mut received = BTreeMap::new();
+        let mut pending = BTreeMap::new();
+
+        // Add checkpoints 1-5 to received
+        for i in 1..=5 {
+            received.insert(i, Indexed::new(0, i, 0, 0, vec![Entry, Entry, Entry]));
+        }
+
+        // With lag of 2 and tip at 5, only checkpoints 1-3 should move
+        let moved = move_ready_checkpoints::<TestHandler>(&mut received, &mut pending, 2);
+
+        assert_eq!(moved, 9); // 3 checkpoints * 3 rows each
+        assert_eq!(received.len(), 2); // 4,5 remain
+        assert_eq!(pending.len(), 3); // 1,2,3 moved
+        assert!(pending.contains_key(&1));
+        assert!(pending.contains_key(&2));
+        assert!(pending.contains_key(&3));
+    }
+
+    #[test]
+    fn test_move_ready_checkpoints_tip_from_pending() {
+        let mut received = BTreeMap::new();
+        let mut pending = BTreeMap::new();
+
+        // Add checkpoint 10 to pending to establish tip
+        pending.insert(10, Pending::from(Indexed::new(0, 10, 0, 0, vec![Entry])));
+
+        // Add checkpoints 1-5 to received
+        for i in 1..=5 {
+            received.insert(i, Indexed::new(0, i, 0, 0, vec![Entry]));
+        }
+
+        // With lag of 3 and tip at 10, checkpoints 1-7 can move
+        let moved = move_ready_checkpoints::<TestHandler>(&mut received, &mut pending, 3);
+
+        assert_eq!(moved, 5); // All 5 checkpoints moved, 1 row each
+        assert!(received.is_empty());
+        assert_eq!(pending.len(), 6); // Original + 5 new
+    }
+
+    #[test]
+    fn test_move_ready_checkpoints_no_eligible() {
+        let mut received = BTreeMap::new();
+        let mut pending = BTreeMap::new();
+
+        // Add checkpoints 8-10 to received
+        for i in 8..=10 {
+            received.insert(i, Indexed::new(0, i, 0, 0, vec![Entry]));
+        }
+
+        // With lag of 5 and tip at 10, no checkpoints can move
+        let moved = move_ready_checkpoints::<TestHandler>(&mut received, &mut pending, 5);
+
+        assert_eq!(moved, 0);
+        assert_eq!(received.len(), 3);
+        assert!(pending.is_empty());
+    }
 }

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -757,6 +757,7 @@ mod tests {
         let layer = ConcurrentLayer {
             committer: None,
             pruner: None,
+            checkpoint_lag: None,
             extra: Default::default(),
         };
 
@@ -767,6 +768,7 @@ mod tests {
                 watermark_interval_ms: 500,
             },
             pruner: Some(PrunerConfig::default()),
+            checkpoint_lag: None,
         };
 
         assert_matches!(
@@ -778,6 +780,7 @@ mod tests {
                     watermark_interval_ms: 500,
                 },
                 pruner: None,
+                checkpoint_lag: None,
             },
         );
     }
@@ -787,6 +790,7 @@ mod tests {
         let layer = ConcurrentLayer {
             committer: None,
             pruner: None,
+            checkpoint_lag: None,
             extra: Default::default(),
         };
 
@@ -797,6 +801,7 @@ mod tests {
                 watermark_interval_ms: 500,
             },
             pruner: None,
+            checkpoint_lag: None,
         };
 
         assert_matches!(
@@ -808,6 +813,7 @@ mod tests {
                     watermark_interval_ms: 500,
                 },
                 pruner: None,
+                checkpoint_lag: None,
             },
         );
     }
@@ -820,6 +826,7 @@ mod tests {
                 interval_ms: Some(1000),
                 ..Default::default()
             }),
+            checkpoint_lag: Some(200),
             extra: Default::default(),
         };
 
@@ -835,6 +842,7 @@ mod tests {
                 retention: 300,
                 max_chunk_size: 400,
             }),
+            checkpoint_lag: None,
         };
 
         assert_matches!(
@@ -851,6 +859,7 @@ mod tests {
                     retention: 300,
                     max_chunk_size: 400,
                 }),
+                checkpoint_lag: Some(200),
             },
         );
     }

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -143,6 +143,7 @@ pub async fn start_indexer(
                         layer.finish(ConcurrentConfig {
                             committer: committer.clone(),
                             pruner: Some(pruner.clone()),
+                            checkpoint_lag: None,
                         }),
                     )
                     .await?
@@ -188,6 +189,7 @@ pub async fn start_indexer(
                                     .unwrap_or_default()
                                     .finish(committer.clone()),
                                 pruner: Some(pruner_config),
+                                checkpoint_lag: None,
                             },
                         )
                         .await?;


### PR DESCRIPTION
## Description 

Add support for a lagged concurrent pipeline.
To do so we add an extra parameter to ConcurrentConfig, which then gets passed into collector.
Collector would maintain a list of checkpoints received but not ready for sending to the committer.
A checkpoint is only moved off from the received list if it meets the lag contraint.

## Test plan 

Added unit tests for the main utility function.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
