### PR TITLE
Revert "update tuborepo workflow to allow secrets for PRs from forked repos"

### DIFF
--- a/.github/workflows/turborepo.yml
+++ b/.github/workflows/turborepo.yml
@@ -70,13 +70,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KMS_TEST_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.AWS_KMS_AWS_REGION }}
           AWS_KMS_KEY_ID: ${{ secrets.AWS_KMS_TEST_KMS_KEY_ID }}
-          E2E_AWS_KMS_TEST_ENABLE: "true"
+          E2E_AWS_KMS_TEST_ENABLE: "false"
           GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
           GOOGLE_KEYRING: ${{ secrets.GOOGLE_KEYRING }}
           GOOGLE_KEY_NAME: ${{ secrets.GOOGLE_KEY_NAME }}
           GOOGLE_KEY_NAME_VERSION: ${{ secrets.GOOGLE_KEY_NAME_VERSION }}
-          E2E_GCP_KMS_TEST_ENABLE: "true"
+          E2E_GCP_KMS_TEST_ENABLE: "false"
         run: pnpm turbo test
 
       # Pack wallet extension and upload it as an artifact for easy developer use:

--- a/.github/workflows/turborepo.yml
+++ b/.github/workflows/turborepo.yml
@@ -3,7 +3,7 @@ name: Turborepo CI
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
Reverts MystenLabs/sui#20552

`pull_request_target` checks out target branch (i.e. `main`) which means tests aren't run on new code 🤦 

Will also update to not run gcp / kms tests for all prs