### PR TITLE
indexer-alt: fix field count for wal_ types

### DIFF
--- a/crates/sui-indexer-alt/src/models/objects.rs
+++ b/crates/sui-indexer-alt/src/models/objects.rs
@@ -111,7 +111,9 @@ pub struct StoredWalObjType {
 
 /// StoredObjectUpdate is a wrapper type, we want to count the fields of the inner type.
 impl<T: FieldCount> FieldCount for StoredObjectUpdate<T> {
-    const FIELD_COUNT: usize = T::FIELD_COUNT;
+    // Add one here for cp_sequence_number field, because StoredObjectUpdate is used for
+    // wal_* handlers, where the actual type to commit has an additional field besides fields of T.
+    const FIELD_COUNT: usize = T::FIELD_COUNT.saturating_add(1);
 }
 
 impl<DB: Backend> serialize::ToSql<SmallInt, DB> for StoredOwnerKind


### PR DESCRIPTION
## Description 

```
    // Add one here for cp_sequence_number field, because StoredObjectUpdate is used for
    // wal_* handlers, where the actual type has an additional field besides fields of T.
```

## Test plan 

Ci, we will want to add a test for chunk size <> commit limit, and will do that in a separate pr.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
