### PR TITLE
Improve logs for lock conflicts

### DIFF
--- a/crates/sui-core/src/execution_cache/object_locks.rs
+++ b/crates/sui-core/src/execution_cache/object_locks.rs
@@ -96,7 +96,10 @@ impl ObjectLocks {
         };
 
         if prev_lock != new_lock {
-            debug!("lock conflict detected: {:?} != {:?}", prev_lock, new_lock);
+            debug!(
+                "lock conflict detected for {:?}: {:?} != {:?}",
+                obj_ref, prev_lock, new_lock
+            );
             Err(SuiError::ObjectLockConflict {
                 obj_ref: *obj_ref,
                 pending_transaction: prev_lock,


### PR DESCRIPTION
Log the conflicted object as well as transactions digests
