### PR TITLE
fix typo

### DIFF
--- a/crates/sui-framework/docs/sui-framework/package.md
+++ b/crates/sui-framework/docs/sui-framework/package.md
@@ -340,12 +340,12 @@ but multiple per package (!).
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext): <a href="package.md#0x2_package_Publisher">Publisher</a> {
     <b>assert</b>!(<a href="types.md#0x2_types_is_one_time_witness">types::is_one_time_witness</a>(&otw), <a href="package.md#0x2_package_ENotOneTimeWitness">ENotOneTimeWitness</a>);
 
-    <b>let</b> type_name = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;OTW&gt;();
+    <b>let</b> <a href="../move-stdlib/type_name.md#0x1_type_name">type_name</a> = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;OTW&gt;();
 
     <a href="package.md#0x2_package_Publisher">Publisher</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
-        <a href="package.md#0x2_package">package</a>: type_name.get_address(),
-        module_name: type_name.get_module(),
+        <a href="package.md#0x2_package">package</a>: <a href="../move-stdlib/type_name.md#0x1_type_name">type_name</a>.get_address(),
+        module_name: <a href="../move-stdlib/type_name.md#0x1_type_name">type_name</a>.get_module(),
     }
 }
 </code></pre>
@@ -450,9 +450,9 @@ Check whether a type belongs to the same module as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_from_module">from_module</a>&lt;T&gt;(self: &<a href="package.md#0x2_package_Publisher">Publisher</a>): bool {
-    <b>let</b> type_name = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;T&gt;();
+    <b>let</b> <a href="../move-stdlib/type_name.md#0x1_type_name">type_name</a> = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;T&gt;();
 
-    (type_name.get_address() == self.<a href="package.md#0x2_package">package</a>) && (type_name.get_module() == self.module_name)
+    (<a href="../move-stdlib/type_name.md#0x1_type_name">type_name</a>.get_address() == self.<a href="package.md#0x2_package">package</a>) && (<a href="../move-stdlib/type_name.md#0x1_type_name">type_name</a>.get_module() == self.module_name)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-framework/package.md
+++ b/crates/sui-framework/docs/sui-framework/package.md
@@ -340,12 +340,12 @@ but multiple per package (!).
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext): <a href="package.md#0x2_package_Publisher">Publisher</a> {
     <b>assert</b>!(<a href="types.md#0x2_types_is_one_time_witness">types::is_one_time_witness</a>(&otw), <a href="package.md#0x2_package_ENotOneTimeWitness">ENotOneTimeWitness</a>);
 
-    <b>let</b> tyname = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;OTW&gt;();
+    <b>let</b> type_name = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;OTW&gt;();
 
     <a href="package.md#0x2_package_Publisher">Publisher</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
-        <a href="package.md#0x2_package">package</a>: tyname.get_address(),
-        module_name: tyname.get_module(),
+        <a href="package.md#0x2_package">package</a>: type_name.get_address(),
+        module_name: type_name.get_module(),
     }
 }
 </code></pre>
@@ -450,9 +450,9 @@ Check whether a type belongs to the same module as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_from_module">from_module</a>&lt;T&gt;(self: &<a href="package.md#0x2_package_Publisher">Publisher</a>): bool {
-    <b>let</b> tyname = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;T&gt;();
+    <b>let</b> type_name = <a href="../move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">type_name::get_with_original_ids</a>&lt;T&gt;();
 
-    (tyname.get_address() == self.<a href="package.md#0x2_package">package</a>) && (tyname.get_module() == self.module_name)
+    (type_name.get_address() == self.<a href="package.md#0x2_package">package</a>) && (type_name.get_module() == self.module_name)
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-framework/sources/package.move
+++ b/crates/sui-framework/packages/sui-framework/sources/package.move
@@ -137,12 +137,12 @@ public struct UpgradeReceipt {
 public fun claim<OTW: drop>(otw: OTW, ctx: &mut TxContext): Publisher {
     assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
 
-    let tyname = type_name::get_with_original_ids<OTW>();
+    let type_name = type_name::get_with_original_ids<OTW>();
 
     Publisher {
         id: object::new(ctx),
-        package: tyname.get_address(),
-        module_name: tyname.get_module(),
+        package: type_name.get_address(),
+        module_name: type_name.get_module(),
     }
 }
 
@@ -168,9 +168,9 @@ public fun from_package<T>(self: &Publisher): bool {
 
 /// Check whether a type belongs to the same module as the publisher object.
 public fun from_module<T>(self: &Publisher): bool {
-    let tyname = type_name::get_with_original_ids<T>();
+    let type_name = type_name::get_with_original_ids<T>();
 
-    (tyname.get_address() == self.package) && (tyname.get_module() == self.module_name)
+    (type_name.get_address() == self.package) && (type_name.get_module() == self.module_name)
 }
 
 /// Read the name of the module.
@@ -308,12 +308,12 @@ public fun commit_upgrade(cap: &mut UpgradeCap, receipt: UpgradeReceipt) {
 #[test_only]
 /// Test-only function to claim a Publisher object bypassing OTW check.
 public fun test_claim<OTW: drop>(_: OTW, ctx: &mut TxContext): Publisher {
-    let tyname = type_name::get_with_original_ids<OTW>();
+    let type_name = type_name::get_with_original_ids<OTW>();
 
     Publisher {
         id: object::new(ctx),
-        package: tyname.get_address(),
-        module_name: tyname.get_module(),
+        package: type_name.get_address(),
+        module_name: type_name.get_module(),
     }
 }
 


### PR DESCRIPTION
It is recommended to use the full English names instead of abbreviations, as it will be easier to understand.