### PR TITLE
feat: support destroy_supply_for_testing on unit test

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/balance.move
+++ b/crates/sui-framework/packages/sui-framework/sources/balance.move
@@ -140,3 +140,10 @@ public fun destroy_for_testing<T>(self: Balance<T>): u64 {
 public fun create_supply_for_testing<T>(): Supply<T> {
     Supply { value: 0 }
 }
+
+#[test_only]
+/// Destroy a `Supply` preventing any further minting and burning.
+public fun destroy_supply_for_testing<T>(self: Supply<T>): u64 {
+    let Supply { value } = self;
+    value
+}


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

Currently, there is a scenario where coins need to be dynamically minted in the contract. 
However, it has been found that the unit test fails to pass. 
The reason is that `destroy_supply` is defined as `public (package)`. 
Therefore, in order to make the unit test pass, `destroy_supply_for_testing` needs to be introduced.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
